### PR TITLE
[codex] Prune expired auth availability warnings

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -245,6 +245,7 @@ func (h *Handler) ListAuthFiles(c *gin.Context) {
 		h.listAuthFilesFromDisk(c)
 		return
 	}
+	h.authManager.PruneExpiredAvailability(c.Request.Context(), time.Now())
 	auths := h.authManager.List()
 	files := make([]gin.H, 0, len(auths))
 	for _, auth := range auths {

--- a/internal/api/handlers/management/auth_files_recent_requests_test.go
+++ b/internal/api/handlers/management/auth_files_recent_requests_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
@@ -90,5 +91,89 @@ func TestListAuthFiles_IncludesRecentRequestsBuckets(t *testing.T) {
 		if _, ok := bucket["failed"].(float64); !ok {
 			t.Fatalf("expected bucket failed number at %d, got %#v", idx, bucket["failed"])
 		}
+	}
+}
+
+func TestListAuthFiles_PrunesExpiredQuotaWarning(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	past := time.Now().Add(-time.Minute)
+	rawUsageLimit := `{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached"}}`
+	manager := coreauth.NewManager(nil, nil, nil)
+	record := &coreauth.Auth{
+		ID:             "quota-auth",
+		Provider:       "codex",
+		Status:         coreauth.StatusError,
+		StatusMessage:  rawUsageLimit,
+		Unavailable:    true,
+		NextRetryAfter: past,
+		Quota: coreauth.QuotaState{
+			Exceeded:      true,
+			Reason:        "quota",
+			NextRecoverAt: past,
+		},
+		LastError: &coreauth.Error{HTTPStatus: http.StatusTooManyRequests, Message: rawUsageLimit},
+		Attributes: map[string]string{
+			"runtime_only": "true",
+		},
+		Metadata: map[string]any{
+			"type": "codex",
+		},
+		ModelStates: map[string]*coreauth.ModelState{
+			"gpt-5": {
+				Status:         coreauth.StatusError,
+				StatusMessage:  rawUsageLimit,
+				Unavailable:    true,
+				NextRetryAfter: past,
+				Quota: coreauth.QuotaState{
+					Exceeded:      true,
+					Reason:        "quota",
+					NextRecoverAt: past,
+				},
+				LastError: &coreauth.Error{HTTPStatus: http.StatusTooManyRequests, Message: rawUsageLimit},
+			},
+		},
+	}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("failed to register auth record: %v", errRegister)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+	h.tokenStore = &memoryAuthStore{}
+	rec := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/auth-files", nil)
+	ginCtx.Request = req
+
+	h.ListAuthFiles(ginCtx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected list status %d, got %d with body %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	var payload map[string]any
+	if errUnmarshal := json.Unmarshal(rec.Body.Bytes(), &payload); errUnmarshal != nil {
+		t.Fatalf("failed to decode list payload: %v", errUnmarshal)
+	}
+	filesRaw, ok := payload["files"].([]any)
+	if !ok || len(filesRaw) != 1 {
+		t.Fatalf("expected one file entry, payload: %#v", payload)
+	}
+	fileEntry, ok := filesRaw[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected file entry object, got %#v", filesRaw[0])
+	}
+	if got := fileEntry["status"]; got != string(coreauth.StatusActive) {
+		t.Fatalf("status = %#v, want %q", got, coreauth.StatusActive)
+	}
+	if got := fileEntry["status_message"]; got != "" {
+		t.Fatalf("status_message = %#v, want empty", got)
+	}
+	if got := fileEntry["unavailable"]; got != false {
+		t.Fatalf("unavailable = %#v, want false", got)
+	}
+	if _, exists := fileEntry["next_retry_after"]; exists {
+		t.Fatal("next_retry_after should be absent after pruning")
 	}
 }

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -344,6 +344,63 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 	}
 }
 
