### PR TITLE
[codex] Add compact routing controls

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -166,11 +166,18 @@ nonstream-keepalive-interval: 0
 #       - "*flash*"            # wildcard matching substring (e.g. gemini-2.5-flash-lite)
 #   - api-key: "AIzaSy...02"
 
+# compact-default controls /v1/responses/compact routing for codex/openai-compatible
+# credentials whose per-credential compact mode is "auto" (the default).
+#   allow (default): auto credentials may serve compact requests (backward compatible)
+#   deny: auto credentials are excluded; only credentials with compact: force_on serve compact
+# compact-default: allow
+
 # Codex API keys
 # codex-api-key:
 #   - api-key: "sk-atSM..."
 #     prefix: "test" # optional: require calls like "test/gpt-5-codex" to target this credential
 #     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
+#     compact: "auto" # "auto" (follows compact-default) | "force_on" | "force_off"
 #     base-url: "https://www.example.com" # use the custom codex API endpoint
 #     headers:
 #       X-Custom-Header: "custom-value"
@@ -245,6 +252,7 @@ nonstream-keepalive-interval: 0
 #   - name: "openrouter" # The name of the provider; it will be used in the user agent and other places.
 #     disabled: false # optional: set to true to disable this provider without removing it
 #     prefix: "test" # optional: require calls like "test/kimi-k2" to target this provider's credentials
+#     compact: "auto" # provider-level: "auto" | "force_on" | "force_off"
 #     base-url: "https://openrouter.ai/api/v1" # The base URL of the provider.
 #     disable-cooling: false # optional: per-provider override for auth/model cooldown scheduling
 #     headers:

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -349,6 +349,13 @@ func (h *Handler) listAuthFilesFromDisk(c *gin.Context) {
 						fileData["note"] = trimmed
 					}
 				}
+				if strings.EqualFold(typeValue, "codex") {
+					if cv := gjson.GetBytes(data, "compact"); cv.Exists() && cv.Type == gjson.String {
+						if trimmed := strings.TrimSpace(cv.String()); trimmed != "" {
+							fileData["compact"] = trimmed
+						}
+					}
+				}
 			}
 
 			files = append(files, fileData)
@@ -463,6 +470,17 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 		if rawNote, ok := auth.Metadata["note"].(string); ok {
 			if trimmed := strings.TrimSpace(rawNote); trimmed != "" {
 				entry["note"] = trimmed
+			}
+		}
+	}
+	if strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		if mode := strings.TrimSpace(authAttribute(auth, "compact_mode")); mode != "" {
+			entry["compact"] = mode
+		} else if auth.Metadata != nil {
+			if rawCompact, ok := auth.Metadata["compact"].(string); ok {
+				if trimmed := strings.TrimSpace(rawCompact); trimmed != "" {
+					entry["compact"] = trimmed
+				}
 			}
 		}
 	}
@@ -1040,6 +1058,7 @@ func (h *Handler) buildAuthFromFileData(path string, data []byte) (*coreauth.Aut
 		}
 	}
 	coreauth.ApplyCustomHeadersFromMetadata(auth)
+	syncAuthFileCompactAttribute(auth, h.compactDefaultAllow())
 	return auth, nil
 }
 
@@ -1122,7 +1141,7 @@ func (h *Handler) PatchAuthFileStatus(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "ok", "disabled": *req.Disabled})
 }
 
-// PatchAuthFileFields updates editable fields (prefix, proxy_url, headers, priority, note) of an auth file.
+// PatchAuthFileFields updates editable fields (prefix, proxy_url, headers, priority, note, compact) of an auth file.
 func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 	if h.authManager == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "core auth manager unavailable"})
@@ -1136,6 +1155,7 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 		Headers  map[string]string `json:"headers"`
 		Priority *int              `json:"priority"`
 		Note     *string           `json:"note"`
