### PR TITLE
[codex] Port auth transient circuit breaker

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -104,6 +104,13 @@ disable-image-generation: false
 # When > 0, overrides the default worker count (16).
 # auth-auto-refresh-workers: 16
 
+# Consecutive transient upstream failures (HTTP 408/500/502/503/504) before opening
+# a credential circuit. Set to -1 to disable. When <= 0, the default is 5.
+# auth-circuit-breaker-threshold: 5
+
+# Minutes to keep an opened credential circuit cooled down. When <= 0, the default is 10.
+# auth-circuit-breaker-cooldown-minutes: 10
+
 # Quota exceeded behavior
 quota-exceeded:
   switch-project: true # Whether to automatically switch to another project when a quota is exceeded

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,6 +78,15 @@ type Config struct {
 	// When <= 0, the default worker count is used.
 	AuthAutoRefreshWorkers int `yaml:"auth-auto-refresh-workers" json:"auth-auto-refresh-workers"`
 
+	// AuthCircuitBreakerThreshold is the number of consecutive transient errors (5xx/408)
+	// required before a credential's circuit is opened. When <= 0, the default (5) is used.
+	// Set to -1 to disable the circuit breaker entirely.
+	AuthCircuitBreakerThreshold int `yaml:"auth-circuit-breaker-threshold" json:"auth-circuit-breaker-threshold"`
+
+	// AuthCircuitBreakerCooldownMinutes is how long (in minutes) to hold a credential in the
+	// open-circuit state before allowing it to be retried. When <= 0, the default (10) is used.
+	AuthCircuitBreakerCooldownMinutes int `yaml:"auth-circuit-breaker-cooldown-minutes" json:"auth-circuit-breaker-cooldown-minutes"`
+
 	// RequestRetry defines the retry times when the request failed.
 	RequestRetry int `yaml:"request-retry" json:"request-retry"`
 	// MaxRetryCredentials defines the maximum number of credentials to try for a failed request.

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -387,6 +387,56 @@ func (m *Manager) SetConfig(cfg *internalconfig.Config) {
 	m.rebuildAPIKeyModelAliasFromRuntimeConfig()
 }
 
+const (
+	defaultCircuitBreakerThreshold       = 5
+	defaultCircuitBreakerCooldownMinutes = 10
+)
+
+// applyCircuitBreaker opens a credential circuit after repeated transient upstream failures.
+// The caller must hold m.mu.
+func (m *Manager) applyCircuitBreaker(auth *Auth, state *ModelState, statusCode int, now time.Time) {
+	if m == nil || auth == nil {
+		return
+	}
+	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	threshold := defaultCircuitBreakerThreshold
+	cooldown := defaultCircuitBreakerCooldownMinutes * time.Minute
+	if cfg != nil {
+		if cfg.AuthCircuitBreakerThreshold < 0 {
+			return
+		}
+		if cfg.AuthCircuitBreakerThreshold > 0 {
+			threshold = cfg.AuthCircuitBreakerThreshold
+		}
+		if cfg.AuthCircuitBreakerCooldownMinutes > 0 {
+			cooldown = time.Duration(cfg.AuthCircuitBreakerCooldownMinutes) * time.Minute
+		}
+	}
+
+	switch statusCode {
+	case http.StatusRequestTimeout, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+	default:
+		auth.ConsecutiveTransientFailures = 0
+		return
+	}
+
+	auth.ConsecutiveTransientFailures++
+	if auth.ConsecutiveTransientFailures < threshold {
+		return
+	}
+
+	next := now.Add(cooldown)
+	auth.Unavailable = true
+	if auth.NextRetryAfter.IsZero() || auth.NextRetryAfter.Before(next) {
+		auth.NextRetryAfter = next
+		log.Warnf("circuit breaker opened: %s/%s after %d consecutive transient failures, retry after %s",
+			auth.Provider, auth.ID, auth.ConsecutiveTransientFailures, next.Format(time.RFC3339))
+	}
+	if state != nil && (state.NextRetryAfter.IsZero() || state.NextRetryAfter.Before(next)) {
+		state.NextRetryAfter = next
+	}
+}
+
 func (m *Manager) lookupAPIKeyUpstreamModel(authID, requestedModel string) string {
 	if m == nil {
 		return ""
@@ -2189,6 +2239,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 					auth.StatusMessage = ""
 					auth.Status = StatusActive
 				}
+				auth.ConsecutiveTransientFailures = 0
 				auth.UpdatedAt = now
 				shouldResumeModel = true
 				clearModelQuota = true
@@ -2286,9 +2337,11 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 					auth.Status = StatusError
 					auth.UpdatedAt = now
 					updateAggregatedAvailability(auth, now)
+					m.applyCircuitBreaker(auth, state, statusCodeFromResult(result.Error), now)
 				}
 			} else {
 				applyAuthFailureState(auth, result.Error, result.RetryAfter, now)
+				m.applyCircuitBreaker(auth, nil, statusCodeFromResult(result.Error), now)
 			}
 		}
 
