### PR TITLE
[codex] Hydrate auth prefix metadata from stores

### DIFF
--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -380,6 +380,7 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 		"name":           name,
 		"type":           strings.TrimSpace(auth.Provider),
 		"provider":       strings.TrimSpace(auth.Provider),
+		"prefix":         strings.TrimSpace(auth.Prefix),
 		"label":          auth.Label,
 		"status":         auth.Status,
 		"status_message": auth.StatusMessage,
@@ -1039,7 +1040,7 @@ func (h *Handler) buildAuthFromFileData(path string, data []byte) (*coreauth.Aut
 			auth.Runtime = existing.Runtime
 		}
 	}
-	coreauth.ApplyCustomHeadersFromMetadata(auth)
+	coreauth.HydrateAuthFromMetadata(auth)
 	return auth, nil
 }
 

--- a/internal/api/handlers/management/auth_files_recent_requests_test.go
+++ b/internal/api/handlers/management/auth_files_recent_requests_test.go
@@ -20,6 +20,7 @@ func TestListAuthFiles_IncludesRecentRequestsBuckets(t *testing.T) {
 	record := &coreauth.Auth{
 		ID:       "runtime-only-auth-1",
 		Provider: "codex",
+		Prefix:   "team-a",
 		Attributes: map[string]string{
 			"runtime_only": "true",
 		},
@@ -67,6 +68,9 @@ func TestListAuthFiles_IncludesRecentRequestsBuckets(t *testing.T) {
 	}
 	if _, ok := fileEntry["failed"].(float64); !ok {
 		t.Fatalf("expected failed number, got %#v", fileEntry["failed"])
+	}
+	if got, _ := fileEntry["prefix"].(string); got != "team-a" {
+		t.Fatalf("prefix = %q, want team-a", got)
 	}
 
 	recentRaw, ok := fileEntry["recent_requests"].([]any)

--- a/internal/store/gitstore.go
+++ b/internal/store/gitstore.go
@@ -492,8 +492,7 @@ func (s *GitTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth, 
 	if email, ok := metadata["email"].(string); ok && email != "" {
 		auth.Attributes["email"] = email
 	}
-	cliproxyauth.ApplyCustomHeadersFromMetadata(auth)
-	applyDisabledMetadata(auth, metadata)
+	cliproxyauth.HydrateAuthFromMetadata(auth)
 	return auth, nil
 }
 

--- a/internal/store/objectstore.go
+++ b/internal/store/objectstore.go
@@ -599,8 +599,7 @@ func (s *ObjectTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Aut
 		LastRefreshedAt:  time.Time{},
 		NextRefreshAfter: time.Time{},
 	}
-	cliproxyauth.ApplyCustomHeadersFromMetadata(auth)
-	applyDisabledMetadata(auth, metadata)
+	cliproxyauth.HydrateAuthFromMetadata(auth)
 	return auth, nil
 }
 

--- a/internal/store/postgresstore.go
+++ b/internal/store/postgresstore.go
@@ -314,8 +314,7 @@ func (s *PostgresStore) List(ctx context.Context) ([]*cliproxyauth.Auth, error) 
 			LastRefreshedAt:  time.Time{},
 			NextRefreshAfter: time.Time{},
 		}
-		cliproxyauth.ApplyCustomHeadersFromMetadata(auth)
-		applyDisabledMetadata(auth, metadata)
+		cliproxyauth.HydrateAuthFromMetadata(auth)
 		auths = append(auths, auth)
 	}
 	if err = rows.Err(); err != nil {

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -258,7 +258,7 @@ func (s *FileTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth,
 	if email, ok := metadata["email"].(string); ok && email != "" {
 		auth.Attributes["email"] = email
 	}
-	cliproxyauth.ApplyCustomHeadersFromMetadata(auth)
+	cliproxyauth.HydrateAuthFromMetadata(auth)
 	return auth, nil
 }
 

--- a/sdk/auth/filestore_disabled_test.go
+++ b/sdk/auth/filestore_disabled_test.go
@@ -62,3 +62,44 @@ func TestFileTokenStoreSaveDisabledPersistsFlagForTokenStorage(t *testing.T) {
 		t.Fatalf("disabled=%v, want true (raw=%s)", meta["disabled"], string(raw))
 	}
 }
+
+func TestFileTokenStoreListHydratesMetadataFields(t *testing.T) {
+	ctx := context.Background()
+	baseDir := t.TempDir()
+	path := filepath.Join(baseDir, "qwen.json")
+
+	raw := []byte(`{
+		"type":"claude",
+		"email":"user@example.com",
+		"prefix":" /qwenai/ ",
+		"disabled":true,
+		"headers":{"X-Team":"blue"}
+	}`)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("seed auth file: %v", err)
+	}
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(baseDir)
+	auths, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("List() returned %d auths, want 1", len(auths))
+	}
+
+	auth := auths[0]
+	if auth.Prefix != "qwenai" {
+		t.Fatalf("Prefix = %q, want qwenai", auth.Prefix)
+	}
+	if !auth.Disabled {
+		t.Fatal("Disabled = false, want true")
+	}
+	if auth.Status != cliproxyauth.StatusDisabled {
+		t.Fatalf("Status = %q, want %q", auth.Status, cliproxyauth.StatusDisabled)
+	}
+	if got := auth.Attributes["header:X-Team"]; got != "blue" {
+		t.Fatalf("header:X-Team = %q, want blue", got)
+	}
+}

