### PR TITLE
[codex] Add trusted proxies config

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -5,6 +5,13 @@ host: ""
 # Server port
 port: 8317
 
+# Trusted proxies used to resolve the real client IP from forwarded headers.
+# When omitted or empty, forwarded client IP headers are ignored.
+# Add only reverse proxies you control; this sample covers local loopback proxies.
+trusted-proxies:
+  - "127.0.0.0/8"
+  - "::1"
+
 # TLS settings for HTTPS. When enabled, the server listens with the provided certificate and key.
 tls:
   enable: false

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -5,6 +5,7 @@ package management
 import (
 	"crypto/subtle"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -157,7 +158,7 @@ func (h *Handler) Middleware() gin.HandlerFunc {
 		c.Header("X-CPA-COMMIT", buildinfo.Commit)
 		c.Header("X-CPA-BUILD-DATE", buildinfo.BuildDate)
 
-		clientIP := c.ClientIP()
+		clientIP := directClientIP(c.Request.RemoteAddr)
 		localClient := clientIP == "127.0.0.1" || clientIP == "::1"
 
 		// Accept either Authorization: Bearer <key> or X-Management-Key
@@ -181,6 +182,14 @@ func (h *Handler) Middleware() gin.HandlerFunc {
 		}
 		c.Next()
 	}
+}
+
+func directClientIP(remoteAddr string) string {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err == nil {
+		return host
+	}
+	return remoteAddr
 }
 
 // AuthenticateManagementKey verifies the provided management key for the given client.

--- a/internal/api/handlers/management/handler_test.go
+++ b/internal/api/handlers/management/handler_test.go
@@ -2,9 +2,11 @@ package management
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 )
 
