### PR TITLE
[codex] Configure GPT Image 2 base model

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -100,6 +100,10 @@ disable-cooling: false
 # - "chat": disable image_generation injection on non-images endpoints, but keep /v1/images/generations and /v1/images/edits enabled.
 disable-image-generation: false
 
+# Base model used when proxying gpt-image-2 via the hosted image_generation tool.
+# Must start with "gpt-" (case-insensitive). If unset or invalid, defaults to "gpt-5.4-mini".
+# gpt-image-2-base-model: "gpt-5.4-mini"
+
 # Core auth auto-refresh worker pool size (OAuth/file-based auth token refresh).
 # When > 0, overrides the default worker count (16).
 # auth-auto-refresh-workers: 16

--- a/internal/config/openai_compat_image_test.go
+++ b/internal/config/openai_compat_image_test.go
@@ -34,3 +34,21 @@ openai-compatibility:
 		t.Fatalf("expected image flag to load as true")
 	}
 }
+
+func TestLoadConfig_GPTImage2BaseModel(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	data := []byte(`
+gpt-image-2-base-model: gpt-5.5-mini
+`)
+	if err := os.WriteFile(configPath, data, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if cfg.GPTImage2BaseModel != "gpt-5.5-mini" {
+		t.Fatalf("GPTImage2BaseModel = %q, want gpt-5.5-mini", cfg.GPTImage2BaseModel)
+	}
+}

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -19,6 +19,13 @@ type SDKConfig struct {
 	//     while keeping /v1/images/generations and /v1/images/edits enabled and preserving image_generation there.
 	DisableImageGeneration DisableImageGenerationMode `yaml:"disable-image-generation" json:"disable-image-generation"`
 
+	// GPTImage2BaseModel sets the base model used when proxying GPT Image 2
+	// requests via the hosted image_generation tool.
+	//
+	// The value must start with "gpt-" (case-insensitive). If empty or invalid,
+	// the default base model ("gpt-5.4-mini") is used.
+	GPTImage2BaseModel string `yaml:"gpt-image-2-base-model,omitempty" json:"gpt-image-2-base-model,omitempty"`
+
 	// EnableGeminiCLIEndpoint controls whether Gemini CLI internal endpoints (/v1internal:*) are enabled.
 	// Default is false for safety; when false, /v1internal:* requests are rejected.
 	EnableGeminiCLIEndpoint bool `yaml:"enable-gemini-cli-endpoint" json:"enable-gemini-cli-endpoint"`

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -48,6 +48,11 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.DisableImageGeneration != newCfg.DisableImageGeneration {
 		changes = append(changes, fmt.Sprintf("disable-image-generation: %v -> %v", oldCfg.DisableImageGeneration, newCfg.DisableImageGeneration))
 	}
+	oldGPTImage2BaseModel := strings.TrimSpace(oldCfg.GPTImage2BaseModel)
+	newGPTImage2BaseModel := strings.TrimSpace(newCfg.GPTImage2BaseModel)
+	if oldGPTImage2BaseModel != newGPTImage2BaseModel {
+		changes = append(changes, fmt.Sprintf("gpt-image-2-base-model: %s -> %s", oldGPTImage2BaseModel, newGPTImage2BaseModel))
+	}
 	if oldCfg.RequestLog != newCfg.RequestLog {
 		changes = append(changes, fmt.Sprintf("request-log: %t -> %t", oldCfg.RequestLog, newCfg.RequestLog))
 	}

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -317,6 +317,7 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 			APIKeys:                    []string{"key-1"},
 			ForceModelPrefix:           false,
 			NonStreamKeepAliveInterval: 0,
+			GPTImage2BaseModel:         "",
 		},
 	}
 	newCfg := &config.Config{
@@ -357,6 +358,7 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 			ForceModelPrefix:           true,
 			NonStreamKeepAliveInterval: 5,
 			DisableImageGeneration:     config.DisableImageGenerationAll,
+			GPTImage2BaseModel:         "gpt-5.5-mini",
 		},
 	}
 