+		Compact  *string           `json:"compact"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
@@ -1272,7 +1292,7 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 			changed = true
 		}
 	}
-	if req.Priority != nil || req.Note != nil {
+	if req.Priority != nil || req.Note != nil || req.Compact != nil {
 		if targetAuth.Metadata == nil {
 			targetAuth.Metadata = make(map[string]any)
 		}
@@ -1299,6 +1319,15 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 				targetAuth.Attributes["note"] = trimmedNote
 			}
 		}
+		if req.Compact != nil {
+			mode := strings.ToLower(strings.TrimSpace(*req.Compact))
+			if err := validateAuthFileCompactValue(targetAuth, mode); err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
+			targetAuth.Metadata["compact"] = mode
+			syncAuthFileCompactAttribute(targetAuth, h.compactDefaultAllow())
+		}
 		changed = true
 	}
 
@@ -1315,6 +1344,46 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+func validateAuthFileCompactValue(auth *coreauth.Auth, mode string) error {
+	if auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		return fmt.Errorf("compact is only supported for codex auth files")
+	}
+	switch mode {
+	case coreauth.CompactModeAuto, coreauth.CompactModeForceOn, coreauth.CompactModeForceOff:
+		return nil
+	default:
+		return fmt.Errorf("compact must be one of auto, force_on, force_off")
+	}
+}
+
+func (h *Handler) compactDefaultAllow() bool {
+	if h == nil || h.cfg == nil {
+		return true
+	}
+	return !strings.EqualFold(strings.TrimSpace(h.cfg.CompactDefault), "deny")
+}
+
+func syncAuthFileCompactAttribute(auth *coreauth.Auth, defaultAllow bool) {
+	if auth == nil {
+		return
+	}
+	if auth.Attributes == nil {
+		auth.Attributes = make(map[string]string)
+	}
+	if !strings.EqualFold(strings.TrimSpace(auth.Provider), "codex") {
+		delete(auth.Attributes, "compact_mode")
+		delete(auth.Attributes, "compact_allowed")
+		return
+	}
+	raw, ok := auth.Metadata["compact"].(string)
+	if !ok {
+		delete(auth.Attributes, "compact_mode")
+		delete(auth.Attributes, "compact_allowed")
+		return
+	}
+	coreauth.ApplyCompactAttributes(auth, raw, defaultAllow)
 }
 
 func (h *Handler) disableAuth(ctx context.Context, id string) {

--- a/internal/api/handlers/management/auth_files_compact_test.go
+++ b/internal/api/handlers/management/auth_files_compact_test.go
@@ -1,0 +1,159 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
+)
+
+func TestSyncAuthFileCompactAttribute(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:         "codex.json",
+		Provider:   "codex",
+		Metadata:   map[string]any{"compact": "force_off"},
+		Attributes: map[string]string{},
+	}
+	syncAuthFileCompactAttribute(auth, true)
+	if got := auth.Attributes["compact_mode"]; got != "force_off" {
+		t.Fatalf("compact_mode = %q, want force_off", got)
+	}
+	if got := auth.Attributes["compact_allowed"]; got != "false" {
+		t.Fatalf("compact_allowed = %q, want false", got)
+	}
+
+	auth.Metadata["compact"] = "auto"
+	syncAuthFileCompactAttribute(auth, false)
+	if got := auth.Attributes["compact_allowed"]; got != "false" {
+		t.Fatalf("auto with default deny compact_allowed = %q, want false", got)
+	}
+
+	nonCodex := &coreauth.Auth{
+		ID:         "gemini.json",
+		Provider:   "gemini-cli",
+		Metadata:   map[string]any{"compact": "force_on"},
+		Attributes: map[string]string{"compact_mode": "force_on", "compact_allowed": "true"},
+	}
+	syncAuthFileCompactAttribute(nonCodex, true)
+	if _, ok := nonCodex.Attributes["compact_mode"]; ok {
+		t.Fatalf("non-codex compact_mode should be removed, got %#v", nonCodex.Attributes)
+	}
+	if _, ok := nonCodex.Attributes["compact_allowed"]; ok {
+		t.Fatalf("non-codex compact_allowed should be removed, got %#v", nonCodex.Attributes)
+	}
+}
+
+func TestBuildAuthFileEntry_IncludesCodexCompact(t *testing.T) {
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, nil)
+	entry := h.buildAuthFileEntry(&coreauth.Auth{
+		ID:       "codex.json",
+		FileName: "codex.json",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"path":         "/tmp/codex.json",
+			"compact_mode": "force_on",
+		},
+	})
+	if got := entry["compact"]; got != "force_on" {
+		t.Fatalf("entry[compact] = %v, want force_on", got)
+	}
+
+	nonCodex := h.buildAuthFileEntry(&coreauth.Auth{
+		ID:       "claude.json",
+		FileName: "claude.json",
+		Provider: "claude",
+		Attributes: map[string]string{
+			"path":         "/tmp/claude.json",
+			"compact_mode": "force_on",
+		},
+	})
+	if _, ok := nonCodex["compact"]; ok {
+		t.Fatalf("non-codex entry compact = %v, want absent", nonCodex["compact"])
+	}
+}
+
+func TestPatchAuthFileFields_CompactCodex(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	manager := coreauth.NewManager(&memoryAuthStore{}, nil, nil)
+	record := &coreauth.Auth{
+		ID:         "codex.json",
+		FileName:   "codex.json",
+		Provider:   "codex",
+		Attributes: map[string]string{"path": "/tmp/codex.json"},
+		Metadata:   map[string]any{"type": "codex"},
+	}
+	if _, err := manager.Register(context.Background(), record); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir(), CompactDefault: "deny"}, manager)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/fields", strings.NewReader(`{"name":"codex.json","compact":"AUTO"}`))
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+	h.PatchAuthFileFields(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s, want 200", rec.Code, rec.Body.String())
+	}
+	updated, ok := manager.GetByID("codex.json")
+	if !ok {
+		t.Fatal("updated auth missing")
+	}
+	if got := updated.Attributes["compact_mode"]; got != "auto" {
+		t.Fatalf("compact_mode = %q, want auto", got)
+	}
+	if got := updated.Attributes["compact_allowed"]; got != "false" {
+		t.Fatalf("compact_allowed = %q, want false", got)
+	}
+	if got, _ := updated.Metadata["compact"].(string); got != "auto" {
+		raw, _ := json.Marshal(updated.Metadata)
+		t.Fatalf("metadata compact = %q, metadata = %s", got, string(raw))
+	}
+}
+
+func TestPatchAuthFileFields_CompactRejectsInvalidAndNonCodex(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	gin.SetMode(gin.TestMode)
+
+	manager := coreauth.NewManager(&memoryAuthStore{}, nil, nil)
+	for _, record := range []*coreauth.Auth{
+		{ID: "codex.json", FileName: "codex.json", Provider: "codex", Attributes: map[string]string{"path": "/tmp/codex.json"}, Metadata: map[string]any{"type": "codex"}},
+		{ID: "gemini.json", FileName: "gemini.json", Provider: "gemini-cli", Attributes: map[string]string{"path": "/tmp/gemini.json"}, Metadata: map[string]any{"type": "gemini"}},
+	} {
+		if _, err := manager.Register(context.Background(), record); err != nil {
+			t.Fatalf("register %s: %v", record.ID, err)
+		}
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "invalid", body: `{"name":"codex.json","compact":"bad"}`},
+		{name: "non-codex", body: `{"name":"gemini.json","compact":"force_on"}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(rec)
+			req := httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/fields", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			ctx.Request = req
+			h.PatchAuthFileFields(ctx)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d body = %s, want 400", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}

