### PR TITLE
feat(redis): 支持 usage queue retention 配置

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/managementasset"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/redisqueue"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/store"
 	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/translator"
@@ -418,6 +419,7 @@ func main() {
 		}
 	}
 	usage.SetStatisticsEnabled(cfg.UsageStatisticsEnabled)
+	redisqueue.SetRetentionSeconds(cfg.RedisUsageQueueRetentionSeconds)
 	coreauth.SetQuotaCooldownDisabled(cfg.DisableCooling)
 
 	if err = logging.ConfigureLogOutput(cfg); err != nil {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -67,6 +67,10 @@ error-logs-max-files: 10
 # When false, disable in-memory usage statistics aggregation
 usage-statistics-enabled: false
 
+# How long (in seconds) Redis usage queue items are retained in memory for the RESP interface (LPOP/RPOP).
+# Default: 60. Max: 3600.
+redis-usage-queue-retention-seconds: 60
+
 # Proxy URL. Supports socks5/http/https protocols. Example: socks5://user:pass@192.168.1.1:1080/
 # Per-entry proxy-url also supports "direct" or "none" to bypass both the global proxy-url and environment proxies explicitly.
 proxy-url: ""

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -312,6 +312,7 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 	// or when a local management password is provided (e.g. TUI mode).
 	hasManagementSecret := cfg.RemoteManagement.SecretKey != "" || envManagementSecret || s.localPassword != ""
 	s.managementRoutesEnabled.Store(hasManagementSecret)
+	redisqueue.SetRetentionSeconds(cfg.RedisUsageQueueRetentionSeconds)
 	redisqueue.SetEnabled(hasManagementSecret)
 	if hasManagementSecret {
 		s.registerManagementRoutes()
@@ -1005,6 +1006,10 @@ func (s *Server) UpdateClients(cfg *config.Config) {
 
 	if oldCfg == nil || oldCfg.UsageStatisticsEnabled != cfg.UsageStatisticsEnabled {
 		usage.SetStatisticsEnabled(cfg.UsageStatisticsEnabled)
+	}
+
+	if oldCfg == nil || oldCfg.RedisUsageQueueRetentionSeconds != cfg.RedisUsageQueueRetentionSeconds {
+		redisqueue.SetRetentionSeconds(cfg.RedisUsageQueueRetentionSeconds)
 	}
 
 	if s.requestLogger != nil && (oldCfg == nil || oldCfg.ErrorLogsMaxFiles != cfg.ErrorLogsMaxFiles) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,6 +66,11 @@ type Config struct {
 	// UsageStatisticsEnabled toggles in-memory usage aggregation; when false, usage data is discarded.
 	UsageStatisticsEnabled bool `yaml:"usage-statistics-enabled" json:"usage-statistics-enabled"`
 
+	// RedisUsageQueueRetentionSeconds controls how long usage queue items are retained
+	// in memory for the Redis RESP interface.
+	// Default: 60. Max: 3600.
+	RedisUsageQueueRetentionSeconds int `yaml:"redis-usage-queue-retention-seconds" json:"redis-usage-queue-retention-seconds"`
+
 	// DisableCooling disables quota cooldown scheduling when true.
 	DisableCooling bool `yaml:"disable-cooling" json:"disable-cooling"`
 
@@ -622,6 +627,7 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	cfg.LogsMaxTotalSizeMB = 0
 	cfg.ErrorLogsMaxFiles = 10
 	cfg.UsageStatisticsEnabled = false
+	cfg.RedisUsageQueueRetentionSeconds = 60
 	cfg.DisableCooling = false
 	cfg.DisableImageGeneration = DisableImageGenerationOff
 	cfg.Pprof.Enable = false
@@ -682,6 +688,13 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 
 	if cfg.ErrorLogsMaxFiles < 0 {
 		cfg.ErrorLogsMaxFiles = 10
+	}
+
+	if cfg.RedisUsageQueueRetentionSeconds <= 0 {
+		cfg.RedisUsageQueueRetentionSeconds = 60
+	} else if cfg.RedisUsageQueueRetentionSeconds > 3600 {
+		log.WithField("value", cfg.RedisUsageQueueRetentionSeconds).Warn("redis-usage-queue-retention-seconds too large; clamping to 3600")
+		cfg.RedisUsageQueueRetentionSeconds = 3600
 	}
 
 	if cfg.MaxRetryCredentials < 0 {

--- a/internal/config/redis_usage_queue_retention_test.go
+++ b/internal/config/redis_usage_queue_retention_test.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRedisUsageQueueRetentionDefaultAndClamp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	if err := os.WriteFile(path, []byte("port: 8317\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile default config: %v", err)
+	}
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig default: %v", err)
+	}
+	if cfg.RedisUsageQueueRetentionSeconds != 60 {
+		t.Fatalf("default retention = %d, want 60", cfg.RedisUsageQueueRetentionSeconds)
+	}
+
+	if err := os.WriteFile(path, []byte("redis-usage-queue-retention-seconds: -1\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile negative config: %v", err)
+	}
+	cfg, err = LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig negative: %v", err)
+	}
+	if cfg.RedisUsageQueueRetentionSeconds != 60 {
+		t.Fatalf("negative retention = %d, want 60", cfg.RedisUsageQueueRetentionSeconds)
+	}
+
+	if err := os.WriteFile(path, []byte("redis-usage-queue-retention-seconds: 7200\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile large config: %v", err)
+	}
+	cfg, err = LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig large: %v", err)
+	}
+	if cfg.RedisUsageQueueRetentionSeconds != 3600 {
+		t.Fatalf("large retention = %d, want 3600", cfg.RedisUsageQueueRetentionSeconds)
+	}
+}

--- a/internal/redisqueue/queue.go
+++ b/internal/redisqueue/queue.go
@@ -6,7 +6,10 @@ import (
 	"time"
 )
 
-const retentionWindow = time.Minute
+const (
+	defaultRetentionSeconds int64 = 60
+	maxRetentionSeconds     int64 = 3600
+)
 
 type queueItem struct {
 	enqueuedAt time.Time
@@ -20,9 +23,14 @@ type queue struct {
 }
 
 var (
-	enabled atomic.Bool
-	global  queue
+	enabled          atomic.Bool
+	retentionSeconds atomic.Int64
+	global           queue
 )
+
+func init() {
+	retentionSeconds.Store(defaultRetentionSeconds)
+}
 
 func SetEnabled(value bool) {
 	enabled.Store(value)
@@ -33,6 +41,16 @@ func SetEnabled(value bool) {
 
 func Enabled() bool {
 	return enabled.Load()
+}
+
+func SetRetentionSeconds(value int) {
+	normalized := int64(value)
+	if normalized <= 0 {
+		normalized = defaultRetentionSeconds
+	} else if normalized > maxRetentionSeconds {
+		normalized = maxRetentionSeconds
+	}
+	retentionSeconds.Store(normalized)
 }
 
 func Enqueue(payload []byte) {
@@ -110,7 +128,11 @@ func (q *queue) pruneLocked(now time.Time) {
 		return
 	}
 
-	cutoff := now.Add(-retentionWindow)
+	windowSeconds := retentionSeconds.Load()
+	if windowSeconds <= 0 {
+		windowSeconds = defaultRetentionSeconds
+	}
+	cutoff := now.Add(-time.Duration(windowSeconds) * time.Second)
 	for q.head < len(q.items) && q.items[q.head].enqueuedAt.Before(cutoff) {
 		q.head++
 	}

--- a/internal/redisqueue/queue_test.go
+++ b/internal/redisqueue/queue_test.go
@@ -1,0 +1,80 @@
+package redisqueue
+
+import (
+	"testing"
+	"time"
+)
+
+func TestQueueRetentionSecondsPrunesByConfiguredWindow(t *testing.T) {
+	withQueueState(t, func() {
+		SetRetentionSeconds(120)
+		now := time.Now()
+		global.mu.Lock()
+		global.items = []queueItem{
+			{enqueuedAt: now.Add(-3 * time.Minute), payload: []byte("old")},
+			{enqueuedAt: now.Add(-30 * time.Second), payload: []byte("fresh")},
+		}
+		global.head = 0
+		global.mu.Unlock()
+
+		items := PopOldest(10)
+		if len(items) != 1 {
+			t.Fatalf("PopOldest() items = %d, want 1", len(items))
+		}
+		if string(items[0]) != "fresh" {
+			t.Fatalf("PopOldest()[0] = %q, want fresh", items[0])
+		}
+	})
+}
+
+func TestQueueRetentionSecondsDefaultsAndClamps(t *testing.T) {
+	withQueueState(t, func() {
+		SetRetentionSeconds(0)
+		now := time.Now()
+		global.mu.Lock()
+		global.items = []queueItem{
+			{enqueuedAt: now.Add(-61 * time.Second), payload: []byte("expired")},
+			{enqueuedAt: now.Add(-30 * time.Second), payload: []byte("default-window")},
+		}
+		global.head = 0
+		global.mu.Unlock()
+
+		items := PopOldest(10)
+		if len(items) != 1 || string(items[0]) != "default-window" {
+			t.Fatalf("default retention items = %q, want [default-window]", items)
+		}
+	})
+
+	withQueueState(t, func() {
+		SetRetentionSeconds(7200)
+		now := time.Now()
+		global.mu.Lock()
+		global.items = []queueItem{
+			{enqueuedAt: now.Add(-3700 * time.Second), payload: []byte("expired")},
+			{enqueuedAt: now.Add(-3500 * time.Second), payload: []byte("clamped-window")},
+		}
+		global.head = 0
+		global.mu.Unlock()
+
+		items := PopOldest(10)
+		if len(items) != 1 || string(items[0]) != "clamped-window" {
+			t.Fatalf("clamped retention items = %q, want [clamped-window]", items)
+		}
+	})
+}
+
+func withQueueState(t *testing.T, fn func()) {
+	t.Helper()
+
+	prevEnabled := Enabled()
+	prevRetention := retentionSeconds.Load()
+	SetEnabled(false)
+	SetEnabled(true)
+	defer func() {
+		SetEnabled(false)
+		SetEnabled(prevEnabled)
+		retentionSeconds.Store(prevRetention)
+	}()
+
+	fn()
+}

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -39,6 +39,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.UsageStatisticsEnabled != newCfg.UsageStatisticsEnabled {
 		changes = append(changes, fmt.Sprintf("usage-statistics-enabled: %t -> %t", oldCfg.UsageStatisticsEnabled, newCfg.UsageStatisticsEnabled))
 	}
+	if oldCfg.RedisUsageQueueRetentionSeconds != newCfg.RedisUsageQueueRetentionSeconds {
+		changes = append(changes, fmt.Sprintf("redis-usage-queue-retention-seconds: %d -> %d", oldCfg.RedisUsageQueueRetentionSeconds, newCfg.RedisUsageQueueRetentionSeconds))
+	}
 	if oldCfg.DisableCooling != newCfg.DisableCooling {
 		changes = append(changes, fmt.Sprintf("disable-cooling: %t -> %t", oldCfg.DisableCooling, newCfg.DisableCooling))
 	}

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -9,8 +9,9 @@ import (
 
 func TestBuildConfigChangeDetails(t *testing.T) {
 	oldCfg := &config.Config{
-		Port:    8080,
-		AuthDir: "/tmp/auth-old",
+		Port:                            8080,
+		AuthDir:                         "/tmp/auth-old",
+		RedisUsageQueueRetentionSeconds: 60,
 		GeminiKey: []config.GeminiKey{
 			{APIKey: "old", BaseURL: "http://old", ExcludedModels: []string{"old-model"}},
 		},
@@ -41,8 +42,9 @@ func TestBuildConfigChangeDetails(t *testing.T) {
 	}
 
 	newCfg := &config.Config{
-		Port:    9090,
-		AuthDir: "/tmp/auth-new",
+		Port:                            9090,
+		AuthDir:                         "/tmp/auth-new",
+		RedisUsageQueueRetentionSeconds: 300,
 		GeminiKey: []config.GeminiKey{
 			{APIKey: "old", BaseURL: "http://old", ExcludedModels: []string{"old-model", "extra"}},
 		},
@@ -86,6 +88,7 @@ func TestBuildConfigChangeDetails(t *testing.T) {
 
 	expectContains(t, details, "port: 8080 -> 9090")
 	expectContains(t, details, "auth-dir: /tmp/auth-old -> /tmp/auth-new")
+	expectContains(t, details, "redis-usage-queue-retention-seconds: 60 -> 300")
 	expectContains(t, details, "gemini[0].excluded-models: updated (1 -> 2 entries)")
 	expectContains(t, details, "ampcode.upstream-url: http://old-upstream -> http://new-upstream")
 	expectContains(t, details, "ampcode.model-mappings: updated (1 -> 2 entries)")


### PR DESCRIPTION
## 背景

选择性移植上游 `56df3689` 中低风险的 Redis usage queue retention 配置能力。LTS 的完整 usage statistics contract 保持不变：不改 `/v0/management/usage*` 路由，不移除 `internal/usage/`，不改变 `usage-statistics-enabled` 语义。

## 变更

- 新增 `redis-usage-queue-retention-seconds` 配置项，默认 `60` 秒，最大 `3600` 秒。
- Redis RESP usage queue 的内存保留窗口改为读取该配置。
- server 启动和热更新时同步刷新 queue retention。
- config diff 输出新增该配置变化提示。
- 补充 config / redisqueue / watcher diff 单元测试。

## 验证

- `git diff --check`
- `go test ./internal/redisqueue ./internal/config ./internal/watcher/diff`
- `go test ./internal/api`
- `go test ./internal/api/handlers/management`
- `go test ./internal/redisqueue ./internal/config ./internal/watcher/diff ./internal/api ./internal/api/handlers/management`
- `go build -o test-output ./cmd/server && rm -f test-output`

## LTS 兼容性

- 保留 Core 默认 Panel 源：`BlueSkyXN/CPA-Panel-LTS`。
- 保留完整 usage statistics 聚合和 Management usage endpoints。
- 新配置为 additive change，旧配置缺省时继续使用 60 秒窗口。