### PR TITLE
Selectively port upstream runtime, usage, and model fixes

### DIFF
--- a/internal/api/modules/amp/fallback_handlers.go
+++ b/internal/api/modules/amp/fallback_handlers.go
@@ -252,7 +252,7 @@ func (fh *FallbackHandler) WrapHandler(handler gin.HandlerFunc) gin.HandlerFunc 
 			// Log: Model was mapped to another model
 			log.Debugf("amp model mapping: request %s -> %s", normalizedModel, resolvedModel)
 			logAmpRouting(RouteTypeModelMapping, modelName, resolvedModel, providerName, requestPath)
-			rewriter := NewResponseRewriter(c.Writer, modelName)
+			rewriter := NewResponseRewriterForRequest(c.Writer, modelName, bodyBytes)
 			rewriter.suppressThinking = true
 			c.Writer = rewriter
 			// Filter Anthropic-Beta header only for local handling paths
@@ -267,7 +267,7 @@ func (fh *FallbackHandler) WrapHandler(handler gin.HandlerFunc) gin.HandlerFunc 
 			// Wrap with ResponseRewriter for local providers too, because upstream
 			// proxies (e.g. NewAPI) may return a different model name and lack
 			// Amp-required fields like thinking.signature.
-			rewriter := NewResponseRewriter(c.Writer, modelName)
+			rewriter := NewResponseRewriterForRequest(c.Writer, modelName, bodyBytes)
 			rewriter.suppressThinking = providerName != "claude"
 			c.Writer = rewriter
 			// Filter Anthropic-Beta header only for local handling paths

--- a/internal/api/modules/amp/fallback_handlers_test.go
+++ b/internal/api/modules/amp/fallback_handlers_test.go
@@ -13,6 +13,38 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 )
 
+func TestFallbackHandler_RequestToolCasing_RewritesStreamingResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("test-client-amp-tool-casing", "codex", []*registry.ModelInfo{
+		{ID: "test/gpt-tool-casing", OwnedBy: "openai", Type: "codex"},
+	})
+	defer reg.UnregisterClient("test-client-amp-tool-casing")
+
+	fallback := NewFallbackHandlerWithMapper(func() *httputil.ReverseProxy { return nil }, nil, nil)
+	handler := func(c *gin.Context) {
+		c.Writer.Header().Set("Content-Type", "text/event-stream")
+		_, _ = c.Writer.Write([]byte("event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"name\":\"glob\",\"id\":\"toolu_01\",\"input\":{}}}\n\n"))
+	}
+
+	r := gin.New()
+	r.POST("/messages", fallback.WrapHandler(handler))
+
+	reqBody := []byte(`{"model":"test/gpt-tool-casing","tools":[{"name":"Glob","input_schema":{"type":"object"}}]}`)
+	req := httptest.NewRequest(http.MethodPost, "/messages", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d", w.Code)
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte(`"name":"Glob"`)) {
+		t.Fatalf("expected streaming response to restore glob->Glob, got %s", w.Body.String())
+	}
+}
+
 func TestFallbackHandler_ModelMapping_PreservesThinkingSuffixAndRewritesResponse(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/api/modules/amp/response_rewriter.go
+++ b/internal/api/modules/amp/response_rewriter.go
@@ -22,6 +22,7 @@ type ResponseRewriter struct {
 	originalModel    string
 	isStreaming      bool
 	suppressThinking bool
+	requestToolNames map[string]string
 }
 
 // NewResponseRewriter creates a new response rewriter for model name substitution.
@@ -31,6 +32,12 @@ func NewResponseRewriter(w gin.ResponseWriter, originalModel string) *ResponseRe
 		body:           &bytes.Buffer{},
 		originalModel:  originalModel,
 	}
+}
+
+func NewResponseRewriterForRequest(w gin.ResponseWriter, originalModel string, requestBody []byte) *ResponseRewriter {
+	rw := NewResponseRewriter(w, originalModel)
+	rw.requestToolNames = collectRequestToolNames(requestBody)
+	return rw
 }
 
 const maxBufferedResponseBytes = 2 * 1024 * 1024 // 2MB safety cap
