### PR TITLE
feat(config): 支持配置级 disable-cooling

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -146,6 +146,7 @@ nonstream-keepalive-interval: 0
 # gemini-api-key:
 #   - api-key: "AIzaSy...01"
 #     prefix: "test" # optional: require calls like "test/gemini-3-pro-preview" to target this credential
+#     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
 #     base-url: "https://generativelanguage.googleapis.com"
 #     headers:
 #       X-Custom-Header: "custom-value"
@@ -165,6 +166,7 @@ nonstream-keepalive-interval: 0
 # codex-api-key:
 #   - api-key: "sk-atSM..."
 #     prefix: "test" # optional: require calls like "test/gpt-5-codex" to target this credential
+#     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
 #     base-url: "https://www.example.com" # use the custom codex API endpoint
 #     headers:
 #       X-Custom-Header: "custom-value"
@@ -184,6 +186,7 @@ nonstream-keepalive-interval: 0
 #   - api-key: "sk-atSM..." # use the official claude API key, no need to set the base url
 #   - api-key: "sk-atSM..."
 #     prefix: "test" # optional: require calls like "test/claude-sonnet-latest" to target this credential
+#     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
 #     base-url: "https://www.example.com" # use the custom claude API endpoint
 #     headers:
 #       X-Custom-Header: "custom-value"
@@ -239,6 +242,7 @@ nonstream-keepalive-interval: 0
 #     disabled: false # optional: set to true to disable this provider without removing it
 #     prefix: "test" # optional: require calls like "test/kimi-k2" to target this provider's credentials
 #     base-url: "https://openrouter.ai/api/v1" # The base URL of the provider.
+#     disable-cooling: false # optional: per-provider override for auth/model cooldown scheduling
 #     headers:
 #       X-Custom-Header: "custom-value"
 #     api-key-entries:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -396,6 +396,9 @@ type ClaudeKey struct {
 	// ExcludedModels lists model IDs that should be excluded for this provider.
 	ExcludedModels []string `yaml:"excluded-models,omitempty" json:"excluded-models,omitempty"`
 
+	// DisableCooling disables auth/model cooldown scheduling for this credential when true.
+	DisableCooling bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`
+
 	// Cloak configures request cloaking for non-Claude-Code clients.
 	Cloak *CloakConfig `yaml:"cloak,omitempty" json:"cloak,omitempty"`
 
@@ -451,6 +454,9 @@ type CodexKey struct {
 
 	// ExcludedModels lists model IDs that should be excluded for this provider.
 	ExcludedModels []string `yaml:"excluded-models,omitempty" json:"excluded-models,omitempty"`
+
+	// DisableCooling disables auth/model cooldown scheduling for this credential when true.
+	DisableCooling bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`
 }
 
 func (k CodexKey) GetAPIKey() string  { return k.APIKey }
@@ -495,6 +501,9 @@ type GeminiKey struct {
 
 	// ExcludedModels lists model IDs that should be excluded for this provider.
 	ExcludedModels []string `yaml:"excluded-models,omitempty" json:"excluded-models,omitempty"`
+
+	// DisableCooling disables auth/model cooldown scheduling for this credential when true.
+	DisableCooling bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`
 }
 
 func (k GeminiKey) GetAPIKey() string  { return k.APIKey }
@@ -539,6 +548,9 @@ type OpenAICompatibility struct {
 
 	// Headers optionally adds extra HTTP headers for requests sent to this provider.
 	Headers map[string]string `yaml:"headers,omitempty" json:"headers,omitempty"`
+
+	// DisableCooling disables auth/model cooldown scheduling for this provider when true.
+	DisableCooling bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`
 }
 
 // OpenAICompatibilityAPIKey represents an API key configuration with optional proxy setting.

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -18,6 +18,13 @@ func NewConfigSynthesizer() *ConfigSynthesizer {
 	return &ConfigSynthesizer{}
 }
 
+func disableCoolingMetadata(disableCooling bool) map[string]any {
+	if !disableCooling {
+		return nil
+	}
+	return map[string]any{"disable_cooling": true}
+}
+
 // Synthesize generates Auth entries from config API keys.
 func (s *ConfigSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth, error) {
 	out := make([]*coreauth.Auth, 0, 32)
@@ -78,6 +85,7 @@ func (s *ConfigSynthesizer) synthesizeGeminiKeys(ctx *SynthesisContext) []*corea
 			Status:     coreauth.StatusActive,
 			ProxyURL:   proxyURL,
 			Attributes: attrs,
+			Metadata:   disableCoolingMetadata(entry.DisableCooling),
 			CreatedAt:  now,
 			UpdatedAt:  now,
 		}
@@ -126,6 +134,7 @@ func (s *ConfigSynthesizer) synthesizeClaudeKeys(ctx *SynthesisContext) []*corea
 			Status:     coreauth.StatusActive,
 			ProxyURL:   proxyURL,
 			Attributes: attrs,
+			Metadata:   disableCoolingMetadata(ck.DisableCooling),
 			CreatedAt:  now,
 			UpdatedAt:  now,
 		}
@@ -176,6 +185,7 @@ func (s *ConfigSynthesizer) synthesizeCodexKeys(ctx *SynthesisContext) []*coreau
 			Status:     coreauth.StatusActive,
 			ProxyURL:   proxyURL,
 			Attributes: attrs,
