### PR TITLE
[codex] Scope Codex session keys by auth

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -284,7 +284,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	}
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
-	httpReq, err := e.cacheHelper(ctx, from, url, req, body)
+	httpReq, err := e.cacheHelper(ctx, auth, from, url, req, body)
 	if err != nil {
 		return resp, err
 	}
@@ -440,7 +440,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	}
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses/compact"
-	httpReq, err := e.cacheHelper(ctx, from, url, req, body)
+	httpReq, err := e.cacheHelper(ctx, auth, from, url, req, body)
 	if err != nil {
 		return resp, err
 	}
@@ -538,7 +538,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	}
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
-	httpReq, err := e.cacheHelper(ctx, from, url, req, body)
+	httpReq, err := e.cacheHelper(ctx, auth, from, url, req, body)
 	if err != nil {
 		return nil, err
 	}
@@ -841,12 +841,12 @@ func (e *CodexExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*
 	return auth, nil
 }
 
-func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Format, url string, req cliproxyexecutor.Request, rawJSON []byte) (*http.Request, error) {
+func (e *CodexExecutor) cacheHelper(ctx context.Context, auth *cliproxyauth.Auth, from sdktranslator.Format, url string, req cliproxyexecutor.Request, rawJSON []byte) (*http.Request, error) {
 	var cache helps.CodexCache
 	if from == "claude" {
 		userIDResult := gjson.GetBytes(req.Payload, "metadata.user_id")
 		if userIDResult.Exists() {
-			key := fmt.Sprintf("%s-%s", req.Model, userIDResult.String())
+			key := codexClaudeCacheKey(req.Model, auth, userIDResult.String())
 			var ok bool
 			if cache, ok = helps.GetCodexCache(key); !ok {
 				cache = helps.CodexCache{
@@ -859,11 +859,11 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 	} else if from == "openai-response" {
 		promptCacheKey := gjson.GetBytes(req.Payload, "prompt_cache_key")
 		if promptCacheKey.Exists() {
-			cache.ID = promptCacheKey.String()
+			cache.ID = scopedCodexPromptCacheKey(auth, promptCacheKey.String())
 		}
 	} else if from == "openai" {
 		if apiKey := strings.TrimSpace(helps.APIKeyFromContext(ctx)); apiKey != "" {
-			cache.ID = uuid.NewSHA1(uuid.NameSpaceOID, []byte("cli-proxy-api:codex:prompt-cache:"+apiKey)).String()
+			cache.ID = scopedCodexPromptCacheKey(auth, uuid.NewSHA1(uuid.NameSpaceOID, []byte("cli-proxy-api:codex:prompt-cache:"+apiKey)).String())
 		}
 	}
 
@@ -878,6 +878,56 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 		httpReq.Header.Set("Session_id", cache.ID)
 	}
 	return httpReq, nil
+}
+
+func codexClaudeCacheKey(model string, auth *cliproxyauth.Auth, userID string) string {
+	namespace := codexAuthSessionNamespace(auth)
+	if namespace == "" {
+		return fmt.Sprintf("%s-%s", model, userID)
+	}
+	return codexScopedSHA1Key("cli-proxy-api:codex:claude-session", model, namespace, userID)
+}
+
+func scopedCodexPromptCacheKey(auth *cliproxyauth.Auth, promptCacheKey string) string {
+	promptCacheKey = strings.TrimSpace(promptCacheKey)
+	if promptCacheKey == "" {
+		return ""
+	}
+	namespace := codexAuthSessionNamespace(auth)
+	if namespace == "" {
+		return promptCacheKey
+	}
+	return codexScopedSHA1Key("cli-proxy-api:codex:auth-session", namespace, promptCacheKey)
+}
+
+func codexScopedSHA1Key(prefix string, components ...string) string {
+	var b strings.Builder
+	b.WriteString(prefix)
+	for _, component := range components {
+		fmt.Fprintf(&b, ":%d:%s", len(component), component)
+	}
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(b.String())).String()
+}
+
+func codexAuthSessionNamespace(auth *cliproxyauth.Auth) string {
+	if auth == nil {
+		return ""
+	}
+	for _, key := range []string{"codex_installation_id", "installation_id"} {
+		if auth.Metadata != nil {
+			if value, ok := auth.Metadata[key].(string); ok {
+				if trimmed := strings.TrimSpace(value); trimmed != "" {
+					return trimmed
+				}
+			}
+		}
+		if auth.Attributes != nil {
+			if value := strings.TrimSpace(auth.Attributes[key]); value != "" {
+				return value
+			}
+		}
+	}
+	return strings.TrimSpace(auth.ID)
 }
 
 func applyCodexHeaders(r *http.Request, auth *cliproxyauth.Auth, token string, stream bool, cfg *config.Config) {

--- a/internal/runtime/executor/codex_executor_cache_test.go
+++ b/internal/runtime/executor/codex_executor_cache_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
 	"github.com/tidwall/gjson"
@@ -27,7 +28,7 @@ func TestCodexExecutorCacheHelper_OpenAIChatCompletions_StablePromptCacheKeyFrom
 	}
 	url := "https://example.com/responses"
 
-	httpReq, err := executor.cacheHelper(ctx, sdktranslator.FromString("openai"), url, req, rawJSON)
+	httpReq, err := executor.cacheHelper(ctx, nil, sdktranslator.FromString("openai"), url, req, rawJSON)
 	if err != nil {
 		t.Fatalf("cacheHelper error: %v", err)
 	}
@@ -49,7 +50,7 @@ func TestCodexExecutorCacheHelper_OpenAIChatCompletions_StablePromptCacheKeyFrom
 		t.Fatalf("Session_id = %q, want %q", gotSession, expectedKey)
 	}
 
-	httpReq2, err := executor.cacheHelper(ctx, sdktranslator.FromString("openai"), url, req, rawJSON)
+	httpReq2, err := executor.cacheHelper(ctx, nil, sdktranslator.FromString("openai"), url, req, rawJSON)
 	if err != nil {
 		t.Fatalf("cacheHelper error (second call): %v", err)
 	}
@@ -60,5 +61,121 @@ func TestCodexExecutorCacheHelper_OpenAIChatCompletions_StablePromptCacheKeyFrom
 	gotKey2 := gjson.GetBytes(body2, "prompt_cache_key").String()
 	if gotKey2 != expectedKey {
 		t.Fatalf("prompt_cache_key (second call) = %q, want %q", gotKey2, expectedKey)
+	}
+}
+
+func TestCodexClaudeCacheKeyPreservesLegacyKeyWithoutNamespace(t *testing.T) {
+	got := codexClaudeCacheKey("gpt-5-codex", nil, "user-1")
+	if got != "gpt-5-codex-user-1" {
+		t.Fatalf("codexClaudeCacheKey without namespace = %q, want legacy key", got)
+	}
+}
+
+func TestCodexClaudeCacheKeyDisambiguatesScopedComponents(t *testing.T) {
+	authAB := &cliproxyauth.Auth{Metadata: map[string]any{"codex_installation_id": "a-b"}}
+	authA := &cliproxyauth.Auth{Metadata: map[string]any{"codex_installation_id": "a"}}
+
+	keyABUserC := codexClaudeCacheKey("gpt-5-codex", authAB, "c")
+	keyAUserBC := codexClaudeCacheKey("gpt-5-codex", authA, "b-c")
+	if keyABUserC == "" || keyAUserBC == "" {
+		t.Fatalf("codexClaudeCacheKey returned empty scoped key")
+	}
+	if keyABUserC == "gpt-5-codex-a-b-c" || keyAUserBC == "gpt-5-codex-a-b-c" {
+		t.Fatalf("codexClaudeCacheKey used ambiguous delimiter-only key")
+	}
+	if keyABUserC == keyAUserBC {
+		t.Fatalf("codexClaudeCacheKey collided for namespace/user components containing hyphens")
+	}
+
+	keyABUserC2 := codexClaudeCacheKey("gpt-5-codex", authAB, "c")
+	if keyABUserC2 != keyABUserC {
+		t.Fatalf("codexClaudeCacheKey = %q, want stable %q", keyABUserC2, keyABUserC)
+	}
+}
+
+func TestCodexExecutorCacheHelper_OpenAIResponsesScopesPromptCacheKeyByAuth(t *testing.T) {
+	ctx := context.Background()
+	executor := &CodexExecutor{}
+	rawJSON := []byte(`{"model":"gpt-5-codex","prompt_cache_key":"shared-session"}`)
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: rawJSON,
+	}
+	url := "https://example.com/responses"
+	authA := &cliproxyauth.Auth{
+		ID:       "auth-a",
+		Metadata: map[string]any{"codex_installation_id": "install-a"},
+	}
+	authB := &cliproxyauth.Auth{
+		ID:       "auth-b",
+		Metadata: map[string]any{"codex_installation_id": "install-b"},
+	}
+
+	httpReqA, err := executor.cacheHelper(ctx, authA, sdktranslator.FromString("openai-response"), url, req, rawJSON)
+	if err != nil {
+		t.Fatalf("cacheHelper auth A error: %v", err)
+	}
+	bodyA, errReadA := io.ReadAll(httpReqA.Body)
+	if errReadA != nil {
+		t.Fatalf("read auth A body: %v", errReadA)
+	}
+	keyA := gjson.GetBytes(bodyA, "prompt_cache_key").String()
+	if keyA == "" || keyA == "shared-session" {
+		t.Fatalf("auth A prompt_cache_key = %q, want scoped key", keyA)
+	}
+	if gotSession := httpReqA.Header.Get("Session_id"); gotSession != keyA {
+		t.Fatalf("auth A Session_id = %q, want %q", gotSession, keyA)
+	}
+
+	httpReqB, err := executor.cacheHelper(ctx, authB, sdktranslator.FromString("openai-response"), url, req, rawJSON)
+	if err != nil {
+		t.Fatalf("cacheHelper auth B error: %v", err)
+	}
+	bodyB, errReadB := io.ReadAll(httpReqB.Body)
+	if errReadB != nil {
+		t.Fatalf("read auth B body: %v", errReadB)
+	}
+	keyB := gjson.GetBytes(bodyB, "prompt_cache_key").String()
+	if keyB == "" || keyB == keyA {
+		t.Fatalf("auth B prompt_cache_key = %q, want different from auth A %q", keyB, keyA)
+	}
+
+	httpReqA2, err := executor.cacheHelper(ctx, authA, sdktranslator.FromString("openai-response"), url, req, rawJSON)
+	if err != nil {
+		t.Fatalf("cacheHelper auth A second error: %v", err)
+	}
+	bodyA2, errReadA2 := io.ReadAll(httpReqA2.Body)
+	if errReadA2 != nil {
+		t.Fatalf("read auth A second body: %v", errReadA2)
+	}
+	keyA2 := gjson.GetBytes(bodyA2, "prompt_cache_key").String()
+	if keyA2 != keyA {
+		t.Fatalf("auth A prompt_cache_key second = %q, want stable %q", keyA2, keyA)
+	}
+}
+
+func TestScopedCodexPromptCacheKeyDisambiguatesScopedComponents(t *testing.T) {
+	authAB := &cliproxyauth.Auth{Metadata: map[string]any{"codex_installation_id": "a:b"}}
+	authA := &cliproxyauth.Auth{Metadata: map[string]any{"codex_installation_id": "a"}}
+
+	keyABWithC := scopedCodexPromptCacheKey(authAB, "c")
+	keyAWithBC := scopedCodexPromptCacheKey(authA, "b:c")
+	if keyABWithC == "" || keyAWithBC == "" {
+		t.Fatalf("scopedCodexPromptCacheKey returned empty scoped key")
+	}
+	if keyABWithC == keyAWithBC {
+		t.Fatalf("scopedCodexPromptCacheKey collided for namespace/prompt_cache_key components containing colons")
+	}
+
+	ambiguousDelimiterKey := uuid.NewSHA1(uuid.NameSpaceOID, []byte("cli-proxy-api:codex:auth-session:a:b:c")).String()
+	if keyABWithC == ambiguousDelimiterKey || keyAWithBC == ambiguousDelimiterKey {
+		t.Fatalf("scopedCodexPromptCacheKey used ambiguous delimiter-only input")
+	}
+
+	if got := scopedCodexPromptCacheKey(nil, " cache-1 "); got != "cache-1" {
+		t.Fatalf("scopedCodexPromptCacheKey without namespace = %q, want trimmed legacy key", got)
+	}
+	if got := scopedCodexPromptCacheKey(authA, "   "); got != "" {
+		t.Fatalf("scopedCodexPromptCacheKey blank key = %q, want empty", got)
 	}
 }

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -220,7 +220,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		return resp, err
 	}
 
