### PR TITLE
[codex] Clean Gemini CLI request schemas

### DIFF
--- a/internal/runtime/executor/gemini_cli_executor.go
+++ b/internal/runtime/executor/gemini_cli_executor.go
@@ -857,7 +857,12 @@ func cleanGeminiCLIRequestSchemas(body []byte) []byte {
 						}
 						cleaned := util.CleanJSONSchemaForGemini(params.Raw)
 						path := fmt.Sprintf("request.tools.%d.%s.%d.%s", i, declarationsKey, j, schemaKey)
-						body, _ = sjson.SetRawBytes(body, path, []byte(cleaned))
+						updated, errSet := sjson.SetRawBytes(body, path, []byte(cleaned))
+						if errSet != nil {
+							log.Errorf("gemini cli executor: failed to set cleaned schema at %s: %v", path, errSet)
+							continue
+						}
+						body = updated
 					}
 				}
 			}
@@ -873,7 +878,12 @@ func cleanGeminiCLIRequestSchemas(body []byte) []byte {
 			continue
 		}
 		cleaned := util.CleanJSONSchemaForGemini(responseSchema.Raw)
-		body, _ = sjson.SetRawBytes(body, schemaPath, []byte(cleaned))
+		updated, errSet := sjson.SetRawBytes(body, schemaPath, []byte(cleaned))
+		if errSet != nil {
+			log.Errorf("gemini cli executor: failed to set cleaned response schema at %s: %v", schemaPath, errSet)
+			continue
+		}
+		body = updated
 	}
 
 	return body

