### PR TITLE
[codex] Add upstream HTTP/2 disable switch

### DIFF
--- a/internal/runtime/executor/helps/proxy_helpers.go
+++ b/internal/runtime/executor/helps/proxy_helpers.go
@@ -58,7 +58,27 @@ func NewProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 		httpClient.Transport = rt
 	}
 
+	applyUpstreamHTTP2Setting(httpClient)
 	return httpClient
+}
+
+func applyUpstreamHTTP2Setting(httpClient *http.Client) {
+	if httpClient == nil || !proxyutil.DisableUpstreamHTTP2() {
+		return
+	}
+	if httpClient.Transport == nil {
+		if transport, ok := http.DefaultTransport.(*http.Transport); ok && transport != nil {
+			httpClient.Transport = proxyutil.CloneTransportWithHTTP11(transport)
+		} else {
+			transport := &http.Transport{}
+			proxyutil.DisableHTTP2ForTransport(transport)
+			httpClient.Transport = transport
+		}
+		return
+	}
+	if transport, ok := httpClient.Transport.(*http.Transport); ok && transport != nil {
+		httpClient.Transport = proxyutil.CloneTransportWithHTTP11(transport)
+	}
 }
 
 // buildProxyTransport creates an HTTP transport configured for the given proxy URL.

--- a/internal/runtime/executor/helps/proxy_helpers_test.go
+++ b/internal/runtime/executor/helps/proxy_helpers_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/proxyutil"
 )
 
 func TestNewProxyAwareHTTPClientDirectBypassesGlobalProxy(t *testing.T) {
@@ -26,5 +28,70 @@ func TestNewProxyAwareHTTPClientDirectBypassesGlobalProxy(t *testing.T) {
 	}
 	if transport.Proxy != nil {
 		t.Fatal("expected direct transport to disable proxy function")
+	}
+}
+
+func TestNewProxyAwareHTTPClientDisableHTTP2NoProxyForcesHTTP11(t *testing.T) {
+	t.Setenv(proxyutil.DisableUpstreamHTTP2Env, "true")
+
+	client := NewProxyAwareHTTPClient(context.Background(), nil, nil, 3*time.Second)
+
+	if client.Timeout != 3*time.Second {
+		t.Fatalf("Timeout = %v, want 3s", client.Timeout)
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", client.Transport)
+	}
+	assertTransportForcesHTTP11(t, transport)
+}
+
+func TestNewProxyAwareHTTPClientDisableHTTP2ContextTransportForcesHTTP11(t *testing.T) {
+	t.Setenv(proxyutil.DisableUpstreamHTTP2Env, "true")
+
+	base := &http.Transport{ForceAttemptHTTP2: true, Proxy: http.ProxyFromEnvironment}
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", base)
+	client := NewProxyAwareHTTPClient(ctx, nil, nil, 0)
+
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", client.Transport)
+	}
+	if transport == base {
+		t.Fatal("context transport was not cloned")
+	}
+	if transport.Proxy == nil {
+		t.Fatal("Proxy function was not preserved")
+	}
+	assertTransportForcesHTTP11(t, transport)
+}
+
+func TestNewProxyAwareHTTPClientDisableHTTP2FalseKeepsDefaultTransportBehavior(t *testing.T) {
+	t.Setenv(proxyutil.DisableUpstreamHTTP2Env, "false")
+
+	client := NewProxyAwareHTTPClient(context.Background(), nil, nil, 0)
+
+	if client.Transport != nil {
+		t.Fatalf("transport = %T, want nil default transport", client.Transport)
+	}
+}
+
+func assertTransportForcesHTTP11(t *testing.T, transport *http.Transport) {
+	t.Helper()
+
+	if transport.ForceAttemptHTTP2 {
+		t.Fatal("ForceAttemptHTTP2 = true, want false")
+	}
+	if transport.TLSNextProto == nil {
+		t.Fatal("TLSNextProto = nil, want empty map")
+	}
+	if len(transport.TLSNextProto) != 0 {
+		t.Fatalf("TLSNextProto length = %d, want 0", len(transport.TLSNextProto))
+	}
+	if transport.TLSClientConfig == nil {
+		t.Fatal("TLSClientConfig = nil")
+	}
+	if got := transport.TLSClientConfig.NextProtos; len(got) != 1 || got[0] != "http/1.1" {
+		t.Fatalf("NextProtos = %v, want [http/1.1]", got)
 	}
 }

--- a/sdk/proxyutil/proxy.go
+++ b/sdk/proxyutil/proxy.go
@@ -9,10 +9,14 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
+	"strconv"
 	"strings"
 
 	"golang.org/x/net/proxy"
 )
+
+const DisableUpstreamHTTP2Env = "CPA_DISABLE_UPSTREAM_HTTP2"
 
 // Mode describes how a proxy setting should be interpreted.
 type Mode int
