### PR TITLE
fix(auth): 持久化 disabled 标记到 token stores

### DIFF
--- a/internal/store/auth_metadata.go
+++ b/internal/store/auth_metadata.go
@@ -1,0 +1,22 @@
+package store
+
+import cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+
+func ensureDisabledMetadata(auth *cliproxyauth.Auth) map[string]any {
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	auth.Metadata["disabled"] = auth.Disabled
+	return auth.Metadata
+}
+
+func applyDisabledMetadata(auth *cliproxyauth.Auth, metadata map[string]any) {
+	if auth == nil || metadata == nil {
+		return
+	}
+	disabled, _ := metadata["disabled"].(bool)
+	auth.Disabled = disabled
+	if disabled {
+		auth.Status = cliproxyauth.StatusDisabled
+	}
+}

--- a/internal/store/auth_metadata_test.go
+++ b/internal/store/auth_metadata_test.go
@@ -1,0 +1,83 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestEnsureDisabledMetadataInitializesAndStoresFlag(t *testing.T) {
+	auth := &cliproxyauth.Auth{Disabled: true}
+
+	meta := ensureDisabledMetadata(auth)
+	if meta == nil {
+		t.Fatal("ensureDisabledMetadata() returned nil metadata")
+	}
+	if disabled, _ := meta["disabled"].(bool); !disabled {
+		t.Fatalf("disabled=%v, want true", meta["disabled"])
+	}
+
+	auth.Disabled = false
+	meta = ensureDisabledMetadata(auth)
+	if disabled, _ := meta["disabled"].(bool); disabled {
+		t.Fatalf("disabled=%v, want false", meta["disabled"])
+	}
+}
+
+func TestApplyDisabledMetadataMarksAuthDisabled(t *testing.T) {
+	auth := &cliproxyauth.Auth{Status: cliproxyauth.StatusActive}
+
+	applyDisabledMetadata(auth, map[string]any{"disabled": true})
+
+	if !auth.Disabled {
+		t.Fatal("Disabled=false, want true")
+	}
+	if auth.Status != cliproxyauth.StatusDisabled {
+		t.Fatalf("Status=%q, want %q", auth.Status, cliproxyauth.StatusDisabled)
+	}
+}
+
+func TestGitTokenStoreReadAuthFileUsesDisabledMetadata(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "disabled.json")
+	if err := os.WriteFile(path, []byte(`{"type":"test","email":"u@example.com","disabled":true}`), 0o600); err != nil {
+		t.Fatalf("write auth file: %v", err)
+	}
+
+	store := &GitTokenStore{}
+	auth, err := store.readAuthFile(path, dir)
+	if err != nil {
+		t.Fatalf("readAuthFile() error: %v", err)
+	}
+	assertDisabledAuth(t, auth)
+}
+
+func TestObjectTokenStoreReadAuthFileUsesDisabledMetadata(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "disabled.json")
+	if err := os.WriteFile(path, []byte(`{"type":"test","email":"u@example.com","disabled":true}`), 0o600); err != nil {
+		t.Fatalf("write auth file: %v", err)
+	}
+
+	store := &ObjectTokenStore{}
+	auth, err := store.readAuthFile(path, dir)
+	if err != nil {
+		t.Fatalf("readAuthFile() error: %v", err)
+	}
+	assertDisabledAuth(t, auth)
+}
+
+func assertDisabledAuth(t *testing.T, auth *cliproxyauth.Auth) {
+	t.Helper()
+	if auth == nil {
+		t.Fatal("auth=nil, want auth")
+	}
+	if !auth.Disabled {
+		t.Fatal("Disabled=false, want true")
+	}
+	if auth.Status != cliproxyauth.StatusDisabled {
+		t.Fatalf("Status=%q, want %q", auth.Status, cliproxyauth.StatusDisabled)
+	}
+}

