### PR TITLE
[codex] Port upstream Retry-After parsing

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -2386,30 +2385,7 @@ func ensureModelMaxTokens(body []byte, modelID string) []byte {
 func newClaudeStatusErr(statusCode int, body []byte, header http.Header) statusErr {
 	err := statusErr{code: statusCode, msg: string(body)}
 	if statusCode == http.StatusTooManyRequests || statusCode == claudeStatusOverloaded {
-		err.retryAfter = parseClaudeRetryAfter(header, time.Now())
+		err.retryAfter = helps.ParseClaudeRetryAfter(header, time.Now())
 	}
 	return err
-}
-
-func parseClaudeRetryAfter(header http.Header, now time.Time) *time.Duration {
-	val := strings.TrimSpace(header.Get("Retry-After"))
-	if val == "" {
-		return nil
-	}
-
-	secs, err := strconv.ParseFloat(val, 64)
-	if err == nil && secs > 0 {
-		d := time.Duration(secs * float64(time.Second))
-		return &d
-	}
-
-	t, err := http.ParseTime(val)
-	if err != nil {
-		return nil
-	}
-	d := t.Sub(now)
-	if d <= 0 {
-		return nil
-	}
-	return &d
 }

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -80,6 +81,7 @@ var oauthToolsToRemove = map[string]bool{}
 // Anthropic-compatible upstreams may reject or even crash when Claude models
 // omit max_tokens. Prefer registered model metadata before using a fallback.
 const defaultModelMaxTokens = 1024
+const claudeStatusOverloaded = 529
 
 func NewClaudeExecutor(cfg *config.Config) *ClaudeExecutor { return &ClaudeExecutor{cfg: cfg} }
 
@@ -252,7 +254,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		}
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		err = newClaudeStatusErr(httpResp.StatusCode, b, httpResp.Header)
 		if errClose := errBody.Close(); errClose != nil {
 			log.Errorf("response body close error: %v", errClose)
 		}
@@ -429,7 +431,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		if errClose := errBody.Close(); errClose != nil {
 			log.Errorf("response body close error: %v", errClose)
 		}
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		err = newClaudeStatusErr(httpResp.StatusCode, b, httpResp.Header)
 		return nil, err
 	}
 	decodedBody, err := decodeResponseBody(httpResp.Body, httpResp.Header.Get("Content-Encoding"))
@@ -663,7 +665,7 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 		if errClose := errBody.Close(); errClose != nil {
 			log.Errorf("response body close error: %v", errClose)
 		}
-		return cliproxyexecutor.Response{}, statusErr{code: resp.StatusCode, msg: string(b)}
+		return cliproxyexecutor.Response{}, newClaudeStatusErr(resp.StatusCode, b, resp.Header)
 	}
 	decodedBody, err := decodeResponseBody(resp.Body, resp.Header.Get("Content-Encoding"))
 	if err != nil {
@@ -2379,4 +2381,35 @@ func ensureModelMaxTokens(body []byte, modelID string) []byte {
 	}
 
 	return body
+}
+
+func newClaudeStatusErr(statusCode int, body []byte, header http.Header) statusErr {
+	err := statusErr{code: statusCode, msg: string(body)}
+	if statusCode == http.StatusTooManyRequests || statusCode == claudeStatusOverloaded {
+		err.retryAfter = parseClaudeRetryAfter(header, time.Now())
+	}
+	return err
+}
+
+func parseClaudeRetryAfter(header http.Header, now time.Time) *time.Duration {
+	val := strings.TrimSpace(header.Get("Retry-After"))
+	if val == "" {
+		return nil
+	}
+
+	secs, err := strconv.ParseFloat(val, 64)
+	if err == nil && secs > 0 {
+		d := time.Duration(secs * float64(time.Second))
+		return &d
+	}
+
+	t, err := http.ParseTime(val)
+	if err != nil {
+		return nil
+	}
+	d := t.Sub(now)
+	if d <= 0 {
+		return nil
+	}
+	return &d
 }

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -65,6 +65,110 @@ func assertClaudeFingerprint(t *testing.T, headers http.Header, userAgent, pkgVe
 	}
 }
 
