### PR TITLE
[codex] Support Gemini image models on images endpoint

### DIFF
--- a/sdk/api/handlers/openai/openai_images_handlers.go
+++ b/sdk/api/handlers/openai/openai_images_handlers.go
@@ -113,7 +113,7 @@ func isSupportedImagesModel(model string) bool {
 	if baseModel == defaultImagesToolModel {
 		return true
 	}
-	return isOpenAICompatImagesModel(model)
+	return isOpenAICompatImagesModel(model) || isGeminiChatImageModel(model)
 }
 
 func isOpenAICompatImagesModel(model string) bool {
@@ -125,6 +125,15 @@ func isOpenAICompatImagesModel(model string) bool {
 	return info != nil && info.Type == registry.OpenAIImageModelType
 }
 
+func isGeminiChatImageModel(model string) bool {
+	baseModel := strings.TrimSpace(model)
+	if idx := strings.LastIndex(baseModel, "/"); idx >= 0 && idx < len(baseModel)-1 {
+		baseModel = strings.TrimSpace(baseModel[idx+1:])
+	}
+	baseModel = strings.ToLower(baseModel)
+	return strings.Contains(baseModel, "flash-image") || strings.Contains(baseModel, "imagen")
+}
+
 func rejectUnsupportedImagesModel(c *gin.Context, model string) bool {
 	if isSupportedImagesModel(model) {
 		return false
@@ -132,7 +141,7 @@ func rejectUnsupportedImagesModel(c *gin.Context, model string) bool {
 
 	c.JSON(http.StatusBadRequest, handlers.ErrorResponse{
 		Error: handlers.ErrorDetail{
-			Message: fmt.Sprintf("Model %s is not supported on %s or %s. Use %s or a configured openai-compatibility image model.", model, imagesGenerationsPath, imagesEditsPath, defaultImagesToolModel),
+			Message: fmt.Sprintf("Model %s is not supported on %s or %s. Use %s, a Gemini image model, or a configured openai-compatibility image model.", model, imagesGenerationsPath, imagesEditsPath, defaultImagesToolModel),
 			Type:    "invalid_request_error",
 		},
 	})
@@ -350,6 +359,11 @@ func (h *OpenAIAPIHandler) ImagesGenerations(c *gin.Context) {
 	if isOpenAICompatImagesModel(imageModel) {
 		compatReq := buildOpenAICompatImagesJSONRequest(rawJSON, imageModel, stream)
 		h.handleOpenAICompatImages(c, compatReq, imageModel, stream)
+		return
+	}
+	if isGeminiChatImageModel(imageModel) {
+		chatReq := buildGeminiChatImagesRequest(prompt, imageModel)
+		h.collectGeminiChatImages(c, chatReq, imageModel, responseFormat)
 		return
 	}
 
@@ -668,6 +682,83 @@ func (h *OpenAIAPIHandler) imagesEditsFromJSON(c *gin.Context) {
 		return
 	}
 	h.collectImagesFromResponses(c, responsesReq, responseFormat)
+}
+
+func buildGeminiChatImagesRequest(prompt, model string) []byte {
+	req := []byte(`{"messages":[{"role":"user","content":""}],"modalities":["image","text"]}`)
+	req, _ = sjson.SetBytes(req, "model", strings.TrimSpace(model))
+	req, _ = sjson.SetBytes(req, "messages.0.content", strings.TrimSpace(prompt))
+	return req
+}
+
+func extractImagesFromChatCompletions(resp []byte) ([]imageCallResult, int64, error) {
+	createdAt := gjson.GetBytes(resp, "created").Int()
+	if createdAt <= 0 {
+		createdAt = time.Now().Unix()
+	}
+	imagesArr := gjson.GetBytes(resp, "choices.0.message.images")
+	if !imagesArr.IsArray() || len(imagesArr.Array()) == 0 {
+		return nil, createdAt, fmt.Errorf("upstream did not return image output")
+	}
+
+	results := make([]imageCallResult, 0, len(imagesArr.Array()))
+	for _, img := range imagesArr.Array() {
+		dataURI := strings.TrimSpace(img.Get("image_url.url").String())
+		if dataURI == "" {
+			continue
+		}
+		entry := imageCallResult{}
+		if idx := strings.Index(dataURI, ";base64,"); idx >= 0 {
+			mimeType := strings.TrimPrefix(dataURI[:idx], "data:")
+			entry.OutputFormat = strings.TrimPrefix(mimeType, "image/")
+			entry.Result = dataURI[idx+len(";base64,"):]
+		} else {
+			entry.Result = dataURI
+		}
+		results = append(results, entry)
+	}
+	if len(results) == 0 {
+		return nil, createdAt, fmt.Errorf("upstream did not return image output")
+	}
+	return results, createdAt, nil
+}
+
+func (h *OpenAIAPIHandler) collectGeminiChatImages(c *gin.Context, chatReq []byte, model, responseFormat string) {
+	c.Header("Content-Type", "application/json")
+
+	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
+	cliCtx = handlers.WithDisallowFreeAuth(cliCtx)
+	stopKeepAlive := h.StartNonStreamingKeepAlive(c, cliCtx)
+
+	resp, upstreamHeaders, errMsg := h.ExecuteWithAuthManager(cliCtx, "openai", model, chatReq, "")
+	stopKeepAlive()
+	if errMsg != nil {
+		h.WriteErrorResponse(c, errMsg)
+		if errMsg.Error != nil {
+			cliCancel(errMsg.Error)
+		} else {
+			cliCancel(nil)
+		}
+		return
+	}
+
+	results, createdAt, err := extractImagesFromChatCompletions(resp)
+	if err != nil {
+		h.WriteErrorResponse(c, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: err})
+		cliCancel(err)
+		return
+	}
+
+	out, err := buildImagesAPIResponse(results, createdAt, nil, results[0], responseFormat)
+	if err != nil {
+		h.WriteErrorResponse(c, &interfaces.ErrorMessage{StatusCode: http.StatusInternalServerError, Error: err})
+		cliCancel(err)
+		return
+	}
+
+	handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+	_, _ = c.Writer.Write(out)
+	cliCancel(nil)
 }
 
 func buildImagesResponsesRequest(prompt string, images []string, toolJSON []byte) []byte {

--- a/sdk/api/handlers/openai/openai_images_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_images_handlers_test.go
@@ -52,6 +52,37 @@ func (e *imageCaptureExecutor) HttpRequest(context.Context, *coreauth.Auth, *htt
 	return nil, errors.New("not implemented")
 }
 
+type geminiChatImageCaptureExecutor struct {
+	sourceFormat string
+	model        string
+	payload      []byte
+}
+
+func (e *geminiChatImageCaptureExecutor) Identifier() string { return "gemini" }
+
+func (e *geminiChatImageCaptureExecutor) Execute(_ context.Context, _ *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
+	e.sourceFormat = opts.SourceFormat.String()
+	e.model = req.Model
+	e.payload = append([]byte(nil), req.Payload...)
+	return coreexecutor.Response{Payload: []byte(`{"created":1700000000,"choices":[{"message":{"role":"assistant","images":[{"type":"image_url","image_url":{"url":"data:image/jpeg;base64,/9j/ABC="}}]}}]}`)}, nil
+}
+
+func (e *geminiChatImageCaptureExecutor) ExecuteStream(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (e *geminiChatImageCaptureExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *geminiChatImageCaptureExecutor) CountTokens(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *geminiChatImageCaptureExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
 func performImagesEndpointRequest(t *testing.T, endpointPath string, contentType string, body io.Reader, handler gin.HandlerFunc) *httptest.ResponseRecorder {
 	t.Helper()
 
@@ -76,7 +107,7 @@ func assertUnsupportedImagesModelResponse(t *testing.T, resp *httptest.ResponseR
 	}
 
 	message := gjson.GetBytes(resp.Body.Bytes(), "error.message").String()
-	expectedMessage := "Model " + model + " is not supported on " + imagesGenerationsPath + " or " + imagesEditsPath + ". Use " + defaultImagesToolModel + " or a configured openai-compatibility image model."
+	expectedMessage := "Model " + model + " is not supported on " + imagesGenerationsPath + " or " + imagesEditsPath + ". Use " + defaultImagesToolModel + ", a Gemini image model, or a configured openai-compatibility image model."
 	if message != expectedMessage {
 		t.Fatalf("error message = %q, want %q", message, expectedMessage)
 	}
@@ -106,6 +137,74 @@ func TestImagesModelValidationAllowsOpenAICompatImageModel(t *testing.T) {
 
 	if !isSupportedImagesModel(modelID) {
 		t.Fatalf("expected configured openai-compatibility image model %s to be supported", modelID)
+	}
+}
+
+func TestImagesModelValidationAllowsGeminiImageModels(t *testing.T) {
+	for _, model := range []string{
+		"gemini-3.1-flash-image",
+		"antigravity/gemini-3.1-flash-image",
+		"gemini-2.5-flash-image-preview",
+		"imagen-3",
+	} {
+		if !isSupportedImagesModel(model) {
+			t.Fatalf("expected %s to be supported", model)
+		}
+	}
+	for _, model := range []string{"gemini-2.5-flash", "gemini-2.5-pro"} {
+		if isSupportedImagesModel(model) {
+			t.Fatalf("expected %s to be rejected", model)
+		}
+	}
+}
+
+func TestBuildGeminiChatImagesRequest(t *testing.T) {
+	req := buildGeminiChatImagesRequest("a red apple", "antigravity/gemini-3.1-flash-image")
+
+	if got := gjson.GetBytes(req, "model").String(); got != "antigravity/gemini-3.1-flash-image" {
+		t.Fatalf("model = %q, want antigravity/gemini-3.1-flash-image", got)
+	}
+	if got := gjson.GetBytes(req, "messages.0.role").String(); got != "user" {
+		t.Fatalf("messages.0.role = %q, want user", got)
+	}
+	if got := gjson.GetBytes(req, "messages.0.content").String(); got != "a red apple" {
+		t.Fatalf("messages.0.content = %q, want a red apple", got)
+	}
+	if got := gjson.GetBytes(req, "modalities.0").String(); got != "image" {
+		t.Fatalf("modalities.0 = %q, want image", got)
+	}
+	if got := gjson.GetBytes(req, "modalities.1").String(); got != "text" {
+		t.Fatalf("modalities.1 = %q, want text", got)
+	}
+}
+
+func TestExtractImagesFromChatCompletions(t *testing.T) {
+	resp := []byte(`{"created":1700000000,"choices":[{"message":{"role":"assistant","images":[{"type":"image_url","image_url":{"url":"data:image/jpeg;base64,/9j/ABC="}}]}}]}`)
+
+	results, createdAt, err := extractImagesFromChatCompletions(resp)
+	if err != nil {
+		t.Fatalf("extractImagesFromChatCompletions() error = %v", err)
+	}
+	if createdAt != 1700000000 {
+		t.Fatalf("createdAt = %d, want 1700000000", createdAt)
+	}
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	if results[0].Result != "/9j/ABC=" {
+		t.Fatalf("result = %q, want /9j/ABC=", results[0].Result)
+	}
+	if results[0].OutputFormat != "jpeg" {
+		t.Fatalf("output_format = %q, want jpeg", results[0].OutputFormat)
+	}
+}
+
+func TestExtractImagesFromChatCompletionsNoImages(t *testing.T) {
+	resp := []byte(`{"created":1700000000,"choices":[{"message":{"role":"assistant","content":"hello"}}]}`)
+
+	_, _, err := extractImagesFromChatCompletions(resp)
+	if err == nil {
+		t.Fatal("expected error for response with no images")
 	}
 }
 
@@ -145,6 +244,48 @@ func TestImagesGenerationsRoutesOpenAICompatImageModel(t *testing.T) {
 	}
 	if gjson.GetBytes(executor.payload, "stream").Exists() {
 		t.Fatalf("expected non-streaming payload to remove stream flag: %s", string(executor.payload))
+	}
+}
+
+func TestImagesGenerationsRoutesGeminiImageModelThroughChatCompletions(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	executor := &geminiChatImageCaptureExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	modelID := "gemini-3.1-flash-image"
+	auth := &coreauth.Auth{ID: "auth-gemini-image", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: modelID}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	handler := NewOpenAIAPIHandler(base)
+	body := strings.NewReader(`{"model":"gemini-3.1-flash-image","prompt":"draw a red apple","response_format":"url"}`)
+
+	resp := performImagesEndpointRequest(t, imagesGenerationsPath, "application/json", body, handler.ImagesGenerations)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	if got := gjson.GetBytes(resp.Body.Bytes(), "data.0.url").String(); got != "data:image/jpeg;base64,/9j/ABC=" {
+		t.Fatalf("data.0.url = %q, want data:image/jpeg;base64,/9j/ABC=", got)
+	}
+	if executor.sourceFormat != "openai" {
+		t.Fatalf("source format = %q, want openai", executor.sourceFormat)
+	}
+	if executor.model != modelID {
+		t.Fatalf("model = %q, want %q", executor.model, modelID)
+	}
+	if got := gjson.GetBytes(executor.payload, "messages.0.content").String(); got != "draw a red apple" {
+		t.Fatalf("messages.0.content = %q, want draw a red apple; payload=%s", got, string(executor.payload))
+	}
+	if got := gjson.GetBytes(executor.payload, "modalities.0").String(); got != "image" {
+		t.Fatalf("modalities.0 = %q, want image; payload=%s", got, string(executor.payload))
 	}
 }
 


### PR DESCRIPTION
## Summary
- selectively port the code path from upstream router-for-me/CLIProxyAPI#3610
- allow Gemini image model names such as gemini-3.1-flash-image and imagen-* on /v1/images/generations
- route those requests through the existing OpenAI chat-completions flow with modalities:[image,text]
- extract image data URIs from choices[0].message.images[] and return OpenAI Images API-shaped responses
- add model validation, request construction, response extraction, and handler routing tests

## LTS compatibility
- does not touch internal/usage or /v0/management/usage*
- does not change config schema, auth files, Management API, or translator paths
- intentionally leaves upstream README-only wording out of this PR to avoid partial multilingual docs drift

## Validation
- gofmt -w sdk/api/handlers/openai/openai_images_handlers.go sdk/api/handlers/openai/openai_images_handlers_test.go
- go test ./sdk/api/handlers/openai -run 'ImagesModelValidation|BuildGeminiChatImagesRequest|ExtractImagesFromChatCompletions|ImagesGenerationsRoutesGemini|ImagesGenerationsRoutesOpenAICompat|ImagesGenerationsRejectsUnsupportedModel'\n- go test ./sdk/api/handlers/openai\n- go test ./sdk/api/handlers\n- git diff --check\n- go build -o test-output ./cmd/server && rm -f test-output\n- go test ./...\n\nUpstream reference: https://github.com/router-for-me/CLIProxyAPI/pull/3610