### PR TITLE
[codex] Guard object store auth paths

### DIFF
--- a/internal/store/objectstore.go
+++ b/internal/store/objectstore.go
@@ -445,7 +445,7 @@ func (s *ObjectTokenStore) uploadAuth(ctx context.Context, path string) error {
 	if path == "" {
 		return nil
 	}
-	rel, err := filepath.Rel(s.authDir, path)
+	rel, err := s.authRelativePath(path)
 	if err != nil {
 		return fmt.Errorf("object store: resolve auth relative path: %w", err)
 	}
@@ -467,7 +467,7 @@ func (s *ObjectTokenStore) deleteAuthObject(ctx context.Context, path string) er
 	if path == "" {
 		return nil
 	}
-	rel, err := filepath.Rel(s.authDir, path)
+	rel, err := s.authRelativePath(path)
 	if err != nil {
 		return fmt.Errorf("object store: resolve auth relative path: %w", err)
 	}
@@ -516,10 +516,7 @@ func (s *ObjectTokenStore) resolveAuthPath(auth *cliproxyauth.Auth) (string, err
 	}
 	if auth.Attributes != nil {
 		if path := strings.TrimSpace(auth.Attributes["path"]); path != "" {
-			if filepath.IsAbs(path) {
-				return path, nil
-			}
-			return filepath.Join(s.authDir, path), nil
+			return s.authPath(path)
 		}
 	}
 	fileName := strings.TrimSpace(auth.FileName)
@@ -532,7 +529,7 @@ func (s *ObjectTokenStore) resolveAuthPath(auth *cliproxyauth.Auth) (string, err
 	if !strings.HasSuffix(strings.ToLower(fileName), ".json") {
 		fileName += ".json"
 	}
-	return filepath.Join(s.authDir, fileName), nil
+	return s.authPath(fileName)
 }
 
 func (s *ObjectTokenStore) resolveDeletePath(id string) (string, error) {
@@ -540,9 +537,8 @@ func (s *ObjectTokenStore) resolveDeletePath(id string) (string, error) {
 	if id == "" {
 		return "", fmt.Errorf("object store: id is empty")
 	}
-	// Absolute paths are honored as-is; callers must ensure they point inside the mirror.
 	if filepath.IsAbs(id) {
-		return id, nil
+		return s.authPath(id)
 	}
 	// Treat any non-absolute id (including nested like "team/foo") as relative to the mirror authDir.
 	// Normalize separators and guard against path traversal.
@@ -554,7 +550,40 @@ func (s *ObjectTokenStore) resolveDeletePath(id string) (string, error) {
 	if !strings.HasSuffix(strings.ToLower(clean), ".json") {
 		clean += ".json"
 	}
-	return filepath.Join(s.authDir, clean), nil
+	return s.authPath(clean)
+}
+
+func (s *ObjectTokenStore) authPath(path string) (string, error) {
+	var candidate string
+	if filepath.IsAbs(path) {
+		candidate = path
+	} else {
+		candidate = filepath.Join(s.authDir, filepath.FromSlash(path))
+	}
+	rel, err := s.authRelativePath(candidate)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(s.authDir, rel), nil
+}
+
+func (s *ObjectTokenStore) authRelativePath(path string) (string, error) {
+	authDir, err := filepath.Abs(s.authDir)
+	if err != nil {
+		return "", err
+	}
+	authPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(authDir, authPath)
+	if err != nil {
+		return "", err
+	}
+	if rel == "." || rel == ".." || filepath.IsAbs(rel) || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("auth path %q escapes auth directory", path)
+	}
+	return rel, nil
 }
 
 func (s *ObjectTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth, error) {

--- a/internal/store/objectstore_test.go
+++ b/internal/store/objectstore_test.go
@@ -1,0 +1,56 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestObjectTokenStoreRejectsAuthPathsOutsideAuthDir(t *testing.T) {
+	authDir := t.TempDir()
+	outsideDir := t.TempDir()
+	outsidePath := filepath.Join(outsideDir, "token.json")
+
+	store := &ObjectTokenStore{authDir: authDir}
+
+	if _, err := store.resolveAuthPath(&cliproxyauth.Auth{
+		ID:         "outside",
+		Attributes: map[string]string{"path": outsidePath},
+	}); err == nil {
+		t.Fatal("resolveAuthPath accepted absolute path outside auth dir")
+	}
+	if _, err := store.resolveAuthPath(&cliproxyauth.Auth{
+		ID:       "traversal",
+		FileName: "../token.json",
+	}); err == nil {
+		t.Fatal("resolveAuthPath accepted path traversal")
+	}
+	if _, err := store.resolveDeletePath(outsidePath); err == nil {
+		t.Fatal("resolveDeletePath accepted absolute path outside auth dir")
+	}
+	if err := store.uploadAuth(context.Background(), outsidePath); err == nil {
+		t.Fatal("uploadAuth accepted absolute path outside auth dir")
+	}
+	if err := store.deleteAuthObject(context.Background(), outsidePath); err == nil {
+		t.Fatal("deleteAuthObject accepted absolute path outside auth dir")
+	}
+}
+
+func TestObjectTokenStoreAcceptsNestedAuthPathInsideAuthDir(t *testing.T) {
+	authDir := t.TempDir()
+	store := &ObjectTokenStore{authDir: authDir}
+
+	got, err := store.resolveAuthPath(&cliproxyauth.Auth{
+		ID:       "nested",
+		FileName: "team/token",
+	})
+	if err != nil {
+		t.Fatalf("resolveAuthPath returned error: %v", err)
+	}
+	want := filepath.Join(authDir, "team", "token.json")
+	if got != want {
+		t.Fatalf("resolveAuthPath = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- selectively ports the object-store auth path boundary slice from upstream `router-for-me/CLIProxyAPI#3160`
- rejects object-store auth file paths that escape the local auth mirror directory
- applies the same boundary helper to save, delete, upload, and object-delete paths
- keeps nested auth paths inside the mirror working

## LTS compatibility
- does not touch `internal/usage/` or `/v0/management/usage*`
- does not change auth JSON shape, provider IDs, filenames, or Management API response shapes
- does not touch translator paths, config schema, SDK public types, or panel download source
- tightens only invalid/out-of-mirror object-store paths

## Validation
- `go test ./internal/store -run ObjectTokenStore -count=1`
- `git diff --check`
- `go test ./internal/store -count=1`
- `go build -o test-output ./cmd/server && rm -f test-output`
- `go test ./...`
