### PR TITLE
fix(vertex): 移除 OpenAI Responses 工具调用 ID

### DIFF
--- a/internal/runtime/executor/gemini_vertex_executor.go
+++ b/internal/runtime/executor/gemini_vertex_executor.go
@@ -338,6 +338,7 @@ func (e *GeminiVertexExecutor) executeWithServiceAccount(ctx context.Context, au
 		requestPath := helps.PayloadRequestPath(opts)
 		body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel, requestPath)
 		body, _ = sjson.SetBytes(body, "model", baseModel)
+		body = helps.StripVertexOpenAIResponsesToolCallIDs(body, from.String())
 	}
 
 	action := getVertexAction(baseModel, false)
@@ -459,6 +460,7 @@ func (e *GeminiVertexExecutor) executeWithAPIKey(ctx context.Context, auth *clip
 	requestPath := helps.PayloadRequestPath(opts)
 	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel, requestPath)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
+	body = helps.StripVertexOpenAIResponsesToolCallIDs(body, from.String())
 
 	action := getVertexAction(baseModel, false)
 	if req.Metadata != nil {
@@ -570,6 +572,7 @@ func (e *GeminiVertexExecutor) executeStreamWithServiceAccount(ctx context.Conte
 	requestPath := helps.PayloadRequestPath(opts)
 	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel, requestPath)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
+	body = helps.StripVertexOpenAIResponsesToolCallIDs(body, from.String())
 
 	action := getVertexAction(baseModel, true)
 	baseURL := vertexBaseURL(location)
@@ -711,6 +714,7 @@ func (e *GeminiVertexExecutor) executeStreamWithAPIKey(ctx context.Context, auth
 	requestPath := helps.PayloadRequestPath(opts)
 	body = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, to.String(), "", body, originalTranslated, requestedModel, requestPath)
 	body, _ = sjson.SetBytes(body, "model", baseModel)
+	body = helps.StripVertexOpenAIResponsesToolCallIDs(body, from.String())
 
 	action := getVertexAction(baseModel, true)
 	// For API key auth, use simpler URL format without project/location
@@ -840,6 +844,7 @@ func (e *GeminiVertexExecutor) countTokensWithServiceAccount(ctx context.Context
 
 	translatedReq = fixGeminiImageAspectRatio(baseModel, translatedReq)
 	translatedReq, _ = sjson.SetBytes(translatedReq, "model", baseModel)
+	translatedReq = helps.StripVertexOpenAIResponsesToolCallIDs(translatedReq, from.String())
 	respCtx := context.WithValue(ctx, "alt", opts.Alt)
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "tools")
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "generationConfig")
@@ -929,6 +934,7 @@ func (e *GeminiVertexExecutor) countTokensWithAPIKey(ctx context.Context, auth *
 
 	translatedReq = fixGeminiImageAspectRatio(baseModel, translatedReq)
 	translatedReq, _ = sjson.SetBytes(translatedReq, "model", baseModel)
+	translatedReq = helps.StripVertexOpenAIResponsesToolCallIDs(translatedReq, from.String())
 	respCtx := context.WithValue(ctx, "alt", opts.Alt)
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "tools")
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "generationConfig")

--- a/internal/runtime/executor/helps/vertex_payload_helpers.go
+++ b/internal/runtime/executor/helps/vertex_payload_helpers.go
@@ -1,0 +1,43 @@
+package helps
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// StripVertexOpenAIResponsesToolCallIDs removes OpenAI Responses call IDs that
+// Vertex rejects in Gemini functionCall/functionResponse payloads.
+func StripVertexOpenAIResponsesToolCallIDs(payload []byte, sourceFormat string) []byte {
+	if !strings.EqualFold(strings.TrimSpace(sourceFormat), "openai-response") {
+		return payload
+	}
+
+	contents := gjson.GetBytes(payload, "contents")
+	if !contents.IsArray() {
+		return payload
+	}
+
+	out := payload
+	for contentIndex, content := range contents.Array() {
+		parts := content.Get("parts")
+		if !parts.IsArray() {
+			continue
+		}
+		for partIndex, part := range parts.Array() {
+			if part.Get("functionCall.id").Exists() {
+				if updated, errDelete := sjson.DeleteBytes(out, fmt.Sprintf("contents.%d.parts.%d.functionCall.id", contentIndex, partIndex)); errDelete == nil {
+					out = updated
+				}
+			}
+			if part.Get("functionResponse.id").Exists() {
+				if updated, errDelete := sjson.DeleteBytes(out, fmt.Sprintf("contents.%d.parts.%d.functionResponse.id", contentIndex, partIndex)); errDelete == nil {
+					out = updated
+				}
+			}
+		}
+	}
+	return out
+}

