### PR TITLE
[codex] Retry invalid encrypted reasoning

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -312,18 +312,65 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return resp, err
 	}
-	defer func() {
-		if errClose := httpResp.Body.Close(); errClose != nil {
+	defer func(body io.Closer) {
+		if errClose := body.Close(); errClose != nil {
 			log.Errorf("codex executor: close response body error: %v", errClose)
 		}
-	}()
+	}(httpResp.Body)
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		b, _ := io.ReadAll(httpResp.Body)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		err = newCodexStatusErr(httpResp.StatusCode, b)
-		return resp, err
+		if isInvalidResponsesEncryptedContentError(httpResp.StatusCode, b) {
+			if strippedBody, changed := stripInvalidEncryptedContentFromResponsesBody(body); changed {
+				helps.LogWithRequestID(ctx).Warn("codex executor: upstream rejected encrypted_content; retrying once without encrypted reasoning context")
+				retryReq, retryBuildErr := e.cacheHelper(ctx, from, url, req, strippedBody)
+				if retryBuildErr != nil {
+					err = retryBuildErr
+					return resp, err
+				}
+				applyCodexHeaders(retryReq, auth, apiKey, true, e.cfg)
+				helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+					URL:       url,
+					Method:    http.MethodPost,
+					Headers:   retryReq.Header.Clone(),
+					Body:      strippedBody,
+					Provider:  e.Identifier(),
+					AuthID:    authID,
+					AuthLabel: authLabel,
+					AuthType:  authType,
+					AuthValue: authValue,
+				})
+				retryResp, retryErr := httpClient.Do(retryReq)
+				if retryErr != nil {
+					helps.RecordAPIResponseError(ctx, e.cfg, retryErr)
+					err = retryErr
+					return resp, err
+				}
+				defer func(body io.Closer) {
+					if errClose := body.Close(); errClose != nil {
+						log.Errorf("codex executor: close retry response body error: %v", errClose)
+					}
+				}(retryResp.Body)
+				helps.RecordAPIResponseMetadata(ctx, e.cfg, retryResp.StatusCode, retryResp.Header.Clone())
+				if retryResp.StatusCode < 200 || retryResp.StatusCode >= 300 {
+					b, _ = io.ReadAll(retryResp.Body)
+					helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+					helps.LogWithRequestID(ctx).Debugf("request retry error, error status: %d, error message: %s", retryResp.StatusCode, helps.SummarizeErrorBody(retryResp.Header.Get("Content-Type"), b))
+					err = newCodexStatusErr(retryResp.StatusCode, b)
+					return resp, err
+				}
+				body = strippedBody
+				httpResp = retryResp
+			} else {
+				err = newCodexStatusErr(httpResp.StatusCode, b)
+				return resp, err
+			}
+		} else {
+			err = newCodexStatusErr(httpResp.StatusCode, b)
+			return resp, err
+		}
 	}
 	data, err := io.ReadAll(httpResp.Body)
 	if err != nil {
@@ -468,18 +515,65 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return resp, err
 	}
-	defer func() {
-		if errClose := httpResp.Body.Close(); errClose != nil {
+	defer func(body io.Closer) {
+		if errClose := body.Close(); errClose != nil {
 			log.Errorf("codex executor: close response body error: %v", errClose)
 		}
-	}()
+	}(httpResp.Body)
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		b, _ := io.ReadAll(httpResp.Body)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		err = newCodexStatusErr(httpResp.StatusCode, b)
-		return resp, err
+		if isInvalidResponsesEncryptedContentError(httpResp.StatusCode, b) {
+			if strippedBody, changed := stripInvalidEncryptedContentFromResponsesBody(body); changed {
+				helps.LogWithRequestID(ctx).Warn("codex compact executor: upstream rejected encrypted_content; retrying once without encrypted reasoning context")
+				retryReq, retryBuildErr := e.cacheHelper(ctx, from, url, req, strippedBody)
+				if retryBuildErr != nil {
+					err = retryBuildErr
+					return resp, err
+				}
+				applyCodexHeaders(retryReq, auth, apiKey, false, e.cfg)
+				helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+					URL:       url,
+					Method:    http.MethodPost,
+					Headers:   retryReq.Header.Clone(),
+					Body:      strippedBody,
+					Provider:  e.Identifier(),
+					AuthID:    authID,
+					AuthLabel: authLabel,
+					AuthType:  authType,
+					AuthValue: authValue,
+				})
+				retryResp, retryErr := httpClient.Do(retryReq)
+				if retryErr != nil {
+					helps.RecordAPIResponseError(ctx, e.cfg, retryErr)
+					err = retryErr
+					return resp, err
+				}
+				defer func(body io.Closer) {
+					if errClose := body.Close(); errClose != nil {
+						log.Errorf("codex compact executor: close retry response body error: %v", errClose)
+					}
+				}(retryResp.Body)
+				helps.RecordAPIResponseMetadata(ctx, e.cfg, retryResp.StatusCode, retryResp.Header.Clone())
+				if retryResp.StatusCode < 200 || retryResp.StatusCode >= 300 {
+					b, _ = io.ReadAll(retryResp.Body)
+					helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+					helps.LogWithRequestID(ctx).Debugf("request retry error, error status: %d, error message: %s", retryResp.StatusCode, helps.SummarizeErrorBody(retryResp.Header.Get("Content-Type"), b))
+					err = newCodexStatusErr(retryResp.StatusCode, b)
+					return resp, err
+				}
+				body = strippedBody
+				httpResp = retryResp
+			} else {
+				err = newCodexStatusErr(httpResp.StatusCode, b)
+				return resp, err
+			}
+		} else {
+			err = newCodexStatusErr(httpResp.StatusCode, b)
+			return resp, err
+		}
 	}
 	data, err := io.ReadAll(httpResp.Body)
 	if err != nil {
@@ -579,8 +673,55 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		}
 		helps.AppendAPIResponseChunk(ctx, e.cfg, data)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), data))
