### PR TITLE
[codex] Strip invalid Claude thinking signatures

### DIFF
--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -23,6 +23,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/thinking"
+	antigravityclaude "github.com/router-for-me/CLIProxyAPI/v6/internal/translator/antigravity/claude"
 	"github.com/router-for-me/CLIProxyAPI/v6/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v6/sdk/cliproxy/executor"
@@ -170,6 +171,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	// Disable thinking if tool_choice forces tool use (Anthropic API constraint)
 	body = disableThinkingIfToolChoiceForced(body)
 	body = normalizeClaudeTemperatureForThinking(body)
+	body = sanitizeClaudeUpstreamThinkingSignatures(body)
 
 	// Auto-inject cache_control if missing (optimization for ClawdBot/clients without caching support)
 	if countCacheControls(body) == 0 {
@@ -348,6 +350,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	// Disable thinking if tool_choice forces tool use (Anthropic API constraint)
 	body = disableThinkingIfToolChoiceForced(body)
 	body = normalizeClaudeTemperatureForThinking(body)
+	body = sanitizeClaudeUpstreamThinkingSignatures(body)
 
 	// Auto-inject cache_control if missing (optimization for ClawdBot/clients without caching support)
 	if countCacheControls(body) == 0 {
@@ -780,6 +783,10 @@ func normalizeClaudeTemperatureForThinking(body []byte) []byte {
 		body, _ = sjson.SetBytes(body, "temperature", 1)
 	}
 	return body
+}
+
+func sanitizeClaudeUpstreamThinkingSignatures(body []byte) []byte {
+	return antigravityclaude.StripEmptySignatureThinkingBlocks(body)
 }
 
 type compositeReadCloser struct {

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -2093,6 +2093,30 @@ func TestNormalizeClaudeTemperatureForThinking_AfterForcedToolChoiceKeepsOrigina
 	}
 }
 
+func TestSanitizeClaudeUpstreamThinkingSignatures_StripsInvalidAntigravitySignatures(t *testing.T) {
+	payload := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"drop-empty","signature":""},{"type":"thinking","thinking":"drop-antigravity","signature":"not-a-claude-signature"},{"type":"thinking","thinking":"keep-claude","signature":"Evalid-prefix"},{"type":"thinking","thinking":"keep-cached-claude","signature":"model-group#Rvalid-prefix"},{"type":"text","text":"hello"}]}]}`)
+	out := sanitizeClaudeUpstreamThinkingSignatures(payload)
+
+	blocks := gjson.GetBytes(out, "messages.0.content").Array()
+	if len(blocks) != 3 {
+		t.Fatalf("content block count = %d, want 3: %s", len(blocks), string(out))
+	}
+
+	var keptThinking []string
+	for _, block := range blocks {
+		if block.Get("type").String() == "thinking" {
+			keptThinking = append(keptThinking, block.Get("thinking").String())
+		}
+	}
+	got := strings.Join(keptThinking, ",")
+	if got != "keep-claude,keep-cached-claude" {
+		t.Fatalf("kept thinking blocks = %q, want valid Claude signatures only", got)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.2.text").String(); got != "hello" {
+		t.Fatalf("text block = %q, want hello", got)
+	}
+}
+
 func TestRemapOAuthToolNames_TitleCase_NoReverseNeeded(t *testing.T) {
 	body := []byte(`{"tools":[{"name":"Bash","description":"Run shell commands","input_schema":{"type":"object","properties":{"cmd":{"type":"string"}}}}],"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
 


### PR DESCRIPTION
## Summary

- Port the useful behavior from upstream router-for-me/CLIProxyAPI#3652 for LTS: Claude requests now strip invalid/empty Antigravity-style `thinking.signature` blocks before forwarding to native Claude upstreams.
- Wire the cleanup into both non-streaming and streaming Claude executor paths after existing thinking normalization and before cache/signing/request logging.
- Add an executor regression test that drops invalid thinking blocks while preserving valid Claude `E`/`R` signature prefixes, including cached `model#R...` form.

## LTS compatibility

- Keeps the v6 module path and does not modify usage statistics, Management usage endpoints, config schema, auth file shape, or Panel-facing API contracts.
- Avoids `internal/translator/**` file changes, so the PR stays within executor scope while reusing the helper already used by `antigravity_executor.go`.

## Validation

- `git diff --check`
- `go test ./internal/runtime/executor -run 'TestSanitizeClaudeUpstreamThinkingSignatures|TestNormalizeClaudeTemperatureForThinking' -count=1`\n- `go test ./internal/runtime/executor -count=1`\n- `go test ./internal/translator/antigravity/claude -run 'Signature|Validate|Strip' -count=1`\n- `go build -o test-output ./cmd/server`\n- `go test ./...`