--- a/internal/api/handlers/management/config_auth_index.go
+++ b/internal/api/handlers/management/config_auth_index.go
@@ -38,6 +38,7 @@ type openAICompatibilityWithAuthIndex struct {
 	Priority      int                                      `json:"priority,omitempty"`
 	Disabled      bool                                     `json:"disabled"`
 	Prefix        string                                   `json:"prefix,omitempty"`
+	Compact       string                                   `json:"compact,omitempty"`
 	BaseURL       string                                   `json:"base-url"`
 	APIKeyEntries []openAICompatibilityAPIKeyWithAuthIndex `json:"api-key-entries,omitempty"`
 	Models        []config.OpenAICompatibilityModel        `json:"models,omitempty"`
@@ -218,6 +219,7 @@ func (h *Handler) openAICompatibilityWithAuthIndex() []openAICompatibilityWithAu
 			Priority:  entry.Priority,
 			Disabled:  entry.Disabled,
 			Prefix:    entry.Prefix,
+			Compact:   entry.Compact,
 			BaseURL:   entry.BaseURL,
 			Models:    entry.Models,
 			Headers:   entry.Headers,

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 )
 
 // Generic helpers for list[string]
@@ -465,6 +466,7 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 		Name          *string                             `json:"name"`
 		Prefix        *string                             `json:"prefix"`
 		Disabled      *bool                               `json:"disabled"`
+		Compact       *string                             `json:"compact"`
 		BaseURL       *string                             `json:"base-url"`
 		APIKeyEntries *[]config.OpenAICompatibilityAPIKey `json:"api-key-entries"`
 		Models        *[]config.OpenAICompatibilityModel  `json:"models"`
