### PR TITLE
[codex] Drop orphan xAI tool choice

### DIFF
--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -709,18 +709,21 @@ func normalizeXAITools(body []byte) []byte {
 	return updated
 }
 
-// normalizeXAIToolChoiceForTools prevents xAI from rejecting payloads that
-// carry tool_choice without any tools after xAI-specific tool filtering.
+// normalizeXAIToolChoiceForTools prevents xAI from rejecting payloads that carry
+// tool metadata without any tools after xAI-specific tool filtering.
 func normalizeXAIToolChoiceForTools(body []byte) []byte {
 	tools := gjson.GetBytes(body, "tools")
-	if tools.Exists() && tools.IsArray() && len(tools.Array()) == 0 {
-		body, _ = sjson.DeleteBytes(body, "tools")
-		body, _ = sjson.DeleteBytes(body, "tool_choice")
-		body, _ = sjson.DeleteBytes(body, "parallel_tool_calls")
+	hasTools := tools.Exists() && tools.IsArray() && len(tools.Array()) > 0
+	if hasTools {
 		return body
 	}
-	if !tools.Exists() && gjson.GetBytes(body, "tool_choice").Exists() {
+	if tools.Exists() {
+		body, _ = sjson.DeleteBytes(body, "tools")
+	}
+	if gjson.GetBytes(body, "tool_choice").Exists() {
 		body, _ = sjson.DeleteBytes(body, "tool_choice")
+	}
+	if gjson.GetBytes(body, "parallel_tool_calls").Exists() {
 		body, _ = sjson.DeleteBytes(body, "parallel_tool_calls")
 	}
 	return body

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -499,6 +499,7 @@ func (e *XAIExecutor) prepareResponsesRequest(ctx context.Context, req cliproxye
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
 	body, _ = sjson.DeleteBytes(body, "stream_options")
 	body = normalizeXAITools(body)
+	body = normalizeXAIToolChoiceForTools(body)
 	body = normalizeXAIInputReasoningItems(body)
 	body = normalizeCodexInstructions(body)
 	body = sanitizeXAIResponsesBody(body, baseModel)
@@ -706,6 +707,23 @@ func normalizeXAITools(body []byte) []byte {
 		return body
 	}
 	return updated
+}
+
+// normalizeXAIToolChoiceForTools prevents xAI from rejecting payloads that
+// carry tool_choice without any tools after xAI-specific tool filtering.
+func normalizeXAIToolChoiceForTools(body []byte) []byte {
+	tools := gjson.GetBytes(body, "tools")
+	if tools.Exists() && tools.IsArray() && len(tools.Array()) == 0 {
+		body, _ = sjson.DeleteBytes(body, "tools")
+		body, _ = sjson.DeleteBytes(body, "tool_choice")
+		body, _ = sjson.DeleteBytes(body, "parallel_tool_calls")
+		return body
+	}
+	if !tools.Exists() && gjson.GetBytes(body, "tool_choice").Exists() {
+		body, _ = sjson.DeleteBytes(body, "tool_choice")
+		body, _ = sjson.DeleteBytes(body, "parallel_tool_calls")
+	}
+	return body
 }
 
 func normalizeXAITool(tool gjson.Result) ([]byte, bool, bool) {

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -592,3 +592,57 @@ func TestXAIExecutorExecuteVideosUsesNativeEndpointFromRequestPath(t *testing.T)
 		})
 	}
 }
