### PR TITLE
feat(management): 暴露 usage queue 读取接口

### DIFF
--- a/internal/api/handlers/management/usage_queue.go
+++ b/internal/api/handlers/management/usage_queue.go
@@ -1,0 +1,55 @@
+package management
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/redisqueue"
+)
+
+type usageQueueRecord []byte
+
+func (r usageQueueRecord) MarshalJSON() ([]byte, error) {
+	if json.Valid(r) {
+		return append([]byte(nil), r...), nil
+	}
+	return json.Marshal(string(r))
+}
+
+// GetUsageQueue pops queued usage records from the Redis-compatible usage queue.
+func (h *Handler) GetUsageQueue(c *gin.Context) {
+	if h == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "handler unavailable"})
+		return
+	}
+
+	count, errCount := parseUsageQueueCount(c.Query("count"))
+	if errCount != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": errCount.Error()})
+		return
+	}
+
+	items := redisqueue.PopOldest(count)
+	records := make([]usageQueueRecord, 0, len(items))
+	for _, item := range items {
+		records = append(records, usageQueueRecord(append([]byte(nil), item...)))
+	}
+
+	c.JSON(http.StatusOK, records)
+}
+
+func parseUsageQueueCount(value string) (int, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 1, nil
+	}
+	count, errCount := strconv.Atoi(value)
+	if errCount != nil || count <= 0 {
+		return 0, errors.New("count must be a positive integer")
+	}
+	return count, nil
+}

