### PR TITLE
[codex] Classify image response stream failures

### DIFF
--- a/sdk/api/handlers/openai/openai_images_handlers.go
+++ b/sdk/api/handlers/openai/openai_images_handlers.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -43,6 +44,293 @@ type imageCallResult struct {
 
 type sseFrameAccumulator struct {
 	pending []byte
+}
+
+type imagesResponsesStreamStats struct {
+	startedAt            time.Time
+	sawFirstEvent        bool
+	sawResponseCompleted bool
+	sawErrorEvent        bool
+	lastEventType        string
+	lastDataType         string
+	finishReason         string
+	scannerErrorType     string
+	streamEndReason      string
+	chunkCount           int
+	eventCount           int
+	dataCount            int
+	imageCount           int
+	partialImageCount    int
+}
+
+func newImagesResponsesStreamStats() *imagesResponsesStreamStats {
+	return &imagesResponsesStreamStats{startedAt: time.Now()}
+}
+
+func (s *imagesResponsesStreamStats) observeChunk(chunk []byte) {
+	if s == nil || len(chunk) == 0 {
+		return
+	}
+	s.chunkCount++
+}
+
+func (s *imagesResponsesStreamStats) observeFrameLine(line []byte) {
+	if s == nil {
+		return
+	}
+	trimmed := bytes.TrimSpace(bytes.TrimRight(line, "\r"))
+	if len(trimmed) == 0 {
+		return
+	}
+	if bytes.HasPrefix(trimmed, []byte("event:")) {
+		s.eventCount++
+		s.lastEventType = string(bytes.TrimSpace(trimmed[len("event:"):]))
+		s.sawFirstEvent = true
+		if isImagesResponsesErrorEventType(s.lastEventType) {
+			s.sawErrorEvent = true
+		}
+	}
+}
+
+func (s *imagesResponsesStreamStats) observeDataPayload(payload []byte) {
+	if s == nil {
+		return
+	}
+	s.dataCount++
+	if json.Valid(payload) {
+		s.lastDataType = gjson.GetBytes(payload, "type").String()
+		if s.lastDataType != "" {
+			s.sawFirstEvent = true
+		}
+		if s.lastDataType == "response.completed" {
+			s.sawResponseCompleted = true
+			s.observeCompletedPayload(payload)
+		}
+		if isImagesResponsesErrorEventType(s.lastDataType) {
+			s.sawErrorEvent = true
+		}
+		if s.lastDataType == "response.image_generation_call.partial_image" {
+			s.partialImageCount++
+		}
+		if finishReason := firstNonEmptyGJSON(payload,
+			"response.status",
+			"response.incomplete_details.reason",
+			"response.error.code",
+			"item.status",
+		); finishReason != "" && s.finishReason == "" {
+			s.finishReason = finishReason
+		}
+	}
+}
+
+func (s *imagesResponsesStreamStats) observeCompletedPayload(payload []byte) {
+	if s == nil || !json.Valid(payload) {
+		return
+	}
+	output := gjson.GetBytes(payload, "response.output")
+	if !output.IsArray() {
+		return
+	}
+	for _, item := range output.Array() {
+		if item.Get("type").String() == "image_generation_call" && strings.TrimSpace(item.Get("result").String()) != "" {
+			s.imageCount++
+		}
+	}
+}
+
+func (s *imagesResponsesStreamStats) markStreamEnd(reason string) {
+	if s == nil {
+		return
+	}
+	if strings.TrimSpace(reason) != "" {
+		s.streamEndReason = strings.TrimSpace(reason)
+	}
+}
+
+func (s *imagesResponsesStreamStats) markScannerError(err error) {
+	if s == nil {
+		return
+	}
+	s.scannerErrorType = safeImagesResponsesStreamCause(err)
+	s.markStreamEnd("scanner_error")
+}
+
+func (s *imagesResponsesStreamStats) err(classification string, statusCode int, cause error) *interfaces.ErrorMessage {
+	if statusCode <= 0 {
+		statusCode = http.StatusBadGateway
+	}
+	elapsedMS := int64(0)
+	startedAt := ""
+	if s != nil && !s.startedAt.IsZero() {
+		elapsedMS = time.Since(s.startedAt).Milliseconds()
+		startedAt = s.startedAt.UTC().Format(time.RFC3339Nano)
+	}
+	sawFirstEvent := false
+	sawResponseCompleted := false
+	sawErrorEvent := false
+	lastEventType := ""
+	lastDataType := ""
+	finishReason := ""
+	scannerErrorType := ""
+	streamEndReason := ""
+	chunkCount := 0
+	eventCount := 0
+	dataCount := 0
+	imageCount := 0
+	partialImageCount := 0
+	if s != nil {
+		sawFirstEvent = s.sawFirstEvent
+		sawResponseCompleted = s.sawResponseCompleted
+		sawErrorEvent = s.sawErrorEvent
+		lastEventType = s.lastEventType
+		lastDataType = s.lastDataType
+		finishReason = s.finishReason
+		scannerErrorType = s.scannerErrorType
+		streamEndReason = s.streamEndReason
+		chunkCount = s.chunkCount
+		eventCount = s.eventCount
+		dataCount = s.dataCount
+		imageCount = s.imageCount
+		partialImageCount = s.partialImageCount
+	}
+	message := fmt.Sprintf(
+		"images responses stream aggregation failed: classification=%s started_at=%q saw_first_event=%t saw_response_completed=%t saw_error_event=%t last_event_type=%q last_data_type=%q event_count=%d data_count=%d image_count=%d partial_image_count=%d finish_reason=%q scanner_error_type=%q stream_end_reason=%q chunk_count=%d elapsed_ms=%d",
+		classification,
+		startedAt,
+		sawFirstEvent,
+		sawResponseCompleted,
+		sawErrorEvent,
+		lastEventType,
+		lastDataType,
+		eventCount,
+		dataCount,
+		imageCount,
+		partialImageCount,
+		finishReason,
+		scannerErrorType,
+		streamEndReason,
+		chunkCount,
+		elapsedMS,
+	)
+	if cause != nil {
+		message += "; cause=" + safeImagesResponsesStreamCause(cause)
+	}
+	return &interfaces.ErrorMessage{StatusCode: statusCode, Error: fmt.Errorf("%s", message)}
+}
+
+func withImagesResponsesErrorAddon(dst, src *interfaces.ErrorMessage) *interfaces.ErrorMessage {
+	if dst != nil && src != nil && src.Addon != nil {
+		dst.Addon = src.Addon.Clone()
+	}
+	return dst
+}
+
+func safeImagesResponsesStreamCause(err error) string {
+	if err == nil {
+		return ""
+	}
+	text := strings.TrimSpace(err.Error())
+	if text == "" {
+		return ""
+	}
+	if classifyImagesResponsesStreamError(err) == "h2_stream_reset" {
+		return "http2_stream_reset"
+	}
+	if errors.Is(err, context.Canceled) {
+		return "context_canceled"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "context_deadline_exceeded"
+	}
+	lowerText := strings.ToLower(text)
+	if lowerText == "upstream_stream_closed" {
+		return "upstream_stream_closed"
+	}
+	if strings.Contains(lowerText, "request timeout") || strings.Contains(lowerText, "timeout") {
+		return "request_timeout"
+	}
+	if errors.Is(err, io.ErrUnexpectedEOF) || strings.Contains(lowerText, "unexpected eof") {
+		return "unexpected_eof"
+	}
+	if errors.Is(err, io.EOF) || lowerText == "eof" {
+		return "eof"
+	}
+	if strings.Contains(lowerText, "scanner") {
+		return "scanner_error"
+	}
+	return "stream_read_error"
+}
+
+func classifyImagesResponsesStreamError(err error) string {
+	if err == nil {
+		return ""
+	}
+	text := strings.ToLower(err.Error())
+	if isImagesResponsesHTTP2ResetErrorText(text) {
+		return "h2_stream_reset"
+	}
+	if errors.Is(err, context.DeadlineExceeded) ||
+		strings.Contains(text, "context deadline exceeded") ||
+		strings.Contains(text, "request timeout") ||
+		strings.Contains(text, "timeout") {
+		return "context_timeout"
+	}
+	if errors.Is(err, context.Canceled) || strings.Contains(text, "context canceled") {
+		return "context_canceled"
+	}
+	return "scanner_error"
+}
+
+func imagesResponsesStreamStatusCode(classification string, upstreamStatus int) int {
+	if upstreamStatus >= http.StatusBadRequest && upstreamStatus <= 599 {
+		return upstreamStatus
+	}
+	switch classification {
+	case "context_timeout":
+		return http.StatusGatewayTimeout
+	case "context_canceled":
+		return http.StatusRequestTimeout
+	case "missing_response_completed", "upstream_stream_closed", "scanner_error", "upstream_error_event":
+		return http.StatusBadGateway
+	case "h2_stream_reset":
+		return http.StatusBadGateway
+	default:
+		return http.StatusBadGateway
+	}
+}
+
+func isImagesResponsesHTTP2ResetErrorText(text string) bool {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return false
+	}
+	return strings.Contains(text, "stream id") ||
+		strings.Contains(text, "internal_error") ||
+		strings.Contains(text, "received from peer") ||
+		strings.Contains(text, "http2") ||
+		strings.Contains(text, "rst_stream")
+}
+
+func isImagesResponsesErrorEventType(eventType string) bool {
+	eventType = strings.ToLower(strings.TrimSpace(eventType))
+	return eventType == "error" ||
+		eventType == "response.error" ||
+		eventType == "response.failed" ||
+		eventType == "response.incomplete"
+}
+
+func firstNonEmptyGJSON(payload []byte, paths ...string) string {
+	for _, path := range paths {
+		result := gjson.GetBytes(payload, path)
+		if !result.Exists() {
+			continue
+		}
+		value := strings.TrimSpace(result.String())
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func (a *sseFrameAccumulator) AddChunk(chunk []byte) [][]byte {
@@ -847,9 +1135,11 @@ func (h *OpenAIAPIHandler) collectImagesFromResponses(c *gin.Context, responsesR
 
 func collectImagesFromResponsesStream(ctx context.Context, data <-chan []byte, errs <-chan *interfaces.ErrorMessage, responseFormat string) ([]byte, *interfaces.ErrorMessage) {
 	acc := &sseFrameAccumulator{}
+	stats := newImagesResponsesStreamStats()
 
 	processFrame := func(frame []byte) ([]byte, bool, *interfaces.ErrorMessage) {
 		for _, line := range bytes.Split(frame, []byte("\n")) {
+			stats.observeFrameLine(line)
 			trimmed := bytes.TrimSpace(bytes.TrimRight(line, "\r"))
 			if len(trimmed) == 0 {
 				continue
@@ -861,8 +1151,19 @@ func collectImagesFromResponsesStream(ctx context.Context, data <-chan []byte, e
 			if len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) {
 				continue
 			}
+			stats.observeDataPayload(payload)
+			if isImagesResponsesErrorEventType(stats.lastEventType) {
+				stats.markStreamEnd("upstream_error_event")
+				return nil, false, stats.err("upstream_error_event", http.StatusBadGateway, nil)
+			}
 			if !json.Valid(payload) {
-				return nil, false, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("invalid SSE data JSON")}
+				stats.markStreamEnd("invalid_sse_data_json")
+				return nil, false, stats.err("invalid_sse_data_json", http.StatusBadGateway, nil)
+			}
+
+			if isImagesResponsesErrorEventType(stats.lastDataType) {
+				stats.markStreamEnd("upstream_error_event")
+				return nil, false, stats.err("upstream_error_event", http.StatusBadGateway, nil)
 			}
 
 			if gjson.GetBytes(payload, "type").String() != "response.completed" {
@@ -871,14 +1172,14 @@ func collectImagesFromResponsesStream(ctx context.Context, data <-chan []byte, e
 
 			results, createdAt, usageRaw, firstMeta, err := extractImagesFromResponsesCompleted(payload)
 			if err != nil {
-				return nil, false, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: err}
+				return nil, false, stats.err("response_completed_extract_failed", http.StatusBadGateway, err)
 			}
 			if len(results) == 0 {
-				return nil, false, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("upstream did not return image output")}
+				return nil, false, stats.err("missing_image_output", http.StatusBadGateway, nil)
 			}
 			out, err := buildImagesAPIResponse(results, createdAt, usageRaw, firstMeta, responseFormat)
 			if err != nil {
-				return nil, false, &interfaces.ErrorMessage{StatusCode: http.StatusInternalServerError, Error: err}
+				return nil, false, stats.err("image_response_build_failed", http.StatusInternalServerError, err)
 			}
 			return out, true, nil
 		}
@@ -888,10 +1189,26 @@ func collectImagesFromResponsesStream(ctx context.Context, data <-chan []byte, e
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, &interfaces.ErrorMessage{StatusCode: http.StatusRequestTimeout, Error: ctx.Err()}
+			classification := classifyImagesResponsesStreamError(ctx.Err())
+			if classification == "context_canceled" {
+				stats.markStreamEnd("context_canceled")
+			} else {
+				classification = "context_timeout"
+				stats.markStreamEnd("context_timeout")
+			}
+			return nil, stats.err(classification, imagesResponsesStreamStatusCode(classification, 0), ctx.Err())
 		case errMsg, ok := <-errs:
 			if ok && errMsg != nil {
-				return nil, errMsg
+				if errMsg.Error != nil {
+					classification := classifyImagesResponsesStreamError(errMsg.Error)
+					stats.markScannerError(errMsg.Error)
+					if classification == "h2_stream_reset" {
+						stats.markStreamEnd("h2_stream_reset")
+					}
+					return nil, withImagesResponsesErrorAddon(stats.err(classification, imagesResponsesStreamStatusCode(classification, errMsg.StatusCode), errMsg.Error), errMsg)
+				}
+				stats.markStreamEnd("upstream_stream_closed")
+				return nil, withImagesResponsesErrorAddon(stats.err("upstream_stream_closed", imagesResponsesStreamStatusCode("upstream_stream_closed", errMsg.StatusCode), nil), errMsg)
 			}
 			errs = nil
 		case chunk, ok := <-data:
@@ -903,8 +1220,10 @@ func collectImagesFromResponsesStream(ctx context.Context, data <-chan []byte, e
 						return out, nil
 					}
 				}
-				return nil, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("stream disconnected before completion")}
+				stats.markStreamEnd("data_channel_closed")
+				return nil, stats.err("missing_response_completed", imagesResponsesStreamStatusCode("missing_response_completed", 0), fmt.Errorf("upstream_stream_closed"))
 			}
+			stats.observeChunk(chunk)
 			for _, frame := range acc.AddChunk(chunk) {
 				if out, done, errMsg := processFrame(frame); errMsg != nil {
 					return nil, errMsg

--- a/sdk/api/handlers/openai/openai_images_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_images_handlers_test.go
@@ -10,9 +10,11 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -269,5 +271,383 @@ func TestImagesEdits_DisableImageGenerationChat_DoesNotReturn404(t *testing.T) {
 
 	if resp.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d: %s", resp.Code, http.StatusBadRequest, resp.Body.String())
+	}
+}
+
+func TestCollectImagesFromResponsesStreamCompleted(t *testing.T) {
+	data := make(chan []byte, 1)
+	errs := make(chan *interfaces.ErrorMessage)
+	data <- []byte(`event: response.completed
+data: {"type":"response.completed","response":{"created_at":123,"output":[{"type":"image_generation_call","result":"image-data","output_format":"png","revised_prompt":"refined"}],"tool_usage":{"image_gen":{"total_tokens":7}}}}
+
+`)
+	close(data)
+	close(errs)
+
+	out, errMsg := collectImagesFromResponsesStream(context.Background(), data, errs, "b64_json")
+
+	if errMsg != nil {
+		t.Fatalf("collectImagesFromResponsesStream() error = %v", errMsg.Error)
+	}
+	if got := gjson.GetBytes(out, "created").Int(); got != 123 {
+		t.Fatalf("created = %d, want 123", got)
+	}
+	if got := gjson.GetBytes(out, "data.0.b64_json").String(); got != "image-data" {
+		t.Fatalf("data.0.b64_json = %q, want image-data", got)
+	}
+	if got := gjson.GetBytes(out, "data.0.revised_prompt").String(); got != "refined" {
+		t.Fatalf("data.0.revised_prompt = %q, want refined", got)
+	}
+	if got := gjson.GetBytes(out, "usage.total_tokens").Int(); got != 7 {
+		t.Fatalf("usage.total_tokens = %d, want 7", got)
+	}
+}
+
+func TestCollectImagesFromResponsesStreamMissingCompleted(t *testing.T) {
+	data := make(chan []byte, 1)
+	errs := make(chan *interfaces.ErrorMessage)
+	data <- []byte(`event: response.created
+data: {"type":"response.created","response":{"id":"resp-1"}}
+
+`)
+	close(data)
+	close(errs)
+
+	out, errMsg := collectImagesFromResponsesStream(context.Background(), data, errs, "b64_json")
+
+	if out != nil {
+		t.Fatalf("out = %s, want nil", string(out))
+	}
+	requireImagesStreamError(t, errMsg, http.StatusBadGateway, "classification=missing_response_completed")
+	requireImagesStreamErrorContains(t, errMsg, "saw_response_completed=false")
+	requireImagesStreamErrorContains(t, errMsg, "saw_first_event=true")
+	requireImagesStreamErrorContains(t, errMsg, `last_event_type="response.created"`)
+	requireImagesStreamErrorContains(t, errMsg, `last_data_type="response.created"`)
+	requireImagesStreamErrorContains(t, errMsg, "event_count=1")
+	requireImagesStreamErrorContains(t, errMsg, "data_count=1")
+	requireImagesStreamErrorContains(t, errMsg, "chunk_count=1")
+	requireImagesStreamErrorContains(t, errMsg, `stream_end_reason="data_channel_closed"`)
+	requireImagesStreamErrorContains(t, errMsg, "cause=upstream_stream_closed")
+}
+
+func TestCollectImagesFromResponsesStreamUpstreamClosedWithoutPayload(t *testing.T) {
+	data := make(chan []byte, 1)
+	errs := make(chan *interfaces.ErrorMessage, 1)
+	errs <- &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway}
+	close(errs)
+
+	out, errMsg := collectImagesFromResponsesStream(context.Background(), data, errs, "b64_json")
+
+	if out != nil {
+		t.Fatalf("out = %s, want nil", string(out))
+	}
+	requireImagesStreamError(t, errMsg, http.StatusBadGateway, "classification=upstream_stream_closed")
+	requireImagesStreamErrorContains(t, errMsg, `stream_end_reason="upstream_stream_closed"`)
+	requireImagesStreamErrorContains(t, errMsg, "saw_response_completed=false")
+}
+
+func TestCollectImagesFromResponsesStreamPreservesAddonOnWrappedErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		msg        *interfaces.ErrorMessage
+		wantStatus int
+	}{
+		{
+			name: "scanner error",
+			msg: &interfaces.ErrorMessage{
+				StatusCode: http.StatusTooManyRequests,
+				Error:      errors.New("scanner read failed"),
+				Addon: http.Header{
+					"Retry-After":  {"30"},
+					"X-Request-Id": {"req-1", "req-2"},
+				},
+			},
+			wantStatus: http.StatusTooManyRequests,
+		},
+		{
+			name: "closed without error",
+			msg: &interfaces.ErrorMessage{
+				StatusCode: http.StatusUnauthorized,
+				Addon: http.Header{
+					"Retry-After":  {"60"},
+					"X-Request-Id": {"req-3"},
+				},
+			},
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := make(chan []byte)
+			errs := make(chan *interfaces.ErrorMessage, 1)
+			errs <- tt.msg
+			close(errs)
+
+			_, errMsg := collectImagesFromResponsesStream(context.Background(), data, errs, "b64_json")
+
+			if errMsg == nil {
+				t.Fatal("errMsg = nil, want wrapped error")
+			}
+			if errMsg.StatusCode != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", errMsg.StatusCode, tt.wantStatus)
+			}
+			if got := errMsg.Addon.Get("Retry-After"); got != tt.msg.Addon.Get("Retry-After") {
+				t.Fatalf("Retry-After = %q, want %q", got, tt.msg.Addon.Get("Retry-After"))
+			}
+			if got, want := errMsg.Addon.Values("X-Request-Id"), tt.msg.Addon.Values("X-Request-Id"); strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+				t.Fatalf("X-Request-Id = %#v, want %#v", got, want)
+			}
+
+			tt.msg.Addon.Set("Retry-After", "mutated")
+			if got := errMsg.Addon.Get("Retry-After"); got == "mutated" {
+				t.Fatal("wrapped Addon shares source header map")
+			}
+		})
+	}
+}
+
+func TestImagesResponsesStreamStatusCode(t *testing.T) {
+	tests := []struct {
+		name           string
+		classification string
+		upstreamStatus int
+		want           int
+	}{
+		{
+			name:           "preserves upstream client error",
+			classification: "scanner_error",
+			upstreamStatus: http.StatusTooManyRequests,
+			want:           http.StatusTooManyRequests,
+		},
+		{
+			name:           "preserves upstream server error",
+			classification: "upstream_stream_closed",
+			upstreamStatus: http.StatusInternalServerError,
+			want:           http.StatusInternalServerError,
+		},
+		{
+			name:           "scanner fallback without upstream status",
+			classification: "scanner_error",
+			upstreamStatus: 0,
+			want:           http.StatusBadGateway,
+		},
+		{
+			name:           "scanner ignores upstream success status",
+			classification: "scanner_error",
+			upstreamStatus: http.StatusOK,
+			want:           http.StatusBadGateway,
+		},
+		{
+			name:           "timeout fallback without upstream status",
+			classification: "context_timeout",
+			upstreamStatus: 0,
+			want:           http.StatusGatewayTimeout,
+		},
+		{
+			name:           "preserves upstream request timeout",
+			classification: "context_timeout",
+			upstreamStatus: http.StatusRequestTimeout,
+			want:           http.StatusRequestTimeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := imagesResponsesStreamStatusCode(tt.classification, tt.upstreamStatus); got != tt.want {
+				t.Fatalf("status = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCollectImagesFromResponsesStreamPreservesUpstream408Timeout(t *testing.T) {
+	data := make(chan []byte)
+	errs := make(chan *interfaces.ErrorMessage, 1)
+	errs <- &interfaces.ErrorMessage{
+		StatusCode: http.StatusRequestTimeout,
+		Error:      errors.New("upstream request timeout"),
+	}
+	close(errs)
+
+	out, errMsg := collectImagesFromResponsesStream(context.Background(), data, errs, "b64_json")
+
+	if out != nil {
+		t.Fatalf("out = %s, want nil", string(out))
+	}
+	requireImagesStreamError(t, errMsg, http.StatusRequestTimeout, "classification=context_timeout")
+	requireImagesStreamErrorContains(t, errMsg, "cause=request_timeout")
+	requireImagesStreamErrorContains(t, errMsg, `stream_end_reason="scanner_error"`)
+}
+
+func TestCollectImagesFromResponsesStreamScannerError(t *testing.T) {
+	data := make(chan []byte)
+	errs := make(chan *interfaces.ErrorMessage, 1)
+	errs <- &interfaces.ErrorMessage{StatusCode: http.StatusInternalServerError, Error: errors.New("scanner read failed")}
+	close(errs)
+
+	out, errMsg := collectImagesFromResponsesStream(context.Background(), data, errs, "b64_json")
+
+	if out != nil {
+		t.Fatalf("out = %s, want nil", string(out))
+	}
+	requireImagesStreamError(t, errMsg, http.StatusInternalServerError, "classification=scanner_error")
+	requireImagesStreamErrorContains(t, errMsg, "cause=scanner_error")
+	requireImagesStreamErrorContains(t, errMsg, `scanner_error_type="scanner_error"`)
+	requireImagesStreamErrorContains(t, errMsg, `stream_end_reason="scanner_error"`)
+}
+
+func TestCollectImagesFromResponsesStreamContextTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	time.Sleep(time.Millisecond)
+	data := make(chan []byte)
+	errs := make(chan *interfaces.ErrorMessage)
+
+	out, errMsg := collectImagesFromResponsesStream(ctx, data, errs, "b64_json")
+
+	if out != nil {
+		t.Fatalf("out = %s, want nil", string(out))
+	}
+	requireImagesStreamError(t, errMsg, http.StatusGatewayTimeout, "classification=context_timeout")
+	requireImagesStreamErrorContains(t, errMsg, "cause=context_deadline_exceeded")
+	requireImagesStreamErrorContains(t, errMsg, `stream_end_reason="context_timeout"`)
+}
+
+func TestCollectImagesFromResponsesStreamContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	data := make(chan []byte)
+	errs := make(chan *interfaces.ErrorMessage)
+
+	out, errMsg := collectImagesFromResponsesStream(ctx, data, errs, "b64_json")
+
+	if out != nil {
+		t.Fatalf("out = %s, want nil", string(out))
+	}
+	requireImagesStreamError(t, errMsg, http.StatusRequestTimeout, "classification=context_canceled")
+	requireImagesStreamErrorContains(t, errMsg, "cause=context_canceled")
+	requireImagesStreamErrorContains(t, errMsg, `stream_end_reason="context_canceled"`)
+}
+
+func TestCollectImagesFromResponsesStreamHTTP2Reset(t *testing.T) {
+	data := make(chan []byte)
+	errs := make(chan *interfaces.ErrorMessage, 1)
+	errs <- &interfaces.ErrorMessage{
+		StatusCode: http.StatusInternalServerError,
+		Error:      errors.New("stream error: stream ID 15; INTERNAL_ERROR; received from peer"),
+	}
+	close(errs)
+
+	out, errMsg := collectImagesFromResponsesStream(context.Background(), data, errs, "b64_json")
+
+	if out != nil {
+		t.Fatalf("out = %s, want nil", string(out))
+	}
+	requireImagesStreamError(t, errMsg, http.StatusInternalServerError, "classification=h2_stream_reset")
+	requireImagesStreamErrorContains(t, errMsg, "cause=http2_stream_reset")
+	requireImagesStreamErrorContains(t, errMsg, `scanner_error_type="http2_stream_reset"`)
+	requireImagesStreamErrorContains(t, errMsg, `stream_end_reason="h2_stream_reset"`)
+	requireImagesStreamErrorNotContains(t, errMsg, "stream ID 15")
+}
+
+func TestCollectImagesFromResponsesStreamHTTP2ResetRSTStream(t *testing.T) {
+	data := make(chan []byte)
+	errs := make(chan *interfaces.ErrorMessage, 1)
+	errs <- &interfaces.ErrorMessage{
+		StatusCode: http.StatusBadGateway,
+		Error:      errors.New("http2: RST_STREAM closed stream"),
+	}
+	close(errs)
+
+	out, errMsg := collectImagesFromResponsesStream(context.Background(), data, errs, "b64_json")
+
+	if out != nil {
+		t.Fatalf("out = %s, want nil", string(out))
+	}
+	requireImagesStreamError(t, errMsg, http.StatusBadGateway, "classification=h2_stream_reset")
+	requireImagesStreamErrorContains(t, errMsg, "cause=http2_stream_reset")
+	requireImagesStreamErrorNotContains(t, errMsg, "RST_STREAM")
+}
+
+func TestCollectImagesFromResponsesStreamUpstreamErrorEvent(t *testing.T) {
+	data := make(chan []byte, 1)
+	errs := make(chan *interfaces.ErrorMessage)
+	data <- []byte(`event: error
+data: {"type":"error","message":"safe upstream error"}
+
+`)
+	close(data)
+	close(errs)
+
+	out, errMsg := collectImagesFromResponsesStream(context.Background(), data, errs, "b64_json")
+
+	if out != nil {
+		t.Fatalf("out = %s, want nil", string(out))
+	}
+	requireImagesStreamError(t, errMsg, http.StatusBadGateway, "classification=upstream_error_event")
+	requireImagesStreamErrorContains(t, errMsg, "saw_error_event=true")
+	requireImagesStreamErrorContains(t, errMsg, `last_event_type="error"`)
+	requireImagesStreamErrorContains(t, errMsg, `last_data_type="error"`)
+	requireImagesStreamErrorContains(t, errMsg, `stream_end_reason="upstream_error_event"`)
+	requireImagesStreamErrorNotContains(t, errMsg, "safe upstream error")
+}
+
+func TestCollectImagesFromResponsesStreamErrorSummaryDoesNotLeakSensitiveData(t *testing.T) {
+	data := make(chan []byte, 1)
+	errs := make(chan *interfaces.ErrorMessage)
+	data <- []byte(`event: response.created
+data: {"type":"response.created","response":{"id":"resp-1"}}
+
+`)
+	close(data)
+	close(errs)
+
+	_, errMsg := collectImagesFromResponsesStream(context.Background(), data, errs, "b64_json")
+
+	for _, forbidden := range []string{
+		"Authorization",
+		"Cookie",
+		"API key",
+		"api_key",
+		"prompt",
+		"base64",
+		"b64_json",
+		`"response":{"id":"resp-1"}`,
+		"data:",
+		"event: response.created",
+	} {
+		requireImagesStreamErrorNotContains(t, errMsg, forbidden)
+	}
+}
+
+func requireImagesStreamError(t *testing.T, errMsg *interfaces.ErrorMessage, status int, contains string) {
+	t.Helper()
+	if errMsg == nil {
+		t.Fatalf("errMsg = nil, want status %d containing %q", status, contains)
+	}
+	if errMsg.StatusCode != status {
+		t.Fatalf("status = %d, want %d: %v", errMsg.StatusCode, status, errMsg.Error)
+	}
+	requireImagesStreamErrorContains(t, errMsg, contains)
+}
+
+func requireImagesStreamErrorContains(t *testing.T, errMsg *interfaces.ErrorMessage, contains string) {
+	t.Helper()
+	if errMsg == nil || errMsg.Error == nil {
+		t.Fatalf("errMsg/error is nil, want containing %q", contains)
+	}
+	if !strings.Contains(errMsg.Error.Error(), contains) {
+		t.Fatalf("error = %q, want containing %q", errMsg.Error.Error(), contains)
+	}
+}
+
+func requireImagesStreamErrorNotContains(t *testing.T, errMsg *interfaces.ErrorMessage, contains string) {
+	t.Helper()
+	if errMsg == nil || errMsg.Error == nil {
+		return
+	}
+	if strings.Contains(errMsg.Error.Error(), contains) {
+		t.Fatalf("error = %q, want not containing %q", errMsg.Error.Error(), contains)
 	}
 }


### PR DESCRIPTION
## Summary
- selectively ports the handler-side image Responses SSE failure classification from upstream #3483/#3475
- records safe stream diagnostics for missing `response.completed`, upstream error events, scanner errors, context timeout/cancel, and HTTP/2 reset failures
- preserves upstream 4xx/5xx status codes and Addon headers when wrapping stream errors
- keeps the change scoped to `sdk/api/handlers/openai`; no translator, usage, Management API, or config contract changes

## LTS compatibility
- does not touch `internal/usage/`, `usage-statistics-enabled`, or `/v0/management/usage*`
- does not alter CPA-Panel-LTS response contracts
- avoids raw SSE payload, prompt, base64 image data, auth header, cookie, and API key leakage in wrapped error summaries

## Validation
- `go test ./sdk/api/handlers/openai -run 'TestCollectImagesFromResponsesStream|TestImagesResponsesStreamStatusCode' -count=1`\n- `go test ./sdk/api/handlers/openai -count=1`\n- `go test ./sdk/api/handlers -count=1`\n- `git diff --check`\n- `go build -o test-output ./cmd/server && rm -f test-output`\n- `go test ./...`\n