### PR TITLE
[codex] Repack gitstore loose objects before push

### DIFF
--- a/internal/store/gitstore.go
+++ b/internal/store/gitstore.go
@@ -851,6 +851,12 @@ func (s *GitTokenStore) commitAndPushLocked(message string, relPaths ...string) 
 	} else if errRewrite := s.rewriteHeadAsSingleCommit(repo, headRef.Name(), commitHash, message, signature); errRewrite != nil {
 		return errRewrite
 	}
+	// Repack loose objects written by rewriteHeadAsSingleCommit before pushing.
+	// Fresh clones on ephemeral filesystems may otherwise fail go-git push with
+	// "packfile not found" when the squashed commit only exists as a loose object.
+	if err := repo.RepackObjects(&git.RepackConfig{}); err != nil {
+		return fmt.Errorf("git token store: repack: %w", err)
+	}
 	pushOpts := &git.PushOptions{Auth: s.gitAuth(), Force: true}
 	if s.branch != "" {
 		pushOpts.RefSpecs = []config.RefSpec{config.RefSpec("refs/heads/" + s.branch + ":refs/heads/" + s.branch)}


### PR DESCRIPTION
## Summary

- Selectively port upstream router-for-me/CLIProxyAPI#3416.
- Repack loose objects after `rewriteHeadAsSingleCommit` and before gitstore pushes.
- Avoid go-git `packfile not found` failures when freshly cloned repos on ephemeral filesystems only have existing objects in packfiles.

## LTS compatibility

- Scoped to `internal/store/gitstore.go`.
- Does not touch `internal/usage/`, Management API routes, auth/config schema, translator paths, or panel-facing contracts.
- Preserves the existing squash-and-force-push gitstore behavior.

## Validation

- `go test ./internal/store -run 'GitTokenStore|commitAndPush' -count=1`\n- `go test ./internal/store -count=1`\n- `git diff --check`\n- `go build -o test-output ./cmd/server && rm -f test-output`\n- `go test ./...`\n