### PR TITLE
[codex] Type roundtripper context key

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -1620,9 +1620,7 @@ func (e *AntigravityExecutor) ensureAccessToken(ctx context.Context, auth *clipr
 	}
 	refreshCtx := context.Background()
 	if ctx != nil {
-		if rt, ok := ctx.Value("cliproxy.roundtripper").(http.RoundTripper); ok && rt != nil {
-			refreshCtx = context.WithValue(refreshCtx, "cliproxy.roundtripper", rt)
-		}
+		refreshCtx = cliproxyexecutor.WithRoundTripper(refreshCtx, cliproxyexecutor.RoundTripper(ctx))
 	}
 	updated, errRefresh := e.refreshToken(refreshCtx, auth.Clone())
 	if errRefresh != nil {
@@ -1674,9 +1672,7 @@ func (e *AntigravityExecutor) maybeRefreshAntigravityCreditsHint(ctx context.Con
 
 	refreshCtx := context.Background()
 	if ctx != nil {
-		if rt, ok := ctx.Value("cliproxy.roundtripper").(http.RoundTripper); ok && rt != nil {
-			refreshCtx = context.WithValue(refreshCtx, "cliproxy.roundtripper", rt)
-		}
+		refreshCtx = cliproxyexecutor.WithRoundTripper(refreshCtx, cliproxyexecutor.RoundTripper(ctx))
 	}
 	refreshCtx, cancel := context.WithTimeout(refreshCtx, antigravityCreditsHintRefreshTimeout)
 	authCopy := auth.Clone()

--- a/internal/runtime/executor/antigravity_executor_buildrequest_test.go
+++ b/internal/runtime/executor/antigravity_executor_buildrequest_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 )
 
 func TestAntigravityBuildRequest_SanitizesGeminiToolSchema(t *testing.T) {
@@ -116,7 +117,7 @@ func TestAntigravityPrepareRequestAuth_FetchesMissingProjectID(t *testing.T) {
 		"access_token": "token",
 		"expired":      time.Now().Add(1 * time.Hour).Format(time.RFC3339),
 	}}
-	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	ctx := cliproxyexecutor.WithRoundTripper(context.Background(), roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		if req.URL.String() != "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist" {
 			t.Fatalf("unexpected project discovery request: %s", req.URL.String())
 		}

--- a/internal/runtime/executor/antigravity_executor_credits_test.go
+++ b/internal/runtime/executor/antigravity_executor_credits_test.go
@@ -399,7 +399,7 @@ func TestEnsureAccessToken_WarmTokenLoadsCreditsHint(t *testing.T) {
 			"expired":      time.Now().Add(1 * time.Hour).Format(time.RFC3339),
 		},
 	}
-	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	ctx := cliproxyexecutor.WithRoundTripper(context.Background(), roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		if req.URL.String() != "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist" {
 			t.Fatalf("unexpected request url %s", req.URL.String())
 		}
@@ -450,7 +450,7 @@ func TestUpdateAntigravityCreditsBalance_LoadCodeAssistUserAgent(t *testing.T) {
 		ID:         "auth-load-code-assist-ua",
 		Attributes: map[string]string{"user_agent": configuredUserAgent},
 	}
-	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+	ctx := cliproxyexecutor.WithRoundTripper(context.Background(), roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		if req.URL.String() != "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist" {
 			t.Fatalf("unexpected request url %s", req.URL.String())
 		}

--- a/internal/runtime/executor/helps/proxy_helpers.go
+++ b/internal/runtime/executor/helps/proxy_helpers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/proxyutil"
 	log "github.com/sirupsen/logrus"
 )
@@ -54,7 +55,7 @@ func NewProxyAwareHTTPClient(ctx context.Context, cfg *config.Config, auth *clip
 	}
 
 	// Priority 3: Use RoundTripper from context (typically from RoundTripperFor)
-	if rt, ok := ctx.Value("cliproxy.roundtripper").(http.RoundTripper); ok && rt != nil {
+	if rt := cliproxyexecutor.RoundTripper(ctx); rt != nil {
 		httpClient.Transport = rt
 	}
 

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1328,8 +1328,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 		tried[auth.ID] = struct{}{}
 		execCtx := ctx
 		if rt := m.roundTripperFor(auth); rt != nil {
-			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
-			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
+			execCtx = cliproxyexecutor.WithRoundTripper(execCtx, rt)
 		}
 		execCtx = contextWithUsageMetadata(execCtx, opts, routeModel)
 
@@ -1418,8 +1417,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 		tried[auth.ID] = struct{}{}
 		execCtx := ctx
 		if rt := m.roundTripperFor(auth); rt != nil {
-			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
-			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
+			execCtx = cliproxyexecutor.WithRoundTripper(execCtx, rt)
 		}
 		execCtx = contextWithUsageMetadata(execCtx, opts, routeModel)
 
@@ -1508,8 +1506,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 		tried[auth.ID] = struct{}{}
 		execCtx := ctx
 		if rt := m.roundTripperFor(auth); rt != nil {
-			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
-			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
+			execCtx = cliproxyexecutor.WithRoundTripper(execCtx, rt)
 		}
 		execCtx = contextWithUsageMetadata(execCtx, opts, routeModel)
 		models, pooled := m.preparedExecutionModels(auth, routeModel)
@@ -3278,8 +3275,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 		}
 		creditsCtx := WithAntigravityCredits(ctx)
 		if rt := m.roundTripperFor(c.auth); rt != nil {
-			creditsCtx = context.WithValue(creditsCtx, roundTripperContextKey{}, rt)
-			creditsCtx = context.WithValue(creditsCtx, "cliproxy.roundtripper", rt)
+			creditsCtx = cliproxyexecutor.WithRoundTripper(creditsCtx, rt)
 		}
 		creditsOpts := ensureRequestedModelMetadata(opts, routeModel)
 		creditsCtx = contextWithUsageMetadata(creditsCtx, creditsOpts, routeModel)
@@ -3326,8 +3322,7 @@ func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cl
 		}
 		creditsCtx := WithAntigravityCredits(ctx)
 		if rt := m.roundTripperFor(c.auth); rt != nil {
-			creditsCtx = context.WithValue(creditsCtx, roundTripperContextKey{}, rt)
-			creditsCtx = context.WithValue(creditsCtx, "cliproxy.roundtripper", rt)
+			creditsCtx = cliproxyexecutor.WithRoundTripper(creditsCtx, rt)
 		}
 		creditsOpts := ensureRequestedModelMetadata(opts, routeModel)
 		creditsCtx = contextWithUsageMetadata(creditsCtx, creditsOpts, routeModel)
@@ -3732,9 +3727,6 @@ func (m *Manager) executorFor(provider string) ProviderExecutor {
 	defer m.mu.RUnlock()
 	return m.executors[provider]
 }
-
-// roundTripperContextKey is an unexported context key type to avoid collisions.
-type roundTripperContextKey struct{}
 
 // roundTripperFor retrieves an HTTP RoundTripper for the given auth if a provider is registered.
 func (m *Manager) roundTripperFor(auth *Auth) http.RoundTripper {

--- a/sdk/cliproxy/executor/context.go
+++ b/sdk/cliproxy/executor/context.go
@@ -1,6 +1,32 @@
 package executor
 
-import "context"
+import (
+	"context"
+	"net/http"
+)
+
+type roundTripperContextKey struct{}
+
+// WithRoundTripper attaches a per-auth HTTP RoundTripper to the context so
+// downstream executors can reuse the credential's configured transport.
+func WithRoundTripper(ctx context.Context, rt http.RoundTripper) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if rt == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, roundTripperContextKey{}, rt)
+}
+
+// RoundTripper returns the per-auth HTTP RoundTripper stored with WithRoundTripper.
+func RoundTripper(ctx context.Context) http.RoundTripper {
+	if ctx == nil {
+		return nil
+	}
+	rt, _ := ctx.Value(roundTripperContextKey{}).(http.RoundTripper)
+	return rt
+}
 
 type downstreamWebsocketContextKey struct{}
 


### PR DESCRIPTION
## Summary
- Selectively port the typed RoundTripper context-key portion of upstream router-for-me/CLIProxyAPI#3636.
- Add sdk/cliproxy/executor.WithRoundTripper and RoundTripper helpers with an unexported typed key.
- Replace cross-package string context key usage in the auth conductor, proxy helper, and Antigravity refresh/test paths.

## LTS compatibility
- Does not port the larger conductor retry-loop or mixed-once refactors from #3636.
- Does not touch internal/usage, Management usage endpoints, config schema, auth file schema, internal/translator, or release workflows.
- Public SDK change is additive only.

## Validation
- go test ./sdk/cliproxy/... ./internal/runtime/executor/helps ./internal/runtime/executor -run 'TestAntigravity|TestEnsureAccessToken|TestUpdateAntigravityCreditsBalance' -count=1
- go vet ./sdk/cliproxy/auth/... ./sdk/cliproxy/executor/... ./internal/runtime/executor/...
- git diff --check
- go test ./sdk/cliproxy/... ./internal/runtime/executor/helps ./internal/runtime/executor -count=1
- go build -o test-output ./cmd/server && rm -f test-output
- go test ./...