### PR TITLE
feat(sdk): 暴露 Management helper API

### DIFF
--- a/sdk/api/management.go
+++ b/sdk/api/management.go
@@ -1,15 +1,20 @@
 // Package api exposes helpers for embedding CLIProxyAPI.
 //
-// It wraps internal management handler types so external projects can integrate
-// management endpoints without importing internal packages.
+// It wraps internal management handler types and helpers so external projects
+// can integrate management endpoints without importing internal packages.
 package api
 
 import (
+	"context"
+
 	"github.com/gin-gonic/gin"
 	internalmanagement "github.com/router-for-me/CLIProxyAPI/v6/internal/api/handlers/management"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
 )
+
+// Handler re-exports the management handler used by the internal HTTP API.
+type Handler = internalmanagement.Handler
 
 // ManagementTokenRequester exposes a limited subset of management endpoints for requesting tokens.
 type ManagementTokenRequester interface {
@@ -23,13 +28,23 @@ type ManagementTokenRequester interface {
 }
 
 type managementTokenRequester struct {
-	handler *internalmanagement.Handler
+	handler *Handler
+}
+
+// NewHandler creates a management handler for SDK consumers.
+func NewHandler(cfg *config.Config, configFilePath string, manager *coreauth.Manager) *Handler {
+	return internalmanagement.NewHandler(cfg, configFilePath, manager)
+}
+
+// NewHandlerWithoutConfigFilePath creates a management handler that skips config file persistence.
+func NewHandlerWithoutConfigFilePath(cfg *config.Config, manager *coreauth.Manager) *Handler {
+	return internalmanagement.NewHandlerWithoutConfigFilePath(cfg, manager)
 }
 
 // NewManagementTokenRequester creates a limited management handler exposing only token request endpoints.
 func NewManagementTokenRequester(cfg *config.Config, manager *coreauth.Manager) ManagementTokenRequester {
 	return &managementTokenRequester{
-		handler: internalmanagement.NewHandlerWithoutConfigFilePath(cfg, manager),
+		handler: NewHandlerWithoutConfigFilePath(cfg, manager),
 	}
 }
 
@@ -59,4 +74,64 @@ func (m *managementTokenRequester) GetAuthStatus(c *gin.Context) {
 
 func (m *managementTokenRequester) PostOAuthCallback(c *gin.Context) {
 	m.handler.PostOAuthCallback(c)
+}
+
+// WriteConfig persists management configuration to disk.
+func WriteConfig(path string, data []byte) error {
+	return internalmanagement.WriteConfig(path, data)
+}
+
+// RegisterOAuthSession records a pending OAuth callback state.
+func RegisterOAuthSession(state, provider string) {
+	internalmanagement.RegisterOAuthSession(state, provider)
+}
+
+// SetOAuthSessionError stores an OAuth session error message.
+func SetOAuthSessionError(state, message string) {
+	internalmanagement.SetOAuthSessionError(state, message)
+}
+
+// CompleteOAuthSession marks a single OAuth session as completed.
+func CompleteOAuthSession(state string) {
+	internalmanagement.CompleteOAuthSession(state)
+}
+
+// CompleteOAuthSessionsByProvider removes all pending OAuth sessions for a provider.
+func CompleteOAuthSessionsByProvider(provider string) int {
+	return internalmanagement.CompleteOAuthSessionsByProvider(provider)
+}
+
+// GetOAuthSession returns the current OAuth session state.
+func GetOAuthSession(state string) (provider string, status string, ok bool) {
+	return internalmanagement.GetOAuthSession(state)
+}
+
+// IsOAuthSessionPending reports whether a provider/state pair is still pending.
+func IsOAuthSessionPending(state, provider string) bool {
+	return internalmanagement.IsOAuthSessionPending(state, provider)
+}
+
+// ValidateOAuthState validates an OAuth state token.
+func ValidateOAuthState(state string) error {
+	return internalmanagement.ValidateOAuthState(state)
+}
+
+// NormalizeOAuthProvider normalizes a provider name to its canonical form.
+func NormalizeOAuthProvider(provider string) (string, error) {
+	return internalmanagement.NormalizeOAuthProvider(provider)
+}
+
+// WriteOAuthCallbackFile writes an OAuth callback payload to disk.
+func WriteOAuthCallbackFile(authDir, provider, state, code, errorMessage string) (string, error) {
+	return internalmanagement.WriteOAuthCallbackFile(authDir, provider, state, code, errorMessage)
+}
+
+// WriteOAuthCallbackFileForPendingSession writes an OAuth callback payload for a pending session.
+func WriteOAuthCallbackFileForPendingSession(authDir, provider, state, code, errorMessage string) (string, error) {
+	return internalmanagement.WriteOAuthCallbackFileForPendingSession(authDir, provider, state, code, errorMessage)
+}
+
+// PopulateAuthContext copies auth metadata from a Gin context into a request context.
+func PopulateAuthContext(ctx context.Context, c *gin.Context) context.Context {
+	return internalmanagement.PopulateAuthContext(ctx, c)
 }


### PR DESCRIPTION
## 背景

本 PR 选择性移植上游 `router-for-me/CLIProxyAPI` 的 `17219941 feat(management): expose additional OAuth and configuration helpers`。

CPA-Core-LTS 需要在保留 v6.9.49 usage statistics、Management API 和 CPA-Panel-LTS 兼容性的前提下，吸收不破坏 LTS 契约的新增能力。本次改动仅扩展 `sdk/api` 的外部嵌入辅助 API，让 SDK 使用方可以复用现有 Management handler、OAuth session 和 config persistence helper，而不需要直接 import `internal/` 包。

## 变更内容

- 在 `sdk/api/management.go` 中 re-export `management.Handler`。
- 新增 `NewHandler` / `NewHandlerWithoutConfigFilePath` 供 SDK 嵌入方创建完整 Management handler。
- 暴露现有内部 helper：
  - `WriteConfig`
  - OAuth session helpers：`RegisterOAuthSession`、`CompleteOAuthSession`、`GetOAuthSession` 等
  - OAuth provider/state/callback helpers：`ValidateOAuthState`、`NormalizeOAuthProvider`、`WriteOAuthCallbackFile*`
  - `PopulateAuthContext`
- 保留已有 `NewManagementTokenRequester` 行为，仅改为复用新的 wrapper constructor。

## LTS 适配与风险边界

- 保持 Go module path 为 `github.com/router-for-me/CLIProxyAPI/v6`，没有引入 v7 import。
- 不新增、删除或修改 Management HTTP route。
- 不改变 `/v0/management/usage*`、`internal/usage/`、usage record shape 或 CPA-Panel-LTS 依赖接口。
- 不触碰 auth file schema、token store、config schema、watcher 或 runtime executor。
- 本 PR 是 SDK API surface 的 additive export；运行时行为仍由既有 internal management 实现提供。

## 验证

已在隔离 worktree `/private/tmp/cpa-lts-management-sdk-helpers` 运行：

```bash
gofmt -w sdk/api/management.go
go test -count=1 ./sdk/api ./internal/api/handlers/management
git diff --check
rg -n "CLIProxyAPI/v7|internal/home|Home\.Enabled|handleHomeCodex|OpenAIImageModelType" --glob '!AGENTS.md' --glob '!internal/**/AGENTS.md' --glob '!sdk/cliproxy/AGENTS.md'
go build -o test-output ./cmd/server && rm -f test-output
```

结果：全部通过；guard 搜索无命中。