@@ -2472,6 +2525,7 @@ func clearAuthStateOnSuccess(auth *Auth, now time.Time) {
 	auth.Quota.BackoffLevel = 0
 	auth.LastError = nil
 	auth.NextRetryAfter = time.Time{}
+	auth.ConsecutiveTransientFailures = 0
 	auth.UpdatedAt = now
 }
 

--- a/sdk/cliproxy/auth/conductor_circuit_breaker_test.go
+++ b/sdk/cliproxy/auth/conductor_circuit_breaker_test.go
@@ -1,0 +1,133 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestManagerMarkResult_CircuitBreakerExtendsModelCooldown(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{
+		AuthCircuitBreakerThreshold:       2,
+		AuthCircuitBreakerCooldownMinutes: 7,
+	})
+	auth := &Auth{ID: "auth-circuit", Provider: "gemini"}
+	if _, err := manager.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	model := "gemini-test"
+	start := time.Now()
+	for i := 0; i < 2; i++ {
+		manager.MarkResult(context.Background(), Result{
+			AuthID:   auth.ID,
+			Provider: auth.Provider,
+			Model:    model,
+			Success:  false,
+			Error:    &Error{HTTPStatus: http.StatusServiceUnavailable, Message: "upstream unavailable"},
+		})
+	}
+
+	got, ok := manager.GetByID(auth.ID)
+	if !ok || got == nil {
+		t.Fatalf("GetByID() ok=%v auth=%v", ok, got)
+	}
+	if got.ConsecutiveTransientFailures != 2 {
+		t.Fatalf("ConsecutiveTransientFailures = %d, want 2", got.ConsecutiveTransientFailures)
+	}
+	state := got.ModelStates[model]
+	if state == nil {
+		t.Fatalf("expected model state for %q", model)
+	}
+	minRetry := start.Add(6 * time.Minute)
+	if !state.NextRetryAfter.After(minRetry) {
+		t.Fatalf("model NextRetryAfter = %s, want after %s", state.NextRetryAfter, minRetry)
+	}
+	if !got.NextRetryAfter.Equal(state.NextRetryAfter) {
+		t.Fatalf("auth NextRetryAfter = %s, want model retry %s", got.NextRetryAfter, state.NextRetryAfter)
+	}
+	blocked, reason, next := isAuthBlockedForModel(got, "another-model", time.Now())
+	if !blocked || reason != blockReasonOther || !next.Equal(got.NextRetryAfter) {
+		t.Fatalf("isAuthBlockedForModel() = blocked %v reason %v next %s, want circuit block until %s", blocked, reason, next, got.NextRetryAfter)
+	}
+
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    model,
+		Success:  true,
+	})
+	got, ok = manager.GetByID(auth.ID)
+	if !ok || got == nil {
+		t.Fatalf("GetByID() after success ok=%v auth=%v", ok, got)
+	}
+	if got.ConsecutiveTransientFailures != 0 {
+		t.Fatalf("ConsecutiveTransientFailures after success = %d, want 0", got.ConsecutiveTransientFailures)
+	}
+	if state := got.ModelStates[model]; state == nil || !state.NextRetryAfter.IsZero() {
+		t.Fatalf("model state after success = %+v, want cleared retry", state)
+	}
+}
+
+func TestManagerMarkResult_CircuitBreakerResetsOnNonTransientError(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{
+		AuthCircuitBreakerThreshold:       2,
+		AuthCircuitBreakerCooldownMinutes: 7,
+	})
+	auth := &Auth{ID: "auth-circuit-reset", Provider: "claude"}
+	if _, err := manager.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusServiceUnavailable, Message: "upstream unavailable"},
+	})
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"},
+	})
+
+	got, ok := manager.GetByID(auth.ID)
+	if !ok || got == nil {
+		t.Fatalf("GetByID() ok=%v auth=%v", ok, got)
+	}
+	if got.ConsecutiveTransientFailures != 0 {
+		t.Fatalf("ConsecutiveTransientFailures = %d, want 0", got.ConsecutiveTransientFailures)
+	}
+}
+
+func TestManagerMarkResult_CircuitBreakerCanBeDisabled(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{AuthCircuitBreakerThreshold: -1})
+	auth := &Auth{ID: "auth-circuit-disabled", Provider: "codex"}
+	if _, err := manager.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		manager.MarkResult(context.Background(), Result{
+			AuthID:   auth.ID,
+			Provider: auth.Provider,
+			Success:  false,
+			Error:    &Error{HTTPStatus: http.StatusGatewayTimeout, Message: "timeout"},
+		})
+	}
+
+	got, ok := manager.GetByID(auth.ID)
+	if !ok || got == nil {
+		t.Fatalf("GetByID() ok=%v auth=%v", ok, got)
+	}
+	if got.ConsecutiveTransientFailures != 0 {
+		t.Fatalf("ConsecutiveTransientFailures = %d, want 0", got.ConsecutiveTransientFailures)
+	}
+}

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -375,6 +375,19 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 	if auth.Disabled || auth.Status == StatusDisabled {
 		return true, blockReasonDisabled, time.Time{}
 	}