-		err = newCodexStatusErr(httpResp.StatusCode, data)
-		return nil, err
+		if isInvalidResponsesEncryptedContentError(httpResp.StatusCode, data) {
+			if strippedBody, changed := stripInvalidEncryptedContentFromResponsesBody(body); changed {
+				helps.LogWithRequestID(ctx).Warn("codex stream executor: upstream rejected encrypted_content; retrying once without encrypted reasoning context")
+				retryReq, retryBuildErr := e.cacheHelper(ctx, from, url, req, strippedBody)
+				if retryBuildErr != nil {
+					return nil, retryBuildErr
+				}
+				applyCodexHeaders(retryReq, auth, apiKey, true, e.cfg)
+				helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+					URL:       url,
+					Method:    http.MethodPost,
+					Headers:   retryReq.Header.Clone(),
+					Body:      strippedBody,
+					Provider:  e.Identifier(),
+					AuthID:    authID,
+					AuthLabel: authLabel,
+					AuthType:  authType,
+					AuthValue: authValue,
+				})
+				retryResp, retryErr := httpClient.Do(retryReq)
+				if retryErr != nil {
+					helps.RecordAPIResponseError(ctx, e.cfg, retryErr)
+					return nil, retryErr
+				}
+				helps.RecordAPIResponseMetadata(ctx, e.cfg, retryResp.StatusCode, retryResp.Header.Clone())
+				if retryResp.StatusCode < 200 || retryResp.StatusCode >= 300 {
+					retryData, retryReadErr := io.ReadAll(retryResp.Body)
+					if errClose := retryResp.Body.Close(); errClose != nil {
+						log.Errorf("codex executor: close retry response body error: %v", errClose)
+					}
+					if retryReadErr != nil {
+						helps.RecordAPIResponseError(ctx, e.cfg, retryReadErr)
+						return nil, retryReadErr
+					}
+					helps.AppendAPIResponseChunk(ctx, e.cfg, retryData)
+					helps.LogWithRequestID(ctx).Debugf("request retry error, error status: %d, error message: %s", retryResp.StatusCode, helps.SummarizeErrorBody(retryResp.Header.Get("Content-Type"), retryData))
+					err = newCodexStatusErr(retryResp.StatusCode, retryData)
+					return nil, err
+				}
+				body = strippedBody
+				httpResp = retryResp
+			} else {
+				err = newCodexStatusErr(httpResp.StatusCode, data)
+				return nil, err
+			}
+		} else {
+			err = newCodexStatusErr(httpResp.StatusCode, data)
+			return nil, err
+		}
 	}
 	out := make(chan cliproxyexecutor.StreamChunk)
 	go func() {

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -282,6 +282,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
 		body = ensureImageGenerationTool(body, baseModel, auth)
 	}
+	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex executor", body)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
 	httpReq, err := e.cacheHelper(ctx, from, url, req, body)
@@ -485,6 +486,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
 		body = ensureImageGenerationTool(body, baseModel, auth)
 	}
+	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex executor", body)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses/compact"
 	httpReq, err := e.cacheHelper(ctx, from, url, req, body)
@@ -630,6 +632,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
 		body = ensureImageGenerationTool(body, baseModel, auth)
 	}
+	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex executor", body)
 
 	url := strings.TrimSuffix(baseURL, "/") + "/responses"
 	httpReq, err := e.cacheHelper(ctx, from, url, req, body)

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -213,6 +213,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
 		body = ensureImageGenerationTool(body, baseModel, auth)
 	}
+	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex websockets executor", body)
 
 	httpURL := strings.TrimSuffix(baseURL, "/") + "/responses"
 	wsURL, err := buildCodexResponsesWebsocketURL(httpURL)
@@ -413,6 +414,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
 		body = ensureImageGenerationTool(body, baseModel, auth)
 	}
+	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex websockets executor", body)
 
 	httpURL := strings.TrimSuffix(baseURL, "/") + "/responses"
 	wsURL, err := buildCodexResponsesWebsocketURL(httpURL)

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -166,18 +166,70 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		helps.RecordAPIResponseError(ctx, e.cfg, err)
 		return resp, err
 	}
