### PR TITLE
[codex] Preserve compact response evidence

### DIFF
--- a/internal/logging/global_logger.go
+++ b/internal/logging/global_logger.go
@@ -30,7 +30,33 @@ var (
 type LogFormatter struct{}
 
 // logFieldOrder defines the display order for common log fields.
-var logFieldOrder = []string{"provider", "model", "mode", "budget", "level", "original_mode", "original_value", "min", "max", "clamped_to", "error"}
+var logFieldOrder = []string{
+	"provider",
+	"model",
+	"mode",
+	"budget",
+	"level",
+	"original_mode",
+	"original_value",
+	"min",
+	"max",
+	"clamped_to",
+	"compact_input_item_count",
+	"compact_input_assistant_count",
+	"compact_input_tool_call_count",
+	"compact_input_tool_output_count",
+	"compact_output_has_evidence",
+	"compact_same_turn_evidence_hit",
+	"compact_same_turn_evidence_skipped",
+	"compact_same_turn_evidence_skip_reason",
+	"compact_response_evidence_augmented",
+	"compact_fail_reason",
+	"compact_output_item_count",
+	"compact_output_assistant_count",
+	"compact_output_tool_call_count",
+	"compact_output_tool_output_count",
+	"error",
+}
 
 // Format renders a single log entry with custom formatting.
 func (m *LogFormatter) Format(entry *log.Entry) ([]byte, error) {

--- a/internal/logging/global_logger_test.go
+++ b/internal/logging/global_logger_test.go
@@ -1,0 +1,65 @@
+package logging
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func TestLogFormatterIncludesCompactEvidenceFields(t *testing.T) {
+	entry := &log.Entry{
+		Time:    time.Date(2026, 5, 8, 1, 2, 3, 0, time.UTC),
+		Level:   log.InfoLevel,
+		Message: "openai responses compact evidence diagnostic",
+		Data: log.Fields{
+			"compact_input_item_count":               4,
+			"compact_input_assistant_count":          1,
+			"compact_input_tool_call_count":          1,
+			"compact_input_tool_output_count":        1,
+			"compact_output_has_evidence":            false,
+			"compact_same_turn_evidence_hit":         true,
+			"compact_same_turn_evidence_skipped":     true,
+			"compact_same_turn_evidence_skip_reason": "tool_output_without_prior_call",
+			"compact_response_evidence_augmented":    true,
+			"compact_fail_reason":                    "none",
+			"compact_output_item_count":              4,
+			"compact_output_assistant_count":         1,
+			"compact_output_tool_call_count":         1,
+			"compact_output_tool_output_count":       1,
+			"raw_body":                               "SECRET_PROMPT_TEXT",
+		},
+	}
+
+	out, err := (&LogFormatter{}).Format(entry)
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		"compact_input_item_count=4",
+		"compact_input_assistant_count=1",
+		"compact_input_tool_call_count=1",
+		"compact_input_tool_output_count=1",
+		"compact_output_has_evidence=false",
+		"compact_same_turn_evidence_hit=true",
+		"compact_same_turn_evidence_skipped=true",
+		"compact_same_turn_evidence_skip_reason=tool_output_without_prior_call",
+		"compact_response_evidence_augmented=true",
+		"compact_fail_reason=none",
+		"compact_output_item_count=4",
+		"compact_output_assistant_count=1",
+		"compact_output_tool_call_count=1",
+		"compact_output_tool_output_count=1",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("formatted log missing %q: %s", want, got)
+		}
+	}
+	for _, forbidden := range []string{"SECRET_PROMPT_TEXT", "raw_body="} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("formatted log leaked %q: %s", forbidden, got)
+		}
+	}
+}