--- a/internal/store/gitstore.go
+++ b/internal/store/gitstore.go
@@ -287,11 +287,15 @@ func (s *GitTokenStore) Save(_ context.Context, auth *cliproxyauth.Auth) (string
 
 	switch {
 	case auth.Storage != nil:
+		metadata := ensureDisabledMetadata(auth)
+		if setter, ok := auth.Storage.(interface{ SetMetadata(map[string]any) }); ok {
+			setter.SetMetadata(metadata)
+		}
 		if err = auth.Storage.SaveTokenToFile(path); err != nil {
 			return "", err
 		}
 	case auth.Metadata != nil:
-		raw, errMarshal := json.Marshal(auth.Metadata)
+		raw, errMarshal := json.Marshal(ensureDisabledMetadata(auth))
 		if errMarshal != nil {
 			return "", fmt.Errorf("auth filestore: marshal metadata failed: %w", errMarshal)
 		}
@@ -489,6 +493,7 @@ func (s *GitTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth, 
 		auth.Attributes["email"] = email
 	}
 	cliproxyauth.ApplyCustomHeadersFromMetadata(auth)
+	applyDisabledMetadata(auth, metadata)
 	return auth, nil
 }
 

--- a/internal/store/objectstore.go
+++ b/internal/store/objectstore.go
@@ -184,11 +184,15 @@ func (s *ObjectTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (s
 
 	switch {
 	case auth.Storage != nil:
+		metadata := ensureDisabledMetadata(auth)
+		if setter, ok := auth.Storage.(interface{ SetMetadata(map[string]any) }); ok {
+			setter.SetMetadata(metadata)
+		}
 		if err = auth.Storage.SaveTokenToFile(path); err != nil {
 			return "", err
 		}
 	case auth.Metadata != nil:
-		raw, errMarshal := json.Marshal(auth.Metadata)
+		raw, errMarshal := json.Marshal(ensureDisabledMetadata(auth))
 		if errMarshal != nil {
 			return "", fmt.Errorf("object store: marshal metadata: %w", errMarshal)
 		}
@@ -596,6 +600,7 @@ func (s *ObjectTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Aut
 		NextRefreshAfter: time.Time{},
 	}
 	cliproxyauth.ApplyCustomHeadersFromMetadata(auth)
+	applyDisabledMetadata(auth, metadata)
 	return auth, nil
 }
 

--- a/internal/store/postgresstore.go
+++ b/internal/store/postgresstore.go
@@ -214,11 +214,15 @@ func (s *PostgresStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (stri
 
 	switch {
 	case auth.Storage != nil:
+		metadata := ensureDisabledMetadata(auth)
+		if setter, ok := auth.Storage.(interface{ SetMetadata(map[string]any) }); ok {
+			setter.SetMetadata(metadata)
+		}
 		if err = auth.Storage.SaveTokenToFile(path); err != nil {
 			return "", err
 		}
 	case auth.Metadata != nil:
-		raw, errMarshal := json.Marshal(auth.Metadata)
+		raw, errMarshal := json.Marshal(ensureDisabledMetadata(auth))
 		if errMarshal != nil {
 			return "", fmt.Errorf("postgres store: marshal metadata: %w", errMarshal)
 		}
@@ -311,6 +315,7 @@ func (s *PostgresStore) List(ctx context.Context) ([]*cliproxyauth.Auth, error) 
 			NextRefreshAfter: time.Time{},
 		}
 		cliproxyauth.ApplyCustomHeadersFromMetadata(auth)
+		applyDisabledMetadata(auth, metadata)
 		auths = append(auths, auth)
 	}
 	if err = rows.Err(); err != nil {

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -72,6 +72,10 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 
 	switch {
 	case auth.Storage != nil:
+		if auth.Metadata == nil {
+			auth.Metadata = make(map[string]any)
+		}
+		auth.Metadata["disabled"] = auth.Disabled
 		if setter, ok := auth.Storage.(metadataSetter); ok {
 			setter.SetMetadata(auth.Metadata)
 		}

--- a/sdk/auth/filestore_disabled_test.go
+++ b/sdk/auth/filestore_disabled_test.go
@@ -1,0 +1,64 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+type testTokenStorage struct {
+	meta map[string]any
+}
+
+func (s *testTokenStorage) SetMetadata(meta map[string]any) { s.meta = meta }
+
+func (s *testTokenStorage) SaveTokenToFile(authFilePath string) error {
+	raw, err := json.Marshal(s.meta)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(authFilePath, raw, 0o600)
+}
+
+func TestFileTokenStoreSaveDisabledPersistsFlagForTokenStorage(t *testing.T) {
+	ctx := context.Background()
+	baseDir := t.TempDir()
+	path := filepath.Join(baseDir, "disabled.json")
+
+	if err := os.WriteFile(path, []byte(`{"type":"test","disabled":false}`), 0o600); err != nil {
+		t.Fatalf("seed auth file: %v", err)
+	}
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(baseDir)
+	storage := &testTokenStorage{}
+
+	auth := &cliproxyauth.Auth{
+		ID:       "disabled.json",
+		Provider: "test",
+		FileName: "disabled.json",
+		Disabled: true,
+		Storage:  storage,
+		Metadata: map[string]any{"type": "test"},
+	}
+
+	if _, err := store.Save(ctx, auth); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read auth file: %v", err)
+	}
+	var meta map[string]any
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		t.Fatalf("unmarshal auth file: %v", err)
+	}
+	if disabled, _ := meta["disabled"].(bool); !disabled {
+		t.Fatalf("disabled=%v, want true (raw=%s)", meta["disabled"], string(raw))
+	}
+}


### PR DESCRIPTION
## 背景

上游近期加入了 auth `disabled` 标记的持久化/读回能力。CPA-Core-LTS 当前已经在部分本地 file store 读回 `metadata.disabled`，但仍存在几个缺口：

- `TokenStorage.SetMetadata` 路径没有把 `auth.Disabled` 注入 metadata，provider 自定义存储保存时可能丢失禁用状态。
- `gitstore`、`objectstore`、`postgresstore` 在 metadata 写入时不会显式保存 `disabled`。
- `gitstore`、`objectstore`、`postgresstore` 读回 auth metadata 后没有把 `metadata.disabled=true` 同步到 `Auth.Disabled` / `StatusDisabled`。

## 改动

- 在 `sdk/auth/FileTokenStore` 的 `TokenStorage` 保存路径注入 `metadata["disabled"]`。
- 为 `internal/store` 增加共享 helper，统一写入 `disabled` metadata，并在读回时同步 `Auth.Disabled` / `StatusDisabled`。
- 覆盖 `gitstore`、`objectstore`、`postgresstore` 的 metadata 保存和读回路径。
- 新增 focused regression tests，覆盖 file store 的 `TokenStorage` 路径，以及 internal stores 的 disabled metadata 读回。

## LTS 安全边界

- 保留 Go module path `github.com/router-for-me/CLIProxyAPI/v6`。
- 不触碰 `internal/usage/`、Management usage endpoints 或 `usage-statistics-enabled`。
- 不移植上游 v7/Home/cluster 方向代码。
- 不改变当前 LTS 的 disabled auth 自动刷新语义：`sdk/cliproxy/auth` 仍保持 disabled auth 不参与自动 refresh，相关测试已覆盖。

## 验证

- `gofmt -w sdk/auth/filestore.go sdk/auth/filestore_disabled_test.go internal/store/auth_metadata.go internal/store/auth_metadata_test.go internal/store/gitstore.go internal/store/objectstore.go internal/store/postgresstore.go`
- `go test -count=1 ./sdk/auth ./internal/store ./sdk/cliproxy/auth`
- `go test -count=1 ./internal/watcher ./internal/api/handlers/management`
- `git diff --check`
- `rg -n "CLIProxyAPI/v7|internal/home|Home\\.Enabled|registerHomeExecutors" --glob '!AGENTS.md' --glob '!internal/**/AGENTS.md' --glob '!sdk/cliproxy/AGENTS.md'`
- `go test -count=1 ./...`
- `go build -o test-output ./cmd/server && rm -f test-output`
