### PR TITLE
[codex] Harden Gemini handler errors

### DIFF
--- a/sdk/api/handlers/gemini/gemini-cli_handlers.go
+++ b/sdk/api/handlers/gemini/gemini-cli_handlers.go
@@ -76,7 +76,16 @@ func (h *GeminiCLIAPIHandler) CLIHandler(c *gin.Context) {
 		return
 	}
 
-	rawJSON, _ := c.GetRawData()
+	rawJSON, err := c.GetRawData()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, handlers.ErrorResponse{
+			Error: handlers.ErrorDetail{
+				Message: fmt.Sprintf("Invalid request: %v", err),
+				Type:    "invalid_request_error",
+			},
+		})
+		return
+	}
 	requestRawURI := c.Request.URL.Path
 
 	if requestRawURI == "/v1internal:generateContent" {
@@ -130,7 +139,9 @@ func (h *GeminiCLIAPIHandler) CLIHandler(c *gin.Context) {
 		}
 
 		defer func() {
-			_ = resp.Body.Close()
+			if errClose := resp.Body.Close(); errClose != nil {
+				log.WithError(errClose).Warn("failed to close response body")
+			}
 		}()
 
 		for key, value := range resp.Header {
@@ -138,7 +149,13 @@ func (h *GeminiCLIAPIHandler) CLIHandler(c *gin.Context) {
 		}
 		output, err := io.ReadAll(resp.Body)
 		if err != nil {
-			log.Errorf("Failed to read response body: %v", err)
+			log.WithError(err).Error("failed to read response body")
+			c.JSON(http.StatusBadGateway, handlers.ErrorResponse{
+				Error: handlers.ErrorDetail{
+					Message: "failed to read upstream response body",
+					Type:    "upstream_error",
+				},
+			})
 			return
 		}
 		c.Set("API_RESPONSE_TIMESTAMP", time.Now())

--- a/sdk/api/handlers/gemini/gemini_handlers.go
+++ b/sdk/api/handlers/gemini/gemini_handlers.go
@@ -151,7 +151,16 @@ func (h *GeminiAPIHandler) GeminiHandler(c *gin.Context) {
 	}
 
 	method := action[1]
-	rawJSON, _ := c.GetRawData()
+	rawJSON, err := c.GetRawData()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, handlers.ErrorResponse{
+			Error: handlers.ErrorDetail{
+				Message: fmt.Sprintf("Invalid request: %v", err),
+				Type:    "invalid_request_error",
+			},
+		})
+		return
+	}
 
 	switch method {
 	case "generateContent":
@@ -160,6 +169,13 @@ func (h *GeminiAPIHandler) GeminiHandler(c *gin.Context) {
 		h.handleStreamGenerateContent(c, action[0], rawJSON)
 	case "countTokens":
 		h.handleCountTokens(c, action[0], rawJSON)
+	default:
+		c.JSON(http.StatusNotFound, handlers.ErrorResponse{
+			Error: handlers.ErrorDetail{
+				Message: fmt.Sprintf("%s not found.", c.Request.URL.Path),
+				Type:    "invalid_request_error",
+			},
+		})
 	}
 }
 

--- a/sdk/api/handlers/gemini/gemini_handlers_test.go
+++ b/sdk/api/handlers/gemini/gemini_handlers_test.go
@@ -1,0 +1,70 @@
+package gemini
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
+	"github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+)
+
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("read failed") }
+func (errReader) Close() error             { return nil }
+
+func TestGeminiHandlerUnknownMethodReturnsNotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	handler := NewGeminiAPIHandler(&handlers.BaseAPIHandler{})
+	router.POST("/v1beta/models/*action", handler.GeminiHandler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-test:unknownMethod", strings.NewReader(`{}`))
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d; body=%s", resp.Code, http.StatusNotFound, resp.Body.String())
+	}
+}
+
+func TestGeminiHandlerBodyReadErrorReturnsBadRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	handler := NewGeminiAPIHandler(&handlers.BaseAPIHandler{})
+	router.POST("/v1beta/models/*action", handler.GeminiHandler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-test:generateContent", errReader{})
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", resp.Code, http.StatusBadRequest, resp.Body.String())
+	}
+}
+
+func TestGeminiCLIHandlerBodyReadErrorReturnsBadRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	handler := NewGeminiCLIAPIHandler(&handlers.BaseAPIHandler{
+		Cfg: &config.SDKConfig{EnableGeminiCLIEndpoint: true},
+	})
+	router.POST("/v1internal:method", handler.CLIHandler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1internal:generateContent", errReader{})
+	req.Host = "127.0.0.1"
+	req.RemoteAddr = "127.0.0.1:34567"
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", resp.Code, http.StatusBadRequest, resp.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- Selectively port the Gemini handler robustness slice from upstream router-for-me/CLIProxyAPI#3160.
- Return `400` when Gemini or Gemini CLI handlers fail to read the request body instead of continuing with an empty body.
- Return `404` for unsupported Gemini API methods and `502` if the Gemini CLI upstream response body cannot be read.
- Add handler regression tests for bad request bodies and unsupported methods.

## LTS compatibility
- Scope is limited to `sdk/api/handlers/gemini`; no config schema, usage statistics, Management API, auth-store, translator, or CPA-Panel-LTS contract changes.
- Keeps existing supported methods and routing unchanged.

## Validation
- `go test ./sdk/api/handlers/gemini -run 'TestGeminiHandlerUnknownMethodReturnsNotFound|TestGeminiHandlerBodyReadErrorReturnsBadRequest|TestGeminiCLIHandlerBodyReadErrorReturnsBadRequest' -count=1`
- `git diff --check`
- `go test ./sdk/api/handlers/gemini -count=1`
- `go build -o test-output ./cmd/server && rm -f test-output`
- `go test ./...`