+// PruneExpiredAvailability clears expired quota/cooldown state so status views
+// match scheduler availability after the recovery window has elapsed.
+func (m *Manager) PruneExpiredAvailability(ctx context.Context, now time.Time) int {
+	if m == nil {
+		return 0
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	type prunedAuth struct {
+		snapshot *Auth
+		models   []string
+	}
+	pruned := make([]prunedAuth, 0)
+
+	m.mu.Lock()
+	for _, auth := range m.auths {
+		changed, models := pruneExpiredAvailability(auth, now)
+		if !changed {
+			continue
+		}
+		auth.UpdatedAt = now
+		if errPersist := m.persist(ctx, auth); errPersist != nil {
+			logEntryWithRequestID(ctx).WithField("auth_id", auth.ID).Warnf("failed to persist auth changes during expired availability pruning: %v", errPersist)
+		}
+		pruned = append(pruned, prunedAuth{
+			snapshot: auth.Clone(),
+			models:   models,
+		})
+	}
+	m.mu.Unlock()
+
+	if len(pruned) == 0 {
+		return 0
+	}
+
+	reg := registry.GetGlobalRegistry()
+	for _, item := range pruned {
+		if item.snapshot == nil {
+			continue
+		}
+		if m.scheduler != nil {
+			m.scheduler.upsertAuth(item.snapshot)
+		}
+		for _, model := range item.models {
+			if strings.TrimSpace(model) == "" {
+				continue
+			}
+			reg.ClearModelQuotaExceeded(item.snapshot.ID, model)
+			reg.ResumeClientModel(item.snapshot.ID, model)
+		}
+	}
+
+	return len(pruned)
+}
+
 func (m *Manager) SetSelector(selector Selector) {
 	if m == nil {
 		return
@@ -2341,6 +2398,70 @@ func resetModelState(state *ModelState, now time.Time) {
 	state.LastError = nil
 	state.Quota = QuotaState{}
 	state.UpdatedAt = now
+}
+
+func pruneExpiredAvailability(auth *Auth, now time.Time) (bool, []string) {
+	if auth == nil || auth.Disabled || auth.Status == StatusDisabled {
+		return false, nil
+	}
+
+	changed := false
+	prunedModels := make([]string, 0)
+	if len(auth.ModelStates) > 0 {
+		for model, state := range auth.ModelStates {
+			if !pruneExpiredModelAvailability(state, now) {
+				continue
+			}
+			changed = true
+			if strings.TrimSpace(model) != "" {
+				prunedModels = append(prunedModels, model)
+			}
+		}
+		if changed {
+			updateAggregatedAvailability(auth, now)
+			if !hasModelError(auth, now) {
+				clearAuthStateOnSuccess(auth, now)
+			}
+		}
+	}
+
+	if expiredQuotaWarning(auth.Status, auth.Unavailable, auth.NextRetryAfter, auth.Quota, auth.LastError, auth.StatusMessage, now) && !hasModelError(auth, now) {
+		clearAuthStateOnSuccess(auth, now)
+		changed = true
+	}
+
+	return changed, prunedModels
+}
+
+func pruneExpiredModelAvailability(state *ModelState, now time.Time) bool {
+	if state == nil {
+		return false
+	}
+	if !expiredQuotaWarning(state.Status, state.Unavailable, state.NextRetryAfter, state.Quota, state.LastError, state.StatusMessage, now) {
+		return false
+	}
+	resetModelState(state, now)
+	return true
+}
+
+func expiredQuotaWarning(status Status, unavailable bool, nextRetryAfter time.Time, quota QuotaState, lastErr *Error, statusMessage string, now time.Time) bool {
+	if !nextRetryAfter.IsZero() && nextRetryAfter.After(now) {
+		return false
+	}
+	if !quota.NextRecoverAt.IsZero() && quota.NextRecoverAt.After(now) {
+		return false
+	}
+	if quota.Exceeded || strings.EqualFold(strings.TrimSpace(quota.Reason), "quota") {
+		return true
+	}
+	if statusCodeFromResult(lastErr) == http.StatusTooManyRequests {
+		return true
+	}
+	if status != StatusError && !unavailable {
+		return false
+	}
+	lower := strings.ToLower(strings.TrimSpace(statusMessage))
+	return strings.Contains(lower, "usage_limit_reached") || strings.Contains(lower, "quota")
 }
 
 func modelStateIsClean(state *ModelState) bool {

--- a/sdk/cliproxy/auth/conductor_availability_test.go
+++ b/sdk/cliproxy/auth/conductor_availability_test.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"context"
+	"net/http"
 	"testing"
 	"time"
 )
@@ -57,5 +59,129 @@ func TestUpdateAggregatedAvailability_FutureNextRetryBlocksAuth(t *testing.T) {
 	}
 	if auth.NextRetryAfter.Sub(next) > time.Second || next.Sub(auth.NextRetryAfter) > time.Second {
 		t.Fatalf("auth.NextRetryAfter = %v, want %v", auth.NextRetryAfter, next)
+	}
+}
+
+func TestManagerPruneExpiredAvailability_ClearsExpiredModelQuotaWarning(t *testing.T) {
+	now := time.Now()
+	past := now.Add(-time.Minute)
+	model := "gpt-5"
+	rawUsageLimit := `{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached"}}`
+	m := NewManager(nil, nil, nil)
+	if _, errRegister := m.Register(context.Background(), &Auth{
+		ID:             "quota-auth",
+		Provider:       "codex",
+		Status:         StatusError,
+		StatusMessage:  rawUsageLimit,
+		Unavailable:    true,
+		NextRetryAfter: past,
+		Quota: QuotaState{
+			Exceeded:      true,
+			Reason:        "quota",
+			NextRecoverAt: past,
+		},
+		LastError: &Error{HTTPStatus: http.StatusTooManyRequests, Message: rawUsageLimit},
+		ModelStates: map[string]*ModelState{
+			model: {
+				Status:         StatusError,
+				StatusMessage:  rawUsageLimit,
+				Unavailable:    true,
+				NextRetryAfter: past,
+				Quota: QuotaState{
+					Exceeded:      true,
+					Reason:        "quota",
+					NextRecoverAt: past,
+				},
+				LastError: &Error{HTTPStatus: http.StatusTooManyRequests, Message: rawUsageLimit},
+			},
+		},
+	}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	if got := m.PruneExpiredAvailability(context.Background(), now); got != 1 {
+		t.Fatalf("PruneExpiredAvailability() = %d, want 1", got)
+	}
+
+	updated, ok := m.GetByID("quota-auth")
+	if !ok || updated == nil {
+		t.Fatal("expected auth to be present")
+	}
+	if updated.Status != StatusActive {
+		t.Fatalf("auth status = %q, want %q", updated.Status, StatusActive)
+	}
+	if updated.StatusMessage != "" {
+		t.Fatalf("auth status message = %q, want empty", updated.StatusMessage)
+	}
+	if updated.Unavailable {
+		t.Fatal("auth unavailable = true, want false")
+	}
+	if updated.LastError != nil {
+		t.Fatalf("auth last error = %#v, want nil", updated.LastError)
+	}
+	if updated.Quota.Exceeded || updated.Quota.Reason != "" || !updated.Quota.NextRecoverAt.IsZero() {
+		t.Fatalf("auth quota = %+v, want cleared", updated.Quota)
+	}
+	state := updated.ModelStates[model]
+	if state == nil {
+		t.Fatalf("expected model state for %q", model)
+	}
+	if !modelStateIsClean(state) {
+		t.Fatalf("model state = %+v, want clean", state)
+	}
+}
+
+func TestManagerPruneExpiredAvailability_KeepsActiveModelQuotaWarning(t *testing.T) {
+	now := time.Now()
+	next := now.Add(time.Hour)
+	model := "gpt-5"
+	m := NewManager(nil, nil, nil)
+	if _, errRegister := m.Register(context.Background(), &Auth{
+		ID:             "quota-auth-active",
+		Provider:       "codex",
+		Status:         StatusError,
+		StatusMessage:  "quota exhausted",
+		Unavailable:    true,
+		NextRetryAfter: next,
+		Quota: QuotaState{
+			Exceeded:      true,
+			Reason:        "quota",
+			NextRecoverAt: next,
+		},
+		LastError: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota exhausted"},
+		ModelStates: map[string]*ModelState{
+			model: {
+				Status:         StatusError,
+				StatusMessage:  "quota exhausted",
+				Unavailable:    true,
+				NextRetryAfter: next,
+				Quota: QuotaState{
+					Exceeded:      true,
+					Reason:        "quota",
+					NextRecoverAt: next,
+				},
+				LastError: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota exhausted"},
+			},
+		},
+	}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	if got := m.PruneExpiredAvailability(context.Background(), now); got != 0 {
+		t.Fatalf("PruneExpiredAvailability() = %d, want 0", got)
+	}
+
+	updated, ok := m.GetByID("quota-auth-active")
+	if !ok || updated == nil {
+		t.Fatal("expected auth to be present")
+	}
+	if updated.Status != StatusError {
+		t.Fatalf("auth status = %q, want %q", updated.Status, StatusError)
+	}
+	if !updated.Unavailable {
+		t.Fatal("auth unavailable = false, want true")
+	}
+	if state := updated.ModelStates[model]; state == nil || !state.Unavailable {
+		t.Fatalf("model state = %+v, want unavailable", state)
 	}
 }


### PR DESCRIPTION
## Summary

- Selectively port upstream router-for-me/CLIProxyAPI#3277.
- Clear expired auth/model quota availability state before `/v0/management/auth-files` is listed.
- Keep active/future quota cooldown warnings intact.
- Resume registry model availability when expired per-model quota state is pruned.

## LTS compatibility

- Scoped to Management auth-files status and `sdk/cliproxy/auth` conductor availability state.
- Does not touch `internal/usage/`, `/v0/management/usage*`, usage import/export, config schema, translator paths, or panel-facing usage contract.
- Management auth-files response shape is unchanged; stale fields are cleared when the recovery window is already past.

## Validation

- `go test ./sdk/cliproxy/auth -run 'TestManagerPruneExpiredAvailability|TestUpdateAggregatedAvailability' -count=1`\n- `go test ./internal/api/handlers/management -run 'TestListAuthFiles_PrunesExpiredQuotaWarning|TestListAuthFiles_IncludesRecentRequestsBuckets' -count=1`\n- `go test ./sdk/cliproxy/... -count=1`\n- `go test ./internal/api ./internal/api/handlers/management ./internal/api/modules/amp ./test -run Amp -count=1`\n- `go test ./internal/api/handlers/management -count=1`\n- `git diff --check`\n- `go build -o test-output ./cmd/server && rm -f test-output`\n- `go test ./internal/runtime/executor -count=1` after an unrelated first-pass Antigravity background refresh panic in the initial full run\n- `go test ./...`\n- `go test ./... -count=1`\n