+
+func TestNormalizeXAIToolChoiceForToolsDropsWhenToolsEmpty(t *testing.T) {
+	body := []byte(`{"model":"grok-4","tools":[],"tool_choice":"auto","parallel_tool_calls":true,"input":"hi"}`)
+	out := normalizeXAIToolChoiceForTools(body)
+
+	if gjson.GetBytes(out, "tools").Exists() {
+		t.Fatalf("empty tools should be removed: %s", string(out))
+	}
+	if gjson.GetBytes(out, "tool_choice").Exists() {
+		t.Fatalf("tool_choice should be removed when tools empty: %s", string(out))
+	}
+	if gjson.GetBytes(out, "parallel_tool_calls").Exists() {
+		t.Fatalf("parallel_tool_calls should be removed when tools empty: %s", string(out))
+	}
+}
+
+func TestNormalizeXAIToolChoiceForToolsDropsWhenToolsMissing(t *testing.T) {
+	body := []byte(`{"model":"grok-4","tool_choice":"auto","parallel_tool_calls":true,"input":"hi"}`)
+	out := normalizeXAIToolChoiceForTools(body)
+
+	if gjson.GetBytes(out, "tool_choice").Exists() {
+		t.Fatalf("tool_choice should be removed when tools missing: %s", string(out))
+	}
+	if gjson.GetBytes(out, "parallel_tool_calls").Exists() {
+		t.Fatalf("parallel_tool_calls should be removed when tools missing: %s", string(out))
+	}
+}
+
+func TestNormalizeXAIToolChoiceForToolsKeepsWhenToolsPresent(t *testing.T) {
+	body := []byte(`{"model":"grok-4","tools":[{"type":"function","name":"Bash"}],"tool_choice":"auto","parallel_tool_calls":true,"input":"hi"}`)
+	out := normalizeXAIToolChoiceForTools(body)
+
+	if !gjson.GetBytes(out, "tools").Exists() {
+		t.Fatalf("tools should be kept: %s", string(out))
+	}
+	if got := gjson.GetBytes(out, "tool_choice").String(); got != "auto" {
+		t.Fatalf("tool_choice = %q, want auto: %s", got, string(out))
+	}
+	if !gjson.GetBytes(out, "parallel_tool_calls").Bool() {
+		t.Fatalf("parallel_tool_calls should be kept: %s", string(out))
+	}
+}
+
+func TestNormalizeXAIToolChoiceForToolsNoOpWhenBothAbsent(t *testing.T) {
+	body := []byte(`{"model":"grok-4","input":"hi"}`)
+	out := normalizeXAIToolChoiceForTools(body)
+
+	if gjson.GetBytes(out, "tool_choice").Exists() {
+		t.Fatalf("tool_choice should not appear: %s", string(out))
+	}
+	if gjson.GetBytes(out, "parallel_tool_calls").Exists() {
+		t.Fatalf("parallel_tool_calls should not appear: %s", string(out))
+	}
+}

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -620,6 +620,15 @@ func TestNormalizeXAIToolChoiceForToolsDropsWhenToolsMissing(t *testing.T) {
 	}
 }
 
+func TestNormalizeXAIToolChoiceForToolsDropsOrphanedParallelToolCalls(t *testing.T) {
+	body := []byte(`{"model":"grok-4","parallel_tool_calls":true,"input":"hi"}`)
+	out := normalizeXAIToolChoiceForTools(body)
+
+	if gjson.GetBytes(out, "parallel_tool_calls").Exists() {
+		t.Fatalf("parallel_tool_calls should be removed when tools missing even without tool_choice: %s", string(out))
+	}
+}
+
 func TestNormalizeXAIToolChoiceForToolsKeepsWhenToolsPresent(t *testing.T) {
 	body := []byte(`{"model":"grok-4","tools":[{"type":"function","name":"Bash"}],"tool_choice":"auto","parallel_tool_calls":true,"input":"hi"}`)
 	out := normalizeXAIToolChoiceForTools(body)


### PR DESCRIPTION
## Summary
- Selectively port the xAI executor safety net from upstream router-for-me/CLIProxyAPI#3649 without touching translator paths.
- Drop empty tools, orphan tool_choice, and parallel_tool_calls after xAI tool filtering so xAI does not reject payloads with no usable tools.
- Add regression coverage for empty, missing, present, and absent tool metadata.

## LTS compatibility
- Does not touch internal/usage, Management usage endpoints, config schema, auth files, SDK public types, or internal/translator.
- Preserves the LTS usage statistics contract and avoids the translator-path guard.

## Validation
- go test ./internal/runtime/executor -run 'TestNormalizeXAIToolChoiceForTools|TestXAIExecutor' -count=1
- git diff --check
- go test ./internal/runtime/executor -count=1
- go build -o test-output ./cmd/server && rm -f test-output
- go test ./...