### PR TITLE
[codex] Port auth refresh staggering

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -104,6 +104,14 @@ disable-image-generation: false
 # When > 0, overrides the default worker count (16).
 # auth-auto-refresh-workers: 16
 
+# Stable per-credential jitter window for auth auto-refresh scheduling.
+# When > 0, spreads refresh checks for bulk-provisioned credentials over this many minutes.
+# auth-refresh-jitter-minutes: 5
+
+# Maximum concurrent token refreshes per provider.
+# When <= 0, uses the default limit (3).
+# auth-max-concurrent-refresh-per-provider: 3
+
 # Quota exceeded behavior
 quota-exceeded:
   switch-project: true # Whether to automatically switch to another project when a quota is exceeded

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,6 +78,14 @@ type Config struct {
 	// When <= 0, the default worker count is used.
 	AuthAutoRefreshWorkers int `yaml:"auth-auto-refresh-workers" json:"auth-auto-refresh-workers"`
 
+	// AuthRefreshJitterMinutes adds a stable per-credential jitter to refresh scheduling.
+	// When <= 0, no jitter is applied.
+	AuthRefreshJitterMinutes int `yaml:"auth-refresh-jitter-minutes" json:"auth-refresh-jitter-minutes"`
+
+	// AuthMaxConcurrentRefreshPerProvider limits simultaneous token refreshes per provider.
+	// When <= 0, the default limit is used.
+	AuthMaxConcurrentRefreshPerProvider int `yaml:"auth-max-concurrent-refresh-per-provider" json:"auth-max-concurrent-refresh-per-provider"`
+
 	// RequestRetry defines the retry times when the request failed.
 	RequestRetry int `yaml:"request-retry" json:"request-retry"`
 	// MaxRetryCredentials defines the maximum number of credentials to try for a failed request.

--- a/sdk/cliproxy/auth/auto_refresh_loop.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"container/heap"
 	"context"
+	"hash/fnv"
 	"strings"
 	"sync"
 	"time"
@@ -44,6 +45,17 @@ func newAuthAutoRefreshLoop(manager *Manager, interval time.Duration, concurrenc
 		wakeCh:      make(chan struct{}, 1),
 		jobs:        make(chan string, jobBuffer),
 	}
+}
+
+// stableJitter returns a deterministic duration in [0, window) derived from the auth ID.
+// The offset stays stable across queue rebuilds, so refresh schedules do not drift.
+func stableJitter(authID string, window time.Duration) time.Duration {
+	if window <= 0 || authID == "" {
+		return 0
+	}
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(authID))
+	return time.Duration(h.Sum64() % uint64(window))
 }
 
 func (l *authAutoRefreshLoop) queueReschedule(authID string) {
@@ -99,8 +111,9 @@ func (l *authAutoRefreshLoop) rebuild(now time.Time) {
 	entries := make([]entry, 0)
 
 	l.manager.mu.RLock()
+	jitterWindow := l.manager.authRefreshJitterWindow()
 	for id, auth := range l.manager.auths {
-		next, ok := nextRefreshCheckAt(now, auth, l.interval)
+		next, ok := nextRefreshCheckAt(now, auth, l.interval, jitterWindow)
 		if !ok {
 			continue
 		}
@@ -231,7 +244,7 @@ func (l *authAutoRefreshLoop) handleDueAuth(ctx context.Context, now time.Time, 
 		manager.mu.RUnlock()
 		return
 	}
-	next, shouldSchedule := nextRefreshCheckAt(now, auth, l.interval)
+	next, shouldSchedule := nextRefreshCheckAt(now, auth, l.interval, manager.authRefreshJitterWindow())
 	shouldRefresh := manager.shouldRefresh(auth, now)
 	exec := manager.executors[auth.Provider]
 	manager.mu.RUnlock()
@@ -254,7 +267,7 @@ func (l *authAutoRefreshLoop) handleDueAuth(ctx context.Context, now time.Time, 
 	if !manager.markRefreshPending(authID, now) {
 		manager.mu.RLock()
 		auth = manager.auths[authID]
-		next, shouldSchedule = nextRefreshCheckAt(now, auth, l.interval)
+		next, shouldSchedule = nextRefreshCheckAt(now, auth, l.interval, manager.authRefreshJitterWindow())
 		manager.mu.RUnlock()
 		if shouldSchedule {
 			l.upsert(authID, next)
@@ -280,7 +293,7 @@ func (l *authAutoRefreshLoop) applyDirty(now time.Time) {
 	for _, authID := range dirty {
 		l.manager.mu.RLock()
 		auth := l.manager.auths[authID]
-		next, ok := nextRefreshCheckAt(now, auth, l.interval)
+		next, ok := nextRefreshCheckAt(now, auth, l.interval, l.manager.authRefreshJitterWindow())
 		l.manager.mu.RUnlock()
 
 		if !ok {
@@ -335,7 +348,7 @@ func (l *authAutoRefreshLoop) remove(authID string) {
 	delete(l.index, authID)
 }
 
-func nextRefreshCheckAt(now time.Time, auth *Auth, interval time.Duration) (time.Time, bool) {
+func nextRefreshCheckAt(now time.Time, auth *Auth, interval, jitterWindow time.Duration) (time.Time, bool) {
 	if auth == nil || auth.Disabled {
 		return time.Time{}, false
 	}
@@ -392,20 +405,21 @@ func nextRefreshCheckAt(now time.Time, auth *Auth, interval time.Duration) (time
 		return next, true
 	}
 
+	jitter := stableJitter(auth.ID, jitterWindow)
 	provider := strings.ToLower(auth.Provider)
 	lead := ProviderRefreshLead(provider, auth.Runtime)
 	if lead == nil {
 		return time.Time{}, false
 	}
 	if hasExpiry && !expiry.IsZero() {
-		dueAt := expiry.Add(-*lead)
+		dueAt := expiry.Add(-*lead).Add(jitter)
 		if !dueAt.After(now) {
 			return now, true
 		}
 		return dueAt, true
 	}
 	if !lastRefresh.IsZero() {
-		dueAt := lastRefresh.Add(*lead)
+		dueAt := lastRefresh.Add(*lead).Add(jitter)
 		if !dueAt.After(now) {
 			return now, true
 		}

--- a/sdk/cliproxy/auth/auto_refresh_loop_test.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop_test.go
@@ -35,7 +35,7 @@ func setRefreshLeadFactory(t *testing.T, provider string, factory func() *time.D
 func TestNextRefreshCheckAt_DisabledUnschedule(t *testing.T) {
 	now := time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC)
 	auth := &Auth{ID: "a1", Provider: "test", Disabled: true}
-	if _, ok := nextRefreshCheckAt(now, auth, 15*time.Minute); ok {
+	if _, ok := nextRefreshCheckAt(now, auth, 15*time.Minute, 0); ok {
 		t.Fatalf("nextRefreshCheckAt() ok = true, want false")
 	}
 }
@@ -43,7 +43,7 @@ func TestNextRefreshCheckAt_DisabledUnschedule(t *testing.T) {
 func TestNextRefreshCheckAt_APIKeyUnschedule(t *testing.T) {
 	now := time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC)
 	auth := &Auth{ID: "a1", Provider: "test", Attributes: map[string]string{"api_key": "k"}}
-	if _, ok := nextRefreshCheckAt(now, auth, 15*time.Minute); ok {
+	if _, ok := nextRefreshCheckAt(now, auth, 15*time.Minute, 0); ok {
 		t.Fatalf("nextRefreshCheckAt() ok = true, want false")
 	}
 }
@@ -57,7 +57,7 @@ func TestNextRefreshCheckAt_NextRefreshAfterGate(t *testing.T) {
 		NextRefreshAfter: nextAfter,
 		Metadata:         map[string]any{"email": "x@example.com"},
 	}
-	got, ok := nextRefreshCheckAt(now, auth, 15*time.Minute)
+	got, ok := nextRefreshCheckAt(now, auth, 15*time.Minute, 0)
 	if !ok {
 		t.Fatalf("nextRefreshCheckAt() ok = false, want true")
 	}
@@ -79,7 +79,7 @@ func TestNextRefreshCheckAt_PreferredInterval_PicksEarliestCandidate(t *testing.
 			"refresh_interval_seconds": 900, // 15m
 		},
 	}
-	got, ok := nextRefreshCheckAt(now, auth, 15*time.Minute)
+	got, ok := nextRefreshCheckAt(now, auth, 15*time.Minute, 0)
 	if !ok {
 		t.Fatalf("nextRefreshCheckAt() ok = false, want true")
 	}
@@ -107,11 +107,82 @@ func TestNextRefreshCheckAt_ProviderLead_Expiry(t *testing.T) {
 		},
 	}
 
-	got, ok := nextRefreshCheckAt(now, auth, 15*time.Minute)
+	got, ok := nextRefreshCheckAt(now, auth, 15*time.Minute, 0)
 	if !ok {
 		t.Fatalf("nextRefreshCheckAt() ok = false, want true")
 	}
 	want := expiry.Add(-lead)
+	if !got.Equal(want) {
+		t.Fatalf("nextRefreshCheckAt() = %s, want %s", got, want)
+	}
+}
+
+func TestStableJitterDeterministicAndBounded(t *testing.T) {
+	window := 5 * time.Minute
+	got1 := stableJitter("auth-a", window)
+	got2 := stableJitter("auth-a", window)
+	if got1 != got2 {
+		t.Fatalf("stableJitter() = %s then %s, want deterministic", got1, got2)
+	}
+	if got1 < 0 || got1 >= window {
+		t.Fatalf("stableJitter() = %s, want in [0,%s)", got1, window)
+	}
+	if got := stableJitter("auth-a", 0); got != 0 {
+		t.Fatalf("stableJitter() with zero window = %s, want 0", got)
+	}
+	if got := stableJitter("", window); got != 0 {
+		t.Fatalf("stableJitter() with empty auth ID = %s, want 0", got)
+	}
+}
+
+func TestNextRefreshCheckAt_ProviderLeadAppliesStableJitter(t *testing.T) {
+	now := time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC)
+	expiry := now.Add(time.Hour)
+	lead := 10 * time.Minute
+	jitterWindow := 5 * time.Minute
+	setRefreshLeadFactory(t, "provider-lead-jitter", func() *time.Duration {
+		d := lead
+		return &d
+	})
+
+	auth := &Auth{
+		ID:       "auth-with-stable-jitter",
+		Provider: "provider-lead-jitter",
+		Metadata: map[string]any{
+			"email":      "x@example.com",
+			"expires_at": expiry.Format(time.RFC3339),
+		},
+	}
+
+	got, ok := nextRefreshCheckAt(now, auth, 15*time.Minute, jitterWindow)
+	if !ok {
+		t.Fatalf("nextRefreshCheckAt() ok = false, want true")
+	}
+	want := expiry.Add(-lead).Add(stableJitter(auth.ID, jitterWindow))
+	if !got.Equal(want) {
+		t.Fatalf("nextRefreshCheckAt() = %s, want %s", got, want)
+	}
+}
+
+func TestNextRefreshCheckAt_PreferredIntervalDoesNotApplyJitter(t *testing.T) {
+	now := time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC)
+	expiry := now.Add(time.Hour)
+	auth := &Auth{
+		ID:              "auth-preferred-no-jitter",
+		Provider:        "test",
+		LastRefreshedAt: now,
+		Metadata: map[string]any{
+			"email":                    "x@example.com",
+			"expires_at":               expiry.Format(time.RFC3339),
+			"refresh_interval_seconds": 900,
+		},
+	}
+
+	got, ok := nextRefreshCheckAt(now, auth, 15*time.Minute, 5*time.Minute)
+	if !ok {
+		t.Fatalf("nextRefreshCheckAt() ok = false, want true")
+	}
+	want := now.Add(15 * time.Minute)
 	if !got.Equal(want) {
 		t.Fatalf("nextRefreshCheckAt() = %s, want %s", got, want)
 	}
@@ -126,7 +197,7 @@ func TestNextRefreshCheckAt_RefreshEvaluatorFallback(t *testing.T) {
 		Metadata: map[string]any{"email": "x@example.com"},
 		Runtime:  testRefreshEvaluator{},
 	}
-	got, ok := nextRefreshCheckAt(now, auth, interval)
+	got, ok := nextRefreshCheckAt(now, auth, interval, 0)
 	if !ok {
 		t.Fatalf("nextRefreshCheckAt() ok = false, want true")
 	}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -187,6 +187,10 @@ type Manager struct {
 	refreshLoop   *authAutoRefreshLoop
 
 	requestPrepareLocks sync.Map
+
+	// providerRefreshSems limits concurrent token refreshes per provider.
+	providerRefreshSems   map[string]chan struct{}
+	providerRefreshSemsMu sync.RWMutex
 }
 
 // NewManager constructs a manager with optional custom selector and hook.
@@ -198,13 +202,14 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 		hook = NoopHook{}
 	}
 	manager := &Manager{
-		store:            store,
-		executors:        make(map[string]ProviderExecutor),
-		selector:         selector,
-		hook:             hook,
-		auths:            make(map[string]*Auth),
-		providerOffsets:  make(map[string]int),
-		modelPoolOffsets: make(map[string]int),
+		store:               store,
+		executors:           make(map[string]ProviderExecutor),
+		selector:            selector,
+		hook:                hook,
+		auths:               make(map[string]*Auth),
+		providerOffsets:     make(map[string]int),
+		modelPoolOffsets:    make(map[string]int),
+		providerRefreshSems: make(map[string]chan struct{}),
 	}
 	// atomic.Value requires non-nil initial value.
 	manager.runtimeConfig.Store(&internalconfig.Config{})
@@ -385,6 +390,90 @@ func (m *Manager) SetConfig(cfg *internalconfig.Config) {
 	}
 	m.runtimeConfig.Store(cfg)
 	m.rebuildAPIKeyModelAliasFromRuntimeConfig()
+	m.rebuildProviderRefreshSems(cfg)
+}
+
+const defaultMaxConcurrentRefreshPerProvider = 3
+
+func authMaxConcurrentRefreshPerProvider(cfg *internalconfig.Config) int {
+	if cfg != nil && cfg.AuthMaxConcurrentRefreshPerProvider > 0 {
+		return cfg.AuthMaxConcurrentRefreshPerProvider
+	}
+	return defaultMaxConcurrentRefreshPerProvider
+}
+
+func (m *Manager) authRefreshJitterWindow() time.Duration {
+	if m == nil {
+		return 0
+	}
+	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	if cfg == nil || cfg.AuthRefreshJitterMinutes <= 0 {
+		return 0
+	}
+	return time.Duration(cfg.AuthRefreshJitterMinutes) * time.Minute
+}
+
+func (m *Manager) rebuildProviderRefreshSems(cfg *internalconfig.Config) {
+	if m == nil {
+		return
+	}
+	limit := authMaxConcurrentRefreshPerProvider(cfg)
+
+	m.mu.RLock()
+	providers := make([]string, 0, len(m.executors))
+	for provider := range m.executors {
+		provider = strings.ToLower(strings.TrimSpace(provider))
+		if provider != "" {
+			providers = append(providers, provider)
+		}
+	}
+	m.mu.RUnlock()
+
+	sems := make(map[string]chan struct{}, len(providers))
+	for _, provider := range providers {
+		if _, exists := sems[provider]; !exists {
+			sems[provider] = make(chan struct{}, limit)
+		}
+	}
+
+	m.providerRefreshSemsMu.Lock()
+	m.providerRefreshSems = sems
+	m.providerRefreshSemsMu.Unlock()
+}
+
+func (m *Manager) ensureProviderRefreshSem(provider string) chan struct{} {
+	if m == nil {
+		return nil
+	}
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "" {
+		return nil
+	}
+
+	m.providerRefreshSemsMu.RLock()
+	sem := m.providerRefreshSems[provider]
+	m.providerRefreshSemsMu.RUnlock()
+	if sem != nil {
+		return sem
+	}
+
+	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	limit := authMaxConcurrentRefreshPerProvider(cfg)
+	m.providerRefreshSemsMu.Lock()
+	defer m.providerRefreshSemsMu.Unlock()
+	if m.providerRefreshSems == nil {
+		m.providerRefreshSems = make(map[string]chan struct{})
+	}
+	if sem = m.providerRefreshSems[provider]; sem != nil {
+		return sem
+	}
+	sem = make(chan struct{}, limit)
+	m.providerRefreshSems[provider] = sem
+	return sem
+}
+
+func (m *Manager) providerRefreshSem(provider string) chan struct{} {
+	return m.ensureProviderRefreshSem(provider)
 }
 
 func (m *Manager) lookupAPIKeyUpstreamModel(authID, requestedModel string) string {
@@ -1084,6 +1173,7 @@ func (m *Manager) RegisterExecutor(executor ProviderExecutor) {
 	replaced = m.executors[provider]
 	m.executors[provider] = executor
 	m.mu.Unlock()
+	m.ensureProviderRefreshSem(provider)
 
 	if replaced == nil || replaced == executor {
 		return
@@ -3675,6 +3765,14 @@ func (m *Manager) refreshAuth(ctx context.Context, id string) {
 	m.mu.RUnlock()
 	if auth == nil || exec == nil {
 		return
+	}
+	if sem := m.providerRefreshSem(auth.Provider); sem != nil {
+		select {
+		case <-ctx.Done():
+			return
+		case sem <- struct{}{}:
+		}
+		defer func() { <-sem }()
 	}
 	updated, err := exec.Refresh(ctx, cloned)
 	if err != nil && errors.Is(err, context.Canceled) {

--- a/sdk/cliproxy/auth/conductor_scheduler_refresh_test.go
+++ b/sdk/cliproxy/auth/conductor_scheduler_refresh_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 )
@@ -37,12 +40,125 @@ func (e schedulerProviderTestExecutor) HttpRequest(ctx context.Context, auth *Au
 	return nil, nil
 }
 
+type blockingRefreshTestExecutor struct {
+	schedulerProviderTestExecutor
+	entered   chan struct{}
+	release   chan struct{}
+	active    int32
+	maxActive int32
+}
+
+func (e *blockingRefreshTestExecutor) Refresh(ctx context.Context, auth *Auth) (*Auth, error) {
+	active := atomic.AddInt32(&e.active, 1)
+	for {
+		maxActive := atomic.LoadInt32(&e.maxActive)
+		if active <= maxActive || atomic.CompareAndSwapInt32(&e.maxActive, maxActive, active) {
+			break
+		}
+	}
+	select {
+	case e.entered <- struct{}{}:
+	default:
+	}
+	select {
+	case <-ctx.Done():
+		atomic.AddInt32(&e.active, -1)
+		return nil, ctx.Err()
+	case <-e.release:
+	}
+	time.Sleep(10 * time.Millisecond)
+	atomic.AddInt32(&e.active, -1)
+	return auth, nil
+}
+
 type unauthorizedRefreshTestExecutor struct {
 	schedulerProviderTestExecutor
 }
 
 func (e unauthorizedRefreshTestExecutor) Refresh(ctx context.Context, auth *Auth) (*Auth, error) {
 	return nil, errors.New("token refresh failed with status 401: invalid_grant")
+}
+
+func TestManager_AuthRefreshJitterWindowReadsRuntimeConfig(t *testing.T) {
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	if got := manager.authRefreshJitterWindow(); got != 0 {
+		t.Fatalf("authRefreshJitterWindow() = %s, want 0", got)
+	}
+	manager.SetConfig(&internalconfig.Config{AuthRefreshJitterMinutes: 7})
+	if got := manager.authRefreshJitterWindow(); got != 7*time.Minute {
+		t.Fatalf("authRefreshJitterWindow() = %s, want 7m", got)
+	}
+}
+
+func TestManager_ProviderRefreshSemaphoreRespectsConfigBeforeExecutorRegistration(t *testing.T) {
+	ctx := context.Background()
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.SetConfig(&internalconfig.Config{AuthMaxConcurrentRefreshPerProvider: 1})
+	executor := &blockingRefreshTestExecutor{
+		schedulerProviderTestExecutor: schedulerProviderTestExecutor{provider: "codex"},
+		entered:                       make(chan struct{}, 3),
+		release:                       make(chan struct{}),
+	}
+	manager.RegisterExecutor(executor)
+
+	for _, id := range []string{"refresh-a", "refresh-b", "refresh-c"} {
+		if _, errRegister := manager.Register(ctx, &Auth{
+			ID:       id,
+			Provider: "codex",
+			Metadata: map[string]any{
+				"email": id + "@example.com",
+			},
+		}); errRegister != nil {
+			t.Fatalf("register %s: %v", id, errRegister)
+		}
+	}
+
+	var wg sync.WaitGroup
+	for _, id := range []string{"refresh-a", "refresh-b", "refresh-c"} {
+		id := id
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			manager.refreshAuth(ctx, id)
+		}()
+	}
+	select {
+	case <-executor.entered:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first refresh to enter")
+	}
+	time.Sleep(50 * time.Millisecond)
+	if got := atomic.LoadInt32(&executor.maxActive); got != 1 {
+		t.Fatalf("max concurrent refreshes = %d, want 1", got)
+	}
+	if extra := len(executor.entered); extra != 0 {
+		t.Fatalf("refreshes entered while semaphore was held = %d, want 0", extra)
+	}
+
+	close(executor.release)
+	wg.Wait()
+	if got := atomic.LoadInt32(&executor.maxActive); got != 1 {
+		t.Fatalf("max concurrent refreshes after completion = %d, want 1", got)
+	}
+}
+
+func TestManager_ProviderRefreshSemaphoreRebuildsOnConfigReload(t *testing.T) {
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.RegisterExecutor(schedulerProviderTestExecutor{provider: "codex"})
+	manager.SetConfig(&internalconfig.Config{AuthMaxConcurrentRefreshPerProvider: 2})
+	first := manager.providerRefreshSem("codex")
+	if first == nil || cap(first) != 2 {
+		t.Fatalf("providerRefreshSem cap = %d, want 2", cap(first))
+	}
+
+	manager.SetConfig(&internalconfig.Config{AuthMaxConcurrentRefreshPerProvider: 4})
+	second := manager.providerRefreshSem("codex")
+	if second == nil || cap(second) != 4 {
+		t.Fatalf("providerRefreshSem cap = %d, want 4", cap(second))
+	}
+	if second == first {
+		t.Fatal("expected config reload to rebuild provider refresh semaphore")
+	}
 }
 
 func TestManager_RefreshAuthUnauthorizedFailureStopsAutoRefreshRetry(t *testing.T) {
@@ -85,7 +201,7 @@ func TestManager_RefreshAuthUnauthorizedFailureStopsAutoRefreshRetry(t *testing.
 	if manager.shouldRefresh(updated, now) {
 		t.Fatal("expected unauthorized auth to stop refresh attempts")
 	}
-	if _, shouldSchedule := nextRefreshCheckAt(now, updated, time.Second); shouldSchedule {
+	if _, shouldSchedule := nextRefreshCheckAt(now, updated, time.Second, 0); shouldSchedule {
 		t.Fatal("expected unauthorized auth to be removed from the auto-refresh schedule")
 	}
 }


### PR DESCRIPTION
## Summary
- Port the useful parts of upstream PR #3597 (`router-for-me/CLIProxyAPI#3597`) for auth refresh stability.
- Add `auth-refresh-jitter-minutes` to spread OAuth/file-backed refresh checks with stable per-credential jitter.
- Add `auth-max-concurrent-refresh-per-provider` to cap simultaneous token refreshes per provider, defaulting to 3.
- Document both config keys in `config.example.yaml`.

## LTS adaptation notes
- Preserves `github.com/router-for-me/CLIProxyAPI/v6`, `internal/usage`, and Management usage endpoints.
- Keeps the change scoped to config + SDK auth refresh scheduling; no translator or AGENTS changes.
- Improves on the upstream draft by making jitter read from runtime config at scheduling time, so hot reload can affect subsequent scheduling.
- Makes provider refresh semaphores robust when `SetConfig` runs before `RegisterExecutor`, which is a normal LTS startup path.
- Leaves upstream PR #3598 circuit breaker for a separate PR because it changes auth failure/cooldown semantics.

## Validation
- `go test ./sdk/cliproxy/auth -run 'StableJitter|NextRefreshCheckAt|ProviderRefreshSemaphore|AuthRefreshJitterWindow'`
- `go test ./internal/config -run 'Config|Load|Parse|Yaml|YAML'`
- `go test ./internal/config ./sdk/cliproxy/auth ./sdk/cliproxy/...`
- `go test ./internal/watcher/diff ./internal/api/handlers/management`
- `go test -race ./sdk/cliproxy/auth -run 'StableJitter|NextRefreshCheckAt|ProviderRefreshSemaphore|AuthRefreshJitterWindow'`
- `git diff --check`
- `go test ./...`
- `go build -o test-output ./cmd/server && rm -f test-output`