### PR TITLE
[codex] Warn on OAuth alias exclusions

### DIFF
--- a/internal/watcher/synthesizer/alias_exclusion_test.go
+++ b/internal/watcher/synthesizer/alias_exclusion_test.go
@@ -1,0 +1,166 @@
+package synthesizer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestWarnAuthAliasExclusionConflicts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		auth           *coreauth.Auth
+		cfg            *config.Config
+		perKey         []string
+		authKind       string
+		wantCount      int
+		wantSubstrings []string
+	}{
+		{
+			name: "antigravity per-account claude wildcard blocks claude aliases",
+			auth: &coreauth.Auth{ID: "antigravity-account.json", Provider: "antigravity"},
+			cfg: &config.Config{
+				OAuthModelAlias: map[string][]config.OAuthModelAlias{
+					"antigravity": {
+						{Name: "claude-opus-4-6-thinking", Alias: "opus"},
+						{Name: "claude-opus-4-6-thinking", Alias: "opus[1m]"},
+					},
+				},
+			},
+			perKey:    []string{"claude-*"},
+			authKind:  "oauth",
+			wantCount: 2,
+			wantSubstrings: []string{
+				`auth="antigravity-account.json"`,
+				`channel="antigravity"`,
+				`alias="opus"`,
+				`alias="opus[1m]"`,
+				`pattern="claude-*"`,
+			},
+		},
+		{
+			name:      "no aliases for channel returns no warnings",
+			auth:      &coreauth.Auth{ID: "claude-acct.json", Provider: "claude"},
+			cfg:       &config.Config{OAuthModelAlias: map[string][]config.OAuthModelAlias{"antigravity": {{Name: "x", Alias: "y"}}}},
+			perKey:    []string{"claude-*"},
+			authKind:  "oauth",
+			wantCount: 0,
+		},
+		{
+			name:      "empty per-account exclusions return no warnings",
+			auth:      &coreauth.Auth{ID: "x", Provider: "antigravity"},
+			cfg:       &config.Config{OAuthModelAlias: map[string][]config.OAuthModelAlias{"antigravity": {{Name: "claude-opus", Alias: "opus"}}}},
+			authKind:  "oauth",
+			wantCount: 0,
+		},
+		{
+			name:      "api key auth has no oauth alias channel",
+			auth:      &coreauth.Auth{ID: "claude-key", Provider: "claude"},
+			cfg:       &config.Config{OAuthModelAlias: map[string][]config.OAuthModelAlias{"claude": {{Name: "claude-opus-4-6", Alias: "opus"}}}},
+			perKey:    []string{"claude-*"},
+			authKind:  "apikey",
+			wantCount: 0,
+		},
+		{
+			name:      "self alias is filtered",
+			auth:      &coreauth.Auth{ID: "x", Provider: "antigravity"},
+			cfg:       &config.Config{OAuthModelAlias: map[string][]config.OAuthModelAlias{"antigravity": {{Name: "Claude-Opus-4-6", Alias: "claude-opus-4-6"}}}},
+			perKey:    []string{"claude-*"},
+			authKind:  "oauth",
+			wantCount: 0,
+		},
+		{
+			name:      "case insensitive match",
+			auth:      &coreauth.Auth{ID: "x", Provider: "claude"},
+			cfg:       &config.Config{OAuthModelAlias: map[string][]config.OAuthModelAlias{"claude": {{Name: "Claude-Sonnet-4-5", Alias: "sonnet"}}}},
+			perKey:    []string{"CLAUDE-*"},
+			authKind:  "oauth",
+			wantCount: 1,
+		},
+		{
+			name:      "empty auth ID falls back to unknown",
+			auth:      &coreauth.Auth{ID: "", Provider: "antigravity"},
+			cfg:       &config.Config{OAuthModelAlias: map[string][]config.OAuthModelAlias{"antigravity": {{Name: "claude-opus", Alias: "opus"}}}},
+			perKey:    []string{"claude-*"},
+			authKind:  "oauth",
+			wantCount: 1,
+			wantSubstrings: []string{
+				`auth="<unknown>"`,
+			},
+		},
+		{
+			name:      "nil cfg returns no warnings",
+			auth:      &coreauth.Auth{ID: "x", Provider: "claude"},
+			perKey:    []string{"claude-*"},
+			authKind:  "oauth",
+			wantCount: 0,
+		},
+		{
+			name:      "nil auth returns no warnings",
+			cfg:       &config.Config{OAuthModelAlias: map[string][]config.OAuthModelAlias{"claude": {{Name: "x", Alias: "y"}}}},
+			perKey:    []string{"x"},
+			authKind:  "oauth",
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := WarnAuthAliasExclusionConflicts(tt.auth, tt.cfg, tt.perKey, tt.authKind)
+			if len(got) != tt.wantCount {
+				t.Fatalf("warning count: got %d, want %d; warnings=%v", len(got), tt.wantCount, got)
+			}
+			for _, want := range tt.wantSubstrings {
+				found := false
+				for _, warning := range got {
+					if strings.Contains(warning, want) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("expected warning containing %q, got %v", want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestMatchExclusionWildcard(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		pattern string
+		value   string
+		want    bool
+	}{
+		{"", "anything", false},
+		{"claude-opus-4-6", "claude-opus-4-6", true},
+		{"claude-opus-4-6", "claude-opus-4-7", false},
+		{"claude-*", "claude-opus-4-6-thinking", true},
+		{"claude-*", "gemini-2.5-pro", false},
+		{"*-thinking", "claude-opus-4-6-thinking", true},
+		{"*-thinking", "claude-opus-4-6", false},
+		{"claude-*-thinking", "claude-opus-4-6-thinking", true},
+		{"claude-*-thinking", "claude-thinking", false},
+		{"claude-*-*-thinking", "claude-opus-4-6-thinking", true},
+		{"*", "anything", true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.pattern+"_vs_"+tt.value, func(t *testing.T) {
+			t.Parallel()
+			got := matchExclusionWildcard(tt.pattern, tt.value)
+			if got != tt.want {
+				t.Fatalf("matchExclusionWildcard(%q, %q): got %v, want %v", tt.pattern, tt.value, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/auth/codex"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/geminicli"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
@@ -159,6 +161,9 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 	}
 	coreauth.ApplyCustomHeadersFromMetadata(a)
 	ApplyAuthExcludedModelsMeta(a, cfg, perAccountExcluded, "oauth")
+	for _, warning := range WarnAuthAliasExclusionConflicts(a, cfg, perAccountExcluded, "oauth") {
+		log.Warnf("%s", warning)
+	}
 	// For codex auth files, extract plan_type from the JWT id_token.
 	if provider == "codex" {
 		if idTokenRaw, ok := metadata["id_token"].(string); ok && strings.TrimSpace(idTokenRaw) != "" {
@@ -173,6 +178,9 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 		if virtuals := SynthesizeGeminiVirtualAuths(a, metadata, now); len(virtuals) > 0 {
 			for _, v := range virtuals {
 				ApplyAuthExcludedModelsMeta(v, cfg, perAccountExcluded, "oauth")
+				for _, warning := range WarnAuthAliasExclusionConflicts(v, cfg, perAccountExcluded, "oauth") {
+					log.Warnf("%s", warning)
+				}
 			}
 			out := make([]*coreauth.Auth, 0, 1+len(virtuals))
 			out = append(out, a)

--- a/internal/watcher/synthesizer/helpers.go
+++ b/internal/watcher/synthesizer/helpers.go
@@ -103,6 +103,87 @@ func ApplyAuthExcludedModelsMeta(auth *coreauth.Auth, cfg *config.Config, perKey
 	}
 }
 
+// WarnAuthAliasExclusionConflicts returns warnings for oauth-model-alias
+// upstream names that would be wildcard-blocked by this auth's per-account
+// excluded_models. Provider-wide exclusions are checked in sdk/cliproxy during
+// config load; this helper handles the auth-file layer where per-account data
+// is visible.
+func WarnAuthAliasExclusionConflicts(auth *coreauth.Auth, cfg *config.Config, perKey []string, authKind string) []string {
+	if auth == nil || cfg == nil || len(cfg.OAuthModelAlias) == 0 || len(perKey) == 0 {
+		return nil
+	}
+	channel := coreauth.OAuthModelAliasChannel(strings.TrimSpace(auth.Provider), authKind)
+	if channel == "" {
+		return nil
+	}
+	aliases := cfg.OAuthModelAlias[channel]
+	if len(aliases) == 0 {
+		return nil
+	}
+	authID := strings.TrimSpace(auth.ID)
+	if authID == "" {
+		authID = "<unknown>"
+	}
+	var warnings []string
+	for _, entry := range aliases {
+		upstream := strings.TrimSpace(entry.Name)
+		alias := strings.TrimSpace(entry.Alias)
+		if upstream == "" || alias == "" || strings.EqualFold(upstream, alias) {
+			continue
+		}
+		upstreamLower := strings.ToLower(upstream)
+		for _, pattern := range perKey {
+			p := strings.TrimSpace(pattern)
+			if p == "" {
+				continue
+			}
+			if matchExclusionWildcard(strings.ToLower(p), upstreamLower) {
+				warnings = append(warnings, fmt.Sprintf(
+					"oauth-model-alias: auth=%q channel=%q alias=%q upstream=%q matches per-account excluded-models pattern=%q; alias will not resolve at runtime",
+					authID, channel, alias, upstream, p,
+				))
+			}
+		}
+	}
+	return warnings
+}
+
+// matchExclusionWildcard mirrors sdk/cliproxy.matchWildcard semantics without
+// adding a synthesizer -> sdk/cliproxy import edge. Inputs are expected to be
+// lowercased by the caller.
+func matchExclusionWildcard(pattern, value string) bool {
+	if pattern == "" {
+		return false
+	}
+	if !strings.Contains(pattern, "*") {
+		return pattern == value
+	}
+	parts := strings.Split(pattern, "*")
+	if prefix := parts[0]; prefix != "" {
+		if !strings.HasPrefix(value, prefix) {
+			return false
+		}
+		value = value[len(prefix):]
+	}
+	if suffix := parts[len(parts)-1]; suffix != "" {
+		if !strings.HasSuffix(value, suffix) {
+			return false
+		}
+		value = value[:len(value)-len(suffix)]
+	}
+	for _, segment := range parts[1 : len(parts)-1] {
+		if segment == "" {
+			continue
+		}
+		idx := strings.Index(value, segment)
+		if idx < 0 {
+			return false
+		}
+		value = value[idx+len(segment):]
+	}
+	return true
+}
+
 // addConfigHeadersToAttrs adds header configuration to auth attributes.
 // Headers are prefixed with "header:" in the attributes map.
 func addConfigHeadersToAttrs(headers map[string]string, attrs map[string]string) {

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	configaccess "github.com/router-for-me/CLIProxyAPI/v6/internal/access/config_access"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/api"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v6/sdk/access"
@@ -243,6 +245,9 @@ func (b *Builder) Build() (*Service, error) {
 	coreManager.SetRoundTripperProvider(newDefaultRoundTripperProvider())
 	coreManager.SetConfig(b.cfg)
 	coreManager.SetOAuthModelAlias(b.cfg.OAuthModelAlias)
+	for _, warning := range validateOAuthAliasExclusions(b.cfg.OAuthModelAlias, b.cfg.OAuthExcludedModels) {
+		log.Warnf("%s", warning)
+	}
 
 	service := &Service{
 		cfg:            b.cfg,

--- a/sdk/cliproxy/oauth_alias_validation.go
+++ b/sdk/cliproxy/oauth_alias_validation.go
@@ -1,0 +1,50 @@
+package cliproxy
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+// validateOAuthAliasExclusions returns warning strings for alias mappings whose
+// upstream model name is blocked by a provider-wide exclusion in the same
+// channel. It mirrors the runtime wildcard matching and self-alias filtering so
+// warnings describe mappings that would otherwise enter the runtime alias table.
+func validateOAuthAliasExclusions(aliases map[string][]config.OAuthModelAlias, excluded map[string][]string) []string {
+	if len(aliases) == 0 || len(excluded) == 0 {
+		return nil
+	}
+	var warnings []string
+	for rawChannel, entries := range aliases {
+		channel := strings.ToLower(strings.TrimSpace(rawChannel))
+		if channel == "" || len(entries) == 0 {
+			continue
+		}
+		patterns := excluded[channel]
+		if len(patterns) == 0 {
+			continue
+		}
+		for _, entry := range entries {
+			upstream := strings.TrimSpace(entry.Name)
+			alias := strings.TrimSpace(entry.Alias)
+			if upstream == "" || alias == "" || strings.EqualFold(upstream, alias) {
+				continue
+			}
+			upstreamLower := strings.ToLower(upstream)
+			for _, pattern := range patterns {
+				p := strings.TrimSpace(pattern)
+				if p == "" {
+					continue
+				}
+				if matchWildcard(strings.ToLower(p), upstreamLower) {
+					warnings = append(warnings, fmt.Sprintf(
+						"oauth-model-alias: alias=%q channel=%q upstream=%q matches provider-wide exclusion pattern=%q; alias will not resolve at runtime",
+						alias, channel, upstream, p,
+					))
+				}
+			}
+		}
+	}
+	return warnings
+}

--- a/sdk/cliproxy/oauth_alias_validation_test.go
+++ b/sdk/cliproxy/oauth_alias_validation_test.go
@@ -1,0 +1,161 @@
+package cliproxy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestValidateOAuthAliasExclusions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		aliases        map[string][]config.OAuthModelAlias
+		excluded       map[string][]string
+		wantCount      int
+		wantSubstrings []string
+	}{
+		{
+			name:      "empty aliases returns nil",
+			excluded:  map[string][]string{"claude": {"claude-*"}},
+			wantCount: 0,
+		},
+		{
+			name: "empty exclusions returns nil",
+			aliases: map[string][]config.OAuthModelAlias{
+				"claude": {{Name: "claude-opus-4-6-thinking", Alias: "opus"}},
+			},
+			wantCount: 0,
+		},
+		{
+			name: "wildcard matches alias upstream in same channel",
+			aliases: map[string][]config.OAuthModelAlias{
+				"antigravity": {{Name: "claude-opus-4-6-thinking", Alias: "opus"}},
+			},
+			excluded:  map[string][]string{"antigravity": {"claude-*"}},
+			wantCount: 1,
+			wantSubstrings: []string{
+				`alias="opus"`,
+				`channel="antigravity"`,
+				`upstream="claude-opus-4-6-thinking"`,
+				`pattern="claude-*"`,
+			},
+		},
+		{
+			name: "exact match without wildcard",
+			aliases: map[string][]config.OAuthModelAlias{
+				"claude": {{Name: "claude-sonnet-4-5", Alias: "sonnet"}},
+			},
+			excluded:  map[string][]string{"claude": {"claude-sonnet-4-5"}},
+			wantCount: 1,
+			wantSubstrings: []string{
+				`alias="sonnet"`,
+				`upstream="claude-sonnet-4-5"`,
+				`pattern="claude-sonnet-4-5"`,
+			},
+		},
+		{
+			name: "different channel does not warn",
+			aliases: map[string][]config.OAuthModelAlias{
+				"antigravity": {{Name: "claude-opus-4-6-thinking", Alias: "opus"}},
+			},
+			excluded:  map[string][]string{"claude": {"claude-*"}},
+			wantCount: 0,
+		},
+		{
+			name: "case-insensitive matching preserves original text in warning",
+			aliases: map[string][]config.OAuthModelAlias{
+				"claude": {{Name: "Claude-Opus-4-6", Alias: "opus"}},
+			},
+			excluded:  map[string][]string{"claude": {"CLAUDE-*"}},
+			wantCount: 1,
+			wantSubstrings: []string{
+				`upstream="Claude-Opus-4-6"`,
+				`pattern="CLAUDE-*"`,
+			},
+		},
+		{
+			name: "self alias is filtered",
+			aliases: map[string][]config.OAuthModelAlias{
+				"claude": {{Name: "Claude-Opus-4-6", Alias: "claude-opus-4-6"}},
+			},
+			excluded:  map[string][]string{"claude": {"claude-*"}},
+			wantCount: 0,
+		},
+		{
+			name: "multiple aliases only colliding aliases warn",
+			aliases: map[string][]config.OAuthModelAlias{
+				"claude": {
+					{Name: "claude-opus-4-6-thinking", Alias: "opus"},
+					{Name: "claude-haiku-4-5", Alias: "haiku"},
+				},
+			},
+			excluded:  map[string][]string{"claude": {"claude-opus-*"}},
+			wantCount: 1,
+			wantSubstrings: []string{
+				`alias="opus"`,
+			},
+		},
+		{
+			name: "empty pattern or alias data is skipped",
+			aliases: map[string][]config.OAuthModelAlias{
+				"claude": {
+					{Name: "", Alias: "opus"},
+					{Name: "claude-opus-4-6", Alias: ""},
+					{Name: "claude-opus-4-6", Alias: "opus"},
+				},
+			},
+			excluded:  map[string][]string{"claude": {"", "claude-*"}},
+			wantCount: 1,
+		},
+		{
+			name: "channel key is normalized",
+			aliases: map[string][]config.OAuthModelAlias{
+				" CLAUDE ": {{Name: "claude-opus-4-6", Alias: "opus"}},
+			},
+			excluded:  map[string][]string{"claude": {"claude-*"}},
+			wantCount: 1,
+		},
+		{
+			name: "documented antigravity case warns for non-self aliases",
+			aliases: map[string][]config.OAuthModelAlias{
+				"antigravity": {
+					{Name: "claude-opus-4-6-thinking", Alias: "opus"},
+					{Name: "claude-opus-4-6-thinking", Alias: "opus[1m]"},
+					{Name: "claude-opus-4-6-thinking", Alias: "claude-opus-4-6-thinking"},
+				},
+			},
+			excluded:  map[string][]string{"antigravity": {"claude-*"}},
+			wantCount: 2,
+			wantSubstrings: []string{
+				`alias="opus"`,
+				`alias="opus[1m]"`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := validateOAuthAliasExclusions(tt.aliases, tt.excluded)
+			if len(got) != tt.wantCount {
+				t.Fatalf("warning count: got %d, want %d; warnings=%v", len(got), tt.wantCount, got)
+			}
+			for _, want := range tt.wantSubstrings {
+				found := false
+				for _, warning := range got {
+					if strings.Contains(warning, want) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("expected warning containing %q, got %v", want, got)
+				}
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -688,6 +688,9 @@ func (s *Service) Run(ctx context.Context) error {
 		if s.coreManager != nil {
 			s.coreManager.SetConfig(newCfg)
 			s.coreManager.SetOAuthModelAlias(newCfg.OAuthModelAlias)
+			for _, warning := range validateOAuthAliasExclusions(newCfg.OAuthModelAlias, newCfg.OAuthExcludedModels) {
+				log.Warnf("%s", warning)
+			}
 		}
 		s.rebindExecutors()
 	}


### PR DESCRIPTION
## Summary
- Selectively port upstream router-for-me/CLIProxyAPI#3250 with v6 compatibility.
- Warn when `oauth-model-alias` upstream targets are blocked by provider-wide `oauth-excluded-models` during SDK build/reload.
- Warn when auth-file per-account `excluded-models` blocks OAuth aliases during synthesizer passes, including Gemini virtual auths.
- Add regression tests for provider-wide alias/exclusion conflicts, per-account conflicts, and wildcard matching.

## LTS compatibility
- Does not change routing, request execution, usage collection, Management usage endpoints, config schema, auth file schema, SDK public types, or AGENTS.md.
- Warnings are non-fatal and only surface misconfiguration earlier; runtime exclusion behavior remains unchanged.
- Does not touch `internal/translator/`.

## Validation
- `go test ./sdk/cliproxy -run TestValidateOAuthAliasExclusions -count=1`
- `go test ./internal/watcher/synthesizer -run 'TestWarnAuthAliasExclusionConflicts|TestMatchExclusionWildcard' -count=1`
- `go test ./sdk/cliproxy/... -count=1`
- `go test ./internal/watcher/... -count=1`
- `go build -o test-output ./cmd/server && rm -f test-output`
- `go test ./...`
- `git diff --check`
