### PR TITLE
[codex] Repair HTTP Responses tool call order

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_compact_test.go
+++ b/sdk/api/handlers/openai/openai_responses_compact_test.go
@@ -16,11 +16,13 @@ import (
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+	"github.com/tidwall/gjson"
 )
 
 type compactCaptureExecutor struct {
 	alt          string
 	sourceFormat string
+	payload      []byte
 	calls        int
 }
 
@@ -30,6 +32,7 @@ func (e *compactCaptureExecutor) Execute(ctx context.Context, auth *coreauth.Aut
 	e.calls++
 	e.alt = opts.Alt
 	e.sourceFormat = opts.SourceFormat.String()
+	e.payload = append([]byte(nil), req.Payload...)
 	return coreexecutor.Response{Payload: []byte(`{"ok":true}`)}, nil
 }
 
@@ -118,6 +121,91 @@ func TestOpenAIResponsesCompactExecute(t *testing.T) {
 	}
 	if strings.TrimSpace(resp.Body.String()) != `{"ok":true}` {
 		t.Fatalf("body = %s", resp.Body.String())
+	}
+}
+
+func TestOpenAIResponsesCompactRepairsHTTPToolCallOrder(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	executor := &compactCaptureExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	auth := &coreauth.Auth{ID: "auth-http-repair", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses/compact", h.Compact)
+
+	body := `{"model":"test-model","input":[{"type":"function_call_output","call_id":"call-1","output":"ok"},{"type":"message","id":"msg-1"},{"type":"function_call","call_id":"call-1","name":"tool"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	input := gjson.GetBytes(executor.payload, "input").Array()
+	if len(input) != 3 {
+		t.Fatalf("forwarded input len = %d, want 3: %s", len(input), executor.payload)
+	}
+	if input[0].Get("type").String() != "message" || input[0].Get("id").String() != "msg-1" {
+		t.Fatalf("unexpected first item: %s", input[0].Raw)
+	}
+	if input[1].Get("type").String() != "function_call" || input[1].Get("call_id").String() != "call-1" {
+		t.Fatalf("unexpected repaired call: %s", input[1].Raw)
+	}
+	if input[2].Get("type").String() != "function_call_output" || input[2].Get("call_id").String() != "call-1" {
+		t.Fatalf("unexpected repaired output: %s", input[2].Raw)
+	}
+}
+
+func TestOpenAIResponsesRepairsHTTPToolCallOrder(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	executor := &compactCaptureExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	auth := &coreauth.Auth{ID: "auth-http-responses-repair", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses", h.Responses)
+
+	body := `{"model":"test-model","input":[{"type":"function_call_output","call_id":"call-1","output":"ok"},{"type":"function_call","call_id":"call-1","name":"tool"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	input := gjson.GetBytes(executor.payload, "input").Array()
+	if len(input) != 2 {
+		t.Fatalf("forwarded input len = %d, want 2: %s", len(input), executor.payload)
+	}
+	if input[0].Get("type").String() != "function_call" || input[0].Get("call_id").String() != "call-1" {
+		t.Fatalf("unexpected repaired call: %s", input[0].Raw)
+	}
+	if input[1].Get("type").String() != "function_call_output" || input[1].Get("call_id").String() != "call-1" {
+		t.Fatalf("unexpected repaired output: %s", input[1].Raw)
 	}
 }
 

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -382,6 +382,8 @@ func (h *OpenAIResponsesAPIHandler) Responses(c *gin.Context) {
 		return
 	}
 
+	rawJSON = repairResponsesHTTPToolCalls(rawJSON)
+
 	// Check if the client requested a streaming response.
 	streamResult := gjson.GetBytes(rawJSON, "stream")
 	if streamResult.Type == gjson.True {
@@ -419,6 +421,8 @@ func (h *OpenAIResponsesAPIHandler) Compact(c *gin.Context) {
 			rawJSON = updated
 		}
 	}
+
+	rawJSON = repairResponsesHTTPToolCalls(rawJSON)
 
 	c.Header("Content-Type", "application/json")
 	modelName := gjson.GetBytes(rawJSON, "model").String()

--- a/sdk/api/handlers/openai/openai_responses_http_toolcall_repair_test.go
+++ b/sdk/api/handlers/openai/openai_responses_http_toolcall_repair_test.go
@@ -1,0 +1,44 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestRepairResponsesHTTPToolCallsReordersOutputBeforeCall(t *testing.T) {
+	raw := []byte(`{"input":[{"type":"function_call_output","call_id":"call-1","output":"ok"},{"type":"message","id":"msg-1"},{"type":"function_call","call_id":"call-1","name":"tool"}]}`)
+
+	repaired := repairResponsesHTTPToolCalls(raw)
+
+	input := gjson.GetBytes(repaired, "input").Array()
+	if len(input) != 3 {
+		t.Fatalf("input len = %d, want 3: %s", len(input), repaired)
+	}
+	if input[0].Get("type").String() != "message" {
+		t.Fatalf("unexpected first item: %s", input[0].Raw)
+	}
+	if input[1].Get("type").String() != "function_call" || input[1].Get("call_id").String() != "call-1" {
+		t.Fatalf("unexpected call item: %s", input[1].Raw)
+	}
+	if input[2].Get("type").String() != "function_call_output" || input[2].Get("call_id").String() != "call-1" {
+		t.Fatalf("unexpected output item: %s", input[2].Raw)
+	}
+}
+
+func TestRepairResponsesHTTPToolCallsKeepsOrphanOutputsStable(t *testing.T) {
+	raw := []byte(`{"input":[{"type":"function_call_output","call_id":"b","output":"second"},{"type":"message","id":"msg-1"},{"type":"function_call_output","call_id":"a","output":"first"}]}`)
+
+	repaired := repairResponsesHTTPToolCalls(raw)
+
+	input := gjson.GetBytes(repaired, "input").Array()
+	if len(input) != 3 {
+		t.Fatalf("input len = %d, want 3: %s", len(input), repaired)
+	}
+	if input[0].Get("type").String() != "message" {
+		t.Fatalf("unexpected first item: %s", input[0].Raw)
+	}
+	if input[1].Get("call_id").String() != "a" || input[2].Get("call_id").String() != "b" {
+		t.Fatalf("orphan outputs not stable: %s", repaired)
+	}
+}

--- a/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"encoding/json"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -417,4 +418,91 @@ func isResponsesToolCallOutputType(itemType string) bool {
 	default:
 		return false
 	}
+}
+
+func repairResponsesHTTPToolCalls(payload []byte) []byte {
+	if len(payload) == 0 {
+		return payload
+	}
+	input := gjson.GetBytes(payload, "input")
+	if !input.Exists() || !input.IsArray() {
+		return payload
+	}
+
+	updatedRaw := reorderResponsesToolCallsNoCache(input.Raw)
+	if updatedRaw == "" || updatedRaw == input.Raw {
+		return payload
+	}
+	updated, errSet := sjson.SetRawBytes(payload, "input", []byte(updatedRaw))
+	if errSet != nil {
+		return payload
+	}
+	return updated
+}
+
+func reorderResponsesToolCallsNoCache(rawArray string) string {
+	rawArray = strings.TrimSpace(rawArray)
+	if rawArray == "" {
+		return "[]"
+	}
+
+	var items []json.RawMessage
+	if errUnmarshal := json.Unmarshal([]byte(rawArray), &items); errUnmarshal != nil {
+		return ""
+	}
+
+	outputsByCallID := make(map[string][]json.RawMessage, len(items))
+	for _, item := range items {
+		if len(item) == 0 {
+			continue
+		}
+		itemType := strings.TrimSpace(gjson.GetBytes(item, "type").String())
+		if !isResponsesToolCallOutputType(itemType) {
+			continue
+		}
+		callID := strings.TrimSpace(gjson.GetBytes(item, "call_id").String())
+		if callID == "" {
+			continue
+		}
+		outputsByCallID[callID] = append(outputsByCallID[callID], item)
+	}
+
+	result := make([]json.RawMessage, 0, len(items))
+	for _, item := range items {
+		if len(item) == 0 {
+			continue
+		}
+		itemType := strings.TrimSpace(gjson.GetBytes(item, "type").String())
+		if isResponsesToolCallOutputType(itemType) {
+			continue
+		}
+		if !isResponsesToolCallType(itemType) {
+			result = append(result, item)
+			continue
+		}
+
+		callID := strings.TrimSpace(gjson.GetBytes(item, "call_id").String())
+		if callID == "" {
+			// Upstream rejects tool calls without call_id.
+			continue
+		}
+		result = append(result, item)
+		result = append(result, outputsByCallID[callID]...)
+		delete(outputsByCallID, callID)
+	}
+
+	orphanOrder := make([]string, 0, len(outputsByCallID))
+	for callID := range outputsByCallID {
+		orphanOrder = append(orphanOrder, callID)
+	}
+	sort.Strings(orphanOrder)
+	for _, callID := range orphanOrder {
+		result = append(result, outputsByCallID[callID]...)
+	}
+
+	out, errMarshal := json.Marshal(result)
+	if errMarshal != nil {
+		return ""
+	}
+	return string(out)
 }


### PR DESCRIPTION
## Summary
- Port the safe HTTP request-body repair boundary from upstream router-for-me/CLIProxyAPI#3105 without adopting its still-open HTTP session cache design.
- Repair `/v1/responses` and `/v1/responses/compact` inputs so `function_call_output` / `custom_tool_call_output` items are forwarded immediately after the matching tool call when both appear in the same HTTP request.
- Keep the repair cache-free: no client-controlled headers are trusted for HTTP session keys and no HTTP traffic is mixed into WebSocket repair caches.
- Add helper and handler regression tests covering `/v1/responses`, `/v1/responses/compact`, reversed order, and stable orphan output ordering.

## LTS boundary
- Does not touch `internal/usage/`, `/v0/management/usage*`, Management API response shapes, config schema, auth files, or translator paths.
- Keeps the LTS usage statistics contract intact.

## Validation
- `gofmt -w sdk/api/handlers/openai/openai_responses_handlers.go sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go sdk/api/handlers/openai/openai_responses_compact_test.go sdk/api/handlers/openai/openai_responses_http_toolcall_repair_test.go`
- `go test ./sdk/api/handlers/openai -run 'HTTPToolCalls|CompactRepairsHTTP|Compact|Responses' -count=1`\n- `go test ./sdk/api/handlers/openai -run 'HTTPToolCalls|RepairsHTTP|Compact' -count=1`\n- `go test ./sdk/api/handlers/openai`\n- `git diff --check`\n- `go build -o test-output ./cmd/server && rm -f test-output`\n- `go test ./...`