@@ -509,6 +511,9 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 	}
 	if body.Value.Disabled != nil {
 		entry.Disabled = *body.Value.Disabled
+	}
+	if body.Value.Compact != nil {
+		entry.Compact = strings.ToLower(strings.TrimSpace(*body.Value.Compact))
 	}
 	if body.Value.BaseURL != nil {
 		trimmed := strings.TrimSpace(*body.Value.BaseURL)
@@ -958,6 +963,7 @@ func (h *Handler) PatchCodexKey(c *gin.Context) {
 		APIKey         *string              `json:"api-key"`
 		Prefix         *string              `json:"prefix"`
 		BaseURL        *string              `json:"base-url"`
+		Compact        *string              `json:"compact"`
 		ProxyURL       *string              `json:"proxy-url"`
 		Models         *[]config.CodexModel `json:"models"`
 		Headers        *map[string]string   `json:"headers"`
@@ -1009,6 +1015,9 @@ func (h *Handler) PatchCodexKey(c *gin.Context) {
 			return
 		}
 		entry.BaseURL = trimmed
+	}
+	if body.Value.Compact != nil {
+		entry.Compact = strings.ToLower(strings.TrimSpace(*body.Value.Compact))
 	}
 	if body.Value.ProxyURL != nil {
 		entry.ProxyURL = strings.TrimSpace(*body.Value.ProxyURL)
@@ -1087,6 +1096,7 @@ func normalizeOpenAICompatibilityEntry(entry *config.OpenAICompatibility) {
 	}
 	// Trim base-url; empty base-url indicates provider should be removed by sanitization
 	entry.BaseURL = strings.TrimSpace(entry.BaseURL)
+	entry.Compact = coreauth.NormalizeCompactMode(entry.Compact)
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
 	existing := make(map[string]struct{}, len(entry.APIKeyEntries))
 	for i := range entry.APIKeyEntries {
@@ -1146,6 +1156,7 @@ func normalizeCodexKey(entry *config.CodexKey) {
 	entry.APIKey = strings.TrimSpace(entry.APIKey)
 	entry.Prefix = strings.TrimSpace(entry.Prefix)
 	entry.BaseURL = strings.TrimSpace(entry.BaseURL)
+	entry.Compact = coreauth.NormalizeCompactMode(entry.Compact)
 	entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
 	entry.Headers = config.NormalizeHeaders(entry.Headers)
 	entry.ExcludedModels = config.NormalizeExcludedModels(entry.ExcludedModels)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,6 +108,10 @@ type Config struct {
 	// Codex defines a list of Codex API key configurations as specified in the YAML configuration file.
 	CodexKey []CodexKey `yaml:"codex-api-key" json:"codex-api-key"`
 
+	// CompactDefault controls how credentials with compact mode "auto" are treated for
+	// /responses/compact routing: "allow" (default, backward compatible) or "deny".
+	CompactDefault string `yaml:"compact-default,omitempty" json:"compact-default,omitempty"`
+
 	// CodexHeaderDefaults configures fallback headers for Codex OAuth model requests.
 	// These are used only when the client does not send its own headers.
 	CodexHeaderDefaults CodexHeaderDefaults `yaml:"codex-header-defaults" json:"codex-header-defaults"`
@@ -448,6 +452,10 @@ type CodexKey struct {
 	// Websockets enables the Responses API websocket transport for this credential.
 	Websockets bool `yaml:"websockets,omitempty" json:"websockets,omitempty"`
 
+	// Compact controls /responses/compact eligibility for this credential:
+	// "auto" (default, follows compact-default), "force_on", or "force_off".
+	Compact string `yaml:"compact,omitempty" json:"compact,omitempty"`
+
 	// ProxyURL overrides the global proxy setting for this API key if provided.
 	ProxyURL string `yaml:"proxy-url" json:"proxy-url"`
 
@@ -541,6 +549,10 @@ type OpenAICompatibility struct {
 
 	// Prefix optionally namespaces model aliases for this provider (e.g., "teamA/kimi-k2").
 	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
+
+	// Compact controls /responses/compact eligibility for all credentials of this provider:
+	// "auto" (default, follows compact-default), "force_on", or "force_off".
+	Compact string `yaml:"compact,omitempty" json:"compact,omitempty"`
 
 	// BaseURL is the base URL for the external OpenAI-compatible API endpoint.
 	BaseURL string `yaml:"base-url" json:"base-url"`
@@ -703,6 +715,8 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	if cfg.MaxRetryCredentials < 0 {
 		cfg.MaxRetryCredentials = 0
 	}
+
+	cfg.CompactDefault = normalizeConfigCompactDefault(cfg.CompactDefault)
 
 	// Sanitize Gemini API key configuration and migrate legacy entries.
 	cfg.SanitizeGeminiKeys()
@@ -883,6 +897,7 @@ func (cfg *Config) SanitizeOpenAICompatibility() {
 		e.Name = strings.TrimSpace(e.Name)
 		e.Prefix = normalizeModelPrefix(e.Prefix)
 		e.BaseURL = strings.TrimSpace(e.BaseURL)
+		e.Compact = normalizeConfigCompactMode(e.Compact, fmt.Sprintf("openai-compatibility[%d].compact", i))
 		e.Headers = NormalizeHeaders(e.Headers)
 		if e.BaseURL == "" {
 			// Skip providers with no base-url; treated as removed
@@ -904,6 +919,7 @@ func (cfg *Config) SanitizeCodexKeys() {
 		e := cfg.CodexKey[i]
 		e.Prefix = normalizeModelPrefix(e.Prefix)
 		e.BaseURL = strings.TrimSpace(e.BaseURL)
+		e.Compact = normalizeConfigCompactMode(e.Compact, fmt.Sprintf("codex-api-key[%d].compact", i))
 		e.Headers = NormalizeHeaders(e.Headers)
 		e.ExcludedModels = NormalizeExcludedModels(e.ExcludedModels)
 		if e.BaseURL == "" {
@@ -967,6 +983,37 @@ func normalizeModelPrefix(prefix string) string {
 		return ""
 	}
 	return trimmed
+}
+
+func normalizeConfigCompactDefault(raw string) string {
+	trimmed := strings.ToLower(strings.TrimSpace(raw))
+	switch trimmed {
+	case "", "allow":
+		return "allow"
+	case "deny":
+		return "deny"
+	default:
+		log.WithField("value", raw).Warn("invalid compact-default; falling back to allow")
+		return "allow"
+	}
+}
+
+func normalizeConfigCompactMode(raw string, location string) string {
+	trimmed := strings.ToLower(strings.TrimSpace(raw))
+	switch trimmed {
+	case "", "auto":
+		return "auto"
+	case "force_on":
+		return "force_on"
+	case "force_off":
+		return "force_off"
+	default:
+		log.WithFields(log.Fields{
+			"field": location,
+			"value": raw,
+		}).Warn("invalid compact mode; falling back to auto")
+		return "auto"
+	}
 }
 
 // looksLikeBcrypt returns true if the provided string appears to be a bcrypt hash.

--- a/internal/config/config_compact_test.go
+++ b/internal/config/config_compact_test.go
@@ -1,0 +1,92 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfig_CompactRoutingControls(t *testing.T) {
+	cfg := loadCompactConfigForTest(t, `
+compact-default: deny
+codex-api-key:
+  - api-key: "codex-key"
+    base-url: "https://codex.example.com"
+    compact: force_on
+openai-compatibility:
+  - name: "compat"
+    base-url: "https://compat.example.com/v1"
+    compact: force_off
+`)
+
+	if cfg.CompactDefault != "deny" {
+		t.Fatalf("CompactDefault = %q, want deny", cfg.CompactDefault)
+	}
+	if len(cfg.CodexKey) != 1 || cfg.CodexKey[0].Compact != "force_on" {
+		t.Fatalf("CodexKey compact = %+v, want force_on", cfg.CodexKey)
+	}
+	if len(cfg.OpenAICompatibility) != 1 || cfg.OpenAICompatibility[0].Compact != "force_off" {
+		t.Fatalf("OpenAICompatibility compact = %+v, want force_off", cfg.OpenAICompatibility)
+	}
+}
+
+func TestLoadConfig_CompactRoutingControlsNormalizeCase(t *testing.T) {
+	cfg := loadCompactConfigForTest(t, `
+compact-default: "  DeNy "
+codex-api-key:
+  - api-key: "codex-key"
+    base-url: "https://codex.example.com"
+    compact: " FORCE_OFF "
+openai-compatibility:
+  - name: "compat"
+    base-url: "https://compat.example.com/v1"
+    compact: " Force_On "
+`)
+
+	if cfg.CompactDefault != "deny" {
+		t.Fatalf("CompactDefault = %q, want deny", cfg.CompactDefault)
+	}
+	if got := cfg.CodexKey[0].Compact; got != "force_off" {
+		t.Fatalf("CodexKey compact = %q, want force_off", got)
+	}
+	if got := cfg.OpenAICompatibility[0].Compact; got != "force_on" {
+		t.Fatalf("OpenAICompatibility compact = %q, want force_on", got)
+	}
+}
+
+func TestLoadConfig_CompactRoutingControlsInvalidFallbacks(t *testing.T) {
+	cfg := loadCompactConfigForTest(t, `
+compact-default: invalid
+codex-api-key:
+  - api-key: "codex-key"
+    base-url: "https://codex.example.com"
+    compact: wrong
+openai-compatibility:
+  - name: "compat"
+    base-url: "https://compat.example.com/v1"
+    compact: wrong
+`)
+
+	if cfg.CompactDefault != "allow" {
+		t.Fatalf("CompactDefault = %q, want allow", cfg.CompactDefault)
+	}
+	if got := cfg.CodexKey[0].Compact; got != "auto" {
+		t.Fatalf("CodexKey compact = %q, want auto", got)
+	}
+	if got := cfg.OpenAICompatibility[0].Compact; got != "auto" {
+		t.Fatalf("OpenAICompatibility compact = %q, want auto", got)
+	}
+}
+
+func loadCompactConfigForTest(t *testing.T, body string) *Config {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	return cfg
+}

--- a/internal/watcher/synthesizer/compact_meta_test.go
+++ b/internal/watcher/synthesizer/compact_meta_test.go
@@ -1,0 +1,76 @@
+package synthesizer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v6/internal/config"
+)
+
+func TestConfigSynthesizer_CompactMetadata(t *testing.T) {
+	cfg := &config.Config{
+		CompactDefault: "deny",
+		CodexKey: []config.CodexKey{
+			{APIKey: "codex-on", BaseURL: "https://codex.example.com", Compact: "force_on"},
+			{APIKey: "codex-auto", BaseURL: "https://codex.example.com", Compact: "auto"},
+		},
+		OpenAICompatibility: []config.OpenAICompatibility{
+			{
+				Name:          "compat",
+				BaseURL:       "https://compat.example.com/v1",
+				Compact:       "force_off",
+				APIKeyEntries: []config.OpenAICompatibilityAPIKey{{APIKey: "compat-key"}},
+			},
+		},
+	}
+	ctx := &SynthesisContext{Config: cfg, Now: time.Now(), IDGenerator: NewStableIDGenerator()}
+
+	auths, err := NewConfigSynthesizer().Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+
+	got := map[string]string{}
+	for _, auth := range auths {
+		got[auth.Attributes["api_key"]] = auth.Attributes["compact_allowed"]
+	}
+	if got["codex-on"] != "true" {
+		t.Fatalf("codex force_on compact_allowed = %q, want true", got["codex-on"])
+	}
+	if got["codex-auto"] != "false" {
+		t.Fatalf("codex auto compact_allowed = %q, want false", got["codex-auto"])
+	}
+	if got["compat-key"] != "false" {
+		t.Fatalf("compat force_off compact_allowed = %q, want false", got["compat-key"])
+	}
+}
+
+func TestFileSynthesizer_CodexCompactMetadata(t *testing.T) {
+	authDir := t.TempDir()
+	path := filepath.Join(authDir, "codex.json")
+	if err := os.WriteFile(path, []byte(`{"type":"codex","compact":"force_off"}`), 0o600); err != nil {
+		t.Fatalf("write auth file: %v", err)
+	}
+
+	ctx := &SynthesisContext{
+		Config:      &config.Config{CompactDefault: "allow"},
+		AuthDir:     authDir,
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+	auths, err := NewFileSynthesizer().Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("auths len = %d, want 1", len(auths))
+	}
+	if got := auths[0].Attributes["compact_allowed"]; got != "false" {
+		t.Fatalf("compact_allowed = %q, want false", got)
+	}
+	if got := auths[0].Attributes["compact_mode"]; got != "force_off" {
+		t.Fatalf("compact_mode = %q, want force_off", got)
+	}
+}

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -190,6 +190,7 @@ func (s *ConfigSynthesizer) synthesizeCodexKeys(ctx *SynthesisContext) []*coreau
 			UpdatedAt:  now,
 		}
 		ApplyAuthExcludedModelsMeta(a, cfg, ck.ExcludedModels, "apikey")
+		ApplyAuthCompactMeta(a, cfg, ck.Compact)
 		out = append(out, a)
 	}
 	return out
@@ -250,6 +251,7 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 				CreatedAt:  now,
 				UpdatedAt:  now,
 			}
+			ApplyAuthCompactMeta(a, cfg, compat.Compact)
 			out = append(out, a)
 			createdEntries++
 		}
@@ -281,6 +283,7 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 				CreatedAt:  now,
 				UpdatedAt:  now,
 			}
+			ApplyAuthCompactMeta(a, cfg, compat.Compact)
 			out = append(out, a)
 		}
 	}

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -168,6 +168,8 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 				}
 			}
 		}
