### PR TITLE
[codex] Port Claude OAuth MCP tool-name normalization

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -73,6 +73,26 @@ var oauthToolRenameMap = map[string]string{
 // then the global reverse map incorrectly rewrote every `Bash` in the
 // response to `bash`, causing Amp to reject the tool_use as unknown).
 
+const (
+	mcpSingleUnderscorePrefix = "mcp_"
+	mcpDoubleUnderscorePrefix = "mcp__"
+)
+
+// oauthRenamedToolName returns the Claude Code-compatible upstream name for a
+// client-supplied OAuth tool name and whether a rename is needed. Besides the
+// static built-in map, it normalizes single-underscore MCP names used by some
+// third-party clients (`mcp_<tool>`) into Claude Code's double-underscore form
+// (`mcp__<tool>`), which Anthropic treats as first-party OAuth traffic.
+func oauthRenamedToolName(name string) (string, bool) {
+	if newName, ok := oauthToolRenameMap[name]; ok && newName != name {
+		return newName, true
+	}
+	if strings.HasPrefix(name, mcpSingleUnderscorePrefix) && !strings.HasPrefix(name, mcpDoubleUnderscorePrefix) {
+		return mcpDoubleUnderscorePrefix + name[len(mcpSingleUnderscorePrefix):], true
+	}
+	return name, false
+}
+
 // oauthToolsToRemove lists tool names that must be stripped from OAuth requests
 // even after remapping. Currently empty — all tools are mapped instead of removed.
 var oauthToolsToRemove = map[string]bool{}
@@ -1131,7 +1151,7 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 			}
 
 			toolJSON := tool.Raw
