### PR TITLE
[codex] Short-circuit Claude sample probes

### DIFF
--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 // ClaudeCodeAPIHandler contains the handlers for Claude API endpoints.
@@ -75,6 +76,11 @@ func (h *ClaudeCodeAPIHandler) ClaudeMessages(c *gin.Context) {
 				Type:    "invalid_request_error",
 			},
 		})
+		return
+	}
+
+	if shouldShortCircuitClaudeSample(rawJSON) {
+		h.writeClaudeSampleResponse(c, rawJSON)
 		return
 	}
 
@@ -474,4 +480,73 @@ func appendClaudeAPIResponse(c *gin.Context, data []byte) {
 		}
 	}
 	c.Set("API_RESPONSE", bytes.Clone(data))
+}
+
+func shouldShortCircuitClaudeSample(rawJSON []byte) bool {
+	maxTokens := gjson.GetBytes(rawJSON, "max_tokens")
+	return maxTokens.Exists() && maxTokens.Int() == 1
+}
+
+func buildClaudeSampleResponseBody(rawJSON []byte, now time.Time) []byte {
+	modelName := gjson.GetBytes(rawJSON, "model").String()
+	if strings.TrimSpace(modelName) == "" {
+		modelName = "claude-sonnet-4-6"
+	}
+	responseID := fmt.Sprintf("msg_cli_proxy_sample_%d", now.UnixNano())
+	out := []byte(`{"id":"","type":"message","role":"assistant","model":"","content":[],"stop_reason":"max_tokens","stop_sequence":null,"usage":{"input_tokens":8,"output_tokens":0}}`)
+	out, _ = sjson.SetBytes(out, "id", responseID)
+	out, _ = sjson.SetBytes(out, "model", modelName)
+	return out
+}
+
+func buildClaudeSampleSSE(rawJSON []byte, now time.Time) []byte {
+	modelName := gjson.GetBytes(rawJSON, "model").String()
+	if strings.TrimSpace(modelName) == "" {
+		modelName = "claude-sonnet-4-6"
+	}
+	responseID := fmt.Sprintf("msg_cli_proxy_sample_%d", now.UnixNano())
+	messageStart := []byte(`{"type":"message_start","message":{"id":"","type":"message","role":"assistant","content":[],"model":"","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":8,"output_tokens":0}}}`)
+	messageStart, _ = sjson.SetBytes(messageStart, "message.id", responseID)
+	messageStart, _ = sjson.SetBytes(messageStart, "message.model", modelName)
+
+	messageDelta := []byte(`{"type":"message_delta","delta":{"stop_reason":"max_tokens","stop_sequence":null},"usage":{"output_tokens":0}}`)
+	messageStop := []byte(`{"type":"message_stop"}`)
+
+	var out []byte
+	out = appendClaudeSSEEvent(out, "message_start", messageStart)
+	out = appendClaudeSSEEvent(out, "message_delta", messageDelta)
+	out = appendClaudeSSEEvent(out, "message_stop", messageStop)
+	return out
+}
+
+func appendClaudeSSEEvent(dst []byte, event string, data []byte) []byte {
+	dst = append(dst, "event: "...)
+	dst = append(dst, event...)
+	dst = append(dst, '\n')
+	dst = append(dst, "data: "...)
+	dst = append(dst, data...)
+	dst = append(dst, '\n', '\n')
+	return dst
+}
+
+func (h *ClaudeCodeAPIHandler) writeClaudeSampleResponse(c *gin.Context, rawJSON []byte) {
+	streamResult := gjson.GetBytes(rawJSON, "stream")
+	now := time.Now()
+	if streamResult.Exists() && streamResult.Type != gjson.False {
+		payload := buildClaudeSampleSSE(rawJSON, now)
+		c.Header("Content-Type", "text/event-stream")
+		c.Header("Cache-Control", "no-cache")
+		c.Header("Connection", "keep-alive")
+		c.Header("Access-Control-Allow-Origin", "*")
+		appendClaudeAPIResponse(c, payload)
+		c.Status(http.StatusOK)
+		_, _ = c.Writer.Write(payload)
+		return
+	}
+
+	payload := buildClaudeSampleResponseBody(rawJSON, now)
+	appendClaudeAPIResponse(c, payload)
+	c.Header("Content-Type", "application/json")
+	c.Status(http.StatusOK)
+	_, _ = c.Writer.Write(payload)
 }