--- a/sdk/api/handlers/openai/openai_responses_compact_evidence.go
+++ b/sdk/api/handlers/openai/openai_responses_compact_evidence.go
@@ -1,0 +1,262 @@
+package openai
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const (
+	compactEvidenceFailNone                 = "none"
+	compactEvidenceFailInvalidSameTurnInput = "invalid_same_turn_evidence"
+	compactEvidenceSkipNone                 = "none"
+	compactEvidenceSkipToolOutputBeforeCall = "tool_output_without_prior_call"
+)
+
+type compactEvidenceDiagnostic struct {
+	compactOutputHasEvidence         bool
+	sameTurnEvidenceHit              bool
+	sameTurnEvidenceSkipped          bool
+	sameTurnEvidenceSkipReason       string
+	compactResponseEvidenceAugmented bool
+	failReason                       string
+	inputCounts                      compactEvidenceCounts
+	outputCounts                     compactEvidenceCounts
+}
+
+type compactEvidenceCounts struct {
+	itemCount             int
+	assistantMessageCount int
+	toolCallCount         int
+	toolCallOutputCount   int
+}
+
+func compactResponseWithSameTurnEvidence(requestJSON, responseJSON []byte) ([]byte, compactEvidenceDiagnostic, error) {
+	diagnostic := compactEvidenceDiagnostic{
+		failReason:                 compactEvidenceFailNone,
+		sameTurnEvidenceSkipReason: compactEvidenceSkipNone,
+		inputCounts:                compactEvidenceInputCounts(requestJSON),
+	}
+
+	outputJSON, outputPath := compactResponseOutputJSON(gjson.ParseBytes(responseJSON))
+	outputResult := gjson.ParseBytes(normalizeCompactOutputJSON(outputJSON))
+	diagnostic.outputCounts, diagnostic.compactOutputHasEvidence = compactEvidenceCountsAndHasEvidence(outputResult)
+	if diagnostic.compactOutputHasEvidence {
+		return responseJSON, diagnostic, nil
+	}
+
+	evidence, errEvidence := compactSameTurnEvidenceJSON(requestJSON)
+	diagnostic.sameTurnEvidenceHit = evidence.hit
+	diagnostic.sameTurnEvidenceSkipped = evidence.skipped
+	diagnostic.sameTurnEvidenceSkipReason = evidence.skipReason
+	if errEvidence != nil {
+		diagnostic.failReason = compactEvidenceFailInvalidSameTurnInput
+		return nil, diagnostic, errEvidence
+	}
+	if !evidence.hit {
+		return responseJSON, diagnostic, nil
+	}
+
+	mergedOutput, errMerge := mergeJSONArrayRaw(string(outputJSON), evidence.rawJSON)
+	if errMerge != nil {
+		diagnostic.failReason = compactEvidenceFailInvalidSameTurnInput
+		return nil, diagnostic, fmt.Errorf("merge compact evidence: %w", errMerge)
+	}
+	updated, errSet := compactSetResponseOutputJSON(responseJSON, outputPath, []byte(mergedOutput))
+	if errSet != nil {
+		diagnostic.failReason = compactEvidenceFailInvalidSameTurnInput
+		return nil, diagnostic, fmt.Errorf("set compact response output: %w", errSet)
+	}
+
+	diagnostic.compactResponseEvidenceAugmented = true
+	diagnostic.outputCounts = compactEvidenceOutputCounts([]byte(mergedOutput))
+	return updated, diagnostic, nil
+}
+
+func logCompactEvidenceDiagnostic(diagnostic compactEvidenceDiagnostic) {
+	fields := log.Fields{
+		"compact_input_item_count":               diagnostic.inputCounts.itemCount,
+		"compact_input_assistant_count":          diagnostic.inputCounts.assistantMessageCount,
+		"compact_input_tool_call_count":          diagnostic.inputCounts.toolCallCount,
+		"compact_input_tool_output_count":        diagnostic.inputCounts.toolCallOutputCount,
+		"compact_output_has_evidence":            diagnostic.compactOutputHasEvidence,
+		"compact_same_turn_evidence_hit":         diagnostic.sameTurnEvidenceHit,
+		"compact_same_turn_evidence_skipped":     diagnostic.sameTurnEvidenceSkipped,
+		"compact_same_turn_evidence_skip_reason": diagnostic.sameTurnEvidenceSkipReason,
+		"compact_response_evidence_augmented":    diagnostic.compactResponseEvidenceAugmented,
+		"compact_fail_reason":                    diagnostic.failReason,
+		"compact_output_item_count":              diagnostic.outputCounts.itemCount,
+		"compact_output_assistant_count":         diagnostic.outputCounts.assistantMessageCount,
+		"compact_output_tool_call_count":         diagnostic.outputCounts.toolCallCount,
+		"compact_output_tool_output_count":       diagnostic.outputCounts.toolCallOutputCount,
+	}
+	if diagnostic.failReason != compactEvidenceFailNone {
+		log.WithFields(fields).Warn("openai responses compact evidence diagnostic")
+		return
+	}
+	log.WithFields(fields).Info("openai responses compact evidence diagnostic")
+}
+
+type compactSameTurnEvidence struct {
+	rawJSON    string
+	hit        bool
+	skipped    bool
+	skipReason string
+}
+
+func compactSameTurnEvidenceJSON(rawJSON []byte) (compactSameTurnEvidence, error) {
+	evidence := compactSameTurnEvidence{
+		rawJSON:    "[]",
+		skipReason: compactEvidenceSkipNone,
+	}
+	input := gjson.GetBytes(rawJSON, "input")
+	if !input.IsArray() {
+		return evidence, nil
+	}
+
+	tail := compactLatestTailWindow(input)
+	if len(tail) == 0 {
+		return evidence, nil
+	}
+
+	seenCallIDs := make(map[string]struct{}, len(tail))
+	items := make([]string, 0, len(tail))
+	for _, item := range tail {
+		itemType := strings.TrimSpace(item.Get("type").String())
+		if itemType == "message" && strings.TrimSpace(item.Get("role").String()) == "assistant" {
+			items = append(items, item.Raw)
+			continue
+		}
+		if isResponsesToolCallType(itemType) {
+			callID := strings.TrimSpace(item.Get("call_id").String())
+			if callID == "" {
+				continue
+			}
+			items = append(items, item.Raw)
+			seenCallIDs[callID] = struct{}{}
+			continue
+		}
+		if isResponsesToolCallOutputType(itemType) {
+			callID := strings.TrimSpace(item.Get("call_id").String())
+			if _, ok := seenCallIDs[callID]; ok {
+				items = append(items, item.Raw)
+				continue
+			}
+			evidence.skipped = true
+			evidence.skipReason = compactEvidenceSkipToolOutputBeforeCall
+		}
+	}
+	if len(items) == 0 {
+		return evidence, nil
+	}
+
+	evidence.rawJSON = "[" + strings.Join(items, ",") + "]"
+	evidence.hit = true
+	return evidence, nil
+}
+
+func compactLatestTailWindow(input gjson.Result) []gjson.Result {
+	if !input.IsArray() {
+		return nil
+	}
+	array := input.Array()
+	tailStart := -1
+	for i, item := range array {
+		if isCompactTailMarker(item) {
+			tailStart = i + 1
+		}
+	}
+	if tailStart < 0 || tailStart >= len(array) {
+		return nil
+	}
+	return array[tailStart:]
+}
+
+func isCompactTailMarker(item gjson.Result) bool {
+	itemType := strings.TrimSpace(item.Get("type").String())
+	if itemType == "compaction" || itemType == "compaction_summary" {
+		return true
+	}
+	return (itemType == "" || itemType == "message") && strings.TrimSpace(item.Get("role").String()) == "user"
+}
+
+func compactResponseOutputJSON(root gjson.Result) ([]byte, string) {
+	for _, path := range []string{"output", "response.output"} {
+		output := root.Get(path)
+		if output.Exists() && output.IsArray() {
+			return []byte(output.Raw), path
+		}
+	}
+	return []byte("[]"), "output"
+}
+
+func compactSetResponseOutputJSON(payload []byte, outputPath string, outputJSON []byte) ([]byte, error) {
+	outputPath = strings.TrimSpace(outputPath)
+	if outputPath == "" {
+		outputPath = "output"
+	}
+	return sjson.SetRawBytes(payload, outputPath, outputJSON)
+}
+
+func compactOutputHasAssistantOrToolEvidence(raw []byte) bool {
+	_, hasEvidence := compactEvidenceCountsAndHasEvidence(gjson.ParseBytes(normalizeCompactOutputJSON(raw)))
+	return hasEvidence
+}
+
+func compactEvidenceInputCounts(rawJSON []byte) compactEvidenceCounts {
+	return compactEvidenceCountsFromArray(gjson.GetBytes(rawJSON, "input"))
+}
+
+func compactEvidenceOutputCounts(rawJSON []byte) compactEvidenceCounts {
+	return compactEvidenceCountsFromArray(gjson.ParseBytes(normalizeCompactOutputJSON(rawJSON)))
+}
+
+func compactEvidenceCountsFromArray(input gjson.Result) compactEvidenceCounts {
+	counts, _ := compactEvidenceCountsAndHasEvidence(input)
+	return counts
+}
+
+func compactEvidenceCountsAndHasEvidence(input gjson.Result) (compactEvidenceCounts, bool) {
+	if !input.IsArray() {
+		return compactEvidenceCounts{}, false
+	}
+	array := input.Array()
+	counts := compactEvidenceCounts{itemCount: len(array)}
+	hasEvidence := false
+	for _, item := range array {
+		itemType := strings.TrimSpace(item.Get("type").String())
+		if itemType == "message" && strings.TrimSpace(item.Get("role").String()) == "assistant" {
+			counts.assistantMessageCount++
+			hasEvidence = true
+		}
+		if isResponsesToolCallType(itemType) {
+			counts.toolCallCount++
+			if strings.TrimSpace(item.Get("call_id").String()) != "" {
+				hasEvidence = true
+			}
+		}
+		if isResponsesToolCallOutputType(itemType) {
+			counts.toolCallOutputCount++
+			if strings.TrimSpace(item.Get("call_id").String()) != "" {
+				hasEvidence = true
+			}
+		}
+	}
+	return counts, hasEvidence
+}
+
+func normalizeCompactOutputJSON(raw []byte) []byte {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return []byte("[]")
+	}
+	result := gjson.ParseBytes(trimmed)
+	if result.Type == gjson.JSON && result.IsArray() {
+		return trimmed
+	}
+	return []byte("[]")
+}

