### PR TITLE
[codex] Decouple panel GitHub token

### DIFF
--- a/internal/managementasset/updater.go
+++ b/internal/managementasset/updater.go
@@ -46,6 +46,11 @@ var (
 	sfGroup             singleflight.Group
 )
 
+func isGitHubReleaseHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	return host == "github.com" || host == "api.github.com"
+}
+
 // SetCurrentConfig stores the latest configuration snapshot for management asset decisions.
 func SetCurrentConfig(cfg *config.Config) {
 	if cfg == nil {
@@ -343,9 +348,14 @@ func fetchLatestAsset(ctx context.Context, client *http.Client, releaseURL strin
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("User-Agent", httpUserAgent)
-	gitURL := strings.ToLower(strings.TrimSpace(os.Getenv("GITSTORE_GIT_URL")))
-	if tok := strings.TrimSpace(os.Getenv("GITSTORE_GIT_TOKEN")); tok != "" && strings.Contains(gitURL, "github.com") {
+	releaseHost := strings.ToLower(strings.TrimSpace(req.URL.Host))
+	if tok := strings.TrimSpace(os.Getenv("CLIPROXYAPI_PANEL_GITHUB_TOKEN")); tok != "" && isGitHubReleaseHost(releaseHost) {
 		req.Header.Set("Authorization", "Bearer "+tok)
+	} else if isGitHubReleaseHost(releaseHost) {
+		gitURL := strings.ToLower(strings.TrimSpace(os.Getenv("GITSTORE_GIT_URL")))
+		if tok := strings.TrimSpace(os.Getenv("GITSTORE_GIT_TOKEN")); tok != "" && strings.Contains(gitURL, "github.com") {
+			req.Header.Set("Authorization", "Bearer "+tok)
+		}
 	}
 
 	resp, err := client.Do(req)

--- a/internal/managementasset/updater_test.go
+++ b/internal/managementasset/updater_test.go
@@ -1,6 +1,14 @@
 package managementasset
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+)
 
 func TestResolveReleaseURLDefaultsToCPAPanelLTS(t *testing.T) {
 	t.Parallel()
@@ -21,5 +29,160 @@ func TestResolveReleaseURLAcceptsGitHubRepository(t *testing.T) {
 	want := "https://api.github.com/repos/BlueSkyXN/CPA-Panel-LTS/releases/latest"
 	if got != want {
 		t.Fatalf("resolveReleaseURL(repo) = %q, want %q", got, want)
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func githubHostRewritingClient(t *testing.T, serverURL string) *http.Client {
+	t.Helper()
+
+	target, err := url.Parse(serverURL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	base := http.DefaultTransport
+	return &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		clone := req.Clone(req.Context())
+		clone.URL.Scheme = target.Scheme
+		clone.URL.Host = target.Host
+		return base.RoundTrip(clone)
+	})}
+}
+
+func setTestEnv(t *testing.T, key string, value string) {
+	t.Helper()
+
+	old, had := os.LookupEnv(key)
+	if err := os.Setenv(key, value); err != nil {
+		t.Fatalf("set %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(key, old)
+			return
+		}
+		_ = os.Unsetenv(key)
+	})
+}
+
+func unsetTestEnv(t *testing.T, key string) {
+	t.Helper()
+
+	old, had := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unset %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if had {
+			_ = os.Setenv(key, old)
+			return
+		}
+		_ = os.Unsetenv(key)
+	})
+}
+
+func latestReleaseServer(t *testing.T, gotAuth *string) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(releaseResponse{
+			Assets: []releaseAsset{{
+				Name:               managementAssetName,
+				BrowserDownloadURL: "https://example.test/management.html",
+				Digest:             "sha256:abcd",
+			}},
+		})
+	}))
+}
+
+func githubReleaseURLForTest(t *testing.T, serverURL string) string {
+	t.Helper()
+
+	releaseURL, err := url.Parse(serverURL)
+	if err != nil {
+		t.Fatalf("parse release URL: %v", err)
+	}
+	releaseURL.Host = "api.github.com"
+	return releaseURL.String()
+}
+
+func TestFetchLatestAssetUsesPanelGitHubTokenWithoutGitStoreMode(t *testing.T) {
+	setTestEnv(t, "CLIPROXYAPI_PANEL_GITHUB_TOKEN", "panel-token")
+	unsetTestEnv(t, "GITSTORE_GIT_URL")
+	unsetTestEnv(t, "GITSTORE_GIT_TOKEN")
+
+	var gotAuth string
+	server := latestReleaseServer(t, &gotAuth)
+	defer server.Close()
+
+	client := githubHostRewritingClient(t, server.URL)
+	asset, hash, err := fetchLatestAsset(context.Background(), client, githubReleaseURLForTest(t, server.URL))
+	if err != nil {
+		t.Fatalf("fetchLatestAsset returned error: %v", err)
+	}
+	if gotAuth != "Bearer panel-token" {
+		t.Fatalf("Authorization header = %q, want panel token", gotAuth)
+	}
+	if asset == nil || asset.Name != managementAssetName {
+		t.Fatalf("unexpected asset: %#v", asset)
+	}
+	if hash != "abcd" {
+		t.Fatalf("hash = %q, want abcd", hash)
+	}
+}
+
+func TestFetchLatestAssetPrefersPanelTokenOverGitStoreToken(t *testing.T) {
+	setTestEnv(t, "CLIPROXYAPI_PANEL_GITHUB_TOKEN", "panel-token")
+	setTestEnv(t, "GITSTORE_GIT_URL", "https://github.com/BlueSkyXN/CPA-Panel-LTS")
+	setTestEnv(t, "GITSTORE_GIT_TOKEN", "gitstore-token")
+
+	var gotAuth string
+	server := latestReleaseServer(t, &gotAuth)
+	defer server.Close()
+
+	client := githubHostRewritingClient(t, server.URL)
+	if _, _, err := fetchLatestAsset(context.Background(), client, githubReleaseURLForTest(t, server.URL)); err != nil {
+		t.Fatalf("fetchLatestAsset returned error: %v", err)
+	}
+	if gotAuth != "Bearer panel-token" {
+		t.Fatalf("Authorization header = %q, want panel token", gotAuth)
+	}
+}
+
+func TestFetchLatestAssetDoesNotLeakPanelTokenToNonGitHubHosts(t *testing.T) {
+	setTestEnv(t, "CLIPROXYAPI_PANEL_GITHUB_TOKEN", "panel-token")
+
+	var gotAuth string
+	server := latestReleaseServer(t, &gotAuth)
+	defer server.Close()
+
+	if _, _, err := fetchLatestAsset(context.Background(), server.Client(), server.URL); err != nil {
+		t.Fatalf("fetchLatestAsset returned error: %v", err)
+	}
+	if gotAuth != "" {
+		t.Fatalf("Authorization header = %q, want empty for non-GitHub host", gotAuth)
+	}
+}
+
+func TestFetchLatestAssetDoesNotLeakGitStoreTokenToNonGitHubHosts(t *testing.T) {
+	setTestEnv(t, "GITSTORE_GIT_URL", "https://github.com/BlueSkyXN/CPA-Panel-LTS")
+	setTestEnv(t, "GITSTORE_GIT_TOKEN", "gitstore-token")
+
+	var gotAuth string
+	server := latestReleaseServer(t, &gotAuth)
+	defer server.Close()
+
+	if _, _, err := fetchLatestAsset(context.Background(), server.Client(), server.URL); err != nil {
+		t.Fatalf("fetchLatestAsset returned error: %v", err)
+	}
+	if gotAuth != "" {
+		t.Fatalf("Authorization header = %q, want empty for non-GitHub host", gotAuth)
 	}
 }


### PR DESCRIPTION
## Summary

- Port the useful behavior from upstream router-for-me/CLIProxyAPI#3122 for LTS panel asset updates.
- Add a dedicated `CLIPROXYAPI_PANEL_GITHUB_TOKEN` path for GitHub release checks, so panel downloads do not need to be coupled to `GITSTORE_GIT_TOKEN` / `GITSTORE_GIT_URL`.
- Keep `GITSTORE_GIT_TOKEN` as a fallback only for GitHub release hosts and avoid sending either bearer token to non-GitHub release URLs.
- Add focused regression coverage for token precedence and non-GitHub no-leak behavior.

## LTS compatibility

- Keeps the default CPA-Panel-LTS release source and does not change usage statistics, Management usage endpoints, auth file schema, or public SDK types.
- Scope is limited to `internal/managementasset`; no `AGENTS.md` or translator files changed.

## Validation

- `git diff --check`
- `go test ./internal/managementasset -run 'TestResolveReleaseURL|TestFetchLatestAsset' -count=1`\n- `go test ./internal/managementasset -count=1`\n- `go build -o test-output ./cmd/server`\n- `go test ./...`