### PR TITLE
fix(sdk): 收窄 Antigravity credits fallback 触发范围

### DIFF
--- a/sdk/cliproxy/auth/antigravity_credits_test.go
+++ b/sdk/cliproxy/auth/antigravity_credits_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	log "github.com/sirupsen/logrus"
 )
 
 type antigravityCreditsFallbackExecutor struct {
@@ -46,6 +48,43 @@ func (e *antigravityCreditsFallbackExecutor) CountTokens(context.Context, *Auth,
 
 func (e *antigravityCreditsFallbackExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
 	return nil, &Error{HTTPStatus: http.StatusNotImplemented, Message: "HttpRequest not implemented"}
+}
+
+type codexOnlyFailureExecutor struct{}
+
+func (codexOnlyFailureExecutor) Identifier() string { return "codex" }
+
+func (codexOnlyFailureExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusTooManyRequests, Message: "codex quota exhausted"}
+}
+
+func (codexOnlyFailureExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, &Error{HTTPStatus: http.StatusTooManyRequests, Message: "codex quota exhausted"}
+}
+
+func (codexOnlyFailureExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (codexOnlyFailureExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusTooManyRequests, Message: "codex quota exhausted"}
+}
+
+func (codexOnlyFailureExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, &Error{HTTPStatus: http.StatusTooManyRequests, Message: "codex quota exhausted"}
+}
+
+type captureLogHook struct {
+	messages []string
+}
+
+func (h *captureLogHook) Levels() []log.Level {
+	return log.AllLevels
+}
+
+func (h *captureLogHook) Fire(entry *log.Entry) error {
+	h.messages = append(h.messages, entry.Message)
+	return nil
 }
 
 func TestManagerExecuteStream_AntigravityCreditsFallbackAfterBootstrap429(t *testing.T) {
@@ -85,6 +124,51 @@ func TestManagerExecuteStream_AntigravityCreditsFallbackAfterBootstrap429(t *tes
 	}
 	if executor.streamCreditsRequested[0] || !executor.streamCreditsRequested[1] {
 		t.Fatalf("credits flags = %v, want [false true]", executor.streamCreditsRequested)
+	}
+}
+
+func TestManagerExecuteStream_CodexOnlyDoesNotEnterAntigravityCreditsFallback(t *testing.T) {
+	const model = "gpt-5.5"
+	logger := log.StandardLogger()
+	oldLevel := logger.GetLevel()
+	oldHooks := logger.ReplaceHooks(make(log.LevelHooks))
+	hook := &captureLogHook{}
+	logger.SetLevel(log.DebugLevel)
+	logger.AddHook(hook)
+	t.Cleanup(func() {
+		logger.SetLevel(oldLevel)
+		logger.ReplaceHooks(oldHooks)
+	})
+
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{
+		QuotaExceeded: internalconfig.QuotaExceeded{AntigravityCredits: true},
+	})
+	manager.RegisterExecutor(codexOnlyFailureExecutor{})
+	manager.RegisterExecutor(&antigravityCreditsFallbackExecutor{})
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("codex-only", "codex", []*registry.ModelInfo{{ID: model}})
+	reg.RegisterClient("ag-unrelated", "antigravity", []*registry.ModelInfo{{ID: "gemini-3-flash"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient("codex-only")
+		reg.UnregisterClient("ag-unrelated")
+	})
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: "codex-only", Provider: "codex"}); errRegister != nil {
+		t.Fatalf("register codex auth: %v", errRegister)
+	}
+	if _, errRegister := manager.Register(context.Background(), &Auth{ID: "ag-unrelated", Provider: "antigravity"}); errRegister != nil {
+		t.Fatalf("register antigravity auth: %v", errRegister)
+	}
+
+	_, errExecute := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if errExecute == nil {
+		t.Fatal("expected codex execution failure")
+	}
+
+	for _, message := range hook.messages {
+		if strings.Contains(message, "shouldAttemptAntigravityCreditsFallback") {
+			t.Fatalf("codex-only request entered antigravity credits fallback gate; messages=%v", hook.messages)
+		}
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1208,7 +1208,7 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 		}
 	}
 	if lastErr != nil {
-		if shouldAttemptAntigravityCreditsFallback(m, lastErr, normalized) {
+		if hasAntigravityProvider(normalized) && shouldAttemptAntigravityCreditsFallback(m, lastErr, normalized) {
 			if resp, ok := m.tryAntigravityCreditsExecute(ctx, req, opts); ok {
 				return resp, nil
 			}
@@ -1274,7 +1274,7 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 		}
 	}
 	if lastErr != nil {
-		if shouldAttemptAntigravityCreditsFallback(m, lastErr, normalized) {
+		if hasAntigravityProvider(normalized) && shouldAttemptAntigravityCreditsFallback(m, lastErr, normalized) {
 			if result, ok := m.tryAntigravityCreditsExecuteStream(ctx, req, opts); ok {
 				return result, nil
 			}
@@ -3129,6 +3129,15 @@ type creditsCandidateEntry struct {
 	provider string
 }
 
+func hasAntigravityProvider(providers []string) bool {
+	for _, p := range providers {
+		if strings.EqualFold(strings.TrimSpace(p), "antigravity") {
+			return true
+		}
+	}
+	return false
+}
+
 func shouldAttemptAntigravityCreditsFallback(m *Manager, lastErr error, providers []string) bool {
 	status := statusCodeFromError(lastErr)
 	log.WithFields(log.Fields{
@@ -3138,18 +3147,6 @@ func shouldAttemptAntigravityCreditsFallback(m *Manager, lastErr error, provider
 	}).Debug("shouldAttemptAntigravityCreditsFallback")
 	if m == nil || lastErr == nil {
 		return false
-	}
-	if len(providers) > 0 {
-		hasAntigravity := false
-		for _, p := range providers {
-			if strings.EqualFold(strings.TrimSpace(p), "antigravity") {
-				hasAntigravity = true
-				break
-			}
-		}
-		if !hasAntigravity {
-			return false
-		}
 	}
 	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
 	if cfg == nil || !cfg.QuotaExceeded.AntigravityCredits {


### PR DESCRIPTION
## 背景

手工移植 upstream `router-for-me/CLIProxyAPI` 的修复提交：

- `bfdc0b39 fix: scope antigravity credits fallback gate`

当前 LTS 已保留 Antigravity credits fallback 能力，但原逻辑会先进入 `shouldAttemptAntigravityCreditsFallback`，再在函数内部判断 provider list 是否包含 `antigravity`。这会让 Codex-only 等非 Antigravity 请求在开启 `quota-exceeded.antigravity-credits` 后仍进入 Antigravity fallback gate 的判断路径，容易产生不必要的 fallback 尝试/日志噪声，也增加后续维护误判风险。

## 改动

- 在 `Execute` 和 `ExecuteStream` 的 fallback 入口前增加 `hasAntigravityProvider(normalized)` 显式 gate。
- 保留 `shouldAttemptAntigravityCreditsFallback` 对错误状态和配置开关的判断职责。
- 增加 Codex-only streaming 回归测试，验证非 Antigravity provider list 不会进入 Antigravity credits fallback gate。

## LTS 适配说明

- 仅改 `sdk/cliproxy/auth` 内部调度逻辑和测试，没有修改 public SDK type、Management API、usage statistics 数据结构或 config schema。
- Go module path 保持 `github.com/router-for-me/CLIProxyAPI/v6`。
- 未触碰 `internal/usage/`、`/v0/management/usage*`、默认 CPA-Panel-LTS 来源或 release/Docker 配置。

## 验证

已在隔离 worktree `/private/tmp/cpa-lts-antigravity-credits-fallback-scope` 运行：

```bash
gofmt -w sdk/cliproxy/auth/conductor.go sdk/cliproxy/auth/antigravity_credits_test.go
go test -count=1 ./sdk/cliproxy/auth -run 'AntigravityCredits|CodexOnly|Fallback'
go test -count=1 ./sdk/cliproxy/...
go build -o test-output ./cmd/server && rm -f test-output
git diff --check
rg -n "CLIProxyAPI/v7|internal/home|Home\\.Enabled|handleHomeCodex|OpenAIImageModelType" --glob '!AGENTS.md' --glob '!internal/**/AGENTS.md' --glob '!sdk/cliproxy/AGENTS.md'
```

说明：最后一个 `rg` guard 无命中，返回码为 1，符合预期。
