### PR TITLE
fix(translator): 跳过 Claude 到 Gemini 的空文本片段

### DIFF
--- a/internal/translator/gemini/claude/gemini_claude_request.go
+++ b/internal/translator/gemini/claude/gemini_claude_request.go
@@ -78,8 +78,12 @@ func ConvertClaudeRequestToGemini(modelName string, inputRawJSON []byte, _ bool)
 				contentsResult.ForEach(func(_, contentResult gjson.Result) bool {
 					switch contentResult.Get("type").String() {
 					case "text":
+						text := contentResult.Get("text").String()
+						if text == "" {
+							return true
+						}
 						part := []byte(`{"text":""}`)
-						part, _ = sjson.SetBytes(part, "text", contentResult.Get("text").String())
+						part, _ = sjson.SetBytes(part, "text", text)
 						contentJSON, _ = sjson.SetRawBytes(contentJSON, "parts.-1", part)
 
 					case "tool_use":

--- a/internal/translator/gemini/claude/gemini_claude_request_test.go
+++ b/internal/translator/gemini/claude/gemini_claude_request_test.go
@@ -78,3 +78,29 @@ func TestConvertClaudeRequestToGemini_ImageContent(t *testing.T) {
 		t.Fatalf("Expected image data 'aGVsbG8=', got '%s'", got)
 	}
 }
+
+func TestConvertClaudeRequestToGemini_SkipsEmptyTextParts(t *testing.T) {
+	inputJSON := []byte(`{
+		"model": "claude-3-5-sonnet",
+		"messages": [
+			{
+				"role": "assistant",
+				"content": [
+					{"type": "text", "text": ""},
+					{"type": "text", "text": "hello"},
+					{"type": "text", "text": ""}
+				]
+			}
+		]
+	}`)
+
+	output := ConvertClaudeRequestToGemini("gemini-3-flash-preview", inputJSON, false)
+
+	parts := gjson.GetBytes(output, "contents.0.parts").Array()
+	if len(parts) != 1 {
+		t.Fatalf("Expected 1 part after skipping empty text, got %d: %s", len(parts), output)
+	}
+	if got := parts[0].Get("text").String(); got != "hello" {
+		t.Fatalf("Expected part text 'hello', got '%s'", got)
+	}
+}


### PR DESCRIPTION
## 背景

本 PR 从上游 `router-for-me/CLIProxyAPI` selective port 一个小型 translator 修复：

- `1c632d15` `fix(translator): skip empty text parts in Claude request conversion`

该修复避免 Claude request 转 Gemini request 时把 `{"type":"text","text":""}` 这类空文本片段转成 Gemini `parts`，减少上游 Gemini 对空 part 的兼容风险。

## 改动

- `ConvertClaudeRequestToGemini` 在处理 array content 的 text part 时跳过空字符串。
- 增加回归测试，确认空 text 被跳过且非空文本仍保留。

## LTS 适配边界

- 保持 Go module/import path 为 `github.com/router-for-me/CLIProxyAPI/v6`。
- 只触碰 `internal/translator/gemini/claude` translator pair。
- 未修改 Management API、usage statistics、auth/config、runtime executor 或 panel source。
- 未引入上游 v7、Home control plane、xAI/image/video 相关改动。

## 验证

- `git diff --check`
- `go test -count=1 ./internal/translator/gemini/claude`
- `go test -count=1 ./internal/translator/...`
- `go build -o test-output ./cmd/server && rm -f test-output`
