### PR TITLE
[codex] Ignore empty Gemini usage metadata

### DIFF
--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -436,6 +436,9 @@ func ParseGeminiStreamUsage(line []byte) (usage.Detail, bool) {
 	if !node.Exists() {
 		return usage.Detail{}, false
 	}
+	if !hasGeminiFamilyUsageTokenFields(node) {
+		return usage.Detail{}, false
+	}
 	return parseGeminiFamilyUsageDetail(node), true
 }
 

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -146,6 +146,30 @@ func TestParseGeminiCLIStreamUsage_ResponseSnakeCaseUsageMetadata(t *testing.T) 
 	}
 }
 
+func TestParseGeminiStreamUsage_TopLevelUsageMetadata(t *testing.T) {
+	line := []byte(`data: {"usageMetadata":{"promptTokenCount":13,"candidatesTokenCount":2,"totalTokenCount":15}}`)
+	detail, ok := ParseGeminiStreamUsage(line)
+	if !ok {
+		t.Fatal("ParseGeminiStreamUsage() ok = false, want true")
+	}
+	if detail.InputTokens != 13 {
+		t.Fatalf("input tokens = %d, want %d", detail.InputTokens, 13)
+	}
+	if detail.OutputTokens != 2 {
+		t.Fatalf("output tokens = %d, want %d", detail.OutputTokens, 2)
+	}
+	if detail.TotalTokens != 15 {
+		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 15)
+	}
+}
+
+func TestParseGeminiStreamUsage_IgnoresTrafficTypeOnlyUsageMetadata(t *testing.T) {
+	line := []byte(`data: {"usageMetadata":{"trafficType":"ON_DEMAND"}}`)
+	if detail, ok := ParseGeminiStreamUsage(line); ok {
+		t.Fatalf("ParseGeminiStreamUsage() = (%+v, true), want false for traffic-only usage metadata", detail)
+	}
+}
+
 func TestParseGeminiCLIStreamUsage_IgnoresTrafficTypeOnlyUsageMetadata(t *testing.T) {
 	line := []byte(`data: {"response":{"usageMetadata":{"trafficType":"ON_DEMAND"}}}`)
 	if detail, ok := ParseGeminiCLIStreamUsage(line); ok {


### PR DESCRIPTION
## Summary
- Ignore Gemini `usageMetadata` SSE events that do not contain any token-count fields.
- Keep top-level Gemini `usageMetadata` with `promptTokenCount`, `candidatesTokenCount`, or `totalTokenCount` as valid usage input.
- Add regression coverage for top-level Gemini stream usage and traffic-type-only metadata.

## LTS compatibility
- Does not touch `internal/usage/`, `/v0/management/usage*`, `internal/translator/`, config schema, auth file structure, SDK public types, or AGENTS.md.
- This is a usage accuracy guard: it prevents traffic classification metadata like `trafficType` from creating zero-token usage records.
- Existing Gemini CLI usage handling already filters traffic-only metadata; this aligns the plain Gemini stream helper with that behavior.

## Validation
- `go test ./internal/runtime/executor/helps -run 'GeminiStreamUsage|GeminiCLIStreamUsage|Usage' -count=1`
- `go test ./internal/runtime/executor/helps -count=1`
- `git diff --check origin/main...HEAD`