--- a/internal/runtime/executor/helps/vertex_payload_helpers_test.go
+++ b/internal/runtime/executor/helps/vertex_payload_helpers_test.go
@@ -1,0 +1,46 @@
+package helps
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestStripVertexOpenAIResponsesToolCallIDs(t *testing.T) {
+	payload := []byte(`{
+		"contents":[
+			{"role":"model","parts":[
+				{"functionCall":{"id":"call-1","name":"lookup","args":{"q":"x"}}},
+				{"text":"done"}
+			]},
+			{"role":"user","parts":[
+				{"functionResponse":{"id":"call-1","name":"lookup","response":{"result":"ok"}}}
+			]}
+		]
+	}`)
+
+	out := StripVertexOpenAIResponsesToolCallIDs(payload, "openai-response")
+
+	if gjson.GetBytes(out, "contents.0.parts.0.functionCall.id").Exists() {
+		t.Fatalf("functionCall.id should be stripped: %s", out)
+	}
+	if gjson.GetBytes(out, "contents.1.parts.0.functionResponse.id").Exists() {
+		t.Fatalf("functionResponse.id should be stripped: %s", out)
+	}
+	if got := gjson.GetBytes(out, "contents.0.parts.0.functionCall.name").String(); got != "lookup" {
+		t.Fatalf("functionCall.name = %q, want lookup", got)
+	}
+	if got := gjson.GetBytes(out, "contents.1.parts.0.functionResponse.response.result").String(); got != "ok" {
+		t.Fatalf("functionResponse.response.result = %q, want ok", got)
+	}
+}
+
+func TestStripVertexOpenAIResponsesToolCallIDsKeepsOtherSourceFormats(t *testing.T) {
+	payload := []byte(`{"contents":[{"parts":[{"functionCall":{"id":"call-1","name":"lookup"}}]}]}`)
+
+	out := StripVertexOpenAIResponsesToolCallIDs(payload, "openai")
+
+	if string(out) != string(payload) {
+		t.Fatalf("payload changed for non-openai-response source: %s", out)
+	}
+}


### PR DESCRIPTION
## 背景

选择性移植上游 Vertex executor 修复：OpenAI Responses 请求经 Gemini/Vertex payload 转换后，`functionCall.id` / `functionResponse.id` 会被带入 Vertex Gemini payload；Vertex 会拒绝这类 OpenAI Responses call ID 字段。本 PR 在 Vertex 发送前只对 `openai-response` 来源剥离这些 ID，保留工具名、参数和响应内容。

上游来源：
- `bf6fa402` `fix(executor): strip Vertex OpenAI response tool call IDs for consistency`

## 改动

- 新增 `helps.StripVertexOpenAIResponsesToolCallIDs`。
- Vertex service account/API key 的非流式、流式、countTokens 路径都在发送前剥离 OpenAI Responses tool call IDs。
- 补充 `helps` 单元测试，覆盖 OpenAI Responses 来源会删除 ID，普通 OpenAI 来源不会修改 payload。

## LTS 兼容性

- 不触碰 `internal/usage/`、Management API、auth/config schema 或 Panel contract。
- 不改 translator，也不改变 Vertex streaming/non-streaming 执行结构。
- 行为只限 Vertex executor 发往上游前的 payload 清理，并且只在 `SourceFormat=openai-response` 时启用。

## 验证

- `gofmt -w internal/runtime/executor/gemini_vertex_executor.go internal/runtime/executor/helps/vertex_payload_helpers.go internal/runtime/executor/helps/vertex_payload_helpers_test.go`
- `git diff --check origin/main...HEAD`
- `go test ./internal/runtime/executor/helps -run 'Vertex|OpenAIResponsesToolCallIDs'`
- `go test ./internal/runtime/executor -run 'Vertex|GeminiVertex'`（当前包内无匹配测试，编译通过）
- `go build -o test-output ./cmd/server`
