### PR TITLE
[codex] Emit keepalive for OpenAI non-stream chat waits

### DIFF
--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -436,7 +436,9 @@ func (h *OpenAIAPIHandler) handleNonStreamingResponse(c *gin.Context, rawJSON []
 
 	modelName := gjson.GetBytes(rawJSON, "model").String()
 	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
+	stopKeepAlive := h.StartNonStreamingKeepAlive(c, cliCtx)
 	resp, upstreamHeaders, errMsg := h.ExecuteWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, h.GetAlt(c))
+	stopKeepAlive()
 	if errMsg != nil {
 		h.WriteErrorResponse(c, errMsg)
 		cliCancel(errMsg.Error)

--- a/sdk/api/handlers/openai/openai_handlers_keepalive_test.go
+++ b/sdk/api/handlers/openai/openai_handlers_keepalive_test.go
@@ -1,0 +1,99 @@
+package openai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+)
+
+type delayedOpenAIExecutor struct {
+	delay   time.Duration
+	payload []byte
+}
+
+func (e *delayedOpenAIExecutor) Identifier() string { return "openai" }
+
+func (e *delayedOpenAIExecutor) Execute(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
+	_ = auth
+	_ = req
+	_ = opts
+	select {
+	case <-time.After(e.delay):
+		return coreexecutor.Response{Payload: e.payload}, nil
+	case <-ctx.Done():
+		return coreexecutor.Response{}, ctx.Err()
+	}
+}
+
+func (e *delayedOpenAIExecutor) ExecuteStream(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	_ = ctx
+	_ = auth
+	_ = req
+	_ = opts
+	return nil, nil
+}
+
+func (e *delayedOpenAIExecutor) Refresh(ctx context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	_ = ctx
+	return auth, nil
+}
+
+func (e *delayedOpenAIExecutor) CountTokens(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
+	return e.Execute(ctx, auth, req, opts)
+}
+
+func (e *delayedOpenAIExecutor) HttpRequest(ctx context.Context, auth *coreauth.Auth, req *http.Request) (*http.Response, error) {
+	_ = ctx
+	_ = auth
+	_ = req
+	return nil, nil
+}
+
+func TestChatCompletionsNonStreamingEmitsKeepAliveWhileWaiting(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const model = "slow-openai-model"
+	const authID = "openai-keepalive-test-auth"
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(&delayedOpenAIExecutor{
+		delay:   1200 * time.Millisecond,
+		payload: []byte(`{"id":"chatcmpl-test"}`),
+	})
+	if _, err := manager.Register(context.Background(), &coreauth.Auth{
+		ID:       authID,
+		Provider: "openai",
+		Status:   coreauth.StatusActive,
+	}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "openai", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(authID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{NonStreamKeepAliveInterval: 1}, manager)
+	handler := NewOpenAIAPIHandler(base)
+
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"`+model+`","messages":[{"role":"user","content":"hi"}]}`))
+
+	handler.ChatCompletions(ctx)
+
+	if body := rec.Body.String(); !strings.HasPrefix(body, "\n") {
+		t.Fatalf("expected non-streaming chat completions to emit keepalive before final JSON, got %q", body)
+	}
+}


### PR DESCRIPTION
## Summary

- Selectively port upstream router-for-me/CLIProxyAPI#3211.
- Start non-streaming keepalive writes while `/v1/chat/completions` waits for upstream execution.
- Add regression coverage for a delayed non-streaming OpenAI-compatible chat completion.

## LTS compatibility

- Scoped to `sdk/api/handlers/openai`.
- Does not touch `internal/usage/`, Management API routes, auth/config schema, translator paths, or panel-facing contracts.
- Reuses the existing `StartNonStreamingKeepAlive` behavior already used by other non-streaming handlers.

## Validation

- `go test ./sdk/api/handlers/openai -run TestChatCompletionsNonStreamingEmitsKeepAliveWhileWaiting -count=1`
- `go test ./sdk/api/handlers/openai -count=1`
- `git diff --check`
- `go build -o test-output ./cmd/server && rm -f test-output`
- `go test ./...`