+	if auth.Unavailable && auth.NextRetryAfter.After(now) {
+		next := auth.NextRetryAfter
+		if !auth.Quota.NextRecoverAt.IsZero() && auth.Quota.NextRecoverAt.After(now) {
+			next = auth.Quota.NextRecoverAt
+		}
+		if next.Before(now) {
+			next = now
+		}
+		if auth.Quota.Exceeded {
+			return true, blockReasonCooldown, next
+		}
+		return true, blockReasonOther, next
+	}
 	if model != "" {
 		if len(auth.ModelStates) > 0 {
 			state, ok := auth.ModelStates[model]
@@ -410,19 +423,6 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 			}
 		}
 		return false, blockReasonNone, time.Time{}
-	}
-	if auth.Unavailable && auth.NextRetryAfter.After(now) {
-		next := auth.NextRetryAfter
-		if !auth.Quota.NextRecoverAt.IsZero() && auth.Quota.NextRecoverAt.After(now) {
-			next = auth.Quota.NextRecoverAt
-		}
-		if next.Before(now) {
-			next = now
-		}
-		if auth.Quota.Exceeded {
-			return true, blockReasonCooldown, next
-		}
-		return true, blockReasonOther, next
 	}
 	return false, blockReasonNone, time.Time{}
 }

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -95,6 +95,10 @@ type Auth struct {
 	Success int64 `json:"-"`
 	Failed  int64 `json:"-"`
 
+	// ConsecutiveTransientFailures counts consecutive 5xx/408 execution errors.
+	// Reset to zero on any successful request or non-transient error.
+	ConsecutiveTransientFailures int `json:"-"`
+
 	recentRequests recentRequestRing `json:"-"`
 	indexAssigned  bool              `json:"-"`
 }


### PR DESCRIPTION
## Summary

Ports the useful auth circuit-breaker behavior from upstream PR #3598 without pulling in the separate auth refresh jitter/semaphore work already covered by PR #51.

- adds `auth-circuit-breaker-threshold` and `auth-circuit-breaker-cooldown-minutes` config keys
- tracks consecutive HTTP 408/500/502/503/504 execution failures per credential
- opens a credential-level cooldown after the configured threshold and clears it on success or non-transient errors
- adapts the behavior for LTS model-aware scheduling by extending the active `ModelState` cooldown and making auth-level cooldowns apply before model-specific checks
- documents the new keys in `config.example.yaml`

## Upstream

Selective port of the circuit-breaker portion of router-for-me/CLIProxyAPI#3598 (`10a16a47`, `3be4c9ac`). This intentionally excludes the auth refresh jitter and per-provider refresh semaphore commits because they are already handled separately in #51.

## Validation

- `go test ./sdk/cliproxy/auth -run 'CircuitBreaker'`\n- `go test ./internal/config ./internal/watcher/diff ./internal/api/handlers/management`\n- `go test ./sdk/cliproxy/auth ./sdk/cliproxy/...`\n- `go test -race ./sdk/cliproxy/auth -run 'CircuitBreaker|SchedulerTracksMarkResultCooldownAndRecovery|DisableCooling'`\n- `git diff --check`\n- `go test ./...`\n- `go build -o test-output ./cmd/server && rm -f test-output`\n\n## LTS Notes\n\nThis preserves the v6 module path and does not touch `internal/usage/`, Management usage endpoints, `internal/translator/`, or AGENTS.md.