@@ -374,6 +376,7 @@ func TestBuildConfigChangeDetails_FlagsAndKeys(t *testing.T) {
 	expectContains(t, details, "ws-auth: false -> true")
 	expectContains(t, details, "force-model-prefix: false -> true")
 	expectContains(t, details, "nonstream-keepalive-interval: 0 -> 5")
+	expectContains(t, details, "gpt-image-2-base-model:  -> gpt-5.5-mini")
 	expectContains(t, details, "quota-exceeded.switch-project: false -> true")
 	expectContains(t, details, "quota-exceeded.switch-preview-model: false -> true")
 	expectContains(t, details, "quota-exceeded.antigravity-credits: false -> true")

--- a/sdk/api/handlers/openai/openai_images_handlers.go
+++ b/sdk/api/handlers/openai/openai_images_handlers.go
@@ -296,6 +296,24 @@ func parseBoolField(raw string, fallback bool) bool {
 	}
 }
 
+func normalizeGPTImage2BaseModel(model string) string {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return defaultImagesMainModel
+	}
+	if strings.HasPrefix(strings.ToLower(model), "gpt-") {
+		return model
+	}
+	return defaultImagesMainModel
+}
+
+func (h *OpenAIAPIHandler) resolveGPTImage2BaseModel() string {
+	if h == nil || h.BaseAPIHandler == nil || h.BaseAPIHandler.Cfg == nil {
+		return defaultImagesMainModel
+	}
+	return normalizeGPTImage2BaseModel(h.BaseAPIHandler.Cfg.GPTImage2BaseModel)
+}
+
 func (h *OpenAIAPIHandler) ImagesGenerations(c *gin.Context) {
 	if h != nil && h.BaseAPIHandler != nil && h.BaseAPIHandler.Cfg != nil && h.BaseAPIHandler.Cfg.DisableImageGeneration == internalconfig.DisableImageGenerationAll {
 		c.AbortWithStatus(http.StatusNotFound)
@@ -382,7 +400,7 @@ func (h *OpenAIAPIHandler) ImagesGenerations(c *gin.Context) {
 		tool, _ = sjson.SetBytes(tool, "moderation", v)
 	}
 
-	responsesReq := buildImagesResponsesRequest(prompt, nil, tool)
+	responsesReq := buildImagesResponsesRequest(prompt, nil, tool, h.resolveGPTImage2BaseModel())
 	if stream {
 		h.streamImagesFromResponses(c, responsesReq, responseFormat, "image_generation")
 		return
@@ -546,7 +564,7 @@ func (h *OpenAIAPIHandler) imagesEditsFromMultipart(c *gin.Context) {
 		tool, _ = sjson.SetBytes(tool, "input_image_mask.image_url", strings.TrimSpace(*maskDataURL))
 	}
 
-	responsesReq := buildImagesResponsesRequest(prompt, images, tool)
+	responsesReq := buildImagesResponsesRequest(prompt, images, tool, h.resolveGPTImage2BaseModel())
 	if stream {
 		h.streamImagesFromResponses(c, responsesReq, responseFormat, "image_edit")
 		return
@@ -662,7 +680,7 @@ func (h *OpenAIAPIHandler) imagesEditsFromJSON(c *gin.Context) {
 		tool, _ = sjson.SetBytes(tool, "input_image_mask.image_url", strings.TrimSpace(*maskDataURL))
 	}
 
-	responsesReq := buildImagesResponsesRequest(prompt, images, tool)
+	responsesReq := buildImagesResponsesRequest(prompt, images, tool, h.resolveGPTImage2BaseModel())
 	if stream {
 		h.streamImagesFromResponses(c, responsesReq, responseFormat, "image_edit")
 		return
@@ -670,15 +688,15 @@ func (h *OpenAIAPIHandler) imagesEditsFromJSON(c *gin.Context) {
 	h.collectImagesFromResponses(c, responsesReq, responseFormat)
 }
 
-func buildImagesResponsesRequest(prompt string, images []string, toolJSON []byte) []byte {
+func buildImagesResponsesRequest(prompt string, images []string, toolJSON []byte, baseModel string) []byte {
 	req := []byte(`{"instructions":"","stream":true,"reasoning":{"effort":"medium","summary":"auto"},"parallel_tool_calls":true,"include":["reasoning.encrypted_content"],"model":"","store":false,"tool_choice":{"type":"image_generation"}}`)
-	mainModel := defaultImagesMainModel
+	mainModel := normalizeGPTImage2BaseModel(baseModel)
 	if len(toolJSON) > 0 && json.Valid(toolJSON) {
 		toolModel := strings.TrimSpace(gjson.GetBytes(toolJSON, "model").String())
 		if idx := strings.LastIndex(toolModel, "/"); idx > 0 && idx < len(toolModel)-1 {
 			prefix := strings.TrimSpace(toolModel[:idx])
 			if prefix != "" {
-				mainModel = prefix + "/" + defaultImagesMainModel
+				mainModel = prefix + "/" + mainModel
 			}
 		}
 	}

--- a/sdk/api/handlers/openai/openai_images_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_images_handlers_test.go
@@ -109,6 +109,52 @@ func TestImagesModelValidationAllowsOpenAICompatImageModel(t *testing.T) {
 	}
 }
 
+func TestGPTImage2BaseModelResolution(t *testing.T) {
+	var nilHandler *OpenAIAPIHandler
+	if got := nilHandler.resolveGPTImage2BaseModel(); got != defaultImagesMainModel {
+		t.Fatalf("nil handler base model = %q, want %q", got, defaultImagesMainModel)
+	}
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{GPTImage2BaseModel: " gpt-5.5-mini "}, nil)
+	handler := NewOpenAIAPIHandler(base)
+	if got := handler.resolveGPTImage2BaseModel(); got != "gpt-5.5-mini" {
+		t.Fatalf("configured base model = %q, want gpt-5.5-mini", got)
+	}
+
+	base = handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{GPTImage2BaseModel: "claude-sonnet-4.5"}, nil)
+	handler = NewOpenAIAPIHandler(base)
+	if got := handler.resolveGPTImage2BaseModel(); got != defaultImagesMainModel {
+		t.Fatalf("invalid base model = %q, want %q", got, defaultImagesMainModel)
+	}
+}
+
+func TestBuildImagesResponsesRequestUsesConfiguredGPTImage2BaseModel(t *testing.T) {
+	tool := []byte(`{"type":"image_generation","model":"gpt-image-2"}`)
+	req := buildImagesResponsesRequest("draw", nil, tool, "gpt-5.5-mini")
+
+	if got := gjson.GetBytes(req, "model").String(); got != "gpt-5.5-mini" {
+		t.Fatalf("responses model = %q, want gpt-5.5-mini; payload=%s", got, string(req))
+	}
+}
+
+func TestBuildImagesResponsesRequestPreservesPrefixForConfiguredGPTImage2BaseModel(t *testing.T) {
+	tool := []byte(`{"type":"image_generation","model":"team-a/gpt-image-2"}`)
+	req := buildImagesResponsesRequest("draw", nil, tool, "gpt-5.5-mini")
+
+	if got := gjson.GetBytes(req, "model").String(); got != "team-a/gpt-5.5-mini" {
+		t.Fatalf("responses model = %q, want team-a/gpt-5.5-mini; payload=%s", got, string(req))
+	}
+}
+
+func TestBuildImagesResponsesRequestFallsBackForInvalidGPTImage2BaseModel(t *testing.T) {
+	tool := []byte(`{"type":"image_generation","model":"team-a/gpt-image-2"}`)
+	req := buildImagesResponsesRequest("draw", nil, tool, "claude-sonnet-4.5")
+
+	if got := gjson.GetBytes(req, "model").String(); got != "team-a/"+defaultImagesMainModel {
+		t.Fatalf("responses model = %q, want team-a/%s; payload=%s", got, defaultImagesMainModel, string(req))
+	}
+}
+
 func TestImagesGenerationsRoutesOpenAICompatImageModel(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	executor := &imageCaptureExecutor{}


### PR DESCRIPTION
## Summary
- Add `gpt-image-2-base-model` to SDK config and `config.example.yaml`.
- Use the configured GPT base model when building `gpt-image-2` Responses requests, preserving credential prefixes from `prefix/gpt-image-2`.
- Report the new config key in watcher reload diffs and cover config load / handler fallback behavior with tests.

## Upstream Context
- Selectively ports the config/base-model portion of upstream `e399edd3`.
- Does not duplicate the image SSE classification work already covered by PR #75.
- Does not touch LTS usage statistics endpoints or `internal/usage`.

## Validation
- `go test ./internal/config ./internal/watcher/diff ./sdk/api/handlers/openai -run 'GPTImage|Image|Config|Diff' -count=1`
- `go test ./sdk/api/handlers/openai -count=1`
- `go build -o test-output ./cmd/server && rm -f test-output`
- `git diff --check`
- `go test ./...`