### PR TITLE
[codex] Add streaming diagnostics

### DIFF
--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -14,12 +14,15 @@ import (
 	"io"
 	"net/http"
 	"sort"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	. "github.com/router-for-me/CLIProxyAPI/v6/internal/constant"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
+	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -485,7 +488,38 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 	// New core execution path
 	modelName := gjson.GetBytes(rawJSON, "model").String()
 	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
+	requestLog := log.WithField("request_id", "--------")
+	if reqID := logging.GetRequestID(cliCtx); reqID != "" {
+		requestLog = log.WithField("request_id", reqID)
+	}
+	streamStartedAt := time.Now()
+	requestLog.Infof("openai responses stream start model=%q body_bytes=%d", modelName, len(rawJSON))
+	executeDone := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-executeDone:
+				return
+			case <-c.Request.Context().Done():
+				return
+			case <-ticker.C:
+				requestLog.Warnf("openai responses stream waiting ExecuteStreamWithAuthManager elapsed=%s request_ctx_err=%v cli_ctx_err=%v",
+					time.Since(streamStartedAt).Truncate(time.Second),
+					c.Request.Context().Err(),
+					cliCtx.Err(),
+				)
+			}
+		}
+	}()
 	dataChan, upstreamHeaders, errChan := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, "")
+	close(executeDone)
+	requestLog.Infof("openai responses stream ExecuteStreamWithAuthManager returned elapsed=%s data_chan_nil=%t err_chan_nil=%t",
+		time.Since(streamStartedAt).Truncate(time.Millisecond),
+		dataChan == nil,
+		errChan == nil,
+	)
 
 	setSSEHeaders := func() {
 		c.Header("Content-Type", "text/event-stream")
@@ -494,13 +528,18 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 		c.Header("Access-Control-Allow-Origin", "*")
 	}
 	framer := &responsesSSEFramer{}
