### PR TITLE
[codex] Strip Claude context-1m beta for OAuth

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -80,6 +80,7 @@ var oauthToolsToRemove = map[string]bool{}
 // Anthropic-compatible upstreams may reject or even crash when Claude models
 // omit max_tokens. Prefer registered model metadata before using a fallback.
 const defaultModelMaxTokens = 1024
+const claudeContext1MBeta = "context-1m-2025-08-07"
 
 func NewClaudeExecutor(cfg *config.Config) *ClaudeExecutor { return &ClaudeExecutor{cfg: cfg} }
 
@@ -972,6 +973,9 @@ func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string,
 			}
 		}
 	}
+	if !useAPIKey {
+		baseBetas = removeClaudeBeta(baseBetas, claudeContext1MBeta)
+	}
 	r.Header.Set("Anthropic-Beta", baseBetas)
 
 	misc.EnsureHeader(r.Header, ginHeaders, "Anthropic-Version", "2023-06-01")
@@ -1021,6 +1025,23 @@ func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string,
 	if stream {
 		r.Header.Set("Accept-Encoding", "identity")
 	}
+}
+
+func removeClaudeBeta(baseBetas, betaToRemove string) string {
+	betaToRemove = strings.TrimSpace(betaToRemove)
+	if betaToRemove == "" || strings.TrimSpace(baseBetas) == "" {
+		return strings.TrimSpace(baseBetas)
+	}
+	parts := strings.Split(baseBetas, ",")
+	kept := parts[:0]
+	for _, part := range parts {
+		beta := strings.TrimSpace(part)
+		if beta == "" || beta == betaToRemove {
+			continue
+		}
+		kept = append(kept, beta)
+	}
+	return strings.Join(kept, ",")
 }
 
 func claudeCreds(a *cliproxyauth.Auth) (apiKey, baseURL string) {

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -65,6 +65,63 @@ func assertClaudeFingerprint(t *testing.T, headers http.Header, userAgent, pkgVe
 	}
 }
 
+func TestApplyClaudeHeaders_StripsContext1MBetaForOAuth(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		ID:       "oauth-auth",
+		Metadata: map[string]any{"access_token": "oauth-token"},
+	}
+	req := newClaudeHeaderTestRequest(t, http.Header{
+		"Anthropic-Beta": []string{"claude-code-20250219, context-1m-2025-08-07,custom-beta-2026-01-01"},
+	})
+
+	applyClaudeHeaders(req, auth, "oauth-token", false, []string{"context-1m-2025-08-07", "another-beta-2026-01-01"}, nil)
+
+	got := req.Header.Get("Anthropic-Beta")
+	if strings.Contains(got, claudeContext1MBeta) {
+		t.Fatalf("Anthropic-Beta = %q, must not contain %q for OAuth", got, claudeContext1MBeta)
+	}
+	for _, want := range []string{"claude-code-20250219", "oauth-2025-04-20", "interleaved-thinking-2025-05-14", "custom-beta-2026-01-01", "another-beta-2026-01-01"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Anthropic-Beta = %q, want to contain %q", got, want)
+		}
+	}
+	if gotAuth := req.Header.Get("Authorization"); gotAuth != "Bearer oauth-token" {
+		t.Fatalf("Authorization = %q, want Bearer oauth-token", gotAuth)
+	}
+}
+
+func TestApplyClaudeHeaders_KeepsContext1MBetaForAPIKey(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		ID: "api-key-auth",
+		Attributes: map[string]string{
+			"api_key": "key-123",
+		},
+	}
+	req := newClaudeHeaderTestRequest(t, http.Header{
+		"Anthropic-Beta": []string{"claude-code-20250219"},
+	})
+
+	applyClaudeHeaders(req, auth, "key-123", false, []string{"context-1m-2025-08-07"}, nil)
+
+	got := req.Header.Get("Anthropic-Beta")
+	if !strings.Contains(got, claudeContext1MBeta) {
+		t.Fatalf("Anthropic-Beta = %q, want to contain %q for API key auth", got, claudeContext1MBeta)
+	}
+	if gotAPIKey := req.Header.Get("x-api-key"); gotAPIKey != "key-123" {
+		t.Fatalf("x-api-key = %q, want key-123", gotAPIKey)
+	}
+}
+
+func TestRemoveClaudeBetaMatchesWholeBetaNames(t *testing.T) {
+	got := removeClaudeBeta("context-1m-2025-08-07-extra, context-1m-2025-08-07, other", claudeContext1MBeta)
+	if strings.Contains(got, ", context-1m-2025-08-07,") || strings.HasSuffix(got, ","+claudeContext1MBeta) || strings.HasPrefix(got, claudeContext1MBeta+",") {
+		t.Fatalf("removeClaudeBeta() = %q, still contains exact removed beta", got)
+	}
+	if !strings.Contains(got, "context-1m-2025-08-07-extra") {
+		t.Fatalf("removeClaudeBeta() = %q, should keep similarly-prefixed beta", got)
+	}
+}
+
 func TestApplyClaudeHeaders_UsesConfiguredBaselineFingerprint(t *testing.T) {
 	resetClaudeDeviceProfileCache()
 	stabilize := true


### PR DESCRIPTION
## Summary
- Selectively port the safe executor subset of upstream router-for-me/CLIProxyAPI#3567 / #3571.
- Strip `context-1m-2025-08-07` from outbound Claude OAuth requests so subscription accounts without pay-as-you-go credits fall back to the standard context window instead of receiving upstream 429 errors.
- Keep `context-1m-2025-08-07` for API-key auth, preserving full 1M-context behavior where it is explicitly available.
- Filter beta names by exact token match rather than substring matching.

## LTS boundary
- Executor-only change in `internal/runtime/executor/claude_executor.go`.
- Does not port the upstream `max_tokens=1` probe short-circuit; that is a separate, higher-risk handler behavior change and should be reviewed independently.
- Does not touch `internal/usage`, `/v0/management/usage*`, config schema, auth file structure, translator paths, SDK handler paths, or Panel-facing contracts.

## Validation
- `gofmt -w internal/runtime/executor/claude_executor.go internal/runtime/executor/claude_executor_test.go`
- `go test ./internal/runtime/executor -run 'TestApplyClaudeHeaders_(StripsContext1MBetaForOAuth|KeepsContext1MBetaForAPIKey)|TestRemoveClaudeBeta' -count=1`\n- `go test ./internal/runtime/executor`\n- `go build -o test-output ./cmd/server && rm -f test-output`\n- `git diff --check`\n- `go test ./...`