### PR TITLE
[codex] Reject sample API keys by default

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -257,13 +257,15 @@ func main() {
 		}
 		examplePath := filepath.Join(wd, "config.example.yaml")
 		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
-		if errBootstrap := pgStoreInst.Bootstrap(ctx, examplePath); errBootstrap != nil {
+		generatedClientAPIKey, errBootstrap := pgStoreInst.Bootstrap(ctx, examplePath)
+		if errBootstrap != nil {
 			cancel()
 			log.Errorf("failed to bootstrap postgres-backed config: %v", errBootstrap)
 			return
 		}
 		cancel()
 		configFilePath = pgStoreInst.ConfigPath()
+		logGeneratedClientAPIKey(configFilePath, generatedClientAPIKey)
 		cfg, err = config.LoadConfigOptional(configFilePath, isCloudDeploy)
 		if err == nil {
 			cfg.AuthDir = pgStoreInst.AuthDir()
@@ -321,13 +323,15 @@ func main() {
 		}
 		examplePath := filepath.Join(wd, "config.example.yaml")
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		if errBootstrap := objectStoreInst.Bootstrap(ctx, examplePath); errBootstrap != nil {
+		generatedClientAPIKey, errBootstrap := objectStoreInst.Bootstrap(ctx, examplePath)
+		if errBootstrap != nil {
 			cancel()
 			log.Errorf("failed to bootstrap object-backed config: %v", errBootstrap)
 			return
 		}
 		cancel()
 		configFilePath = objectStoreInst.ConfigPath()
+		logGeneratedClientAPIKey(configFilePath, generatedClientAPIKey)
 		cfg, err = config.LoadConfigOptional(configFilePath, isCloudDeploy)
 		if err == nil {
 			if cfg == nil {
@@ -362,10 +366,12 @@ func main() {
 				log.Errorf("failed to find template config file: %v", errExample)
 				return
 			}
-			if errCopy := misc.CopyConfigTemplate(examplePath, configFilePath); errCopy != nil {
+			generatedClientAPIKey, errCopy := misc.CopyConfigTemplate(examplePath, configFilePath)
+			if errCopy != nil {
 				log.Errorf("failed to bootstrap git-backed config: %v", errCopy)
 				return
 			}
+			logGeneratedClientAPIKey(configFilePath, generatedClientAPIKey)
 			if errCommit := gitStoreInst.PersistConfig(context.Background()); errCommit != nil {
 				log.Errorf("failed to commit initial git-backed config: %v", errCommit)
 				return
@@ -583,4 +589,11 @@ func main() {
 			cmd.StartService(cfg, configFilePath, password)
 		}
 	}
+}
+
+func logGeneratedClientAPIKey(configPath, generatedKey string) {
+	if strings.TrimSpace(generatedKey) == "" {
+		return
+	}
+	log.Infof("generated private client API key in %s; read that config file to retrieve it", filepath.Clean(configPath))
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -36,11 +36,12 @@ remote-management:
 # Authentication directory (supports ~ for home directory)
 auth-dir: "~/.cli-proxy-api"
 
-# API keys for authentication
+# API keys for authentication.
+# Sample keys are rejected; generate private keys before exposing port 8317 publicly.
 api-keys:
-  - "your-api-key-1"
-  - "your-api-key-2"
-  - "your-api-key-3"
+  # - "your-api-key-1"
+  # - "your-api-key-2"
+  # - "your-api-key-3"
 
 # Enable debug logging
 debug: false

--- a/internal/access/config_access/provider.go
+++ b/internal/access/config_access/provider.go
@@ -5,8 +5,10 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/samplekeys"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+	log "github.com/sirupsen/logrus"
 )
 
 // Register ensures the config-access provider is available to the access manager.
@@ -17,6 +19,9 @@ func Register(cfg *sdkconfig.SDKConfig) {
 	}
 
 	keys := normalizeKeys(cfg.APIKeys)
+	if samplekeys.ContainsClientAPIKey(keys) {
+		log.Warn("configured API keys include rejected sample values; replace them with private keys before exposing the server")
+	}
 	if len(keys) == 0 {
 		sdkaccess.UnregisterProvider(sdkaccess.AccessProviderTypeConfigAPIKey)
 		return
@@ -86,7 +91,11 @@ func (p *provider) Authenticate(_ context.Context, r *http.Request) (*sdkaccess.
 	}
 
 	for _, candidate := range candidates {
+		candidate.value = strings.TrimSpace(candidate.value)
 		if candidate.value == "" {
+			continue
+		}
+		if samplekeys.IsClientAPIKey(candidate.value) {
 			continue
 		}
 		if _, ok := p.keys[candidate.value]; ok {

--- a/internal/access/config_access/provider_test.go
+++ b/internal/access/config_access/provider_test.go
@@ -1,0 +1,93 @@
+package configaccess
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
+)
+
+func TestAuthenticateRejectsBlockedSampleAPIKeys(t *testing.T) {
+	p := newProvider("test", []string{"your-api-key-1", "your-api-key-2", "your-api-key-3", "real-key"})
+
+	tests := []struct {
+		name   string
+		header string
+	}{
+		{name: "bearer", header: "Bearer your-api-key-1"},
+		{name: "plain authorization", header: "your-api-key-2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			req.Header.Set("Authorization", tt.header)
+
+			result, authErr := p.Authenticate(context.Background(), req)
+			if result != nil {
+				t.Fatalf("Authenticate() result = %#v, want nil", result)
+			}
+			if !sdkaccess.IsAuthErrorCode(authErr, sdkaccess.AuthErrorCodeInvalidCredential) {
+				t.Fatalf("Authenticate() error = %#v, want invalid credential", authErr)
+			}
+		})
+	}
+}
+
+func TestAuthenticateAllowsCustomAPIKey(t *testing.T) {
+	p := newProvider("test", []string{"your-api-key-1", "real-key"})
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer real-key")
+
+	result, authErr := p.Authenticate(context.Background(), req)
+	if authErr != nil {
+		t.Fatalf("Authenticate() error = %v, want nil", authErr)
+	}
+	if result == nil {
+		t.Fatal("Authenticate() result = nil, want result")
+	}
+	if result.Principal != "real-key" {
+		t.Fatalf("Authenticate() principal = %q, want real-key", result.Principal)
+	}
+}
+
+func TestAuthenticateAllowsLaterCustomAPIKeyAfterBlockedSample(t *testing.T) {
+	p := newProvider("test", []string{"your-api-key-1", "real-key"})
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer your-api-key-1")
+	req.Header.Set("X-Api-Key", "real-key")
+
+	result, authErr := p.Authenticate(context.Background(), req)
+	if authErr != nil {
+		t.Fatalf("Authenticate() error = %v, want nil", authErr)
+	}
+	if result == nil {
+		t.Fatal("Authenticate() result = nil, want result")
+	}
+	if result.Principal != "real-key" {
+		t.Fatalf("Authenticate() principal = %q, want real-key", result.Principal)
+	}
+	if got := result.Metadata["source"]; got != "x-api-key" {
+		t.Fatalf("Authenticate() source = %q, want x-api-key", got)
+	}
+}
+
+func TestAuthenticateTrimsCandidateAPIKey(t *testing.T) {
+	p := newProvider("test", []string{"real-key"})
+	req := httptest.NewRequest("GET", "/?key=%20real-key%20", nil)
+
+	result, authErr := p.Authenticate(context.Background(), req)
+	if authErr != nil {
+		t.Fatalf("Authenticate() error = %v, want nil", authErr)
+	}
+	if result == nil {
+		t.Fatal("Authenticate() result = nil, want result")
+	}
+	if result.Principal != "real-key" {
+		t.Fatalf("Authenticate() principal = %q, want trimmed real-key", result.Principal)
+	}
+	if got := result.Metadata["source"]; got != "query-key" {
+		t.Fatalf("Authenticate() source = %q, want query-key", got)
+	}
+}

--- a/internal/misc/copy-example-config.go
+++ b/internal/misc/copy-example-config.go
@@ -1,31 +1,39 @@
 package misc
 
 import (
-	"io"
+	"bytes"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/samplekeys"
 	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
 )
 
-func CopyConfigTemplate(src, dst string) error {
-	in, err := os.Open(src)
+const generatedClientAPIKeyBytes = 32
+
+func CopyConfigTemplate(src, dst string) (string, error) {
+	data, err := os.ReadFile(src)
 	if err != nil {
-		return err
+		return "", err
 	}
-	defer func() {
-		if errClose := in.Close(); errClose != nil {
-			log.WithError(errClose).Warn("failed to close source config file")
-		}
-	}()
+
+	rendered, generatedKey, generated, err := renderConfigTemplateWithGeneratedAPIKey(data)
+	if err != nil {
+		return "", err
+	}
 
 	if err = os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
-		return err
+		return "", err
 	}
 
 	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer func() {
 		if errClose := out.Close(); errClose != nil {
@@ -33,8 +41,133 @@ func CopyConfigTemplate(src, dst string) error {
 		}
 	}()
 
-	if _, err = io.Copy(out, in); err != nil {
-		return err
+	if _, err = out.Write(rendered); err != nil {
+		return "", err
 	}
-	return out.Sync()
+	if err = out.Sync(); err != nil {
+		return "", err
+	}
+	if generated {
+		return generatedKey, nil
+	}
+	return "", nil
+}
+
+func generateClientAPIKey() (string, error) {
+	buf := make([]byte, generatedClientAPIKeyBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate client API key: %w", err)
+	}
+	return "cpak-" + base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+func renderConfigTemplateWithGeneratedAPIKey(data []byte) ([]byte, string, bool, error) {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return data, "", false, nil
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, "", false, fmt.Errorf("parse config template: %w", err)
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 || doc.Content[0] == nil {
+		return data, "", false, nil
+	}
+
+	apiKeysKeyNode, apiKeysValueNode := topLevelMappingEntry(doc.Content[0], "api-keys")
+	if apiKeysValueNode == nil {
+		return data, "", false, nil
+	}
+	if !shouldGenerateClientAPIKey(apiKeysValueNode) {
+		return data, "", false, nil
+	}
+
+	key, err := generateClientAPIKey()
+	if err != nil {
+		return nil, "", false, err
+	}
+
+	if apiKeysKeyNode != nil {
+		apiKeysKeyNode.FootComment = ""
+	}
+	*apiKeysValueNode = yaml.Node{
+		Kind: yaml.SequenceNode,
+		Tag:  "!!seq",
+		Content: []*yaml.Node{
+			{
+				Kind:  yaml.ScalarNode,
+				Tag:   "!!str",
+				Value: key,
+				Style: yaml.DoubleQuotedStyle,
+			},
+		},
+	}
+
+	var out bytes.Buffer
+	// Encoding yaml.Node may normalize whitespace and comments. This only runs when
+	// generating a fresh bootstrap config from sample placeholders.
+	encoder := yaml.NewEncoder(&out)
+	encoder.SetIndent(2)
+	if err = encoder.Encode(&doc); err != nil {
+		_ = encoder.Close()
+		return nil, "", false, fmt.Errorf("render config template: %w", err)
+	}
+	if err = encoder.Close(); err != nil {
+		return nil, "", false, fmt.Errorf("close yaml encoder: %w", err)
+	}
+	return removeTopLevelSampleAPIKeyComments(out.Bytes()), key, true, nil
+}
+
+func topLevelMappingEntry(root *yaml.Node, key string) (*yaml.Node, *yaml.Node) {
+	if root == nil || root.Kind != yaml.MappingNode {
+		return nil, nil
+	}
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		keyNode := root.Content[i]
+		if keyNode != nil && keyNode.Value == key {
+			return keyNode, root.Content[i+1]
+		}
+	}
+	return nil, nil
+}
+
+func shouldGenerateClientAPIKey(node *yaml.Node) bool {
+	if node == nil {
+		return false
+	}
+	if node.Kind == yaml.ScalarNode && node.Tag == "!!null" {
+		return true
+	}
+	if node.Kind != yaml.SequenceNode {
+		return false
+	}
+	sawSample := false
+	for _, child := range node.Content {
+		if child == nil || child.Kind != yaml.ScalarNode {
+			continue
+		}
+		key := strings.TrimSpace(child.Value)
+		if key == "" {
+			continue
+		}
+		if !samplekeys.IsClientAPIKey(key) {
+			return false
+		}
+		sawSample = true
+	}
+	return sawSample
+}
+
+func removeTopLevelSampleAPIKeyComments(data []byte) []byte {
+	var out strings.Builder
+	// The sample template keeps inactive api-keys as commented list items. After
+	// generating a real key, drop those placeholder lines from the copied config.
+	for _, line := range strings.SplitAfter(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, `# - "your-api-key-`) {
+			continue
+		}
+		out.WriteString(line)
+	}
+	return []byte(out.String())
 }

--- a/internal/misc/copy-example-config_test.go
+++ b/internal/misc/copy-example-config_test.go
@@ -1,0 +1,172 @@
+package misc
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestGenerateClientAPIKey(t *testing.T) {
+	key, err := generateClientAPIKey()
+	if err != nil {
+		t.Fatalf("generateClientAPIKey() error = %v", err)
+	}
+	if !strings.HasPrefix(key, "cpak-") {
+		t.Fatalf("generateClientAPIKey() = %q, want cpak- prefix", key)
+	}
+	if strings.ContainsAny(key, " \t\r\n") {
+		t.Fatalf("generateClientAPIKey() contains whitespace: %q", key)
+	}
+}
+
+func TestRenderConfigTemplateWithGeneratedAPIKey(t *testing.T) {
+	template := []byte(`host: ""
+port: 8317
+
+# API keys for authentication
+# Sample keys are rejected; generate private keys before exposing port 8317 publicly.
+api-keys:
+  # - "your-api-key-1"
+  # - "your-api-key-2"
+  # - "your-api-key-3"
+
+debug: false
+`)
+
+	rendered, key, generated, err := renderConfigTemplateWithGeneratedAPIKey(template)
+	if err != nil {
+		t.Fatalf("renderConfigTemplateWithGeneratedAPIKey() error = %v", err)
+	}
+	if !generated {
+		t.Fatal("renderConfigTemplateWithGeneratedAPIKey() generated = false, want true")
+	}
+	if key == "" || strings.Contains(key, "your-api-key") {
+		t.Fatalf("generated key = %q, want private non-sample key", key)
+	}
+
+	var cfg struct {
+		APIKeys []string `yaml:"api-keys"`
+	}
+	if err = yaml.Unmarshal(rendered, &cfg); err != nil {
+		t.Fatalf("unmarshal rendered config: %v\n%s", err, rendered)
+	}
+	if len(cfg.APIKeys) != 1 {
+		t.Fatalf("api-keys length = %d, want 1\n%s", len(cfg.APIKeys), rendered)
+	}
+	if cfg.APIKeys[0] != key {
+		t.Fatalf("api-keys[0] = %q, want %q", cfg.APIKeys[0], key)
+	}
+	if strings.Contains(string(rendered), "\n  - \"your-api-key-1\"") {
+		t.Fatalf("rendered config still contains active sample key:\n%s", rendered)
+	}
+	if strings.Contains(string(rendered), "your-api-key-1") {
+		t.Fatalf("rendered generated config should not keep sample key comments:\n%s", rendered)
+	}
+}
+
+func TestRenderConfigTemplatePreservesOperatorAPIKeys(t *testing.T) {
+	template := []byte(`host: ""
+api-keys:
+  - "operator-key"
+  - "your-api-key-1"
+debug: false
+`)
+
+	rendered, key, generated, err := renderConfigTemplateWithGeneratedAPIKey(template)
+	if err != nil {
+		t.Fatalf("renderConfigTemplateWithGeneratedAPIKey() error = %v", err)
+	}
+	if generated {
+		t.Fatalf("renderConfigTemplateWithGeneratedAPIKey() generated = true, want false")
+	}
+	if key != "" {
+		t.Fatalf("generated key = %q, want empty", key)
+	}
+	if string(rendered) != string(template) {
+		t.Fatalf("rendered config changed operator keys:\n%s", rendered)
+	}
+}
+
+func TestRenderConfigTemplateReplacesOnlySampleAPIKeys(t *testing.T) {
+	template := []byte(`host: ""
+api-keys:
+  - "your-api-key-1"
+  - "your-api-key-2"
+`)
+
+	rendered, key, generated, err := renderConfigTemplateWithGeneratedAPIKey(template)
+	if err != nil {
+		t.Fatalf("renderConfigTemplateWithGeneratedAPIKey() error = %v", err)
+	}
+	if !generated {
+		t.Fatal("renderConfigTemplateWithGeneratedAPIKey() generated = false, want true")
+	}
+
+	var cfg struct {
+		APIKeys []string `yaml:"api-keys"`
+	}
+	if err = yaml.Unmarshal(rendered, &cfg); err != nil {
+		t.Fatalf("unmarshal rendered config: %v\n%s", err, rendered)
+	}
+	if len(cfg.APIKeys) != 1 || cfg.APIKeys[0] != key || strings.Contains(cfg.APIKeys[0], "your-api-key") {
+		t.Fatalf("api-keys = %#v, generated key = %q", cfg.APIKeys, key)
+	}
+}
+
+func TestRenderConfigTemplatePreservesExplicitEmptyAPIKeys(t *testing.T) {
+	template := []byte(`host: ""
+api-keys: []
+debug: false
+`)
+
+	rendered, key, generated, err := renderConfigTemplateWithGeneratedAPIKey(template)
+	if err != nil {
+		t.Fatalf("renderConfigTemplateWithGeneratedAPIKey() error = %v", err)
+	}
+	if generated {
+		t.Fatalf("renderConfigTemplateWithGeneratedAPIKey() generated = true, want false")
+	}
+	if key != "" {
+		t.Fatalf("generated key = %q, want empty", key)
+	}
+	if string(rendered) != string(template) {
+		t.Fatalf("rendered config changed explicit empty api-keys:\n%s", rendered)
+	}
+}
+
+func TestCopyConfigTemplateGeneratesClientAPIKey(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "config.example.yaml")
+	dst := filepath.Join(dir, "nested", "config.yaml")
+	if err := os.WriteFile(src, []byte("api-keys:\n  # - \"your-api-key-1\"\n"), 0o600); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	generatedKey, err := CopyConfigTemplate(src, dst)
+	if err != nil {
+		t.Fatalf("CopyConfigTemplate() error = %v", err)
+	}
+	if !strings.HasPrefix(generatedKey, "cpak-") {
+		t.Fatalf("CopyConfigTemplate() generated key = %q, want cpak- prefix", generatedKey)
+	}
+
+	data, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read destination: %v", err)
+	}
+	var cfg struct {
+		APIKeys []string `yaml:"api-keys"`
+	}
+	if err = yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal destination: %v\n%s", err, data)
+	}
+	if len(cfg.APIKeys) != 1 || !strings.HasPrefix(cfg.APIKeys[0], "cpak-") {
+		t.Fatalf("api-keys = %#v, want one generated cpak key", cfg.APIKeys)
+	}
+	if cfg.APIKeys[0] != generatedKey {
+		t.Fatalf("api-keys[0] = %q, generated key = %q", cfg.APIKeys[0], generatedKey)
+	}
+}

--- a/internal/samplekeys/api_keys.go
+++ b/internal/samplekeys/api_keys.go
@@ -1,0 +1,22 @@
+package samplekeys
+
+import "strings"
+
+// IsClientAPIKey reports whether key is one of the documented sample client keys.
+func IsClientAPIKey(key string) bool {
+	switch strings.TrimSpace(key) {
+	case "your-api-key-1", "your-api-key-2", "your-api-key-3":
+		return true
+	}
+	return false
+}
+
+// ContainsClientAPIKey reports whether keys includes any documented sample client key.
+func ContainsClientAPIKey(keys []string) bool {
+	for _, key := range keys {
+		if IsClientAPIKey(key) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/store/objectstore.go
+++ b/internal/store/objectstore.go
@@ -139,20 +139,21 @@ func (s *ObjectTokenStore) AuthDir() string {
 }
 
 // Bootstrap ensures the target bucket exists and synchronizes data from the object storage backend.
-func (s *ObjectTokenStore) Bootstrap(ctx context.Context, exampleConfigPath string) error {
+func (s *ObjectTokenStore) Bootstrap(ctx context.Context, exampleConfigPath string) (string, error) {
 	if s == nil {
-		return fmt.Errorf("object store: not initialized")
+		return "", fmt.Errorf("object store: not initialized")
 	}
 	if err := s.ensureBucket(ctx); err != nil {
-		return err
+		return "", err
 	}
-	if err := s.syncConfigFromBucket(ctx, exampleConfigPath); err != nil {
-		return err
+	generatedKey, err := s.syncConfigFromBucket(ctx, exampleConfigPath)
+	if err != nil {
+		return "", err
 	}
 	if err := s.syncAuthFromBucket(ctx); err != nil {
-		return err
+		return "", err
 	}
-	return nil
+	return generatedKey, nil
 }
 
 // Save persists authentication metadata to disk and uploads it to the object storage backend.
@@ -342,51 +343,54 @@ func (s *ObjectTokenStore) ensureBucket(ctx context.Context) error {
 	return nil
 }
 
-func (s *ObjectTokenStore) syncConfigFromBucket(ctx context.Context, example string) error {
+func (s *ObjectTokenStore) syncConfigFromBucket(ctx context.Context, example string) (string, error) {
+	generatedKey := ""
 	key := s.prefixedKey(objectStoreConfigKey)
 	_, err := s.client.StatObject(ctx, s.cfg.Bucket, key, minio.StatObjectOptions{})
 	switch {
 	case err == nil:
 		object, errGet := s.client.GetObject(ctx, s.cfg.Bucket, key, minio.GetObjectOptions{})
 		if errGet != nil {
-			return fmt.Errorf("object store: fetch config: %w", errGet)
+			return "", fmt.Errorf("object store: fetch config: %w", errGet)
 		}
 		defer object.Close()
 		data, errRead := io.ReadAll(object)
 		if errRead != nil {
-			return fmt.Errorf("object store: read config: %w", errRead)
+			return "", fmt.Errorf("object store: read config: %w", errRead)
 		}
 		if errWrite := os.WriteFile(s.configPath, normalizeLineEndingsBytes(data), 0o600); errWrite != nil {
-			return fmt.Errorf("object store: write config: %w", errWrite)
+			return "", fmt.Errorf("object store: write config: %w", errWrite)
 		}
 	case isObjectNotFound(err):
 		if _, statErr := os.Stat(s.configPath); errors.Is(statErr, fs.ErrNotExist) {
 			if example != "" {
-				if errCopy := misc.CopyConfigTemplate(example, s.configPath); errCopy != nil {
-					return fmt.Errorf("object store: copy example config: %w", errCopy)
+				copiedKey, errCopy := misc.CopyConfigTemplate(example, s.configPath)
+				if errCopy != nil {
+					return "", fmt.Errorf("object store: copy example config: %w", errCopy)
 				}
+				generatedKey = copiedKey
 			} else {
 				if errCreate := os.MkdirAll(filepath.Dir(s.configPath), 0o700); errCreate != nil {
-					return fmt.Errorf("object store: prepare config directory: %w", errCreate)
+					return "", fmt.Errorf("object store: prepare config directory: %w", errCreate)
 				}
 				if errWrite := os.WriteFile(s.configPath, []byte{}, 0o600); errWrite != nil {
-					return fmt.Errorf("object store: create empty config: %w", errWrite)
+					return "", fmt.Errorf("object store: create empty config: %w", errWrite)
 				}
 			}
 		}
 		data, errRead := os.ReadFile(s.configPath)
 		if errRead != nil {
-			return fmt.Errorf("object store: read local config: %w", errRead)
+			return "", fmt.Errorf("object store: read local config: %w", errRead)
 		}
 		if len(data) > 0 {
 			if errPut := s.putObject(ctx, objectStoreConfigKey, data, "application/x-yaml"); errPut != nil {
-				return errPut
+				return "", errPut
 			}
 		}
 	default:
-		return fmt.Errorf("object store: stat config: %w", err)
+		return "", fmt.Errorf("object store: stat config: %w", err)
 	}
-	return nil
+	return generatedKey, nil
 }
 
 func (s *ObjectTokenStore) syncAuthFromBucket(ctx context.Context) error {

--- a/internal/store/postgresstore.go
+++ b/internal/store/postgresstore.go
@@ -144,17 +144,18 @@ func (s *PostgresStore) EnsureSchema(ctx context.Context) error {
 }
 
 // Bootstrap synchronizes configuration and auth records between PostgreSQL and the local workspace.
-func (s *PostgresStore) Bootstrap(ctx context.Context, exampleConfigPath string) error {
+func (s *PostgresStore) Bootstrap(ctx context.Context, exampleConfigPath string) (string, error) {
 	if err := s.EnsureSchema(ctx); err != nil {
-		return err
+		return "", err
 	}
-	if err := s.syncConfigFromDatabase(ctx, exampleConfigPath); err != nil {
-		return err
+	generatedKey, err := s.syncConfigFromDatabase(ctx, exampleConfigPath)
+	if err != nil {
+		return "", err
 	}
 	if err := s.syncAuthFromDatabase(ctx); err != nil {
-		return err
+		return "", err
 	}
-	return nil
+	return generatedKey, nil
 }
 
 // ConfigPath returns the managed configuration file path inside the spool directory.
@@ -398,7 +399,8 @@ func (s *PostgresStore) PersistConfig(ctx context.Context) error {
 }
 
 // syncConfigFromDatabase writes the database-stored config to disk or seeds the database from template.
-func (s *PostgresStore) syncConfigFromDatabase(ctx context.Context, exampleConfigPath string) error {
+func (s *PostgresStore) syncConfigFromDatabase(ctx context.Context, exampleConfigPath string) (string, error) {
+	generatedKey := ""
 	query := fmt.Sprintf("SELECT content FROM %s WHERE id = $1", s.fullTableName(s.cfg.ConfigTable))
 	var content string
 	err := s.db.QueryRowContext(ctx, query, defaultConfigKey).Scan(&content)
@@ -406,37 +408,39 @@ func (s *PostgresStore) syncConfigFromDatabase(ctx context.Context, exampleConfi
 	case errors.Is(err, sql.ErrNoRows):
 		if _, errStat := os.Stat(s.configPath); errors.Is(errStat, fs.ErrNotExist) {
 			if exampleConfigPath != "" {
-				if errCopy := misc.CopyConfigTemplate(exampleConfigPath, s.configPath); errCopy != nil {
-					return fmt.Errorf("postgres store: copy example config: %w", errCopy)
+				copiedKey, errCopy := misc.CopyConfigTemplate(exampleConfigPath, s.configPath)
+				if errCopy != nil {
+					return "", fmt.Errorf("postgres store: copy example config: %w", errCopy)
 				}
+				generatedKey = copiedKey
 			} else {
 				if errCreate := os.MkdirAll(filepath.Dir(s.configPath), 0o700); errCreate != nil {
-					return fmt.Errorf("postgres store: prepare config directory: %w", errCreate)
+					return "", fmt.Errorf("postgres store: prepare config directory: %w", errCreate)
 				}
 				if errWrite := os.WriteFile(s.configPath, []byte{}, 0o600); errWrite != nil {
-					return fmt.Errorf("postgres store: create empty config: %w", errWrite)
+					return "", fmt.Errorf("postgres store: create empty config: %w", errWrite)
 				}
 			}
 		}
 		data, errRead := os.ReadFile(s.configPath)
 		if errRead != nil {
-			return fmt.Errorf("postgres store: read local config: %w", errRead)
+			return "", fmt.Errorf("postgres store: read local config: %w", errRead)
 		}
 		if errPersist := s.persistConfig(ctx, data); errPersist != nil {
-			return errPersist
+			return "", errPersist
 		}
 	case err != nil:
-		return fmt.Errorf("postgres store: load config from database: %w", err)
+		return "", fmt.Errorf("postgres store: load config from database: %w", err)
 	default:
 		if err = os.MkdirAll(filepath.Dir(s.configPath), 0o700); err != nil {
-			return fmt.Errorf("postgres store: prepare config directory: %w", err)
+			return "", fmt.Errorf("postgres store: prepare config directory: %w", err)
 		}
 		normalized := normalizeLineEndings(content)
 		if err = os.WriteFile(s.configPath, []byte(normalized), 0o600); err != nil {
-			return fmt.Errorf("postgres store: write config to spool: %w", err)
+			return "", fmt.Errorf("postgres store: write config to spool: %w", err)
 		}
 	}
-	return nil
+	return generatedKey, nil
 }
 
 // syncAuthFromDatabase populates the local auth directory from PostgreSQL data.


### PR DESCRIPTION
## Summary
- Manually port the security hardening from upstream router-for-me/CLIProxyAPI#3375.
- Reject documented sample client API keys (`your-api-key-1`, `your-api-key-2`, `your-api-key-3`) at runtime even if they remain in an existing config.
- Comment out the sample values in `config.example.yaml` and generate a private `cpak-...` key when bootstrapping a fresh config from sample placeholders.
- Propagate generated-key detection through git/object/postgres config bootstrap paths.

## LTS compatibility
- Preserves the `github.com/router-for-me/CLIProxyAPI/v6` module path.
- Does not change `/v0/management/usage*`, `internal/usage`, or usage statistics response schemas.
- Existing custom API keys continue to work. Explicit `api-keys: []` templates are preserved.
- Deliberate LTS adjustment: unlike upstream, the generated client API key is not printed in logs; logs only point to the local config file that contains it. This follows the local rule against logging raw API keys.

## Validation
- `gofmt -w cmd/server/main.go internal/access/config_access/provider.go internal/access/config_access/provider_test.go internal/misc/copy-example-config.go internal/misc/copy-example-config_test.go internal/samplekeys/api_keys.go internal/store/objectstore.go internal/store/postgresstore.go`
- `go test ./internal/access/config_access ./internal/misc ./internal/samplekeys ./internal/store`
- `go build -o test-output ./cmd/server && rm -f test-output`
- `go test ./internal/config ./cmd/server ./internal/api/handlers/management`
- `go test ./...`
- `git diff --check`