### PR TITLE
[codex] Route GPT-5.5 over supported transports

### DIFF
--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
@@ -1549,11 +1550,9 @@ func CloseCodexWebsocketSessionsForAuthID(authID string, reason string) {
 	}
 }
 
-// CodexAutoExecutor routes Codex requests to the websocket transport only when:
-//  1. The downstream transport is websocket, and
-//  2. The selected auth enables websockets.
-//
-// For non-websocket downstream requests, it always uses the legacy HTTP implementation.
+// CodexAutoExecutor routes Codex requests to WebSockets when the downstream
+// transport requires it or when the embedded Codex model catalog marks the
+// model as preferring WebSockets.
 type CodexAutoExecutor struct {
 	httpExec *CodexExecutor
 	wsExec   *CodexWebsocketsExecutor
@@ -1586,7 +1585,7 @@ func (e *CodexAutoExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth
 	if e == nil || e.httpExec == nil || e.wsExec == nil {
 		return cliproxyexecutor.Response{}, fmt.Errorf("codex auto executor: executor is nil")
 	}
-	if cliproxyexecutor.DownstreamWebsocket(ctx) && codexWebsocketsEnabled(auth) {
+	if codexShouldUseWebsockets(ctx, auth, req.Model) {
 		return e.wsExec.Execute(ctx, auth, req, opts)
 	}
 	return e.httpExec.Execute(ctx, auth, req, opts)
@@ -1596,10 +1595,53 @@ func (e *CodexAutoExecutor) ExecuteStream(ctx context.Context, auth *cliproxyaut
 	if e == nil || e.httpExec == nil || e.wsExec == nil {
 		return nil, fmt.Errorf("codex auto executor: executor is nil")
 	}
-	if cliproxyexecutor.DownstreamWebsocket(ctx) && codexWebsocketsEnabled(auth) {
+	if codexShouldUseWebsockets(ctx, auth, req.Model) {
 		return e.wsExec.ExecuteStream(ctx, auth, req, opts)
 	}
 	return e.httpExec.ExecuteStream(ctx, auth, req, opts)
+}
+
+func codexShouldUseWebsockets(ctx context.Context, auth *cliproxyauth.Auth, model string) bool {
+	if !codexWebsocketsEnabled(auth) {
+		return false
+	}
+	if cliproxyexecutor.DownstreamWebsocket(ctx) {
+		return true
+	}
+	return codexModelRequiresWebsockets(model)
+}
+
+func codexModelRequiresWebsockets(model string) bool {
+	base := thinking.ParseSuffix(model).ModelName
+	if base == "" {
+		return false
+	}
+	codexWSPreferredModelsOnce.Do(loadCodexWSPreferredModels)
+	_, ok := codexWSPreferredModels[base]
+	return ok
+}
+
+var (
+	codexWSPreferredModelsOnce sync.Once
+	codexWSPreferredModels     map[string]struct{}
+)
+
+func loadCodexWSPreferredModels() {
+	codexWSPreferredModels = make(map[string]struct{})
+	models := gjson.GetBytes(registry.GetCodexClientModelsJSON(), "models")
+	if !models.IsArray() {
+		return
+	}
+	for _, model := range models.Array() {
+		if !model.Get("prefer_websockets").Bool() {
+			continue
+		}
+		slug := strings.TrimSpace(model.Get("slug").String())
+		if slug == "" {
+			continue
+		}
+		codexWSPreferredModels[slug] = struct{}{}
+	}
 }
 
 func (e *CodexAutoExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -93,6 +93,77 @@ func TestCodexWebsocketsExecutePreservesPreviousResponseIDUpstream(t *testing.T)
 	}
 }
 
+func TestCodexModelRequiresWebsocketsReadsCatalog(t *testing.T) {
+	cases := []struct {
+		name  string
+		model string
+		want  bool
+	}{
+		{"gpt-5.5 in catalog", "gpt-5.5", true},
+		{"gpt-5.4 in catalog", "gpt-5.4", true},
+		{"gpt-5.4-mini in catalog", "gpt-5.4-mini", true},
+		{"gpt-5.3-codex in catalog", "gpt-5.3-codex", true},
+		{"gpt-5.5 with thinking suffix", "gpt-5.5(low)", true},
+		{"gpt-5-codex not in catalog", "gpt-5-codex", false},
+		{"empty model", "", false},
+		{"unknown model", "claude-3-opus", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := codexModelRequiresWebsockets(tc.model); got != tc.want {
+				t.Fatalf("codexModelRequiresWebsockets(%q) = %v, want %v", tc.model, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCodexAutoExecutorForcesWebsocketsForGPT55OnHTTPDownstream(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	upgraded := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/responses" {
+			t.Errorf("request path = %s, want /responses", r.URL.Path)
+			http.Error(w, "wrong path", http.StatusBadRequest)
+			return
+		}
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		upgraded <- struct{}{}
+
+		if _, _, errRead := conn.ReadMessage(); errRead != nil {
+			return
+		}
+		completed := []byte(`{"type":"response.completed","response":{"id":"resp-1","output":[],"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0}}}`)
+		_ = conn.WriteMessage(websocket.TextMessage, completed)
+	}))
+	defer server.Close()
+
+	auto := NewCodexAutoExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":    "sk-test",
+		"base_url":   server.URL,
+		"websockets": "true",
+	}}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":[{"type":"message","id":"msg-1"}]}`),
+	}
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("codex")}
+
+	if _, err := auto.Execute(context.Background(), auth, req, opts); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	select {
+	case <-upgraded:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected websocket upgrade for gpt-5.5 over HTTP downstream; auto executor fell back to HTTP /responses")
+	}
+}
+
 func TestCodexWebsocketsUpstreamDisconnectChanSignalsOnInvalidate(t *testing.T) {
 	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -22,11 +22,13 @@ import (
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
 	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
 
 const (
 	openAICompatImageHandlerType            = "openai-image"
+	openAICompatResponsesEndpointPath       = "/responses"
 	openAICompatImagesGenerationsPath       = "/images/generations"
 	openAICompatImagesEditsPath             = "/images/edits"
 	openAICompatDefaultImageEndpoint        = openAICompatImagesGenerationsPath
@@ -101,17 +103,23 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("openai")
 	endpoint := "/chat/completions"
+	upstreamStream := opts.Stream
+	useResponsesEndpoint := openAICompatUseResponsesEndpoint(baseModel, opts.Alt)
 	if opts.Alt == "responses/compact" {
 		to = sdktranslator.FromString("openai-response")
 		endpoint = "/responses/compact"
+	} else if useResponsesEndpoint {
+		to = sdktranslator.FromString("codex")
+		endpoint = openAICompatResponsesEndpointPath
+		upstreamStream = true
 	}
 	originalPayloadSource := req.Payload
 	if len(opts.OriginalRequest) > 0 {
 		originalPayloadSource = opts.OriginalRequest
 	}
 	originalPayload := originalPayloadSource
-	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, opts.Stream)
-	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, opts.Stream)
+	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, upstreamStream)
+	translated := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, upstreamStream)
 
 	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
 	if err != nil {
@@ -125,6 +133,10 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		if updated, errDelete := sjson.DeleteBytes(translated, "stream"); errDelete == nil {
 			translated = updated
 		}
+	} else if useResponsesEndpoint {
+		translated, _ = sjson.SetBytes(translated, "model", baseModel)
+		translated, _ = sjson.SetBytes(translated, "stream", true)
+		translated, _ = sjson.DeleteBytes(translated, "stream_options")
 	}
 
 	url := strings.TrimSuffix(baseURL, "/") + endpoint
