### PR TITLE
[codex] Fix auth cooldown quorum for disabled accounts

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -620,6 +620,7 @@ func (m *Manager) availableAuthsForRouteModel(auths []*Auth, provider, routeMode
 
 	availableByPriority := make(map[int][]*Auth)
 	cooldownCount := 0
+	disabledCount := 0
 	var earliest time.Time
 	for _, candidate := range auths {
 		checkModel := m.selectionModelForAuth(candidate, routeModel)
@@ -634,11 +635,14 @@ func (m *Manager) availableAuthsForRouteModel(auths []*Auth, provider, routeMode
 			if !next.IsZero() && (earliest.IsZero() || next.Before(earliest)) {
 				earliest = next
 			}
+		} else if reason == blockReasonDisabled {
+			disabledCount++
 		}
 	}
 
 	if len(availableByPriority) == 0 {
-		if cooldownCount == len(auths) && !earliest.IsZero() {
+		recoverableCount := len(auths) - disabledCount
+		if cooldownCount > 0 && cooldownCount == recoverableCount && !earliest.IsZero() {
 			providerForError := provider
 			if providerForError == "mixed" {
 				providerForError = ""

--- a/sdk/cliproxy/auth/scheduler.go
+++ b/sdk/cliproxy/auth/scheduler.go
@@ -432,6 +432,7 @@ func (s *authScheduler) mixedUnavailableErrorLocked(providers []string, model st
 	now := time.Now()
 	total := 0
 	cooldownCount := 0
+	disabledCount := 0
 	earliest := time.Time{}
 	for _, providerKey := range providers {
 		providerState := s.providers[providerKey]
@@ -442,9 +443,10 @@ func (s *authScheduler) mixedUnavailableErrorLocked(providers []string, model st
 		if shard == nil {
 			continue
 		}
-		localTotal, localCooldownCount, localEarliest := shard.availabilitySummaryLocked(triedPredicate(tried))
+		localTotal, localCooldownCount, localDisabledCount, localEarliest := shard.availabilitySummaryLocked(triedPredicate(tried))
 		total += localTotal
 		cooldownCount += localCooldownCount
+		disabledCount += localDisabledCount
 		if !localEarliest.IsZero() && (earliest.IsZero() || localEarliest.Before(earliest)) {
 			earliest = localEarliest
 		}
@@ -452,7 +454,8 @@ func (s *authScheduler) mixedUnavailableErrorLocked(providers []string, model st
 	if total == 0 {
 		return &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
-	if cooldownCount == total && !earliest.IsZero() {
+	recoverableCount := total - disabledCount
+	if cooldownCount > 0 && cooldownCount == recoverableCount && !earliest.IsZero() {
 		resetIn := earliest.Sub(now)
 		if resetIn < 0 {
 			resetIn = 0
@@ -843,11 +846,12 @@ func (m *modelScheduler) readyCountAtPriorityLocked(preferWebsocket bool, priori
 // unavailableErrorLocked returns the correct unavailable or cooldown error for the shard.
 func (m *modelScheduler) unavailableErrorLocked(provider, model string, predicate func(*scheduledAuth) bool) error {
 	now := time.Now()
-	total, cooldownCount, earliest := m.availabilitySummaryLocked(predicate)
+	total, cooldownCount, disabledCount, earliest := m.availabilitySummaryLocked(predicate)
 	if total == 0 {
 		return &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
-	if cooldownCount == total && !earliest.IsZero() {
+	recoverableCount := total - disabledCount
+	if cooldownCount > 0 && cooldownCount == recoverableCount && !earliest.IsZero() {
 		providerForError := provider
 		if providerForError == "mixed" {
 			providerForError = ""
@@ -861,13 +865,14 @@ func (m *modelScheduler) unavailableErrorLocked(provider, model string, predicat
 	return &Error{Code: "auth_unavailable", Message: "no auth available"}
 }
 
-// availabilitySummaryLocked summarizes total candidates, cooldown count, and earliest retry time.
-func (m *modelScheduler) availabilitySummaryLocked(predicate func(*scheduledAuth) bool) (int, int, time.Time) {
+// availabilitySummaryLocked summarizes total candidates, cooldown count, disabled count, and earliest retry time.
+func (m *modelScheduler) availabilitySummaryLocked(predicate func(*scheduledAuth) bool) (int, int, int, time.Time) {
 	if m == nil {
-		return 0, 0, time.Time{}
+		return 0, 0, 0, time.Time{}
 	}
 	total := 0
 	cooldownCount := 0
+	disabledCount := 0
 	earliest := time.Time{}
 	for _, entry := range m.entries {
 		if predicate != nil && !predicate(entry) {
@@ -877,15 +882,17 @@ func (m *modelScheduler) availabilitySummaryLocked(predicate func(*scheduledAuth
 		if entry == nil || entry.auth == nil {
 			continue
 		}
-		if entry.state != scheduledStateCooldown {
-			continue
-		}
-		cooldownCount++
-		if !entry.nextRetryAt.IsZero() && (earliest.IsZero() || entry.nextRetryAt.Before(earliest)) {
-			earliest = entry.nextRetryAt
+		switch entry.state {
+		case scheduledStateCooldown:
+			cooldownCount++
+			if !entry.nextRetryAt.IsZero() && (earliest.IsZero() || entry.nextRetryAt.Before(earliest)) {
+				earliest = entry.nextRetryAt
+			}
+		case scheduledStateDisabled:
+			disabledCount++
 		}
 	}
-	return total, cooldownCount, earliest
+	return total, cooldownCount, disabledCount, earliest
 }
 
 // rebuildIndexesLocked reconstructs ready and blocked views from the current entry map.

--- a/sdk/cliproxy/auth/scheduler_test.go
+++ b/sdk/cliproxy/auth/scheduler_test.go
@@ -151,6 +151,44 @@ func TestSchedulerPick_PromotesExpiredCooldownBeforePick(t *testing.T) {
 	}
 }
 
+func TestSchedulerPickSingle_DisabledAndCooldownReturnsModelCooldownError(t *testing.T) {
+	t.Parallel()
+
+	model := "scheduler-disabled-cooldown-model"
+	next := time.Now().Add(60 * time.Second)
+	registerSchedulerModels(t, "gemini", model, "disabled", "cooldown")
+	scheduler := newSchedulerForTest(
+		&RoundRobinSelector{},
+		testDisabledAuth("disabled", "gemini"),
+		testCooldownAuth("cooldown", "gemini", model, next),
+	)
+
+	_, errPick := scheduler.pickSingle(context.Background(), "gemini", model, cliproxyexecutor.Options{}, nil)
+	if errPick == nil {
+		t.Fatalf("pickSingle() error = nil")
+	}
+	assertModelCooldownError(t, errPick)
+}
+
+func TestSchedulerPickSingle_TransientBlockPreventsCooldownQuorum(t *testing.T) {
+	t.Parallel()
+
+	model := "scheduler-transient-cooldown-model"
+	next := time.Now().Add(60 * time.Second)
+	registerSchedulerModels(t, "gemini", model, "cooldown", "transient")
+	scheduler := newSchedulerForTest(
+		&RoundRobinSelector{},
+		testCooldownAuth("cooldown", "gemini", model, next),
+		testTransientBlockedAuth("transient", "gemini", model, next),
+	)
+
+	_, errPick := scheduler.pickSingle(context.Background(), "gemini", model, cliproxyexecutor.Options{}, nil)
+	if errPick == nil {
+		t.Fatalf("pickSingle() error = nil")
+	}
+	assertAuthUnavailableError(t, errPick)
+}
+
 func TestSchedulerPick_GeminiVirtualParentUsesTwoLevelRotation(t *testing.T) {
 	t.Parallel()
 
@@ -298,6 +336,26 @@ func TestSchedulerPick_MixedProvidersPrefersHighestPriorityTier(t *testing.T) {
 	}
 }
 
+func TestSchedulerPickMixed_DisabledAndCooldownReturnsModelCooldownError(t *testing.T) {
+	t.Parallel()
+
+	model := "scheduler-mixed-disabled-cooldown-model"
+	next := time.Now().Add(60 * time.Second)
+	registerSchedulerModels(t, "gemini", model, "disabled")
+	registerSchedulerModels(t, "claude", model, "cooldown")
+	scheduler := newSchedulerForTest(
+		&RoundRobinSelector{},
+		testDisabledAuth("disabled", "gemini"),
+		testCooldownAuth("cooldown", "claude", model, next),
+	)
+
+	_, _, errPick := scheduler.pickMixed(context.Background(), []string{"gemini", "claude"}, model, cliproxyexecutor.Options{}, nil)
+	if errPick == nil {
+		t.Fatalf("pickMixed() error = nil")
+	}
+	assertModelCooldownError(t, errPick)
+}
+
 func TestManager_PickNextMixed_UsesWeightedProviderRotationBeforeCredentialRotation(t *testing.T) {
 	t.Parallel()
 
@@ -391,6 +449,27 @@ func TestManagerCustomSelector_FallsBackToLegacyPath(t *testing.T) {
 	if got.ID != selector.lastAuthID[len(selector.lastAuthID)-1] {
 		t.Fatalf("pickNext() auth.ID = %q, want selector-picked %q", got.ID, selector.lastAuthID[len(selector.lastAuthID)-1])
 	}
+}
+
+func TestManagerAvailableAuths_DisabledAndCooldownReturnsModelCooldownError(t *testing.T) {
+	t.Parallel()
+
+	model := "manager-disabled-cooldown-model"
+	next := time.Now().Add(60 * time.Second)
+	manager := NewManager(nil, &trackingSelector{}, nil)
+	_, err := manager.availableAuthsForRouteModel(
+		[]*Auth{
+			testDisabledAuth("disabled", "gemini"),
+			testCooldownAuth("cooldown", "gemini", model, next),
+		},
+		"gemini",
+		model,
+		time.Now(),
+	)
+	if err == nil {
+		t.Fatalf("availableAuthsForRouteModel() error = nil")
+	}
+	assertModelCooldownError(t, err)
 }
 
 func TestManager_InitializesSchedulerForBuiltInSelector(t *testing.T) {

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -197,7 +197,7 @@ func preferCodexWebsocketAuths(ctx context.Context, provider string, available [
 	return available
 }
 
-func collectAvailableByPriority(auths []*Auth, model string, now time.Time) (available map[int][]*Auth, cooldownCount int, earliest time.Time) {
+func collectAvailableByPriority(auths []*Auth, model string, now time.Time) (available map[int][]*Auth, cooldownCount, disabledCount int, earliest time.Time) {
 	available = make(map[int][]*Auth)
 	for i := 0; i < len(auths); i++ {
 		candidate := auths[i]
@@ -212,9 +212,11 @@ func collectAvailableByPriority(auths []*Auth, model string, now time.Time) (ava
 			if !next.IsZero() && (earliest.IsZero() || next.Before(earliest)) {
 				earliest = next
 			}
+		} else if reason == blockReasonDisabled {
+			disabledCount++
 		}
 	}
-	return available, cooldownCount, earliest
+	return available, cooldownCount, disabledCount, earliest
 }
 
 func getAvailableAuths(auths []*Auth, provider, model string, now time.Time) ([]*Auth, error) {
@@ -222,9 +224,12 @@ func getAvailableAuths(auths []*Auth, provider, model string, now time.Time) ([]
 		return nil, &Error{Code: "auth_not_found", Message: "no auth candidates"}
 	}
 
-	availableByPriority, cooldownCount, earliest := collectAvailableByPriority(auths, model, now)
+	availableByPriority, cooldownCount, disabledCount, earliest := collectAvailableByPriority(auths, model, now)
 	if len(availableByPriority) == 0 {
-		if cooldownCount == len(auths) && !earliest.IsZero() {
+		// Disabled auths are permanently unavailable. Transient blocks stay in the
+		// quorum so mixed cooldown + transient failure still reports unavailable.
+		recoverableCount := len(auths) - disabledCount
+		if cooldownCount > 0 && cooldownCount == recoverableCount && !earliest.IsZero() {
 			providerForError := provider
 			if providerForError == "mixed" {
 				providerForError = ""

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -14,6 +14,70 @@ import (
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 )
 
+func testCooldownAuth(id, provider, model string, next time.Time) *Auth {
+	return &Auth{
+		ID:       id,
+		Provider: provider,
+		ModelStates: map[string]*ModelState{
+			model: {
+				Status:         StatusActive,
+				Unavailable:    true,
+				NextRetryAfter: next,
+				Quota: QuotaState{
+					Exceeded:      true,
+					NextRecoverAt: next,
+				},
+			},
+		},
+	}
+}
+
+func testTransientBlockedAuth(id, provider, model string, next time.Time) *Auth {
+	return &Auth{
+		ID:       id,
+		Provider: provider,
+		ModelStates: map[string]*ModelState{
+			model: {
+				Status:         StatusError,
+				Unavailable:    true,
+				NextRetryAfter: next,
+			},
+		},
+	}
+}
+
+func testDisabledAuth(id, provider string) *Auth {
+	return &Auth{
+		ID:       id,
+		Provider: provider,
+		Disabled: true,
+		Status:   StatusDisabled,
+	}
+}
+
+func assertModelCooldownError(t *testing.T, err error) *modelCooldownError {
+	t.Helper()
+	var mce *modelCooldownError
+	if !errors.As(err, &mce) {
+		t.Fatalf("error = %T, want *modelCooldownError", err)
+	}
+	if mce.StatusCode() != http.StatusTooManyRequests {
+		t.Fatalf("StatusCode() = %d, want %d", mce.StatusCode(), http.StatusTooManyRequests)
+	}
+	return mce
+}
+
+func assertAuthUnavailableError(t *testing.T, err error) {
+	t.Helper()
+	var authErr *Error
+	if !errors.As(err, &authErr) {
+		t.Fatalf("error = %T, want *Error", err)
+	}
+	if authErr.Code != "auth_unavailable" {
+		t.Fatalf("Error.Code = %q, want %q", authErr.Code, "auth_unavailable")
+	}
+}
+
 func TestFillFirstSelectorPick_Deterministic(t *testing.T) {
 	t.Parallel()
 
@@ -281,6 +345,43 @@ func TestSelectorPick_AllCooldownReturnsModelCooldownError(t *testing.T) {
 			t.Fatalf("Error().error.provider = %q, want %q", got, "gemini")
 		}
 	})
+}
+
+func TestSelectorPick_DisabledAndCooldownReturnsModelCooldownError(t *testing.T) {
+	t.Parallel()
+
+	model := "selector-disabled-cooldown-model"
+	next := time.Now().Add(60 * time.Second)
+	auths := []*Auth{
+		testDisabledAuth("disabled", "gemini"),
+		testCooldownAuth("cooldown", "gemini", model, next),
+	}
+
+	selector := &FillFirstSelector{}
+	_, err := selector.Pick(context.Background(), "gemini", model, cliproxyexecutor.Options{}, auths)
+	if err == nil {
+		t.Fatalf("Pick() error = nil")
+	}
+	assertModelCooldownError(t, err)
+}
+
+func TestSelectorPick_TransientBlockPreventsCooldownQuorum(t *testing.T) {
+	t.Parallel()
+
+	model := "selector-transient-cooldown-model"
+	next := time.Now().Add(60 * time.Second)
+	auths := []*Auth{
+		testDisabledAuth("disabled", "gemini"),
+		testCooldownAuth("cooldown", "gemini", model, next),
+		testTransientBlockedAuth("transient", "gemini", model, next),
+	}
+
+	selector := &FillFirstSelector{}
+	_, err := selector.Pick(context.Background(), "gemini", model, cliproxyexecutor.Options{}, auths)
+	if err == nil {
+		t.Fatalf("Pick() error = nil")
+	}
+	assertAuthUnavailableError(t, err)
 }
 
 func TestIsAuthBlockedForModel_UnavailableWithoutNextRetryIsNotBlocked(t *testing.T) {


### PR DESCRIPTION
## Summary
- selectively port upstream router-for-me/CLIProxyAPI#3489 cooldown quorum behavior
- count disabled auths outside the recoverable cooldown quorum in selector, conductor, and scheduler paths
- keep transient blocked auths inside the quorum so cooldown + transient failures still return auth_unavailable instead of an inaccurate model_cooldown
- add focused regression coverage for selector, scheduler single-provider, scheduler mixed-provider, and legacy manager availability paths

## LTS compatibility
- does not touch internal/usage or /v0/management/usage*
- does not change config schema, Management API shape, translator paths, or module path
- keeps auth behavior scoped to recoverability/error classification

## Validation
- gofmt -w sdk/cliproxy/auth/conductor.go sdk/cliproxy/auth/scheduler.go sdk/cliproxy/auth/selector.go sdk/cliproxy/auth/selector_test.go sdk/cliproxy/auth/scheduler_test.go
- go test ./sdk/cliproxy/auth -run 'DisabledAndCooldown|TransientBlockPreventsCooldownQuorum'\n- go test ./sdk/cliproxy/auth\n- go test ./sdk/cliproxy/...\n- git diff --check\n- go build -o test-output ./cmd/server && rm -f test-output\n- go test ./...\n\nUpstream reference: https://github.com/router-for-me/CLIProxyAPI/pull/3489