### PR TITLE
[codex] Add Claude Opus 4.8 model registry entry

### DIFF
--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -96,6 +96,29 @@
       }
     },
     {
+      "id": "claude-opus-4-8",
+      "object": "model",
+      "created": 1779984000,
+      "owned_by": "anthropic",
+      "type": "claude",
+      "display_name": "Claude Opus 4.8",
+      "description": "Premium model combining maximum intelligence with practical performance",
+      "context_length": 1000000,
+      "max_completion_tokens": 128000,
+      "thinking": {
+        "min": 1024,
+        "max": 128000,
+        "zero_allowed": true,
+        "levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      }
+    },
+    {
       "id": "claude-opus-4-5-20251101",
       "object": "model",
       "created": 1761955200,


### PR DESCRIPTION
## Summary
- Selectively port upstream router-for-me/CLIProxyAPI commit df0176a1.
- Add the `claude-opus-4-8` registry entry with the upstream context length, completion token limit, and thinking levels.

## LTS boundary
- Registry-only change in `internal/registry/models/models.json`.
- Does not touch `internal/usage`, `/v0/management/usage*`, Management API response shape, config schema, auth file structure, translator paths, SDK public types, or Panel-facing contracts.
- Leaves the Go module path at `github.com/router-for-me/CLIProxyAPI/v6`.

## Validation
- `python3 -m json.tool internal/registry/models/models.json >/tmp/cpa_core_lts_models_json_check.txt`
- `git diff --check origin/main...HEAD`
- `go test ./internal/registry/...`
- `go build -o test-output ./cmd/server && rm -f test-output`