### PR TITLE
feat(api): 支持 zstd request log 解码并补齐 payload diff

### DIFF
--- a/internal/api/middleware/request_logging.go
+++ b/internal/api/middleware/request_logging.go
@@ -5,12 +5,14 @@ package middleware
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/klauspost/compress/zstd"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 )
@@ -136,7 +138,7 @@ func captureRequestInfo(c *gin.Context, captureBody bool) (*RequestInfo, error) 
 
 		// Restore the body for the actual request processing
 		c.Request.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
-		body = bodyBytes
+		body = decodeCapturedRequestBodyForLog(bodyBytes, c.Request.Header.Get("Content-Encoding"))
 	}
 
 	return &RequestInfo{
@@ -147,6 +149,58 @@ func captureRequestInfo(c *gin.Context, captureBody bool) (*RequestInfo, error) 
 		RequestID: logging.GetGinRequestID(c),
 		Timestamp: time.Now(),
 	}, nil
+}
+
+func decodeCapturedRequestBodyForLog(raw []byte, encoding string) []byte {
+	if len(raw) == 0 {
+		return raw
+	}
+
+	decoded, errDecode := decodeCapturedRequestBody(raw, encoding)
+	if errDecode != nil {
+		return raw
+	}
+	return decoded
+}
+
+func decodeCapturedRequestBody(raw []byte, encoding string) ([]byte, error) {
+	encoding = strings.TrimSpace(encoding)
+	if encoding == "" || strings.EqualFold(encoding, "identity") {
+		return raw, nil
+	}
+
+	parts := strings.Split(encoding, ",")
+	body := raw
+	for i := len(parts) - 1; i >= 0; i-- {
+		enc := strings.ToLower(strings.TrimSpace(parts[i]))
+		switch enc {
+		case "", "identity":
+			continue
+		case "zstd":
+			decoded, errDecode := decodeCapturedZstdRequestBody(body)
+			if errDecode != nil {
+				return nil, errDecode
+			}
+			body = decoded
+		default:
+			return nil, fmt.Errorf("unsupported request content encoding: %s", enc)
+		}
+	}
+	return body, nil
+}
+
+func decodeCapturedZstdRequestBody(raw []byte) ([]byte, error) {
+	decoder, errNewReader := zstd.NewReader(bytes.NewReader(raw))
+	if errNewReader != nil {
+		return nil, fmt.Errorf("failed to create zstd request decoder: %w", errNewReader)
+	}
+	defer decoder.Close()
+
+	decoded, errRead := io.ReadAll(decoder)
+	if errRead != nil {
+		return nil, fmt.Errorf("failed to decode zstd request body: %w", errRead)
+	}
+	return decoded, nil
 }
 
 // shouldLogRequest determines whether the request should be logged.

--- a/internal/api/middleware/request_logging_test.go
+++ b/internal/api/middleware/request_logging_test.go
@@ -1,11 +1,16 @@
 package middleware
 
 import (
+	"bytes"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/klauspost/compress/zstd"
 )
 
 func TestShouldSkipMethodForRequestLogging(t *testing.T) {
@@ -134,5 +139,45 @@ func TestShouldCaptureRequestBody(t *testing.T) {
 		if got != tests[i].want {
 			t.Fatalf("%s: got %t, want %t", tests[i].name, got, tests[i].want)
 		}
+	}
+}
+
+func TestCaptureRequestInfoDecodesZstdRequestBodyForLog(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	payload := []byte(`{"model":"test-model","stream":true}`)
+	var compressed bytes.Buffer
+	encoder, errNewWriter := zstd.NewWriter(&compressed)
+	if errNewWriter != nil {
+		t.Fatalf("zstd.NewWriter: %v", errNewWriter)
+	}
+	if _, errWrite := encoder.Write(payload); errWrite != nil {
+		t.Fatalf("zstd write: %v", errWrite)
+	}
+	if errClose := encoder.Close(); errClose != nil {
+		t.Fatalf("zstd close: %v", errClose)
+	}
+	compressedBytes := compressed.Bytes()
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(compressedBytes))
+	req.Header.Set("Content-Encoding", "zstd")
+	c.Request = req
+
+	info, errCapture := captureRequestInfo(c, true)
+	if errCapture != nil {
+		t.Fatalf("captureRequestInfo: %v", errCapture)
+	}
+	if !bytes.Equal(info.Body, payload) {
+		t.Fatalf("logged request body = %q, want %q", string(info.Body), string(payload))
+	}
+
+	restoredBody, errRead := io.ReadAll(c.Request.Body)
+	if errRead != nil {
+		t.Fatalf("read restored request body: %v", errRead)
+	}
+	if !bytes.Equal(restoredBody, compressedBytes) {
+		t.Fatal("request body was not restored with the original compressed bytes")
 	}
 }

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -93,6 +93,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.Routing.Strategy != newCfg.Routing.Strategy {
 		changes = append(changes, fmt.Sprintf("routing.strategy: %s -> %s", oldCfg.Routing.Strategy, newCfg.Routing.Strategy))
 	}
