### PR TITLE
[codex] Strip compact defer loading

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -435,6 +435,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 	body, _ = sjson.DeleteBytes(body, "stream")
 	body = normalizeCodexInstructions(body)
+	body = stripCodexToolDeferLoading(body)
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
 		body = ensureImageGenerationTool(body, baseModel, auth)
 	}
@@ -997,6 +998,23 @@ func normalizeCodexInstructions(body []byte) []byte {
 	instructions := gjson.GetBytes(body, "instructions")
 	if !instructions.Exists() || instructions.Type == gjson.Null {
 		body, _ = sjson.SetBytes(body, "instructions", "")
+	}
+	return body
+}
+
+func stripCodexToolDeferLoading(body []byte) []byte {
+	return stripCodexToolDeferLoadingAtPath(body, "tools")
+}
+
+func stripCodexToolDeferLoadingAtPath(body []byte, path string) []byte {
+	tools := gjson.GetBytes(body, path)
+	if !tools.IsArray() {
+		return body
+	}
+	for i := range tools.Array() {
+		toolPath := fmt.Sprintf("%s.%d", path, i)
+		body, _ = sjson.DeleteBytes(body, toolPath+".defer_loading")
+		body = stripCodexToolDeferLoadingAtPath(body, toolPath+".tools")
 	}
 	return body
 }

--- a/internal/runtime/executor/codex_executor_compact_test.go
+++ b/internal/runtime/executor/codex_executor_compact_test.go
@@ -77,3 +77,52 @@ func TestCodexExecutorCompactAddsDefaultInstructions(t *testing.T) {
 		})
 	}
 }
+
+func TestCodexExecutorCompactStripsToolDeferLoading(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody = body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_1","object":"response.compaction","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}`))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+	payload := []byte(`{
+		"model":"gpt-5.4",
+		"input":"summarize",
+		"tools":[
+			{"type":"function","name":"read","description":"read files","parameters":{"type":"object"},"defer_loading":true},
+			{"type":"namespace","name":"codex_app","description":"app tools","tools":[{"type":"function","name":"automation_update","description":"manage automations","parameters":{"type":"object"},"defer_loading":true}]}
+		]
+	}`)
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Alt:          "responses/compact",
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error: %v", err)
+	}
+	if gjson.GetBytes(gotBody, "tools.0.defer_loading").Exists() {
+		t.Fatalf("compact request kept defer_loading: %s", string(gotBody))
+	}
+	if gjson.GetBytes(gotBody, "tools.1.tools.0.defer_loading").Exists() {
+		t.Fatalf("compact request kept nested defer_loading: %s", string(gotBody))
+	}
+	if got := gjson.GetBytes(gotBody, "tools.0.name").String(); got != "read" {
+		t.Fatalf("tool name = %q, want read; body=%s", got, string(gotBody))
+	}
+	if got := gjson.GetBytes(gotBody, "tools.1.tools.0.name").String(); got != "automation_update" {
+		t.Fatalf("nested tool name = %q, want automation_update; body=%s", got, string(gotBody))
+	}
+}


### PR DESCRIPTION
## Summary
- Selectively ports upstream router-for-me/CLIProxyAPI#3167 for Codex compact requests.
- Removes top-level and nested `defer_loading` fields from compact tool definitions before calling `/responses/compact`.
- Preserves the rest of the tool shape, including nested namespace tools.

## Validation
- git diff --check
- go test ./internal/runtime/executor -run 'TestCodexExecutorCompact|stripCodexToolDeferLoading' -count=1\n- go test ./internal/runtime/executor -count=1\n- go build -o test-output ./cmd/server\n\n## LTS notes\n- No changes to internal/usage or /v0/management/usage*.\n- No changes to internal/translator or AGENTS.md.\n- Leaves module path unchanged at github.com/router-for-me/CLIProxyAPI/v6.