### PR TITLE
chore(docker): 更新运行时 Alpine 基础镜像

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG BUILD_DATE=unknown
 
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X 'main.Version=${VERSION}' -X 'main.Commit=${COMMIT}' -X 'main.BuildDate=${BUILD_DATE}'" -o ./CLIProxyAPI ./cmd/server/
 
-FROM alpine:3.22.0
+FROM alpine:3.23
 
 RUN apk add --no-cache tzdata
 


### PR DESCRIPTION
## 背景

本 PR 选择性移植上游 `router-for-me/CLIProxyAPI` 的 Docker runtime image 更新：

- `38dad2af chore(docker): upgrade base image to alpine 3.23`

该改动只影响容器运行时基础镜像，不触碰 Go module path、Management API、usage statistics、auth/config 或 CPA-Panel-LTS 兼容契约。

## 变更内容

- 将 Docker runtime stage 从 `alpine:3.22.0` 更新为 `alpine:3.23`。
- 补齐 `Dockerfile` 文件末尾换行。

## LTS 风险边界

- 不修改 builder stage、构建命令、端口、volume、启动命令或 release 配置。
- 不引入 v7、Home control plane、translator 或 usage contract 变更。
- 该 PR 不运行 Docker build；Docker daemon / image pull 属于分发路径验证，留给需要时的 CI 或手动环境执行。

## 验证

已在隔离 worktree `/private/tmp/cpa-lts-docker-alpine-323` 运行：

```bash
git diff --check
go build -o test-output ./cmd/server && rm -f test-output
rg -n "CLIProxyAPI/v7|internal/home|Home\\.Enabled|handleHomeCodex|OpenAIImageModelType" --glob '!AGENTS.md' --glob '!internal/**/AGENTS.md' --glob '!sdk/cliproxy/AGENTS.md'
```

结果：`git diff --check` 和 Go build 通过；guard 搜索无命中。
