### PR TITLE
[codex] Add Claude login label

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -62,6 +62,7 @@ func main() {
 	var codexLogin bool
 	var codexDeviceLogin bool
 	var claudeLogin bool
+	var claudeLabel string
 	var noBrowser bool
 	var oauthCallbackPort int
 	var antigravityLogin bool
@@ -81,6 +82,7 @@ func main() {
 	flag.BoolVar(&codexLogin, "codex-login", false, "Login to Codex using OAuth")
 	flag.BoolVar(&codexDeviceLogin, "codex-device-login", false, "Login to Codex using device code flow")
 	flag.BoolVar(&claudeLogin, "claude-login", false, "Login to Claude using OAuth")
+	flag.StringVar(&claudeLabel, "claude-label", "", "Label suffix appended to the auth filename (claude-<email>-<label>.json); allows multiple Claude orgs to coexist in one auth-dir")
 	flag.BoolVar(&noBrowser, "no-browser", false, "Don't open browser automatically for OAuth")
 	flag.IntVar(&oauthCallbackPort, "oauth-callback-port", 0, "Override OAuth callback port (defaults to provider-specific port)")
 	flag.BoolVar(&antigravityLogin, "antigravity-login", false, "Login to Antigravity using OAuth")
@@ -446,6 +448,7 @@ func main() {
 	options := &cmd.LoginOptions{
 		NoBrowser:    noBrowser,
 		CallbackPort: oauthCallbackPort,
+		Label:        claudeLabel,
 	}
 
 	// Register the shared token store once so all components use the same persistence backend.

--- a/internal/cmd/anthropic_login.go
+++ b/internal/cmd/anthropic_login.go
@@ -24,6 +24,11 @@ func DoClaudeLogin(cfg *config.Config, options *LoginOptions) {
 		options = &LoginOptions{}
 	}
 
+	if err := sdkAuth.ValidateLabel(options.Label); err != nil {
+		log.Errorf("invalid claude-label: %v", err)
+		return
+	}
+
 	promptFn := options.Prompt
 	if promptFn == nil {
 		promptFn = defaultProjectPrompt()
@@ -36,6 +41,7 @@ func DoClaudeLogin(cfg *config.Config, options *LoginOptions) {
 		CallbackPort: options.CallbackPort,
 		Metadata:     map[string]string{},
 		Prompt:       promptFn,
+		Label:        options.Label,
 	}
 
 	_, savedPath, err := manager.Login(context.Background(), "claude", cfg, authOpts)

--- a/internal/cmd/openai_login.go
+++ b/internal/cmd/openai_login.go
@@ -24,6 +24,10 @@ type LoginOptions struct {
 
 	// Prompt allows the caller to provide interactive input when needed.
 	Prompt func(prompt string) (string, error)
+
+	// Label is appended to the auth filename so multiple accounts for the
+	// same provider can coexist in one auth-dir. See sdk/auth.LoginOptions.
+	Label string
 }
 
 // DoCodexLogin triggers the Codex OAuth flow through the shared authentication manager.

--- a/sdk/auth/claude.go
+++ b/sdk/auth/claude.go
@@ -27,6 +27,14 @@ func NewClaudeAuthenticator() *ClaudeAuthenticator {
 	return &ClaudeAuthenticator{CallbackPort: 54545}
 }
 
+// claudeFileName returns the auth filename for a Claude account.
+func claudeFileName(email, label string) string {
+	if label != "" {
+		return fmt.Sprintf("claude-%s-%s.json", email, label)
+	}
+	return fmt.Sprintf("claude-%s.json", email)
+}
+
 func (a *ClaudeAuthenticator) Provider() string {
 	return "claude"
 }
@@ -44,6 +52,10 @@ func (a *ClaudeAuthenticator) Login(ctx context.Context, cfg *config.Config, opt
 	}
 	if opts == nil {
 		opts = &LoginOptions{}
+	}
+
+	if err := ValidateLabel(opts.Label); err != nil {
+		return nil, err
 	}
 
 	callbackPort := a.CallbackPort
@@ -200,7 +212,7 @@ waitForCallback:
 		return nil, fmt.Errorf("claude token storage missing account information")
 	}
 
-	fileName := fmt.Sprintf("claude-%s.json", tokenStorage.Email)
+	fileName := claudeFileName(tokenStorage.Email, opts.Label)
 	metadata := map[string]any{
 		"email": tokenStorage.Email,
 	}

--- a/sdk/auth/interfaces.go
+++ b/sdk/auth/interfaces.go
@@ -3,11 +3,15 @@ package auth
 import (
 	"context"
 	"errors"
+	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
+
+var labelRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
 var ErrRefreshNotSupported = errors.New("cliproxy auth: refresh not supported")
 
@@ -19,6 +23,27 @@ type LoginOptions struct {
 	CallbackPort int
 	Metadata     map[string]string
 	Prompt       func(prompt string) (string, error)
+
+	// Label, when set, is appended to the auth filename so multiple accounts
+	// for the same provider can coexist in one auth-dir without overwriting
+	// each other. For Claude the file becomes claude-<email>-<label>.json.
+	// Must contain only alphanumeric characters, hyphens and underscores.
+	Label string
+}
+
+// ValidateLabel returns an error if label contains characters that are not
+// safe for use in a filename (anything outside [a-zA-Z0-9_-]).
+func ValidateLabel(label string) error {
+	if label == "" {
+		return nil
+	}
+	if len(label) > 32 {
+		return fmt.Errorf("label %q is too long: maximum 32 characters", label)
+	}
+	if !labelRe.MatchString(label) {
+		return fmt.Errorf("label %q contains invalid characters: only letters, digits, hyphens and underscores are allowed", label)
+	}
+	return nil
 }
 
 // Authenticator manages login and optional refresh flows for a provider.

--- a/sdk/auth/label_test.go
+++ b/sdk/auth/label_test.go
@@ -1,0 +1,54 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateLabel(t *testing.T) {
+	valid := []string{"work", "org-2", "my_team", "ABC", "a1b2", "x"}
+	for _, label := range valid {
+		if err := ValidateLabel(label); err != nil {
+			t.Errorf("ValidateLabel(%q) unexpected error: %v", label, err)
+		}
+	}
+
+	invalid := []string{"a/b", "foo bar", "../etc", "org@home", "label!", "a:b"}
+	for _, label := range invalid {
+		if err := ValidateLabel(label); err == nil {
+			t.Errorf("ValidateLabel(%q) expected error, got nil", label)
+		}
+	}
+
+	if err := ValidateLabel(""); err != nil {
+		t.Errorf("ValidateLabel(\"\") unexpected error: %v", err)
+	}
+
+	long := strings.Repeat("a", 33)
+	if err := ValidateLabel(long); err == nil {
+		t.Errorf("ValidateLabel(%q) expected error for >32 chars, got nil", long)
+	}
+	exactly32 := strings.Repeat("a", 32)
+	if err := ValidateLabel(exactly32); err != nil {
+		t.Errorf("ValidateLabel(%q) unexpected error at exactly 32 chars: %v", exactly32, err)
+	}
+}
+
+func TestClaudeFilenameConstruction(t *testing.T) {
+	email := "user@example.com"
+	cases := []struct {
+		label string
+		want  string
+	}{
+		{"", "claude-user@example.com.json"},
+		{"work", "claude-user@example.com-work.json"},
+		{"org-2", "claude-user@example.com-org-2.json"},
+		{"my_team", "claude-user@example.com-my_team.json"},
+	}
+	for _, tc := range cases {
+		got := claudeFileName(email, tc.label)
+		if got != tc.want {
+			t.Errorf("claudeFileName(%q, %q) = %q, want %q", email, tc.label, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- port the useful subset of upstream #3391 for multi-org Claude OAuth login
- add `-claude-label` so a second Claude login can save as `claude-<email>-<label>.json` instead of overwriting `claude-<email>.json`
- validate label values at both CLI and SDK boundaries and cover filename construction with tests

## LTS boundary
- default filename remains `claude-<email>.json` when no label is set
- no changes to auth file payload shape, watcher synthesis, Management API, usage statistics, or translator paths
- label is restricted to `[a-zA-Z0-9_-]` and 32 characters to avoid path traversal / unsafe filename components

## Validation
- `git diff --check`
- `go test ./sdk/auth -run 'TestValidateLabel|TestClaudeFilenameConstruction' -count=1`\n- `go test ./sdk/auth ./internal/cmd -count=1`\n- `go build -o test-output ./cmd/server && rm -f test-output`\n- `go test ./...`