### PR TITLE
[codex] Rotate Claude extra usage errors

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2211,6 +2211,14 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 					}
 
 					statusCode := statusCodeFromResult(result.Error)
+					// Anthropic 400 "out of extra usage" is per-credential
+					// subscription quota; treat like 429 so the auth gets cooled
+					// rather than returning the error to the client.
+					if statusCode == http.StatusBadRequest && result.Error != nil &&
+						(strings.Contains(result.Error.Message, "out of extra usage") ||
+							strings.Contains(result.Error.Message, "claude.ai/settings/usage")) {
+						statusCode = http.StatusTooManyRequests
+					}
 					if isModelSupportResultError(result.Error) {
 						next := now.Add(12 * time.Hour)
 						state.NextRetryAfter = next
@@ -2649,6 +2657,13 @@ func isRequestInvalidError(err error) bool {
 	switch status {
 	case http.StatusBadRequest:
 		msg := err.Error()
+		// Anthropic OAuth subscription quota exhaustion arrives as 400
+		// invalid_request_error but is per-credential, not per-request.
+		// Let it fall through to rotation + cool-down (see MarkResult promotion).
+		if strings.Contains(msg, "out of extra usage") ||
+			strings.Contains(msg, "claude.ai/settings/usage") {
+			return false
+		}
 		return strings.Contains(msg, "invalid_request_error") ||
 			strings.Contains(msg, "INVALID_ARGUMENT") ||
 			strings.Contains(msg, "FAILED_PRECONDITION")

--- a/sdk/cliproxy/auth/conductor_availability_test.go
+++ b/sdk/cliproxy/auth/conductor_availability_test.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"context"
+	"net/http"
 	"testing"
 	"time"
 )
@@ -57,5 +59,70 @@ func TestUpdateAggregatedAvailability_FutureNextRetryBlocksAuth(t *testing.T) {
 	}
 	if auth.NextRetryAfter.Sub(next) > time.Second || next.Sub(auth.NextRetryAfter) > time.Second {
 		t.Fatalf("auth.NextRetryAfter = %v, want %v", auth.NextRetryAfter, next)
+	}
+}
+
+func TestIsRequestInvalidError_AllowsClaudeExtraUsageRotation(t *testing.T) {
+	t.Parallel()
+
+	extraUsageErr := &Error{
+		HTTPStatus: http.StatusBadRequest,
+		Message:    `{"type":"error","error":{"type":"invalid_request_error","message":"You're out of extra usage. Add more at claude.ai/settings/usage and keep going."}}`,
+	}
+	if isRequestInvalidError(extraUsageErr) {
+		t.Fatal("extra usage 400 should be treated as credential quota, not request-shape failure")
+	}
+
+	malformedErr := &Error{
+		HTTPStatus: http.StatusBadRequest,
+		Message:    "invalid_request_error: malformed payload",
+	}
+	if !isRequestInvalidError(malformedErr) {
+		t.Fatal("malformed invalid_request_error should remain request-scoped")
+	}
+}
+
+func TestManagerMarkResult_PromotesClaudeExtraUsageToQuotaCooldown(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+
+	auth := &Auth{
+		ID:       "claude-extra-usage-auth",
+		Provider: "claude",
+	}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	model := "claude-sonnet-4-5"
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    model,
+		Success:  false,
+		Error: &Error{
+			HTTPStatus: http.StatusBadRequest,
+			Message:    `{"type":"error","error":{"type":"invalid_request_error","message":"You're out of extra usage. Add more at claude.ai/settings/usage and keep going."}}`,
+		},
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	state := updated.ModelStates[model]
+	if state == nil {
+		t.Fatalf("expected model state for %q", model)
+	}
+	if !state.Unavailable || state.Status != StatusError {
+		t.Fatalf("model state = %+v, want unavailable error state", state)
+	}
+	if !state.Quota.Exceeded || state.Quota.Reason != "quota" {
+		t.Fatalf("model quota = %+v, want quota exceeded", state.Quota)
+	}
+	if state.NextRetryAfter.IsZero() || state.Quota.NextRecoverAt.IsZero() {
+		t.Fatalf("expected quota cooldown times, state = %+v", state)
+	}
+	if updated.LastError == nil || updated.LastError.HTTPStatus != http.StatusBadRequest {
+		t.Fatalf("last error = %+v, want original 400 error recorded", updated.LastError)
 	}
 }


### PR DESCRIPTION
## Summary
- Selectively port upstream router-for-me/CLIProxyAPI#3305 with v6 compatibility.
- Treat Anthropic OAuth `out of extra usage` 400 responses as per-credential quota instead of request-shape errors, allowing auth rotation.
- Promote that specific 400 class to quota cooldown in `MarkResult` while preserving the original 400 error record.
- Add regression tests for request-invalid classification and quota cooldown state.

## LTS compatibility
- Does not touch `internal/usage/`, `/v0/management/usage*`, `internal/translator/`, config schema, auth file structure, SDK public types, or AGENTS.md.
- Behavior is limited to Anthropic/Claude extra-usage quota messages containing `out of extra usage` or `claude.ai/settings/usage`; ordinary malformed 400 `invalid_request_error` responses remain non-retriable.

## Validation
- `go test ./sdk/cliproxy/auth -run 'Test(IsRequestInvalidError_AllowsClaudeExtraUsageRotation|ManagerMarkResult_PromotesClaudeExtraUsageToQuotaCooldown)' -count=1`
- `go test ./sdk/cliproxy/auth -count=1`
- `go test ./sdk/cliproxy/... -count=1`
- `go build -o test-output ./cmd/server && rm -f test-output`
- `go test ./...`
- `git diff --check`
