### PR TITLE
fix(config): 保留空 auth-dir 的默认目录回退

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ import (
 const (
 	DefaultPanelGitHubRepository = "https://github.com/BlueSkyXN/CPA-Panel-LTS"
 	DefaultPprofAddr             = "127.0.0.1:8316"
+	DefaultAuthDir               = "~/.cli-proxy-api"
 )
 
 // Config represents the application's configuration, loaded from a YAML file.

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -75,7 +75,7 @@ func SetLogLevel(cfg *config.Config) {
 // It expands a leading tilde (~) to the user's home directory and returns a cleaned path.
 func ResolveAuthDir(authDir string) (string, error) {
 	if authDir == "" {
-		return "", nil
+		authDir = "~/.cli-proxy-api"
 	}
 	if strings.HasPrefix(authDir, "~") {
 		home, err := os.UserHomeDir()

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -73,9 +73,10 @@ func SetLogLevel(cfg *config.Config) {
 
 // ResolveAuthDir normalizes the auth directory path for consistent reuse throughout the app.
 // It expands a leading tilde (~) to the user's home directory and returns a cleaned path.
+// If authDir is empty, it defaults to ~/.cli-proxy-api.
 func ResolveAuthDir(authDir string) (string, error) {
 	if authDir == "" {
-		authDir = "~/.cli-proxy-api"
+		authDir = config.DefaultAuthDir
 	}
 	if strings.HasPrefix(authDir, "~") {
 		home, err := os.UserHomeDir()


### PR DESCRIPTION
## 背景

这是从上游 `router-for-me/CLIProxyAPI` 选择性移植的低风险配置修复，目标是在不改变 LTS usage statistics 契约的前提下吸收上游已修复问题。

上游来源提交：

- `4071fdef8417b052163a192f7d043526c7db9821`：`fix: apply default auth-dir when config value is empty`
- `4cbe1729340542bb5759c0925476324875347ab8`：`refactor: extract DefaultAuthDir constant per review feedback`

## 变更内容

- 新增 `config.DefaultAuthDir` 常量，集中表达默认 auth 目录 `~/.cli-proxy-api`。
- `util.ResolveAuthDir("")` 不再返回空路径，而是回退到默认 auth 目录。

## LTS 契约检查

- 未触碰 `internal/usage/`。
- 未触碰 `/v0/management/usage*` 路由或响应结构。
- 未改动 `usage-statistics-enabled`、Panel 下载源、Management API auth 行为。
- 只修复空 `auth-dir` 的默认值解析，旧配置文件无需迁移。

## 验证

- `git diff --check`
- `go test ./internal/config ./internal/util`