### PR TITLE
fix(kimi): 丢弃空 assistant 消息

### DIFF
--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -333,7 +333,17 @@ func normalizeKimiToolMessageLinks(body []byte) ([]byte, error) {
 		return body, nil
 	}
 
-	out := body
+	msgs := messages.Array()
+	out, dropped, err := filterKimiEmptyAssistantMessages(body, msgs)
+	if err != nil {
+		return body, err
+	}
+	if dropped > 0 {
+		log.WithField("dropped_assistant_messages", dropped).Debug("kimi executor: dropped empty assistant messages")
+	}
+
+	messages = gjson.GetBytes(out, "messages")
+	msgs = messages.Array()
 	pending := make([]string, 0)
 	patched := 0
 	patchedReasoning := 0
@@ -351,7 +361,6 @@ func normalizeKimiToolMessageLinks(body []byte) ([]byte, error) {
 		}
 	}
 
-	msgs := messages.Array()
 	for msgIdx := range msgs {
 		msg := msgs[msgIdx]
 		role := strings.TrimSpace(msg.Get("role").String())
@@ -437,6 +446,96 @@ func normalizeKimiToolMessageLinks(body []byte) ([]byte, error) {
 	}
 
 	return out, nil
+}
+
+func filterKimiEmptyAssistantMessages(body []byte, msgs []gjson.Result) ([]byte, int, error) {
+	kept := make([]string, 0, len(msgs))
+	dropped := 0
+	for _, msg := range msgs {
+		if shouldDropKimiAssistantMessage(msg) {
+			dropped++
+			continue
+		}
+		kept = append(kept, msg.Raw)
+	}
+	if dropped == 0 {
+		return body, 0, nil
+	}
+
+	rawMessages := []byte("[" + strings.Join(kept, ",") + "]")
+	out, err := sjson.SetRawBytes(body, "messages", rawMessages)
+	if err != nil {
+		return body, 0, fmt.Errorf("kimi executor: failed to drop empty assistant messages: %w", err)
+	}
+	return out, dropped, nil
+}
+
+func shouldDropKimiAssistantMessage(msg gjson.Result) bool {
+	if strings.TrimSpace(msg.Get("role").String()) != "assistant" {
+		return false
+	}
+	if hasKimiToolCalls(msg) || hasKimiLegacyFunctionCall(msg) || hasKimiAssistantReasoning(msg) {
+		return false
+	}
+	return isKimiAssistantContentEmpty(msg.Get("content"))
+}
+
+func hasKimiToolCalls(msg gjson.Result) bool {
+	toolCalls := msg.Get("tool_calls")
+	return toolCalls.Exists() && toolCalls.IsArray() && len(toolCalls.Array()) > 0
+}
+
+func hasKimiLegacyFunctionCall(msg gjson.Result) bool {
+	functionCall := msg.Get("function_call")
+	if !functionCall.Exists() || functionCall.Type == gjson.Null {
+		return false
+	}
+	if functionCall.IsObject() && strings.TrimSpace(functionCall.Raw) == "{}" {
+		return false
+	}
+	return strings.TrimSpace(functionCall.Raw) != ""
+}
+
+func hasKimiAssistantReasoning(msg gjson.Result) bool {
+	reasoning := msg.Get("reasoning_content")
+	return reasoning.Exists() && strings.TrimSpace(reasoning.String()) != ""
+}
+
+func isKimiAssistantContentEmpty(content gjson.Result) bool {
+	if !content.Exists() || content.Type == gjson.Null {
+		return true
+	}
+	if content.Type == gjson.String {
+		return strings.TrimSpace(content.String()) == ""
+	}
+	if !content.IsArray() {
+		return false
+	}
+	for _, part := range content.Array() {
+		if !isKimiAssistantContentPartEmpty(part) {
+			return false
+		}
+	}
+	return true
+}
+
+func isKimiAssistantContentPartEmpty(part gjson.Result) bool {
+	if !part.Exists() || part.Type == gjson.Null {
+		return true
+	}
+	if part.Type == gjson.String {
+		return strings.TrimSpace(part.String()) == ""
+	}
+	if !part.IsObject() {
+		return false
+	}
+	if text := part.Get("text"); text.Exists() {
+		return strings.TrimSpace(text.String()) == ""
+	}
+	if strings.TrimSpace(part.Get("type").String()) == "text" {
+		return true
+	}
+	return strings.TrimSpace(part.Raw) == "{}"
 }
 
 func fallbackAssistantReasoning(msg gjson.Result, hasLatest bool, latest string) string {

--- a/internal/runtime/executor/kimi_executor_test.go
+++ b/internal/runtime/executor/kimi_executor_test.go
@@ -203,3 +203,70 @@ func TestNormalizeKimiToolMessageLinks_RepairsIDsAndReasoningTogether(t *testing
 		t.Fatalf("messages.2.reasoning_content = %q, want %q", got, "r1")
 	}
 }