+			Metadata:   disableCoolingMetadata(ck.DisableCooling),
 			CreatedAt:  now,
 			UpdatedAt:  now,
 		}
@@ -236,6 +246,7 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 				Status:     coreauth.StatusActive,
 				ProxyURL:   proxyURL,
 				Attributes: attrs,
+				Metadata:   disableCoolingMetadata(compat.DisableCooling),
 				CreatedAt:  now,
 				UpdatedAt:  now,
 			}
@@ -266,6 +277,7 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 				Prefix:     prefix,
 				Status:     coreauth.StatusActive,
 				Attributes: attrs,
+				Metadata:   disableCoolingMetadata(compat.DisableCooling),
 				CreatedAt:  now,
 				UpdatedAt:  now,
 			}

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -369,6 +369,82 @@ func TestConfigSynthesizer_OpenAICompat(t *testing.T) {
 	}
 }
 
+func TestConfigSynthesizer_DisableCoolingMetadataFromConfig(t *testing.T) {
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{
+			GeminiKey: []config.GeminiKey{
+				{APIKey: "gemini-key", DisableCooling: true},
+			},
+			ClaudeKey: []config.ClaudeKey{
+				{APIKey: "claude-key", DisableCooling: true},
+			},
+			CodexKey: []config.CodexKey{
+				{APIKey: "codex-key", DisableCooling: true},
+			},
+			OpenAICompatibility: []config.OpenAICompatibility{
+				{
+					Name:           "openrouter",
+					BaseURL:        "https://openrouter.ai/api/v1",
+					DisableCooling: true,
+					APIKeyEntries: []config.OpenAICompatibilityAPIKey{
+						{APIKey: "openrouter-key"},
+					},
+				},
+			},
+		},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, provider := range []string{"gemini", "claude", "codex", "openrouter"} {
+		auth := findSynthesizedAuthByProvider(auths, provider)
+		if auth == nil {
+			t.Fatalf("expected synthesized auth for provider %q", provider)
+		}
+		if got, ok := auth.Metadata["disable_cooling"].(bool); !ok || !got {
+			t.Fatalf("%s disable_cooling metadata = %#v, want true", provider, auth.Metadata["disable_cooling"])
+		}
+	}
+}
+
+func TestConfigSynthesizer_DisableCoolingFalseOmitsMetadata(t *testing.T) {
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{
+			GeminiKey: []config.GeminiKey{
+				{APIKey: "gemini-key", DisableCooling: false},
+			},
+		},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("auths len = %d, want 1", len(auths))
+	}
+	if auths[0].Metadata != nil {
+		t.Fatalf("metadata = %#v, want nil when disable-cooling is false", auths[0].Metadata)
+	}
+}
+
+func findSynthesizedAuthByProvider(auths []*coreauth.Auth, provider string) *coreauth.Auth {
+	for _, auth := range auths {
+		if auth != nil && auth.Provider == provider {
+			return auth
+		}
+	}
+	return nil
+}
+
 func TestConfigSynthesizer_VertexCompat(t *testing.T) {
 	synth := NewConfigSynthesizer()
 	ctx := &SynthesisContext{


### PR DESCRIPTION
## 背景

选择性吸收上游 `0f0fcd23` 的 per-auth `disable-cooling` 能力，但没有原样 cherry-pick。

上游原提交除了新增 config 支持外，还夹带了移除旧 `ClaudeCodeSessionAffinity` 字段和改变 SDK auth-file `disable_cooling=false` override 语义的内容。LTS 目标是增加新功能、少减旧功能，因此本 PR 只移植 additive 部分：让 config API key / OpenAI-compatible provider 能生成 `disable_cooling` metadata，继续复用现有 auth manager 的 cooldown override 逻辑。

## 改动

- `gemini-api-key`、`codex-api-key`、`claude-api-key` 增加可选 `disable-cooling` 字段。
- `openai-compatibility` provider 增加可选 `disable-cooling` 字段。
- Config synthesizer 在该字段为 `true` 时生成 `Metadata["disable_cooling"] = true`。
- `config.example.yaml` 补充对应示例。
- 新增 synthesizer 测试，覆盖开启时 metadata 写入，以及 `false`/默认值不会写入 metadata。

## LTS 兼容性

- 不触碰 `internal/usage/` 和 `/v0/management/usage*`。
- 不改变 auth index、usage attribution、Management API route shape 或 Panel 统计契约。
- 不移除旧 routing/session 字段；不改 auth-file 中已有 `disable_cooling=false` 的 SDK override 语义。
- 新字段为可选，旧配置文件继续按默认行为加载。

## 验证

- `gofmt -w internal/config/config.go internal/watcher/synthesizer/config.go internal/watcher/synthesizer/config_test.go`
- `git diff --check origin/main...HEAD`
- `go test ./internal/watcher/synthesizer -run 'ConfigSynthesizer|DisableCooling'`
- `go test ./internal/config`
- `go test ./internal/watcher/diff`
- `go test ./sdk/cliproxy/auth -run 'DisableCooling|MarkResult|Execute_DisableCooling'`
- `go build -o test-output ./cmd/server`
