### PR TITLE
[codex] Surface auth store list errors

### DIFF
--- a/internal/store/gitstore.go
+++ b/internal/store/gitstore.go
@@ -363,7 +363,7 @@ func (s *GitTokenStore) List(_ context.Context) ([]*cliproxyauth.Auth, error) {
 		}
 		auth, err := s.readAuthFile(path, dir)
 		if err != nil {
-			return nil
+			return fmt.Errorf("auth gitstore: read auth file %q: %w", path, err)
 		}
 		if auth != nil {
 			entries = append(entries, auth)

--- a/internal/store/gitstore_test.go
+++ b/internal/store/gitstore_test.go
@@ -1,10 +1,12 @@
 package store
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -43,6 +45,41 @@ func TestEnsureRepositoryUsesRemoteDefaultBranchWhenBranchNotConfigured(t *testi
 
 	assertRepositoryBranchAndContents(t, filepath.Join(root, "workspace"), "trunk", "remote default branch updated\n")
 	assertRemoteHeadBranch(t, remoteDir, "trunk")
+}
+
+func TestGitTokenStoreListReturnsAuthFileErrors(t *testing.T) {
+	root := t.TempDir()
+	remoteDir := setupGitRemoteRepository(t, root, "main",
+		testBranchSpec{name: "main", contents: "remote default branch\n"},
+	)
+
+	authDir := filepath.Join(root, "workspace", "auths")
+	store := NewGitTokenStore(remoteDir, "", "", "")
+	store.SetBaseDir(authDir)
+
+	if err := store.EnsureRepository(); err != nil {
+		t.Fatalf("EnsureRepository: %v", err)
+	}
+	if err := os.MkdirAll(authDir, 0o700); err != nil {
+		t.Fatalf("create auth dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(authDir, "valid.json"), []byte(`{"type":"custom"}`), 0o600); err != nil {
+		t.Fatalf("write valid auth: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(authDir, "broken.json"), []byte(`{"type":`), 0o600); err != nil {
+		t.Fatalf("write broken auth: %v", err)
+	}
+
+	entries, err := store.List(context.Background())
+	if err == nil {
+		t.Fatal("List succeeded, want error for broken auth file")
+	}
+	if entries != nil {
+		t.Fatalf("entries = %#v, want nil on error", entries)
+	}
+	if !strings.Contains(err.Error(), "broken.json") {
+		t.Fatalf("error = %q, want broken file path", err.Error())
+	}
 }
 
 func TestEnsureRepositoryUsesConfiguredBranchWhenExplicitlySet(t *testing.T) {

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -145,7 +145,7 @@ func (s *FileTokenStore) List(ctx context.Context) ([]*cliproxyauth.Auth, error)
 		}
 		auth, err := s.readAuthFile(path, dir)
 		if err != nil {
-			return nil
+			return fmt.Errorf("auth filestore: read auth file %q: %w", path, err)
 		}
 		if auth != nil {
 			entries = append(entries, auth)

--- a/sdk/auth/filestore_test.go
+++ b/sdk/auth/filestore_test.go
@@ -1,6 +1,12 @@
 package auth
 
-import "testing"
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestExtractAccessToken(t *testing.T) {
 	t.Parallel()
@@ -76,5 +82,29 @@ func TestExtractAccessToken(t *testing.T) {
 				t.Errorf("extractAccessToken() = %q, want %q", got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestFileTokenStoreListReturnsAuthFileErrors(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "valid.json"), []byte(`{"type":"custom"}`), 0o600); err != nil {
+		t.Fatalf("write valid auth: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "broken.json"), []byte(`{"type":`), 0o600); err != nil {
+		t.Fatalf("write broken auth: %v", err)
+	}
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(dir)
+
+	entries, err := store.List(context.Background())
+	if err == nil {
+		t.Fatal("List succeeded, want error for broken auth file")
+	}
+	if entries != nil {
+		t.Fatalf("entries = %#v, want nil on error", entries)
+	}
+	if !strings.Contains(err.Error(), "broken.json") {
+		t.Fatalf("error = %q, want broken file path", err.Error())
 	}
 }


### PR DESCRIPTION
## Summary
- Selectively port the auth-store list error behavior from upstream router-for-me/CLIProxyAPI#3160.
- Return explicit errors when file-backed or git-backed auth stores encounter corrupt auth JSON instead of silently skipping the credential.
- Add regression coverage that verifies the broken file path is present in the returned error.

## LTS compatibility
- Does not change the v6 module path, config schema, usage statistics contract, Management API response shape, or CPA-Panel-LTS expectations.
- Leaves valid and empty auth JSON handling unchanged; only malformed auth files now fail loudly during List.

## Validation
- `go test ./sdk/auth -run FileTokenStoreListReturnsAuthFileErrors -count=1`
- `go test ./internal/store -run GitTokenStoreListReturnsAuthFileErrors -count=1`
- `git diff --check`
- `go test ./sdk/auth ./internal/store -count=1`
- `go build -o test-output ./cmd/server && rm -f test-output`
- `go test ./...`