-	defer func() {
-		if errClose := httpResp.Body.Close(); errClose != nil {
+	defer func(body io.Closer) {
+		if errClose := body.Close(); errClose != nil {
 			log.Errorf("openai compat executor: close response body error: %v", errClose)
 		}
-	}()
+	}(httpResp.Body)
 	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
 		b, _ := io.ReadAll(httpResp.Body)
 		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
 		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
-		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
-		return resp, err
+		if opts.Alt == "responses/compact" && isInvalidResponsesEncryptedContentError(httpResp.StatusCode, b) {
+			if strippedTranslated, changed := stripInvalidEncryptedContentFromResponsesBody(translated); changed {
+				helps.LogWithRequestID(ctx).Warn("openai compat executor: upstream rejected encrypted_content; retrying once without encrypted reasoning context")
+				retryReq, retryBuildErr := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(strippedTranslated))
+				if retryBuildErr != nil {
+					err = retryBuildErr
+					return resp, err
+				}
+				retryReq.Header.Set("Content-Type", "application/json")
+				if apiKey != "" {
+					retryReq.Header.Set("Authorization", "Bearer "+apiKey)
+				}
+				retryReq.Header.Set("User-Agent", "cli-proxy-openai-compat")
+				util.ApplyCustomHeadersFromAttrs(retryReq, attrs)
+				helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+					URL:       url,
+					Method:    http.MethodPost,
+					Headers:   retryReq.Header.Clone(),
+					Body:      strippedTranslated,
+					Provider:  e.Identifier(),
+					AuthID:    authID,
+					AuthLabel: authLabel,
+					AuthType:  authType,
+					AuthValue: authValue,
+				})
+				retryResp, retryErr := httpClient.Do(retryReq)
+				if retryErr != nil {
+					helps.RecordAPIResponseError(ctx, e.cfg, retryErr)
+					err = retryErr
+					return resp, err
+				}
+				defer func(body io.Closer) {
+					if errClose := body.Close(); errClose != nil {
+						log.Errorf("openai compat executor: close retry response body error: %v", errClose)
+					}
+				}(retryResp.Body)
+				helps.RecordAPIResponseMetadata(ctx, e.cfg, retryResp.StatusCode, retryResp.Header.Clone())
+				if retryResp.StatusCode < 200 || retryResp.StatusCode >= 300 {
+					b, _ = io.ReadAll(retryResp.Body)
+					helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+					helps.LogWithRequestID(ctx).Debugf("request retry error, error status: %d, error message: %s", retryResp.StatusCode, helps.SummarizeErrorBody(retryResp.Header.Get("Content-Type"), b))
+					err = statusErr{code: retryResp.StatusCode, msg: string(b)}
+					return resp, err
+				}
+				translated = strippedTranslated
+				httpResp = retryResp
+			} else {
+				err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+				return resp, err
+			}
+		} else {
+			err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+			return resp, err
+		}
 	}
 	body, err := io.ReadAll(httpResp.Body)
 	if err != nil {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -125,6 +125,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 		if updated, errDelete := sjson.DeleteBytes(translated, "stream"); errDelete == nil {
 			translated = updated
 		}
+		translated = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "openai compat executor", translated)
 	}
 
 	url := strings.TrimSuffix(baseURL, "/") + endpoint

--- a/internal/runtime/executor/openai_responses_signature.go
+++ b/internal/runtime/executor/openai_responses_signature.go
@@ -1,0 +1,68 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor/helps"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/signature"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+func sanitizeOpenAIResponsesReasoningEncryptedContent(ctx context.Context, provider string, body []byte) []byte {
+	input := gjson.GetBytes(body, "input")
+	if !input.Exists() || !input.IsArray() {
+		return body
+	}
+	provider = strings.TrimSpace(provider)
+	if provider == "" {
+		provider = "openai responses upstream"
+	}
+
+	updated := body
+	for index, item := range input.Array() {
+		if strings.TrimSpace(item.Get("type").String()) != "reasoning" {
+			continue
+		}
+
+		encryptedContentPath := fmt.Sprintf("input.%d.encrypted_content", index)
+		encryptedContent := gjson.GetBytes(updated, encryptedContentPath)
+		if !encryptedContent.Exists() {
+			continue
+		}
+
+		reason := ""
+		switch encryptedContent.Type {
+		case gjson.String:
+			rawSignature := encryptedContent.String()
+			if rawSignature != strings.TrimSpace(rawSignature) {
+				reason = "encrypted_content has leading or trailing whitespace"
+			} else if _, err := signature.InspectGPTReasoningSignature(rawSignature); err != nil {
+				reason = err.Error()
+			}
+		case gjson.Null:
+			reason = "encrypted_content is null"
+		default:
+			reason = fmt.Sprintf("encrypted_content must be a string, got %s", encryptedContent.Type.String())
+		}
+		if reason == "" {
+			continue
+		}
+
+		next, err := sjson.DeleteBytes(updated, encryptedContentPath)
+		if err != nil {
+			helps.LogWithRequestID(ctx).Debugf("%s: failed to drop invalid reasoning encrypted_content at input[%d]: %v", provider, index, err)
+			continue
+		}
+		updated = next
+
+		itemID := strings.TrimSpace(gjson.GetBytes(updated, fmt.Sprintf("input.%d.id", index)).String())
+		if itemID == "" {
+			itemID = fmt.Sprintf("input[%d]", index)
+		}
+		helps.LogWithRequestID(ctx).Debugf("%s: dropped invalid reasoning encrypted_content at input[%d] item_id=%q reason=%s", provider, index, itemID, reason)
+	}
+	return updated
+}