--- a/sdk/api/handlers/openai/openai_responses_compact_test.go
+++ b/sdk/api/handlers/openai/openai_responses_compact_test.go
@@ -16,12 +16,14 @@ import (
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v6/sdk/config"
+	"github.com/tidwall/gjson"
 )
 
 type compactCaptureExecutor struct {
 	alt          string
 	sourceFormat string
 	calls        int
+	payload      []byte
 }
 
 func (e *compactCaptureExecutor) Identifier() string { return "test-provider" }
@@ -30,7 +32,11 @@ func (e *compactCaptureExecutor) Execute(ctx context.Context, auth *coreauth.Aut
 	e.calls++
 	e.alt = opts.Alt
 	e.sourceFormat = opts.SourceFormat.String()
-	return coreexecutor.Response{Payload: []byte(`{"ok":true}`)}, nil
+	payload := e.payload
+	if len(payload) == 0 {
+		payload = []byte(`{"ok":true}`)
+	}
+	return coreexecutor.Response{Payload: payload}, nil
 }
 
 func (e *compactCaptureExecutor) ExecuteStream(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (*coreexecutor.StreamResult, error) {
@@ -170,5 +176,209 @@ func TestOpenAIResponsesCompactDecodesZstdRequestBody(t *testing.T) {
 	}
 	if strings.TrimSpace(resp.Body.String()) != `{"ok":true}` {
 		t.Fatalf("body = %s", resp.Body.String())
+	}
+}
+
+func TestOpenAIResponsesCompactAugmentsHiddenOnlyOutputWithSameTurnEvidence(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	executor := &compactCaptureExecutor{
+		payload: []byte(`{"id":"resp-compact","output":[{"type":"compaction_summary","summary":"hidden"}]}`),
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	auth := &coreauth.Auth{ID: "auth-compact-evidence", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses/compact", h.Compact)
+
+	body := `{
+		"model":"test-model",
+		"input":[
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"old turn"}]},
+			{"type":"message","role":"assistant","id":"stale-assistant","content":[{"type":"output_text","text":"stale assistant"}]},
+			{"type":"function_call","call_id":"stale-call","name":"shell","arguments":"{}"},
+			{"type":"function_call_output","call_id":"stale-call","output":"stale"},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"please inspect"}]},
+			{"type":"message","role":"assistant","id":"latest-assistant","content":[{"type":"output_text","text":"I will inspect the logs."}]},
+			{"type":"function_call","call_id":"latest-call","name":"shell","arguments":"{}"},
+			{"type":"function_call_output","call_id":"latest-call","output":"ok"}
+		]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	output := gjson.GetBytes(resp.Body.Bytes(), "output")
+	if got, want := len(output.Array()), 4; got != want {
+		t.Fatalf("output item count = %d, want %d; body=%s", got, want, resp.Body.String())
+	}
+	if got := output.Array()[1].Get("role").String(); got != "assistant" {
+		t.Fatalf("merged assistant role = %q, want assistant", got)
+	}
+	if got := output.Array()[1].Get("id").String(); got != "latest-assistant" {
+		t.Fatalf("merged assistant id = %q, want latest-assistant", got)
+	}
+	if got := output.Array()[2].Get("type").String(); got != "function_call" {
+		t.Fatalf("merged tool call type = %q, want function_call", got)
+	}
+	if got := output.Array()[2].Get("call_id").String(); got != "latest-call" {
+		t.Fatalf("merged tool call id = %q, want latest-call", got)
+	}
+	if got := output.Array()[3].Get("type").String(); got != "function_call_output" {
+		t.Fatalf("merged tool output type = %q, want function_call_output", got)
+	}
+	if got := output.Array()[3].Get("call_id").String(); got != "latest-call" {
+		t.Fatalf("merged tool output id = %q, want latest-call", got)
+	}
+	if strings.Contains(resp.Body.String(), "stale-call") || strings.Contains(resp.Body.String(), "stale-assistant") {
+		t.Fatalf("response injected stale evidence: %s", resp.Body.String())
+	}
+}
+
+func TestOpenAIResponsesCompactSkipsOrphanToolOutputEvidence(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	executor := &compactCaptureExecutor{
+		payload: []byte(`{"id":"resp-compact","output":[{"type":"compaction_summary","summary":"hidden"}]}`),
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	auth := &coreauth.Auth{ID: "auth-compact-orphan", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses/compact", h.Compact)
+
+	body := `{
+		"model":"test-model",
+		"input":[
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"continue"}]},
+			{"type":"function_call_output","call_id":"missing-call","output":"orphan"}
+		]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	output := gjson.GetBytes(resp.Body.Bytes(), "output")
+	if got, want := len(output.Array()), 1; got != want {
+		t.Fatalf("output item count = %d, want %d; body=%s", got, want, resp.Body.String())
+	}
+	if got := output.Array()[0].Get("type").String(); got != "compaction_summary" {
+		t.Fatalf("output[0].type = %q, want compaction_summary", got)
+	}
+	if strings.Contains(resp.Body.String(), "missing-call") || strings.Contains(resp.Body.String(), "orphan") {
+		t.Fatalf("response injected orphan tool output: %s", resp.Body.String())
+	}
+}
+
+func TestCompactSameTurnEvidenceRequiresTailMarker(t *testing.T) {
+	evidence, err := compactSameTurnEvidenceJSON([]byte(`{
+		"input":[
+			{"type":"message","role":"assistant","id":"assistant-without-marker"},
+			{"type":"function_call","call_id":"call-without-marker","name":"shell"},
+			{"type":"function_call_output","call_id":"call-without-marker","output":"ok"}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("compactSameTurnEvidenceJSON: %v", err)
+	}
+	if evidence.hit {
+		t.Fatalf("evidence hit = true, want false; evidence=%s", evidence.rawJSON)
+	}
+	if evidence.skipped {
+		t.Fatalf("evidence skipped = true, want false; reason=%s", evidence.skipReason)
+	}
+}
+
+func TestCompactSameTurnEvidenceUsesCompactionMarkerTail(t *testing.T) {
+	evidenceResult, err := compactSameTurnEvidenceJSON([]byte(`{
+		"input":[
+			{"type":"message","role":"assistant","id":"stale-assistant"},
+			{"type":"function_call","call_id":"stale-call","name":"shell"},
+			{"type":"function_call_output","call_id":"stale-call","output":"stale"},
+			{"type":"compaction_summary","summary":"hidden"},
+			{"type":"message","role":"assistant","id":"latest-assistant"},
+			{"type":"custom_tool_call","call_id":"latest-call","name":"apply_patch"},
+			{"type":"custom_tool_call_output","call_id":"latest-call","output":"ok"},
+			{"type":"custom_tool_call_output","call_id":"orphan-call","output":"skip"}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("compactSameTurnEvidenceJSON: %v", err)
+	}
+	if !evidenceResult.hit {
+		t.Fatalf("evidence hit = false, want true")
+	}
+	if !evidenceResult.skipped {
+		t.Fatalf("evidence skipped = false, want true for orphan output")
+	}
+	if evidenceResult.skipReason != compactEvidenceSkipToolOutputBeforeCall {
+		t.Fatalf("skip reason = %q, want %q", evidenceResult.skipReason, compactEvidenceSkipToolOutputBeforeCall)
+	}
+	evidence := gjson.Parse(evidenceResult.rawJSON)
+	if got, want := len(evidence.Array()), 3; got != want {
+		t.Fatalf("evidence item count = %d, want %d; evidence=%s", got, want, evidenceResult.rawJSON)
+	}
+	if strings.Contains(evidenceResult.rawJSON, "stale-call") || strings.Contains(evidenceResult.rawJSON, "orphan-call") {
+		t.Fatalf("evidence contains stale or orphan item: %s", evidenceResult.rawJSON)
+	}
+}
+
+func TestCompactSameTurnEvidenceRequiresCallBeforeOutput(t *testing.T) {
+	evidenceResult, err := compactSameTurnEvidenceJSON([]byte(`{
+		"input":[
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"continue"}]},
+			{"type":"function_call_output","call_id":"late-call","output":"skip"},
+			{"type":"function_call","call_id":"late-call","name":"shell","arguments":"{}"}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("compactSameTurnEvidenceJSON: %v", err)
+	}
+	if !evidenceResult.hit {
+		t.Fatalf("evidence hit = false, want true for later tool call")
+	}
+	if !evidenceResult.skipped {
+		t.Fatalf("evidence skipped = false, want true for output before call")
+	}
+	if evidenceResult.skipReason != compactEvidenceSkipToolOutputBeforeCall {
+		t.Fatalf("skip reason = %q, want %q", evidenceResult.skipReason, compactEvidenceSkipToolOutputBeforeCall)
+	}
+	evidence := gjson.Parse(evidenceResult.rawJSON)
+	if got, want := len(evidence.Array()), 1; got != want {
+		t.Fatalf("evidence item count = %d, want %d; evidence=%s", got, want, evidenceResult.rawJSON)
+	}
+	if got := evidence.Array()[0].Get("type").String(); got != "function_call" {
+		t.Fatalf("evidence[0].type = %q, want function_call; evidence=%s", got, evidenceResult.rawJSON)
+	}
+	if strings.Contains(evidenceResult.rawJSON, "skip") || strings.Contains(evidenceResult.rawJSON, "function_call_output") {
+		t.Fatalf("evidence injected out-of-order tool output: %s", evidenceResult.rawJSON)
 	}
 }

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -431,6 +431,18 @@ func (h *OpenAIResponsesAPIHandler) Compact(c *gin.Context) {
 		cliCancel(errMsg.Error)
 		return
 	}
+	resp, diagnostic, errCompactEvidence := compactResponseWithSameTurnEvidence(rawJSON, resp)
+	logCompactEvidenceDiagnostic(diagnostic)
+	if errCompactEvidence != nil {
+		c.JSON(http.StatusConflict, handlers.ErrorResponse{
+			Error: handlers.ErrorDetail{
+				Message: "Invalid compact same-turn evidence",
+				Type:    "invalid_request_error",
+			},
+		})
+		cliCancel(errCompactEvidence)
+		return
+	}
 	handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 	_, _ = c.Writer.Write(resp)
 	cliCancel()


### PR DESCRIPTION
## Summary
- Selectively port upstream router-for-me/CLIProxyAPI#3274 with v6 import adaptation.
- Preserve same-turn assistant/tool evidence when `/v1/responses/compact` returns hidden-only output.
- Add redacted compact evidence diagnostics to the log formatter and regression coverage for stale/orphan evidence handling.

## LTS compatibility
- Does not touch `internal/usage/`, `/v0/management/usage*`, `internal/translator/`, config schema, auth files, SDK public types, or AGENTS.md.
- Keeps evidence merge scoped to the latest compact tail and skips orphan/out-of-order tool outputs instead of leaking stale transcript content.
- Upstream source PR is currently open, so this is intentionally draft for review before adoption.

## Validation
- `go test ./sdk/api/handlers/openai -run 'TestOpenAIResponsesCompact|TestCompact' -count=1`\n- `go test ./internal/logging -count=1`\n- `git diff --cached --check`\n- `go test ./sdk/api/handlers/openai -count=1`\n- `go build -o test-output ./cmd/server && rm -f test-output`\n- `go test ./sdk/api/handlers/... -count=1`\n- `go test ./...`\n