### PR TITLE
fix(gemini-cli): 使用 onboarding 返回的 backend project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ _bmad-output/*
 # macOS
 .DS_Store
 ._*
+.gocache/

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -2400,10 +2400,8 @@ func performGeminiCLISetup(ctx context.Context, httpClient *http.Client, storage
 				if explicitProject && !strings.EqualFold(responseProjectID, projectID) {
 					log.Infof("Gemini onboarding: requested project %s maps to backend project %s", projectID, responseProjectID)
 					log.Infof("Using backend project ID: %s", responseProjectID)
-					finalProjectID = responseProjectID
-				} else {
-					finalProjectID = responseProjectID
 				}
+				finalProjectID = responseProjectID
 			}
 
 			storage.ProjectID = strings.TrimSpace(finalProjectID)

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -2398,20 +2398,9 @@ func performGeminiCLISetup(ctx context.Context, httpClient *http.Client, storage
 			finalProjectID := projectID
 			if responseProjectID != "" {
 				if explicitProject && !strings.EqualFold(responseProjectID, projectID) {
-					// Check if this is a free user (gen-lang-client projects or free/legacy tier)
-					isFreeUser := strings.HasPrefix(projectID, "gen-lang-client-") ||
-						strings.EqualFold(tierID, "FREE") ||
-						strings.EqualFold(tierID, "LEGACY")
-
-					if isFreeUser {
-						// For free users, use backend project ID for preview model access
-						log.Infof("Gemini onboarding: frontend project %s maps to backend project %s", projectID, responseProjectID)
-						log.Infof("Using backend project ID: %s (recommended for preview model access)", responseProjectID)
-						finalProjectID = responseProjectID
-					} else {
-						// Pro users: keep requested project ID (original behavior)
-						log.Warnf("Gemini onboarding returned project %s instead of requested %s; keeping requested project ID.", responseProjectID, projectID)
-					}
+					log.Infof("Gemini onboarding: requested project %s maps to backend project %s", projectID, responseProjectID)
+					log.Infof("Using backend project ID: %s", responseProjectID)
+					finalProjectID = responseProjectID
 				} else {
 					finalProjectID = responseProjectID
 				}

--- a/internal/api/handlers/management/auth_files_gemini_cli_test.go
+++ b/internal/api/handlers/management/auth_files_gemini_cli_test.go
@@ -1,0 +1,45 @@
+package management
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	geminiAuth "github.com/router-for-me/CLIProxyAPI/v6/internal/auth/gemini"
+)
+
+func TestPerformGeminiCLISetupUsesBackendProjectID(t *testing.T) {
+	client := &http.Client{Transport: geminiCLITestTransport{}}
+	storage := &geminiAuth.GeminiTokenStorage{}
+
+	if err := performGeminiCLISetup(context.Background(), client, storage, "frontend-project"); err != nil {
+		t.Fatalf("performGeminiCLISetup() error = %v", err)
+	}
+
+	if got := storage.ProjectID; got != "backend-project" {
+		t.Fatalf("storage.ProjectID = %q, want backend-project", got)
+	}
+}
+
+type geminiCLITestTransport struct{}
+
+func (geminiCLITestTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	var body string
+	switch {
+	case strings.HasSuffix(req.URL.Path, "/v1internal:loadCodeAssist"):
+		body = `{"allowedTiers":[{"id":"PRO","isDefault":true}]}`
+	case strings.HasSuffix(req.URL.Path, "/v1internal:onboardUser"):
+		body = `{"done":true,"response":{"cloudaicompanionProject":{"id":"backend-project"}}}`
+	default:
+		body = `{}`
+	}
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}, nil
+}

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -335,10 +335,8 @@ func performGeminiCLISetup(ctx context.Context, httpClient *http.Client, storage
 				if explicitProject && !strings.EqualFold(responseProjectID, projectID) {
 					log.Infof("Gemini onboarding: requested project %s maps to backend project %s", projectID, responseProjectID)
 					log.Infof("Using backend project ID: %s", responseProjectID)
-					finalProjectID = responseProjectID
-				} else {
-					finalProjectID = responseProjectID
 				}
+				finalProjectID = responseProjectID
 			}
 
 			storage.ProjectID = strings.TrimSpace(finalProjectID)

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -333,39 +333,9 @@ func performGeminiCLISetup(ctx context.Context, httpClient *http.Client, storage
 			finalProjectID := projectID
 			if responseProjectID != "" {
 				if explicitProject && !strings.EqualFold(responseProjectID, projectID) {
-					// Check if this is a free user (gen-lang-client projects or free/legacy tier)
-					isFreeUser := strings.HasPrefix(projectID, "gen-lang-client-") ||
-						strings.EqualFold(tierID, "FREE") ||
-						strings.EqualFold(tierID, "LEGACY")
-
-					if isFreeUser {
-						// Interactive prompt for free users
-						fmt.Printf("\nGoogle returned a different project ID:\n")
-						fmt.Printf("  Requested (frontend): %s\n", projectID)
-						fmt.Printf("  Returned (backend):   %s\n\n", responseProjectID)
-						fmt.Printf("  Backend project IDs have access to preview models (gemini-3-*).\n")
-						fmt.Printf("  This is normal for free tier users.\n\n")
-						fmt.Printf("Which project ID would you like to use?\n")
-						fmt.Printf("  [1] Backend (recommended): %s\n", responseProjectID)
-						fmt.Printf("  [2] Frontend: %s\n\n", projectID)
-						fmt.Printf("Enter choice [1]: ")
-
-						reader := bufio.NewReader(os.Stdin)
-						choice, _ := reader.ReadString('\n')
-						choice = strings.TrimSpace(choice)
-
-						if choice == "2" {
-							log.Infof("Using frontend project ID: %s", projectID)
-							fmt.Println(". Warning: Frontend project IDs may not have access to preview models.")
-							finalProjectID = projectID
-						} else {
-							log.Infof("Using backend project ID: %s (recommended)", responseProjectID)
-							finalProjectID = responseProjectID
-						}
-					} else {
-						// Pro users: keep requested project ID (original behavior)
-						log.Warnf("Gemini onboarding returned project %s instead of requested %s; keeping requested project ID.", responseProjectID, projectID)
-					}
+					log.Infof("Gemini onboarding: requested project %s maps to backend project %s", projectID, responseProjectID)
+					log.Infof("Using backend project ID: %s", responseProjectID)
+					finalProjectID = responseProjectID
 				} else {
 					finalProjectID = responseProjectID
 				}

--- a/internal/cmd/login_gemini_cli_test.go
+++ b/internal/cmd/login_gemini_cli_test.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/gemini"
+)
+
+func TestPerformGeminiCLISetupUsesBackendProjectID(t *testing.T) {
+	client := &http.Client{Transport: geminiCLILoginTestTransport{}}
+	storage := &gemini.GeminiTokenStorage{}
+
+	if err := performGeminiCLISetup(context.Background(), client, storage, "frontend-project"); err != nil {
+		t.Fatalf("performGeminiCLISetup() error = %v", err)
+	}
+
+	if got := storage.ProjectID; got != "backend-project" {
+		t.Fatalf("storage.ProjectID = %q, want backend-project", got)
+	}
+}
+
+type geminiCLILoginTestTransport struct{}
+
+func (geminiCLILoginTestTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	var body string
+	switch {
+	case strings.HasSuffix(req.URL.Path, "/v1internal:loadCodeAssist"):
+		body = `{"allowedTiers":[{"id":"PRO","isDefault":true}]}`
+	case strings.HasSuffix(req.URL.Path, "/v1internal:onboardUser"):
+		body = `{"done":true,"response":{"cloudaicompanionProject":{"id":"backend-project"}}}`
+	default:
+		body = `{}`
+	}
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}, nil
+}

--- a/internal/misc/header_utils.go
+++ b/internal/misc/header_utils.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// GeminiCLIVersion is the version string reported in the User-Agent for upstream requests.
-	GeminiCLIVersion = "0.31.0"
+	GeminiCLIVersion = "0.34.0"
 
 	// GeminiCLIApiClientHeader is the value for the X-Goog-Api-Client header sent to the Gemini CLI upstream.
 	GeminiCLIApiClientHeader = "google-genai-sdk/1.41.0 gl-node/v22.19.0"
@@ -46,7 +46,7 @@ func GeminiCLIUserAgent(model string) string {
 	if model == "" {
 		model = "unknown"
 	}
-	return fmt.Sprintf("GeminiCLI/%s/%s (%s; %s)", GeminiCLIVersion, model, geminiCLIOS(), geminiCLIArch())
+	return fmt.Sprintf("GeminiCLI/%s/%s (%s; %s; terminal)", GeminiCLIVersion, model, geminiCLIOS(), geminiCLIArch())
 }
 
 // ScrubProxyAndFingerprintHeaders removes all headers that could reveal

--- a/internal/misc/header_utils_test.go
+++ b/internal/misc/header_utils_test.go
@@ -1,0 +1,17 @@
+package misc
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGeminiCLIUserAgentIncludesTerminalMarker(t *testing.T) {
+	ua := GeminiCLIUserAgent("gemini-test")
+
+	if !strings.Contains(ua, "GeminiCLI/0.34.0/gemini-test") {
+		t.Fatalf("GeminiCLIUserAgent() = %q, want Gemini CLI 0.34.0 model marker", ua)
+	}
+	if !strings.Contains(ua, "; terminal)") {
+		t.Fatalf("GeminiCLIUserAgent() = %q, want terminal marker", ua)
+	}
+}


### PR DESCRIPTION
## 背景

选择性移植上游 Gemini CLI onboarding 修复：当 Google onboarding 返回的 backend project 与用户显式传入的 frontend project 不一致时，Core 统一保存 backend project ID，以匹配新版 Gemini CLI 行为并改善 preview model 访问兼容性。

上游来源：
- `fccfb162` `fix(gemini-cli): use backend project ID from onboarding response`
- `91387ca2` `refactor(gemini-cli): simplify redundant if/else in project ID assignment`

## 改动

- Management Gemini CLI setup 与 CLI login setup 都改为使用 onboarding response 中的 backend project ID。
- Gemini CLI User-Agent 从 `0.31.0` 更新到 `0.34.0`，并追加 `terminal` 标识。
- `.gitignore` 增加 `.gocache/`。
- 补充 LTS 回归测试，覆盖 Management/CLI onboarding 保存 backend project，以及 User-Agent terminal marker。

## LTS 兼容性

- 不触碰 `internal/usage/` 和 `/v0/management/usage*`。
- 不改 Management route shape、auth file response shape 或 Panel 统计契约。
- 行为变化仅限 Gemini CLI onboarding 最终 `ProjectID` 选择；显式传入 frontend project 时，如果 Google 返回 backend project，会保存 backend project。

## 验证

- `git diff --check origin/main...HEAD`
- `go test ./internal/api/handlers/management -run 'GeminiCLI|Auth|Project'`
- `go test ./internal/cmd -run 'GeminiCLI|Login|Project'`
- `go test ./internal/misc -run GeminiCLIUserAgent`
- `go build -o test-output ./cmd/server`