--- a/internal/runtime/executor/responses_encrypted_retry.go
+++ b/internal/runtime/executor/responses_encrypted_retry.go
@@ -1,0 +1,119 @@
+package executor
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+func isInvalidResponsesEncryptedContentError(statusCode int, body []byte) bool {
+	if statusCode != http.StatusBadRequest {
+		return false
+	}
+	for _, path := range []string{"error.code", "detail.code", "code"} {
+		if strings.EqualFold(strings.TrimSpace(gjson.GetBytes(body, path).String()), "invalid_encrypted_content") {
+			return true
+		}
+	}
+
+	msgParts := []string{
+		gjson.GetBytes(body, "error.message").String(),
+		gjson.GetBytes(body, "detail").String(),
+		string(body),
+	}
+	for _, msg := range msgParts {
+		msg = strings.ToLower(msg)
+		if strings.Contains(msg, "invalid_encrypted_content") {
+			return true
+		}
+		if strings.Contains(msg, "encrypted content") &&
+			(strings.Contains(msg, "could not be verified") || strings.Contains(msg, "could not be decrypted")) {
+			return true
+		}
+	}
+	return false
+}
+
+func stripInvalidEncryptedContentFromResponsesBody(body []byte) ([]byte, bool) {
+	var root map[string]any
+	if err := json.Unmarshal(body, &root); err != nil || root == nil {
+		return body, false
+	}
+	input, ok := root["input"]
+	if !ok {
+		return body, false
+	}
+	strippedInput, changed, keep := stripInvalidEncryptedContentValue(input, false)
+	if !changed {
+		return body, false
+	}
+	if keep {
+		root["input"] = strippedInput
+	} else {
+		delete(root, "input")
+	}
+	stripped, err := json.Marshal(root)
+	if err != nil {
+		return body, false
+	}
+	return stripped, true
+}
+
+func stripInvalidEncryptedContentValue(value any, arrayItem bool) (any, bool, bool) {
+	switch v := value.(type) {
+	case []any:
+		changed := false
+		out := make([]any, 0, len(v))
+		for _, item := range v {
+			stripped, itemChanged, keep := stripInvalidEncryptedContentValue(item, true)
+			if itemChanged {
+				changed = true
+			}
+			if !keep {
+				changed = true
+				continue
+			}
+			out = append(out, stripped)
+		}
+		return out, changed, true
+	case map[string]any:
+		changed := false
+		if strings.TrimSpace(firstNonEmptyAnyString(v["type"])) == "reasoning" {
+			if _, hasEncrypted := v["encrypted_content"]; hasEncrypted {
+				if arrayItem {
+					return nil, true, false
+				}
+				delete(v, "encrypted_content")
+				changed = true
+			}
+		} else if _, hasEncrypted := v["encrypted_content"]; hasEncrypted {
+			delete(v, "encrypted_content")
+			changed = true
+		}
+		for key, child := range v {
+			stripped, childChanged, keep := stripInvalidEncryptedContentValue(child, false)
+			if childChanged {
+				changed = true
+			}
+			if keep {
+				v[key] = stripped
+			} else {
+				delete(v, key)
+			}
+		}
+		return v, changed, true
+	default:
+		return value, false, true
+	}
+}
+
+func firstNonEmptyAnyString(values ...any) string {
+	for _, value := range values {
+		if s, ok := value.(string); ok && strings.TrimSpace(s) != "" {
+			return s
+		}
+	}
+	return ""
+}

--- a/internal/runtime/executor/responses_encrypted_retry_test.go
+++ b/internal/runtime/executor/responses_encrypted_retry_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"encoding/base64"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,15 @@ import (
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
 	"github.com/tidwall/gjson"
 )