+
+func TestNormalizeKimiToolMessageLinks_DropsEmptyAssistantWithoutToolLink(t *testing.T) {
+	body := []byte(`{
+		"messages":[
+			{"role":"user","content":"start"},
+			{"role":"assistant","content":""},
+			{"role":"assistant","content":"   "},
+			{"role":"assistant","content":"","tool_calls":null},
+			{"role":"assistant","content":[{"type":"text","text":"  "}]},
+			{"role":"assistant"},
+			{"role":"assistant","content":"keep"},
+			{"role":"user","content":"next"}
+		]
+	}`)
+
+	out, err := normalizeKimiToolMessageLinks(body)
+	if err != nil {
+		t.Fatalf("normalizeKimiToolMessageLinks() error = %v", err)
+	}
+
+	messages := gjson.GetBytes(out, "messages").Array()
+	if len(messages) != 3 {
+		t.Fatalf("messages length = %d, want 3, raw = %s", len(messages), gjson.GetBytes(out, "messages").Raw)
+	}
+	if got := messages[0].Get("content").String(); got != "start" {
+		t.Fatalf("messages.0.content = %q, want %q", got, "start")
+	}
+	if got := messages[1].Get("content").String(); got != "keep" {
+		t.Fatalf("messages.1.content = %q, want %q", got, "keep")
+	}
+	if got := messages[2].Get("content").String(); got != "next" {
+		t.Fatalf("messages.2.content = %q, want %q", got, "next")
+	}
+}
+
+func TestNormalizeKimiToolMessageLinks_PreservesAssistantWithToolLinkOrReasoning(t *testing.T) {
+	body := []byte(`{
+		"messages":[
+			{"role":"assistant","content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"list_directory","arguments":"{}"}}]},
+			{"role":"assistant","content":"","function_call":{"name":"legacy_call","arguments":"{}"}},
+			{"role":"assistant","content":"","reasoning_content":"thought"},
+			{"role":"assistant","content":[{"type":"text","text":" visible "}]}
+		]
+	}`)
+
+	out, err := normalizeKimiToolMessageLinks(body)
+	if err != nil {
+		t.Fatalf("normalizeKimiToolMessageLinks() error = %v", err)
+	}
+
+	messages := gjson.GetBytes(out, "messages").Array()
+	if len(messages) != 4 {
+		t.Fatalf("messages length = %d, want 4, raw = %s", len(messages), gjson.GetBytes(out, "messages").Raw)
+	}
+	if !messages[0].Get("tool_calls").Exists() {
+		t.Fatalf("messages.0.tool_calls should exist")
+	}
+	if !messages[1].Get("function_call").Exists() {
+		t.Fatalf("messages.1.function_call should exist")
+	}
+	if got := messages[2].Get("reasoning_content").String(); got != "thought" {
+		t.Fatalf("messages.2.reasoning_content = %q, want %q", got, "thought")
+	}
+	if got := messages[3].Get("content.0.text").String(); got != " visible " {
+		t.Fatalf("messages.3.content.0.text = %q, want %q", got, " visible ")
+	}
+}


### PR DESCRIPTION
## 背景

选择性移植上游 Kimi executor 修复：Kimi 上游会拒绝没有内容、没有 tool call、没有 reasoning 的空 assistant message。本 PR 在发送 Kimi 请求前过滤这类空 assistant message，保留带 tool/function call、reasoning 或有效内容的 assistant message。

上游来源：
- `672fdd14` `feat: filter and drop empty assistant messages in Kimi executor`

## 改动

- 在 `normalizeKimiToolMessageLinks` 前段增加空 assistant message 过滤。
- 保留带 `tool_calls`、legacy `function_call`、`reasoning_content` 或非空文本内容的 assistant message。
- 增加两条 Kimi 归一化测试，覆盖空 assistant 被删除以及带工具/推理/内容的 assistant 被保留。

## LTS 兼容性

- 不触碰 `internal/usage/`、Management API、auth/config schema 或 Panel contract。
- 行为范围只限 Kimi executor 的上游请求 payload 清理。
- 不改变 streaming/non-streaming 执行结构，也不新增网络 timeout。

## 验证

- `gofmt -w internal/runtime/executor/kimi_executor.go internal/runtime/executor/kimi_executor_test.go`
- `git diff --check origin/main...HEAD`
- `go test ./internal/runtime/executor -run 'Kimi|NormalizeKimiToolMessageLinks'`
- `go build -o test-output ./cmd/server`
