### PR TITLE
[codex] Guard Antigravity deprecated versions

### DIFF
--- a/internal/misc/antigravity_version.go
+++ b/internal/misc/antigravity_version.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	antigravityReleasesURL     = "https://antigravity-auto-updater-974169037036.us-central1.run.app/releases"
-	antigravityFallbackVersion = "1.21.9"
+	antigravityFallbackVersion = "2.10.0"
 	antigravityVersionCacheTTL = 6 * time.Hour
 	antigravityFetchTimeout    = 10 * time.Second
 	AntigravityNodeAPIClientUA = "google-api-nodejs-client/10.3.0"
@@ -74,10 +74,13 @@ func refreshAntigravityVersion(ctx context.Context) {
 	now := time.Now()
 
 	if errFetch == nil {
-		cachedAntigravityVersion = version
-		antigravityVersionExpiry = now.Add(antigravityVersionCacheTTL)
-		log.WithField("version", version).Info("fetched latest antigravity version")
-		return
+		if isSupportedAntigravityVersion(version) {
+			cachedAntigravityVersion = version
+			antigravityVersionExpiry = now.Add(antigravityVersionCacheTTL)
+			log.WithField("version", version).Info("fetched latest antigravity version")
+			return
+		}
+		log.WithField("version", version).Warn("fetched antigravity version is deprecated, using fallback")
 	}
 
 	if cachedAntigravityVersion == "" || now.After(antigravityVersionExpiry) {
@@ -91,17 +94,23 @@ func refreshAntigravityVersion(ctx context.Context) {
 }
 
 // AntigravityLatestVersion returns the cached antigravity version refreshed by StartAntigravityVersionUpdater.
-// It falls back to antigravityFallbackVersion if the cache is empty or stale.
+// It falls back to antigravityFallbackVersion if the cache is empty, stale, or deprecated.
 func AntigravityLatestVersion() string {
 	antigravityVersionMu.RLock()
+	defer antigravityVersionMu.RUnlock()
+
 	if cachedAntigravityVersion != "" && time.Now().Before(antigravityVersionExpiry) {
-		v := cachedAntigravityVersion
-		antigravityVersionMu.RUnlock()
-		return v
+		if isSupportedAntigravityVersion(cachedAntigravityVersion) {
+			return cachedAntigravityVersion
+		}
 	}
-	antigravityVersionMu.RUnlock()
 
 	return antigravityFallbackVersion
+}
+
+func isSupportedAntigravityVersion(version string) bool {
+	version = strings.TrimSpace(version)
+	return strings.HasPrefix(version, "2.") || strings.HasPrefix(version, "3.")
 }
 
 // AntigravityUserAgent returns the User-Agent string for antigravity requests

--- a/internal/misc/antigravity_version_test.go
+++ b/internal/misc/antigravity_version_test.go
@@ -1,0 +1,63 @@
+package misc
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIsSupportedAntigravityVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{name: "v2", version: "2.10.0", want: true},
+		{name: "v3", version: "3.0.1", want: true},
+		{name: "trimmed", version: " 2.11.0 ", want: true},
+		{name: "v1 deprecated", version: "1.21.9", want: false},
+		{name: "v0 deprecated", version: "0.8.2", want: false},
+		{name: "empty", version: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSupportedAntigravityVersion(tt.version); got != tt.want {
+				t.Fatalf("isSupportedAntigravityVersion(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAntigravityLatestVersionRejectsDeprecatedCachedVersion(t *testing.T) {
+	withAntigravityVersionState(t, "1.21.9", time.Now().Add(time.Hour))
+
+	if got := AntigravityLatestVersion(); got != antigravityFallbackVersion {
+		t.Fatalf("AntigravityLatestVersion() = %q, want fallback %q", got, antigravityFallbackVersion)
+	}
+}
+
+func TestAntigravityLatestVersionKeepsSupportedCachedVersion(t *testing.T) {
+	withAntigravityVersionState(t, "3.0.1", time.Now().Add(time.Hour))
+
+	if got := AntigravityLatestVersion(); got != "3.0.1" {
+		t.Fatalf("AntigravityLatestVersion() = %q, want cached supported version", got)
+	}
+}
+
+func withAntigravityVersionState(t *testing.T, version string, expiry time.Time) {
+	t.Helper()
+
+	antigravityVersionMu.Lock()
+	oldVersion := cachedAntigravityVersion
+	oldExpiry := antigravityVersionExpiry
+	cachedAntigravityVersion = version
+	antigravityVersionExpiry = expiry
+	antigravityVersionMu.Unlock()
+
+	t.Cleanup(func() {
+		antigravityVersionMu.Lock()
+		cachedAntigravityVersion = oldVersion
+		antigravityVersionExpiry = oldExpiry
+		antigravityVersionMu.Unlock()
+	})
+}


### PR DESCRIPTION
## Summary
- Selectively port the useful intent from upstream router-for-me/CLIProxyAPI#3648.
- Update the Antigravity fallback client version from `1.21.9` to `2.10.0` so backend requests do not use a deprecated client version.
- Reject cached/fetched Antigravity versions unless they are supported `2.x` or `3.x` versions.
- Add unit coverage for supported/deprecated version decisions and cached-version fallback behavior.

## LTS adaptation
- Scoped to `internal/misc/antigravity_version.go` and tests.
- Keeps the dynamic updater behavior, but avoids poisoning the cached version with a deprecated release before falling back.
- Does not touch `internal/usage`, `/v0/management/usage*`, Management API response shape, config schema, auth file structure, translator paths, SDK public types, or Panel-facing contracts.

## Validation
- `gofmt -w internal/misc/antigravity_version.go internal/misc/antigravity_version_test.go`
- `git diff --check origin/main...HEAD`
- `go test ./internal/misc`
- `go test ./internal/runtime/executor -run Antigravity -count=1`
- `go build -o test-output ./cmd/server && rm -f test-output`