### PR TITLE
[codex] Port Gemini stream usage metadata guard

### DIFF
--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -436,6 +436,9 @@ func ParseGeminiStreamUsage(line []byte) (usage.Detail, bool) {
 	if !node.Exists() {
 		return usage.Detail{}, false
 	}
+	if !hasGeminiFamilyUsageTokenFields(node) {
+		return usage.Detail{}, false
+	}
 	return parseGeminiFamilyUsageDetail(node), true
 }
 

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -146,6 +146,30 @@ func TestParseGeminiCLIStreamUsage_ResponseSnakeCaseUsageMetadata(t *testing.T) 
 	}
 }
 
+func TestParseGeminiStreamUsage_TopLevelUsageMetadata(t *testing.T) {
+	line := []byte(`data: {"usageMetadata":{"promptTokenCount":13,"candidatesTokenCount":2,"totalTokenCount":15}}`)
+	detail, ok := ParseGeminiStreamUsage(line)
+	if !ok {
+		t.Fatal("ParseGeminiStreamUsage() ok = false, want true")
+	}
+	if detail.InputTokens != 13 {
+		t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 13)
+	}
+	if detail.OutputTokens != 2 {
+		t.Fatalf("output tokens = %d, want %d", detail.OutputTokens, 2)
+	}
+	if detail.TotalTokens != 15 {
+		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 15)
+	}
+}
+
+func TestParseGeminiStreamUsage_IgnoresTrafficTypeOnlyUsageMetadata(t *testing.T) {
+	line := []byte(`data: {"usageMetadata":{"trafficType":"ON_DEMAND"}}`)
+	if detail, ok := ParseGeminiStreamUsage(line); ok {
+		t.Fatalf("ParseGeminiStreamUsage() = (%+v, true), want false for traffic-only usage metadata", detail)
+	}
+}
+
 func TestParseGeminiCLIStreamUsage_IgnoresTrafficTypeOnlyUsageMetadata(t *testing.T) {
 	line := []byte(`data: {"response":{"usageMetadata":{"trafficType":"ON_DEMAND"}}}`)
 	if detail, ok := ParseGeminiCLIStreamUsage(line); ok {


### PR DESCRIPTION
## Summary
- Manually port the useful part of upstream router-for-me/CLIProxyAPI#3304.
- Ignore Gemini/Vertex stream `usageMetadata` objects that do not contain token fields, such as traffic-only metadata.
- Add regression coverage to keep valid top-level Gemini stream token metadata parsing intact.

## LTS compatibility
- Preserves the `github.com/router-for-me/CLIProxyAPI/v6` module path.
- Does not change Management API routes or `/v0/management/usage*` response shape.
- Improves LTS usage statistics accuracy by preventing traffic-only metadata from being recorded as zero-token usage.

## Validation
- `gofmt -w internal/runtime/executor/helps/usage_helpers.go internal/runtime/executor/helps/usage_helpers_test.go`
- `go test ./internal/runtime/executor/helps -run 'ParseGeminiStreamUsage|ParseGeminiCLIStreamUsage'`\n- `go test ./internal/runtime/executor/helps`\n- `git diff --check`