--- a/sdk/cliproxy/auth/metadata_hydrate.go
+++ b/sdk/cliproxy/auth/metadata_hydrate.go
@@ -1,0 +1,35 @@
+package auth
+
+import "strings"
+
+// HydrateAuthFromMetadata applies typed fields mirrored in auth.Metadata.
+// Store backends should call this after constructing an Auth from persisted
+// metadata so runtime routing fields match the on-disk/source record.
+func HydrateAuthFromMetadata(auth *Auth) {
+	if auth == nil || len(auth.Metadata) == 0 {
+		return
+	}
+	hydratePrefix(auth)
+	ApplyCustomHeadersFromMetadata(auth)
+	hydrateDisabled(auth)
+}
+
+func hydratePrefix(auth *Auth) {
+	raw, ok := auth.Metadata["prefix"].(string)
+	if !ok {
+		return
+	}
+	trimmed := strings.TrimSpace(raw)
+	trimmed = strings.Trim(trimmed, "/")
+	if trimmed == "" || strings.Contains(trimmed, "/") {
+		return
+	}
+	auth.Prefix = trimmed
+}
+
+func hydrateDisabled(auth *Auth) {
+	if disabled, ok := auth.Metadata["disabled"].(bool); ok && disabled {
+		auth.Disabled = true
+		auth.Status = StatusDisabled
+	}
+}

--- a/sdk/cliproxy/auth/metadata_hydrate_test.go
+++ b/sdk/cliproxy/auth/metadata_hydrate_test.go
@@ -1,0 +1,64 @@
+package auth
+
+import "testing"
+
+func TestHydrateAuthFromMetadata_Prefix(t *testing.T) {
+	cases := []struct {
+		name       string
+		metadata   map[string]any
+		wantPrefix string
+	}{
+		{name: "nil metadata", metadata: nil},
+		{name: "empty metadata", metadata: map[string]any{}},
+		{name: "no prefix key", metadata: map[string]any{"email": "test"}},
+		{name: "simple prefix", metadata: map[string]any{"prefix": "qwenai"}, wantPrefix: "qwenai"},
+		{name: "prefix with spaces", metadata: map[string]any{"prefix": "  qwenai  "}, wantPrefix: "qwenai"},
+		{name: "prefix with leading slash", metadata: map[string]any{"prefix": "/qwenai"}, wantPrefix: "qwenai"},
+		{name: "prefix with trailing slash", metadata: map[string]any{"prefix": "qwenai/"}, wantPrefix: "qwenai"},
+		{name: "prefix with both slashes", metadata: map[string]any{"prefix": "/qwenai/"}, wantPrefix: "qwenai"},
+		{name: "prefix containing slash rejected", metadata: map[string]any{"prefix": "qwen/ai"}},
+		{name: "empty prefix after trim", metadata: map[string]any{"prefix": "  "}},
+		{name: "slash-only prefix", metadata: map[string]any{"prefix": "///"}},
+		{name: "non-string prefix ignored", metadata: map[string]any{"prefix": 42}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			auth := &Auth{Metadata: tc.metadata}
+			HydrateAuthFromMetadata(auth)
+			if auth.Prefix != tc.wantPrefix {
+				t.Fatalf("Prefix = %q, want %q", auth.Prefix, tc.wantPrefix)
+			}
+		})
+	}
+}
+
+func TestHydrateAuthFromMetadata_CustomHeaders(t *testing.T) {
+	auth := &Auth{
+		Attributes: map[string]string{},
+		Metadata: map[string]any{
+			"headers": map[string]any{"X-Custom": "value"},
+		},
+	}
+
+	HydrateAuthFromMetadata(auth)
+	if auth.Attributes["header:X-Custom"] != "value" {
+		t.Fatalf("custom header not applied: %v", auth.Attributes)
+	}
+}
+
+func TestHydrateAuthFromMetadata_Disabled(t *testing.T) {
+	auth := &Auth{Metadata: map[string]any{"disabled": true}}
+
+	HydrateAuthFromMetadata(auth)
+	if !auth.Disabled {
+		t.Fatal("Disabled = false, want true")
+	}
+	if auth.Status != StatusDisabled {
+		t.Fatalf("Status = %q, want %q", auth.Status, StatusDisabled)
+	}
+}
+
+func TestHydrateAuthFromMetadata_NilAuth(t *testing.T) {
+	HydrateAuthFromMetadata(nil)
+}


### PR DESCRIPTION
## Summary
- Selectively ports the core idea from upstream router-for-me/CLIProxyAPI#2669.
- Adds `HydrateAuthFromMetadata` as the shared metadata-to-runtime mapping for auth records, currently covering `prefix`, custom headers, and disabled state.
- Applies it to file, git, object, postgres, and Management auth-file fallback loading so OAuth prefixes survive reload/restart across store backends.
- Exposes `prefix` in `/v0/management/auth-files` entries so the Management UI can read the same field it can already patch.

## LTS compatibility
- Additive Management response field only; no route, auth, config schema, usage statistics, or `/v0/management/usage*` changes.
- Keeps existing watcher/synthesizer prefix behavior intact and reuses the same single-segment prefix validation.

## Validation
- `git diff --check`
- `go test ./sdk/cliproxy/auth -run 'TestHydrateAuthFromMetadata' -count=1`\n- `go test ./sdk/auth -run 'TestFileTokenStoreListHydratesMetadataFields|TestFileTokenStoreSaveDisabledPersistsFlagForTokenStorage' -count=1`\n- `go test ./internal/api/handlers/management -run 'TestListAuthFiles_IncludesRecentRequestsBuckets|TestPatchAuthFileFields_MergeHeadersAndDeleteEmptyValues' -count=1`\n- `go test ./internal/store ./sdk/auth ./sdk/cliproxy/auth ./internal/api/handlers/management -count=1`\n- `go build -o test-output ./cmd/server && rm -f test-output`\n- `go test ./...`