@@ -134,17 +141,70 @@ var ampCanonicalToolNames = map[string]string{
 	"check": "Check",
 }
 
+func collectRequestToolNames(data []byte) map[string]string {
+	if len(data) == 0 {
+		return nil
+	}
+	parsed := gjson.ParseBytes(data)
+	names := map[string]string{}
+	conflicts := map[string]bool{}
+	record := func(name string) {
+		if name == "" {
+			return
+		}
+		key := strings.ToLower(name)
+		if conflicts[key] {
+			return
+		}
+		if existing, exists := names[key]; exists {
+			if existing != name {
+				names[key] = ""
+				conflicts[key] = true
+			}
+			return
+		}
+		names[key] = name
+	}
+
+	for _, tool := range parsed.Get("tools").Array() {
+		record(tool.Get("name").String())
+	}
+	if parsed.Get("tool_choice.type").String() == "tool" {
+		record(parsed.Get("tool_choice.name").String())
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	return names
+}
+
+func canonicalAmpToolName(name string, requestToolNames map[string]string) (string, bool) {
+	key := strings.ToLower(name)
+	if canonical, ok := requestToolNames[key]; ok {
+		if canonical == "" {
+			return "", false
+		}
+		return canonical, true
+	}
+	canonical, ok := ampCanonicalToolNames[key]
+	return canonical, ok
+}
+
 // normalizeAmpToolNames fixes tool_use block names to match Amp's canonical casing.
 // Some upstream models return lowercase tool names (e.g. "bash" instead of "Bash")
 // which causes Amp's case-sensitive mode whitelist to reject them.
 func normalizeAmpToolNames(data []byte) []byte {
+	return normalizeAmpToolNamesForRequest(data, nil)
+}
+
+func normalizeAmpToolNamesForRequest(data []byte, requestToolNames map[string]string) []byte {
 	// Non-streaming: content[].name in tool_use blocks
 	for index, block := range gjson.GetBytes(data, "content").Array() {
 		if block.Get("type").String() != "tool_use" {
 			continue
 		}
 		name := block.Get("name").String()
-		if canonical, ok := ampCanonicalToolNames[strings.ToLower(name)]; ok && name != canonical {
+		if canonical, ok := canonicalAmpToolName(name, requestToolNames); ok && name != canonical {
 			path := fmt.Sprintf("content.%d.name", index)
 			var err error
 			data, err = sjson.SetBytes(data, path, canonical)
@@ -157,7 +217,7 @@ func normalizeAmpToolNames(data []byte) []byte {
 	// Streaming: content_block.name in content_block_start events
 	if gjson.GetBytes(data, "content_block.type").String() == "tool_use" {
 		name := gjson.GetBytes(data, "content_block.name").String()
-		if canonical, ok := ampCanonicalToolNames[strings.ToLower(name)]; ok && name != canonical {
+		if canonical, ok := canonicalAmpToolName(name, requestToolNames); ok && name != canonical {
 			var err error
 			data, err = sjson.SetBytes(data, "content_block.name", canonical)
 			if err != nil {
@@ -167,6 +227,10 @@ func normalizeAmpToolNames(data []byte) []byte {
 	}
 
 	return data
+}
+
+func (rw *ResponseRewriter) normalizeToolNames(data []byte) []byte {
+	return normalizeAmpToolNamesForRequest(data, rw.requestToolNames)
 }
 
 // ensureAmpSignature injects empty signature fields into tool_use/thinking blocks
@@ -225,7 +289,7 @@ func (rw *ResponseRewriter) suppressAmpThinking(data []byte) []byte {
 
 func (rw *ResponseRewriter) rewriteModelInResponse(data []byte) []byte {
 	data = ensureAmpSignature(data)
-	data = normalizeAmpToolNames(data)
+	data = rw.normalizeToolNames(data)
 	data = rw.suppressAmpThinking(data)
 	if len(data) == 0 {
 		return data
@@ -326,7 +390,7 @@ func (rw *ResponseRewriter) rewriteStreamEvent(data []byte) []byte {
 	data = ensureAmpSignature(data)
 
 	// Normalize tool names to canonical casing
-	data = normalizeAmpToolNames(data)
+	data = rw.normalizeToolNames(data)
 
 	// Rewrite model name
 	if rw.originalModel != "" {

--- a/internal/api/modules/amp/response_rewriter_test.go
+++ b/internal/api/modules/amp/response_rewriter_test.go
@@ -217,6 +217,96 @@ func TestNormalizeAmpToolNames_GlobPreserved(t *testing.T) {
 	}
 }
 
+func TestNormalizeAmpToolNames_RequestToolCasing_NonStreaming(t *testing.T) {
+	input := []byte(`{"content":[{"type":"tool_use","id":"toolu_01","name":"glob","input":{"pattern":"*.go"}}]}`)
+	result := normalizeAmpToolNamesForRequest(input, map[string]string{"glob": "Glob"})
+
+	if !contains(result, []byte(`"name":"Glob"`)) {
+		t.Errorf("expected glob->Glob when request advertised Glob, got %s", string(result))
+	}
+}
+
+func TestNormalizeAmpToolNames_RequestToolCasing_Streaming(t *testing.T) {
+	input := []byte(`{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","name":"glob","id":"toolu_01","input":{}}}`)
+	result := normalizeAmpToolNamesForRequest(input, map[string]string{"glob": "Glob"})
+
+	if !contains(result, []byte(`"name":"Glob"`)) {
+		t.Errorf("expected glob->Glob in streaming when request advertised Glob, got %s", string(result))
+	}
+}
+
+func TestResponseRewriter_RequestToolCasingFromBody(t *testing.T) {
+	requestBody := []byte(`{"tools":[{"name":"Glob","input_schema":{"type":"object"}}]}`)
+	rw := &ResponseRewriter{requestToolNames: collectRequestToolNames(requestBody)}
+	input := []byte(`{"content":[{"type":"tool_use","id":"toolu_01","name":"glob","input":{"pattern":"*.go"}}]}`)
+
+	result := rw.rewriteModelInResponse(input)
+
+	if !contains(result, []byte(`"name":"Glob"`)) {
+		t.Errorf("expected request body casing to restore glob->Glob, got %s", string(result))
+	}
+}
+
+func TestResponseRewriter_LowercaseNativeRequestPreserved(t *testing.T) {
+	requestBody := []byte(`{"tools":[{"name":"glob","input_schema":{"type":"object"}}]}`)
+	rw := &ResponseRewriter{requestToolNames: collectRequestToolNames(requestBody)}
+	input := []byte(`{"content":[{"type":"tool_use","id":"toolu_01","name":"glob","input":{"pattern":"*.go"}}]}`)
+
+	result := rw.rewriteModelInResponse(input)
+
+	if string(result) == string(input) {
+		return
+	}
+	if !contains(result, []byte(`"name":"glob"`)) {
+		t.Errorf("expected lowercase-native request to preserve glob, got %s", string(result))
+	}
+}
+
+func TestCollectRequestToolNames_CollisionIgnored(t *testing.T) {
+	tests := []struct {
+		requestBody []byte
+		input       []byte
+		forbidden   []byte
+	}{
+		{
+			requestBody: []byte(`{"tools":[{"name":"Glob","input_schema":{"type":"object"}},{"name":"glob","input_schema":{"type":"object"}}]}`),
+			input:       []byte(`{"content":[{"type":"tool_use","id":"toolu_01","name":"glob","input":{"pattern":"*.go"}}]}`),
+			forbidden:   []byte(`"name":"Glob"`),
+		},
+		{
+			requestBody: []byte(`{"tools":[{"name":"glob","input_schema":{"type":"object"}},{"name":"Glob","input_schema":{"type":"object"}}]}`),
+			input:       []byte(`{"content":[{"type":"tool_use","id":"toolu_01","name":"glob","input":{"pattern":"*.go"}}]}`),
+			forbidden:   []byte(`"name":"Glob"`),
+		},
+		{
+			requestBody: []byte(`{"tools":[{"name":"Bash","input_schema":{"type":"object"}},{"name":"bash","input_schema":{"type":"object"}}]}`),
+			input:       []byte(`{"content":[{"type":"tool_use","id":"toolu_01","name":"bash","input":{"cmd":"ls"}}]}`),
+			forbidden:   []byte(`"name":"Bash"`),
+		},
+	}
+
+	for _, tt := range tests {
+		rw := &ResponseRewriter{requestToolNames: collectRequestToolNames(tt.requestBody)}
+		result := rw.rewriteModelInResponse(tt.input)
+
+		if contains(result, tt.forbidden) {
+			t.Errorf("expected conflicting tool casing not to force %s, got %s", string(tt.forbidden), string(result))
+		}
+	}
+}
+
+func TestResponseRewriter_RequestToolCasingFromBody_Streaming(t *testing.T) {
+	requestBody := []byte(`{"tools":[{"name":"Glob","input_schema":{"type":"object"}}]}`)
+	rw := &ResponseRewriter{requestToolNames: collectRequestToolNames(requestBody)}
+	input := []byte("event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"tool_use\",\"name\":\"glob\",\"id\":\"toolu_01\",\"input\":{}}}\n\n")
+
+	result := rw.rewriteStreamChunk(input)
+
+	if !contains(result, []byte(`"name":"Glob"`)) {
+		t.Errorf("expected streaming response to restore glob->Glob from request body, got %s", string(result))
+	}
+}
+
 func TestNormalizeAmpToolNames_UnknownToolUntouched(t *testing.T) {
 	input := []byte(`{"content":[{"type":"tool_use","id":"toolu_01","name":"edit_file","input":{"path":"/tmp/x"}}]}`)
 	result := normalizeAmpToolNames(input)

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -96,6 +96,29 @@
       }
     },
     {
+      "id": "claude-opus-4-8",
+      "object": "model",
+      "created": 1779984000,
+      "owned_by": "anthropic",
+      "type": "claude",
+      "display_name": "Claude Opus 4.8",
+      "description": "Premium model combining maximum intelligence with practical performance",
+      "context_length": 1000000,
+      "max_completion_tokens": 128000,
+      "thinking": {
+        "min": 1024,
+        "max": 128000,
+        "zero_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      }
+    },
+    {
       "id": "claude-opus-4-5-20251101",
       "object": "model",
       "created": 1761955200,

--- a/internal/runtime/executor/gemini_cli_executor.go
+++ b/internal/runtime/executor/gemini_cli_executor.go
@@ -857,7 +857,12 @@ func cleanGeminiCLIRequestSchemas(body []byte) []byte {
 						}
 						cleaned := util.CleanJSONSchemaForGemini(params.Raw)
 						path := fmt.Sprintf("request.tools.%d.%s.%d.%s", i, declarationsKey, j, schemaKey)
-						body, _ = sjson.SetRawBytes(body, path, []byte(cleaned))
+						updated, errSet := sjson.SetRawBytes(body, path, []byte(cleaned))
+						if errSet != nil {
+							log.Errorf("gemini cli executor: failed to set cleaned schema at %s: %v", path, errSet)
+							continue
+						}
+						body = updated
 					}
 				}
 			}
@@ -873,7 +878,12 @@ func cleanGeminiCLIRequestSchemas(body []byte) []byte {
 			continue
 		}
 		cleaned := util.CleanJSONSchemaForGemini(responseSchema.Raw)
-		body, _ = sjson.SetRawBytes(body, schemaPath, []byte(cleaned))
+		updated, errSet := sjson.SetRawBytes(body, schemaPath, []byte(cleaned))
+		if errSet != nil {
+			log.Errorf("gemini cli executor: failed to set cleaned response schema at %s: %v", schemaPath, errSet)
+			continue
+		}
+		body = updated
 	}
 
 	return body

--- a/internal/runtime/executor/gemini_cli_executor.go
+++ b/internal/runtime/executor/gemini_cli_executor.go
@@ -141,6 +141,7 @@ func (e *GeminiCLIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	basePayload = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, "gemini", "request", basePayload, originalTranslated, requestedModel, requestPath)
+	basePayload = cleanGeminiCLIRequestSchemas(basePayload)
 
 	action := "generateContent"
 	if req.Metadata != nil {
@@ -297,6 +298,7 @@ func (e *GeminiCLIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyaut
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	basePayload = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, "gemini", "request", basePayload, originalTranslated, requestedModel, requestPath)
+	basePayload = cleanGeminiCLIRequestSchemas(basePayload)
 
 	projectID := resolveGeminiProjectID(auth)
 
@@ -530,6 +532,7 @@ func (e *GeminiCLIExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.
 		payload = deleteJSONField(payload, "model")
 		payload = deleteJSONField(payload, "request.safetySettings")
 		payload = fixGeminiCLIImageAspectRatio(baseModel, payload)
+		payload = cleanGeminiCLIRequestSchemas(payload)
 
 		tok, errTok := tokenSource.Token()
 		if errTok != nil {
@@ -825,6 +828,55 @@ func deleteJSONField(body []byte, key string) []byte {
 		return body
 	}
 	return updated
+}
+
+func cleanGeminiCLIRequestSchemas(body []byte) []byte {
+	if len(body) == 0 {
+		return body
+	}
+	hasTools := gjson.GetBytes(body, "request.tools.0").Exists()
+	hasResponseSchema := gjson.GetBytes(body, "request.generationConfig.responseSchema").Exists()
+	hasResponseJSONSchema := gjson.GetBytes(body, "request.generationConfig.responseJsonSchema").Exists()
+	if !hasTools && !hasResponseSchema && !hasResponseJSONSchema {
+		return body
+	}
+
+	tools := gjson.GetBytes(body, "request.tools")
+	if tools.IsArray() {
+		for i, tool := range tools.Array() {
+			for _, declarationsKey := range []string{"function_declarations", "functionDeclarations"} {
+				funcDecls := tool.Get(declarationsKey)
+				if !funcDecls.IsArray() {
+					continue
+				}
+				for j, decl := range funcDecls.Array() {
+					for _, schemaKey := range []string{"parameters", "parametersJsonSchema"} {
+						params := decl.Get(schemaKey)
+						if !params.Exists() || !params.IsObject() {
+							continue
+						}
+						cleaned := util.CleanJSONSchemaForGemini(params.Raw)
+						path := fmt.Sprintf("request.tools.%d.%s.%d.%s", i, declarationsKey, j, schemaKey)
+						body, _ = sjson.SetRawBytes(body, path, []byte(cleaned))
+					}
+				}
+			}
+		}
+	}
+
+	for _, schemaPath := range []string{
+		"request.generationConfig.responseSchema",
+		"request.generationConfig.responseJsonSchema",
+	} {
+		responseSchema := gjson.GetBytes(body, schemaPath)
+		if !responseSchema.IsObject() {
+			continue
+		}
+		cleaned := util.CleanJSONSchemaForGemini(responseSchema.Raw)
+		body, _ = sjson.SetRawBytes(body, schemaPath, []byte(cleaned))
+	}
+
+	return body
 }
 
 func fixGeminiCLIImageAspectRatio(modelName string, rawJSON []byte) []byte {

--- a/internal/runtime/executor/gemini_cli_executor_test.go
+++ b/internal/runtime/executor/gemini_cli_executor_test.go
@@ -1,0 +1,75 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestCleanGeminiCLIRequestSchemasFlattensFunctionDeclarationTypeArray(t *testing.T) {
+	input := []byte(`{
+		"request": {
+			"tools": [
+				{
+					"function_declarations": [
+						{
+							"name": "wecom_mcp",
+							"parameters": {
+								"type": "object",
+								"properties": {
+									"args": {
+										"description": "call args",
+										"type": ["string", "object"]
+									}
+								}
+							}
+						}
+					]
+				},
+				{
+					"functionDeclarations": [
+						{
+							"name": "camel_tool",
+							"parametersJsonSchema": {
+								"type": "object",
+								"properties": {
+									"value": {
+										"type": ["integer", "string"]
+									}
+								}
+							}
+						}
+					]
+				}
+			],
+			"nonSchema": {
+				"type": ["string", "object"]
+			}
+		}
+	}`)
+
+	out := cleanGeminiCLIRequestSchemas(input)
+
+	argsType := gjson.GetBytes(out, "request.tools.0.function_declarations.0.parameters.properties.args.type")
+	if argsType.String() != "string" {
+		t.Fatalf("args.type = %s, want string; body=%s", argsType.Raw, string(out))
+	}
+	argsDesc := gjson.GetBytes(out, "request.tools.0.function_declarations.0.parameters.properties.args.description").String()
+	if !strings.Contains(argsDesc, "Accepts: string | object") {
+		t.Fatalf("args.description = %q, want accepted type hint", argsDesc)
+	}
+
+	valueType := gjson.GetBytes(out, "request.tools.1.functionDeclarations.0.parametersJsonSchema.properties.value.type")
+	if valueType.String() != "integer" {
+		t.Fatalf("value.type = %s, want integer; body=%s", valueType.Raw, string(out))
+	}
+	valueDesc := gjson.GetBytes(out, "request.tools.1.functionDeclarations.0.parametersJsonSchema.properties.value.description").String()
+	if !strings.Contains(valueDesc, "Accepts: integer | string") {
+		t.Fatalf("value.description = %q, want accepted type hint", valueDesc)
+	}
+
+	if nonSchema := gjson.GetBytes(out, "request.nonSchema.type"); !nonSchema.IsArray() {
+		t.Fatalf("request.nonSchema.type should be preserved outside schema paths, got %s", nonSchema.Raw)
+	}
+}

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -372,7 +372,7 @@ func parseClaudeUsageNode(usageNode gjson.Result) usage.Detail {
 	if detail.CachedTokens == 0 {
 		detail.CachedTokens = detail.CacheCreationTokens
 	}
-	detail.TotalTokens = detail.InputTokens + detail.OutputTokens
+	detail.TotalTokens = detail.InputTokens + detail.OutputTokens + detail.CacheReadTokens + detail.CacheCreationTokens
 	return detail
 }
 

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -86,26 +86,37 @@ func TestParseOpenAIStreamUsageResponsesFields(t *testing.T) {
 	}
 }
 
-func TestParseClaudeUsageTracksDetailedCacheTokens(t *testing.T) {
-	data := []byte(`{"usage":{"input_tokens":10,"output_tokens":20,"cache_read_input_tokens":7,"cache_creation_input_tokens":3}}`)
+func TestParseClaudeUsageIncludesCacheTokensInTotal(t *testing.T) {
+	data := []byte(`{"usage":{"input_tokens":3085,"output_tokens":253,"cache_read_input_tokens":7,"cache_creation_input_tokens":19514}}`)
 	detail := ParseClaudeUsage(data)
-	if detail.InputTokens != 10 {
-		t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 10)
+	if detail.InputTokens != 3085 {
+		t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 3085)
 	}
-	if detail.OutputTokens != 20 {
-		t.Fatalf("output tokens = %d, want %d", detail.OutputTokens, 20)
-	}
-	if detail.CachedTokens != 7 {
-		t.Fatalf("cached tokens = %d, want %d", detail.CachedTokens, 7)
+	if detail.OutputTokens != 253 {
+		t.Fatalf("output tokens = %d, want %d", detail.OutputTokens, 253)
 	}
 	if detail.CacheReadTokens != 7 {
 		t.Fatalf("cache read tokens = %d, want %d", detail.CacheReadTokens, 7)
 	}
-	if detail.CacheCreationTokens != 3 {
-		t.Fatalf("cache creation tokens = %d, want %d", detail.CacheCreationTokens, 3)
+	if detail.CacheCreationTokens != 19514 {
+		t.Fatalf("cache creation tokens = %d, want %d", detail.CacheCreationTokens, 19514)
 	}
-	if detail.TotalTokens != 30 {
-		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 30)
+	if detail.CachedTokens != 7 {
+		t.Fatalf("cached tokens = %d, want %d", detail.CachedTokens, 7)
+	}
+	if detail.TotalTokens != 22859 {
+		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 22859)
+	}
+}
+
+func TestParseClaudeUsageFallsBackCachedTokensToCacheCreation(t *testing.T) {
+	data := []byte(`{"usage":{"input_tokens":3085,"output_tokens":253,"cache_creation_input_tokens":19514}}`)
+	detail := ParseClaudeUsage(data)
+	if detail.CachedTokens != 19514 {
+		t.Fatalf("cached tokens = %d, want %d", detail.CachedTokens, 19514)
+	}
+	if detail.TotalTokens != 22852 {
+		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 22852)
 	}
 }
 


### PR DESCRIPTION
## Summary

Selectively ports upstream CLIProxyAPI fixes into CPA-Core-LTS while preserving the LTS contract around full usage statistics, `/v0/management/usage*`, `usage-statistics-enabled`, the v6 module path, and the CPA-Panel-LTS management UI source.

This PR intentionally avoids `internal/translator/**` because this repository has a PR path guard that rejects translator changes.

Included upstream commits:

- `01a7cc4a` - restore Amp response tool casing from request context.
- `65e760aa` - include Claude cache read/creation tokens in parsed total usage.
- `df0176a1` - add Claude Opus 4.8 to the embedded model registry.
- `70a8cf02` / `4a85b6b9` - clean Gemini CLI request schemas and log cleanup write failures.

## Upstream audit notes

Already covered in CPA-Core-LTS before this PR:

- xAI provider, image/video endpoints, OpenAI-compatible image support.
- Redis usage pubsub/retention, zstd request-log decoding, disabled auth metadata.
- Antigravity project ID fixes, Codex context-length stream errors, Gemini 3.5 model catalog updates.
- Management usage queue/API helper work and detailed usage metadata enrichment.

Worthwhile but deferred because of repository guard or broader compatibility review:

- `d606faa9`, `1c632d15`, `33f4904b`, `2cbb8c7b`: translator fixes that are useful, but blocked by `.github/workflows/pr-path-guard.yml` forbidding `internal/translator/**` changes in PRs.
- TTFT, service-tier, and translated reasoning-effort usage fields: useful but broader usage schema/API semantics; should be a separate compatibility-reviewed PR.
- GPT Image 2 configurable base model and WebSocket/auth-file parsing extensions: useful candidates, but they touch config/Management/SDK surfaces and deserve separate targeted review.
- v7 module/import-path migration: conflicts with LTS v6 module contract.
- Home control-plane, cluster, file-backed log forwarding: broader architecture surface, not a small LTS-safe port.
- Deprecated codex-free model removals: intentionally skipped to avoid surprising existing LTS users.

## Validation

- `git diff --check`
- `go test ./internal/api/modules/amp ./internal/runtime/executor/helps ./internal/runtime/executor ./internal/usage ./internal/api/handlers/management -run 'Test(ParseClaudeUsage|CleanGeminiCLIRequestSchemas)|Usage|usage'`
- `go test ./...`
- `go build -o test-output ./cmd/server && rm -f test-output`
