### PR TITLE
[codex] Preserve watcher auth updates before queue attach

### DIFF
--- a/internal/watcher/dispatcher.go
+++ b/internal/watcher/dispatcher.go
@@ -106,18 +106,11 @@ func (w *Watcher) prepareAuthUpdatesLocked(auths []*coreauth.Auth, force bool) [
 	}
 	if w.currentAuths == nil {
 		w.currentAuths = newState
-		if w.authQueue == nil {
-			return nil
-		}
 		updates := make([]AuthUpdate, 0, len(newState))
 		for id, auth := range newState {
 			updates = append(updates, AuthUpdate{Action: AuthUpdateActionAdd, ID: id, Auth: auth.Clone()})
 		}
 		return updates
-	}
-	if w.authQueue == nil {
-		w.currentAuths = newState
-		return nil
 	}
 	updates := make([]AuthUpdate, 0, len(newState)+len(w.currentAuths))
 	for id, auth := range newState {

--- a/internal/watcher/dispatcher_test.go
+++ b/internal/watcher/dispatcher_test.go
@@ -1,0 +1,61 @@
+package watcher
+
+import (
+	"testing"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestPrepareAuthUpdatesLockedNilQueueInitialAdd(t *testing.T) {
+	w := &Watcher{}
+
+	updates := w.prepareAuthUpdatesLocked([]*coreauth.Auth{{ID: "a", Provider: "p"}}, false)
+
+	if len(updates) != 1 {
+		t.Fatalf("expected 1 update, got %d: %+v", len(updates), updates)
+	}
+	if updates[0].Action != AuthUpdateActionAdd || updates[0].ID != "a" {
+		t.Fatalf("expected add for auth a, got %+v", updates[0])
+	}
+	if w.currentAuths["a"] == nil {
+		t.Fatal("expected current auth state to be initialized")
+	}
+}
+
+func TestPrepareAuthUpdatesLockedNilQueueSubsequentDiff(t *testing.T) {
+	w := &Watcher{
+		currentAuths: map[string]*coreauth.Auth{
+			"a": {ID: "a", Provider: "old"},
+			"c": {ID: "c", Provider: "p"},
+		},
+	}
+
+	updates := w.prepareAuthUpdatesLocked([]*coreauth.Auth{
+		{ID: "a", Provider: "new"},
+		{ID: "b", Provider: "p"},
+	}, false)
+
+	got := map[string]AuthUpdateAction{}
+	for _, update := range updates {
+		got[update.ID] = update.Action
+	}
+	want := map[string]AuthUpdateAction{
+		"a": AuthUpdateActionModify,
+		"b": AuthUpdateActionAdd,
+		"c": AuthUpdateActionDelete,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d updates, got %d: %+v", len(want), len(got), updates)
+	}
+	for id, action := range want {
+		if got[id] != action {
+			t.Fatalf("expected %s for auth %s, got %s in %+v", action, id, got[id], updates)
+		}
+	}
+	if w.currentAuths["a"].Provider != "new" || w.currentAuths["b"] == nil {
+		t.Fatalf("expected current auth state to update, got %+v", w.currentAuths)
+	}
+	if _, ok := w.currentAuths["c"]; ok {
+		t.Fatalf("expected deleted auth c to be removed, got %+v", w.currentAuths)
+	}
+}


### PR DESCRIPTION
## Summary

- Selectively port upstream router-for-me/CLIProxyAPI#3390.
- Stop `prepareAuthUpdatesLocked` from dropping initial or subsequent auth diffs when `authQueue` has not been attached yet.
- Add regression coverage for initial add and later add/modify/delete diffs while the queue is nil.

## LTS compatibility

- Does not touch `internal/usage/`, `/v0/management/usage*`, config schema, Management API response shapes, or the panel contract.
- Keeps the v6 module path.

## Validation

- `go test ./internal/watcher -run 'TestPrepareAuthUpdatesLockedNilQueue|TestPrepareAuthUpdatesLockedForceAndDelete'`\n- `go test ./internal/watcher`\n- `git diff --check`\n- `go build -o test-output ./cmd/server && rm -f test-output`\n- `go test ./...`\n