### PR TITLE
[codex] Validate embedded model catalog in tests

### DIFF
--- a/internal/registry/model_updater_embed_test.go
+++ b/internal/registry/model_updater_embed_test.go
@@ -1,0 +1,16 @@
+package registry
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestEmbeddedModelsCatalogIsValid(t *testing.T) {
+	var parsed staticModelsJSON
+	if err := json.Unmarshal(embeddedModelsJSON, &parsed); err != nil {
+		t.Fatalf("embedded models.json failed to decode: %v", err)
+	}
+	if err := validateModelsCatalog(&parsed); err != nil {
+		t.Fatalf("embedded models.json failed validation: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Selectively port upstream router-for-me/CLIProxyAPI#3436.
- Add a registry test that decodes the embedded `models.json` bytes and runs the same catalog validation used at startup.
- Catches empty or invalid required provider sections before a release build ships.

## LTS compatibility

- Test-only change under `internal/registry`.
- Does not touch `internal/usage/`, Management API routes, auth/config schema, or panel-facing contracts.
- Keeps the v6 module path.

## Validation

- `go test ./internal/registry -run TestEmbeddedModelsCatalogIsValid`
- `go test ./internal/registry`
- `git diff --check`
- `go build -o test-output ./cmd/server && rm -f test-output`
- `go test ./...`