-	body, wsHeaders := applyCodexPromptCacheHeaders(from, req, body)
+	body, wsHeaders := applyCodexPromptCacheHeaders(from, auth, req, body)
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
 
 	var authID, authLabel, authType, authValue string
@@ -420,7 +420,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		return nil, err
 	}
 
-	body, wsHeaders := applyCodexPromptCacheHeaders(from, req, body)
+	body, wsHeaders := applyCodexPromptCacheHeaders(from, auth, req, body)
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
 
 	var authID, authLabel, authType, authValue string
@@ -803,7 +803,7 @@ func buildCodexResponsesWebsocketURL(httpURL string) (string, error) {
 	return parsed.String(), nil
 }
 
-func applyCodexPromptCacheHeaders(from sdktranslator.Format, req cliproxyexecutor.Request, rawJSON []byte) ([]byte, http.Header) {
+func applyCodexPromptCacheHeaders(from sdktranslator.Format, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, rawJSON []byte) ([]byte, http.Header) {
 	headers := http.Header{}
 	if len(rawJSON) == 0 {
 		return rawJSON, headers
@@ -813,7 +813,7 @@ func applyCodexPromptCacheHeaders(from sdktranslator.Format, req cliproxyexecuto
 	if from == "claude" {
 		userIDResult := gjson.GetBytes(req.Payload, "metadata.user_id")
 		if userIDResult.Exists() {
-			key := fmt.Sprintf("%s-%s", req.Model, userIDResult.String())
+			key := codexClaudeCacheKey(req.Model, auth, userIDResult.String())
 			if cached, ok := helps.GetCodexCache(key); ok {
 				cache = cached
 			} else {
@@ -826,7 +826,7 @@ func applyCodexPromptCacheHeaders(from sdktranslator.Format, req cliproxyexecuto
 		}
 	} else if from == "openai-response" {
 		if promptCacheKey := gjson.GetBytes(req.Payload, "prompt_cache_key"); promptCacheKey.Exists() {
-			cache.ID = promptCacheKey.String()
+			cache.ID = scopedCodexPromptCacheKey(auth, promptCacheKey.String())
 		}
 	}
 

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -347,7 +347,7 @@ func TestApplyCodexWebsocketHeadersPreservesExplicitAPIKeyUserAgent(t *testing.T
 func TestApplyCodexPromptCacheHeadersSetsLowercaseSessionAndLegacyConversation(t *testing.T) {
 	req := cliproxyexecutor.Request{Model: "gpt-5-codex", Payload: []byte(`{"prompt_cache_key":"cache-1"}`)}
 
-	_, headers := applyCodexPromptCacheHeaders("openai-response", req, []byte(`{"model":"gpt-5-codex"}`))
+	_, headers := applyCodexPromptCacheHeaders("openai-response", nil, req, []byte(`{"model":"gpt-5-codex"}`))
 
 	if got := headerValueCaseInsensitive(headers, "session_id"); got != "cache-1" {
 		t.Fatalf("session_id = %s, want cache-1", got)
@@ -357,6 +357,30 @@ func TestApplyCodexPromptCacheHeadersSetsLowercaseSessionAndLegacyConversation(t
 	}
 	if got := headers.Get("Conversation_id"); got != "cache-1" {
 		t.Fatalf("Conversation_id = %s, want cache-1", got)
+	}
+}
+
+func TestApplyCodexPromptCacheHeadersScopesSessionByAuth(t *testing.T) {
+	req := cliproxyexecutor.Request{Model: "gpt-5-codex", Payload: []byte(`{"prompt_cache_key":"cache-1"}`)}
+	authA := &cliproxyauth.Auth{ID: "auth-a", Metadata: map[string]any{"codex_installation_id": "install-a"}}
+	authB := &cliproxyauth.Auth{ID: "auth-b", Metadata: map[string]any{"codex_installation_id": "install-b"}}
+
+	bodyA, headersA := applyCodexPromptCacheHeaders("openai-response", authA, req, []byte(`{"model":"gpt-5-codex"}`))
+	bodyB, headersB := applyCodexPromptCacheHeaders("openai-response", authB, req, []byte(`{"model":"gpt-5-codex"}`))
+
+	keyA := gjson.GetBytes(bodyA, "prompt_cache_key").String()
+	keyB := gjson.GetBytes(bodyB, "prompt_cache_key").String()
+	if keyA == "" || keyA == "cache-1" {
+		t.Fatalf("auth A prompt_cache_key = %q, want scoped key", keyA)
+	}
+	if keyB == "" || keyB == keyA {
+		t.Fatalf("auth B prompt_cache_key = %q, want different from auth A %q", keyB, keyA)
+	}
+	if got := headerValueCaseInsensitive(headersA, "session_id"); got != keyA {
+		t.Fatalf("auth A session_id = %q, want %q", got, keyA)
+	}
+	if got := headersB.Get("Conversation_id"); got != keyB {
+		t.Fatalf("auth B Conversation_id = %q, want %q", got, keyB)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Selectively port the auth-scoped Codex session key behavior from upstream router-for-me/CLIProxyAPI#3642.
- Scope direct Codex HTTP `prompt_cache_key` / `Session_id` values by the selected auth namespace when one is available.
- Apply the same scoping to Codex WebSocket session headers.
- Preserve legacy unscoped behavior when no auth namespace is available.
- Add collision-resistance tests for scoped key construction and HTTP/WebSocket header propagation.

## LTS boundary
- Executor-only change for Codex HTTP/WebSocket paths.
- Does not touch `internal/usage`, `/v0/management/usage*`, config schema, auth file structure, translator paths, or Panel-facing contracts.
- LTS `main` does not currently have upstream `codex_openai_images.go`, so this PR intentionally adapts only the paths present in CPA-Core-LTS.

## Validation
- `gofmt -w internal/runtime/executor/codex_executor.go internal/runtime/executor/codex_websockets_executor.go internal/runtime/executor/codex_executor_cache_test.go internal/runtime/executor/codex_websockets_executor_test.go`
- `go test ./internal/runtime/executor -run 'TestCodexExecutorCacheHelper|TestCodexClaudeCacheKey|TestScopedCodexPromptCacheKey|TestApplyCodexPromptCacheHeaders' -count=1`\n- `go test ./internal/runtime/executor`\n- `go build -o test-output ./cmd/server && rm -f test-output`\n- `git diff --check`\n- `go test ./...`