### PR TITLE
[codex] Port Codex request translation reuse

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -207,6 +207,16 @@ func NewCodexExecutor(cfg *config.Config) *CodexExecutor { return &CodexExecutor
 
 func (e *CodexExecutor) Identifier() string { return "codex" }
 
+func translateCodexRequestPair(from, to sdktranslator.Format, model string, originalPayload, payload []byte, stream bool) ([]byte, []byte) {
+	if bytes.Equal(originalPayload, payload) {
+		body := sdktranslator.TranslateRequest(from, to, model, payload, stream)
+		return body, body
+	}
+	originalTranslated := sdktranslator.TranslateRequest(from, to, model, originalPayload, stream)
+	body := sdktranslator.TranslateRequest(from, to, model, payload, stream)
+	return originalTranslated, body
+}
+
 // PrepareRequest injects Codex credentials into the outgoing HTTP request.
 func (e *CodexExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Auth) error {
 	if req == nil {
@@ -261,8 +271,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		originalPayloadSource = opts.OriginalRequest
 	}
 	originalPayload := originalPayloadSource
-	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, false)
-	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
+	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false)
 
 	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
 	if err != nil {
@@ -421,8 +430,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 		originalPayloadSource = opts.OriginalRequest
 	}
 	originalPayload := originalPayloadSource
-	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, false)
-	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
+	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false)
 
 	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
 	if err != nil {
@@ -516,8 +524,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		originalPayloadSource = opts.OriginalRequest
 	}
 	originalPayload := originalPayloadSource
-	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
-	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, true)
+	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, true)
 
 	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
 	if err != nil {

--- a/internal/runtime/executor/codex_executor_translate_test.go
+++ b/internal/runtime/executor/codex_executor_translate_test.go
@@ -1,0 +1,59 @@
+package executor
+
+import (
+	"bytes"
+	"sync/atomic"
+	"testing"
+
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+)
+
+func TestTranslateCodexRequestPairReusesEqualPayload(t *testing.T) {
+	from := sdktranslator.Format("codex-test-from-equal")
+	to := sdktranslator.Format("codex-test-to-equal")
+	var calls int32
+	sdktranslator.Register(from, to, func(model string, rawJSON []byte, stream bool) []byte {
+		atomic.AddInt32(&calls, 1)
+		if model != "test-model" {
+			t.Errorf("model = %q, want test-model", model)
+		}
+		if !stream {
+			t.Error("stream = false, want true")
+		}
+		return append([]byte(nil), rawJSON...)
+	}, sdktranslator.ResponseTransform{})
+
+	payload := []byte(`{"model":"test-model","input":[{"role":"user"}]}`)
+	originalTranslated, body := translateCodexRequestPair(from, to, "test-model", payload, bytes.Clone(payload), true)
+
+	if gotCalls := atomic.LoadInt32(&calls); gotCalls != 1 {
+		t.Fatalf("TranslateRequest calls = %d, want 1", gotCalls)
+	}
+	if !bytes.Equal(originalTranslated, body) {
+		t.Fatalf("translated payloads differ: original=%s body=%s", originalTranslated, body)
+	}
+}
+
+func TestTranslateCodexRequestPairTranslatesDifferentPayloads(t *testing.T) {
+	from := sdktranslator.Format("codex-test-from-different")
+	to := sdktranslator.Format("codex-test-to-different")
+	var calls int32
+	sdktranslator.Register(from, to, func(_ string, rawJSON []byte, _ bool) []byte {
+		atomic.AddInt32(&calls, 1)
+		return append([]byte(nil), rawJSON...)
+	}, sdktranslator.ResponseTransform{})
+
+	originalPayload := []byte(`{"model":"test-model","input":[{"role":"system"}]}`)
+	payload := []byte(`{"model":"test-model","input":[{"role":"user"}]}`)
+	originalTranslated, body := translateCodexRequestPair(from, to, "test-model", originalPayload, payload, false)
+
+	if gotCalls := atomic.LoadInt32(&calls); gotCalls != 2 {
+		t.Fatalf("TranslateRequest calls = %d, want 2", gotCalls)
+	}
+	if !bytes.Equal(originalTranslated, originalPayload) {
+		t.Fatalf("original translated = %s, want %s", originalTranslated, originalPayload)
+	}
+	if !bytes.Equal(body, payload) {
+		t.Fatalf("body = %s, want %s", body, payload)
+	}
+}

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -194,8 +194,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		originalPayloadSource = opts.OriginalRequest
 	}
 	originalPayload := originalPayloadSource
-	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, false)
-	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
+	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false)
 
 	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
 	if err != nil {


### PR DESCRIPTION
## Summary

Ports upstream commit `33983b6f` with LTS v6 import adaptation.

- adds `translateCodexRequestPair` so Codex HTTP, compact, stream, and WebSocket execution paths reuse a single translated body when `OriginalRequest` matches the request payload
- keeps different original/current payloads translated separately for payload config diffing
- adds unit coverage for both equal-payload reuse and different-payload translation

## Upstream

Selective port of router-for-me/CLIProxyAPI commit `33983b6f` (`refactor(executor): consolidate Codex request translation logic`).

## Validation

- `go test ./internal/runtime/executor -run 'TranslateCodexRequestPair|Codex'`\n- `git diff --check`\n- `go test ./internal/runtime/executor ./internal/runtime/executor/helps`\n- `go test ./...`\n- `go build -o test-output ./cmd/server && rm -f test-output`\n\n## LTS Notes\n\nThis preserves the v6 module path and does not touch `internal/usage/`, Management usage endpoints, `internal/translator/`, config schema, auth behavior, or AGENTS.md. It may need a trivial rebase depending on the merge order with PR #50 because both touch `internal/runtime/executor/codex_executor.go`.