@@ -78,6 +82,48 @@ func cloneDefaultTransport() *http.Transport {
 	return &http.Transport{}
 }
 
+// DisableUpstreamHTTP2 reports whether CPA upstream HTTP clients should force HTTP/1.1.
+func DisableUpstreamHTTP2() bool {
+	raw, ok := os.LookupEnv(DisableUpstreamHTTP2Env)
+	if !ok || strings.TrimSpace(raw) == "" {
+		return false
+	}
+	enabled, errParse := strconv.ParseBool(strings.TrimSpace(raw))
+	return errParse == nil && enabled
+}
+
+// DisableHTTP2ForTransport mutates a transport so TLS requests negotiate HTTP/1.1 only.
+func DisableHTTP2ForTransport(transport *http.Transport) {
+	if transport == nil {
+		return
+	}
+	transport.ForceAttemptHTTP2 = false
+	transport.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper)
+	if transport.TLSClientConfig == nil {
+		transport.TLSClientConfig = &tls.Config{}
+	} else {
+		transport.TLSClientConfig = transport.TLSClientConfig.Clone()
+	}
+	transport.TLSClientConfig.NextProtos = []string{"http/1.1"}
+}
+
+// CloneTransportWithHTTP11 clones a transport and disables HTTP/2 on the clone.
+func CloneTransportWithHTTP11(base *http.Transport) *http.Transport {
+	if base == nil {
+		return nil
+	}
+	clone := base.Clone()
+	DisableHTTP2ForTransport(clone)
+	return clone
+}
+
+func applyUpstreamHTTP2Setting(transport *http.Transport) *http.Transport {
+	if transport != nil && DisableUpstreamHTTP2() {
+		DisableHTTP2ForTransport(transport)
+	}
+	return transport
+}
+
 // NewDirectTransport returns a transport that bypasses environment proxies.
 func NewDirectTransport() *http.Transport {
 	clone := cloneDefaultTransport()
@@ -94,9 +140,12 @@ func BuildHTTPTransport(raw string) (*http.Transport, Mode, error) {
 
 	switch setting.Mode {
 	case ModeInherit:
+		if DisableUpstreamHTTP2() {
+			return applyUpstreamHTTP2Setting(cloneDefaultTransport()), setting.Mode, nil
+		}
 		return nil, setting.Mode, nil
 	case ModeDirect:
-		return NewDirectTransport(), setting.Mode, nil
+		return applyUpstreamHTTP2Setting(NewDirectTransport()), setting.Mode, nil
 	case ModeProxy:
 		if setting.URL.Scheme == "socks5" || setting.URL.Scheme == "socks5h" {
 			var proxyAuth *proxy.Auth
@@ -114,11 +163,11 @@ func BuildHTTPTransport(raw string) (*http.Transport, Mode, error) {
 			transport.DialContext = func(_ context.Context, network, addr string) (net.Conn, error) {
 				return dialer.Dial(network, addr)
 			}
-			return transport, setting.Mode, nil
+			return applyUpstreamHTTP2Setting(transport), setting.Mode, nil
 		}
 		transport := cloneDefaultTransport()
 		transport.Proxy = http.ProxyURL(setting.URL)
-		return transport, setting.Mode, nil
+		return applyUpstreamHTTP2Setting(transport), setting.Mode, nil
 	default:
 		return nil, setting.Mode, nil
 	}

--- a/sdk/proxyutil/proxy_test.go
+++ b/sdk/proxyutil/proxy_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -75,6 +76,136 @@ func TestBuildHTTPTransportDirectBypassesProxy(t *testing.T) {
 	}
 	if transport.Proxy != nil {
 		t.Fatal("expected direct transport to disable proxy function")
+	}
+}
+
+func TestBuildHTTPTransportInheritKeepsDefaultTransportWhenHTTP2Enabled(t *testing.T) {
+	t.Setenv(DisableUpstreamHTTP2Env, "false")
+
+	transport, mode, errBuild := BuildHTTPTransport("")
+	if errBuild != nil {
+		t.Fatalf("BuildHTTPTransport returned error: %v", errBuild)
+	}
+	if mode != ModeInherit {
+		t.Fatalf("mode = %d, want %d", mode, ModeInherit)
+	}
+	if transport != nil {
+		t.Fatalf("transport = %T, want nil default transport", transport)
+	}
+}
+
+func TestBuildHTTPTransportInheritDisablesHTTP2WhenRequested(t *testing.T) {
+	t.Setenv(DisableUpstreamHTTP2Env, "true")
+
+	transport, mode, errBuild := BuildHTTPTransport("")
+	if errBuild != nil {
+		t.Fatalf("BuildHTTPTransport returned error: %v", errBuild)
+	}
+	if mode != ModeInherit {
+		t.Fatalf("mode = %d, want %d", mode, ModeInherit)
+	}
+	if transport == nil {
+		t.Fatal("expected transport, got nil")
+	}
+	assertTransportForcesHTTP11(t, transport)
+}
+
+func TestBuildHTTPTransportDisableHTTP2TrueForcesHTTP11AndKeepsProxy(t *testing.T) {
+	t.Setenv(DisableUpstreamHTTP2Env, "true")
+
+	transport, mode, errBuild := BuildHTTPTransport("http://proxy.example.com:8080")
+	if errBuild != nil {
+		t.Fatalf("BuildHTTPTransport returned error: %v", errBuild)
+	}
+	if mode != ModeProxy {
+		t.Fatalf("mode = %d, want %d", mode, ModeProxy)
+	}
+	if transport == nil {
+		t.Fatal("expected transport, got nil")
+	}
+
+	req, errRequest := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	if errRequest != nil {
+		t.Fatalf("http.NewRequest returned error: %v", errRequest)
+	}
+	proxyURL, errProxy := transport.Proxy(req)
+	if errProxy != nil {
+		t.Fatalf("transport.Proxy returned error: %v", errProxy)
+	}
+	if proxyURL == nil || proxyURL.String() != "http://proxy.example.com:8080" {
+		t.Fatalf("proxy URL = %v, want http://proxy.example.com:8080", proxyURL)
+	}
+	assertTransportForcesHTTP11(t, transport)
+}
+
+func TestBuildHTTPTransportDisableHTTP2TrueForcesHTTP11OnDirect(t *testing.T) {
+	t.Setenv(DisableUpstreamHTTP2Env, "true")
+
+	transport, mode, errBuild := BuildHTTPTransport("direct")
+	if errBuild != nil {
+		t.Fatalf("BuildHTTPTransport returned error: %v", errBuild)
+	}
+	if mode != ModeDirect {
+		t.Fatalf("mode = %d, want %d", mode, ModeDirect)
+	}
+	if transport == nil {
+		t.Fatal("expected transport, got nil")
+	}
+	if transport.Proxy != nil {
+		t.Fatal("expected direct transport to disable proxy function")
+	}
+	assertTransportForcesHTTP11(t, transport)
+}
+
+func TestDisableHTTP2ForTransportNegotiatesHTTP11WithHTTP2Server(t *testing.T) {
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	defer server.Close()
+
+	base, ok := server.Client().Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("server client transport type = %T, want *http.Transport", server.Client().Transport)
+	}
+	transport := base.Clone()
+	transport.ForceAttemptHTTP2 = true
+	DisableHTTP2ForTransport(transport)
+
+	client := &http.Client{Transport: transport}
+	resp, errGet := client.Get(server.URL)
+	if errGet != nil {
+		t.Fatalf("client.Get returned error: %v", errGet)
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			t.Errorf("resp.Body.Close returned error: %v", errClose)
+		}
+	}()
+
+	if resp.Proto != "HTTP/1.1" {
+		t.Fatalf("resp.Proto = %s, want HTTP/1.1", resp.Proto)
+	}
+}
+
+func assertTransportForcesHTTP11(t *testing.T, transport *http.Transport) {
+	t.Helper()
+
+	if transport.ForceAttemptHTTP2 {
+		t.Fatal("ForceAttemptHTTP2 = true, want false")
+	}
+	if transport.TLSNextProto == nil {
+		t.Fatal("TLSNextProto = nil, want empty map")
+	}
+	if len(transport.TLSNextProto) != 0 {
+		t.Fatalf("TLSNextProto length = %d, want 0", len(transport.TLSNextProto))
+	}
+	if transport.TLSClientConfig == nil {
+		t.Fatal("TLSClientConfig = nil")
+	}
+	if got := transport.TLSClientConfig.NextProtos; len(got) != 1 || got[0] != "http/1.1" {
+		t.Fatalf("NextProtos = %v, want [http/1.1]", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Split a low-risk transport slice from upstream image/SSE reliability work in router-for-me/CLIProxyAPI#3483/#3475.
- Add `CPA_DISABLE_UPSTREAM_HTTP2=true` to force upstream HTTP clients onto HTTP/1.1.
- Apply the switch to proxy-built transports, direct transports, inherited default transport, and executor context transports.
- Leave default behavior unchanged when the env var is unset or false.

## LTS compatibility

- Scoped to transport/proxy helpers.
- Does not touch `internal/usage/`, `/v0/management/usage*`, config schema, Management routes, auth files, translator paths, or panel-facing contracts.
- The switch is opt-in via environment variable; default upstream HTTP behavior stays unchanged.

## Validation

- `go test ./sdk/proxyutil ./internal/runtime/executor/helps -run 'HTTP2|ProxyAwareHTTPClient|BuildHTTPTransport' -count=1`\n- `go test ./sdk/proxyutil ./internal/runtime/executor/helps -count=1`\n- `go test ./internal/runtime/executor -count=1`\n- `git diff --check`\n- `go build -o test-output ./cmd/server && rm -f test-output`\n- `go test ./...`\n