+
+func validResponsesEncryptedContentForTest() string {
+	payload := make([]byte, 1+8+16+16+32)
+	payload[0] = 0x80
+	for i := 9; i < len(payload); i++ {
+		payload[i] = byte(i)
+	}
+	return base64.RawURLEncoding.EncodeToString(payload)
+}
 
 func TestIsInvalidResponsesEncryptedContentError(t *testing.T) {
 	body := []byte(`{
@@ -29,6 +39,33 @@ func TestIsInvalidResponsesEncryptedContentError(t *testing.T) {
 	}
 	if isInvalidResponsesEncryptedContentError(http.StatusInternalServerError, body) {
 		t.Fatalf("non-400 response should not trigger encrypted content fallback")
+	}
+}
+
+func TestSanitizeOpenAIResponsesReasoningEncryptedContent(t *testing.T) {
+	valid := validResponsesEncryptedContentForTest()
+	raw := []byte(`{
+		"model":"gpt-5.4",
+		"input":[
+			{"type":"message","role":"user","content":"hello","encrypted_content":"message-field"},
+			{"type":"reasoning","id":"rs_valid","encrypted_content":"` + valid + `"},
+			{"type":"reasoning","id":"rs_bad_prefix","encrypted_content":"not-a-gpt-signature"},
+			{"type":"reasoning","id":"rs_null","encrypted_content":null}
+		]
+	}`)
+
+	got := sanitizeOpenAIResponsesReasoningEncryptedContent(context.Background(), "test executor", raw)
+	if gotValid := gjson.GetBytes(got, "input.1.encrypted_content").String(); gotValid != valid {
+		t.Fatalf("valid encrypted_content should be preserved, got %q; body=%s", gotValid, got)
+	}
+	if gjson.GetBytes(got, "input.2.encrypted_content").Exists() {
+		t.Fatalf("invalid reasoning encrypted_content should be removed: %s", got)
+	}
+	if gjson.GetBytes(got, "input.3.encrypted_content").Exists() {
+		t.Fatalf("null reasoning encrypted_content should be removed: %s", got)
+	}
+	if gotMessage := gjson.GetBytes(got, "input.0.encrypted_content").String(); gotMessage != "message-field" {
+		t.Fatalf("non-reasoning encrypted_content should be left alone, got %q; body=%s", gotMessage, got)
 	}
 }
 
@@ -63,6 +100,7 @@ func TestStripInvalidEncryptedContentFromResponsesBody(t *testing.T) {
 }
 
 func TestCodexExecutorRetriesInvalidEncryptedContentWithStrippedBody(t *testing.T) {
+	valid := validResponsesEncryptedContentForTest()
 	var bodies [][]byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
@@ -90,7 +128,7 @@ func TestCodexExecutorRetriesInvalidEncryptedContentWithStrippedBody(t *testing.
 		Model: "gpt-5.4",
 		Payload: []byte(`{"model":"gpt-5.4","input":[` +
 			`{"type":"message","role":"user","content":"hello"},` +
-			`{"type":"reasoning","id":"rs_bad","encrypted_content":"gAAA"},` +
+			`{"type":"reasoning","id":"rs_bad","encrypted_content":"` + valid + `"},` +
 			`{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done","encrypted_content":"nested"}]}` +
 			`]}`),
 	}, cliproxyexecutor.Options{
@@ -125,6 +163,7 @@ func TestCodexExecutorRetriesInvalidEncryptedContentWithStrippedBody(t *testing.
 }
 
 func TestOpenAICompatCompactRetriesInvalidEncryptedContentWithStrippedBody(t *testing.T) {
+	valid := validResponsesEncryptedContentForTest()
 	var bodies [][]byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
@@ -152,7 +191,7 @@ func TestOpenAICompatCompactRetriesInvalidEncryptedContentWithStrippedBody(t *te
 		Model: "gpt-5.4",
 		Payload: []byte(`{"model":"gpt-5.4","input":[` +
 			`{"type":"message","role":"user","content":"hello"},` +
-			`{"type":"reasoning","id":"rs_bad","encrypted_content":"gAAA"}` +
+			`{"type":"reasoning","id":"rs_bad","encrypted_content":"` + valid + `"}` +
 			`]}`),
 	}, cliproxyexecutor.Options{
 		SourceFormat: sdktranslator.FromString("openai-response"),

--- a/internal/runtime/executor/responses_encrypted_retry_test.go
+++ b/internal/runtime/executor/responses_encrypted_retry_test.go
@@ -1,0 +1,182 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v6/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestIsInvalidResponsesEncryptedContentError(t *testing.T) {
+	body := []byte(`{
+		"error":{
+			"code":"invalid_encrypted_content",
+			"type":"invalid_request_error",
+			"message":"The encrypted content gAAA...Vw== could not be verified. Reason: Encrypted content could not be decrypted or parsed."
+		}
+	}`)
+
+	if !isInvalidResponsesEncryptedContentError(http.StatusBadRequest, body) {
+		t.Fatalf("expected invalid encrypted content error to be detected")
+	}
+	if isInvalidResponsesEncryptedContentError(http.StatusInternalServerError, body) {
+		t.Fatalf("non-400 response should not trigger encrypted content fallback")
+	}
+}
+
+func TestStripInvalidEncryptedContentFromResponsesBody(t *testing.T) {
+	raw := []byte(`{
+		"model":"gpt-5.4",
+		"input":[
+			{"type":"message","role":"user","content":"hello"},
+			{"type":"reasoning","id":"rs_bad","encrypted_content":"gAAA"},
+			{"type":"function_call","call_id":"call_123","name":"lookup","arguments":"{}"},
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done","encrypted_content":"nested"}]}
+		]
+	}`)
+
+	got, changed := stripInvalidEncryptedContentFromResponsesBody(raw)
+	if !changed {
+		t.Fatalf("expected body to be changed")
+	}
+	items := gjson.GetBytes(got, "input").Array()
+	if len(items) != 3 {
+		t.Fatalf("expected reasoning item to be removed, got %d items: %s", len(items), got)
+	}
+	if typ := gjson.GetBytes(got, "input.0.type").String(); typ != "message" {
+		t.Fatalf("first input should remain message, got %q; body=%s", typ, got)
+	}
+	if typ := gjson.GetBytes(got, "input.1.type").String(); typ != "function_call" {
+		t.Fatalf("function call should remain, got %q; body=%s", typ, got)
+	}
+	if strings.Contains(string(got), "encrypted_content") {
+		t.Fatalf("encrypted_content should be removed from retry body: %s", got)
+	}
+}
+
+func TestCodexExecutorRetriesInvalidEncryptedContentWithStrippedBody(t *testing.T) {
+	var bodies [][]byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		bodies = append(bodies, body)
+		if len(bodies) == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"code":"invalid_encrypted_content","message":"Encrypted content could not be decrypted"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(`data: {"type":"response.completed","response":{"id":"resp_1","object":"response","created_at":1775555723,"status":"completed","model":"gpt-5.4","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}` + "\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model: "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","input":[` +
+			`{"type":"message","role":"user","content":"hello"},` +
+			`{"type":"reasoning","id":"rs_bad","encrypted_content":"gAAA"},` +
+			`{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done","encrypted_content":"nested"}]}` +
+			`]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("request count = %d, want 2", len(bodies))
+	}
+	if !strings.Contains(string(bodies[0]), "encrypted_content") {
+		t.Fatalf("first request should include encrypted_content: %s", bodies[0])
+	}
+	if got := len(gjson.GetBytes(bodies[1], "input").Array()); got != 2 {
+		t.Fatalf("retry input item count = %d, want 2; body=%s", got, bodies[1])
+	}
+	for _, item := range gjson.GetBytes(bodies[1], "input").Array() {
+		if item.Get("type").String() == "reasoning" {
+			t.Fatalf("retry request should remove encrypted reasoning items: %s", bodies[1])
+		}
+		if item.Get("encrypted_content").Exists() {
+			t.Fatalf("retry request should strip input encrypted_content fields: %s", bodies[1])
+		}
+		for _, part := range item.Get("content").Array() {
+			if part.Get("encrypted_content").Exists() {
+				t.Fatalf("retry request should strip nested encrypted_content fields: %s", bodies[1])
+			}
+		}
+	}
+}
+
+func TestOpenAICompatCompactRetriesInvalidEncryptedContentWithStrippedBody(t *testing.T) {
+	var bodies [][]byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		bodies = append(bodies, body)
+		if len(bodies) == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"code":"invalid_encrypted_content","message":"Encrypted content could not be decrypted"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_1","object":"response.compaction","usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+	}}
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model: "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","input":[` +
+			`{"type":"message","role":"user","content":"hello"},` +
+			`{"type":"reasoning","id":"rs_bad","encrypted_content":"gAAA"}` +
+			`]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Alt:          "responses/compact",
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("request count = %d, want 2", len(bodies))
+	}
+	if !strings.Contains(string(bodies[0]), "encrypted_content") {
+		t.Fatalf("first request should include encrypted_content: %s", bodies[0])
+	}
+	if got := len(gjson.GetBytes(bodies[1], "input").Array()); got != 1 {
+		t.Fatalf("retry input item count = %d, want 1; body=%s", got, bodies[1])
+	}
+	for _, item := range gjson.GetBytes(bodies[1], "input").Array() {
+		if item.Get("type").String() == "reasoning" {
+			t.Fatalf("retry request should remove encrypted reasoning items: %s", bodies[1])
+		}
+		if item.Get("encrypted_content").Exists() {
+			t.Fatalf("retry request should strip input encrypted_content fields: %s", bodies[1])
+		}
+	}
+}

--- a/internal/signature/gpt_validation.go
+++ b/internal/signature/gpt_validation.go
@@ -1,0 +1,83 @@
+package signature
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+)
+
+const MaxGPTReasoningSignatureLen = 32 * 1024 * 1024
+
+type GPTReasoningSignatureInfo struct {
+	DecodedLen    int
+	CiphertextLen int
+}
+
+func IsValidGPTReasoningSignature(rawSignature string) bool {
+	_, err := InspectGPTReasoningSignature(rawSignature)
+	return err == nil
+}
+
+// InspectGPTReasoningSignature validates the Fernet-like outer format used by
+// GPT/Codex reasoning encrypted_content. This is only a transport-shape check;
+// it does not prove decryptability.
+func InspectGPTReasoningSignature(rawSignature string) (*GPTReasoningSignatureInfo, error) {
+	sig := strings.TrimSpace(rawSignature)
+	if sig == "" {
+		return nil, fmt.Errorf("empty GPT reasoning signature")
+	}
+	if len(sig) > MaxGPTReasoningSignatureLen {
+		return nil, fmt.Errorf("GPT reasoning signature exceeds maximum length (%d bytes)", MaxGPTReasoningSignatureLen)
+	}
+	if index, r, ok := firstInvalidGPTReasoningSignatureChar(sig); ok {
+		return nil, fmt.Errorf("invalid GPT reasoning signature: contains non-base64url character U+%04X at byte %d", r, index)
+	}
+	if !strings.HasPrefix(sig, "gAAAA") {
+		return nil, fmt.Errorf("invalid GPT reasoning signature: expected gAAAA prefix")
+	}
+
+	decoded, err := decodeGPTReasoningSignature(sig)
+	if err != nil {
+		return nil, err
+	}
+	if len(decoded) < 73 {
+		return nil, fmt.Errorf("invalid GPT reasoning signature: decoded payload too short")
+	}
+	if decoded[0] != 0x80 {
+		return nil, fmt.Errorf("invalid GPT reasoning signature: expected version 0x80, got 0x%02x", decoded[0])
+	}
+
+	ciphertextLen := len(decoded) - 1 - 8 - 16 - 32
+	if ciphertextLen <= 0 || ciphertextLen%16 != 0 {
+		return nil, fmt.Errorf("invalid GPT reasoning signature: ciphertext length %d is not a positive AES block multiple", ciphertextLen)
+	}
+
+	return &GPTReasoningSignatureInfo{
+		DecodedLen:    len(decoded),
+		CiphertextLen: ciphertextLen,
+	}, nil
+}
+
+func decodeGPTReasoningSignature(sig string) ([]byte, error) {
+	if decoded, err := base64.RawURLEncoding.DecodeString(sig); err == nil {
+		return decoded, nil
+	}
+	if decoded, err := base64.URLEncoding.DecodeString(sig); err == nil {
+		return decoded, nil
+	}
+	return nil, fmt.Errorf("invalid GPT reasoning signature: base64url decode failed")
+}
+
+func firstInvalidGPTReasoningSignatureChar(sig string) (int, rune, bool) {
+	for index, r := range sig {
+		switch {
+		case r >= 'A' && r <= 'Z':
+		case r >= 'a' && r <= 'z':
+		case r >= '0' && r <= '9':
+		case r == '-' || r == '_' || r == '=':
+		default:
+			return index, r, true
+		}
+	}
+	return 0, 0, false
+}

--- a/internal/signature/gpt_validation_test.go
+++ b/internal/signature/gpt_validation_test.go
@@ -1,0 +1,49 @@
+package signature
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func testGPTReasoningSignature() string {
+	payload := make([]byte, 1+8+16+16+32)
+	payload[0] = 0x80
+	for i := 9; i < len(payload); i++ {
+		payload[i] = byte(i)
+	}
+	return base64.RawURLEncoding.EncodeToString(payload)
+}
+
+func TestInspectGPTReasoningSignatureAcceptsTransportShape(t *testing.T) {
+	info, err := InspectGPTReasoningSignature(testGPTReasoningSignature())
+	if err != nil {
+		t.Fatalf("InspectGPTReasoningSignature returned error: %v", err)
+	}
+	if info.CiphertextLen != 16 {
+		t.Fatalf("ciphertext length = %d, want 16", info.CiphertextLen)
+	}
+}
+
+func TestInspectGPTReasoningSignatureRejectsUnicodeEllipsis(t *testing.T) {
+	sig := testGPTReasoningSignature()
+	polluted := sig[:20] + string(rune(0x2026)) + sig[20:]
+
+	_, err := InspectGPTReasoningSignature(polluted)
+	if err == nil {
+		t.Fatal("expected invalid GPT reasoning signature")
+	}
+	if !strings.Contains(err.Error(), "non-base64url character U+2026") {
+		t.Fatalf("error = %q, want U+2026 base64url detail", err.Error())
+	}
+}
+
+func TestInspectGPTReasoningSignatureRejectsWrongPrefix(t *testing.T) {
+	_, err := InspectGPTReasoningSignature("not-a-gpt-signature")
+	if err == nil {
+		t.Fatal("expected invalid GPT reasoning signature")
+	}
+	if !strings.Contains(err.Error(), "expected gAAAA prefix") {
+		t.Fatalf("error = %q, want prefix detail", err.Error())
+	}
+}

--- a/internal/thinking/validate.go
+++ b/internal/thinking/validate.go
@@ -53,12 +53,11 @@ func ValidateConfig(config ThinkingConfig, modelInfo *registry.ModelInfo, fromFo
 		return &config, nil
 	}
 
-	// allowClampUnsupported determines whether to clamp unsupported levels instead of returning an error.
-	// This applies when crossing provider families (e.g., openai→gemini, claude→gemini) and the target
-	// model supports discrete levels. Same-family conversions require strict validation.
+	// allowClampUnsupported determines whether to clamp unsupported recognized levels instead of returning an error.
+	// This applies when the target model supports discrete levels, including same-family requests.
 	toCapability := detectModelCapability(modelInfo)
 	toHasLevelSupport := toCapability == CapabilityLevelOnly || toCapability == CapabilityHybrid
-	allowClampUnsupported := toHasLevelSupport && !isSameProviderFamily(fromFormat, toFormat)
+	allowClampUnsupported := toHasLevelSupport
 
 	// strictBudget determines whether to enforce strict budget range validation.
 	// This applies when: (1) config comes from request body (not suffix), (2) source format is known,

--- a/test/thinking_conversion_test.go
+++ b/test/thinking_conversion_test.go
@@ -73,15 +73,16 @@ func TestThinkingE2EMatrix_Suffix(t *testing.T) {
 			expectValue: "medium",
 			expectErr:   false,
 		},
-		// Case 3: Specified xhigh → out of range error
+		// Case 3: Specified xhigh -> clamped to high
 		{
 			name:        "3",
 			from:        "openai",
 			to:          "codex",
 			model:       "level-model(xhigh)",
 			inputJSON:   `{"model":"level-model(xhigh)","messages":[{"role":"user","content":"hi"}]}`,
-			expectField: "",
-			expectErr:   true,
+			expectField: "reasoning.effort",
+			expectValue: "high",
+			expectErr:   false,
 		},
 		// Case 4: Level none → clamped to minimal (ZeroAllowed=false)
 		{
@@ -963,15 +964,16 @@ func TestThinkingE2EMatrix_Suffix(t *testing.T) {
 			expectValue: "high",
 			expectErr:   false,
 		},
-		// Case 81: OpenAI to OpenAI, level xhigh → out of range error
+		// Case 81: OpenAI to OpenAI, level xhigh -> clamped to high
 		{
 			name:        "81",
 			from:        "openai",
 			to:          "openai",
 			model:       "level-model(xhigh)",
 			inputJSON:   `{"model":"level-model(xhigh)","messages":[{"role":"user","content":"hi"}]}`,
-			expectField: "",
-			expectErr:   true,
+			expectField: "reasoning_effort",
+			expectValue: "high",
+			expectErr:   false,
 		},
 		// Case 82: OpenAI-Response to Codex, level high → passthrough reasoning.effort
 		{
@@ -984,15 +986,16 @@ func TestThinkingE2EMatrix_Suffix(t *testing.T) {
 			expectValue: "high",
 			expectErr:   false,
 		},
-		// Case 83: OpenAI-Response to Codex, level xhigh → out of range error
+		// Case 83: OpenAI-Response to Codex, level xhigh -> clamped to high
 		{
 			name:        "83",
 			from:        "openai-response",
 			to:          "codex",
 			model:       "level-model(xhigh)",
 			inputJSON:   `{"model":"level-model(xhigh)","input":[{"role":"user","content":"hi"}]}`,
-			expectField: "",
-			expectErr:   true,
+			expectField: "reasoning.effort",
+			expectValue: "high",
+			expectErr:   false,
 		},
 		// Case 84: Gemini to Gemini, budget 8192 → passthrough thinkingBudget
 		{
@@ -1179,15 +1182,16 @@ func TestThinkingE2EMatrix_Body(t *testing.T) {
 			expectValue: "medium",
 			expectErr:   false,
 		},
-		// Case 3: reasoning_effort=xhigh → out of range error
+		// Case 3: reasoning_effort=xhigh -> clamped to high
 		{
 			name:        "3",
 			from:        "openai",
 			to:          "codex",
 			model:       "level-model",
 			inputJSON:   `{"model":"level-model","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"xhigh"}`,
-			expectField: "",
-			expectErr:   true,
+			expectField: "reasoning.effort",
+			expectValue: "high",
+			expectErr:   false,
 		},
 		// Case 4: reasoning_effort=none → clamped to minimal
 		{
@@ -2069,15 +2073,16 @@ func TestThinkingE2EMatrix_Body(t *testing.T) {
 			expectValue: "high",
 			expectErr:   false,
 		},
-		// Case 81: OpenAI to OpenAI, reasoning_effort=xhigh → out of range error
+		// Case 81: OpenAI to OpenAI, reasoning_effort=xhigh -> clamped to high
 		{
 			name:        "81",
 			from:        "openai",
 			to:          "openai",
 			model:       "level-model",
 			inputJSON:   `{"model":"level-model","messages":[{"role":"user","content":"hi"}],"reasoning_effort":"xhigh"}`,
-			expectField: "",
-			expectErr:   true,
+			expectField: "reasoning_effort",
+			expectValue: "high",
+			expectErr:   false,
 		},
 		// Case 82: OpenAI-Response to Codex, reasoning.effort=high → passthrough
 		{
@@ -2090,15 +2095,16 @@ func TestThinkingE2EMatrix_Body(t *testing.T) {
 			expectValue: "high",
 			expectErr:   false,
 		},
-		// Case 83: OpenAI-Response to Codex, reasoning.effort=xhigh → out of range error
+		// Case 83: OpenAI-Response to Codex, reasoning.effort=xhigh -> clamped to high
 		{
 			name:        "83",
 			from:        "openai-response",
 			to:          "codex",
 			model:       "level-model",
 			inputJSON:   `{"model":"level-model","input":[{"role":"user","content":"hi"}],"reasoning":{"effort":"xhigh"}}`,
-			expectField: "",
-			expectErr:   true,
+			expectField: "reasoning.effort",
+			expectValue: "high",
+			expectErr:   false,
 		},
 		// Case 84: Gemini to Gemini, thinkingBudget=8192 → passthrough
 		{
@@ -2697,12 +2703,16 @@ func TestThinkingE2EClaudeAdaptive_Body(t *testing.T) {
 			expectErr:    false,
 		},
 		{
-			name:      "C24",
-			from:      "claude",
-			to:        "claude",
-			model:     "claude-opus-4-6-model",
-			inputJSON: `{"model":"claude-opus-4-6-model","messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"},"output_config":{"effort":"xhigh"}}`,
-			expectErr: true,
+			name:         "C24",
+			from:         "claude",
+			to:           "claude",
+			model:        "claude-opus-4-6-model",
+			inputJSON:    `{"model":"claude-opus-4-6-model","messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"},"output_config":{"effort":"xhigh"}}`,
+			expectField:  "thinking.type",
+			expectValue:  "adaptive",
+			expectField2: "output_config.effort",
+			expectValue2: "high",
+			expectErr:    false,
 		},
 		{
 			name:         "C25",
@@ -2717,20 +2727,28 @@ func TestThinkingE2EClaudeAdaptive_Body(t *testing.T) {
 			expectErr:    false,
 		},
 		{
-			name:      "C26",
-			from:      "claude",
-			to:        "claude",
-			model:     "claude-sonnet-4-6-model",
-			inputJSON: `{"model":"claude-sonnet-4-6-model","messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"},"output_config":{"effort":"max"}}`,
-			expectErr: true,
+			name:         "C26",
+			from:         "claude",
+			to:           "claude",
+			model:        "claude-sonnet-4-6-model",
+			inputJSON:    `{"model":"claude-sonnet-4-6-model","messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"},"output_config":{"effort":"max"}}`,
+			expectField:  "thinking.type",
+			expectValue:  "adaptive",
+			expectField2: "output_config.effort",
+			expectValue2: "high",
+			expectErr:    false,
 		},
 		{
-			name:      "C27",
-			from:      "claude",
-			to:        "claude",
-			model:     "claude-sonnet-4-6-model",
-			inputJSON: `{"model":"claude-sonnet-4-6-model","messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"},"output_config":{"effort":"xhigh"}}`,
-			expectErr: true,
+			name:         "C27",
+			from:         "claude",
+			to:           "claude",
+			model:        "claude-sonnet-4-6-model",
+			inputJSON:    `{"model":"claude-sonnet-4-6-model","messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"},"output_config":{"effort":"xhigh"}}`,
+			expectField:  "thinking.type",
+			expectValue:  "adaptive",
+			expectField2: "output_config.effort",
+			expectValue2: "high",
+			expectErr:    false,
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Selectively port upstream router-for-me/CLIProxyAPI#3537 with v6 import adaptation.
- Retry Codex Responses and Codex compact requests once when upstream rejects stale `encrypted_content` with `invalid_encrypted_content`.
- Retry OpenAI-compatible `/responses/compact` once with invalid encrypted reasoning context stripped.
- Add executor-side preflight sanitization for obviously invalid GPT/Codex Responses `reasoning.encrypted_content` before Codex HTTP, Codex WebSocket, and OpenAI-compatible compact upstream requests.
- Add a small `internal/signature` GPT encrypted-content transport-shape validator, without touching `internal/translator/**`.
- Add response-body helper tests plus executor regression tests proving Codex and OpenAI-compatible retry paths resend stripped payloads.
- Clamp recognized unsupported thinking levels to the nearest supported level instead of failing compatible conversions.

## LTS compatibility
- Does not touch `internal/usage/`, `/v0/management/usage*`, `internal/translator/`, config schema, auth file structure, SDK public types, or AGENTS.md.
- Preflight sanitization only removes `encrypted_content` from reasoning items when the value is empty, null, non-string, whitespace-padded, or fails GPT/Codex Fernet-like transport-shape checks; valid-looking encrypted content is preserved.
- Retry only triggers on HTTP 400 `invalid_encrypted_content` style errors and only when the request body actually changes after stripping stale encrypted reasoning.
- Preserves explicit upstream errors for all other status/error classes.
- This upstream PR is still open, so this LTS port is intentionally draft for review before adoption.

## Validation
- `go test ./internal/signature -count=1`
- `go test ./internal/runtime/executor -run 'Test(SanitizeOpenAIResponsesReasoningEncryptedContent|IsInvalidResponsesEncryptedContentError|StripInvalidEncryptedContentFromResponsesBody|CodexExecutorRetriesInvalidEncryptedContentWithStrippedBody|OpenAICompatCompactRetriesInvalidEncryptedContentWithStrippedBody)' -count=1`
- `go test ./internal/runtime/executor ./internal/signature -count=1`
- `go test ./internal/thinking ./test -run 'TestThinkingE2EMatrix|TestThinkingE2EClaudeAdaptive' -count=1`
- `go test ./internal/runtime/executor ./internal/thinking ./test -count=1`
- `go build -o test-output ./cmd/server && rm -f test-output`
- `go test ./...`
- `git diff --check`
- `git diff --cached --check`
