### PR TITLE
[codex] Expose auth quota state

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -392,6 +392,10 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 	entry["success"] = auth.Success
 	entry["failed"] = auth.Failed
 	entry["recent_requests"] = auth.RecentRequestsSnapshot(time.Now())
+	entry["quota"] = auth.Quota
+	if len(auth.ModelStates) > 0 {
+		entry["model_states"] = auth.ModelStates
+	}
 	if email := authEmail(auth); email != "" {
 		entry["email"] = email
 	}

--- a/internal/api/handlers/management/auth_files_quota_test.go
+++ b/internal/api/handlers/management/auth_files_quota_test.go
@@ -1,0 +1,89 @@
+package management
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestListAuthFilesIncludesQuotaAndModelStates(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	nextRecover := time.Unix(1_800_000_000, 0).UTC()
+	manager := coreauth.NewManager(&memoryAuthStore{}, nil, nil)
+	record := &coreauth.Auth{
+		ID:       "codex.json",
+		FileName: "codex.json",
+		Provider: "codex",
+		Status:   coreauth.StatusError,
+		Attributes: map[string]string{
+			"path": "/tmp/codex.json",
+		},
+		Quota: coreauth.QuotaState{
+			Exceeded:      true,
+			Reason:        "quota",
+			NextRecoverAt: nextRecover,
+			BackoffLevel:  2,
+		},
+		ModelStates: map[string]*coreauth.ModelState{
+			"gpt-5.5-codex": {
+				Status:         coreauth.StatusError,
+				StatusMessage:  "quota exhausted",
+				Unavailable:    true,
+				NextRetryAfter: nextRecover,
+				Quota: coreauth.QuotaState{
+					Exceeded:      true,
+					Reason:        "quota",
+					NextRecoverAt: nextRecover,
+					BackoffLevel:  2,
+				},
+				UpdatedAt: nextRecover,
+			},
+		},
+	}
+	if _, errRegister := manager.Register(t.Context(), record); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/v0/management/auth-files", nil)
+
+	h.ListAuthFiles(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var payload struct {
+		Files []struct {
+			Quota       coreauth.QuotaState            `json:"quota"`
+			ModelStates map[string]coreauth.ModelState `json:"model_states"`
+		} `json:"files"`
+	}
+	if errDecode := json.Unmarshal(rec.Body.Bytes(), &payload); errDecode != nil {
+		t.Fatalf("decode response: %v; body=%s", errDecode, rec.Body.String())
+	}
+	if len(payload.Files) != 1 {
+		t.Fatalf("files = %d, want 1", len(payload.Files))
+	}
+	file := payload.Files[0]
+	if !file.Quota.Exceeded || file.Quota.Reason != "quota" || file.Quota.BackoffLevel != 2 {
+		t.Fatalf("quota = %+v, want exceeded quota with backoff 2", file.Quota)
+	}
+	state, ok := file.ModelStates["gpt-5.5-codex"]
+	if !ok {
+		t.Fatalf("expected gpt-5.5-codex model state, got %+v", file.ModelStates)
+	}
+	if !state.Quota.Exceeded || state.StatusMessage != "quota exhausted" || !state.Unavailable {
+		t.Fatalf("model state = %+v, want unavailable quota exhausted state", state)
+	}
+}


### PR DESCRIPTION
## Summary
- Selectively port upstream router-for-me/CLIProxyAPI#3240 with v6 import compatibility.
- Add `quota` and `model_states` to `/v0/management/auth-files` entries so management clients can see active auth quota/model cooldown state.
- Add a management handler regression test covering file-level quota and per-model quota state serialization.

## LTS compatibility
- Additive Management API response fields only; no route, method, status code, auth, or existing field changes.
- Does not touch `internal/usage/`, `/v0/management/usage*`, `internal/translator/`, config schema, auth file structure, SDK public types, or AGENTS.md.
- Existing Panel/TUI clients that ignore unknown JSON fields remain compatible; clients can opt into the new fields for quota visibility.

## Validation
- `go test ./internal/api/handlers/management -run TestListAuthFilesIncludesQuotaAndModelStates -count=1`
- `go test ./internal/api/handlers/management -count=1`
- `go test ./internal/api -count=1`
- `go build -o test-output ./cmd/server && rm -f test-output`
- `go test ./...`
- `git diff --check`
