### PR TITLE
fix(auth): 脱敏 Antigravity project_id 输出

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -2052,7 +2052,7 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 				log.Warnf("antigravity: failed to fetch project ID: %v", errProject)
 			} else {
 				projectID = fetchedProjectID
-				log.Infof("antigravity: obtained project ID %s", projectID)
+				log.Infof("antigravity: obtained project ID %s", util.HideAPIKey(projectID))
 			}
 		}
 
@@ -2096,7 +2096,7 @@ func (h *Handler) RequestAntigravityToken(c *gin.Context) {
 		CompleteOAuthSessionsByProvider("antigravity")
 		fmt.Printf("Authentication successful! Token saved to %s\n", savedPath)
 		if projectID != "" {
-			fmt.Printf("Using GCP project: %s\n", projectID)
+			fmt.Printf("Using GCP project: %s\n", util.HideAPIKey(projectID))
 		}
 		fmt.Println("You can now use Antigravity services through this CLI")
 	}()

--- a/internal/auth/antigravity/auth.go
+++ b/internal/auth/antigravity/auth.go
@@ -323,7 +323,7 @@ func (o *AntigravityAuth) OnboardUser(ctx context.Context, accessToken, tierID s
 				}
 
 				if projectID != "" {
-					log.Infof("Successfully fetched project_id: %s", projectID)
+					log.Infof("Successfully fetched project_id: %s", util.HideAPIKey(projectID))
 					return projectID, nil
 				}
 

--- a/sdk/auth/antigravity.go
+++ b/sdk/auth/antigravity.go
@@ -180,7 +180,7 @@ waitForCallback:
 			log.Warnf("antigravity: failed to fetch project ID: %v", errProject)
 		} else {
 			projectID = fetchedProjectID
-			log.Infof("antigravity: obtained project ID %s", projectID)
+			log.Infof("antigravity: obtained project ID %s", util.HideAPIKey(projectID))
 		}
 	}
 
@@ -208,7 +208,7 @@ waitForCallback:
 
 	fmt.Println("Antigravity authentication successful")
 	if projectID != "" {
-		fmt.Printf("Using GCP project: %s\n", projectID)
+		fmt.Printf("Using GCP project: %s\n", util.HideAPIKey(projectID))
 	}
 	return &coreauth.Auth{
 		ID:       fileName,


### PR DESCRIPTION
## 背景

手工移植 upstream `router-for-me/CLIProxyAPI` 的安全修复提交：

- `809feb1e fix(antigravity): mask project_id in logs`

Antigravity OAuth / onboarding 流程会获取 `project_id` 并写入 auth metadata。metadata 中保留原值是运行所需，但日志和终端输出不应直接暴露完整项目 ID。

## 改动

- `internal/api/handlers/management/auth_files.go`：Web/Management 发起 Antigravity OAuth 时，日志和终端输出改为 `util.HideAPIKey(projectID)`。
- `internal/auth/antigravity/auth.go`：`OnboardUser` 成功取得 `project_id` 时日志改为脱敏输出。
- `sdk/auth/antigravity.go`：SDK login 成功路径中的日志和终端输出改为脱敏输出。

## LTS 适配说明

- 这是最小化安全移植：只替换输出展示，不改变 Antigravity token exchange、project ID discovery、auth metadata 保存、Management API response shape 或 config schema。
- 上游同批次还有 `33130f18 fix: require antigravity project id`，该提交会改变 project ID 必填语义和 executor/auth conductor 行为，本 PR 未引入该行为，避免把高风险认证语义改动混进日志脱敏修复。
- 未触碰 `internal/usage/`、`/v0/management/usage*`、默认 CPA-Panel-LTS 来源或 release/Docker 配置。

## 验证

已在隔离 worktree `/private/tmp/cpa-lts-antigravity-project-log-mask` 运行：

```bash
gofmt -w internal/api/handlers/management/auth_files.go internal/auth/antigravity/auth.go sdk/auth/antigravity.go
go test -count=1 ./internal/auth/antigravity
go test -count=1 ./sdk/auth
go test -count=1 ./internal/api/handlers/management -run 'Antigravity|Auth'
go build -o test-output ./cmd/server && rm -f test-output
git diff --check
rg -n "obtained project ID|Successfully fetched project_id|Using GCP project" internal/api/handlers/management/auth_files.go internal/auth/antigravity/auth.go sdk/auth/antigravity.go -S
rg -n "CLIProxyAPI/v7|internal/home|Home\\.Enabled|handleHomeCodex|OpenAIImageModelType" --glob '!AGENTS.md' --glob '!internal/**/AGENTS.md' --glob '!sdk/cliproxy/AGENTS.md'
```

说明：`internal/auth/antigravity` 当前无 test files；最后一个 v7/Home guard 无命中，返回码为 1，符合预期。
