### PR TITLE
[codex] Refresh OpenAI-compatible thinking metadata

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -580,7 +580,7 @@ type OpenAICompatibilityModel struct {
 	Image bool `yaml:"image,omitempty" json:"image,omitempty"`
 
 	// Thinking configures the thinking/reasoning capability for this model.
-	// If nil, the model defaults to level-based reasoning with levels ["low", "medium", "high"].
+	// If nil, static model definitions are reused when available; otherwise levels default to ["low", "medium", "high"].
 	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
 }
 

--- a/internal/watcher/diff/model_hash.go
+++ b/internal/watcher/diff/model_hash.go
@@ -21,7 +21,12 @@ func ComputeOpenAICompatModelsHash(models []config.OpenAICompatibilityModel) str
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|image=" + strconv.FormatBool(model.Image))
+			thinking := ""
+			if model.Thinking != nil {
+				data, _ := json.Marshal(model.Thinking)
+				thinking = string(data)
+			}
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|image=" + strconv.FormatBool(model.Image) + "|thinking=" + thinking)
 		}
 	})
 	return hashJoined(keys)

--- a/internal/watcher/diff/model_hash_test.go
+++ b/internal/watcher/diff/model_hash_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 )
 
 func TestComputeOpenAICompatModelsHash_Deterministic(t *testing.T) {
@@ -54,6 +55,23 @@ func TestComputeOpenAICompatModelsHash_IncludesImageFlag(t *testing.T) {
 	}
 	if textHash == imageHash {
 		t.Fatal("hash should change when image flag changes")
+	}
+}
+
+func TestComputeOpenAICompatModelsHash_IncludesThinking(t *testing.T) {
+	low := ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{
+		Name:     "gpt-5.5",
+		Thinking: &registry.ThinkingSupport{Levels: []string{"low"}},
+	}})
+	xhigh := ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{
+		Name:     "gpt-5.5",
+		Thinking: &registry.ThinkingSupport{Levels: []string{"low", "xhigh"}},
+	}})
+	if low == "" || xhigh == "" {
+		t.Fatal("hashes should not be empty")
+	}
+	if low == xhigh {
+		t.Fatal("hash should change when thinking support changes")
 	}
 }
 

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -371,6 +371,21 @@ func openAICompatInfoFromAuth(a *coreauth.Auth) (providerKey string, compatName 
 	return "", "", false
 }
 
+// shouldRefreshAuthForModelCatalogChange reports whether an auth's model
+// registration depends on refreshed static catalog data. OpenAI-compatible
+// configured models may inherit thinking metadata from any static provider.
+func shouldRefreshAuthForModelCatalogChange(auth *coreauth.Auth, changedProviders map[string]bool) bool {
+	if auth == nil || len(changedProviders) == 0 {
+		return false
+	}
+	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+	if changedProviders[provider] {
+		return true
+	}
+	_, _, isCompat := openAICompatInfoFromAuth(auth)
+	return isCompat
+}
+
 func (s *Service) ensureExecutorsForAuth(a *coreauth.Auth) {
 	s.ensureExecutorsForAuthWithMode(a, false)
 }
