### PR TITLE
fix(api): 避免 idle TCP 阻塞协议复用 accept loop

### DIFF
--- a/internal/api/protocol_multiplexer.go
+++ b/internal/api/protocol_multiplexer.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -48,62 +49,82 @@ func (s *Server) acceptMuxConnections(listener net.Listener, httpListener *muxLi
 			continue
 		}
 
-		tlsConn, ok := conn.(*tls.Conn)
-		if ok {
-			if errHandshake := tlsConn.Handshake(); errHandshake != nil {
+		// Dispatch each connection to a goroutine so that slow/idle clients
+		// cannot block the accept loop. Previously, TLS handshake and
+		// reader.Peek(1) were performed inline; an idle TCP connection that
+		// never sent bytes would block Peek indefinitely, preventing all
+		// subsequent connections from being accepted (issue #3267).
+		go s.routeMuxConnection(conn, httpListener)
+	}
+}
+
+// routeMuxConnection performs per-connection protocol detection and routing.
+func (s *Server) routeMuxConnection(conn net.Conn, httpListener *muxListener) {
+	// Set a read deadline so that idle connections that never send bytes do not
+	// leak goroutines and file descriptors. The deadline is cleared once the
+	// connection is successfully routed to its handler.
+	const muxSniffDeadline = 10 * time.Second
+	_ = conn.SetReadDeadline(time.Now().Add(muxSniffDeadline))
+
+	tlsConn, ok := conn.(*tls.Conn)
+	if ok {
+		if errHandshake := tlsConn.Handshake(); errHandshake != nil {
+			if errClose := conn.Close(); errClose != nil {
+				log.Errorf("failed to close connection after TLS handshake error: %v", errClose)
+			}
+			return
+		}
+		proto := strings.TrimSpace(tlsConn.ConnectionState().NegotiatedProtocol)
+		if proto == "h2" || proto == "http/1.1" {
+			if httpListener == nil {
 				if errClose := conn.Close(); errClose != nil {
-					log.Errorf("failed to close connection after TLS handshake error: %v", errClose)
+					log.Errorf("failed to close connection: %v", errClose)
 				}
-				continue
+				return
 			}
-			proto := strings.TrimSpace(tlsConn.ConnectionState().NegotiatedProtocol)
-			if proto == "h2" || proto == "http/1.1" {
-				if httpListener == nil {
-					if errClose := conn.Close(); errClose != nil {
-						log.Errorf("failed to close connection: %v", errClose)
-					}
-					continue
-				}
-				if errPut := httpListener.Put(tlsConn); errPut != nil {
-					if errClose := conn.Close(); errClose != nil {
-						log.Errorf("failed to close connection after HTTP routing failure: %v", errClose)
-					}
-				}
-				continue
-			}
-		}
-
-		reader := bufio.NewReader(conn)
-		prefix, errPeek := reader.Peek(1)
-		if errPeek != nil {
-			if errClose := conn.Close(); errClose != nil {
-				log.Errorf("failed to close connection after protocol peek failure: %v", errClose)
-			}
-			continue
-		}
-
-		if isRedisRESPPrefix(prefix[0]) {
-			if !s.managementRoutesEnabled.Load() {
+			if errPut := httpListener.Put(tlsConn); errPut != nil {
 				if errClose := conn.Close(); errClose != nil {
-					log.Errorf("failed to close redis connection while management is disabled: %v", errClose)
+					log.Errorf("failed to close connection after HTTP routing failure: %v", errClose)
 				}
-				continue
+			} else {
+				_ = conn.SetReadDeadline(time.Time{})
 			}
-			go s.handleRedisConnection(conn, reader)
-			continue
+			return
 		}
+	}
 
-		if httpListener == nil {
-			if errClose := conn.Close(); errClose != nil {
-				log.Errorf("failed to close connection without HTTP listener: %v", errClose)
-			}
-			continue
+	reader := bufio.NewReader(conn)
+	prefix, errPeek := reader.Peek(1)
+	if errPeek != nil {
+		if errClose := conn.Close(); errClose != nil {
+			log.Errorf("failed to close connection after protocol peek failure: %v", errClose)
 		}
+		return
+	}
 
-		if errPut := httpListener.Put(&bufferedConn{Conn: conn, reader: reader}); errPut != nil {
+	if isRedisRESPPrefix(prefix[0]) {
+		if !s.managementRoutesEnabled.Load() {
 			if errClose := conn.Close(); errClose != nil {
-				log.Errorf("failed to close connection after HTTP routing failure: %v", errClose)
+				log.Errorf("failed to close redis connection while management is disabled: %v", errClose)
 			}
+			return
 		}
+		s.handleRedisConnection(conn, reader)
+		return
+	}
+
+	if httpListener == nil {
+		if errClose := conn.Close(); errClose != nil {
+			log.Errorf("failed to close connection without HTTP listener: %v", errClose)
+		}
+		return
+	}
+
+	if errPut := httpListener.Put(&bufferedConn{Conn: conn, reader: reader}); errPut != nil {
+		if errClose := conn.Close(); errClose != nil {
+			log.Errorf("failed to close connection after HTTP routing failure: %v", errClose)
+		}
+	} else {
+		_ = conn.SetReadDeadline(time.Time{})
 	}
 }

--- a/internal/api/protocol_multiplexer.go
+++ b/internal/api/protocol_multiplexer.go
@@ -109,6 +109,7 @@ func (s *Server) routeMuxConnection(conn net.Conn, httpListener *muxListener) {
 			}
 			return
 		}
+		_ = conn.SetReadDeadline(time.Time{})
 		s.handleRedisConnection(conn, reader)
 		return
 	}

--- a/internal/api/protocol_multiplexer_test.go
+++ b/internal/api/protocol_multiplexer_test.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestAcceptMuxNotBlockedByIdleConnection(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer listener.Close()
+
+	var routed atomic.Int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		routed.Add(1)
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewUnstartedServer(handler)
+	defer srv.Close()
+
+	muxLn := newMuxListener(listener.Addr(), 1024)
+	server := &Server{managementRoutesEnabled: atomic.Bool{}}
+	server.managementRoutesEnabled.Store(false)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.acceptMuxConnections(listener, muxLn)
+	}()
+
+	srv.Listener = muxLn
+	srv.Start()
+
+	// Open an idle TCP connection that never sends any bytes.
+	idleConn, err := net.DialTimeout("tcp", listener.Addr().String(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("failed to dial idle connection: %v", err)
+	}
+	defer idleConn.Close()
+
+	// Give the accept loop time to pick up the idle connection.
+	time.Sleep(50 * time.Millisecond)
+
+	// Send a real HTTP request. Before the fix, the accept loop would be
+	// blocked on Peek(1) for the idle connection, causing this request to
+	// time out.
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get("http://" + listener.Addr().String() + "/")
+	if err != nil {
+		listener.Close()
+		t.Fatalf("HTTP request failed (accept loop may be blocked by idle connection): %v", err)
+	}
+	resp.Body.Close()
+
+	listener.Close()
+
+	if routed.Load() == 0 {
+		t.Error("expected at least one request to be routed")
+	}
+}


### PR DESCRIPTION
## 背景

这是从上游 `router-for-me/CLIProxyAPI` 选择性移植的协议复用稳定性修复，目标是修复 idle TCP connection 卡住 `accept` 循环的问题，同时保持 CPA-Core-LTS 的 Management/Redis 安全边界。

上游来源提交：

- `28dfcae3508d2de402bcca8d8b8644b1b0448170`：`fix(api): prevent idle TCP connections from blocking the accept loop`
- `c5596e09256d3f6dd1941ec97bb0709493d0c5cd`：`fix(api): clear sniff deadline before entering Redis handler`

## 变更内容

- 将 mux connection 的 TLS handshake / protocol sniff 从 accept loop 移到 per-connection goroutine。
- 给协议探测阶段设置 10s read deadline，避免 idle client 永久占住 goroutine/fd。
- HTTP 路由成功后清除 sniff deadline。
- Redis handler 接管前清除 sniff deadline，避免合法 Redis client 10s 空闲后被误断开。
- 增加 `TestAcceptMuxNotBlockedByIdleConnection` 回归测试。

## LTS 冲突处理

- 上游当前版本已经去掉了 LTS 当前的 `managementRoutesEnabled` Redis gate；本 PR 保留 CPA-Core-LTS 现有 gate，不让 Redis protocol 在 Management disabled 时被接管。
- 未移植上游 Home mode 判断，因为 CPA-Core-LTS 当前配置结构没有该 Home control-plane 能力，强行带入会扩大范围。

## LTS 契约检查

- 未触碰 `internal/usage/`。
- 未触碰 `/v0/management/usage*` route、export/import 或 usage 统计字段。
- 未改变 Management API response shape、auth header、Panel source 或 config key。
- Redis protocol 仍受 Management enabled gate 保护。

## 验证

- `git diff --check`
- `go test ./internal/api`