### PR TITLE
fix(api): 禁用默认可信代理头

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -213,6 +213,9 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 
 	// Create gin engine
 	engine := gin.New()
+	if errSetTrustedProxies := engine.SetTrustedProxies(nil); errSetTrustedProxies != nil {
+		log.Warnf("failed to disable trusted proxy headers: %v", errSetTrustedProxies)
+	}
 	if optionState.engineConfigurator != nil {
 		optionState.engineConfigurator(engine)
 	}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -19,6 +19,10 @@ import (
 )
 
 func newTestServer(t *testing.T) *Server {
+	return newTestServerWithOptions(t)
+}
+
+func newTestServerWithOptions(t *testing.T, opts ...ServerOption) *Server {
 	t.Helper()
 
 	gin.SetMode(gin.TestMode)
@@ -44,7 +48,7 @@ func newTestServer(t *testing.T) *Server {
 	accessManager := sdkaccess.NewManager()
 
 	configPath := filepath.Join(tmpDir, "config.yaml")
-	return NewServer(cfg, authManager, accessManager, configPath)
+	return NewServer(cfg, authManager, accessManager, configPath, opts...)
 }
 
 func TestHealthz(t *testing.T) {
@@ -82,6 +86,26 @@ func TestHealthz(t *testing.T) {
 			t.Fatalf("expected empty body for HEAD request, got %q", rr.Body.String())
 		}
 	})
+}
+
+func TestManagementLocalPasswordRejectsSpoofedForwardedFor(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+
+	server := newTestServerWithOptions(t, WithLocalManagementPassword("test-local-key"))
+
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/config", nil)
+	req.RemoteAddr = "203.0.113.10:45678"
+	req.Header.Set("X-Forwarded-For", "127.0.0.1")
+	req.Header.Set("Authorization", "Bearer test-local-key")
+
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d body=%s", rr.Code, http.StatusForbidden, rr.Body.String())
+	}
+	if body := rr.Body.String(); !strings.Contains(body, "remote management disabled") {
+		t.Fatalf("body = %q, want remote management disabled", body)
+	}
 }
 
 func TestAmpProviderModelRoutes(t *testing.T) {


### PR DESCRIPTION
## 背景

本 PR 选择性移植上游 `605adaa3` 中的安全修复部分：禁用 Gin 默认对 forwarded IP headers 的信任，避免 Management 本地鉴权判断被客户端伪造 `X-Forwarded-For` 绕过。

没有完整 cherry-pick 上游提交，因为上游同提交还包含 `CLAUDE.md`、`ws-auth` 默认值、Home 相关上下文和测试辅助改动；这些不属于本次 LTS 最小安全修复范围。

## 变更内容

- 在 `NewServer` 创建 Gin engine 后调用 `engine.SetTrustedProxies(nil)`。
- 增加 `TestManagementLocalPasswordRejectsSpoofedForwardedFor`，覆盖远端 `RemoteAddr` 伪造 `X-Forwarded-For: 127.0.0.1` 时，local management password 不应绕过 `remote-management` 限制。
- 将 `newTestServer` 拆成可传 `ServerOption` 的测试 helper，现有测试默认行为不变。

## LTS 兼容性说明

- 不触碰 `internal/usage/`、`usage-statistics-enabled` 或 `/v0/management/usage*`。
- 不修改 Management API route、response shape、auth key 格式、config schema 或 Panel source。
- 变更只影响 Gin `ClientIP()` 对 forwarded headers 的信任策略；这是安全收紧，和上游修复意图一致。

## 验证

已在隔离 worktree `/private/tmp/cpa-lts-gin-disable-trusted-proxies` 验证：

- `gofmt -w internal/api/server.go internal/api/server_test.go`
- `go test ./internal/api -run 'TestManagementLocalPasswordRejectsSpoofedForwardedFor|TestHealthz'`
- `go test ./internal/api`
- `git diff --check`
- `go build -o test-output ./cmd/server`