@@ -185,6 +197,16 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		return resp, err
 	}
 	helps.AppendAPIResponseChunk(ctx, e.cfg, body)
+	if useResponsesEndpoint {
+		out, errTranslate := openAICompatTranslateResponsesNonStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, body, reporter)
+		if errTranslate != nil {
+			err = errTranslate
+			return resp, err
+		}
+		reporter.EnsurePublished(ctx)
+		resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
+		return resp, nil
+	}
 	reporter.Publish(ctx, helps.ParseOpenAIUsage(body))
 	// Ensure we at least record the request even if upstream doesn't return usage
 	reporter.EnsurePublished(ctx)
@@ -193,6 +215,119 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	out := sdktranslator.TranslateNonStream(ctx, to, from, req.Model, opts.OriginalRequest, translated, body, &param)
 	resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
 	return resp, nil
+}
+
+func openAICompatUseResponsesEndpoint(model, alt string) bool {
+	if strings.TrimSpace(alt) != "" {
+		return false
+	}
+	normalized := strings.ToLower(strings.TrimSpace(model))
+	if idx := strings.LastIndex(normalized, "/"); idx >= 0 && idx < len(normalized)-1 {
+		normalized = strings.TrimSpace(normalized[idx+1:])
+	}
+	return normalized == "gpt-5.5" || strings.HasPrefix(normalized, "gpt-5.5-")
+}
+
+func openAICompatTranslateResponsesNonStream(ctx context.Context, to, from sdktranslator.Format, model string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, reporter *helps.UsageReporter) ([]byte, error) {
+	if completed := openAICompatWrapResponsesObject(rawJSON); len(completed) > 0 {
+		if reporter != nil {
+			if detail, ok := helps.ParseCodexUsage(completed); ok {
+				reporter.Publish(ctx, detail)
+			}
+		}
+		var param any
+		return sdktranslator.TranslateNonStream(ctx, to, from, model, originalRequestRawJSON, requestRawJSON, completed, &param), nil
+	}
+
+	outputItemsByIndex := make(map[int64][]byte)
+	var outputItemsFallback [][]byte
+	for _, line := range bytes.Split(rawJSON, []byte("\n")) {
+		trimmedLine := bytes.TrimSpace(line)
+		if !bytes.HasPrefix(trimmedLine, []byte("data:")) {
+			continue
+		}
+		eventData := bytes.TrimSpace(trimmedLine[len("data:"):])
+		if len(eventData) == 0 || bytes.Equal(eventData, []byte("[DONE]")) {
+			continue
+		}
+		if !gjson.ValidBytes(eventData) {
+			return nil, statusErr{code: http.StatusBadGateway, msg: string(eventData)}
+		}
+
+		switch gjson.GetBytes(eventData, "type").String() {
+		case "response.output_item.done":
+			collectCodexOutputItemDone(eventData, outputItemsByIndex, &outputItemsFallback)
+		case "response.completed":
+			if reporter != nil {
+				if detail, ok := helps.ParseCodexUsage(eventData); ok {
+					reporter.Publish(ctx, detail)
+				}
+			}
+			completedData := patchCodexCompletedOutput(eventData, outputItemsByIndex, outputItemsFallback)
+			var param any
+			return sdktranslator.TranslateNonStream(ctx, to, from, model, originalRequestRawJSON, requestRawJSON, completedData, &param), nil
+		case "error", "response.failed":
+			return nil, openAICompatResponsesStreamError(eventData)
+		}
+	}
+	return nil, statusErr{code: http.StatusRequestTimeout, msg: "openai compatibility responses stream disconnected before response.completed"}
+}
+
+func openAICompatWrapResponsesObject(rawJSON []byte) []byte {
+	rawJSON = bytes.TrimSpace(rawJSON)
+	if len(rawJSON) == 0 || !gjson.ValidBytes(rawJSON) {
+		return nil
+	}
+	if gjson.GetBytes(rawJSON, "type").String() == "response.completed" {
+		return rawJSON
+	}
+	if gjson.GetBytes(rawJSON, "object").String() != "response" {
+		return nil
+	}
+	completed := []byte(`{"type":"response.completed","response":{}}`)
+	completed, _ = sjson.SetRawBytes(completed, "response", rawJSON)
+	return completed
+}
+
+func openAICompatResponsesStreamError(eventData []byte) statusErr {
+	status := http.StatusBadGateway
+	errType := strings.ToLower(strings.TrimSpace(firstGJSONString(eventData,
+		"response.error.type",
+		"error.type",
+		"type",
+	)))
+	code := strings.ToLower(strings.TrimSpace(firstGJSONString(eventData,
+		"response.error.code",
+		"error.code",
+		"code",
+	)))
+	if strings.Contains(errType, "invalid") || strings.Contains(code, "invalid") {
+		status = http.StatusBadRequest
+	}
+	message := strings.TrimSpace(firstGJSONString(eventData,
+		"response.error.message",
+		"error.message",
+		"message",
+		"response.error.code",
+		"error.code",
+	))
+	if message == "" {
+		message = string(eventData)
+	}
+	return statusErr{code: status, msg: message}
+}
+
+func firstGJSONString(rawJSON []byte, paths ...string) string {
+	for _, path := range paths {
+		value := gjson.GetBytes(rawJSON, path)
+		if !value.Exists() {
+			continue
+		}
+		if s := strings.TrimSpace(value.String()); s != "" {
+			return s
+		}
+	}
+	return ""
 }
 
 func (e *OpenAICompatExecutor) executeImages(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, endpointPath string) (resp cliproxyexecutor.Response, err error) {
@@ -300,6 +435,12 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 
 	from := opts.SourceFormat
 	to := sdktranslator.FromString("openai")
+	endpoint := "/chat/completions"
+	useResponsesEndpoint := openAICompatUseResponsesEndpoint(baseModel, opts.Alt)
+	if useResponsesEndpoint {
+		to = sdktranslator.FromString("codex")
+		endpoint = openAICompatResponsesEndpointPath
+	}
 	originalPayloadSource := req.Payload
 	if len(opts.OriginalRequest) > 0 {
 		originalPayloadSource = opts.OriginalRequest
@@ -319,9 +460,15 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 
 	// Request usage data in the final streaming chunk so that token statistics
 	// are captured even when the upstream is an OpenAI-compatible provider.
-	translated, _ = sjson.SetBytes(translated, "stream_options.include_usage", true)
+	if useResponsesEndpoint {
+		translated, _ = sjson.SetBytes(translated, "model", baseModel)
+		translated, _ = sjson.SetBytes(translated, "stream", true)
+		translated, _ = sjson.DeleteBytes(translated, "stream_options")
+	} else {
+		translated, _ = sjson.SetBytes(translated, "stream_options.include_usage", true)
+	}
 
-	url := strings.TrimSuffix(baseURL, "/") + "/chat/completions"
+	url := strings.TrimSuffix(baseURL, "/") + endpoint
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(translated))
 	if err != nil {
 		return nil, err
@@ -387,12 +534,17 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
-			if detail, ok := helps.ParseOpenAIStreamUsage(line); ok {
-				reporter.Publish(ctx, detail)
-			}
 			trimmedLine := bytes.TrimSpace(line)
 			if len(trimmedLine) == 0 {
 				continue
+			}
+			if useResponsesEndpoint && bytes.HasPrefix(trimmedLine, []byte("data:")) {
+				payload := bytes.TrimSpace(trimmedLine[len("data:"):])
+				if detail, ok := helps.ParseCodexUsage(payload); ok {
+					reporter.Publish(ctx, detail)
+				}
+			} else if detail, ok := helps.ParseOpenAIStreamUsage(line); ok {
+				reporter.Publish(ctx, detail)
 			}
 
 			if !bytes.HasPrefix(trimmedLine, []byte("data:")) {

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	_ "github.com/router-for-me/CLIProxyAPI/v6/internal/translator"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
@@ -207,6 +209,99 @@ func TestOpenAICompatExecutorPayloadOverrideWinsOverThinkingSuffix(t *testing.T)
 		t.Fatalf("reasoning_effort = %q, want %q; body=%s", got, "low", string(gotBody))
 	}
 }
+
+func TestOpenAICompatExecutorGPT55ChatUsesResponsesEndpoint(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		gotBody = body
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"ok\"}]},\"output_index\":0}\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"created_at\":1775555723,\"status\":\"completed\",\"model\":\"gpt-5.5\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":2,\"total_tokens\":3}}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+	}}
+	resp, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","messages":[{"role":"user","content":"Say ok"}]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if gotPath != "/v1/responses" {
+		t.Fatalf("path = %q, want /v1/responses", gotPath)
+	}
+	if !gjson.GetBytes(gotBody, "stream").Bool() {
+		t.Fatalf("expected upstream responses body to be streaming: %s", string(gotBody))
+	}
+	if !gjson.GetBytes(gotBody, "input").IsArray() {
+		t.Fatalf("expected responses input array in upstream body: %s", string(gotBody))
+	}
+	if gjson.GetBytes(gotBody, "messages").Exists() {
+		t.Fatalf("unexpected chat messages in upstream body: %s", string(gotBody))
+	}
+	if got := gjson.GetBytes(resp.Payload, "choices.0.message.content").String(); got != "ok" {
+		t.Fatalf("choices.0.message.content = %q, want ok; payload=%s", got, string(resp.Payload))
+	}
+}
+
+func TestOpenAICompatExecutorGPT55ChatStreamUsesResponsesEndpoint(t *testing.T) {
+	var gotPath string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		gotBody = body
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_2\",\"object\":\"response\",\"created_at\":1775555723,\"status\":\"in_progress\",\"model\":\"gpt-5.5\"}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.output_text.delta\",\"delta\":\"hello\"}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_2\",\"object\":\"response\",\"created_at\":1775555723,\"status\":\"completed\",\"model\":\"gpt-5.5\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":2,\"total_tokens\":3}}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+	}}
+	streamResult, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","messages":[{"role":"user","content":"Say hello"}],"stream":true}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+	var streamed bytes.Buffer
+	for chunk := range streamResult.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+		streamed.Write(chunk.Payload)
+	}
+	if gotPath != "/v1/responses" {
+		t.Fatalf("path = %q, want /v1/responses", gotPath)
+	}
+	if !gjson.GetBytes(gotBody, "stream").Bool() {
+		t.Fatalf("expected upstream responses body to be streaming: %s", string(gotBody))
+	}
+	if !strings.Contains(streamed.String(), `"content":"hello"`) {
+		t.Fatalf("streamed chunks = %q", streamed.String())
+	}
+}
+
 func TestOpenAICompatExecutorStreamRejectsPlainJSONAfterBlankLines(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")


### PR DESCRIPTION
## Summary
- selectively ports upstream #3513 runtime routing for GPT-5.5-compatible models
- routes Codex HTTP-downstream requests through the WebSocket executor when the embedded Codex model catalog marks the model `prefer_websockets`
- routes OpenAI-compatible `gpt-5.5` chat requests to `/responses`, translates non-stream and stream responses back to the downstream OpenAI shape, and preserves usage reporting
- adds focused tests for catalog-driven WebSocket routing and OpenAI-compatible `/responses` routing

## LTS compatibility
- scoped to `internal/runtime/executor` and executor tests
- does not modify `internal/translator/**`, config schema, Management API, `internal/usage/`, `usage-statistics-enabled`, or `/v0/management/usage*`
- preserves existing `/responses/compact` behavior and image endpoint routing

## Validation
- `go test ./internal/runtime/executor -run 'TestCodexModelRequiresWebsockets|TestCodexAutoExecutorForcesWebsockets|TestOpenAICompatExecutorGPT55' -count=1`\n- `git diff --check`\n- `go test ./internal/runtime/executor -count=1`\n- `go test ./internal/runtime/executor/helps ./internal/translator/codex/openai/... ./internal/translator/openai/openai/responses ./test -count=1`\n- `go build -o test-output ./cmd/server && rm -f test-output`\n- `go test ./...`\n