### PR TITLE
fix(registry): embedded model catalog 解析失败时继续启动

### DIFF
--- a/internal/registry/model_updater.go
+++ b/internal/registry/model_updater.go
@@ -67,7 +67,7 @@ func SetModelRefreshCallback(cb ModelRefreshCallback) {
 func init() {
 	// Load embedded data as fallback on startup.
 	if err := loadModelsFromBytes(embeddedModelsJSON, "embed"); err != nil {
-		panic(fmt.Sprintf("registry: failed to parse embedded models.json: %v", err))
+		log.Warnf("registry: failed to parse embedded models.json (embedded catalog may be incomplete or invalid; continuing startup and will rely on remote model refresh): %v", err)
 	}
 }
 


### PR DESCRIPTION
## 背景

这是从上游 `router-for-me/CLIProxyAPI` 选择性移植的 model registry resiliency 修复。CPA-Core-LTS 已经使用远程 model catalog 作为运行时刷新来源；embedded catalog 解析失败时直接 panic 会让服务没有机会依赖远程刷新恢复。

上游来源提交：

- `be841b88ee08b73ccba7d0c90bc73e32a9517c87`：`log(registry): replace panic with warning on embedded model parse failure`

## 变更内容

- `internal/registry/model_updater.go` 中 embedded `models.json` 解析失败时从 `panic` 改为 `log.Warnf`。
- 服务可继续启动，并依赖后续 remote model refresh 恢复/更新 model catalog。

## LTS 契约检查

- 未触碰 `internal/usage/`。
- 未触碰 `/v0/management/usage*` route、export/import 或 usage 字段。
- 未改变 model updater 远程来源、Panel source、auth file schema、Management API 或 config key。
- 这是 startup resiliency 变化；不会修改嵌入 catalog 内容。

## 验证

已通过：

- `git diff --check`
- `go test ./internal/registry -run 'Test(CodexStaticModelsIncludeGPT55|GetAvailableModelsReturnsClonedSnapshots|GetAvailableModelsInvalidatesCacheOnRegistryChanges|ModelRegistryHook_OnModelsRegisteredCalled|ModelRegistryHook_OnModelsUnregisteredCalled|ModelRegistryHook_DoesNotBlockRegisterClient|ModelRegistryHook_PanicDoesNotAffectRegistry|GetModelInfoReturnsClone|GetModelsForClientReturnsClones|GetAvailableModelsByProviderReturnsClones|CleanupExpiredQuotasInvalidatesAvailableModelsCache|GetAvailableModelsReturnsClonedSupportedParameters|LookupModelInfoReturnsCloneForStaticDefinitions)'`

已知既有问题：

- `go test ./internal/registry` 当前在 `origin/main` 也会失败：`TestCodexFreeModelsExcludeGPT55` 断言 free tier 不应包含 `gpt-5.5`，但当前 catalog 已包含该模型。该失败不是本 PR 引入。