### PR TITLE
feat(models): 同步 Gemini 3.5 Flash 模型目录

### DIFF
--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -738,6 +738,36 @@
       "supportedGenerationMethods": [
         "predict"
       ]
+    },
+    {
+      "id": "gemini-3.5-flash",
+      "object": "model",
+      "created": 1779235200,
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini 3.5 Flash",
+      "name": "models/gemini-3.5-flash",
+      "version": "3.5",
+      "description": "Our most intelligent model built for speed, combining frontier intelligence with superior search and grounding.",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": [
+        "generateContent",
+        "countTokens",
+        "createCachedContent",
+        "batchGenerateContent"
+      ],
+      "thinking": {
+        "min": 128,
+        "max": 32768,
+        "dynamic_allowed": true,
+        "levels": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     }
   ],
   "gemini-cli": [

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -1931,6 +1931,28 @@
       }
     },
     {
+      "id": "gemini-3-flash-agent",
+      "object": "model",
+      "owned_by": "antigravity",
+      "type": "antigravity",
+      "display_name": "Gemini 3.5 Flash",
+      "name": "gemini-3-flash-agent",
+      "description": "Gemini 3.5 Flash",
+      "context_length": 1048576,
+      "max_completion_tokens": 65536,
+      "thinking": {
+        "min": 128,
+        "max": 32768,
+        "dynamic_allowed": true,
+        "levels": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
       "id": "gemini-3-pro-high",
       "object": "model",
       "owned_by": "antigravity",
@@ -2058,6 +2080,27 @@
         "dynamic_allowed": true,
         "levels": [
           "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
+      "id": "gemini-3.5-flash-low",
+      "object": "model",
+      "owned_by": "antigravity",
+      "type": "antigravity",
+      "display_name": "Gemini 3.5 Flash (Low)",
+      "name": "gemini-3.5-flash-low",
+      "description": "Gemini 3.5 Flash (Low)",
+      "context_length": 1048576,
+      "max_completion_tokens": 65535,
+      "thinking": {
+        "min": 1,
+        "max": 65535,
+        "dynamic_allowed": true,
+        "levels": [
           "low",
           "medium",
           "high"

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -421,6 +421,36 @@
           "high"
         ]
       }
+    },
+    {
+      "id": "gemini-3.5-flash",
+      "object": "model",
+      "created": 1779235200,
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini 3.5 Flash",
+      "name": "models/gemini-3.5-flash",
+      "version": "3.5",
+      "description": "Our most intelligent model built for speed, combining frontier intelligence with superior search and grounding.",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": [
+        "generateContent",
+        "countTokens",
+        "createCachedContent",
+        "batchGenerateContent"
+      ],
+      "thinking": {
+        "min": 128,
+        "max": 32768,
+        "dynamic_allowed": true,
+        "levels": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     }
   ],
   "vertex": [
@@ -1227,6 +1257,36 @@
         "createCachedContent",
         "batchGenerateContent"
       ]
+    },
+    {
+      "id": "gemini-3.5-flash",
+      "object": "model",
+      "created": 1779235200,
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini 3.5 Flash",
+      "name": "models/gemini-3.5-flash",
+      "version": "3.5",
+      "description": "Our most intelligent model built for speed, combining frontier intelligence with superior search and grounding.",
+      "inputTokenLimit": 1048576,
+      "outputTokenLimit": 65536,
+      "supportedGenerationMethods": [
+        "generateContent",
+        "countTokens",
+        "createCachedContent",
+        "batchGenerateContent"
+      ],
+      "thinking": {
+        "min": 128,
+        "max": 32768,
+        "dynamic_allowed": true,
+        "levels": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
     }
   ],
   "codex-free": [


### PR DESCRIPTION
## 背景

本 PR 从上游 `router-for-me/CLIProxyAPI` 选择性移植 Gemini 3.5 Flash 模型目录更新，属于 registry-only 变更。

上游来源：

- `ea259494` `feat(models): add Gemini 3.5 Flash models to registry`
- `fdffe499` `feat(models): register Gemini 3.5 Flash with dynamic thinking levels`
- `0ec07e57` `feat(models): add Gemini 3.5 Flash to registry with enhanced thinking capabilities`

## 变更内容

- 在 `gemini` provider 目录加入 `gemini-3.5-flash`。
- 在 `vertex` provider 目录加入 `gemini-3.5-flash`。
- 在 `antigravity` provider 目录加入：
  - `gemini-3-flash-agent`
  - `gemini-3.5-flash-low`
- 保留现有 LTS catalog 结构，不引入本次提交上下文之外的 `xai` registry 段。

## LTS 兼容性说明

- 不触碰 `internal/usage/`、`usage-statistics-enabled` 或 `/v0/management/usage*`。
- 不修改 Management API、auth/config schema、translator、executor、SDK public type 或 Panel source。
- 这是模型可见性数据更新，不改变请求执行路径和统计归因语义。

## 验证

已在隔离 worktree `/private/tmp/cpa-lts-gemini-35-models` 验证：

- `python3 -m json.tool internal/registry/models/models.json >/dev/null`
- `git diff --check origin/main...HEAD`
- `go test ./internal/api -run 'Models|Model'`
- `go test ./internal/registry -run 'TestCodexStaticModelsIncludeGPT55|TestModelRegistryHook|TestGetAvailableModels|TestGetModelInfo|TestGetModelsForClient|TestCleanupExpiredQuotas|TestLookupModelInfo'`
- `go build -o test-output ./cmd/server`

补充说明：完整 `go test ./internal/registry` 目前在 `origin/main` 也会因既有 `TestCodexFreeModelsExcludeGPT55` 失败；已用 detached `origin/main` worktree 单独复现，未归因到本 PR。
