### PR TITLE
Port upstream WebSocket tool-call repair

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -662,7 +662,7 @@ func TestRepairResponsesWebsocketToolCallsInsertsCachedCallForOrphanOutput(t *te
 	}
 }
 
-func TestRepairResponsesWebsocketToolCallsInsertsCachedCallForPreviousResponseOutput(t *testing.T) {
+func TestRepairResponsesWebsocketToolCallsKeepsPreviousResponseOutputIncremental(t *testing.T) {
 	outputCache := newWebsocketToolOutputCache(time.Minute, 10)
 	callCache := newWebsocketToolOutputCache(time.Minute, 10)
 	sessionKey := "session-1"
@@ -676,17 +676,39 @@ func TestRepairResponsesWebsocketToolCallsInsertsCachedCallForPreviousResponseOu
 		t.Fatalf("previous_response_id = %q, want resp-latest", got)
 	}
 	input := gjson.GetBytes(repaired, "input").Array()
-	if len(input) != 3 {
-		t.Fatalf("repaired input len = %d, want 3: %s", len(input), repaired)
+	if len(input) != 2 {
+		t.Fatalf("repaired input len = %d, want 2: %s", len(input), repaired)
+	}
+	if input[0].Get("type").String() != "function_call_output" || input[0].Get("call_id").String() != "call-1" {
+		t.Fatalf("unexpected output item: %s", input[0].Raw)
+	}
+	if input[1].Get("type").String() != "message" || input[1].Get("id").String() != "msg-1" {
+		t.Fatalf("unexpected trailing item: %s", input[1].Raw)
+	}
+}
+
+func TestRepairResponsesWebsocketToolCallsKeepsPreviousResponseCallIncremental(t *testing.T) {
+	outputCache := newWebsocketToolOutputCache(time.Minute, 10)
+	callCache := newWebsocketToolOutputCache(time.Minute, 10)
+	sessionKey := "session-1"
+
+	outputCache.record(sessionKey, "call-1", []byte(`{"type":"function_call_output","call_id":"call-1","id":"tool-out-1","output":"ok"}`))
+
+	raw := []byte(`{"previous_response_id":"resp-latest","input":[{"type":"function_call","id":"fc-1","call_id":"call-1","name":"tool"},{"type":"message","id":"msg-1"}]}`)
+	repaired := repairResponsesWebsocketToolCallsWithCaches(outputCache, callCache, sessionKey, raw)
+
+	if got := gjson.GetBytes(repaired, "previous_response_id").String(); got != "resp-latest" {
+		t.Fatalf("previous_response_id = %q, want resp-latest", got)
+	}
+	input := gjson.GetBytes(repaired, "input").Array()
+	if len(input) != 2 {
+		t.Fatalf("repaired input len = %d, want 2: %s", len(input), repaired)
 	}
 	if input[0].Get("type").String() != "function_call" || input[0].Get("call_id").String() != "call-1" {
-		t.Fatalf("missing inserted call: %s", input[0].Raw)
+		t.Fatalf("unexpected call item: %s", input[0].Raw)
 	}
-	if input[1].Get("type").String() != "function_call_output" || input[1].Get("call_id").String() != "call-1" {
-		t.Fatalf("unexpected output item: %s", input[1].Raw)
-	}
-	if input[2].Get("type").String() != "message" || input[2].Get("id").String() != "msg-1" {
-		t.Fatalf("unexpected trailing item: %s", input[2].Raw)
+	if input[1].Get("type").String() != "message" || input[1].Get("id").String() != "msg-1" {
+		t.Fatalf("unexpected trailing item: %s", input[1].Raw)
 	}
 }
 
@@ -773,6 +795,31 @@ func TestRepairResponsesWebsocketToolCallsInsertsCachedCustomToolCallForOrphanOu
 	}
 	if input[2].Get("type").String() != "message" || input[2].Get("id").String() != "msg-1" {
 		t.Fatalf("unexpected trailing item: %s", input[2].Raw)
+	}
+}
+
+func TestRepairResponsesWebsocketToolCallsKeepsPreviousResponseCustomToolOutputIncremental(t *testing.T) {
+	outputCache := newWebsocketToolOutputCache(time.Minute, 10)
+	callCache := newWebsocketToolOutputCache(time.Minute, 10)
+	sessionKey := "session-1"
+
+	callCache.record(sessionKey, "call-1", []byte(`{"type":"custom_tool_call","call_id":"call-1","name":"apply_patch"}`))
+
+	raw := []byte(`{"previous_response_id":"resp-latest","input":[{"type":"custom_tool_call_output","call_id":"call-1","output":"ok"},{"type":"message","id":"msg-1"}]}`)
+	repaired := repairResponsesWebsocketToolCallsWithCaches(outputCache, callCache, sessionKey, raw)
+
+	if got := gjson.GetBytes(repaired, "previous_response_id").String(); got != "resp-latest" {
+		t.Fatalf("previous_response_id = %q, want resp-latest", got)
+	}
+	input := gjson.GetBytes(repaired, "input").Array()
+	if len(input) != 2 {
+		t.Fatalf("repaired input len = %d, want 2: %s", len(input), repaired)
+	}
+	if input[0].Get("type").String() != "custom_tool_call_output" || input[0].Get("call_id").String() != "call-1" {
+		t.Fatalf("unexpected output item: %s", input[0].Raw)
+	}
+	if input[1].Get("type").String() != "message" || input[1].Get("id").String() != "msg-1" {
+		t.Fatalf("unexpected trailing item: %s", input[1].Raw)
 	}
 }
 

--- a/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
@@ -305,6 +305,11 @@ func repairResponsesToolCallsArray(outputCache, callCache *websocketToolOutputCa
 				continue
 			}
 
+			if allowOrphanOutputs {
+				filtered = append(filtered, item)
+				continue
+			}
+
 			if callCache != nil {
 				if cached, ok := callCache.get(sessionKey, callID); ok {
 					if _, already := insertedCalls[callID]; !already {
@@ -315,11 +320,6 @@ func repairResponsesToolCallsArray(outputCache, callCache *websocketToolOutputCa
 					filtered = append(filtered, item)
 					continue
 				}
-			}
-
-			if allowOrphanOutputs {
-				filtered = append(filtered, item)
-				continue
 			}
 
 			// Drop orphaned function_call_output items; upstream rejects transcripts with missing calls.
@@ -337,6 +337,11 @@ func repairResponsesToolCallsArray(outputCache, callCache *websocketToolOutputCa
 		}
 
 		if _, ok := outputPresent[callID]; ok {
+			filtered = append(filtered, item)
+			continue
+		}
+
+		if allowOrphanOutputs {
 			filtered = append(filtered, item)
 			continue
 		}


### PR DESCRIPTION
## Summary
- selectively cherry-pick upstream `de280d99` to refine WebSocket Responses tool-call repair
- preserve incremental `previous_response_id` payloads instead of reinserting cached calls/outputs when orphan outputs are allowed
- add regression coverage for function and custom tool incremental repair cases

## LTS contract
- does not touch `internal/usage/`, Management usage endpoints, config schema, auth files, or `internal/translator/**`
- keeps the CPA-Core-LTS usage statistics contract unchanged

## Validation
- `git diff --check origin/main..HEAD`
- `gofmt -w sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go sdk/api/handlers/openai/openai_responses_websocket_test.go && git diff --exit-code`
- `go test ./sdk/api/handlers/openai -run 'Websocket|WebSocket|RepairResponses'`\n- `go test ./...`\n- `go build -o test-output ./cmd/server && rm -f test-output`\n