-			if newName, ok := oauthToolRenameMap[name]; ok && newName != name {
+			if newName, ok := oauthRenamedToolName(name); ok {
 				updatedTool, err := sjson.Set(toolJSON, "name", newName)
 				if err == nil {
 					toolJSON = updatedTool
@@ -1158,7 +1178,7 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 			// The chosen tool was removed from the tools array, so drop tool_choice to
 			// keep the payload internally consistent and fall back to normal auto tool use.
 			body, _ = sjson.DeleteBytes(body, "tool_choice")
-		} else if newName, ok := oauthToolRenameMap[tcName]; ok && newName != tcName {
+		} else if newName, ok := oauthRenamedToolName(tcName); ok {
 			body, _ = sjson.SetBytes(body, "tool_choice.name", newName)
 			recordRename(tcName, newName)
 		}
@@ -1177,14 +1197,14 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 				switch partType {
 				case "tool_use":
 					name := part.Get("name").String()
-					if newName, ok := oauthToolRenameMap[name]; ok && newName != name {
+					if newName, ok := oauthRenamedToolName(name); ok {
 						path := fmt.Sprintf("messages.%d.content.%d.name", msgIndex.Int(), contentIndex.Int())
 						body, _ = sjson.SetBytes(body, path, newName)
 						recordRename(name, newName)
 					}
 				case "tool_reference":
 					toolName := part.Get("tool_name").String()
-					if newName, ok := oauthToolRenameMap[toolName]; ok && newName != toolName {
+					if newName, ok := oauthRenamedToolName(toolName); ok {
 						path := fmt.Sprintf("messages.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int())
 						body, _ = sjson.SetBytes(body, path, newName)
 						recordRename(toolName, newName)
@@ -1198,7 +1218,7 @@ func remapOAuthToolNames(body []byte) ([]byte, map[string]string) {
 						nestedContent.ForEach(func(nestedIndex, nestedPart gjson.Result) bool {
 							if nestedPart.Get("type").String() == "tool_reference" {
 								nestedToolName := nestedPart.Get("tool_name").String()
-								if newName, ok := oauthToolRenameMap[nestedToolName]; ok && newName != nestedToolName {
+								if newName, ok := oauthRenamedToolName(nestedToolName); ok {
 									nestedPath := fmt.Sprintf("messages.%d.content.%d.content.%d.tool_name", msgIndex.Int(), contentIndex.Int(), nestedIndex.Int())
 									body, _ = sjson.SetBytes(body, nestedPath, newName)
 									recordRename(nestedToolName, newName)

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -2198,6 +2198,47 @@ func TestReverseRemapOAuthToolNamesFromStreamLine_HonorsPerRequestMap(t *testing
 	}
 }
 
+func TestRemapOAuthToolNames_McpSingleUnderscore_NormalizedAndReversed(t *testing.T) {
+	body := []byte(`{"tools":[` +
+		`{"name":"mcp_search_youtube_z50gm8","input_schema":{"type":"object","properties":{"query":{"type":"string"}}}},` +
+		`{"name":"mcp__already__ok","input_schema":{"type":"object","properties":{"q":{"type":"string"}}}}` +
+		`],"tool_choice":{"type":"tool","name":"mcp_search_youtube_z50gm8"},` +
+		`"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01","name":"mcp_search_youtube_z50gm8","input":{"query":"go"}}]}]}`)
+
+	out, reverseMap := remapOAuthToolNames(body)
+
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "mcp__search_youtube_z50gm8" {
+		t.Fatalf("tools.0.name = %q, want %q", got, "mcp__search_youtube_z50gm8")
+	}
+	if got := gjson.GetBytes(out, "tools.1.name").String(); got != "mcp__already__ok" {
+		t.Fatalf("tools.1.name = %q, want unchanged %q", got, "mcp__already__ok")
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "mcp__search_youtube_z50gm8" {
+		t.Fatalf("tool_choice.name = %q, want %q", got, "mcp__search_youtube_z50gm8")
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.0.name").String(); got != "mcp__search_youtube_z50gm8" {
+		t.Fatalf("history tool_use name = %q, want %q", got, "mcp__search_youtube_z50gm8")
+	}
+	if reverseMap["mcp__search_youtube_z50gm8"] != "mcp_search_youtube_z50gm8" {
+		t.Fatalf("reverseMap = %v, want entry mcp__search_youtube_z50gm8 -> mcp_search_youtube_z50gm8", reverseMap)
+	}
+	if _, exists := reverseMap["mcp__already__ok"]; exists {
+		t.Fatalf("reverseMap must not contain already-double-underscore name: %v", reverseMap)
+	}
+
+	resp := []byte(`{"content":[{"type":"tool_use","id":"toolu_02","name":"mcp__search_youtube_z50gm8","input":{"query":"go"}}]}`)
+	reversed := reverseRemapOAuthToolNames(resp, reverseMap)
+	if got := gjson.GetBytes(reversed, "content.0.name").String(); got != "mcp_search_youtube_z50gm8" {
+		t.Fatalf("content.0.name = %q, want restored %q", got, "mcp_search_youtube_z50gm8")
+	}
+
+	line := []byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_02","name":"mcp__search_youtube_z50gm8","input":{}}}`)
+	outLine := reverseRemapOAuthToolNamesFromStreamLine(line, reverseMap)
+	if !bytes.Contains(outLine, []byte(`"name":"mcp_search_youtube_z50gm8"`)) {
+		t.Fatalf("stream reverse failed, got: %s", string(outLine))
+	}
+}
+
 func TestPrepareClaudeOAuthToolNamesForUpstream_MixedCaseWithPrefix(t *testing.T) {
 	body := []byte(`{"tools":[` +
 		`{"name":"Bash","input_schema":{"type":"object","properties":{"cmd":{"type":"string"}}}},` +


### PR DESCRIPTION
## Summary
- Port the useful compatibility fix from upstream router-for-me/CLIProxyAPI PR #3632.
- Normalize single-underscore MCP tool names (`mcp_<tool>`) to Claude Code-style double-underscore names (`mcp__<tool>`) on Claude OAuth upstream requests.
- Preserve already-normalized `mcp__...` names and restore the client's original `mcp_...` names in buffered and streaming responses.
- Add regression coverage across tools, `tool_choice`, message history, buffered response restore, and SSE restore.

## Why
Some third-party clients emit `mcp_<tool>` names. Upstream reported Anthropic OAuth traffic can treat that prefix as third-party MCP usage and reject requests with HTTP 400 when extra usage is disabled. Claude Code uses `mcp__...`, so this keeps LTS compatible with those clients without exposing the rewrite downstream.

## Validation
- `go test ./internal/runtime/executor -run 'RemapOAuthToolNames|PrepareClaudeOAuthToolNames|RestoreClaudeOAuthToolNames'`\n- `git diff --check`\n- `go test ./internal/runtime/executor`\n- `go test ./...`\n- `go build -o test-output ./cmd/server && rm -f test-output`\n\n## LTS compatibility\n- Keeps the `github.com/router-for-me/CLIProxyAPI/v6` module path.\n- Does not touch `internal/usage`, Management usage endpoints, translator paths, config schema, or AGENTS.md.\n- PR is draft for review; do not merge automatically.