### PR TITLE
[codex] Add linux armv7 release artifact

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,8 @@
 name: goreleaser
 
 on:
+  workflow_dispatch:
   push:
-    # run only against tags
     tags:
       - '*'
 
@@ -16,6 +16,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Ensure manual release uses tag ref
+        if: github.event_name == 'workflow_dispatch' && github.ref_type != 'tag'
+        run: |
+          echo "Manual releases must be dispatched from a tag ref."
+          exit 1
       - name: Refresh models catalog
         run: |
           git fetch --depth 1 https://github.com/router-for-me/models.git main

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,11 +16,28 @@ builds:
     binary: cli-proxy-api
     ldflags:
       - -s -w -X 'main.Version={{.Version}}' -X 'main.Commit={{.ShortCommit}}' -X 'main.BuildDate={{.Date}}'
+
+  - id: "cli-proxy-api-linux-armv7"
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - arm
+    goarm:
+      - "7"
+    main: ./cmd/server/
+    binary: cli-proxy-api
+    ldflags:
+      - -s -w -X 'main.Version={{.Version}}' -X 'main.Commit={{.ShortCommit}}' -X 'main.BuildDate={{.Date}}'
 archives:
   - id: "cli-proxy-api"
+    builds:
+      - cli-proxy-api
+      - cli-proxy-api-linux-armv7
     format: tar.gz
     name_template: >-
-      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{- if eq .Arch "arm64" -}}aarch64{{- else -}}{{ .Arch }}{{- end -}}
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{- if eq .Arch "arm64" -}}aarch64{{- else if eq .Arch "arm" -}}armv{{ .Arm }}{{- else -}}{{ .Arch }}{{- end -}}
     format_overrides:
       - goos: windows
         format: zip


### PR DESCRIPTION
## Summary
- Selectively port the release packaging part of upstream router-for-me/CLIProxyAPI#3646.
- Add a GoReleaser `linux/arm/v7` build target and include it in the release archive set.
- Add `workflow_dispatch` for releases while failing manual runs that are not dispatched from a tag ref.

## LTS boundary
- Release-only change in `.goreleaser.yml` and `.github/workflows/release.yaml`.
- Does not touch runtime code, config schema, auth files, `internal/usage/`, Management usage endpoints, or `internal/translator/**`.
- Keeps existing amd64/arm64 archive naming and adds `armv{{ .Arm }}` only for Go `arm` builds.

## Validation
- `git diff --check`
- `GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 go build -o test-output-armv7 ./cmd/server`
- `rm -f test-output-armv7`
- `ruby -e 'require "yaml"; YAML.load_file(".goreleaser.yml"); YAML.load_file(".github/workflows/release.yaml"); puts "yaml ok"'`\n\n`goreleaser check` was not run because `goreleaser` is not installed in the local environment.