### PR TITLE
[codex] Skip count_tokens 404 cooldown

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1457,7 +1457,17 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				if ra := retryAfterFromError(errExec); ra != nil {
 					result.RetryAfter = ra
 				}
-				m.MarkResult(execCtx, result)
+				// count_tokens 404s from non-Anthropic upstreams usually mean the
+				// endpoint is unsupported, not that the model/auth is unusable.
+				// Recording them would cool down the auth for normal requests too.
+				if result.Error.HTTPStatus != http.StatusNotFound {
+					m.MarkResult(execCtx, result)
+				} else {
+					logEntryWithRequestID(execCtx).Debugf(
+						"skipping MarkResult for count_tokens 404 on auth=%s model=%s: %s",
+						auth.ID, upstreamModel, errExec.Error(),
+					)
+				}
 				if isRequestInvalidError(errExec) {
 					return cliproxyexecutor.Response{}, errExec
 				}

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -160,8 +160,10 @@ type authFallbackExecutor struct {
 	mu                sync.Mutex
 	executeCalls      []string
 	streamCalls       []string
+	countTokenCalls   []string
 	executeErrors     map[string]error
 	streamFirstErrors map[string]error
+	countTokenErrors  map[string]error
 }
 
 func (e *authFallbackExecutor) Identifier() string {
@@ -200,8 +202,15 @@ func (e *authFallbackExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, er
 	return auth, nil
 }
 
-func (e *authFallbackExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
-	return cliproxyexecutor.Response{}, &Error{HTTPStatus: 500, Message: "not implemented"}
+func (e *authFallbackExecutor) CountTokens(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.mu.Lock()
+	e.countTokenCalls = append(e.countTokenCalls, auth.ID)
+	err := e.countTokenErrors[auth.ID]
+	e.mu.Unlock()
+	if err != nil {
+		return cliproxyexecutor.Response{}, err
+	}
+	return cliproxyexecutor.Response{Payload: []byte(auth.ID)}, nil
 }
 
 func (e *authFallbackExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
@@ -849,5 +858,57 @@ func TestManager_RequestScopedNotFoundStopsRetryWithoutSuspendingAuth(t *testing
 	}
 	if state := updatedBad.ModelStates[model]; state != nil {
 		t.Fatalf("expected request-scoped 404 to avoid bad auth model cooldown state, got %#v", state)
+	}
+}
+
+func TestManagerExecuteCount_NotFoundDoesNotSuspendAuth(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	executor := &authFallbackExecutor{
+		id: "claude",
+		countTokenErrors: map[string]error{
+			"aa-count-auth": &Error{
+				HTTPStatus: http.StatusNotFound,
+				Message:    "404 page not found",
+			},
+		},
+	}
+	m.RegisterExecutor(executor)
+
+	model := "cc-glm-5.1"
+	auth := &Auth{ID: "aa-count-auth", Provider: "claude"}
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, "claude", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	_, errCount := m.ExecuteCount(context.Background(), []string{"claude"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if errCount == nil {
+		t.Fatal("expected count_tokens 404 error")
+	}
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to remain registered")
+	}
+	if updated.Unavailable {
+		t.Fatalf("expected count_tokens 404 to keep auth available, got unavailable")
+	}
+	if !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("expected count_tokens 404 to keep cooldown unset, got %v", updated.NextRetryAfter)
+	}
+	if state := updated.ModelStates[model]; state != nil {
+		t.Fatalf("expected count_tokens 404 to avoid model cooldown state, got %#v", state)
+	}
+
+	resp, errExec := m.Execute(context.Background(), []string{"claude"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if errExec != nil {
+		t.Fatalf("expected Execute to succeed after count_tokens 404, got: %v", errExec)
+	}
+	if string(resp.Payload) != auth.ID {
+		t.Fatalf("execute payload = %q, want %q", string(resp.Payload), auth.ID)
 	}
 }


### PR DESCRIPTION
## Summary
- Selectively ports upstream router-for-me/CLIProxyAPI#2895 for `count_tokens` 404 handling.
- Skips `MarkResult` only for `ExecuteCount`/`count_tokens` 404 responses so unsupported `/v1/messages/count_tokens` endpoints do not cool down an otherwise usable auth/model for normal requests.
- Adds a regression test proving a 404 count_tokens failure leaves the auth available and a later `Execute` call succeeds.

## LTS compatibility
- Scope is limited to `sdk/cliproxy/auth`; no config schema, Management API, `internal/usage`, or panel contract changes.
- Preserves public SDK types and only narrows a scheduler side effect for unsupported count_tokens endpoints.

## Validation
- `git diff --check`
- `go test ./sdk/cliproxy/auth -run 'TestManagerExecuteCount_NotFoundDoesNotSuspendAuth|TestManager_RequestScopedNotFoundStopsRetryWithoutSuspendingAuth|TestManager_ModelSupportBadRequest_FallsBackAndSuspendsAuth' -count=1`\n- `go test ./sdk/cliproxy/auth -count=1`\n- `go test ./sdk/cliproxy/... -count=1`\n- `go build -o test-output ./cmd/server && rm -f test-output`\n- `go test ./...`