### PR TITLE
[codex] Port stream first-response hardening

### DIFF
--- a/internal/auth/codex/openai_auth.go
+++ b/internal/auth/codex/openai_auth.go
@@ -17,6 +17,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/singleflight"
 )
 
 // OAuth configuration constants for OpenAI Codex
@@ -25,6 +26,11 @@ const (
 	TokenURL    = "https://auth.openai.com/oauth/token"
 	ClientID    = "app_EMoamEEZ73f0CkXaXp7hrann"
 	RedirectURI = "http://localhost:1455/auth/callback"
+)
+
+var (
+	codexRefreshGroup        singleflight.Group
+	codexRefreshGroupTimeout = time.Minute
 )
 
 // CodexAuth handles the OpenAI OAuth2 authentication flow.
@@ -184,6 +190,45 @@ func (o *CodexAuth) ExchangeCodeForTokensWithRedirect(ctx context.Context, code,
 // This method is called when an access token has expired. It makes a request to the
 // token endpoint to obtain a new set of tokens.
 func (o *CodexAuth) RefreshTokens(ctx context.Context, refreshToken string) (*CodexTokenData, error) {
+	if refreshToken == "" {
+		return nil, fmt.Errorf("refresh token is required")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if errCtx := ctx.Err(); errCtx != nil {
+		return nil, errCtx
+	}
+
+	resultC := codexRefreshGroup.DoChan(refreshToken, func() (interface{}, error) {
+		refreshCtx := context.WithoutCancel(ctx)
+		var cancel context.CancelFunc
+		if codexRefreshGroupTimeout > 0 {
+			refreshCtx, cancel = context.WithTimeout(refreshCtx, codexRefreshGroupTimeout)
+		} else {
+			refreshCtx, cancel = context.WithCancel(refreshCtx)
+		}
+		defer cancel()
+		return o.refreshTokensSingleFlight(refreshCtx, refreshToken)
+	})
+
+	var result singleflight.Result
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case result = <-resultC:
+	}
+	if result.Err != nil {
+		return nil, result.Err
+	}
+	tokenData, ok := result.Val.(*CodexTokenData)
+	if !ok || tokenData == nil {
+		return nil, fmt.Errorf("token refresh failed: invalid single-flight result")
+	}
+	return tokenData, nil
+}
+
+func (o *CodexAuth) refreshTokensSingleFlight(ctx context.Context, refreshToken string) (*CodexTokenData, error) {
 	if refreshToken == "" {
 		return nil, fmt.Errorf("refresh token is required")
 	}

--- a/internal/auth/codex/openai_auth_test.go
+++ b/internal/auth/codex/openai_auth_test.go
@@ -5,8 +5,10 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 )
@@ -42,6 +44,160 @@ func TestRefreshTokensWithRetry_NonRetryableOnlyAttemptsOnce(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&calls); got != 1 {
 		t.Fatalf("expected 1 refresh attempt, got %d", got)
+	}
+}
+
+func TestRefreshTokens_DeduplicatesConcurrentRefresh(t *testing.T) {
+	var calls int32
+	var wg sync.WaitGroup
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	auth := &CodexAuth{
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if atomic.AddInt32(&calls, 1) == 1 {
+					close(entered)
+				}
+				<-release
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"access_token":"access-token",
+						"refresh_token":"next-refresh-token",
+						"id_token":"header.payload.signature",
+						"expires_in":3600
+					}`)),
+					Header:  make(http.Header),
+					Request: req,
+				}, nil
+			}),
+		},
+	}
+
+	results := make(chan *CodexTokenData, 2)
+	errs := make(chan error, 2)
+	runRefresh := func() {
+		defer wg.Done()
+		td, err := auth.RefreshTokens(context.Background(), "shared-refresh-token")
+		if err != nil {
+			errs <- err
+			return
+		}
+		results <- td
+	}
+
+	wg.Add(1)
+	go runRefresh()
+	<-entered
+	wg.Add(1)
+	go runRefresh()
+	time.Sleep(20 * time.Millisecond)
+	close(release)
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	if len(errs) > 0 {
+		t.Fatalf("unexpected refresh error: %v", <-errs)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected 1 refresh request, got %d", got)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected both callers to receive token data, got %d", len(results))
+	}
+	for td := range results {
+		if td.RefreshToken != "next-refresh-token" {
+			t.Fatalf("refresh token = %q, want next-refresh-token", td.RefreshToken)
+		}
+	}
+}
+
+func TestRefreshTokens_RespectsCallerCancellationWhileSharedRefreshContinues(t *testing.T) {
+	var calls int32
+	var wg sync.WaitGroup
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	auth := &CodexAuth{
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if atomic.AddInt32(&calls, 1) == 1 {
+					close(entered)
+				}
+				<-release
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body: io.NopCloser(strings.NewReader(`{
+						"access_token":"access-token",
+						"refresh_token":"next-refresh-token",
+						"id_token":"header.payload.signature",
+						"expires_in":3600
+					}`)),
+					Header:  make(http.Header),
+					Request: req,
+				}, nil
+			}),
+		},
+	}
+
+	wg.Add(1)
+	firstErr := make(chan error, 1)
+	go func() {
+		defer wg.Done()
+		_, err := auth.RefreshTokens(context.Background(), "shared-refresh-token-cancel")
+		firstErr <- err
+	}()
+	<-entered
+
+	waitCtx, cancel := context.WithCancel(context.Background())
+	waitErr := make(chan error, 1)
+	go func() {
+		_, err := auth.RefreshTokens(waitCtx, "shared-refresh-token-cancel")
+		waitErr <- err
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-waitErr:
+		if err != context.Canceled {
+			t.Fatalf("RefreshTokens error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for canceled caller")
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected shared refresh to keep single upstream request, got %d", got)
+	}
+
+	close(release)
+	wg.Wait()
+	if err := <-firstErr; err != nil {
+		t.Fatalf("first refresh error: %v", err)
+	}
+}
+
+func TestRefreshTokens_SharedRefreshHasBoundedTimeout(t *testing.T) {
+	origTimeout := codexRefreshGroupTimeout
+	codexRefreshGroupTimeout = 50 * time.Millisecond
+	defer func() {
+		codexRefreshGroupTimeout = origTimeout
+	}()
+
+	auth := &CodexAuth{
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				<-req.Context().Done()
+				return nil, req.Context().Err()
+			}),
+		},
+	}
+
+	_, err := auth.RefreshTokens(context.Background(), "shared-refresh-token-timeout")
+	if err == nil {
+		t.Fatal("expected refresh timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
+		t.Fatalf("expected deadline exceeded error, got %v", err)
 	}
 }
 

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -35,7 +35,11 @@ const (
 	codexDefaultImageToolModel = "gpt-image-2"
 )
 
-var dataTag = []byte("data:")
+var (
+	dataTag                                = []byte("data:")
+	codexHTTPStreamFirstResponseTimeout    = 2 * time.Minute
+	codexHTTPStreamFirstResponseTimeoutMsg = "codex upstream stream first response timeout after %s"
+)
 
 // Streamed Codex responses may emit response.output_item.done events while leaving
 // response.completed.response.output empty. Keep the stream path aligned with the
@@ -562,17 +566,27 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	})
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	applyCodexHTTPStreamFirstResponseTimeout(httpClient, codexHTTPStreamFirstResponseTimeout)
+	httpStartedAt := time.Now()
+	helps.LogWithRequestID(ctx).Debugf("codex http stream upstream request start url=%s body_bytes=%d auth=%s", url, len(body), authID)
 	httpResp, err := httpClient.Do(httpReq)
+	helps.LogWithRequestID(ctx).Debugf("codex http stream upstream request returned elapsed=%s err=%v", time.Since(httpStartedAt).Truncate(time.Millisecond), err)
 	if err != nil {
+		if isCodexHTTPStreamFirstResponseTimeout(err, codexHTTPStreamFirstResponseTimeout) && ctx.Err() == nil {
+			err = statusErr{code: http.StatusGatewayTimeout, msg: fmt.Sprintf(codexHTTPStreamFirstResponseTimeoutMsg, codexHTTPStreamFirstResponseTimeout)}
+		}
+		httpClient.CloseIdleConnections()
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return nil, err
 	}
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	helps.LogWithRequestID(ctx).Debugf("codex http stream upstream connected status=%d content_type=%q", httpResp.StatusCode, httpResp.Header.Get("Content-Type"))
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		data, readErr := io.ReadAll(httpResp.Body)
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("codex executor: close response body error: %v", errClose)
 		}
+		httpClient.CloseIdleConnections()
 		if readErr != nil {
 			helps.RecordAPIResponseError(ctx, e.cfg, readErr)
 			return nil, readErr
@@ -589,6 +603,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 			if errClose := httpResp.Body.Close(); errClose != nil {
 				log.Errorf("codex executor: close response body error: %v", errClose)
 			}
+			httpClient.CloseIdleConnections()
 		}()
 		scanner := bufio.NewScanner(httpResp.Body)
 		scanner.Buffer(nil, 52_428_800) // 50MB
@@ -635,7 +650,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		}
 		if errScan := scanner.Err(); errScan != nil {
 			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
-			reporter.PublishFailure(ctx)
+			reporter.PublishFailure(ctx, errScan)
 			select {
 			case out <- cliproxyexecutor.StreamChunk{Err: errScan}:
 			case <-ctx.Done():
@@ -643,6 +658,32 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		}
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+}
+
+func applyCodexHTTPStreamFirstResponseTimeout(client *http.Client, timeout time.Duration) {
+	if client == nil || timeout <= 0 {
+		return
+	}
+	if client.Transport == nil {
+		if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok && defaultTransport != nil {
+			transport := defaultTransport.Clone()
+			transport.ResponseHeaderTimeout = timeout
+			client.Transport = transport
+		}
+		return
+	}
+	if transport, ok := client.Transport.(*http.Transport); ok && transport != nil {
+		clone := transport.Clone()
+		clone.ResponseHeaderTimeout = timeout
+		client.Transport = clone
+	}
+}
+
+func isCodexHTTPStreamFirstResponseTimeout(err error, timeout time.Duration) bool {
+	if err == nil || timeout <= 0 {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "timeout awaiting response headers")
 }
 
 func (e *CodexExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {

--- a/internal/runtime/executor/codex_executor_stream_output_test.go
+++ b/internal/runtime/executor/codex_executor_stream_output_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/translator"
@@ -125,6 +126,55 @@ func TestCodexExecutorExecuteStreamSurfacesTerminalStreamError(t *testing.T) {
 		t.Fatalf("status code = %d, want %d; err=%v", got, http.StatusBadRequest, streamErr)
 	}
 	assertCodexErrorCode(t, streamErr.Error(), "invalid_request_error", "context_too_large")
+}
+
+func TestCodexExecutorExecuteStreamTimesOutWaitingForUpstreamResponse(t *testing.T) {
+	origTimeout := codexHTTPStreamFirstResponseTimeout
+	codexHTTPStreamFirstResponseTimeout = 50 * time.Millisecond
+	defer func() {
+		codexHTTPStreamFirstResponseTimeout = origTimeout
+	}()
+
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+	}))
+	defer server.Close()
+	defer close(release)
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	errC := make(chan error, 1)
+	go func() {
+		_, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+			Model:   "gpt-5.5",
+			Payload: []byte(`{"model":"gpt-5.5","input":"hello"}`),
+		}, cliproxyexecutor.Options{
+			SourceFormat: sdktranslator.FromString("openai-response"),
+			Stream:       true,
+		})
+		errC <- err
+	}()
+
+	var err error
+	select {
+	case err = <-errC:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for upstream first response timeout error")
+	}
+	if err == nil {
+		t.Fatal("expected first response timeout error, got nil")
+	}
+	if got := statusCodeFromTestError(t, err); got != http.StatusGatewayTimeout {
+		t.Fatalf("status code = %d, want %d; err=%v", got, http.StatusGatewayTimeout, err)
+	}
+	if !strings.Contains(err.Error(), "codex upstream stream first response timeout after 50ms") {
+		t.Fatalf("error message missing first response timeout: %v", err)
+	}
 }
 
 func TestCodexTerminalStreamContextLengthErrFromResponseFailed(t *testing.T) {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -33,6 +33,11 @@ const (
 	openAICompatMultipartMemory       int64 = 32 << 20
 )
 
+var (
+	openAICompatStreamFirstResponseTimeout    = 2 * time.Minute
+	openAICompatStreamFirstResponseTimeoutMsg = "openai-compatible upstream stream first response timeout after %s"
+)
+
 // OpenAICompatExecutor implements a stateless executor for OpenAI-compatible providers.
 // It performs request/response translation and executes against the provider base URL
 // using per-auth credentials (API key) and per-auth HTTP transport (proxy) from context.
@@ -357,8 +362,13 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	})
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	applyOpenAICompatStreamFirstResponseTimeout(httpClient, openAICompatStreamFirstResponseTimeout)
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
+		if isOpenAICompatStreamFirstResponseTimeout(err, openAICompatStreamFirstResponseTimeout) && ctx.Err() == nil {
+			err = statusErr{code: http.StatusGatewayTimeout, msg: fmt.Sprintf(openAICompatStreamFirstResponseTimeoutMsg, openAICompatStreamFirstResponseTimeout)}
+		}
+		httpClient.CloseIdleConnections()
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return nil, err
 	}
@@ -370,6 +380,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("openai compat executor: close response body error: %v", errClose)
 		}
+		httpClient.CloseIdleConnections()
 		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
 		return nil, err
 	}
@@ -380,6 +391,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			if errClose := httpResp.Body.Close(); errClose != nil {
 				log.Errorf("openai compat executor: close response body error: %v", errClose)
 			}
+			httpClient.CloseIdleConnections()
 		}()
 		scanner := bufio.NewScanner(httpResp.Body)
 		scanner.Buffer(nil, 52_428_800) // 50MB
@@ -506,8 +518,13 @@ func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cl
 	})
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	applyOpenAICompatStreamFirstResponseTimeout(httpClient, openAICompatStreamFirstResponseTimeout)
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
+		if isOpenAICompatStreamFirstResponseTimeout(err, openAICompatStreamFirstResponseTimeout) && ctx.Err() == nil {
+			err = statusErr{code: http.StatusGatewayTimeout, msg: fmt.Sprintf(openAICompatStreamFirstResponseTimeoutMsg, openAICompatStreamFirstResponseTimeout)}
+		}
+		httpClient.CloseIdleConnections()
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return nil, err
 	}
@@ -518,6 +535,7 @@ func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cl
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("openai compat executor: close response body error: %v", errClose)
 		}
+		httpClient.CloseIdleConnections()
 		if errRead != nil {
 			helps.RecordAPIResponseError(ctx, e.cfg, errRead)
 			return nil, errRead
@@ -534,6 +552,7 @@ func (e *OpenAICompatExecutor) executeImagesStream(ctx context.Context, auth *cl
 			if errClose := httpResp.Body.Close(); errClose != nil {
 				log.Errorf("openai compat executor: close response body error: %v", errClose)
 			}
+			httpClient.CloseIdleConnections()
 			reporter.EnsurePublished(ctx)
 		}()
 		buffer := make([]byte, 32*1024)
@@ -591,6 +610,32 @@ func (e *OpenAICompatExecutor) CountTokens(ctx context.Context, auth *cliproxyau
 	usageJSON := helps.BuildOpenAIUsageJSON(count)
 	translatedUsage := sdktranslator.TranslateTokenCount(ctx, to, from, count, usageJSON)
 	return cliproxyexecutor.Response{Payload: translatedUsage}, nil
+}
+
+func applyOpenAICompatStreamFirstResponseTimeout(client *http.Client, timeout time.Duration) {
+	if client == nil || timeout <= 0 {
+		return
+	}
+	if client.Transport == nil {
+		if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok && defaultTransport != nil {
+			transport := defaultTransport.Clone()
+			transport.ResponseHeaderTimeout = timeout
+			client.Transport = transport
+		}
+		return
+	}
+	if transport, ok := client.Transport.(*http.Transport); ok && transport != nil {
+		clone := transport.Clone()
+		clone.ResponseHeaderTimeout = timeout
+		client.Transport = clone
+	}
+}
+
+func isOpenAICompatStreamFirstResponseTimeout(err error, timeout time.Duration) bool {
+	if err == nil || timeout <= 0 {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "timeout awaiting response headers")
 }
 
 // Refresh is a no-op for API-key based compatibility providers.

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -246,6 +247,59 @@ func TestOpenAICompatExecutorStreamRejectsPlainJSONAfterBlankLines(t *testing.T)
 	}
 	if !strings.Contains(gotErr.Error(), "upstream failed") {
 		t.Fatalf("stream error = %v", gotErr)
+	}
+}
+
+func TestOpenAICompatExecutorStreamTimesOutWaitingForUpstreamResponse(t *testing.T) {
+	origTimeout := openAICompatStreamFirstResponseTimeout
+	openAICompatStreamFirstResponseTimeout = 50 * time.Millisecond
+	defer func() {
+		openAICompatStreamFirstResponseTimeout = origTimeout
+	}()
+
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+	}))
+	defer server.Close()
+	defer close(release)
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+	}}
+
+	errC := make(chan error, 1)
+	go func() {
+		_, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+			Model:   "openrouter-model",
+			Payload: []byte(`{"model":"openrouter-model","messages":[{"role":"user","content":"hi"}],"stream":true}`),
+		}, cliproxyexecutor.Options{
+			SourceFormat: sdktranslator.FromString("openai"),
+			Stream:       true,
+		})
+		errC <- err
+	}()
+
+	var err error
+	select {
+	case err = <-errC:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for upstream first response timeout error")
+	}
+	if err == nil {
+		t.Fatal("expected first response timeout error, got nil")
+	}
+	statusErr, ok := err.(interface{ StatusCode() int })
+	if !ok {
+		t.Fatalf("error %T does not expose StatusCode(): %v", err, err)
+	}
+	if got := statusErr.StatusCode(); got != http.StatusGatewayTimeout {
+		t.Fatalf("status code = %d, want %d; err=%v", got, http.StatusGatewayTimeout, err)
+	}
+	if !strings.Contains(err.Error(), "openai-compatible upstream stream first response timeout after 50ms") {
+		t.Fatalf("error message missing first response timeout: %v", err)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2197,7 +2197,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			}
 		} else {
 			if result.Model != "" {
-				if !isRequestScopedNotFoundResultError(result.Error) {
+				if !isRequestScopedNotFoundResultError(result.Error) && !isLocalStreamTimeoutResultError(result.Error) {
 					disableCooling := quotaCooldownDisabledForAuth(auth)
 					state := ensureModelState(auth, result.Model)
 					state.Unavailable = true
@@ -2512,10 +2512,13 @@ func isUnauthorizedError(err error) bool {
 	if err == nil {
 		return false
 	}
+	raw := strings.ToLower(err.Error())
+	if strings.Contains(raw, "refresh_token_reused") {
+		return false
+	}
 	if statusCodeFromError(err) == http.StatusUnauthorized {
 		return true
 	}
-	raw := strings.ToLower(err.Error())
 	return strings.Contains(raw, "status 401") || strings.Contains(raw, "401 unauthorized")
 }
 
@@ -2630,6 +2633,15 @@ func isRequestScopedNotFoundResultError(err *Error) bool {
 		return false
 	}
 	return isRequestScopedNotFoundMessage(err.Message)
+}
+
+func isLocalStreamTimeoutResultError(err *Error) bool {
+	if err == nil || statusCodeFromResult(err) != http.StatusGatewayTimeout {
+		return false
+	}
+	lower := strings.ToLower(strings.TrimSpace(err.Message))
+	return strings.HasPrefix(lower, "codex upstream stream first response timeout after ") ||
+		strings.HasPrefix(lower, "openai-compatible upstream stream first response timeout after ")
 }
 
 // isRequestInvalidError returns true if the error represents a client request

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -779,6 +779,110 @@ func TestManager_MarkResult_RequestScopedNotFoundDoesNotCooldownAuth(t *testing.
 	}
 }
 
+func TestManager_MarkResult_LocalStreamTimeoutDoesNotCooldownAuth(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+
+	auth := &Auth{
+		ID:       "auth-local-timeout",
+		Provider: "openai-compatibility",
+	}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	model := "gpt-5.5"
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    model,
+		Success:  false,
+		Error: &Error{
+			HTTPStatus: http.StatusGatewayTimeout,
+			Message:    "openai-compatible upstream stream first response timeout after 2m0s",
+		},
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	if updated.Unavailable {
+		t.Fatalf("expected local stream timeout to keep auth available")
+	}
+	if !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("expected local stream timeout to keep auth cooldown unset, got %v", updated.NextRetryAfter)
+	}
+	if state := updated.ModelStates[model]; state != nil {
+		t.Fatalf("expected local stream timeout to avoid model cooldown state, got %#v", state)
+	}
+	if updated.Failed != 1 {
+		t.Fatalf("failed count = %d, want 1", updated.Failed)
+	}
+}
+
+func TestManager_ExecuteStream_LocalStreamTimeoutDoesNotBlackoutOnlyAuth(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(0, 0, 0)
+	executor := &authFallbackExecutor{
+		id: "openai-compatibility",
+		streamFirstErrors: map[string]error{
+			"auth-local-timeout-stream": &retryAfterStatusError{
+				status:  http.StatusGatewayTimeout,
+				message: "codex upstream stream first response timeout after 2m0s",
+			},
+		},
+	}
+	m.RegisterExecutor(executor)
+
+	auth := &Auth{
+		ID:       "auth-local-timeout-stream",
+		Provider: "openai-compatibility",
+	}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	model := "gpt-5.5"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+
+	req := cliproxyexecutor.Request{Model: model}
+	streamResult1, errExecute1 := m.ExecuteStream(context.Background(), []string{auth.Provider}, req, cliproxyexecutor.Options{})
+	if errExecute1 != nil {
+		t.Fatalf("first ExecuteStream returned setup error = %v", errExecute1)
+	}
+	var chunkErr error
+	for chunk := range streamResult1.Chunks {
+		if chunk.Err != nil {
+			chunkErr = chunk.Err
+		}
+	}
+	if chunkErr == nil {
+		t.Fatal("expected first stream chunk error")
+	}
+	if statusCodeFromError(chunkErr) != http.StatusGatewayTimeout {
+		t.Fatalf("first stream chunk status = %d, want %d", statusCodeFromError(chunkErr), http.StatusGatewayTimeout)
+	}
+
+	streamResult2, errExecute2 := m.ExecuteStream(context.Background(), []string{auth.Provider}, req, cliproxyexecutor.Options{})
+	if errExecute2 != nil {
+		t.Fatalf("second ExecuteStream error = %v, want same auth to remain selectable", errExecute2)
+	}
+	for range streamResult2.Chunks {
+	}
+
+	calls := executor.StreamCalls()
+	if len(calls) != 2 {
+		t.Fatalf("stream calls = %v, want two calls to same auth", calls)
+	}
+	for i, call := range calls {
+		if call != auth.ID {
+			t.Fatalf("stream call %d auth = %q, want %q", i, call, auth.ID)
+		}
+	}
+}
+
 func TestManager_RequestScopedNotFoundStopsRetryWithoutSuspendingAuth(t *testing.T) {
 	m := NewManager(nil, nil, nil)
 	executor := &authFallbackExecutor{

--- a/sdk/cliproxy/auth/conductor_scheduler_refresh_test.go
+++ b/sdk/cliproxy/auth/conductor_scheduler_refresh_test.go
@@ -45,6 +45,14 @@ func (e unauthorizedRefreshTestExecutor) Refresh(ctx context.Context, auth *Auth
 	return nil, errors.New("token refresh failed with status 401: invalid_grant")
 }
 
+type refreshTokenReusedTestExecutor struct {
+	schedulerProviderTestExecutor
+}
+
+func (e refreshTokenReusedTestExecutor) Refresh(ctx context.Context, auth *Auth) (*Auth, error) {
+	return nil, errors.New("token refresh failed with status 401: {\"error\":{\"code\":\"refresh_token_reused\"}}")
+}
+
 func TestManager_RefreshAuthUnauthorizedFailureStopsAutoRefreshRetry(t *testing.T) {
 	ctx := context.Background()
 	manager := NewManager(nil, &RoundRobinSelector{}, nil)
@@ -87,6 +95,51 @@ func TestManager_RefreshAuthUnauthorizedFailureStopsAutoRefreshRetry(t *testing.
 	}
 	if _, shouldSchedule := nextRefreshCheckAt(now, updated, time.Second); shouldSchedule {
 		t.Fatal("expected unauthorized auth to be removed from the auto-refresh schedule")
+	}
+}
+
+func TestManager_RefreshAuthTokenReusedDoesNotMarkAuthUnavailable(t *testing.T) {
+	ctx := context.Background()
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.RegisterExecutor(refreshTokenReusedTestExecutor{
+		schedulerProviderTestExecutor: schedulerProviderTestExecutor{provider: "codex"},
+	})
+
+	auth := &Auth{
+		ID:       "refresh-token-reused",
+		Provider: "codex",
+		Metadata: map[string]any{
+			"email": "x@example.com",
+		},
+	}
+	if _, errRegister := manager.Register(ctx, auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	before := time.Now()
+	manager.refreshAuth(ctx, auth.ID)
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok {
+		t.Fatalf("expected auth %q after refresh", auth.ID)
+	}
+	if updated.Unavailable {
+		t.Fatal("refresh_token_reused should not mark auth unavailable")
+	}
+	if updated.LastError == nil {
+		t.Fatal("expected refresh_token_reused failure to be recorded")
+	}
+	if got := updated.LastError.Code; got == "unauthorized" {
+		t.Fatalf("LastError.Code = %q, want non-unauthorized", got)
+	}
+	if got := updated.LastError.StatusCode(); got == http.StatusUnauthorized {
+		t.Fatalf("LastError.StatusCode() = %d, want non-unauthorized", got)
+	}
+	if !updated.NextRefreshAfter.After(before) {
+		t.Fatalf("NextRefreshAfter = %s, want retry backoff after %s", updated.NextRefreshAfter, before)
+	}
+	if manager.shouldRefresh(updated, time.Now()) {
+		t.Fatal("expected refresh_token_reused auth to wait for retry backoff")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Port the valuable functional parts of upstream PR #3627 (`router-for-me/CLIProxyAPI#3627`) for Codex and OpenAI-compatible stream hangs.
- Add response-header first-response timeouts for Codex HTTP streams and OpenAI-compatible chat/image streams, returning 504 instead of hanging forever before upstream headers arrive.
- Deduplicate concurrent Codex token refreshes with `singleflight`, and avoid blacking out auth/model state for local proxy-generated first-response stream timeouts.
- Treat `refresh_token_reused` refresh failures as retryable/backoff refresh errors rather than permanent unauthorized auth disablement.

## LTS adaptation notes
- Preserves `github.com/router-for-me/CLIProxyAPI/v6` module path and the existing LTS usage reporter flow.
- Does not touch `internal/usage/`, Management usage endpoints, or `AGENTS.md`.
- Does not port upstream PR #3627's broad stream progress logging into `sdk/api`/auth conductor; this PR keeps the behavior hardening and targeted debug logs without adding normal-path log noise.

## Validation
- `go test ./internal/auth/codex -run 'RefreshTokens'`
- `go test ./internal/runtime/executor -run 'CodexExecutorExecuteStreamTimesOut|OpenAICompatExecutorStreamTimesOut'`
- `go test ./sdk/cliproxy/auth -run 'LocalStreamTimeout|RefreshAuthTokenReused'`
- `go test ./internal/auth/codex ./internal/runtime/executor ./sdk/cliproxy/auth`
- `go test ./sdk/cliproxy/...`
- `git diff --check`
- `go test ./...`
- `go build -o test-output ./cmd/server && rm -f test-output`