### PR TITLE
fix(amp): 补齐工具名大小写和 thread actors 路由兼容

### DIFF
--- a/internal/api/modules/amp/response_rewriter.go
+++ b/internal/api/modules/amp/response_rewriter.go
@@ -123,6 +123,52 @@ func (rw *ResponseRewriter) Flush() {
 
 var modelFieldPaths = []string{"message.model", "model", "modelVersion", "response.model", "response.modelVersion"}
 
+// ampCanonicalToolNames maps tool names to the exact casing expected by the
+// Amp mode tool whitelist (case-sensitive match).
+var ampCanonicalToolNames = map[string]string{
+	"bash":  "Bash",
+	"read":  "Read",
+	"grep":  "Grep",
+	"glob":  "glob",
+	"task":  "Task",
+	"check": "Check",
+}
+
+// normalizeAmpToolNames fixes tool_use block names to match Amp's canonical casing.
+// Some upstream models return lowercase tool names (e.g. "bash" instead of "Bash")
+// which causes Amp's case-sensitive mode whitelist to reject them.
+func normalizeAmpToolNames(data []byte) []byte {
+	// Non-streaming: content[].name in tool_use blocks
+	for index, block := range gjson.GetBytes(data, "content").Array() {
+		if block.Get("type").String() != "tool_use" {
+			continue
+		}
+		name := block.Get("name").String()
+		if canonical, ok := ampCanonicalToolNames[strings.ToLower(name)]; ok && name != canonical {
+			path := fmt.Sprintf("content.%d.name", index)
+			var err error
+			data, err = sjson.SetBytes(data, path, canonical)
+			if err != nil {
+				log.Warnf("Amp ResponseRewriter: failed to normalize tool name %q to %q: %v", name, canonical, err)
+			}
+		}
+	}
+
+	// Streaming: content_block.name in content_block_start events
+	if gjson.GetBytes(data, "content_block.type").String() == "tool_use" {
+		name := gjson.GetBytes(data, "content_block.name").String()
+		if canonical, ok := ampCanonicalToolNames[strings.ToLower(name)]; ok && name != canonical {
+			var err error
+			data, err = sjson.SetBytes(data, "content_block.name", canonical)
+			if err != nil {
+				log.Warnf("Amp ResponseRewriter: failed to normalize streaming tool name %q to %q: %v", name, canonical, err)
+			}
+		}
+	}
+
+	return data
+}
+
 // ensureAmpSignature injects empty signature fields into tool_use/thinking blocks
 // in API responses so that the Amp TUI does not crash on P.signature.length.
 func ensureAmpSignature(data []byte) []byte {
@@ -179,6 +225,7 @@ func (rw *ResponseRewriter) suppressAmpThinking(data []byte) []byte {
 
 func (rw *ResponseRewriter) rewriteModelInResponse(data []byte) []byte {
 	data = ensureAmpSignature(data)
+	data = normalizeAmpToolNames(data)
 	data = rw.suppressAmpThinking(data)
 	if len(data) == 0 {
 		return data
@@ -277,6 +324,9 @@ func (rw *ResponseRewriter) rewriteStreamChunk(chunk []byte) []byte {
 func (rw *ResponseRewriter) rewriteStreamEvent(data []byte) []byte {
 	// Inject empty signature where needed
 	data = ensureAmpSignature(data)
+
+	// Normalize tool names to canonical casing
+	data = normalizeAmpToolNames(data)
 
 	// Rewrite model name
 	if rw.originalModel != "" {

--- a/internal/api/modules/amp/response_rewriter_test.go
+++ b/internal/api/modules/amp/response_rewriter_test.go
@@ -175,6 +175,57 @@ func TestSanitizeAmpRequestBody_MixedInvalidThinkingAndToolUseSignature(t *testi
 	}
 }
 
+func TestNormalizeAmpToolNames_NonStreaming(t *testing.T) {
+	input := []byte(`{"content":[{"type":"tool_use","id":"toolu_01","name":"bash","input":{"cmd":"ls"}},{"type":"tool_use","id":"toolu_02","name":"read","input":{"path":"/tmp"}},{"type":"text","text":"hello"}]}`)
+	result := normalizeAmpToolNames(input)
+
+	if !contains(result, []byte(`"name":"Bash"`)) {
+		t.Errorf("expected bash->Bash, got %s", string(result))
+	}
+	if !contains(result, []byte(`"name":"Read"`)) {
+		t.Errorf("expected read->Read, got %s", string(result))
+	}
+	if contains(result, []byte(`"name":"bash"`)) {
+		t.Errorf("expected lowercase bash to be replaced, got %s", string(result))
+	}
+}
+
+func TestNormalizeAmpToolNames_Streaming(t *testing.T) {
+	input := []byte(`{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","name":"grep","id":"toolu_01","input":{}}}`)
+	result := normalizeAmpToolNames(input)
+
+	if !contains(result, []byte(`"name":"Grep"`)) {
+		t.Errorf("expected grep->Grep in streaming, got %s", string(result))
+	}
+}
+
+func TestNormalizeAmpToolNames_AlreadyCorrect(t *testing.T) {
+	input := []byte(`{"content":[{"type":"tool_use","id":"toolu_01","name":"Bash","input":{"cmd":"ls"}}]}`)
+	result := normalizeAmpToolNames(input)
+
+	if string(result) != string(input) {
+		t.Errorf("expected no modification for correctly-cased tool, got %s", string(result))
+	}
+}
+
+func TestNormalizeAmpToolNames_GlobPreserved(t *testing.T) {
+	input := []byte(`{"content":[{"type":"tool_use","id":"toolu_01","name":"glob","input":{"pattern":"*.go"}}]}`)
+	result := normalizeAmpToolNames(input)
+
+	if string(result) != string(input) {
+		t.Errorf("expected glob to remain lowercase, got %s", string(result))
+	}
+}
+
+func TestNormalizeAmpToolNames_UnknownToolUntouched(t *testing.T) {
+	input := []byte(`{"content":[{"type":"tool_use","id":"toolu_01","name":"edit_file","input":{"path":"/tmp/x"}}]}`)
+	result := normalizeAmpToolNames(input)
+
+	if string(result) != string(input) {
+		t.Errorf("expected no modification for unknown tool, got %s", string(result))
+	}
+}
+
 func contains(data, substr []byte) bool {
 	for i := 0; i <= len(data)-len(substr); i++ {
 		if string(data[i:i+len(substr)]) == string(substr) {

--- a/internal/api/modules/amp/routes.go
+++ b/internal/api/modules/amp/routes.go
@@ -199,6 +199,7 @@ func (m *AmpModule) registerManagementRoutes(engine *gin.Engine, baseHandler *ha
 	ampAPI.Any("/telemetry/*path", proxyHandler)
 	ampAPI.Any("/threads", proxyHandler)
 	ampAPI.Any("/threads/*path", proxyHandler)
+	ampAPI.Any("/thread-actors", proxyHandler)
 	ampAPI.Any("/otel", proxyHandler)
 	ampAPI.Any("/otel/*path", proxyHandler)
 	ampAPI.Any("/tab", proxyHandler)

--- a/internal/api/modules/amp/routes_test.go
+++ b/internal/api/modules/amp/routes_test.go
@@ -49,6 +49,7 @@ func TestRegisterManagementRoutes(t *testing.T) {
 		{"/api/meta", http.MethodGet},
 		{"/api/telemetry", http.MethodGet},
 		{"/api/threads", http.MethodGet},
+		{"/api/thread-actors", http.MethodPost},
 		{"/threads/", http.MethodGet},
 		{"/threads.rss", http.MethodGet}, // Root-level route (no /api prefix)
 		{"/api/otel", http.MethodGet},


### PR DESCRIPTION
## 背景

这是从上游 `router-for-me/CLIProxyAPI` 选择性移植的 AMP 兼容性修复，目标是增加客户端兼容能力，同时不改变 LTS usage statistics 和 Management usage 契约。

上游来源提交：

- `95318ad46dce78e19a74e06872b4901b83985bc9`：`fix(amp): preserve lowercase glob tool name`
- `01171742a6378cd55f564421abbfc0acb0fccfea`：`fix(amp): proxy thread actors route`

## 变更内容

- 在 AMP response rewriter 中把 tool_use 名称规范化到 Amp 白名单期望的大小写。
- 保留 `glob` 小写形式，避免被误改成 `Glob` 后被 Amp 侧拒绝。
- 增加 `/api/thread-actors` 代理路由，补齐 Amp CLI 线程 actor 查询路径。
- 增加对应 response rewriter 和 route 测试。

## LTS 契约检查

- 未触碰 `internal/usage/`。
- 未触碰 `/v0/management/usage*` route、export/import 或统计字段。
- 改动范围限定在 AMP module，未改变 Management usage、Panel 源、auth file 结构或 config key。

## 验证

- `git diff --check`
- `go test ./internal/api/modules/amp ./test -run Amp`