--- a/internal/runtime/executor/gemini_cli_executor.go
+++ b/internal/runtime/executor/gemini_cli_executor.go
@@ -141,6 +141,7 @@ func (e *GeminiCLIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	basePayload = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, "gemini", "request", basePayload, originalTranslated, requestedModel, requestPath)
+	basePayload = cleanGeminiCLIRequestSchemas(basePayload)
 
 	action := "generateContent"
 	if req.Metadata != nil {
@@ -297,6 +298,7 @@ func (e *GeminiCLIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyaut
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	basePayload = helps.ApplyPayloadConfigWithRoot(e.cfg, baseModel, "gemini", "request", basePayload, originalTranslated, requestedModel, requestPath)
+	basePayload = cleanGeminiCLIRequestSchemas(basePayload)
 
 	projectID := resolveGeminiProjectID(auth)
 
@@ -530,6 +532,7 @@ func (e *GeminiCLIExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.
 		payload = deleteJSONField(payload, "model")
 		payload = deleteJSONField(payload, "request.safetySettings")
 		payload = fixGeminiCLIImageAspectRatio(baseModel, payload)
+		payload = cleanGeminiCLIRequestSchemas(payload)
 
 		tok, errTok := tokenSource.Token()
 		if errTok != nil {
@@ -825,6 +828,55 @@ func deleteJSONField(body []byte, key string) []byte {
 		return body
 	}
 	return updated
+}
+
+func cleanGeminiCLIRequestSchemas(body []byte) []byte {
+	if len(body) == 0 {
+		return body
+	}
+	hasTools := gjson.GetBytes(body, "request.tools.0").Exists()
+	hasResponseSchema := gjson.GetBytes(body, "request.generationConfig.responseSchema").Exists()
+	hasResponseJSONSchema := gjson.GetBytes(body, "request.generationConfig.responseJsonSchema").Exists()
+	if !hasTools && !hasResponseSchema && !hasResponseJSONSchema {
+		return body
+	}
+
+	tools := gjson.GetBytes(body, "request.tools")
+	if tools.IsArray() {
+		for i, tool := range tools.Array() {
+			for _, declarationsKey := range []string{"function_declarations", "functionDeclarations"} {
+				funcDecls := tool.Get(declarationsKey)
+				if !funcDecls.IsArray() {
+					continue
+				}
+				for j, decl := range funcDecls.Array() {
+					for _, schemaKey := range []string{"parameters", "parametersJsonSchema"} {
+						params := decl.Get(schemaKey)
+						if !params.Exists() || !params.IsObject() {
+							continue
+						}
+						cleaned := util.CleanJSONSchemaForGemini(params.Raw)
+						path := fmt.Sprintf("request.tools.%d.%s.%d.%s", i, declarationsKey, j, schemaKey)
+						body, _ = sjson.SetRawBytes(body, path, []byte(cleaned))
+					}
+				}
+			}
+		}
+	}
+
+	for _, schemaPath := range []string{
+		"request.generationConfig.responseSchema",
+		"request.generationConfig.responseJsonSchema",
+	} {
+		responseSchema := gjson.GetBytes(body, schemaPath)
+		if !responseSchema.IsObject() {
+			continue
+		}
+		cleaned := util.CleanJSONSchemaForGemini(responseSchema.Raw)
+		body, _ = sjson.SetRawBytes(body, schemaPath, []byte(cleaned))
+	}
+
+	return body
 }
 
 func fixGeminiCLIImageAspectRatio(modelName string, rawJSON []byte) []byte {

--- a/internal/runtime/executor/gemini_cli_executor_test.go
+++ b/internal/runtime/executor/gemini_cli_executor_test.go
@@ -1,0 +1,75 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestCleanGeminiCLIRequestSchemasFlattensFunctionDeclarationTypeArray(t *testing.T) {
+	input := []byte(`{
+		"request": {
+			"tools": [
+				{
+					"function_declarations": [
+						{
+							"name": "wecom_mcp",
+							"parameters": {
+								"type": "object",
+								"properties": {
+									"args": {
+										"description": "call args",
+										"type": ["string", "object"]
+									}
+								}
+							}
+						}
+					]
+				},
+				{
+					"functionDeclarations": [
+						{
+							"name": "camel_tool",
+							"parametersJsonSchema": {
+								"type": "object",
+								"properties": {
+									"value": {
+										"type": ["integer", "string"]
+									}
+								}
+							}
+						}
+					]
+				}
+			],
+			"nonSchema": {
+				"type": ["string", "object"]
+			}
+		}
+	}`)
+
+	out := cleanGeminiCLIRequestSchemas(input)
+
+	argsType := gjson.GetBytes(out, "request.tools.0.function_declarations.0.parameters.properties.args.type")
+	if argsType.String() != "string" {
+		t.Fatalf("args.type = %s, want string; body=%s", argsType.Raw, string(out))
+	}
+	argsDesc := gjson.GetBytes(out, "request.tools.0.function_declarations.0.parameters.properties.args.description").String()
+	if !strings.Contains(argsDesc, "Accepts: string | object") {
+		t.Fatalf("args.description = %q, want accepted type hint", argsDesc)
+	}
+
+	valueType := gjson.GetBytes(out, "request.tools.1.functionDeclarations.0.parametersJsonSchema.properties.value.type")
+	if valueType.String() != "integer" {
+		t.Fatalf("value.type = %s, want integer; body=%s", valueType.Raw, string(out))
+	}
+	valueDesc := gjson.GetBytes(out, "request.tools.1.functionDeclarations.0.parametersJsonSchema.properties.value.description").String()
+	if !strings.Contains(valueDesc, "Accepts: integer | string") {
+		t.Fatalf("value.description = %q, want accepted type hint", valueDesc)
+	}
+
+	if nonSchema := gjson.GetBytes(out, "request.nonSchema.type"); !nonSchema.IsArray() {
+		t.Fatalf("request.nonSchema.type should be preserved outside schema paths, got %s", nonSchema.Raw)
+	}
+}


### PR DESCRIPTION
## Summary
- Selectively port upstream router-for-me/CLIProxyAPI#3554 commits 70a8cf02 and 4a85b6b9.
- Clean Gemini CLI tool and response schemas before upstream requests, flattening schema `type` arrays to Gemini-compatible scalar types with an accepted-types hint.
- Apply the cleanup on non-streaming, streaming, and countTokens Gemini CLI paths, and log schema replacement errors instead of silently ignoring them.

## LTS adaptation
- Kept the LTS `helps.ApplyPayloadConfigWithRoot` call path while adding schema cleanup after payload config is applied.
- Executor-only change in `internal/runtime/executor`; no translator-path changes.
- Does not touch `internal/usage`, `/v0/management/usage*`, Management API response shape, config schema, auth file structure, SDK public types, or Panel-facing contracts.

## Validation
- `gofmt -w internal/runtime/executor/gemini_cli_executor.go internal/runtime/executor/gemini_cli_executor_test.go`
- `go test ./internal/runtime/executor -run TestCleanGeminiCLIRequestSchemas -count=1`
- `go test ./internal/runtime/executor`
- `git diff --check origin/main...HEAD`
- `go build -o test-output ./cmd/server && rm -f test-output`