### PR TITLE
fix(store): 在 Git push 成功后再执行 token store GC

### DIFF
--- a/internal/store/gitstore.go
+++ b/internal/store/gitstore.go
@@ -846,7 +846,6 @@ func (s *GitTokenStore) commitAndPushLocked(message string, relPaths ...string) 
 	} else if errRewrite := s.rewriteHeadAsSingleCommit(repo, headRef.Name(), commitHash, message, signature); errRewrite != nil {
 		return errRewrite
 	}
-	s.maybeRunGC(repo)
 	pushOpts := &git.PushOptions{Auth: s.gitAuth(), Force: true}
 	if s.branch != "" {
 		pushOpts.RefSpecs = []config.RefSpec{config.RefSpec("refs/heads/" + s.branch + ":refs/heads/" + s.branch)}
@@ -862,6 +861,7 @@ func (s *GitTokenStore) commitAndPushLocked(message string, relPaths ...string) 
 		}
 		return fmt.Errorf("git token store: push: %w", err)
 	}
+	s.maybeRunGC(repoDir)
 	return nil
 }
 
@@ -895,12 +895,17 @@ func (s *GitTokenStore) rewriteHeadAsSingleCommit(repo *git.Repository, branch p
 	return nil
 }
 
-func (s *GitTokenStore) maybeRunGC(repo *git.Repository) {
+func (s *GitTokenStore) maybeRunGC(repoDir string) {
 	now := time.Now()
 	if now.Sub(s.lastGC) < gcInterval {
 		return
 	}
 	s.lastGC = now
+
+	repo, err := git.PlainOpen(repoDir)
+	if err != nil {
+		return
+	}
 
 	pruneOpts := git.PruneOptions{
 		OnlyObjectsOlderThan: now,

--- a/internal/store/gitstore_test.go
+++ b/internal/store/gitstore_test.go
@@ -239,6 +239,40 @@ func TestEnsureRepositoryResetsToRemoteDefaultWhenBranchUnset(t *testing.T) {
 	assertRemoteBranchContents(t, remoteDir, "master", "local master update\n")
 }
 
+func TestCommitAndPushLockedPushesBeforeRunningGC(t *testing.T) {
+	root := t.TempDir()
+	remoteDir := setupGitRemoteRepository(t, root, "master",
+		testBranchSpec{name: "master", contents: "remote master branch\n"},
+	)
+
+	store := NewGitTokenStore(remoteDir, "", "", "")
+	store.SetBaseDir(filepath.Join(root, "workspace", "auths"))
+	if err := store.EnsureRepository(); err != nil {
+		t.Fatalf("EnsureRepository: %v", err)
+	}
+
+	workspaceDir := filepath.Join(root, "workspace")
+	updates := []string{
+		"local master update one\n",
+		"local master update two\n",
+	}
+	for _, contents := range updates {
+		if err := os.WriteFile(filepath.Join(workspaceDir, "branch.txt"), []byte(contents), 0o600); err != nil {
+			t.Fatalf("write local master marker: %v", err)
+		}
+
+		store.lastGC = time.Now().Add(-gcInterval)
+		store.mu.Lock()
+		err := store.commitAndPushLocked("Update master marker", "branch.txt")
+		store.mu.Unlock()
+		if err != nil {
+			t.Fatalf("commitAndPushLocked with forced GC: %v", err)
+		}
+
+		assertRemoteBranchContents(t, remoteDir, "master", contents)
+	}
+}
+
 func TestEnsureRepositoryFollowsRenamedRemoteDefaultBranchWhenAvailable(t *testing.T) {
 	root := t.TempDir()
 	remoteDir := setupGitRemoteRepository(t, root, "master",


### PR DESCRIPTION
## 背景

这是从上游 `router-for-me/CLIProxyAPI` 选择性移植的 Git token store 稳定性修复。目标是在 auth/token Git store 写入路径中避免 GC 过早运行影响 push 可靠性。

上游来源提交：

- `30a8824b64856bb934d45752112827a13b4ca951`：`fix(gitstore): adjust garbage collection to run after push operation`

## 变更内容

- `commitAndPushLocked` 先完成 push，再触发可能的 GC。
- `maybeRunGC` 改为基于 repo directory 重新打开仓库，避免在 push 前复用当前 repository 对象执行 GC。
- 增加 `TestCommitAndPushLockedPushesBeforeRunningGC` 回归测试，验证强制 GC 时远端内容仍正确更新。

## LTS 契约检查

- 未触碰 `internal/usage/`。
- 未触碰 `/v0/management/usage*` route、export/import 或 usage 字段。
- 未改变 auth file schema、Management API response shape、Panel source 或 config key。
- 改动只影响 Git-backed token store 的内部 push/GC 顺序。

## 验证

- `git diff --check`
- `go test ./internal/store`