+		rawCompact, _ := metadata["compact"].(string)
+		ApplyAuthCompactMeta(a, cfg, rawCompact)
 	}
 	if provider == "gemini-cli" {
 		if virtuals := SynthesizeGeminiVirtualAuths(a, metadata, now); len(virtuals) > 0 {

--- a/internal/watcher/synthesizer/helpers.go
+++ b/internal/watcher/synthesizer/helpers.go
@@ -103,6 +103,19 @@ func ApplyAuthExcludedModelsMeta(auth *coreauth.Auth, cfg *config.Config, perKey
 	}
 }
 
+// ApplyAuthCompactMeta resolves compact routing metadata against the global
+// default and records compact_mode plus compact_allowed on the auth.
+func ApplyAuthCompactMeta(auth *coreauth.Auth, cfg *config.Config, mode string) {
+	if auth == nil {
+		return
+	}
+	defaultAllow := true
+	if cfg != nil && strings.EqualFold(strings.TrimSpace(cfg.CompactDefault), "deny") {
+		defaultAllow = false
+	}
+	coreauth.ApplyCompactAttributes(auth, mode, defaultAllow)
+}
+
 // addConfigHeadersToAttrs adds header configuration to auth attributes.
 // Headers are prefixed with "header:" in the attributes map.
 func addConfigHeadersToAttrs(headers map[string]string, attrs map[string]string) {

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/sdk/api/handlers"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -424,7 +425,7 @@ func (h *OpenAIResponsesAPIHandler) Compact(c *gin.Context) {
 	modelName := gjson.GetBytes(rawJSON, "model").String()
 	cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
 	stopKeepAlive := h.StartNonStreamingKeepAlive(c, cliCtx)
-	resp, upstreamHeaders, errMsg := h.ExecuteWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, "responses/compact")
+	resp, upstreamHeaders, errMsg := h.ExecuteWithAuthManager(cliCtx, h.HandlerType(), modelName, rawJSON, cliproxyexecutor.ResponsesCompactAlt)
 	stopKeepAlive()
 	if errMsg != nil {
 		h.WriteErrorResponse(c, errMsg)

--- a/sdk/cliproxy/auth/compact.go
+++ b/sdk/cliproxy/auth/compact.go
@@ -1,0 +1,85 @@
+package auth
+
+import (
+	"net/http"
+	"strings"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+// Compact mode values stored in Attributes["compact_mode"].
+const (
+	// CompactModeAuto follows the global compact-default when deciding eligibility.
+	CompactModeAuto = "auto"
+	// CompactModeForceOn always treats the credential as compact-capable.
+	CompactModeForceOn = "force_on"
+	// CompactModeForceOff always excludes the credential from compact routing.
+	CompactModeForceOff = "force_off"
+)
+
+// NormalizeCompactMode maps arbitrary input to a known compact mode, defaulting to auto.
+func NormalizeCompactMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case CompactModeForceOn:
+		return CompactModeForceOn
+	case CompactModeForceOff:
+		return CompactModeForceOff
+	default:
+		return CompactModeAuto
+	}
+}
+
+// ApplyCompactAttributes resolves the credential compact mode against the global default
+// and stores both the normalized mode and resolved boolean on the auth.
+func ApplyCompactAttributes(auth *Auth, mode string, defaultAllow bool) {
+	if auth == nil {
+		return
+	}
+	if auth.Attributes == nil {
+		auth.Attributes = make(map[string]string)
+	}
+	norm := NormalizeCompactMode(mode)
+	auth.Attributes["compact_mode"] = norm
+
+	allowed := defaultAllow
+	switch norm {
+	case CompactModeForceOn:
+		allowed = true
+	case CompactModeForceOff:
+		allowed = false
+	}
+	if allowed {
+		auth.Attributes["compact_allowed"] = "true"
+		return
+	}
+	auth.Attributes["compact_allowed"] = "false"
+}
+
+func authCompactAllowed(auth *Auth) bool {
+	if auth == nil {
+		return false
+	}
+	if auth.Attributes == nil {
+		return true
+	}
+	return auth.Attributes["compact_allowed"] != "false"
+}
+
+func requireCompactRequest(opts cliproxyexecutor.Options) bool {
+	return opts.Alt == cliproxyexecutor.ResponsesCompactAlt
+}
+
+func compactCandidateAllowed(auth *Auth, requireCompact bool) bool {
+	if !requireCompact {
+		return true
+	}
+	return authCompactAllowed(auth)
+}
+
+func noCompactAuthError() *Error {
+	return &Error{
+		Code:       "compact_unsupported",
+		Message:    "no available credential supports /responses/compact",
+		HTTPStatus: http.StatusServiceUnavailable,
+	}
+}

--- a/sdk/cliproxy/auth/compact_test.go
+++ b/sdk/cliproxy/auth/compact_test.go
@@ -1,0 +1,80 @@
+package auth
+
+import (
+	"net/http"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+func TestNormalizeCompactMode(t *testing.T) {
+	tests := map[string]string{
+		"":              CompactModeAuto,
+		" AUTO ":        CompactModeAuto,
+		"force_on":      CompactModeForceOn,
+		" FORCE_OFF ":   CompactModeForceOff,
+		"unknown-value": CompactModeAuto,
+	}
+	for input, want := range tests {
+		if got := NormalizeCompactMode(input); got != want {
+			t.Fatalf("NormalizeCompactMode(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestApplyCompactAttributes(t *testing.T) {
+	tests := []struct {
+		name         string
+		mode         string
+		defaultAllow bool
+		wantMode     string
+		wantAllowed  string
+	}{
+		{name: "auto allow", mode: "auto", defaultAllow: true, wantMode: "auto", wantAllowed: "true"},
+		{name: "auto deny", mode: "auto", defaultAllow: false, wantMode: "auto", wantAllowed: "false"},
+		{name: "force on", mode: "force_on", defaultAllow: false, wantMode: "force_on", wantAllowed: "true"},
+		{name: "force off", mode: "force_off", defaultAllow: true, wantMode: "force_off", wantAllowed: "false"},
+		{name: "invalid", mode: "bad", defaultAllow: true, wantMode: "auto", wantAllowed: "true"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			auth := &Auth{}
+			ApplyCompactAttributes(auth, tc.mode, tc.defaultAllow)
+			if got := auth.Attributes["compact_mode"]; got != tc.wantMode {
+				t.Fatalf("compact_mode = %q, want %q", got, tc.wantMode)
+			}
+			if got := auth.Attributes["compact_allowed"]; got != tc.wantAllowed {
+				t.Fatalf("compact_allowed = %q, want %q", got, tc.wantAllowed)
+			}
+		})
+	}
+}
+
+func TestCompactCandidateAllowed(t *testing.T) {
+	if !authCompactAllowed(&Auth{ID: "true", Attributes: map[string]string{"compact_allowed": "true"}}) {
+		t.Fatal("compact_allowed=true should allow compact")
+	}
+	if authCompactAllowed(&Auth{ID: "false", Attributes: map[string]string{"compact_allowed": "false"}}) {
+		t.Fatal("compact_allowed=false should block compact")
+	}
+	if !requireCompactRequest(cliproxyexecutor.Options{Alt: cliproxyexecutor.ResponsesCompactAlt}) {
+		t.Fatal("compact alt should require compact")
+	}
+	off := &Auth{ID: "off", Attributes: map[string]string{"compact_allowed": "false"}}
+	if !compactCandidateAllowed(off, false) {
+		t.Fatal("non-compact request must ignore compact_allowed")
+	}
+	if compactCandidateAllowed(off, true) {
+		t.Fatal("compact request must honor compact_allowed=false")
+	}
+}
+
+func TestNoCompactAuthError(t *testing.T) {
+	err := noCompactAuthError()
+	if err.Code != "compact_unsupported" {
+		t.Fatalf("Code = %q, want compact_unsupported", err.Code)
+	}
+	if err.StatusCode() != http.StatusServiceUnavailable {
+		t.Fatalf("StatusCode = %d, want %d", err.StatusCode(), http.StatusServiceUnavailable)
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -2875,6 +2875,8 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 		return nil, nil, &Error{Code: "executor_not_found", Message: "executor not registered"}
 	}
 	candidates := make([]*Auth, 0, len(m.auths))
+	requireCompact := requireCompactRequest(opts)
+	compactBlocked := false
 	modelKey := strings.TrimSpace(model)
 	// Always use base model name (without thinking suffix) for auth matching.
 	if modelKey != "" {
@@ -2900,10 +2902,17 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 		if modelKey != "" && !m.authSupportsRouteModel(registryRef, candidate, model) {
 			continue
 		}
+		if !compactCandidateAllowed(candidate, requireCompact) {
+			compactBlocked = true
+			continue
+		}
 		candidates = append(candidates, candidate)
 	}
 	if len(candidates) == 0 {
 		m.mu.RUnlock()
+		if requireCompact && compactBlocked {
+			return nil, nil, noCompactAuthError()
+		}
 		return nil, nil, &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
 	available, errAvailable := m.availableAuthsForRouteModel(candidates, provider, model, time.Now())
@@ -2934,6 +2943,9 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 }
 
 func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, error) {
+	if requireCompactRequest(opts) {
+		return m.pickNextLegacy(ctx, provider, model, opts, tried)
+	}
 	if !m.useSchedulerFastPath() {
 		return m.pickNextLegacy(ctx, provider, model, opts, tried)
 	}
@@ -3008,6 +3020,8 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 
 	m.mu.RLock()
 	candidates := make([]*Auth, 0, len(m.auths))
+	requireCompact := requireCompactRequest(opts)
+	compactBlocked := false
 	modelKey := strings.TrimSpace(model)
 	// Always use base model name (without thinking suffix) for auth matching.
 	if modelKey != "" {
@@ -3043,10 +3057,17 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 		if modelKey != "" && !m.authSupportsRouteModel(registryRef, candidate, model) {
 			continue
 		}
+		if !compactCandidateAllowed(candidate, requireCompact) {
+			compactBlocked = true
+			continue
+		}
 		candidates = append(candidates, candidate)
 	}
 	if len(candidates) == 0 {
 		m.mu.RUnlock()
+		if requireCompact && compactBlocked {
+			return nil, nil, "", noCompactAuthError()
+		}
 		return nil, nil, "", &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
 	available, errAvailable := m.availableAuthsForRouteModel(candidates, "mixed", model, time.Now())
@@ -3083,6 +3104,9 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 }
 
 func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, string, error) {
+	if requireCompactRequest(opts) {
+		return m.pickNextMixedLegacy(ctx, providers, model, opts, tried)
+	}
 	if !m.useSchedulerFastPath() {
 		return m.pickNextMixedLegacy(ctx, providers, model, opts, tried)
 	}

--- a/sdk/cliproxy/auth/conductor_compact_test.go
+++ b/sdk/cliproxy/auth/conductor_compact_test.go
@@ -1,0 +1,84 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
+)
+
+type compactProbeExecutor struct{}
+
+func (compactProbeExecutor) Identifier() string { return "codex" }
+func (compactProbeExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (compactProbeExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, nil
+}
+func (compactProbeExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) { return auth, nil }
+func (compactProbeExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (compactProbeExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func newCompactTestManager(t *testing.T) *Manager {
+	t.Helper()
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.RegisterExecutor(compactProbeExecutor{})
+	return manager
+}
+
+func TestPickNextMixed_CompactSkipsForceOff(t *testing.T) {
+	manager := newCompactTestManager(t)
+	ctx := context.Background()
+	if _, err := manager.Register(ctx, &Auth{ID: "on", Provider: "codex", Attributes: map[string]string{"compact_allowed": "true"}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.Register(ctx, &Auth{ID: "off", Provider: "codex", Attributes: map[string]string{"compact_allowed": "false"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := cliproxyexecutor.Options{Alt: cliproxyexecutor.ResponsesCompactAlt}
+	for i := 0; i < 5; i++ {
+		auth, _, _, err := manager.pickNextMixed(ctx, []string{"codex"}, "", opts, map[string]struct{}{})
+		if err != nil {
+			t.Fatalf("pick #%d error: %v", i, err)
+		}
+		if auth.ID != "on" {
+			t.Fatalf("pick #%d auth = %q, want on", i, auth.ID)
+		}
+	}
+}
+
+func TestPickNextMixed_CompactNoneEligibleReturns503(t *testing.T) {
+	manager := newCompactTestManager(t)
+	ctx := context.Background()
+	if _, err := manager.Register(ctx, &Auth{ID: "off", Provider: "codex", Attributes: map[string]string{"compact_allowed": "false"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := cliproxyexecutor.Options{Alt: cliproxyexecutor.ResponsesCompactAlt}
+	_, _, _, err := manager.pickNextMixed(ctx, []string{"codex"}, "", opts, map[string]struct{}{})
+	var authErr *Error
+	if !errors.As(err, &authErr) || authErr.Code != "compact_unsupported" || authErr.StatusCode() != http.StatusServiceUnavailable {
+		t.Fatalf("err = %v, want compact_unsupported/503", err)
+	}
+}
+
+func TestPickNextMixed_NonCompactIgnoresCompactFlag(t *testing.T) {
+	manager := newCompactTestManager(t)
+	ctx := context.Background()
+	if _, err := manager.Register(ctx, &Auth{ID: "off", Provider: "codex", Attributes: map[string]string{"compact_allowed": "false"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	auth, _, _, err := manager.pickNextMixed(ctx, []string{"codex"}, "", cliproxyexecutor.Options{}, map[string]struct{}{})
+	if err != nil || auth == nil || auth.ID != "off" {
+		t.Fatalf("non-compact pick: auth=%v err=%v", auth, err)
+	}
+}

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -20,6 +20,9 @@ const DisallowFreeAuthMetadataKey = "disallow_free_auth"
 // ReasoningEffortMetadataKey stores the client-requested reasoning effort for usage logs.
 const ReasoningEffortMetadataKey = "reasoning_effort"
 
+// ResponsesCompactAlt is the Options.Alt value identifying a POST /v1/responses/compact request.
+const ResponsesCompactAlt = "responses/compact"
+
 const (
 	// PinnedAuthMetadataKey locks execution to a specific auth ID.
 	PinnedAuthMetadataKey = "pinned_auth_id"


### PR DESCRIPTION
## Summary
- Selectively ports upstream router-for-me/CLIProxyAPI#3633 compact routing controls without touching LTS usage statistics or translator code.
- Adds compact-default plus per Codex/OpenAI-compatible compact modes: auto, force_on, force_off.
- Records compact_mode and compact_allowed on synthesized auth entries and filters /v1/responses/compact selection before scheduler fast-path routing.
- Exposes compact controls through Management API config/auth-file surfaces and documents the new config keys.

## Validation
- git diff --check
- go test ./internal/config ./internal/watcher/synthesizer ./internal/api/handlers/management ./sdk/cliproxy/auth ./sdk/api/handlers/openai -run 'Compact|compact' -count=1\n- go test ./internal/config ./internal/watcher/synthesizer ./internal/api/handlers/management ./sdk/api/handlers/openai -count=1\n- go test ./sdk/cliproxy/... -count=1\n- go build -o test-output ./cmd/server\n- go test ./...\n\n## LTS notes\n- Preserves internal/usage and /v0/management/usage* behavior.\n- Leaves module path unchanged at github.com/router-for-me/CLIProxyAPI/v6.\n- Does not modify internal/translator or AGENTS.md.