### PR TITLE
[codex] Harden auth token file permissions

### DIFF
--- a/internal/auth/claude/token.go
+++ b/internal/auth/claude/token.go
@@ -57,7 +57,7 @@ func (ts *ClaudeTokenStorage) SetMetadata(meta map[string]any) {
 //
 // Returns:
 //   - error: An error if the operation fails, nil otherwise
-func (ts *ClaudeTokenStorage) SaveTokenToFile(authFilePath string) error {
+func (ts *ClaudeTokenStorage) SaveTokenToFile(authFilePath string) (err error) {
 	misc.LogSavingCredentials(authFilePath)
 	ts.Type = "claude"
 
@@ -66,14 +66,20 @@ func (ts *ClaudeTokenStorage) SaveTokenToFile(authFilePath string) error {
 		return fmt.Errorf("failed to create directory: %v", err)
 	}
 
-	// Create the token file
-	f, err := os.Create(authFilePath)
+	// Create the token file with private permissions, and also tighten
+	// permissions when replacing an existing wider file.
+	f, err := os.OpenFile(authFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to create token file: %w", err)
 	}
 	defer func() {
-		_ = f.Close()
+		if errClose := f.Close(); errClose != nil && err == nil {
+			err = fmt.Errorf("failed to close token file: %w", errClose)
+		}
 	}()
+	if err = f.Chmod(0o600); err != nil {
+		return fmt.Errorf("failed to set token file permissions: %w", err)
+	}
 
 	// Merge metadata using helper
 	data, errMerge := misc.MergeMetadata(ts, ts.Metadata)

--- a/internal/auth/claude/token_test.go
+++ b/internal/auth/claude/token_test.go
@@ -1,0 +1,29 @@
+package claude
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveTokenToFileUsesPrivatePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "claude.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("precreate token file: %v", err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("chmod token file: %v", err)
+	}
+
+	if err := (&ClaudeTokenStorage{}).SaveTokenToFile(path); err != nil {
+		t.Fatalf("SaveTokenToFile: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat token file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("mode = %v, want 0600", got)
+	}
+}

--- a/internal/auth/codex/token.go
+++ b/internal/auth/codex/token.go
@@ -53,20 +53,25 @@ func (ts *CodexTokenStorage) SetMetadata(meta map[string]any) {
 //
 // Returns:
 //   - error: An error if the operation fails, nil otherwise
-func (ts *CodexTokenStorage) SaveTokenToFile(authFilePath string) error {
+func (ts *CodexTokenStorage) SaveTokenToFile(authFilePath string) (err error) {
 	misc.LogSavingCredentials(authFilePath)
 	ts.Type = "codex"
 	if err := os.MkdirAll(filepath.Dir(authFilePath), 0700); err != nil {
 		return fmt.Errorf("failed to create directory: %v", err)
 	}
 
-	f, err := os.Create(authFilePath)
+	f, err := os.OpenFile(authFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to create token file: %w", err)
 	}
 	defer func() {
-		_ = f.Close()
+		if errClose := f.Close(); errClose != nil && err == nil {
+			err = fmt.Errorf("failed to close token file: %w", errClose)
+		}
 	}()
+	if err = f.Chmod(0o600); err != nil {
+		return fmt.Errorf("failed to set token file permissions: %w", err)
+	}
 
 	// Merge metadata using helper
 	data, errMerge := misc.MergeMetadata(ts, ts.Metadata)

--- a/internal/auth/codex/token_test.go
+++ b/internal/auth/codex/token_test.go
@@ -1,0 +1,29 @@
+package codex
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveTokenToFileUsesPrivatePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "codex.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("precreate token file: %v", err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("chmod token file: %v", err)
+	}
+
+	if err := (&CodexTokenStorage{}).SaveTokenToFile(path); err != nil {
+		t.Fatalf("SaveTokenToFile: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat token file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("mode = %v, want 0600", got)
+	}
+}

--- a/internal/auth/gemini/gemini_token.go
+++ b/internal/auth/gemini/gemini_token.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
-	log "github.com/sirupsen/logrus"
 )
 
 // GeminiTokenStorage stores OAuth2 token information for Google Gemini API authentication.
@@ -56,7 +55,7 @@ func (ts *GeminiTokenStorage) SetMetadata(meta map[string]any) {
 //
 // Returns:
 //   - error: An error if the operation fails, nil otherwise
-func (ts *GeminiTokenStorage) SaveTokenToFile(authFilePath string) error {
+func (ts *GeminiTokenStorage) SaveTokenToFile(authFilePath string) (err error) {
 	misc.LogSavingCredentials(authFilePath)
 	ts.Type = "gemini"
 	// Merge metadata using helper
@@ -68,19 +67,22 @@ func (ts *GeminiTokenStorage) SaveTokenToFile(authFilePath string) error {
 		return fmt.Errorf("failed to create directory: %v", err)
 	}
 
-	f, err := os.Create(authFilePath)
+	f, err := os.OpenFile(authFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to create token file: %w", err)
 	}
 	defer func() {
-		if errClose := f.Close(); errClose != nil {
-			log.Errorf("failed to close file: %v", errClose)
+		if errClose := f.Close(); errClose != nil && err == nil {
+			err = fmt.Errorf("failed to close token file: %w", errClose)
 		}
 	}()
+	if err = f.Chmod(0o600); err != nil {
+		return fmt.Errorf("failed to set token file permissions: %w", err)
+	}
 
 	enc := json.NewEncoder(f)
 	enc.SetIndent("", "  ")
-	if err := enc.Encode(data); err != nil {
+	if err = enc.Encode(data); err != nil {
 		return fmt.Errorf("failed to write token to file: %w", err)
 	}
 	return nil

--- a/internal/auth/gemini/gemini_token_test.go
+++ b/internal/auth/gemini/gemini_token_test.go
@@ -1,0 +1,29 @@
+package gemini
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveTokenToFileUsesPrivatePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gemini.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("precreate token file: %v", err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("chmod token file: %v", err)
+	}
+
+	if err := (&GeminiTokenStorage{}).SaveTokenToFile(path); err != nil {
+		t.Fatalf("SaveTokenToFile: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat token file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("mode = %v, want 0600", got)
+	}
+}

--- a/internal/auth/kimi/token.go
+++ b/internal/auth/kimi/token.go
@@ -79,7 +79,7 @@ type DeviceCodeResponse struct {
 }
 
 // SaveTokenToFile serializes the Kimi token storage to a JSON file.
-func (ts *KimiTokenStorage) SaveTokenToFile(authFilePath string) error {
+func (ts *KimiTokenStorage) SaveTokenToFile(authFilePath string) (err error) {
 	misc.LogSavingCredentials(authFilePath)
 	ts.Type = "kimi"
 
@@ -87,13 +87,18 @@ func (ts *KimiTokenStorage) SaveTokenToFile(authFilePath string) error {
 		return fmt.Errorf("failed to create directory: %v", err)
 	}
 
-	f, err := os.Create(authFilePath)
+	f, err := os.OpenFile(authFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to create token file: %w", err)
 	}
 	defer func() {
-		_ = f.Close()
+		if errClose := f.Close(); errClose != nil && err == nil {
+			err = fmt.Errorf("failed to close token file: %w", errClose)
+		}
 	}()
+	if err = f.Chmod(0o600); err != nil {
+		return fmt.Errorf("failed to set token file permissions: %w", err)
+	}
 
 	// Merge metadata using helper
 	data, errMerge := misc.MergeMetadata(ts, ts.Metadata)

--- a/internal/auth/kimi/token_test.go
+++ b/internal/auth/kimi/token_test.go
@@ -1,0 +1,29 @@
+package kimi
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveTokenToFileUsesPrivatePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "kimi.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("precreate token file: %v", err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("chmod token file: %v", err)
+	}
+
+	if err := (&KimiTokenStorage{}).SaveTokenToFile(path); err != nil {
+		t.Fatalf("SaveTokenToFile: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat token file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("mode = %v, want 0600", got)
+	}
+}

--- a/internal/auth/vertex/vertex_credentials.go
+++ b/internal/auth/vertex/vertex_credentials.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
-	log "github.com/sirupsen/logrus"
 )
 
 // VertexCredentialStorage stores the service account JSON for Vertex AI access.
@@ -38,7 +37,7 @@ type VertexCredentialStorage struct {
 
 // SaveTokenToFile writes the credential payload to the given file path in JSON format.
 // It ensures the parent directory exists and logs the operation for transparency.
-func (s *VertexCredentialStorage) SaveTokenToFile(authFilePath string) error {
+func (s *VertexCredentialStorage) SaveTokenToFile(authFilePath string) (err error) {
 	misc.LogSavingCredentials(authFilePath)
 	if s == nil {
 		return fmt.Errorf("vertex credential: storage is nil")
@@ -52,15 +51,18 @@ func (s *VertexCredentialStorage) SaveTokenToFile(authFilePath string) error {
 	if err := os.MkdirAll(filepath.Dir(authFilePath), 0o700); err != nil {
 		return fmt.Errorf("vertex credential: create directory failed: %w", err)
 	}
-	f, err := os.Create(authFilePath)
+	f, err := os.OpenFile(authFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("vertex credential: create file failed: %w", err)
 	}
 	defer func() {
-		if errClose := f.Close(); errClose != nil {
-			log.Errorf("vertex credential: failed to close file: %v", errClose)
+		if errClose := f.Close(); errClose != nil && err == nil {
+			err = fmt.Errorf("vertex credential: close file failed: %w", errClose)
 		}
 	}()
+	if err = f.Chmod(0o600); err != nil {
+		return fmt.Errorf("vertex credential: set file permissions failed: %w", err)
+	}
 	enc := json.NewEncoder(f)
 	enc.SetIndent("", "  ")
 	if err = enc.Encode(s); err != nil {

--- a/internal/auth/vertex/vertex_credentials_test.go
+++ b/internal/auth/vertex/vertex_credentials_test.go
@@ -1,0 +1,32 @@
+package vertex
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveTokenToFileUsesPrivatePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vertex.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("precreate credential file: %v", err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("chmod credential file: %v", err)
+	}
+	storage := &VertexCredentialStorage{
+		ServiceAccount: map[string]any{"project_id": "test"},
+	}
+
+	if err := storage.SaveTokenToFile(path); err != nil {
+		t.Fatalf("SaveTokenToFile: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat token file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("mode = %v, want 0600", got)
+	}
+}

--- a/internal/auth/xai/token.go
+++ b/internal/auth/xai/token.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/misc"
-	log "github.com/sirupsen/logrus"
 )
 
 // TokenStorage stores xAI OAuth credentials on disk.
@@ -38,22 +37,25 @@ func (ts *TokenStorage) SetMetadata(meta map[string]any) {
 }
 
 // SaveTokenToFile writes xAI credentials to a JSON auth file.
-func (ts *TokenStorage) SaveTokenToFile(authFilePath string) error {
+func (ts *TokenStorage) SaveTokenToFile(authFilePath string) (err error) {
 	misc.LogSavingCredentials(authFilePath)
 	ts.Type = "xai"
 	ts.AuthKind = "oauth"
 	if errMkdirAll := os.MkdirAll(filepath.Dir(authFilePath), 0o700); errMkdirAll != nil {
 		return fmt.Errorf("xai token storage: create directory: %w", errMkdirAll)
 	}
-	file, err := os.Create(authFilePath)
+	file, err := os.OpenFile(authFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("xai token storage: create token file: %w", err)
 	}
 	defer func() {
-		if errClose := file.Close(); errClose != nil {
-			log.Errorf("xai token storage: close token file error: %v", errClose)
+		if errClose := file.Close(); errClose != nil && err == nil {
+			err = fmt.Errorf("xai token storage: close token file: %w", errClose)
 		}
 	}()
+	if err = file.Chmod(0o600); err != nil {
+		return fmt.Errorf("xai token storage: set token file permissions: %w", err)
+	}
 
 	data, errMerge := misc.MergeMetadata(ts, ts.Metadata)
 	if errMerge != nil {

--- a/internal/auth/xai/token_test.go
+++ b/internal/auth/xai/token_test.go
@@ -1,0 +1,29 @@
+package xai
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveTokenToFileUsesPrivatePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "xai.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("precreate token file: %v", err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("chmod token file: %v", err)
+	}
+
+	if err := (&TokenStorage{}).SaveTokenToFile(path); err != nil {
+		t.Fatalf("SaveTokenToFile: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat token file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("mode = %v, want 0600", got)
+	}
+}


### PR DESCRIPTION
## Summary
- selectively ports the auth-file permission hardening slice from upstream `router-for-me/CLIProxyAPI#3160`
- writes provider OAuth/service-account token files with `0600` permissions instead of `os.Create`
- explicitly `Chmod(0600)` after opening so replacing an existing wider file also tightens permissions
- returns close errors from token writers instead of silently dropping them
- extends the hardening to the LTS xAI OAuth token writer, which has the same file-permission pattern

## LTS compatibility
- does not touch `internal/usage/` or `/v0/management/usage*`
- does not change auth file JSON shape, filenames, provider type values, or Management API responses
- does not touch translator paths, config schema, SDK public types, or panel download source
- keeps existing auth metadata merge behavior intact

## Validation
- `go test ./internal/auth/claude ./internal/auth/codex ./internal/auth/gemini ./internal/auth/kimi ./internal/auth/vertex ./internal/auth/xai -run SaveTokenToFileUsesPrivatePermissions -count=1`
- `git diff --check`
- `go test ./internal/auth/claude ./internal/auth/codex ./internal/auth/gemini ./internal/auth/kimi ./internal/auth/vertex ./internal/auth/xai -count=1`
- `go build -o test-output ./cmd/server && rm -f test-output`
- `go test ./...`
