### PR TITLE
[codex] List registered public API routes at root

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -171,6 +172,11 @@ type Server struct {
 
 	// ampModule is the Amp routing module for model mapping hot-reload
 	ampModule *ampmodule.AmpModule
+
+	// rootEndpoints caches the dynamic endpoint list for GET /.
+	// Routes are static after startup, so compute the list once on first request.
+	rootEndpointsOnce sync.Once
+	rootEndpoints     []string
 
 	// managementRoutesRegistered tracks whether the management routes have been attached to the engine.
 	managementRoutesRegistered atomic.Bool
@@ -393,13 +399,22 @@ func (s *Server) setupRoutes() {
 
 	// Root endpoint
 	s.engine.GET("/", func(c *gin.Context) {
+		s.rootEndpointsOnce.Do(func() {
+			routes := s.engine.Routes()
+			s.rootEndpoints = make([]string, 0, len(routes))
+			for _, route := range routes {
+				path := route.Path
+				if strings.HasPrefix(path, "/v1/") ||
+					strings.HasPrefix(path, "/v1beta/") ||
+					strings.HasPrefix(path, "/backend-api/") {
+					s.rootEndpoints = append(s.rootEndpoints, route.Method+" "+path)
+				}
+			}
+			sort.Strings(s.rootEndpoints)
+		})
 		c.JSON(http.StatusOK, gin.H{
-			"message": "CLI Proxy API Server",
-			"endpoints": []string{
-				"POST /v1/chat/completions",
-				"POST /v1/completions",
-				"GET /v1/models",
-			},
+			"message":   "CLI Proxy API Server",
+			"endpoints": s.rootEndpoints,
 		})
 	})
 	s.engine.POST("/v1internal:method", geminiCLIHandlers.CLIHandler)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -90,6 +90,55 @@ func TestHealthz(t *testing.T) {
 	})
 }
 
+func TestRootEndpointListsRegisteredPublicRoutes(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+
+	server := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+
+	var resp struct {
+		Message   string   `json:"message"`
+		Endpoints []string `json:"endpoints"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v body=%s", err, rr.Body.String())
+	}
+	if resp.Message != "CLI Proxy API Server" {
+		t.Fatalf("message = %q, want %q", resp.Message, "CLI Proxy API Server")
+	}
+
+	endpoints := make(map[string]struct{}, len(resp.Endpoints))
+	for _, endpoint := range resp.Endpoints {
+		endpoints[endpoint] = struct{}{}
+		if strings.Contains(endpoint, "/healthz") ||
+			strings.Contains(endpoint, "/management") ||
+			strings.Contains(endpoint, "/callback") {
+			t.Fatalf("endpoints contains non-public route %q: %v", endpoint, resp.Endpoints)
+		}
+	}
+
+	for _, want := range []string{
+		"GET /v1/models",
+		"POST /v1/chat/completions",
+		"POST /v1/images/generations",
+		"POST /v1/responses",
+		"POST /v1/responses/compact",
+		"GET /v1beta/models",
+		"POST /backend-api/codex/responses",
+	} {
+		if _, ok := endpoints[want]; !ok {
+			t.Fatalf("endpoints missing %q: %v", want, resp.Endpoints)
+		}
+	}
+}
+
 func TestManagementLocalPasswordRejectsSpoofedForwardedFor(t *testing.T) {
 	t.Setenv("MANAGEMENT_PASSWORD", "")
 


### PR DESCRIPTION
## Summary
- selectively port upstream router-for-me/CLIProxyAPI#3639 root endpoint behavior
- replace the stale hardcoded GET / endpoint list with a sorted list derived from registered public routes
- include /v1, /v1beta, and /backend-api routes while excluding health, management, OAuth callback, and internal paths
- cache the computed list with sync.Once because routes are static after startup
- add regression coverage for the root endpoint route inventory

## LTS compatibility
- does not touch internal/usage or /v0/management/usage*
- does not change Management API auth or response shapes
- does not change config schema, auth files, translator paths, or provider wire formats

## Validation
- gofmt -w internal/api/server.go internal/api/server_test.go
- go test ./internal/api -run 'TestRootEndpointListsRegisteredPublicRoutes|TestHealthz'\n- go test ./internal/api\n- go test ./internal/api/handlers/management\n- go test ./internal/api/modules/amp\n- go test ./test -run Amp\n- git diff --check\n- go build -o test-output ./cmd/server && rm -f test-output\n- go test ./...\n\nUpstream reference: https://github.com/router-for-me/CLIProxyAPI/pull/3639