@@ -34,5 +36,38 @@ func TestAuthenticateManagementKey_LocalhostIPBan_BlocksCorrectKeyDuringBan(t *t
 	}
 	if !strings.HasPrefix(errMsg, "IP banned due to too many failed attempts. Try again in") {
 		t.Fatalf("unexpected banned message: %q", errMsg)
+	}
+}
+
+func TestMiddlewareDoesNotTrustForwardedLoopbackHeader(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := &Handler{
+		cfg:            &config.Config{},
+		failedAttempts: make(map[string]*attemptInfo),
+		localPassword:  "local-secret",
+	}
+
+	router := gin.New()
+	if err := router.SetTrustedProxies([]string{"192.0.2.0/24"}); err != nil {
+		t.Fatalf("SetTrustedProxies: %v", err)
+	}
+	router.GET("/v0/management/ping", h.Middleware(), func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/ping", nil)
+	req.RemoteAddr = "192.0.2.10:52345"
+	req.Header.Set("X-Forwarded-For", "127.0.0.1")
+	req.Header.Set("Authorization", "Bearer local-secret")
+	resp := httptest.NewRecorder()
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d; body=%s", resp.Code, http.StatusForbidden, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "remote management disabled") {
+		t.Fatalf("body = %q, want remote management disabled", resp.Body.String())
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -213,8 +213,15 @@ func NewServer(cfg *config.Config, authManager *auth.Manager, accessManager *sdk
 
 	// Create gin engine
 	engine := gin.New()
-	if errSetTrustedProxies := engine.SetTrustedProxies(nil); errSetTrustedProxies != nil {
-		log.Warnf("failed to disable trusted proxy headers: %v", errSetTrustedProxies)
+	trustedProxies := []string(nil)
+	if cfg.TrustedProxies != nil {
+		trustedProxies = cfg.TrustedProxies
+	}
+	if errSetTrustedProxies := engine.SetTrustedProxies(trustedProxies); errSetTrustedProxies != nil {
+		log.WithError(errSetTrustedProxies).Warn("failed to configure trusted proxies; disabling trusted proxy headers")
+		if errDisableTrustedProxies := engine.SetTrustedProxies(nil); errDisableTrustedProxies != nil {
+			log.WithError(errDisableTrustedProxies).Warn("failed to disable trusted proxy headers after trusted proxy configuration error")
+		}
 	}
 	if optionState.engineConfigurator != nil {
 		optionState.engineConfigurator(engine)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/redisqueue"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
 )
@@ -396,6 +397,73 @@ func assertCodexSupportedReasoningLevels(t *testing.T, model map[string]any, wan
 		if got, _ := levelEntry["effort"].(string); got != want[index] {
 			t.Fatalf("supported_reasoning_levels[%d].effort = %q, want %q", index, got, want[index])
 		}
+	}
+}
+
+func TestServerTrustedProxiesConfigControlsClientIP(t *testing.T) {
+	testCases := []struct {
+		name           string
+		trustedProxies []string
+		remoteAddr     string
+		wantClientIP   string
+	}{
+		{
+			name:           "omitted config disables forwarded headers",
+			trustedProxies: nil,
+			remoteAddr:     "10.0.0.10:12345",
+			wantClientIP:   "10.0.0.10",
+		},
+		{
+			name:           "explicit empty disables forwarded headers",
+			trustedProxies: []string{},
+			remoteAddr:     "10.0.0.10:12345",
+			wantClientIP:   "10.0.0.10",
+		},
+		{
+			name:           "trusted proxy uses forwarded header",
+			trustedProxies: []string{"10.0.0.0/8"},
+			remoteAddr:     "10.0.0.10:12345",
+			wantClientIP:   "203.0.113.7",
+		},
+		{
+			name:           "invalid proxy config falls back to disabled headers",
+			trustedProxies: []string{"10.0.0.0/8", "not-a-proxy"},
+			remoteAddr:     "10.0.0.10:12345",
+			wantClientIP:   "10.0.0.10",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			cfg := &proxyconfig.Config{
+				TrustedProxies: tc.trustedProxies,
+				AuthDir:        t.TempDir(),
+				Debug:          true,
+			}
+			authManager := auth.NewManager(nil, nil, nil)
+			accessManager := sdkaccess.NewManager()
+			server := NewServer(cfg, authManager, accessManager, filepath.Join(t.TempDir(), "config.yaml"), WithRouterConfigurator(func(engine *gin.Engine, _ *handlers.BaseAPIHandler, _ *proxyconfig.Config) {
+				engine.GET("/client-ip", func(c *gin.Context) {
+					c.String(http.StatusOK, c.ClientIP())
+				})
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/client-ip", nil)
+			req.RemoteAddr = tc.remoteAddr
+			req.Header.Set("X-Forwarded-For", "203.0.113.7")
+			rr := httptest.NewRecorder()
+
+			server.engine.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+			}
+			if got := rr.Body.String(); got != tc.wantClientIP {
+				t.Fatalf("ClientIP = %q, want %q", got, tc.wantClientIP)
+			}
+		})
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,9 @@ type Config struct {
 	Host string `yaml:"host" json:"-"`
 	// Port is the network port on which the API server will listen.
 	Port int `yaml:"port" json:"-"`
+	// TrustedProxies configures Gin trusted proxies for resolving client IPs from forwarded headers.
+	// Nil means the key was omitted; the server keeps LTS-safe behavior by disabling forwarded header trust.
+	TrustedProxies []string `yaml:"trusted-proxies" json:"trusted-proxies"`
 
 	// TLS config controls HTTPS server settings.
 	TLS TLSConfig `yaml:"tls" json:"tls"`
@@ -685,6 +688,8 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 		cfg.Pprof.Addr = DefaultPprofAddr
 	}
 
+	cfg.SanitizeTrustedProxies()
+
 	if cfg.LogsMaxTotalSizeMB < 0 {
 		cfg.LogsMaxTotalSizeMB = 0
 	}
@@ -751,6 +756,22 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 
 	// Return the populated configuration struct.
 	return &cfg, nil
+}
+
+// SanitizeTrustedProxies trims configured Gin trusted proxies and drops empty entries.
+func (cfg *Config) SanitizeTrustedProxies() {
+	if cfg == nil || cfg.TrustedProxies == nil {
+		return
+	}
+	out := make([]string, 0, len(cfg.TrustedProxies))
+	for _, proxy := range cfg.TrustedProxies {
+		trimmed := strings.TrimSpace(proxy)
+		if trimmed == "" {
+			continue
+		}
+		out = append(out, trimmed)
+	}
+	cfg.TrustedProxies = out
 }
 
 // SanitizePayloadRules validates raw JSON payload rule params and drops invalid rules.

--- a/internal/config/trusted_proxies_test.go
+++ b/internal/config/trusted_proxies_test.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestLoadConfigOptional_TrustedProxies(t *testing.T) {
+	testCases := []struct {
+		name    string
+		yaml    string
+		want    []string
+		wantNil bool
+	}{
+		{
+			name:    "omitted",
+			yaml:    "port: 8317\n",
+			wantNil: true,
+		},
+		{
+			name: "custom trims and drops empty entries",
+			yaml: `
+trusted-proxies:
+  - "  10.0.0.0/8  "
+  - ""
+  - "  192.168.1.10  "
+`,
+			want: []string{"10.0.0.0/8", "192.168.1.10"},
+		},
+		{
+			name: "explicit empty",
+			yaml: "trusted-proxies: []\n",
+			want: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			configPath := filepath.Join(dir, "config.yaml")
+			if err := os.WriteFile(configPath, []byte(tc.yaml), 0o600); err != nil {
+				t.Fatalf("failed to write config: %v", err)
+			}
+
+			cfg, err := LoadConfigOptional(configPath, false)
+			if err != nil {
+				t.Fatalf("LoadConfigOptional() error = %v", err)
+			}
+
+			if tc.wantNil {
+				if cfg.TrustedProxies != nil {
+					t.Fatalf("TrustedProxies = %#v, want nil", cfg.TrustedProxies)
+				}
+				return
+			}
+			if !slices.Equal(cfg.TrustedProxies, tc.want) {
+				t.Fatalf("TrustedProxies = %#v, want %#v", cfg.TrustedProxies, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- selectively ports upstream `router-for-me/CLIProxyAPI#3150` trusted proxy configuration
- adds `trusted-proxies` YAML/JSON config support and trims empty entries during config load
- keeps the LTS-safe default: omitted or empty `trusted-proxies` disables forwarded client IP header trust
- falls back to disabled trusted proxy headers when Gin rejects an invalid trusted proxy entry
- hardens Management API localhost checks to use direct `RemoteAddr`, so explicitly trusted proxies cannot turn spoofed `X-Forwarded-For: 127.0.0.1` into local-management access

## LTS compatibility
- does not touch `internal/usage/` or `/v0/management/usage*`
- does not change the Go module path
- does not touch translator paths, auth files, or panel download source
- preserves the existing spoofed `X-Forwarded-For` protection even when users opt in to trusted proxy parsing for ordinary request client IPs

## Validation
- `go test ./internal/config -run TrustedProxies -count=1`
- `go test ./internal/api -run TrustedProxies -count=1`
- `go test ./internal/api/handlers/management -run 'TestMiddlewareDoesNotTrustForwardedLoopbackHeader|TestAuthenticateManagementKey' -count=1`
- `git diff --check`
- `go test ./internal/config ./internal/api ./internal/api/handlers/management -count=1`
- `go build -o test-output ./cmd/server && rm -f test-output`
- `go test ./...`