@@ -579,8 +594,7 @@ func (s *Service) Run(ctx context.Context) error {
 			if !ok || auth == nil || auth.Disabled {
 				continue
 			}
-			provider := strings.ToLower(strings.TrimSpace(auth.Provider))
-			if !providerSet[provider] {
+			if !shouldRefreshAuthForModelCatalogChange(auth, providerSet) {
 				continue
 			}
 			if s.refreshModelRegistrationForAuth(auth) {
@@ -995,7 +1009,20 @@ func (s *Service) registerModelsForAuth(a *coreauth.Auth) {
 						}
 						thinking := m.Thinking
 						if thinking == nil && !m.Image {
-							thinking = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
+							name := strings.TrimSpace(m.Name)
+							if name != "" {
+								if upstream := registry.LookupStaticModelInfo(name); upstream != nil && upstream.Thinking != nil {
+									thinking = upstream.Thinking
+								}
+							}
+							if thinking == nil && name == "" {
+								if upstream := registry.LookupStaticModelInfo(modelID); upstream != nil && upstream.Thinking != nil {
+									thinking = upstream.Thinking
+								}
+							}
+							if thinking == nil {
+								thinking = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
+							}
 						}
 						ms = append(ms, &ModelInfo{
 							ID:          modelID,

--- a/sdk/cliproxy/service_excluded_models_test.go
+++ b/sdk/cliproxy/service_excluded_models_test.go
@@ -108,3 +108,97 @@ func TestRegisterModelsForAuth_MarksOpenAICompatibilityImageModels(t *testing.T)
 		t.Fatalf("expected image model not to receive text reasoning defaults")
 	}
 }
+
+func TestRegisterModelsForAuth_OpenAICompatibilityInheritsStaticThinking(t *testing.T) {
+	service := &Service{
+		cfg: &config.Config{
+			OpenAICompatibility: []config.OpenAICompatibility{{
+				Name: "openrouter",
+				Models: []config.OpenAICompatibilityModel{
+					{Name: "gpt-5.5", Alias: "static-gpt-5.5"},
+					{
+						Name:  "gpt-5.5",
+						Alias: "explicit-gpt-5.5",
+						Thinking: &registry.ThinkingSupport{
+							Levels: []string{"low"},
+						},
+					},
+					{Name: "custom-upstream", Alias: "gpt-5.5"},
+				},
+			}},
+		},
+	}
+	auth := &coreauth.Auth{
+		ID:       "auth-openai-compat-thinking",
+		Provider: "openai-compatibility",
+		Label:    "openrouter",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"compat_name": "openrouter",
+		},
+	}
+
+	modelRegistry := GlobalModelRegistry()
+	modelRegistry.UnregisterClient(auth.ID)
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(auth.ID)
+	})
+
+	service.registerModelsForAuth(auth)
+
+	inherited := registry.LookupModelInfo("static-gpt-5.5", "openai-compatibility")
+	if inherited == nil || inherited.Thinking == nil {
+		t.Fatal("expected static-gpt-5.5 to inherit static thinking support")
+	}
+	hasXHigh := false
+	for _, level := range inherited.Thinking.Levels {
+		if level == "xhigh" {
+			hasXHigh = true
+			break
+		}
+	}
+	if !hasXHigh {
+		t.Fatalf("static-gpt-5.5 thinking levels = %v, want xhigh", inherited.Thinking.Levels)
+	}
+
+	explicit := registry.LookupModelInfo("explicit-gpt-5.5", "openai-compatibility")
+	if explicit == nil || explicit.Thinking == nil {
+		t.Fatal("expected explicit-gpt-5.5 to keep configured thinking support")
+	}
+	if got := explicit.Thinking.Levels; len(got) != 1 || got[0] != "low" {
+		t.Fatalf("explicit thinking levels = %v, want [low]", got)
+	}
+
+	aliasOnly := registry.LookupModelInfo("gpt-5.5", "openai-compatibility")
+	if aliasOnly == nil || aliasOnly.Thinking == nil {
+		t.Fatal("expected custom-upstream alias to keep default thinking support")
+	}
+	for _, level := range aliasOnly.Thinking.Levels {
+		if level == "xhigh" {
+			t.Fatalf("custom-upstream alias thinking levels = %v, want no inherited xhigh", aliasOnly.Thinking.Levels)
+		}
+	}
+}
+
+func TestShouldRefreshAuthForModelCatalogChange(t *testing.T) {
+	changedProviders := map[string]bool{"codex": true}
+
+	if !shouldRefreshAuthForModelCatalogChange(&coreauth.Auth{Provider: "codex"}, changedProviders) {
+		t.Fatal("expected direct codex auth to refresh")
+	}
+	if !shouldRefreshAuthForModelCatalogChange(&coreauth.Auth{
+		Provider: "openai-compatibility",
+		Attributes: map[string]string{
+			"compat_name":  "compat",
+			"provider_key": "compat",
+		},
+	}, changedProviders) {
+		t.Fatal("expected openai-compatible auth to refresh after static catalog change")
+	}
+	if shouldRefreshAuthForModelCatalogChange(&coreauth.Auth{Provider: "gemini"}, changedProviders) {
+		t.Fatal("did not expect unrelated provider auth to refresh")
+	}
+	if shouldRefreshAuthForModelCatalogChange(&coreauth.Auth{Provider: "openai-compatibility"}, nil) {
+		t.Fatal("did not expect refresh without changed providers")
+	}
+}


### PR DESCRIPTION
## Summary
- Selectively port the useful parts of upstream router-for-me/CLIProxyAPI#3560 for OpenAI-compatible model thinking metadata.
- Let configured OpenAI-compatible text models inherit static registry thinking support when their upstream model name is known, while preserving explicit per-model thinking config and image-model behavior.
- Include OpenAI-compatible `thinking` config in the hot-reload model hash so config-only reasoning capability changes are detected.
- Refresh OpenAI-compatible auth model registrations when the static model catalog changes, because these entries can inherit thinking metadata from static providers.

## LTS compatibility
- Preserves `github.com/router-for-me/CLIProxyAPI/v6` module path and the existing LTS usage statistics contract.
- Does not touch `internal/usage`, `/v0/management/usage*`, Management API response shape, auth file schema, translator paths, SDK public API signatures, or AGENTS.md.
- Keeps explicit `thinking` values and image model behavior unchanged.

## Validation
- `go test ./internal/watcher/diff ./sdk/cliproxy -run 'TestComputeOpenAICompatModelsHash|TestRegisterModelsForAuth_OpenAICompatibilityInheritsStaticThinking|TestShouldRefreshAuthForModelCatalogChange' -count=1`\n- `go test ./internal/config ./internal/watcher/diff ./sdk/cliproxy/... -count=1`\n- `go build -o test-output ./cmd/server && rm -f test-output`\n- `go test ./...`\n- `git diff --check`