--- a/sdk/api/handlers/claude/code_handlers_probe_test.go
+++ b/sdk/api/handlers/claude/code_handlers_probe_test.go
@@ -1,0 +1,119 @@
+package claude
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+)
+
+func TestClaudeMessagesShortCircuitNonStreamingSample(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewBufferString(`{"model":"claude-sonnet-4-6","max_tokens":1,"messages":[{"role":"user","content":"hello"}]}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := &ClaudeCodeAPIHandler{}
+	handler.ClaudeMessages(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if got := recorder.Header().Get("Content-Type"); !strings.Contains(got, "application/json") {
+		t.Fatalf("content-type = %q, want application/json", got)
+	}
+	body := recorder.Body.Bytes()
+	if got := gjson.GetBytes(body, "content").Raw; got != "[]" {
+		t.Fatalf("content = %q, want []; body=%s", got, body)
+	}
+	if got := gjson.GetBytes(body, "usage.output_tokens").Int(); got != 0 {
+		t.Fatalf("output_tokens = %d, want 0; body=%s", got, body)
+	}
+	if got := gjson.GetBytes(body, "stop_reason").String(); got != "max_tokens" {
+		t.Fatalf("stop_reason = %q, want max_tokens; body=%s", got, body)
+	}
+	if got := gjson.GetBytes(body, "model").String(); got != "claude-sonnet-4-6" {
+		t.Fatalf("model = %q, want claude-sonnet-4-6; body=%s", got, body)
+	}
+	logged, ok := c.Get("API_RESPONSE")
+	if !ok {
+		t.Fatal("API_RESPONSE missing")
+	}
+	loggedBytes, ok := logged.([]byte)
+	if !ok || !bytes.Equal(loggedBytes, body) {
+		t.Fatalf("API_RESPONSE = %#v, want response body", logged)
+	}
+}
+
+func TestClaudeMessagesShortCircuitStreamingSample(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewBufferString(`{"model":"claude-sonnet-4-6","max_tokens":1,"stream":true,"messages":[{"role":"user","content":"."},{"role":"assistant","content":"x"}]}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler := &ClaudeCodeAPIHandler{}
+	handler.ClaudeMessages(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if got := recorder.Header().Get("Content-Type"); !strings.Contains(got, "text/event-stream") {
+		t.Fatalf("content-type = %q, want text/event-stream", got)
+	}
+	body := recorder.Body.String()
+	for _, want := range []string{
+		"event: message_start",
+		`"stop_reason":"max_tokens"`,
+		"event: message_stop",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("stream missing %q; body=%s", want, body)
+		}
+	}
+	logged, ok := c.Get("API_RESPONSE")
+	if !ok {
+		t.Fatal("API_RESPONSE missing")
+	}
+	loggedBytes, ok := logged.([]byte)
+	if !ok || string(loggedBytes) != body {
+		t.Fatalf("API_RESPONSE = %#v, want response body", logged)
+	}
+}
+
+func TestShouldShortCircuitClaudeSample(t *testing.T) {
+	testCases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "single message not shorted",
+			body: `{"max_tokens":64,"messages":[{"role":"user","content":"hello"}]}`,
+			want: false,
+		},
+		{
+			name: "max tokens one",
+			body: `{"max_tokens":1,"messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"world"}]}`,
+			want: true,
+		},
+		{
+			name: "normal request",
+			body: `{"max_tokens":64,"messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"world"}]}`,
+			want: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldShortCircuitClaudeSample([]byte(tc.body)); got != tc.want {
+				t.Fatalf("shouldShortCircuitClaudeSample() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- selectively ports the Claude `max_tokens=1` sample/probe short-circuit from upstream #3571
- returns local Claude-compatible JSON or SSE responses instead of spending an upstream request on liveness/auth/model probe traffic
- records the synthetic payload through the existing `API_RESPONSE` context path for request logging compatibility
- intentionally excludes the upstream `context-1m` OAuth beta filtering because that is already covered by LTS PR #60

## LTS compatibility
- scoped to `sdk/api/handlers/claude`; no translator, executor, usage, Management API, or config changes
- does not touch `internal/usage/`, `usage-statistics-enabled`, or `/v0/management/usage*`
- reduces upstream quota/auth noise for probe requests while preserving Claude response shape

## Validation
- `go test ./sdk/api/handlers/claude -run 'TestClaudeMessagesShortCircuit|TestShouldShortCircuitClaudeSample' -count=1`\n- `go test ./sdk/api/handlers/claude -count=1`\n- `go test ./sdk/api/handlers -count=1`\n- `git diff --check`\n- `go build -o test-output ./cmd/server && rm -f test-output`\n- `go test ./...`\n