### PR TITLE
[codex] Guard Antigravity stream sends on cancel

### DIFF
--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -894,12 +894,19 @@ attemptLoop:
 						reporter.Publish(ctx, detail)
 					}
 
-					out <- cliproxyexecutor.StreamChunk{Payload: payload}
+					select {
+					case out <- cliproxyexecutor.StreamChunk{Payload: payload}:
+					case <-ctx.Done():
+						return
+					}
 				}
 				if errScan := scanner.Err(); errScan != nil {
 					helps.RecordAPIResponseError(ctx, e.cfg, errScan)
 					reporter.PublishFailure(ctx)
-					out <- cliproxyexecutor.StreamChunk{Err: errScan}
+					select {
+					case out <- cliproxyexecutor.StreamChunk{Err: errScan}:
+					case <-ctx.Done():
+					}
 				} else {
 					reporter.EnsurePublished(ctx)
 				}


### PR DESCRIPTION
## Summary
- Complete the remaining Antigravity slice of upstream router-for-me/CLIProxyAPI#3205.
- Replace the last direct stream result channel sends in the Antigravity stream-to-non-stream path with context-aware sends.
- Preserve existing streaming, usage publication, retry, and response conversion behavior while allowing cancellation to exit promptly.

## LTS compatibility
- Scope is limited to `internal/runtime/executor/antigravity_executor.go`.
- Does not touch config schema, Management API, usage response shape, translator files, auth files, or CPA-Panel-LTS contracts.

## Validation
- `git diff --check`
- `go test ./internal/runtime/executor -count=1`
- `go build -o test-output ./cmd/server && rm -f test-output`
- `go test ./...`