### PR TITLE
feat(redis): 支持 usage 队列 Pub/Sub 订阅

### DIFF
--- a/internal/api/redis_queue_protocol.go
+++ b/internal/api/redis_queue_protocol.go
@@ -14,6 +14,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const redisUsageChannel = "usage"
+
+type redisSubscriptionCommand struct {
+	args []string
+	err  error
+}
+
 func isRedisRESPPrefix(prefix byte) bool {
 	switch prefix {
 	case '*', '$', '+', '-', ':':
@@ -125,6 +132,41 @@ func (s *Server) handleRedisConnection(conn net.Conn, reader *bufio.Reader) {
 			if !flush() {
 				return
 			}
+		case "SUBSCRIBE":
+			if !authed {
+				_ = writeRedisError(writer, "NOAUTH Authentication required.")
+				if !flush() {
+					return
+				}
+				continue
+			}
+			channel, ok := parseSubscribeChannel(args)
+			if !ok {
+				_ = writeRedisError(writer, "ERR wrong number of arguments for 'subscribe' command")
+				if !flush() {
+					return
+				}
+				continue
+			}
+			if !strings.EqualFold(channel, redisUsageChannel) {
+				_ = writeRedisError(writer, fmt.Sprintf("ERR unsupported channel '%s'", channel))
+				if !flush() {
+					return
+				}
+				continue
+			}
+			messages, unsubscribe := redisqueue.SubscribeUsage()
+			if err := writeRedisPubSubSubscribe(writer, redisUsageChannel, 1); err != nil {
+				unsubscribe()
+				log.Errorf("redis protocol subscribe response error: %v", err)
+				return
+			}
+			if !flush() {
+				unsubscribe()
+				return
+			}
+			s.streamRedisUsageSubscription(reader, writer, messages, unsubscribe)
+			return
 		case "LPOP", "RPOP":
 			if !authed {
 				_ = writeRedisError(writer, "NOAUTH Authentication required.")
@@ -176,6 +218,101 @@ func (s *Server) handleRedisConnection(conn net.Conn, reader *bufio.Reader) {
 	}
 }
 
+func (s *Server) streamRedisUsageSubscription(reader *bufio.Reader, writer *bufio.Writer, messages <-chan []byte, unsubscribe func()) {
+	if unsubscribe == nil {
+		return
+	}
+	defer unsubscribe()
+
+	done := make(chan struct{})
+	defer close(done)
+
+	commands := make(chan redisSubscriptionCommand, 1)
+	go readRedisSubscriptionCommands(reader, commands, done)
+
+	for {
+		select {
+		case msg, ok := <-messages:
+			if !ok {
+				return
+			}
+			if err := writeRedisPubSubMessage(writer, redisUsageChannel, msg); err != nil {
+				log.Errorf("redis protocol publish message error: %v", err)
+				return
+			}
+			if err := writer.Flush(); err != nil {
+				log.Errorf("redis protocol flush error: %v", err)
+				return
+			}
+		case command, ok := <-commands:
+			if !ok {
+				return
+			}
+			keepOpen := handleRedisSubscriptionCommand(writer, command)
+			if err := writer.Flush(); err != nil {
+				log.Errorf("redis protocol flush error: %v", err)
+				return
+			}
+			if !keepOpen {
+				return
+			}
+		}
+	}
+}
+
+func readRedisSubscriptionCommands(reader *bufio.Reader, commands chan<- redisSubscriptionCommand, done <-chan struct{}) {
+	defer close(commands)
+
+	for {
+		args, err := readRESPArray(reader)
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				select {
+				case commands <- redisSubscriptionCommand{err: err}:
+				case <-done:
+				}
+			}
+			return
+		}
+		select {
+		case commands <- redisSubscriptionCommand{args: args}:
+		case <-done:
+			return
+		}
+	}
+}
+
+func handleRedisSubscriptionCommand(writer *bufio.Writer, command redisSubscriptionCommand) bool {
+	if command.err != nil {
+		_ = writeRedisError(writer, "ERR "+command.err.Error())
+		return false
+	}
+	if len(command.args) == 0 {
+		_ = writeRedisError(writer, "ERR empty command")
+		return true
+	}
+
+	cmd := strings.ToUpper(strings.TrimSpace(command.args[0]))
+	switch cmd {
+	case "PING":
+		payload := []byte(nil)
+		if len(command.args) > 1 {
+			payload = []byte(command.args[1])
+		}
+		_ = writeRedisPubSubPong(writer, payload)
+		return true
+	case "UNSUBSCRIBE":
+		_ = writeRedisPubSubUnsubscribe(writer, redisUsageChannel, 0)
+		return false
+	case "QUIT":
+		_ = writeRedisSimpleString(writer, "OK")
+		return false
+	default:
+		_ = writeRedisError(writer, fmt.Sprintf("ERR unknown command '%s'", strings.ToLower(cmd)))
+		return true
+	}
+}
+
 func resolveRemoteIP(addr net.Addr) (ip string, localClient bool) {
 	if addr == nil {
 		return "", false
@@ -224,6 +361,13 @@ func parseAuthPassword(args []string) (string, bool) {
 	default:
 		return "", false
 	}
+}
+
+func parseSubscribeChannel(args []string) (string, bool) {
+	if len(args) != 2 {
+		return "", false
+	}
+	return strings.TrimSpace(args[1]), true
 }
 
 func parsePopCount(args []string) (count int, hasCount bool, ok bool) {
@@ -368,4 +512,69 @@ func writeRedisArrayOfBulkStrings(writer *bufio.Writer, items [][]byte) error {
 		}
 	}
 	return nil
+}
+
+func writeRedisInteger(writer *bufio.Writer, value int) error {
+	if writer == nil {
+		return net.ErrClosed
+	}
+	_, err := writer.WriteString(":" + strconv.Itoa(value) + "\r\n")
+	return err
+}
+
+func writeRedisArrayHeader(writer *bufio.Writer, count int) error {
+	if writer == nil {
+		return net.ErrClosed
+	}
+	_, err := writer.WriteString("*" + strconv.Itoa(count) + "\r\n")
+	return err
+}
+
+func writeRedisPubSubSubscribe(writer *bufio.Writer, channel string, count int) error {
+	if err := writeRedisArrayHeader(writer, 3); err != nil {
+		return err
+	}
+	if err := writeRedisBulkString(writer, []byte("subscribe")); err != nil {
+		return err
+	}
+	if err := writeRedisBulkString(writer, []byte(channel)); err != nil {
+		return err
+	}
+	return writeRedisInteger(writer, count)
+}
+
+func writeRedisPubSubUnsubscribe(writer *bufio.Writer, channel string, count int) error {
+	if err := writeRedisArrayHeader(writer, 3); err != nil {
+		return err
+	}
+	if err := writeRedisBulkString(writer, []byte("unsubscribe")); err != nil {
+		return err
+	}
+	if err := writeRedisBulkString(writer, []byte(channel)); err != nil {
+		return err
+	}
+	return writeRedisInteger(writer, count)
+}
+
+func writeRedisPubSubMessage(writer *bufio.Writer, channel string, payload []byte) error {
+	if err := writeRedisArrayHeader(writer, 3); err != nil {
+		return err
+	}
+	if err := writeRedisBulkString(writer, []byte("message")); err != nil {
+		return err
+	}
+	if err := writeRedisBulkString(writer, []byte(channel)); err != nil {
+		return err
+	}
+	return writeRedisBulkString(writer, payload)
+}
+
+func writeRedisPubSubPong(writer *bufio.Writer, payload []byte) error {
+	if err := writeRedisArrayHeader(writer, 2); err != nil {
+		return err
+	}
+	if err := writeRedisBulkString(writer, []byte("pong")); err != nil {
+		return err
+	}
+	return writeRedisBulkString(writer, payload)
 }

--- a/internal/api/redis_queue_protocol_integration_test.go
+++ b/internal/api/redis_queue_protocol_integration_test.go
@@ -171,6 +171,105 @@ func readRESPArrayOfBulkStrings(r *bufio.Reader) ([][]byte, error) {
 	return out, nil
 }
 
+func readTestRESPInteger(r *bufio.Reader) (int, error) {
+	prefix, err := r.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	if prefix != ':' {
+		return 0, fmt.Errorf("expected integer prefix ':', got %q", prefix)
+	}
+
+	line, err := readTestRESPLine(r)
+	if err != nil {
+		return 0, err
+	}
+	value, err := strconv.Atoi(line)
+	if err != nil {
+		return 0, fmt.Errorf("invalid integer %q: %v", line, err)
+	}
+	return value, nil
+}
+
+func readTestRESPArrayHeader(r *bufio.Reader) (int, error) {
+	prefix, err := r.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	if prefix != '*' {
+		return 0, fmt.Errorf("expected array prefix '*', got %q", prefix)
+	}
+
+	line, err := readTestRESPLine(r)
+	if err != nil {
+		return 0, err
+	}
+	count, err := strconv.Atoi(line)
+	if err != nil {
+		return 0, fmt.Errorf("invalid array length %q: %v", line, err)
+	}
+	if count < 0 {
+		return 0, fmt.Errorf("invalid array length %d", count)
+	}
+	return count, nil
+}
+
+func readTestRESPPubSubSubscribe(r *bufio.Reader) (string, int, error) {
+	count, err := readTestRESPArrayHeader(r)
+	if err != nil {
+		return "", 0, err
+	}
+	if count != 3 {
+		return "", 0, fmt.Errorf("subscribe array length = %d, want 3", count)
+	}
+
+	kind, err := readTestRESPBulkString(r)
+	if err != nil {
+		return "", 0, err
+	}
+	if string(kind) != "subscribe" {
+		return "", 0, fmt.Errorf("pubsub kind = %q, want subscribe", string(kind))
+	}
+
+	channel, err := readTestRESPBulkString(r)
+	if err != nil {
+		return "", 0, err
+	}
+	subscriptions, err := readTestRESPInteger(r)
+	if err != nil {
+		return "", 0, err
+	}
+	return string(channel), subscriptions, nil
+}
+
+func readTestRESPPubSubMessage(r *bufio.Reader) (string, []byte, error) {
+	count, err := readTestRESPArrayHeader(r)
+	if err != nil {
+		return "", nil, err
+	}
+	if count != 3 {
+		return "", nil, fmt.Errorf("message array length = %d, want 3", count)
+	}
+
+	kind, err := readTestRESPBulkString(r)
+	if err != nil {
+		return "", nil, err
+	}
+	if string(kind) != "message" {
+		return "", nil, fmt.Errorf("pubsub kind = %q, want message", string(kind))
+	}
+
+	channel, err := readTestRESPBulkString(r)
+	if err != nil {
+		return "", nil, err
+	}
+	payload, err := readTestRESPBulkString(r)
+	if err != nil {
+		return "", nil, err
+	}
+	return string(channel), payload, nil
+}
+
 func TestRedisProtocol_ManagementDisabled_RejectsConnection(t *testing.T) {
 	t.Setenv("MANAGEMENT_PASSWORD", "")
 	redisqueue.SetEnabled(false)
@@ -312,6 +411,91 @@ func TestRedisProtocol_AUTH_And_PopContracts(t *testing.T) {
 	}
 	if len(emptyItems) != 0 {
 		t.Fatalf("expected empty array for empty queue with count, got %#v", emptyItems)
+	}
+}
+
+func TestRedisProtocol_SubscribeUsageBroadcastsAndRetainsQueue(t *testing.T) {
+	const managementPassword = "test-management-password"
+
+	t.Setenv("MANAGEMENT_PASSWORD", managementPassword)
+	redisqueue.SetEnabled(false)
+	t.Cleanup(func() { redisqueue.SetEnabled(false) })
+
+	server := newTestServer(t)
+	if !server.managementRoutesEnabled.Load() {
+		t.Fatalf("expected managementRoutesEnabled to be true")
+	}
+
+	addr, stop := startRedisMuxListener(t, server)
+	t.Cleanup(stop)
+
+	subConn, errDialSub := net.DialTimeout("tcp", addr, time.Second)
+	if errDialSub != nil {
+		t.Fatalf("failed to dial subscriber redis listener: %v", errDialSub)
+	}
+	t.Cleanup(func() { _ = subConn.Close() })
+	subReader := bufio.NewReader(subConn)
+	_ = subConn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	if errWrite := writeTestRESPCommand(subConn, "SUBSCRIBE", "usage"); errWrite != nil {
+		t.Fatalf("failed to write unauthenticated SUBSCRIBE command: %v", errWrite)
+	}
+	if msg, err := readTestRESPError(subReader); err != nil {
+		t.Fatalf("failed to read SUBSCRIBE NOAUTH error: %v", err)
+	} else if msg != "NOAUTH Authentication required." {
+		t.Fatalf("unexpected SUBSCRIBE NOAUTH error: %q", msg)
+	}
+
+	if errWrite := writeTestRESPCommand(subConn, "AUTH", managementPassword); errWrite != nil {
+		t.Fatalf("failed to write subscriber AUTH command: %v", errWrite)
+	}
+	if msg, err := readTestRESPSimpleString(subReader); err != nil {
+		t.Fatalf("failed to read subscriber AUTH response: %v", err)
+	} else if msg != "OK" {
+		t.Fatalf("unexpected subscriber AUTH response: %q", msg)
+	}
+	if errWrite := writeTestRESPCommand(subConn, "SUBSCRIBE", "usage"); errWrite != nil {
+		t.Fatalf("failed to write SUBSCRIBE command: %v", errWrite)
+	}
+	if channel, count, err := readTestRESPPubSubSubscribe(subReader); err != nil {
+		t.Fatalf("failed to read SUBSCRIBE response: %v", err)
+	} else if channel != "usage" || count != 1 {
+		t.Fatalf("unexpected SUBSCRIBE response channel=%q count=%d", channel, count)
+	}
+
+	redisqueue.Enqueue([]byte(`{"id":1}`))
+
+	if channel, payload, err := readTestRESPPubSubMessage(subReader); err != nil {
+		t.Fatalf("failed to read pubsub message: %v", err)
+	} else if channel != "usage" || string(payload) != `{"id":1}` {
+		t.Fatalf("unexpected pubsub message channel=%q payload=%q", channel, string(payload))
+	}
+
+	popConn, errDialPop := net.DialTimeout("tcp", addr, time.Second)
+	if errDialPop != nil {
+		t.Fatalf("failed to dial pop redis listener: %v", errDialPop)
+	}
+	t.Cleanup(func() { _ = popConn.Close() })
+	popReader := bufio.NewReader(popConn)
+	_ = popConn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	if errWrite := writeTestRESPCommand(popConn, "AUTH", managementPassword); errWrite != nil {
+		t.Fatalf("failed to write pop AUTH command: %v", errWrite)
+	}
+	if msg, err := readTestRESPSimpleString(popReader); err != nil {
+		t.Fatalf("failed to read pop AUTH response: %v", err)
+	} else if msg != "OK" {
+		t.Fatalf("unexpected pop AUTH response: %q", msg)
+	}
+	if errWrite := writeTestRESPCommand(popConn, "LPOP", "usage"); errWrite != nil {
+		t.Fatalf("failed to write pop LPOP command: %v", errWrite)
+	}
+	item, errItem := readTestRESPBulkString(popReader)
+	if errItem != nil {
+		t.Fatalf("failed to read pop LPOP response: %v", errItem)
+	}
+	if string(item) != `{"id":1}` {
+		t.Fatalf("expected subscribed usage to remain queued, got %q", string(item))
 	}
 }
 

--- a/internal/redisqueue/queue.go
+++ b/internal/redisqueue/queue.go
@@ -9,6 +9,7 @@ import (
 const (
 	defaultRetentionSeconds int64 = 60
 	maxRetentionSeconds     int64 = 3600
+	usageSubscriberBuffer         = 256
 )
 
 type queueItem struct {
@@ -17,9 +18,11 @@ type queueItem struct {
 }
 
 type queue struct {
-	mu    sync.Mutex
-	items []queueItem
-	head  int
+	mu               sync.Mutex
+	items            []queueItem
+	head             int
+	subscribers      map[uint64]chan []byte
+	nextSubscriberID uint64
 }
 
 var (
@@ -60,6 +63,7 @@ func Enqueue(payload []byte) {
 	if len(payload) == 0 {
 		return
 	}
+	global.publishToSubscribers(payload)
 	global.enqueue(payload)
 }
 
@@ -73,11 +77,25 @@ func PopOldest(count int) [][]byte {
 	return global.popOldest(count)
 }
 
+func SubscribeUsage() (<-chan []byte, func()) {
+	return global.subscribeUsage()
+}
+
 func (q *queue) clear() {
 	q.mu.Lock()
-	defer q.mu.Unlock()
+
+	subscribers := make([]chan []byte, 0, len(q.subscribers))
+	for _, subscriber := range q.subscribers {
+		subscribers = append(subscribers, subscriber)
+	}
 	q.items = nil
 	q.head = 0
+	q.subscribers = nil
+	q.mu.Unlock()
+
+	for _, subscriber := range subscribers {
+		close(subscriber)
+	}
 }
 
 func (q *queue) enqueue(payload []byte) {
@@ -92,6 +110,55 @@ func (q *queue) enqueue(payload []byte) {
 		payload:    append([]byte(nil), payload...),
 	})
 	q.maybeCompactLocked()
+}
+
+func (q *queue) publishToSubscribers(payload []byte) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	for id, subscriber := range q.subscribers {
+		cloned := append([]byte(nil), payload...)
+		select {
+		case subscriber <- cloned:
+		default:
+			delete(q.subscribers, id)
+			close(subscriber)
+		}
+	}
+}
+
+func (q *queue) subscribeUsage() (<-chan []byte, func()) {
+	subscriber := make(chan []byte, usageSubscriberBuffer)
+
+	q.mu.Lock()
+	if q.subscribers == nil {
+		q.subscribers = make(map[uint64]chan []byte)
+	}
+	q.nextSubscriberID++
+	id := q.nextSubscriberID
+	q.subscribers[id] = subscriber
+	q.mu.Unlock()
+
+	var once sync.Once
+	unsubscribe := func() {
+		once.Do(func() {
+			q.unsubscribeUsage(id)
+		})
+	}
+	return subscriber, unsubscribe
+}
+
+func (q *queue) unsubscribeUsage(id uint64) {
+	q.mu.Lock()
+	subscriber, ok := q.subscribers[id]
+	if ok {
+		delete(q.subscribers, id)
+	}
+	q.mu.Unlock()
+
+	if ok {
+		close(subscriber)
+	}
 }
 
 func (q *queue) popOldest(count int) [][]byte {

--- a/internal/redisqueue/queue_test.go
+++ b/internal/redisqueue/queue_test.go
@@ -63,6 +63,52 @@ func TestQueueRetentionSecondsDefaultsAndClamps(t *testing.T) {
 	})
 }
 
+func TestSubscribeUsageBroadcastsAndRetainsQueue(t *testing.T) {
+	withQueueState(t, func() {
+		messages, unsubscribe := SubscribeUsage()
+		defer unsubscribe()
+
+		payload := []byte("usage-event")
+		Enqueue(payload)
+		payload[0] = 'X'
+
+		select {
+		case got, ok := <-messages:
+			if !ok {
+				t.Fatal("subscriber channel closed")
+			}
+			if string(got) != "usage-event" {
+				t.Fatalf("subscriber payload = %q, want usage-event", got)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for subscriber payload")
+		}
+
+		items := PopOldest(1)
+		if len(items) != 1 || string(items[0]) != "usage-event" {
+			t.Fatalf("queued payload = %q, want [usage-event]", items)
+		}
+	})
+}
+
+func TestSubscribeUsageClosesWhenQueueDisabled(t *testing.T) {
+	withQueueState(t, func() {
+		messages, unsubscribe := SubscribeUsage()
+		defer unsubscribe()
+
+		SetEnabled(false)
+
+		select {
+		case _, ok := <-messages:
+			if ok {
+				t.Fatal("subscriber channel remained open after queue disable")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for subscriber close")
+		}
+	})
+}
+
 func withQueueState(t *testing.T, fn func()) {
 	t.Helper()
 


### PR DESCRIPTION
## 背景

选择性吸收 upstream Redis usage Pub/Sub 能力，参考来源：

- `1d529c3c feat(redis): implement Pub/Sub support for usage tracking`
- `a726e373 feat(redis): enhance Redis protocol handling with subscription and queue operations`

这不是直接同步 upstream：upstream 当前实现包含 v7/Home 方向差异，并且在存在订阅者时会只广播、不入队。LTS 目标是增加能力、少减旧功能，因此本 PR 采用 LTS 适配语义：新增 `SUBSCRIBE usage` live broadcast，同时继续保留现有 `LPOP` / `RPOP` 队列消费能力。

## 改动

- Redis RESP 协议新增鉴权后的 `SUBSCRIBE usage`。
- 支持 Redis Pub/Sub frame：`subscribe` ack、`message` broadcast、订阅态下的 `PING` / `UNSUBSCRIBE` / `QUIT`。
- `internal/redisqueue` 增加 subscriber 管理：订阅者会收到 usage payload 的 clone，慢订阅者会被移除，队列禁用时关闭订阅 channel。
- 保留 LTS 既有队列语义：`Enqueue` 会广播给订阅者，同时仍然写入队列，现有轮询消费者不被削弱。
- 增加 queue 单元测试和 Redis protocol 集成测试，覆盖未鉴权订阅拒绝、订阅 ack、live broadcast 和 queue retention。

## LTS 兼容性检查

- 未触碰 `internal/usage/` 的统计存储、import/export 或 `/v0/management/usage*` 接口。
- 未引入 `internal/home`、`-home-jwt`、`Home.Enabled` 或 v7 module path。
- 保留 `github.com/router-for-me/CLIProxyAPI/v6` module path。
- 保留 Management key 鉴权和 IP ban 逻辑；`SUBSCRIBE` 与 `LPOP/RPOP` 一样必须先 `AUTH`。

## 验证

- `go test -count=1 ./internal/redisqueue`
- `go test -count=1 ./internal/api -run 'RedisProtocol|ProtocolMux|ManagementDisabled|IPBan'`
- `go test -count=1 ./internal/api/handlers/management -run 'UsageQueue|usage'`
- `go test -count=1 ./internal/usage`
- `go test -count=1 ./internal/api ./internal/redisqueue ./internal/usage`
- `go build -o test-output ./cmd/server && rm -f test-output`
- `go test -count=1 ./...`
- `git diff --check`
- v7/Home guard search: `CLIProxyAPI/v7|internal/home|Home\.Enabled|handleHomeCodex|OpenAIImageModelType` 无命中