--- a/internal/api/handlers/management/usage_queue_test.go
+++ b/internal/api/handlers/management/usage_queue_test.go
@@ -1,0 +1,98 @@
+package management
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/redisqueue"
+)
+
+func TestGetUsageQueuePopsRequestedRecords(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	withManagementUsageQueue(t, func() {
+		redisqueue.Enqueue([]byte(`{"id":1}`))
+		redisqueue.Enqueue([]byte(`{"id":2}`))
+		redisqueue.Enqueue([]byte(`{"id":3}`))
+
+		rec := httptest.NewRecorder()
+		ginCtx, _ := gin.CreateTestContext(rec)
+		ginCtx.Request = httptest.NewRequest(http.MethodGet, "/v0/management/usage-queue?count=2", nil)
+
+		h := &Handler{}
+		h.GetUsageQueue(ginCtx)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+		}
+
+		var payload []json.RawMessage
+		if errUnmarshal := json.Unmarshal(rec.Body.Bytes(), &payload); errUnmarshal != nil {
+			t.Fatalf("unmarshal response: %v", errUnmarshal)
+		}
+		if len(payload) != 2 {
+			t.Fatalf("response records = %d, want 2", len(payload))
+		}
+		requireUsageQueueRecordID(t, payload[0], 1)
+		requireUsageQueueRecordID(t, payload[1], 2)
+
+		remaining := redisqueue.PopOldest(10)
+		if len(remaining) != 1 || string(remaining[0]) != `{"id":3}` {
+			t.Fatalf("remaining queue = %q, want third item only", remaining)
+		}
+	})
+}
+
+func TestGetUsageQueueInvalidCountDoesNotPop(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	withManagementUsageQueue(t, func() {
+		redisqueue.Enqueue([]byte(`{"id":1}`))
+
+		rec := httptest.NewRecorder()
+		ginCtx, _ := gin.CreateTestContext(rec)
+		ginCtx.Request = httptest.NewRequest(http.MethodGet, "/v0/management/usage-queue?count=0", nil)
+
+		h := &Handler{}
+		h.GetUsageQueue(ginCtx)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+		}
+
+		remaining := redisqueue.PopOldest(10)
+		if len(remaining) != 1 || string(remaining[0]) != `{"id":1}` {
+			t.Fatalf("remaining queue = %q, want original item", remaining)
+		}
+	})
+}
+
+func withManagementUsageQueue(t *testing.T, fn func()) {
+	t.Helper()
+
+	prevQueueEnabled := redisqueue.Enabled()
+	redisqueue.SetEnabled(false)
+	redisqueue.SetEnabled(true)
+
+	defer func() {
+		redisqueue.SetEnabled(false)
+		redisqueue.SetEnabled(prevQueueEnabled)
+	}()
+
+	fn()
+}
+
+func requireUsageQueueRecordID(t *testing.T, raw json.RawMessage, want int) {
+	t.Helper()
+
+	var payload struct {
+		ID int `json:"id"`
+	}
+	if errUnmarshal := json.Unmarshal(raw, &payload); errUnmarshal != nil {
+		t.Fatalf("unmarshal record: %v", errUnmarshal)
+	}
+	if payload.ID != want {
+		t.Fatalf("record id = %d, want %d", payload.ID, want)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -514,6 +514,7 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.GET("/usage", s.mgmt.GetUsageStatistics)
 		mgmt.GET("/usage/export", s.mgmt.ExportUsageStatistics)
 		mgmt.POST("/usage/import", s.mgmt.ImportUsageStatistics)
+		mgmt.GET("/usage-queue", s.mgmt.GetUsageQueue)
 		mgmt.GET("/config", s.mgmt.GetConfig)
 		mgmt.GET("/config.yaml", s.mgmt.GetConfigYAML)
 		mgmt.PUT("/config.yaml", s.mgmt.PutConfigYAML)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -13,6 +13,7 @@ import (
 	gin "github.com/gin-gonic/gin"
 	proxyconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	internallogging "github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/redisqueue"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -106,6 +107,71 @@ func TestManagementLocalPasswordRejectsSpoofedForwardedFor(t *testing.T) {
 	}
 	if body := rr.Body.String(); !strings.Contains(body, "remote management disabled") {
 		t.Fatalf("body = %q, want remote management disabled", body)
+	}
+}
+
+func TestManagementUsageQueueRequiresAuthAndPreservesUsageStatisticsRoute(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "test-management-key")
+
+	prevQueueEnabled := redisqueue.Enabled()
+	redisqueue.SetEnabled(false)
+	t.Cleanup(func() {
+		redisqueue.SetEnabled(false)
+		redisqueue.SetEnabled(prevQueueEnabled)
+	})
+
+	server := newTestServer(t)
+
+	redisqueue.Enqueue([]byte(`{"id":1}`))
+	redisqueue.Enqueue([]byte(`{"id":2}`))
+
+	missingKeyReq := httptest.NewRequest(http.MethodGet, "/v0/management/usage-queue?count=2", nil)
+	missingKeyRR := httptest.NewRecorder()
+	server.engine.ServeHTTP(missingKeyRR, missingKeyReq)
+	if missingKeyRR.Code != http.StatusUnauthorized {
+		t.Fatalf("missing key status = %d, want %d body=%s", missingKeyRR.Code, http.StatusUnauthorized, missingKeyRR.Body.String())
+	}
+
+	usageStatsReq := httptest.NewRequest(http.MethodGet, "/v0/management/usage", nil)
+	usageStatsReq.Header.Set("Authorization", "Bearer test-management-key")
+	usageStatsRR := httptest.NewRecorder()
+	server.engine.ServeHTTP(usageStatsRR, usageStatsReq)
+	if usageStatsRR.Code != http.StatusOK {
+		t.Fatalf("usage stats status = %d, want %d body=%s", usageStatsRR.Code, http.StatusOK, usageStatsRR.Body.String())
+	}
+	if body := usageStatsRR.Body.String(); !strings.Contains(body, `"usage"`) {
+		t.Fatalf("usage stats body missing usage snapshot: %s", body)
+	}
+
+	authReq := httptest.NewRequest(http.MethodGet, "/v0/management/usage-queue?count=2", nil)
+	authReq.Header.Set("Authorization", "Bearer test-management-key")
+	authRR := httptest.NewRecorder()
+	server.engine.ServeHTTP(authRR, authReq)
+	if authRR.Code != http.StatusOK {
+		t.Fatalf("authenticated status = %d, want %d body=%s", authRR.Code, http.StatusOK, authRR.Body.String())
+	}
+
+	var payload []json.RawMessage
+	if errUnmarshal := json.Unmarshal(authRR.Body.Bytes(), &payload); errUnmarshal != nil {
+		t.Fatalf("unmarshal response: %v body=%s", errUnmarshal, authRR.Body.String())
+	}
+	if len(payload) != 2 {
+		t.Fatalf("response records = %d, want 2", len(payload))
+	}
+	for i, raw := range payload {
+		var record struct {
+			ID int `json:"id"`
+		}
+		if errUnmarshal := json.Unmarshal(raw, &record); errUnmarshal != nil {
+			t.Fatalf("unmarshal record %d: %v", i, errUnmarshal)
+		}
+		if record.ID != i+1 {
+			t.Fatalf("record %d id = %d, want %d", i, record.ID, i+1)
+		}
+	}
+
+	if remaining := redisqueue.PopOldest(1); len(remaining) != 0 {
+		t.Fatalf("remaining queue = %q, want empty", remaining)
 	}
 }
 


### PR DESCRIPTION
## 背景

本 PR 选择性移植上游 `router-for-me/CLIProxyAPI` 的 usage queue Management API 能力，参考：

- `61b39d49 feat(management): add usage record retrieval endpoint`
- `da6c599e refactor(management): rename GetUsage to GetUsageQueue and update routes/tests`

CPA-Core-LTS 必须保留完整 usage statistics contract，因此本 PR 不采用上游早期的 `/v0/management/usage` queue 路由，而是按后续命名和 LTS 契约适配为 `/v0/management/usage-queue`。

## 变更内容

- 新增 `GetUsageQueue` Management handler，从现有 `internal/redisqueue` 中按 `count` 弹出最旧 usage queue records。
- 新增 `/v0/management/usage-queue` route，并继续使用现有 Management middleware 鉴权。
- 新增 handler 单测：
  - `count` 默认值和正整数校验
  - invalid count 不弹出队列
  - JSON records 原样作为 JSON 返回，非 JSON payload 会以字符串形式 marshal
- 新增 API 集成测试：
  - 未带 management key 访问 `/usage-queue` 返回 401
  - `/v0/management/usage` 仍返回完整 usage snapshot
  - 带 key 访问 `/usage-queue` 能弹出队列记录

## LTS 适配与风险边界

- 保留 `/v0/management/usage`、`/v0/management/usage/export`、`/v0/management/usage/import` 的完整统计语义。
- 不修改 `internal/usage` 聚合字段、snapshot/import/export 结构或 CPA-Panel-LTS 依赖的 response shape。
- 不改变 Redis RESP 协议行为；HTTP endpoint 只是复用现有 `redisqueue.PopOldest`。
- 不引入 v7、Home control plane 或 translator 变更。
- 新 endpoint 仍在 `/v0/management` 下，继承现有 management secret / remote-management gate。

## 验证

已在隔离 worktree `/private/tmp/cpa-lts-management-usage-queue` 运行：

```bash
gofmt -w internal/api/handlers/management/usage_queue.go internal/api/handlers/management/usage_queue_test.go internal/api/server.go internal/api/server_test.go
go test -count=1 ./internal/api/handlers/management -run 'Usage|UsageQueue'
go test -count=1 ./internal/api -run 'ManagementUsage|UsageQueue|Healthz'
go test -count=1 ./internal/usage
go test -count=1 ./test -run Usage
git diff --check
rg -n "CLIProxyAPI/v7|internal/home|Home\.Enabled|handleHomeCodex|OpenAIImageModelType" --glob '!AGENTS.md' --glob '!internal/**/AGENTS.md' --glob '!sdk/cliproxy/AGENTS.md'
go build -o test-output ./cmd/server && rm -f test-output
```

结果：全部通过；guard 搜索无命中。