+	firstChunkWait := time.NewTicker(30 * time.Second)
+	defer firstChunkWait.Stop()
 
 	// Peek at the first chunk
 	for {
 		select {
 		case <-c.Request.Context().Done():
+			requestLog.Warnf("openai responses stream downstream canceled while waiting first chunk elapsed=%s err=%v", time.Since(streamStartedAt).Truncate(time.Second), c.Request.Context().Err())
 			cliCancel(c.Request.Context().Err())
 			return
+		case <-firstChunkWait.C:
+			requestLog.Warnf("openai responses stream still waiting first chunk elapsed=%s request_ctx_err=%v cli_ctx_err=%v", time.Since(streamStartedAt).Truncate(time.Second), c.Request.Context().Err(), cliCtx.Err())
 		case errMsg, ok := <-errChan:
 			if !ok {
 				// Err channel closed cleanly; wait for data channel.
@@ -508,6 +547,11 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 				continue
 			}
 			// Upstream failed immediately. Return proper error status and JSON.
+			if errMsg != nil {
+				requestLog.Warnf("openai responses stream failed before first chunk elapsed=%s status=%d err=%v", time.Since(streamStartedAt).Truncate(time.Second), errMsg.StatusCode, errMsg.Error)
+			} else {
+				requestLog.Warnf("openai responses stream failed before first chunk elapsed=%s err=<nil>", time.Since(streamStartedAt).Truncate(time.Second))
+			}
 			h.WriteErrorResponse(c, errMsg)
 			if errMsg != nil {
 				cliCancel(errMsg.Error)
@@ -518,6 +562,7 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 		case chunk, ok := <-dataChan:
 			if !ok {
 				// Stream closed without data? Send headers and done.
+				requestLog.Warnf("openai responses stream data channel closed before first chunk elapsed=%s", time.Since(streamStartedAt).Truncate(time.Second))
 				setSSEHeaders()
 				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 				_, _ = c.Writer.Write([]byte("\n"))
@@ -527,6 +572,7 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 			}
 
 			// Success! Set headers.
+			requestLog.Infof("openai responses stream first chunk received elapsed=%s bytes=%d", time.Since(streamStartedAt).Truncate(time.Millisecond), len(chunk))
 			setSSEHeaders()
 			handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 

--- a/sdk/api/handlers/stream_forwarder.go
+++ b/sdk/api/handlers/stream_forwarder.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/logging"
+	log "github.com/sirupsen/logrus"
 )
 
 type StreamForwardOptions struct {
@@ -62,9 +64,36 @@ func (h *BaseAPIHandler) ForwardStream(c *gin.Context, flusher http.Flusher, can
 	}
 
 	var terminalErr *interfaces.ErrorMessage
+	startedAt := time.Now()
+	lastActivityAt := startedAt
+	chunksForwarded := 0
+	bytesForwarded := 0
+	logEntry := log.WithField("request_id", "--------")
+	if c.Request != nil {
+		if reqID := logging.GetRequestID(c.Request.Context()); reqID != "" {
+			logEntry = log.WithField("request_id", reqID)
+		}
+	}
+	logProgress := func(reason string, warn bool) {
+		msg := "stream forwarder " + reason
+		args := []interface{}{
+			time.Since(startedAt).Truncate(time.Second),
+			time.Since(lastActivityAt).Truncate(time.Second),
+			chunksForwarded,
+			bytesForwarded,
+			c.Writer.Status(),
+			c.Request.Context().Err(),
+		}
+		if warn {
+			logEntry.Warnf(msg+" elapsed=%s idle=%s chunks=%d bytes=%d writer_status=%d request_ctx_err=%v", args...)
+			return
+		}
+		logEntry.Infof(msg+" elapsed=%s idle=%s chunks=%d bytes=%d writer_status=%d request_ctx_err=%v", args...)
+	}
 	for {
 		select {
 		case <-c.Request.Context().Done():
+			logProgress("request context done", true)
 			cancel(c.Request.Context().Err())
 			return
 		case chunk, ok := <-data:
@@ -83,19 +112,37 @@ func (h *BaseAPIHandler) ForwardStream(c *gin.Context, flusher http.Flusher, can
 					if opts.WriteTerminalError != nil {
 						opts.WriteTerminalError(terminalErr)
 					}
+					logProgress("terminal error before flush", true)
 					flusher.Flush()
+					logProgress("terminal error flushed", true)
 					cancel(terminalErr.Error)
 					return
 				}
 				if opts.WriteDone != nil {
 					opts.WriteDone()
 				}
+				logProgress("data channel closed before final flush", false)
 				flusher.Flush()
+				logProgress("data channel closed flushed", false)
 				cancel(nil)
 				return
 			}
+			lastActivityAt = time.Now()
+			chunksForwarded++
+			bytesForwarded += len(chunk)
 			writeChunk(chunk)
+			beforeFlush := time.Now()
 			flusher.Flush()
+			if flushDuration := time.Since(beforeFlush); flushDuration > time.Second {
+				logEntry.Warnf("stream forwarder slow flush duration=%s elapsed=%s chunks=%d bytes=%d writer_status=%d request_ctx_err=%v",
+					flushDuration.Truncate(time.Millisecond),
+					time.Since(startedAt).Truncate(time.Second),
+					chunksForwarded,
+					bytesForwarded,
+					c.Writer.Status(),
+					c.Request.Context().Err(),
+				)
+			}
 		case errMsg, ok := <-errs:
 			if !ok {
 				continue
@@ -104,7 +151,9 @@ func (h *BaseAPIHandler) ForwardStream(c *gin.Context, flusher http.Flusher, can
 				terminalErr = errMsg
 				if opts.WriteTerminalError != nil {
 					opts.WriteTerminalError(errMsg)
+					logProgress("error channel received before flush", true)
 					flusher.Flush()
+					logProgress("error channel received flushed", true)
 				}
 			}
 			var execErr error
@@ -114,8 +163,20 @@ func (h *BaseAPIHandler) ForwardStream(c *gin.Context, flusher http.Flusher, can
 			cancel(execErr)
 			return
 		case <-keepAliveC:
+			lastActivityAt = time.Now()
 			writeKeepAlive()
+			beforeFlush := time.Now()
 			flusher.Flush()
+			if flushDuration := time.Since(beforeFlush); flushDuration > time.Second {
+				logEntry.Warnf("stream forwarder slow keepalive flush duration=%s elapsed=%s chunks=%d bytes=%d writer_status=%d request_ctx_err=%v",
+					flushDuration.Truncate(time.Millisecond),
+					time.Since(startedAt).Truncate(time.Second),
+					chunksForwarded,
+					bytesForwarded,
+					c.Writer.Status(),
+					c.Request.Context().Err(),
+				)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Selectively ports the handler-side streaming diagnostics from upstream `router-for-me/CLIProxyAPI#3627`.

This PR keeps the behavioral timeout/cooldown parts out because those are already covered by existing LTS selective-port PRs, and only adds request-scoped progress logging around:

- OpenAI Responses streaming startup and first-chunk wait
- terminal/error-before-first-chunk cases
- shared stream forwarder close, terminal-error, keepalive, and slow-flush paths

## LTS Compatibility

- Does not touch `internal/usage/` or `/v0/management/usage*`.
- Does not touch `internal/translator/**`.
- Does not add a new timeout that can terminate an already-active stream; the 30s tickers only emit diagnostics.
- Keeps the Go module import path on `github.com/router-for-me/CLIProxyAPI/v6`.

## Validation

- `gofmt -w sdk/api/handlers/openai/openai_responses_handlers.go sdk/api/handlers/stream_forwarder.go`
- `git diff --check`
- `go test ./sdk/api/handlers ./sdk/api/handlers/openai -run 'Stream|Responses|Forward' -count=1`
- `go build -o test-output ./cmd/server`
- `git diff --cached --check`
