### PR TITLE
feat(usage): 增补 usage 事件元数据

### DIFF
--- a/internal/logging/requestmeta.go
+++ b/internal/logging/requestmeta.go
@@ -2,14 +2,22 @@ package logging
 
 import (
 	"context"
+	"net/http"
+	"sync"
 	"sync/atomic"
 )
 
 type endpointKey struct{}
 type responseStatusKey struct{}
+type responseHeadersKey struct{}
 
 type responseStatusHolder struct {
 	status atomic.Int32
+}
+
+type responseHeadersHolder struct {
+	mu      sync.RWMutex
+	headers http.Header
 }
 
 func WithEndpoint(ctx context.Context, endpoint string) context.Context {
@@ -39,6 +47,16 @@ func WithResponseStatusHolder(ctx context.Context) context.Context {
 	return context.WithValue(ctx, responseStatusKey{}, &responseStatusHolder{})
 }
 
+func WithResponseHeadersHolder(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if holder, ok := ctx.Value(responseHeadersKey{}).(*responseHeadersHolder); ok && holder != nil {
+		return ctx
+	}
+	return context.WithValue(ctx, responseHeadersKey{}, &responseHeadersHolder{})
+}
+
 func SetResponseStatus(ctx context.Context, status int) {
 	if ctx == nil || status <= 0 {
 		return
@@ -50,6 +68,19 @@ func SetResponseStatus(ctx context.Context, status int) {
 	holder.status.Store(int32(status))
 }
 
+func SetResponseHeaders(ctx context.Context, headers http.Header) {
+	if ctx == nil {
+		return
+	}
+	holder, ok := ctx.Value(responseHeadersKey{}).(*responseHeadersHolder)
+	if !ok || holder == nil {
+		return
+	}
+	holder.mu.Lock()
+	defer holder.mu.Unlock()
+	holder.headers = cloneHTTPHeader(headers)
+}
+
 func GetResponseStatus(ctx context.Context) int {
 	if ctx == nil {
 		return 0
@@ -59,4 +90,28 @@ func GetResponseStatus(ctx context.Context) int {
 		return 0
 	}
 	return int(holder.status.Load())
+}
+
+func GetResponseHeaders(ctx context.Context) http.Header {
+	if ctx == nil {
+		return nil
+	}
+	holder, ok := ctx.Value(responseHeadersKey{}).(*responseHeadersHolder)
+	if !ok || holder == nil {
+		return nil
+	}
+	holder.mu.RLock()
+	defer holder.mu.RUnlock()
+	return cloneHTTPHeader(holder.headers)
+}
+
+func cloneHTTPHeader(src http.Header) http.Header {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(http.Header, len(src))
+	for key, values := range src {
+		dst[key] = append([]string(nil), values...)
+	}
+	return dst
 }

--- a/internal/redisqueue/plugin.go
+++ b/internal/redisqueue/plugin.go
@@ -3,6 +3,7 @@ package redisqueue
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"strings"
 	"time"
 
@@ -34,6 +35,10 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 	if modelName == "" {
 		modelName = "unknown"
 	}
+	aliasName := strings.TrimSpace(record.Alias)
+	if aliasName == "" {
+		aliasName = modelName
+	}
 	provider := strings.TrimSpace(record.Provider)
 	if provider == "" {
 		provider = "unknown"
@@ -44,16 +49,29 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 	}
 	apiKey := strings.TrimSpace(record.APIKey)
 	requestID := strings.TrimSpace(internallogging.GetRequestID(ctx))
+	reasoningEffort := strings.TrimSpace(record.ReasoningEffort)
+	if reasoningEffort == "" {
+		reasoningEffort = coreusage.ReasoningEffortFromContext(ctx)
+	}
 
 	tokens := internalusage.TokenStats{
-		InputTokens:     record.Detail.InputTokens,
-		OutputTokens:    record.Detail.OutputTokens,
-		ReasoningTokens: record.Detail.ReasoningTokens,
-		CachedTokens:    record.Detail.CachedTokens,
-		TotalTokens:     record.Detail.TotalTokens,
+		InputTokens:         record.Detail.InputTokens,
+		OutputTokens:        record.Detail.OutputTokens,
+		ReasoningTokens:     record.Detail.ReasoningTokens,
+		CachedTokens:        record.Detail.CachedTokens,
+		CacheReadTokens:     record.Detail.CacheReadTokens,
+		CacheCreationTokens: record.Detail.CacheCreationTokens,
+		TotalTokens:         record.Detail.TotalTokens,
 	}
 	if tokens.TotalTokens == 0 {
 		tokens.TotalTokens = tokens.InputTokens + tokens.OutputTokens + tokens.ReasoningTokens
+	}
+	if tokens.CachedTokens == 0 {
+		if tokens.CacheReadTokens != 0 {
+			tokens.CachedTokens = tokens.CacheReadTokens
+		} else if tokens.CacheCreationTokens != 0 {
+			tokens.CachedTokens = tokens.CacheCreationTokens
+		}
 	}
 	if tokens.TotalTokens == 0 {
 		tokens.TotalTokens = tokens.InputTokens + tokens.OutputTokens + tokens.ReasoningTokens + tokens.CachedTokens
@@ -64,23 +82,28 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 		failed = !resolveSuccess(ctx)
 	}
 
-	detail := internalusage.RequestDetail{
-		Timestamp: timestamp,
-		LatencyMs: record.Latency.Milliseconds(),
-		Source:    record.Source,
-		AuthIndex: record.AuthIndex,
-		Tokens:    tokens,
-		Failed:    failed,
+	detail := queuedRequestDetail{
+		RequestDetail: internalusage.RequestDetail{
+			Timestamp:       timestamp,
+			LatencyMs:       record.Latency.Milliseconds(),
+			Source:          record.Source,
+			AuthIndex:       record.AuthIndex,
+			Alias:           aliasName,
+			ReasoningEffort: reasoningEffort,
+			Tokens:          tokens,
+			Failed:          failed,
+		},
+		ResponseHeaders: usageResponseHeaders(record.ResponseHeaders),
 	}
 
 	payload, err := json.Marshal(queuedUsageDetail{
-		RequestDetail: detail,
-		Provider:      provider,
-		Model:         modelName,
-		Endpoint:      resolveEndpoint(ctx),
-		AuthType:      authType,
-		APIKey:        apiKey,
-		RequestID:     requestID,
+		queuedRequestDetail: detail,
+		Provider:            provider,
+		Model:               modelName,
+		Endpoint:            resolveEndpoint(ctx),
+		AuthType:            authType,
+		APIKey:              apiKey,
+		RequestID:           requestID,
 	})
 	if err != nil {
 		return
@@ -89,13 +112,18 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 }
 
 type queuedUsageDetail struct {
-	internalusage.RequestDetail
+	queuedRequestDetail
 	Provider  string `json:"provider"`
 	Model     string `json:"model"`
 	Endpoint  string `json:"endpoint"`
 	AuthType  string `json:"auth_type"`
 	APIKey    string `json:"api_key"`
 	RequestID string `json:"request_id"`
+}
+
+type queuedRequestDetail struct {
+	internalusage.RequestDetail
+	ResponseHeaders http.Header `json:"response_headers,omitempty"`
 }
 
 func resolveSuccess(ctx context.Context) bool {
@@ -111,3 +139,28 @@ func resolveEndpoint(ctx context.Context) string {
 }
 
 const httpStatusBadRequest = 400
+
+var sensitiveUsageResponseHeaders = map[string]struct{}{
+	"Authorization":       {},
+	"Proxy-Authorization": {},
+	"Set-Cookie":          {},
+	"Cookie":              {},
+}
+
+func usageResponseHeaders(src http.Header) http.Header {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(http.Header, len(src))
+	for key, values := range src {
+		canonical := http.CanonicalHeaderKey(key)
+		if _, blocked := sensitiveUsageResponseHeaders[canonical]; blocked {
+			continue
+		}
+		dst[canonical] = append([]string(nil), values...)
+	}
+	if len(dst) == 0 {
+		return nil
+	}
+	return dst
+}

--- a/internal/redisqueue/plugin_test.go
+++ b/internal/redisqueue/plugin_test.go
@@ -20,30 +20,48 @@ func TestUsageQueuePluginPayloadIncludesStableFieldsAndSuccess(t *testing.T) {
 		ctx = internallogging.WithEndpoint(ctx, "POST /v1/chat/completions")
 		ctx = internallogging.WithResponseStatusHolder(ctx)
 		internallogging.SetResponseStatus(ctx, http.StatusOK)
+		responseHeaders := http.Header{}
+		responseHeaders.Add("X-Upstream-Request-Id", "upstream-req-1")
+		responseHeaders.Add("Retry-After", "30")
+		responseHeaders.Add("Set-Cookie", "session=secret")
 
 		plugin := &usageQueuePlugin{}
 		plugin.HandleUsage(ctx, coreusage.Record{
-			Provider:    "openai",
-			Model:       "gpt-5.4",
-			APIKey:      "test-key",
-			AuthIndex:   "0",
-			AuthType:    "apikey",
-			Source:      "user@example.com",
-			RequestedAt: time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC),
-			Latency:     1500 * time.Millisecond,
+			Provider:        "openai",
+			Model:           "gpt-5.4",
+			Alias:           "client-gpt",
+			APIKey:          "test-key",
+			AuthIndex:       "0",
+			AuthType:        "apikey",
+			Source:          "user@example.com",
+			ReasoningEffort: "medium",
+			RequestedAt:     time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC),
+			Latency:         1500 * time.Millisecond,
 			Detail: coreusage.Detail{
-				InputTokens:  10,
-				OutputTokens: 20,
-				TotalTokens:  30,
+				InputTokens:         10,
+				OutputTokens:        20,
+				CacheReadTokens:     7,
+				CacheCreationTokens: 3,
+				TotalTokens:         30,
 			},
+			ResponseHeaders: responseHeaders.Clone(),
 		})
+		responseHeaders.Set("Retry-After", "999")
 
 		payload := popSinglePayload(t)
 		requireStringField(t, payload, "provider", "openai")
 		requireStringField(t, payload, "model", "gpt-5.4")
+		requireStringField(t, payload, "alias", "client-gpt")
 		requireStringField(t, payload, "endpoint", "POST /v1/chat/completions")
 		requireStringField(t, payload, "auth_type", "apikey")
 		requireStringField(t, payload, "request_id", "ctx-request-id")
+		requireStringField(t, payload, "reasoning_effort", "medium")
+		requireNestedIntField(t, payload, "tokens", "cache_read_tokens", 7)
+		requireNestedIntField(t, payload, "tokens", "cache_creation_tokens", 3)
+		requireNestedIntField(t, payload, "tokens", "cached_tokens", 7)
+		requireHeaderField(t, payload, "response_headers", "X-Upstream-Request-Id", []string{"upstream-req-1"})
+		requireHeaderField(t, payload, "response_headers", "Retry-After", []string{"30"})
+		requireMissingHeader(t, payload, "response_headers", "Set-Cookie")
 		requireBoolField(t, payload, "failed", false)
 	})
 }
@@ -59,6 +77,7 @@ func TestUsageQueuePluginPayloadIncludesStableFieldsAndFailureAndGinRequestID(t 
 		plugin.HandleUsage(ctx, coreusage.Record{
 			Provider:    "openai",
 			Model:       "gpt-5.4-mini",
+			Alias:       "client-mini",
 			APIKey:      "test-key",
 			AuthIndex:   "0",
 			AuthType:    "apikey",
@@ -75,6 +94,7 @@ func TestUsageQueuePluginPayloadIncludesStableFieldsAndFailureAndGinRequestID(t 
 		payload := popSinglePayload(t)
 		requireStringField(t, payload, "provider", "openai")
 		requireStringField(t, payload, "model", "gpt-5.4-mini")
+		requireStringField(t, payload, "alias", "client-mini")
 		requireStringField(t, payload, "endpoint", "GET /v1/responses")
 		requireStringField(t, payload, "auth_type", "apikey")
 		requireStringField(t, payload, "request_id", "gin-request-id")
@@ -103,6 +123,7 @@ func TestUsageQueuePluginAsyncIgnoresRecycledGinContext(t *testing.T) {
 		mgr.Publish(ctx, coreusage.Record{
 			Provider:    "openai",
 			Model:       "gpt-5.4",
+			Alias:       "client-gpt",
 			APIKey:      "test-key",
 			AuthIndex:   "0",
 			AuthType:    "apikey",
@@ -118,6 +139,7 @@ func TestUsageQueuePluginAsyncIgnoresRecycledGinContext(t *testing.T) {
 
 		payload := waitForSinglePayload(t, 2*time.Second)
 		requireStringField(t, payload, "endpoint", "POST /v1/chat/completions")
+		requireStringField(t, payload, "alias", "client-gpt")
 		requireStringField(t, payload, "request_id", "ctx-request-id")
 		requireBoolField(t, payload, "failed", true)
 	})
@@ -229,4 +251,61 @@ func requireBoolField(t *testing.T, payload map[string]json.RawMessage, key stri
 	if got != want {
 		t.Fatalf("%s = %t, want %t", key, got, want)
 	}
+}
+
+func requireNestedIntField(t *testing.T, payload map[string]json.RawMessage, field, key string, want int64) {
+	t.Helper()
+
+	raw, ok := payload[field]
+	if !ok {
+		t.Fatalf("payload missing %q", field)
+	}
+	var values map[string]int64
+	if err := json.Unmarshal(raw, &values); err != nil {
+		t.Fatalf("unmarshal %q: %v", field, err)
+	}
+	if got := values[key]; got != want {
+		t.Fatalf("%s[%q] = %d, want %d", field, key, got, want)
+	}
+}
+
+func requireHeaderField(t *testing.T, payload map[string]json.RawMessage, field, key string, want []string) {
+	t.Helper()
+
+	headers := responseHeadersFromPayload(t, payload, field)
+	got, ok := headers[key]
+	if !ok {
+		t.Fatalf("%s missing header %q", field, key)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("%s[%q] = %v, want %v", field, key, got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("%s[%q] = %v, want %v", field, key, got, want)
+		}
+	}
+}
+
+func requireMissingHeader(t *testing.T, payload map[string]json.RawMessage, field, key string) {
+	t.Helper()
+
+	headers := responseHeadersFromPayload(t, payload, field)
+	if _, ok := headers[key]; ok {
+		t.Fatalf("%s unexpectedly contains header %q", field, key)
+	}
+}
+
+func responseHeadersFromPayload(t *testing.T, payload map[string]json.RawMessage, field string) map[string][]string {
+	t.Helper()
+
+	raw, ok := payload[field]
+	if !ok {
+		t.Fatalf("payload missing %q", field)
+	}
+	var headers map[string][]string
+	if err := json.Unmarshal(raw, &headers); err != nil {
+		t.Fatalf("unmarshal %q: %v", field, err)
+	}
+	return headers
 }

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -102,6 +102,7 @@ func RecordAPIRequest(ctx context.Context, cfg *config.Config, info UpstreamRequ
 
 // RecordAPIResponseMetadata captures upstream response status/header information for the latest attempt.
 func RecordAPIResponseMetadata(ctx context.Context, cfg *config.Config, status int, headers http.Header) {
+	logging.SetResponseHeaders(ctx, headers)
 	if cfg == nil || !cfg.RequestLog {
 		return
 	}
@@ -227,6 +228,7 @@ func RecordAPIWebsocketRequest(ctx context.Context, cfg *config.Config, info Ups
 
 // RecordAPIWebsocketHandshake stores the upstream websocket handshake response metadata.
 func RecordAPIWebsocketHandshake(ctx context.Context, cfg *config.Config, status int, headers http.Header) {
+	logging.SetResponseHeaders(ctx, headers)
 	if cfg == nil || !cfg.RequestLog {
 		return
 	}
@@ -250,6 +252,7 @@ func RecordAPIWebsocketHandshake(ctx context.Context, cfg *config.Config, status
 
 // RecordAPIWebsocketUpgradeRejection stores a rejected websocket upgrade as an HTTP attempt.
 func RecordAPIWebsocketUpgradeRejection(ctx context.Context, cfg *config.Config, info UpstreamRequestLog, status int, headers http.Header, body []byte) {
+	logging.SetResponseHeaders(ctx, headers)
 	if cfg == nil || !cfg.RequestLog {
 		return
 	}

--- a/internal/runtime/executor/helps/logging_helpers_test.go
+++ b/internal/runtime/executor/helps/logging_helpers_test.go
@@ -1,0 +1,24 @@
+package helps
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
+)
+
+func TestRecordAPIResponseMetadataStoresHeadersWhenRequestLogDisabled(t *testing.T) {
+	ctx := logging.WithResponseHeadersHolder(context.Background())
+	headers := http.Header{}
+	headers.Add("X-Upstream-Request-Id", "upstream-req-1")
+
+	RecordAPIResponseMetadata(ctx, &config.Config{}, http.StatusOK, headers)
+	headers.Set("X-Upstream-Request-Id", "mutated")
+
+	got := logging.GetResponseHeaders(ctx)
+	if got.Get("X-Upstream-Request-Id") != "upstream-req-1" {
+		t.Fatalf("response header = %q, want %q", got.Get("X-Upstream-Request-Id"), "upstream-req-1")
+	}
+}

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	internallogging "github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 	"github.com/tidwall/gjson"
@@ -18,24 +19,32 @@ import (
 type UsageReporter struct {
 	provider    string
 	model       string
+	alias       string
 	authID      string
 	authIndex   string
 	authType    string
 	apiKey      string
 	source      string
+	reasoning   string
 	requestedAt time.Time
 	once        sync.Once
 }
 
 func NewUsageReporter(ctx context.Context, provider, model string, auth *cliproxyauth.Auth) *UsageReporter {
 	apiKey := APIKeyFromContext(ctx)
+	alias := usage.RequestedModelAliasFromContext(ctx)
+	if alias == "" {
+		alias = model
+	}
 	reporter := &UsageReporter{
 		provider:    provider,
 		model:       model,
+		alias:       strings.TrimSpace(alias),
 		requestedAt: time.Now(),
 		apiKey:      apiKey,
 		source:      resolveUsageSource(auth, apiKey),
 		authType:    resolveUsageAuthType(auth),
+		reasoning:   usage.ReasoningEffortFromContext(ctx),
 	}
 	if auth != nil {
 		reporter.authID = auth.ID
@@ -53,7 +62,7 @@ func (r *UsageReporter) PublishAdditionalModel(ctx context.Context, model string
 	if !ok {
 		return
 	}
-	usage.PublishRecord(ctx, record)
+	r.publishRecord(ctx, record)
 }
 
 func (r *UsageReporter) buildAdditionalModelRecord(model string, detail usage.Detail) (usage.Record, bool) {
@@ -90,7 +99,7 @@ func (r *UsageReporter) publishWithOutcome(ctx context.Context, detail usage.Det
 	}
 	detail = normalizeUsageDetailTotal(detail)
 	r.once.Do(func() {
-		usage.PublishRecord(ctx, r.buildRecord(detail, failed))
+		r.publishRecord(ctx, r.buildRecord(detail, failed))
 	})
 }
 
@@ -109,6 +118,8 @@ func hasNonZeroTokenUsage(detail usage.Detail) bool {
 		detail.OutputTokens != 0 ||
 		detail.ReasoningTokens != 0 ||
 		detail.CachedTokens != 0 ||
+		detail.CacheReadTokens != 0 ||
+		detail.CacheCreationTokens != 0 ||
 		detail.TotalTokens != 0
 }
 
@@ -121,8 +132,13 @@ func (r *UsageReporter) EnsurePublished(ctx context.Context) {
 		return
 	}
 	r.once.Do(func() {
-		usage.PublishRecord(ctx, r.buildRecord(usage.Detail{}, false))
+		r.publishRecord(ctx, r.buildRecord(usage.Detail{}, false))
 	})
+}
+
+func (r *UsageReporter) publishRecord(ctx context.Context, record usage.Record) {
+	record.ResponseHeaders = internallogging.GetResponseHeaders(ctx)
+	usage.PublishRecord(ctx, record)
 }
 
 func (r *UsageReporter) buildRecord(detail usage.Detail, failed bool) usage.Record {
@@ -137,17 +153,19 @@ func (r *UsageReporter) buildRecordForModel(model string, detail usage.Detail, f
 		return usage.Record{Model: model, Detail: detail, Failed: failed}
 	}
 	return usage.Record{
-		Provider:    r.provider,
-		Model:       model,
-		Source:      r.source,
-		APIKey:      r.apiKey,
-		AuthID:      r.authID,
-		AuthIndex:   r.authIndex,
-		AuthType:    r.authType,
-		RequestedAt: r.requestedAt,
-		Latency:     r.latency(),
-		Failed:      failed,
-		Detail:      detail,
+		Provider:        r.provider,
+		Model:           model,
+		Alias:           r.alias,
+		Source:          r.source,
+		APIKey:          r.apiKey,
+		AuthID:          r.authID,
+		AuthIndex:       r.authIndex,
+		AuthType:        r.authType,
+		ReasoningEffort: r.reasoning,
+		RequestedAt:     r.requestedAt,
+		Latency:         r.latency(),
+		Failed:          failed,
+		Detail:          detail,
 	}
 }
 
@@ -326,17 +344,7 @@ func ParseClaudeUsage(data []byte) usage.Detail {
 	if !usageNode.Exists() {
 		return usage.Detail{}
 	}
-	detail := usage.Detail{
-		InputTokens:  usageNode.Get("input_tokens").Int(),
-		OutputTokens: usageNode.Get("output_tokens").Int(),
-		CachedTokens: usageNode.Get("cache_read_input_tokens").Int(),
-	}
-	if detail.CachedTokens == 0 {
-		// fall back to creation tokens when read tokens are absent
-		detail.CachedTokens = usageNode.Get("cache_creation_input_tokens").Int()
-	}
-	detail.TotalTokens = detail.InputTokens + detail.OutputTokens
-	return detail
+	return parseClaudeUsageNode(usageNode)
 }
 
 func ParseClaudeStreamUsage(line []byte) (usage.Detail, bool) {
@@ -348,16 +356,24 @@ func ParseClaudeStreamUsage(line []byte) (usage.Detail, bool) {
 	if !usageNode.Exists() {
 		return usage.Detail{}, false
 	}
+	return parseClaudeUsageNode(usageNode), true
+}
+
+func parseClaudeUsageNode(usageNode gjson.Result) usage.Detail {
+	cacheReadTokens := usageNode.Get("cache_read_input_tokens").Int()
+	cacheCreationTokens := usageNode.Get("cache_creation_input_tokens").Int()
 	detail := usage.Detail{
-		InputTokens:  usageNode.Get("input_tokens").Int(),
-		OutputTokens: usageNode.Get("output_tokens").Int(),
-		CachedTokens: usageNode.Get("cache_read_input_tokens").Int(),
+		InputTokens:         usageNode.Get("input_tokens").Int(),
+		OutputTokens:        usageNode.Get("output_tokens").Int(),
+		CachedTokens:        cacheReadTokens,
+		CacheReadTokens:     cacheReadTokens,
+		CacheCreationTokens: cacheCreationTokens,
 	}
 	if detail.CachedTokens == 0 {
-		detail.CachedTokens = usageNode.Get("cache_creation_input_tokens").Int()
+		detail.CachedTokens = detail.CacheCreationTokens
 	}
 	detail.TotalTokens = detail.InputTokens + detail.OutputTokens
-	return detail, true
+	return detail
 }
 
 func parseGeminiFamilyUsageDetail(node gjson.Result) usage.Detail {

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -1,6 +1,7 @@
 package helps
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -85,6 +86,29 @@ func TestParseOpenAIStreamUsageResponsesFields(t *testing.T) {
 	}
 }
 
+func TestParseClaudeUsageTracksDetailedCacheTokens(t *testing.T) {
+	data := []byte(`{"usage":{"input_tokens":10,"output_tokens":20,"cache_read_input_tokens":7,"cache_creation_input_tokens":3}}`)
+	detail := ParseClaudeUsage(data)
+	if detail.InputTokens != 10 {
+		t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 10)
+	}
+	if detail.OutputTokens != 20 {
+		t.Fatalf("output tokens = %d, want %d", detail.OutputTokens, 20)
+	}
+	if detail.CachedTokens != 7 {
+		t.Fatalf("cached tokens = %d, want %d", detail.CachedTokens, 7)
+	}
+	if detail.CacheReadTokens != 7 {
+		t.Fatalf("cache read tokens = %d, want %d", detail.CacheReadTokens, 7)
+	}
+	if detail.CacheCreationTokens != 3 {
+		t.Fatalf("cache creation tokens = %d, want %d", detail.CacheCreationTokens, 3)
+	}
+	if detail.TotalTokens != 30 {
+		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 30)
+	}
+}
+
 func TestParseGeminiCLIUsage_TopLevelUsageMetadata(t *testing.T) {
 	data := []byte(`{"usageMetadata":{"promptTokenCount":11,"candidatesTokenCount":7,"thoughtsTokenCount":3,"totalTokenCount":21,"cachedContentTokenCount":5}}`)
 	detail := ParseGeminiCLIUsage(data)
@@ -145,6 +169,23 @@ func TestUsageReporterBuildRecordIncludesLatency(t *testing.T) {
 	}
 }
 
+func TestUsageReporterBuildRecordIncludesUsageMetadata(t *testing.T) {
+	ctx := usage.WithRequestedModelAlias(context.Background(), "client-gpt")
+	ctx = usage.WithReasoningEffort(ctx, "medium")
+	reporter := NewUsageReporter(ctx, "openai", "gpt-5.4", nil)
+
+	record := reporter.buildRecord(usage.Detail{TotalTokens: 3}, false)
+	if record.Model != "gpt-5.4" {
+		t.Fatalf("model = %q, want %q", record.Model, "gpt-5.4")
+	}
+	if record.Alias != "client-gpt" {
+		t.Fatalf("alias = %q, want %q", record.Alias, "client-gpt")
+	}
+	if record.ReasoningEffort != "medium" {
+		t.Fatalf("reasoning effort = %q, want %q", record.ReasoningEffort, "medium")
+	}
+}
+
 func TestUsageReporterBuildAdditionalModelRecordSkipsZeroTokens(t *testing.T) {
 	reporter := &UsageReporter{
 		provider:    "codex",
@@ -160,5 +201,8 @@ func TestUsageReporterBuildAdditionalModelRecordSkipsZeroTokens(t *testing.T) {
 	}
 	if _, ok := reporter.buildAdditionalModelRecord("gpt-image-2", usage.Detail{CachedTokens: 2}); !ok {
 		t.Fatalf("expected non-zero cached token usage to be recorded")
+	}
+	if _, ok := reporter.buildAdditionalModelRecord("gpt-image-2", usage.Detail{CacheReadTokens: 2}); !ok {
+		t.Fatalf("expected non-zero cache read token usage to be recorded")
 	}
 }

--- a/internal/thinking/apply.go
+++ b/internal/thinking/apply.go
@@ -338,6 +338,54 @@ func hasThinkingConfig(config ThinkingConfig) bool {
 	return config.Mode != ModeBudget || config.Budget != 0 || config.Level != ""
 }
 
+// ExtractReasoningEffort returns the request's thinking setting as a canonical
+// reasoning_effort label for usage logging. Model suffixes follow the same
+// priority as ApplyThinking, so a valid suffix overrides body fields.
+func ExtractReasoningEffort(body []byte, provider, model string) string {
+	if effort := reasoningEffortFromSuffix(ParseSuffix(model)); effort != "" {
+		return effort
+	}
+
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	config := extractThinkingConfig(body, provider)
+	if !hasThinkingConfig(config) {
+		switch provider {
+		case "openai", "openai-response":
+			config = extractCodexConfig(body)
+		}
+	}
+	return reasoningEffortFromConfig(config)
+}
+
+func reasoningEffortFromSuffix(suffix SuffixResult) string {
+	if !suffix.HasSuffix {
+		return ""
+	}
+	return reasoningEffortFromConfig(parseSuffixToConfig(suffix.RawSuffix, "", suffix.ModelName))
+}
+
+func reasoningEffortFromConfig(config ThinkingConfig) string {
+	if !hasThinkingConfig(config) {
+		return ""
+	}
+	switch config.Mode {
+	case ModeNone:
+		return string(LevelNone)
+	case ModeAuto:
+		return string(LevelAuto)
+	case ModeLevel:
+		return strings.ToLower(strings.TrimSpace(string(config.Level)))
+	case ModeBudget:
+		level, ok := ConvertBudgetToLevel(config.Budget)
+		if !ok {
+			return ""
+		}
+		return level
+	default:
+		return ""
+	}
+}
+
 // extractClaudeConfig extracts thinking configuration from Claude format request body.
 //
 // Claude API format:

--- a/internal/thinking/reasoning_effort_test.go
+++ b/internal/thinking/reasoning_effort_test.go
@@ -1,0 +1,31 @@
+package thinking
+
+import "testing"
+
+func TestExtractReasoningEffortUsesSuffixOverBody(t *testing.T) {
+	got := ExtractReasoningEffort([]byte(`{"reasoning_effort":"low"}`), "openai", "gpt-5.4(high)")
+	if got != "high" {
+		t.Fatalf("ExtractReasoningEffort() = %q, want %q", got, "high")
+	}
+}
+
+func TestExtractReasoningEffortConvertsBudgetToLevel(t *testing.T) {
+	got := ExtractReasoningEffort([]byte(`{"thinking":{"type":"enabled","budget_tokens":8192}}`), "claude", "claude-sonnet-4-5")
+	if got != "medium" {
+		t.Fatalf("ExtractReasoningEffort() = %q, want %q", got, "medium")
+	}
+}
+
+func TestExtractReasoningEffortSupportsOpenAIResponses(t *testing.T) {
+	got := ExtractReasoningEffort([]byte(`{"reasoning":{"effort":"medium"}}`), "openai-response", "gpt-5.4")
+	if got != "medium" {
+		t.Fatalf("ExtractReasoningEffort() = %q, want %q", got, "medium")
+	}
+}
+
+func TestExtractReasoningEffortMissingConfigIsEmpty(t *testing.T) {
+	got := ExtractReasoningEffort([]byte(`{"messages":[{"role":"user","content":"hi"}]}`), "openai", "gpt-5.4")
+	if got != "" {
+		t.Fatalf("ExtractReasoningEffort() = %q, want empty", got)
+	}
+}

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -89,21 +89,25 @@ type modelStats struct {
 
 // RequestDetail stores the timestamp, latency, and token usage for a single request.
 type RequestDetail struct {
-	Timestamp time.Time  `json:"timestamp"`
-	LatencyMs int64      `json:"latency_ms"`
-	Source    string     `json:"source"`
-	AuthIndex string     `json:"auth_index"`
-	Tokens    TokenStats `json:"tokens"`
-	Failed    bool       `json:"failed"`
+	Timestamp       time.Time  `json:"timestamp"`
+	LatencyMs       int64      `json:"latency_ms"`
+	Source          string     `json:"source"`
+	AuthIndex       string     `json:"auth_index"`
+	Alias           string     `json:"alias,omitempty"`
+	ReasoningEffort string     `json:"reasoning_effort,omitempty"`
+	Tokens          TokenStats `json:"tokens"`
+	Failed          bool       `json:"failed"`
 }
 
 // TokenStats captures the token usage breakdown for a request.
 type TokenStats struct {
-	InputTokens     int64 `json:"input_tokens"`
-	OutputTokens    int64 `json:"output_tokens"`
-	ReasoningTokens int64 `json:"reasoning_tokens"`
-	CachedTokens    int64 `json:"cached_tokens"`
-	TotalTokens     int64 `json:"total_tokens"`
+	InputTokens         int64 `json:"input_tokens"`
+	OutputTokens        int64 `json:"output_tokens"`
+	ReasoningTokens     int64 `json:"reasoning_tokens"`
+	CachedTokens        int64 `json:"cached_tokens"`
+	CacheReadTokens     int64 `json:"cache_read_tokens,omitempty"`
+	CacheCreationTokens int64 `json:"cache_creation_tokens,omitempty"`
+	TotalTokens         int64 `json:"total_tokens"`
 }
 
 // StatisticsSnapshot represents an immutable view of the aggregated metrics.
@@ -198,12 +202,14 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 		s.apis[statsKey] = stats
 	}
 	s.updateAPIStats(stats, modelName, RequestDetail{
-		Timestamp: timestamp,
-		LatencyMs: normaliseLatency(record.Latency),
-		Source:    record.Source,
-		AuthIndex: record.AuthIndex,
-		Tokens:    detail,
-		Failed:    failed,
+		Timestamp:       timestamp,
+		LatencyMs:       normaliseLatency(record.Latency),
+		Source:          record.Source,
+		AuthIndex:       record.AuthIndex,
+		Alias:           strings.TrimSpace(record.Alias),
+		ReasoningEffort: strings.TrimSpace(record.ReasoningEffort),
+		Tokens:          detail,
+		Failed:          failed,
 	})
 
 	s.requestsByDay[dayKey]++
@@ -423,14 +429,23 @@ const httpStatusBadRequest = 400
 
 func normaliseDetail(detail coreusage.Detail) TokenStats {
 	tokens := TokenStats{
-		InputTokens:     detail.InputTokens,
-		OutputTokens:    detail.OutputTokens,
-		ReasoningTokens: detail.ReasoningTokens,
-		CachedTokens:    detail.CachedTokens,
-		TotalTokens:     detail.TotalTokens,
+		InputTokens:         detail.InputTokens,
+		OutputTokens:        detail.OutputTokens,
+		ReasoningTokens:     detail.ReasoningTokens,
+		CachedTokens:        detail.CachedTokens,
+		CacheReadTokens:     detail.CacheReadTokens,
+		CacheCreationTokens: detail.CacheCreationTokens,
+		TotalTokens:         detail.TotalTokens,
 	}
 	if tokens.TotalTokens == 0 {
 		tokens.TotalTokens = detail.InputTokens + detail.OutputTokens + detail.ReasoningTokens
+	}
+	if tokens.CachedTokens == 0 {
+		if tokens.CacheReadTokens != 0 {
+			tokens.CachedTokens = tokens.CacheReadTokens
+		} else if tokens.CacheCreationTokens != 0 {
+			tokens.CachedTokens = tokens.CacheCreationTokens
+		}
 	}
 	if tokens.TotalTokens == 0 {
 		tokens.TotalTokens = detail.InputTokens + detail.OutputTokens + detail.ReasoningTokens + detail.CachedTokens
@@ -441,6 +456,13 @@ func normaliseDetail(detail coreusage.Detail) TokenStats {
 func normaliseTokenStats(tokens TokenStats) TokenStats {
 	if tokens.TotalTokens == 0 {
 		tokens.TotalTokens = tokens.InputTokens + tokens.OutputTokens + tokens.ReasoningTokens
+	}
+	if tokens.CachedTokens == 0 {
+		if tokens.CacheReadTokens != 0 {
+			tokens.CachedTokens = tokens.CacheReadTokens
+		} else if tokens.CacheCreationTokens != 0 {
+			tokens.CachedTokens = tokens.CacheCreationTokens
+		}
 	}
 	if tokens.TotalTokens == 0 {
 		tokens.TotalTokens = tokens.InputTokens + tokens.OutputTokens + tokens.ReasoningTokens + tokens.CachedTokens

--- a/internal/usage/logger_plugin_test.go
+++ b/internal/usage/logger_plugin_test.go
@@ -32,6 +32,46 @@ func TestRequestStatisticsRecordIncludesLatency(t *testing.T) {
 	}
 }
 
+func TestRequestStatisticsRecordIncludesUsageMetadata(t *testing.T) {
+	stats := NewRequestStatistics()
+	stats.Record(context.Background(), coreusage.Record{
+		APIKey:          "test-key",
+		Model:           "gpt-5.4",
+		Alias:           "client-gpt",
+		ReasoningEffort: "medium",
+		RequestedAt:     time.Date(2026, 3, 20, 12, 0, 0, 0, time.UTC),
+		Detail: coreusage.Detail{
+			InputTokens:         10,
+			OutputTokens:        20,
+			CacheReadTokens:     7,
+			CacheCreationTokens: 3,
+			TotalTokens:         30,
+		},
+	})
+
+	snapshot := stats.Snapshot()
+	details := snapshot.APIs["test-key"].Models["gpt-5.4"].Details
+	if len(details) != 1 {
+		t.Fatalf("details len = %d, want 1", len(details))
+	}
+	detail := details[0]
+	if detail.Alias != "client-gpt" {
+		t.Fatalf("alias = %q, want %q", detail.Alias, "client-gpt")
+	}
+	if detail.ReasoningEffort != "medium" {
+		t.Fatalf("reasoning_effort = %q, want %q", detail.ReasoningEffort, "medium")
+	}
+	if detail.Tokens.CacheReadTokens != 7 {
+		t.Fatalf("cache_read_tokens = %d, want 7", detail.Tokens.CacheReadTokens)
+	}
+	if detail.Tokens.CacheCreationTokens != 3 {
+		t.Fatalf("cache_creation_tokens = %d, want 3", detail.Tokens.CacheCreationTokens)
+	}
+	if detail.Tokens.CachedTokens != 7 {
+		t.Fatalf("cached_tokens = %d, want 7", detail.Tokens.CachedTokens)
+	}
+}
+
 func TestRequestStatisticsMergeSnapshotDedupIgnoresLatency(t *testing.T) {
 	stats := NewRequestStatistics()
 	timestamp := time.Date(2026, 3, 20, 12, 0, 0, 0, time.UTC)

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -231,6 +231,17 @@ func requestExecutionMetadata(ctx context.Context) map[string]any {
 	return meta
 }
 
+func setReasoningEffortMetadata(meta map[string]any, handlerType, model string, rawJSON []byte) {
+	if meta == nil {
+		return
+	}
+	effort := thinking.ExtractReasoningEffort(rawJSON, handlerType, model)
+	if effort == "" {
+		return
+	}
+	meta[coreexecutor.ReasoningEffortMetadataKey] = effort
+}
+
 // headersFromContext extracts the original HTTP request headers from the gin context
 // embedded in the provided context. This allows session affinity selectors to read
 // client headers like X-Amp-Thread-Id.
@@ -400,6 +411,7 @@ func (h *BaseAPIHandler) GetContextWithCancel(handler interfaces.APIHandler, c *
 		newCtx = logging.WithEndpoint(newCtx, endpoint)
 	}
 	newCtx = logging.WithResponseStatusHolder(newCtx)
+	newCtx = logging.WithResponseHeadersHolder(newCtx)
 
 	cancelCtx := newCtx
 	if requestCtx != nil && requestCtx != parentCtx {
@@ -539,7 +551,8 @@ func (h *BaseAPIHandler) ExecuteWithAuthManager(ctx context.Context, handlerType
 		return nil, nil, errMsg
 	}
 	reqMeta := requestExecutionMetadata(ctx)
-	reqMeta[coreexecutor.RequestedModelMetadataKey] = normalizedModel
+	reqMeta[coreexecutor.RequestedModelMetadataKey] = modelName
+	setReasoningEffortMetadata(reqMeta, handlerType, normalizedModel, rawJSON)
 	payload := rawJSON
 	if len(payload) == 0 {
 		payload = nil
@@ -587,7 +600,8 @@ func (h *BaseAPIHandler) ExecuteCountWithAuthManager(ctx context.Context, handle
 		return nil, nil, errMsg
 	}
 	reqMeta := requestExecutionMetadata(ctx)
-	reqMeta[coreexecutor.RequestedModelMetadataKey] = normalizedModel
+	reqMeta[coreexecutor.RequestedModelMetadataKey] = modelName
+	setReasoningEffortMetadata(reqMeta, handlerType, normalizedModel, rawJSON)
 	payload := rawJSON
 	if len(payload) == 0 {
 		payload = nil
@@ -639,7 +653,8 @@ func (h *BaseAPIHandler) ExecuteStreamWithAuthManager(ctx context.Context, handl
 		return nil, nil, errChan
 	}
 	reqMeta := requestExecutionMetadata(ctx)
-	reqMeta[coreexecutor.RequestedModelMetadataKey] = normalizedModel
+	reqMeta[coreexecutor.RequestedModelMetadataKey] = modelName
+	setReasoningEffortMetadata(reqMeta, handlerType, normalizedModel, rawJSON)
 	payload := rawJSON
 	if len(payload) == 0 {
 		payload = nil

--- a/sdk/api/handlers/handlers_metadata_test.go
+++ b/sdk/api/handlers/handlers_metadata_test.go
@@ -18,3 +18,23 @@ func TestRequestExecutionMetadataIncludesExecutionSessionWithoutIdempotencyKey(t
 		t.Fatalf("unexpected idempotency key in metadata: %v", meta[idempotencyKeyMetadataKey])
 	}
 }
+
+func TestSetReasoningEffortMetadataUsesSuffixOverBody(t *testing.T) {
+	meta := make(map[string]any)
+
+	setReasoningEffortMetadata(meta, "openai", "gpt-5.4(high)", []byte(`{"reasoning_effort":"low"}`))
+
+	if got := meta[coreexecutor.ReasoningEffortMetadataKey]; got != "high" {
+		t.Fatalf("ReasoningEffortMetadataKey = %v, want %q", got, "high")
+	}
+}
+
+func TestSetReasoningEffortMetadataSupportsOpenAIResponses(t *testing.T) {
+	meta := make(map[string]any)
+
+	setReasoningEffortMetadata(meta, "openai-response", "gpt-5.4", []byte(`{"reasoning":{"effort":"medium"}}`))
+
+	if got := meta[coreexecutor.ReasoningEffortMetadataKey]; got != "medium" {
+		t.Fatalf("ReasoningEffortMetadataKey = %v, want %q", got, "medium")
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -22,6 +23,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -827,6 +829,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 	if executor == nil {
 		return nil, &Error{Code: "executor_not_found", Message: "executor not registered"}
 	}
+	ctx = contextWithUsageMetadata(ctx, opts, routeModel)
 	var lastErr error
 	for idx, execModel := range execModels {
 		resultModel := m.stateModelForExecution(auth, routeModel, execModel, pooled)
@@ -1319,6 +1322,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
 		}
+		execCtx = contextWithUsageMetadata(execCtx, opts, routeModel)
 
 		models, pooled := m.preparedExecutionModels(auth, routeModel)
 		if len(models) == 0 {
@@ -1397,6 +1401,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
 		}
+		execCtx = contextWithUsageMetadata(execCtx, opts, routeModel)
 
 		models, pooled := m.preparedExecutionModels(auth, routeModel)
 		if len(models) == 0 {
@@ -1531,6 +1536,50 @@ func hasRequestedModelMetadata(meta map[string]any) bool {
 		return strings.TrimSpace(string(v)) != ""
 	default:
 		return false
+	}
+}
+
+func contextWithUsageMetadata(ctx context.Context, opts cliproxyexecutor.Options, fallbackModel string) context.Context {
+	ctx = coreusage.WithRequestedModelAlias(ctx, requestedModelAliasFromOptions(opts, fallbackModel))
+	if effort := reasoningEffortFromOptions(opts); effort != "" {
+		ctx = coreusage.WithReasoningEffort(ctx, effort)
+	}
+	return ctx
+}
+
+func requestedModelAliasFromOptions(opts cliproxyexecutor.Options, fallback string) string {
+	fallback = strings.TrimSpace(fallback)
+	if len(opts.Metadata) == 0 {
+		return fallback
+	}
+	value := stringMetadataValue(opts.Metadata, cliproxyexecutor.RequestedModelMetadataKey)
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func reasoningEffortFromOptions(opts cliproxyexecutor.Options) string {
+	if len(opts.Metadata) == 0 {
+		return ""
+	}
+	return stringMetadataValue(opts.Metadata, cliproxyexecutor.ReasoningEffortMetadataKey)
+}
+
+func stringMetadataValue(meta map[string]any, key string) string {
+	raw, ok := meta[key]
+	if !ok || raw == nil {
+		return ""
+	}
+	switch value := raw.(type) {
+	case string:
+		return strings.TrimSpace(value)
+	case []byte:
+		return strings.TrimSpace(string(value))
+	case fmt.Stringer:
+		return strings.TrimSpace(value.String())
+	default:
+		return ""
 	}
 }
 
@@ -3103,6 +3152,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 			creditsCtx = context.WithValue(creditsCtx, "cliproxy.roundtripper", rt)
 		}
 		creditsOpts := ensureRequestedModelMetadata(opts, routeModel)
+		creditsCtx = contextWithUsageMetadata(creditsCtx, creditsOpts, routeModel)
 		publishSelectedAuthMetadata(creditsOpts.Metadata, c.auth.ID)
 		models := m.executionModelCandidates(c.auth, routeModel)
 		if len(models) == 0 {

--- a/sdk/cliproxy/auth/conductor_oauth_alias_suspension_test.go
+++ b/sdk/cliproxy/auth/conductor_oauth_alias_suspension_test.go
@@ -10,20 +10,23 @@ import (
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
 )
 
 type aliasRoutingExecutor struct {
 	id string
 
-	mu            sync.Mutex
-	executeModels []string
+	mu             sync.Mutex
+	executeModels  []string
+	executeAliases []string
 }
 
 func (e *aliasRoutingExecutor) Identifier() string { return e.id }
 
-func (e *aliasRoutingExecutor) Execute(_ context.Context, _ *Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+func (e *aliasRoutingExecutor) Execute(ctx context.Context, _ *Auth, req cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
 	e.mu.Lock()
 	e.executeModels = append(e.executeModels, req.Model)
+	e.executeAliases = append(e.executeAliases, coreusage.RequestedModelAliasFromContext(ctx))
 	e.mu.Unlock()
 	return cliproxyexecutor.Response{Payload: []byte(req.Model)}, nil
 }
@@ -49,6 +52,14 @@ func (e *aliasRoutingExecutor) ExecuteModels() []string {
 	defer e.mu.Unlock()
 	out := make([]string, len(e.executeModels))
 	copy(out, e.executeModels)
+	return out
+}
+
+func (e *aliasRoutingExecutor) ExecuteAliases() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]string, len(e.executeAliases))
+	copy(out, e.executeAliases)
 	return out
 }
 
@@ -107,5 +118,13 @@ func TestManagerExecute_OAuthAliasBypassesBlockedRouteModel(t *testing.T) {
 	}
 	if gotModels[0] != targetModel {
 		t.Fatalf("execute model = %q, want %q", gotModels[0], targetModel)
+	}
+
+	gotAliases := executor.ExecuteAliases()
+	if len(gotAliases) != 1 {
+		t.Fatalf("execute aliases len = %d, want 1", len(gotAliases))
+	}
+	if gotAliases[0] != routeModel {
+		t.Fatalf("execute alias = %q, want %q", gotAliases[0], routeModel)
 	}
 }

--- a/sdk/cliproxy/auth/conductor_usage_test.go
+++ b/sdk/cliproxy/auth/conductor_usage_test.go
@@ -1,0 +1,25 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/usage"
+)
+
+func TestContextWithUsageMetadataIncludesAliasAndReasoningEffort(t *testing.T) {
+	ctx := contextWithUsageMetadata(context.Background(), cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.RequestedModelMetadataKey:  "client-model",
+			cliproxyexecutor.ReasoningEffortMetadataKey: "medium",
+		},
+	}, "fallback-model")
+
+	if got := coreusage.RequestedModelAliasFromContext(ctx); got != "client-model" {
+		t.Fatalf("requested model alias = %q, want %q", got, "client-model")
+	}
+	if got := coreusage.ReasoningEffortFromContext(ctx); got != "medium" {
+		t.Fatalf("reasoning effort = %q, want %q", got, "medium")
+	}
+}

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -17,6 +17,9 @@ const RequestPathMetadataKey = "request_path"
 // DisallowFreeAuthMetadataKey instructs auth selection to skip known free-tier credentials.
 const DisallowFreeAuthMetadataKey = "disallow_free_auth"
 
+// ReasoningEffortMetadataKey stores the client-requested reasoning effort for usage logs.
+const ReasoningEffortMetadataKey = "reasoning_effort"
+
 const (
 	// PinnedAuthMetadataKey locks execution to a specific auth ID.
 	PinnedAuthMetadataKey = "pinned_auth_id"

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -2,6 +2,8 @@ package usage
 
 import (
 	"context"
+	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -10,26 +12,92 @@ import (
 
 // Record contains the usage statistics captured for a single provider request.
 type Record struct {
-	Provider    string
-	Model       string
-	APIKey      string
-	AuthID      string
-	AuthIndex   string
-	AuthType    string
-	Source      string
-	RequestedAt time.Time
-	Latency     time.Duration
-	Failed      bool
-	Detail      Detail
+	Provider  string
+	Model     string
+	Alias     string
+	APIKey    string
+	AuthID    string
+	AuthIndex string
+	AuthType  string
+	Source    string
+	// ReasoningEffort stores the client-requested thinking level for usage logs.
+	ReasoningEffort string
+	RequestedAt     time.Time
+	Latency         time.Duration
+	Failed          bool
+	Detail          Detail
+	// ResponseHeaders stores a snapshot of upstream response headers for usage sinks.
+	ResponseHeaders http.Header
 }
 
 // Detail holds the token usage breakdown.
 type Detail struct {
-	InputTokens     int64
-	OutputTokens    int64
-	ReasoningTokens int64
-	CachedTokens    int64
-	TotalTokens     int64
+	InputTokens         int64
+	OutputTokens        int64
+	ReasoningTokens     int64
+	CachedTokens        int64
+	CacheReadTokens     int64
+	CacheCreationTokens int64
+	TotalTokens         int64
+}
+
+type requestedModelAliasContextKey struct{}
+type reasoningEffortContextKey struct{}
+
+// WithRequestedModelAlias stores the client-requested model name for usage sinks.
+func WithRequestedModelAlias(ctx context.Context, alias string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	alias = strings.TrimSpace(alias)
+	if alias == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, requestedModelAliasContextKey{}, alias)
+}
+
+// RequestedModelAliasFromContext returns the client-requested model name stored in ctx.
+func RequestedModelAliasFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	raw := ctx.Value(requestedModelAliasContextKey{})
+	switch value := raw.(type) {
+	case string:
+		return strings.TrimSpace(value)
+	case []byte:
+		return strings.TrimSpace(string(value))
+	default:
+		return ""
+	}
+}
+
+// WithReasoningEffort stores the client-requested reasoning effort for usage sinks.
+func WithReasoningEffort(ctx context.Context, effort string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	effort = strings.TrimSpace(effort)
+	if effort == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, reasoningEffortContextKey{}, effort)
+}
+
+// ReasoningEffortFromContext returns the client-requested reasoning effort stored in ctx.
+func ReasoningEffortFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	raw := ctx.Value(reasoningEffortContextKey{})
+	switch value := raw.(type) {
+	case string:
+		return strings.TrimSpace(value)
+	case []byte:
+		return strings.TrimSpace(string(value))
+	default:
+		return ""
+	}
 }
 
 // Plugin consumes usage records emitted by the proxy runtime.


### PR DESCRIPTION
## 摘要

- Selective port upstream `ba5d8ca7`, `bd8c05a8`, `ad98c954`, `0de0ad0d` 中的 usage 元数据增量，保留 LTS 的完整 `internal/usage` 统计实现。
- 在 SDK usage record / executor helper / auth conductor 链路中透传 requested model alias、`reasoning_effort`、Claude cache read/creation token 细分和 upstream response headers。
- LTS `/v0/management/usage*` 路由、snapshot 聚合结构和 import/export 继续保留；snapshot 只新增兼容字段，Redis queue payload 中的 response headers 会过滤 `Authorization` / `Proxy-Authorization` / `Set-Cookie` / `Cookie`。

## LTS 兼容性

- 未引入 upstream v7 module path，Go module path 仍为 `github.com/router-for-me/CLIProxyAPI/v6`。
- 未采用 upstream 后续移除完整 usage statistics / 改名 usage queue endpoint 的方向。
- 未修改 `usage-statistics-enabled`、`/v0/management/usage`、`/v0/management/usage/export`、`/v0/management/usage/import` 的路由和鉴权边界。

## 验证

- `gofmt` touched Go files
- `git diff --check`
- `go test ./internal/thinking ./internal/runtime/executor/helps ./internal/redisqueue ./internal/usage ./sdk/api/handlers ./sdk/cliproxy/auth`
- `go test ./internal/api/handlers/management -run Usage`
- `go test ./test -run Usage`
- `go test ./sdk/cliproxy/...`
- `go test ./internal/api`
- `go test ./internal/api/handlers/management`
- `go build -o test-output ./cmd/server && rm -f test-output`

## 已知非本 PR 问题

- `go test ./internal/logging ./internal/runtime/executor` 中 `internal/logging` 通过，但 `internal/runtime/executor` 的 Antigravity credits 两个测试失败；已在当前 `origin/main` 复跑同一命令，失败一致，属于既有测试期望与当前 `daily-cloudcode-pa.googleapis.com/v1internal:loadCodeAssist` URL 不一致的问题，不是本 PR 引入。