+	if !reflect.DeepEqual(oldCfg.Payload, newCfg.Payload) {
+		changes = appendPayloadConfigChanges(changes, oldCfg.Payload, newCfg.Payload)
+	}
 
 	// API keys (redacted) and counts
 	if len(oldCfg.APIKeys) != len(newCfg.APIKeys) {
@@ -336,6 +339,29 @@ func trimStrings(in []string) []string {
 		out[i] = strings.TrimSpace(in[i])
 	}
 	return out
+}
+
+func appendPayloadConfigChanges(changes []string, oldPayload, newPayload config.PayloadConfig) []string {
+	changes = appendPayloadRuleChanges(changes, "default", oldPayload.Default, newPayload.Default)
+	changes = appendPayloadRuleChanges(changes, "default-raw", oldPayload.DefaultRaw, newPayload.DefaultRaw)
+	changes = appendPayloadRuleChanges(changes, "override", oldPayload.Override, newPayload.Override)
+	changes = appendPayloadRuleChanges(changes, "override-raw", oldPayload.OverrideRaw, newPayload.OverrideRaw)
+	changes = appendPayloadFilterRuleChanges(changes, "filter", oldPayload.Filter, newPayload.Filter)
+	return changes
+}
+
+func appendPayloadRuleChanges(changes []string, section string, oldRules, newRules []config.PayloadRule) []string {
+	if reflect.DeepEqual(oldRules, newRules) {
+		return changes
+	}
+	return append(changes, fmt.Sprintf("payload.%s: updated (%d -> %d rules)", section, len(oldRules), len(newRules)))
+}
+
+func appendPayloadFilterRuleChanges(changes []string, section string, oldRules, newRules []config.PayloadFilterRule) []string {
+	if reflect.DeepEqual(oldRules, newRules) {
+		return changes
+	}
+	return append(changes, fmt.Sprintf("payload.%s: updated (%d -> %d rules)", section, len(oldRules), len(newRules)))
 }
 
 func equalStringMap(a, b map[string]string) bool {

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -102,6 +102,80 @@ func TestBuildConfigChangeDetails(t *testing.T) {
 	expectContains(t, details, "  provider updated: compat-a (models 1 -> 2)")
 }
 
+func TestBuildConfigChangeDetails_PayloadRules(t *testing.T) {
+	oldCfg := &config.Config{
+		Payload: config.PayloadConfig{
+			Default: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "gpt-*", Protocol: "responses"}},
+					Params: map[string]any{"temperature": 0.2},
+				},
+			},
+			DefaultRaw: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "claude-*", Protocol: "anthropic"}},
+					Params: map[string]any{"metadata": `{"source":"old"}`},
+				},
+			},
+			Override: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "gemini-*", Protocol: "gemini"}},
+					Params: map[string]any{"top_p": 0.9},
+				},
+			},
+			OverrideRaw: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "xai-*", Protocol: "responses"}},
+					Params: map[string]any{"extra": `{"old":true}`},
+				},
+			},
+			Filter: []config.PayloadFilterRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "codex-*", Protocol: "responses"}},
+					Params: []string{"stream_options.include_usage"},
+				},
+			},
+		},
+	}
+	newCfg := &config.Config{
+		Payload: config.PayloadConfig{
+			Default: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "gpt-*", Protocol: "responses"}},
+					Params: map[string]any{"temperature": 0.3},
+				},
+				{
+					Models: []config.PayloadModelRule{{Name: "o*", Protocol: "responses"}},
+					Params: map[string]any{"reasoning.effort": "medium"},
+				},
+			},
+			Override: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "gemini-*", Protocol: "gemini"}},
+					Params: map[string]any{"top_p": 0.8},
+				},
+			},
+			OverrideRaw: []config.PayloadRule{
+				{
+					Models: []config.PayloadModelRule{{Name: "xai-*", Protocol: "responses"}},
+					Params: map[string]any{"extra": `{"new":true}`},
+				},
+				{
+					Models: []config.PayloadModelRule{{Name: "*", Protocol: "responses"}},
+					Params: map[string]any{"metadata": `{"trace":true}`},
+				},
+			},
+		},
+	}
+
+	details := BuildConfigChangeDetails(oldCfg, newCfg)
+	expectContains(t, details, "payload.default: updated (1 -> 2 rules)")
+	expectContains(t, details, "payload.default-raw: updated (1 -> 0 rules)")
+	expectContains(t, details, "payload.override: updated (1 -> 1 rules)")
+	expectContains(t, details, "payload.override-raw: updated (1 -> 2 rules)")
+	expectContains(t, details, "payload.filter: updated (1 -> 0 rules)")
+}
+
 func TestBuildConfigChangeDetails_NoChanges(t *testing.T) {
 	cfg := &config.Config{
 		Port: 8080,


### PR DESCRIPTION
## 背景

从上游 `router-for-me/CLIProxyAPI` 的 `82c9e0de feat(api, watcher): add zstd decoding for request logs and payload diff support` 中选择性移植 LTS-safe 子集。

该上游提交还包含 `sdk/cliproxy/service.go` 里的 Home/v7 相关 hook；本 PR 明确排除该部分，只保留与 LTS 兼容的 request logging 和 watcher diff 行为。

## 变更内容

- 在 `internal/api/middleware` 捕获 request log body 时识别 `Content-Encoding: zstd`，日志记录使用解压后的正文。
- 保持实际请求处理使用原始 body：捕获后仍把 `c.Request.Body` 恢复为原始压缩字节，避免影响后续 handler。
- 在 `internal/watcher/diff` 中补齐 `payload.default`、`payload.default-raw`、`payload.override`、`payload.override-raw`、`payload.filter` 的配置差异摘要。
- 新增针对 zstd request body 日志解码和 payload diff 输出的回归测试。

## LTS 兼容性边界

- 未引入 `CLIProxyAPI/v7` import。
- 未引入 `internal/home`、`Home.Enabled` 或 `registerHomeExecutors`。
- 未修改 `internal/usage/`、`usage-statistics-enabled` 或 `/v0/management/usage*` endpoints。
- payload diff 只输出规则数量摘要，不打印 `Params` 具体值，避免把配置参数内容直接写进 reload 日志。

## 验证

- `gofmt -w internal/api/middleware/request_logging.go internal/api/middleware/request_logging_test.go internal/watcher/diff/config_diff.go internal/watcher/diff/config_diff_test.go`
- `go test -count=1 ./internal/api/middleware ./internal/watcher/diff`
- `go test -count=1 ./internal/api ./internal/watcher`
- `go build -o test-output ./cmd/server && rm -f test-output`
- `git diff --check`
- `go test -count=1 ./...`
- `rg -n "CLIProxyAPI/v7|internal/home|Home\\.Enabled|registerHomeExecutors" --glob '!AGENTS.md' --glob '!internal/**/AGENTS.md' --glob '!sdk/cliproxy/AGENTS.md'` 无匹配
