### PR TITLE
fix(gemini): 按模型上限收敛 maxOutputTokens

### DIFF
--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
@@ -135,6 +136,7 @@ func (e *GeminiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	requestPath := helps.PayloadRequestPath(opts)
 	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel, requestPath)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
+	body = capGeminiMaxOutputTokens(body, baseModel)
 
 	action := "generateContent"
 	if req.Metadata != nil {
@@ -243,6 +245,7 @@ func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	requestPath := helps.PayloadRequestPath(opts)
 	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel, requestPath)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
+	body = capGeminiMaxOutputTokens(body, baseModel)
 
 	baseURL := resolveGeminiBaseURL(auth)
 	url := fmt.Sprintf("%s/%s/models/%s:%s", baseURL, glAPIVersion, baseModel, "streamGenerateContent")
@@ -511,6 +514,26 @@ func applyGeminiHeaders(req *http.Request, auth *cliproxyauth.Auth) {
 		attrs = auth.Attributes
 	}
 	util.ApplyCustomHeadersFromAttrs(req, attrs)
+}
+
+func capGeminiMaxOutputTokens(body []byte, modelName string) []byte {
+	maxOut := gjson.GetBytes(body, "generationConfig.maxOutputTokens")
+	if !maxOut.Exists() || maxOut.Type != gjson.Number {
+		return body
+	}
+	modelInfo := registry.LookupModelInfo(modelName, "gemini")
+	if modelInfo == nil {
+		return body
+	}
+	limit := modelInfo.OutputTokenLimit
+	if limit <= 0 {
+		limit = modelInfo.MaxCompletionTokens
+	}
+	if limit <= 0 || maxOut.Int() <= int64(limit) {
+		return body
+	}
+	body, _ = sjson.SetBytes(body, "generationConfig.maxOutputTokens", limit)
+	return body
 }
 
 func fixGeminiImageAspectRatio(modelName string, rawJSON []byte) []byte {

--- a/internal/runtime/executor/gemini_executor_test.go
+++ b/internal/runtime/executor/gemini_executor_test.go
@@ -1,0 +1,90 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestCapGeminiMaxOutputTokensUsesOutputTokenLimit(t *testing.T) {
+	body := []byte(`{"generationConfig":{"maxOutputTokens":500000,"temperature":0.2},"contents":[]}`)
+
+	out := capGeminiMaxOutputTokens(body, "gemini-3.1-pro-preview")
+
+	if got := gjson.GetBytes(out, "generationConfig.maxOutputTokens").Int(); got != 65536 {
+		t.Fatalf("maxOutputTokens = %d, want 65536", got)
+	}
+	if got := gjson.GetBytes(out, "generationConfig.temperature").Float(); got != 0.2 {
+		t.Fatalf("temperature = %v, want 0.2", got)
+	}
+}
+
+func TestCapGeminiMaxOutputTokensLeavesAllowedOrUnknown(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+		body  []byte
+		want  int64
+	}{
+		{
+			name:  "allowed value",
+			model: "gemini-3.1-pro-preview",
+			body:  []byte(`{"generationConfig":{"maxOutputTokens":64000}}`),
+			want:  64000,
+		},
+		{
+			name:  "unknown model",
+			model: "custom-gemini-model",
+			body:  []byte(`{"generationConfig":{"maxOutputTokens":500000}}`),
+			want:  500000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := capGeminiMaxOutputTokens(tt.body, tt.model)
+			if got := gjson.GetBytes(out, "generationConfig.maxOutputTokens").Int(); got != tt.want {
+				t.Fatalf("maxOutputTokens = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGeminiExecutorExecuteCapsMaxOutputTokensBeforeUpstream(t *testing.T) {
+	var upstreamMaxOutputTokens int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		upstreamMaxOutputTokens = gjson.GetBytes(body, "generationConfig.maxOutputTokens").Int()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}`))
+	}))
+	defer server.Close()
+
+	exec := NewGeminiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "test-key",
+		"base_url": server.URL,
+	}}
+	req := cliproxyexecutor.Request{
+		Model:   "gemini-3.1-pro-preview",
+		Payload: []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}],"generationConfig":{"maxOutputTokens":500000}}`),
+	}
+
+	if _, err := exec.Execute(context.Background(), auth, req, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatGemini}); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if upstreamMaxOutputTokens != 65536 {
+		t.Fatalf("upstream maxOutputTokens = %d, want 65536", upstreamMaxOutputTokens)
+	}
+}


### PR DESCRIPTION
## Summary

本 PR 从上游选择性移植 Gemini executor 的 `maxOutputTokens` 上限收敛逻辑，避免请求值超过模型 registry 中声明的输出上限时被上游拒绝。

移植的 upstream commit：

- `1583cb4e` `Cap Gemini max output tokens`

LTS 适配：

- 保持 Go module path 为 `github.com/router-for-me/CLIProxyAPI/v6`。
- 使用 LTS 现有 `registry.LookupModelInfo(model, "gemini")` 读取 `outputTokenLimit` / `max_completion_tokens`。

## Changes

- 在 Gemini non-stream 和 stream 请求发往 upstream 之前，对 `generationConfig.maxOutputTokens` 做上限收敛。
- 只有当 registry 能找到模型，且请求值大于模型 `outputTokenLimit` 或 fallback `max_completion_tokens` 时才修改请求体。
- 未知模型、未设置 `maxOutputTokens`、非数字值、以及未超过上限的值保持原样。
- 新增 regression tests 覆盖 helper、未知模型、合法值和 Execute 发往 upstream 前的收敛行为。

## LTS compatibility

- 这是一个有意的行为限制：只把超过模型公开输出上限的请求值降到可接受范围，用于减少 upstream 400/invalid argument 风险。
- 不影响 usage statistics、Management API、auth/config schema、Panel 源或统计字段兼容性。
- 不改变未知/自定义 Gemini model 的请求行为，避免对本地自定义模型做过度限制。

## Validation

- `gofmt -w internal/runtime/executor/gemini_executor.go internal/runtime/executor/gemini_executor_test.go`
- `git diff --check`
- `go test ./internal/runtime/executor -run 'Gemini|CapGemini'`
- `go test ./internal/registry -run 'LookupModelInfo|StaticDefinitions'`
- `go build -o test-output ./cmd/server && rm -f test-output`
