### PR TITLE
[codex] Port Grok Build 0.1 model registry entry

### DIFF
--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -2200,6 +2200,27 @@
   ],
   "xai": [
     {
+      "id": "grok-build-0.1",
+      "object": "model",
+      "created": 1779321600,
+      "owned_by": "xai",
+      "type": "xai",
+      "display_name": "Grok Build 0.1",
+      "name": "grok-build-0.1",
+      "description": "Grok Build 0.1 is xAI’s fast coding model trained specifically for agentic software engineering workflows.",
+      "context_length": 256000,
+      "max_completion_tokens": 256000,
+      "thinking": {
+        "zero_allowed": true,
+        "levels": [
+          "none",
+          "low",
+          "medium",
+          "high"
+        ]
+      }
+    },
+    {
       "id": "grok-4.3",
       "object": "model",
       "created": 1775606400,


### PR DESCRIPTION
## Summary

Ports the upstream `grok-build-0.1` model registry entry from router-for-me/CLIProxyAPI commit `aaec9194`.

- adds the xAI `grok-build-0.1` model to `internal/registry/models/models.json`
- keeps this as a small model-catalog-only PR
- does not remove deprecated GPT-5.x aliases or change runtime behavior

## Validation

- `python3 -m json.tool internal/registry/models/models.json >/dev/null`
- `git diff --check`
- `go test ./internal/registry ./internal/runtime/executor -run 'XAI|Registry|Model|Grok'`\n- `go test ./...`\n- `go build -o test-output ./cmd/server && rm -f test-output`\n\n## LTS Notes\n\nThis preserves the v6 module path and does not touch usage statistics, Management API, auth/config behavior, translator paths, or AGENTS.md.