+func TestParseClaudeRetryAfter(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+
+	t.Run("seconds", func(t *testing.T) {
+		header := http.Header{"Retry-After": []string{"2.5"}}
+		got := parseClaudeRetryAfter(header, now)
+		if got == nil {
+			t.Fatal("expected retryAfter, got nil")
+		}
+		if *got != 2500*time.Millisecond {
+			t.Fatalf("retryAfter = %v, want %v", *got, 2500*time.Millisecond)
+		}
+	})
+
+	t.Run("http date", func(t *testing.T) {
+		header := http.Header{"Retry-After": []string{now.Add(3 * time.Minute).Format(http.TimeFormat)}}
+		got := parseClaudeRetryAfter(header, now)
+		if got == nil {
+			t.Fatal("expected retryAfter, got nil")
+		}
+		if *got != 3*time.Minute {
+			t.Fatalf("retryAfter = %v, want %v", *got, 3*time.Minute)
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		header := http.Header{"Retry-After": []string{"not-a-duration"}}
+		if got := parseClaudeRetryAfter(header, now); got != nil {
+			t.Fatalf("expected nil for invalid header, got %v", *got)
+		}
+	})
+
+	t.Run("past date", func(t *testing.T) {
+		header := http.Header{"Retry-After": []string{now.Add(-time.Minute).Format(http.TimeFormat)}}
+		if got := parseClaudeRetryAfter(header, now); got != nil {
+			t.Fatalf("expected nil for past date, got %v", *got)
+		}
+	})
+
+	t.Run("missing", func(t *testing.T) {
+		if got := parseClaudeRetryAfter(http.Header{}, now); got != nil {
+			t.Fatalf("expected nil for missing header, got %v", *got)
+		}
+	})
+}
+
+func TestNewClaudeStatusErrAttachesRetryAfterForRateLimits(t *testing.T) {
+	header := http.Header{"Retry-After": []string{"7"}}
+
+	for _, statusCode := range []int{http.StatusTooManyRequests, claudeStatusOverloaded} {
+		t.Run(fmt.Sprintf("status_%d", statusCode), func(t *testing.T) {
+			err := newClaudeStatusErr(statusCode, []byte(`{"error":"rate limited"}`), header)
+			got := err.RetryAfter()
+			if got == nil {
+				t.Fatal("expected retryAfter, got nil")
+			}
+			if *got != 7*time.Second {
+				t.Fatalf("retryAfter = %v, want %v", *got, 7*time.Second)
+			}
+		})
+	}
+
+	err := newClaudeStatusErr(http.StatusBadRequest, []byte(`{"error":"bad request"}`), header)
+	if got := err.RetryAfter(); got != nil {
+		t.Fatalf("expected nil retryAfter for non-rate-limit status, got %v", *got)
+	}
+}
+
+func TestClaudeExecutorExecuteReturnsRetryAfterFromHeader(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Retry-After", "4")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"rate_limit_error","message":"rate limited"}}`))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-3-5-sonnet",
+		Payload: payload,
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	retryable, ok := err.(interface{ RetryAfter() *time.Duration })
+	if !ok {
+		t.Fatalf("expected retryable status error, got %T", err)
+	}
+	got := retryable.RetryAfter()
+	if got == nil {
+		t.Fatal("expected retryAfter, got nil")
+	}
+	if *got != 4*time.Second {
+		t.Fatalf("retryAfter = %v, want %v", *got, 4*time.Second)
+	}
+}
+
 func TestApplyClaudeHeaders_UsesConfiguredBaselineFingerprint(t *testing.T) {
 	resetClaudeDeviceProfileCache()
 	stabilize := true

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -70,7 +70,7 @@ func TestParseClaudeRetryAfter(t *testing.T) {
 
 	t.Run("seconds", func(t *testing.T) {
 		header := http.Header{"Retry-After": []string{"2.5"}}
-		got := parseClaudeRetryAfter(header, now)
+		got := helps.ParseClaudeRetryAfter(header, now)
 		if got == nil {
 			t.Fatal("expected retryAfter, got nil")
 		}
@@ -81,7 +81,7 @@ func TestParseClaudeRetryAfter(t *testing.T) {
 
 	t.Run("http date", func(t *testing.T) {
 		header := http.Header{"Retry-After": []string{now.Add(3 * time.Minute).Format(http.TimeFormat)}}
-		got := parseClaudeRetryAfter(header, now)
+		got := helps.ParseClaudeRetryAfter(header, now)
 		if got == nil {
 			t.Fatal("expected retryAfter, got nil")
 		}
@@ -92,20 +92,20 @@ func TestParseClaudeRetryAfter(t *testing.T) {
 
 	t.Run("invalid", func(t *testing.T) {
 		header := http.Header{"Retry-After": []string{"not-a-duration"}}
-		if got := parseClaudeRetryAfter(header, now); got != nil {
+		if got := helps.ParseClaudeRetryAfter(header, now); got != nil {
 			t.Fatalf("expected nil for invalid header, got %v", *got)
 		}
 	})
 
 	t.Run("past date", func(t *testing.T) {
 		header := http.Header{"Retry-After": []string{now.Add(-time.Minute).Format(http.TimeFormat)}}
-		if got := parseClaudeRetryAfter(header, now); got != nil {
+		if got := helps.ParseClaudeRetryAfter(header, now); got != nil {
 			t.Fatalf("expected nil for past date, got %v", *got)
 		}
 	})
 
 	t.Run("missing", func(t *testing.T) {
-		if got := parseClaudeRetryAfter(http.Header{}, now); got != nil {
+		if got := helps.ParseClaudeRetryAfter(http.Header{}, now); got != nil {
 			t.Fatalf("expected nil for missing header, got %v", *got)
 		}
 	})

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -197,7 +197,7 @@ func (e *GeminiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		b, _ := io.ReadAll(httpResp.Body)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		err = newGeminiStatusErr(httpResp.StatusCode, b)
 		return resp, err
 	}
 	data, err := io.ReadAll(httpResp.Body)
@@ -300,7 +300,7 @@ func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("gemini executor: close response body error: %v", errClose)
 		}
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		err = newGeminiStatusErr(httpResp.StatusCode, b)
 		return nil, err
 	}
 	out := make(chan cliproxyexecutor.StreamChunk)
@@ -431,7 +431,7 @@ func (e *GeminiExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	helps.AppendAPIResponseChunk(ctx, e.cfg, data)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", resp.StatusCode, helps.SummarizeErrorBody(resp.Header.Get("Content-Type"), data))
-		return cliproxyexecutor.Response{}, statusErr{code: resp.StatusCode, msg: string(data)}
+		return cliproxyexecutor.Response{}, newGeminiStatusErr(resp.StatusCode, data)
 	}
 
 	count := gjson.GetBytes(data, "totalTokens").Int()

--- a/internal/runtime/executor/gemini_executor_test.go
+++ b/internal/runtime/executor/gemini_executor_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -86,5 +87,40 @@ func TestGeminiExecutorExecuteCapsMaxOutputTokensBeforeUpstream(t *testing.T) {
 	}
 	if upstreamMaxOutputTokens != 65536 {
 		t.Fatalf("upstream maxOutputTokens = %d, want 65536", upstreamMaxOutputTokens)
+	}
+}
+
+func TestGeminiExecutorExecuteReturnsRetryAfterFromRetryInfo(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"details":[{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":"2.500s"}]}}`))
+	}))
+	defer server.Close()
+
+	exec := NewGeminiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "test-key",
+		"base_url": server.URL,
+	}}
+	req := cliproxyexecutor.Request{
+		Model:   "gemini-3.1-pro-preview",
+		Payload: []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`),
+	}
+
+	_, err := exec.Execute(context.Background(), auth, req, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatGemini})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	retryable, ok := err.(interface{ RetryAfter() *time.Duration })
+	if !ok {
+		t.Fatalf("expected retryable status error, got %T", err)
+	}
+	got := retryable.RetryAfter()
+	if got == nil {
+		t.Fatal("expected retryAfter, got nil")
+	}
+	if *got != 2500*time.Millisecond {
+		t.Fatalf("retryAfter = %v, want %v", *got, 2500*time.Millisecond)
 	}
 }

--- a/internal/runtime/executor/gemini_vertex_executor.go
+++ b/internal/runtime/executor/gemini_vertex_executor.go
@@ -406,7 +406,7 @@ func (e *GeminiVertexExecutor) executeWithServiceAccount(ctx context.Context, au
 		b, _ := io.ReadAll(httpResp.Body)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		err = newGeminiStatusErr(httpResp.StatusCode, b)
 		return resp, err
 	}
 	data, errRead := io.ReadAll(httpResp.Body)
@@ -528,7 +528,7 @@ func (e *GeminiVertexExecutor) executeWithAPIKey(ctx context.Context, auth *clip
 		b, _ := io.ReadAll(httpResp.Body)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		err = newGeminiStatusErr(httpResp.StatusCode, b)
 		return resp, err
 	}
 	data, errRead := io.ReadAll(httpResp.Body)
@@ -637,7 +637,7 @@ func (e *GeminiVertexExecutor) executeStreamWithServiceAccount(ctx context.Conte
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("vertex executor: close response body error: %v", errClose)
 		}
-		return nil, statusErr{code: httpResp.StatusCode, msg: string(b)}
+		return nil, newGeminiStatusErr(httpResp.StatusCode, b)
 	}
 
 	out := make(chan cliproxyexecutor.StreamChunk)
@@ -779,7 +779,7 @@ func (e *GeminiVertexExecutor) executeStreamWithAPIKey(ctx context.Context, auth
 		if errClose := httpResp.Body.Close(); errClose != nil {
 			log.Errorf("vertex executor: close response body error: %v", errClose)
 		}
-		return nil, statusErr{code: httpResp.StatusCode, msg: string(b)}
+		return nil, newGeminiStatusErr(httpResp.StatusCode, b)
 	}
 
 	out := make(chan cliproxyexecutor.StreamChunk)
@@ -905,7 +905,7 @@ func (e *GeminiVertexExecutor) countTokensWithServiceAccount(ctx context.Context
 		b, _ := io.ReadAll(httpResp.Body)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		return cliproxyexecutor.Response{}, statusErr{code: httpResp.StatusCode, msg: string(b)}
+		return cliproxyexecutor.Response{}, newGeminiStatusErr(httpResp.StatusCode, b)
 	}
 	data, errRead := io.ReadAll(httpResp.Body)
 	if errRead != nil {
@@ -995,7 +995,7 @@ func (e *GeminiVertexExecutor) countTokensWithAPIKey(ctx context.Context, auth *
 		b, _ := io.ReadAll(httpResp.Body)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		return cliproxyexecutor.Response{}, statusErr{code: httpResp.StatusCode, msg: string(b)}
+		return cliproxyexecutor.Response{}, newGeminiStatusErr(httpResp.StatusCode, b)
 	}
 	data, errRead := io.ReadAll(httpResp.Body)
 	if errRead != nil {

--- a/internal/runtime/executor/helps/claude_retry_after.go
+++ b/internal/runtime/executor/helps/claude_retry_after.go
@@ -1,0 +1,59 @@
+package helps
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const maxClaudeRetryAfter = 7 * 24 * time.Hour
+
+// ParseClaudeRetryAfter extracts an upstream cooldown duration from Claude
+// rate-limit response headers. Anthropic's unified reset header wins over the
+// generic Retry-After fallback, and long future values are capped to the
+// longest known Anthropic quota window.
+func ParseClaudeRetryAfter(headers http.Header, fallbackNow time.Time) *time.Duration {
+	now := fallbackNow
+	if dateStr := headers.Get("Date"); dateStr != "" {
+		if serverTime, err := http.ParseTime(dateStr); err == nil {
+			now = serverTime
+		}
+	}
+
+	if val := strings.TrimSpace(headers.Get("anthropic-ratelimit-unified-reset")); val != "" {
+		if epoch, err := strconv.ParseInt(val, 10, 64); err == nil {
+			if d := clampedClaudeRetryAfter(time.Unix(epoch, 0).Sub(now)); d != nil {
+				return d
+			}
+		}
+	}
+
+	if val := strings.TrimSpace(headers.Get("Retry-After")); val != "" {
+		if secs, err := strconv.ParseFloat(val, 64); err == nil && secs >= 0 {
+			maxSecs := maxClaudeRetryAfter.Seconds()
+			if secs > maxSecs {
+				secs = maxSecs
+			}
+			d := time.Duration(secs * float64(time.Second))
+			return &d
+		}
+		if resetAt, err := http.ParseTime(val); err == nil {
+			if d := clampedClaudeRetryAfter(resetAt.Sub(now)); d != nil {
+				return d
+			}
+		}
+	}
+
+	return nil
+}
+
+func clampedClaudeRetryAfter(d time.Duration) *time.Duration {
+	if d < 0 {
+		return nil
+	}
+	if d > maxClaudeRetryAfter {
+		d = maxClaudeRetryAfter
+	}
+	return &d
+}

--- a/internal/runtime/executor/helps/claude_retry_after_test.go
+++ b/internal/runtime/executor/helps/claude_retry_after_test.go
@@ -1,0 +1,79 @@
+package helps
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestParseClaudeRetryAfterUnifiedReset(t *testing.T) {
+	now := time.Unix(1_777_482_352, 0).UTC()
+	header := http.Header{
+		"Anthropic-Ratelimit-Unified-Reset": {"1777500000"},
+		"Retry-After":                       {"30"},
+	}
+
+	got := ParseClaudeRetryAfter(header, now)
+	if got == nil {
+		t.Fatal("expected retryAfter, got nil")
+	}
+	if want := 17648 * time.Second; *got != want {
+		t.Fatalf("retryAfter = %v, want %v", *got, want)
+	}
+}
+
+func TestParseClaudeRetryAfterFallsBackWhenUnifiedResetIsPast(t *testing.T) {
+	now := time.Unix(1_777_482_352, 0).UTC()
+	header := http.Header{
+		"Anthropic-Ratelimit-Unified-Reset": {"1777400000"},
+		"Retry-After":                       {"45"},
+	}
+
+	got := ParseClaudeRetryAfter(header, now)
+	if got == nil {
+		t.Fatal("expected retryAfter, got nil")
+	}
+	if want := 45 * time.Second; *got != want {
+		t.Fatalf("retryAfter = %v, want %v", *got, want)
+	}
+}
+
+func TestParseClaudeRetryAfterUsesServerDateAnchor(t *testing.T) {
+	serverNow := time.Unix(1_777_482_352, 0).UTC()
+	clientNow := serverNow.Add(10 * time.Minute)
+	header := http.Header{
+		"Date":                              {serverNow.Format(http.TimeFormat)},
+		"Anthropic-Ratelimit-Unified-Reset": {"1777482652"},
+	}
+
+	got := ParseClaudeRetryAfter(header, clientNow)
+	if got == nil {
+		t.Fatal("expected retryAfter, got nil")
+	}
+	if want := 5 * time.Minute; *got != want {
+		t.Fatalf("retryAfter = %v, want %v", *got, want)
+	}
+}
+
+func TestParseClaudeRetryAfterClampsLongCooldowns(t *testing.T) {
+	now := time.Unix(1_777_482_352, 0).UTC()
+	header := http.Header{"Retry-After": {"99999999999"}}
+
+	got := ParseClaudeRetryAfter(header, now)
+	if got == nil {
+		t.Fatal("expected retryAfter, got nil")
+	}
+	if *got != maxClaudeRetryAfter {
+		t.Fatalf("retryAfter = %v, want %v", *got, maxClaudeRetryAfter)
+	}
+}
+
+func TestParseClaudeRetryAfterPreservesZero(t *testing.T) {
+	got := ParseClaudeRetryAfter(http.Header{"Retry-After": {"0"}}, time.Now())
+	if got == nil {
+		t.Fatal("expected retryAfter, got nil")
+	}
+	if *got != 0 {
+		t.Fatalf("retryAfter = %v, want 0", *got)
+	}
+}


### PR DESCRIPTION
## Summary

- Selectively port useful upstream retry cooldown behavior from `router-for-me/CLIProxyAPI#3527` and `#3148`.
- Attach explicit retry delays to Claude 429/529 responses by parsing standard `Retry-After` seconds/HTTP-date headers.
- Add Claude support for Anthropic `anthropic-ratelimit-unified-reset`, anchored to upstream `Date` when present and capped at 7 days.
- Route Gemini and Gemini Vertex error paths through the existing `newGeminiStatusErr` helper so Google `RetryInfo.retryDelay` hints reach cooldown handling.
- Add regression coverage for Claude parsing/status propagation, Anthropic reset behavior, and Gemini execute retry metadata.

## LTS boundary

- Executor/helper-only change.
- Does not touch `internal/usage`, `/v0/management/usage*`, config schema, auth file structure, translator paths, or Panel-facing contracts.
- Keeps this PR scoped to retry/cooldown behavior.

## Validation

- `gofmt -w internal/runtime/executor/claude_executor.go internal/runtime/executor/claude_executor_test.go internal/runtime/executor/helps/claude_retry_after.go internal/runtime/executor/helps/claude_retry_after_test.go internal/runtime/executor/gemini_executor.go internal/runtime/executor/gemini_vertex_executor.go internal/runtime/executor/gemini_executor_test.go`
- `git diff --check`
- `go test ./internal/runtime/executor/helps ./internal/runtime/executor -run 'ClaudeRetryAfter|ParseClaudeRetryAfter|NewClaudeStatusErr|ClaudeExecutorExecuteReturnsRetryAfterFromHeader' -count=1`
- `go build -o test-output ./cmd/server`
