### PR TITLE
docs: define protected full-sync contract

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,48 @@
+## Type
+
+- [ ] Protected upstream full-sync
+- [ ] Staged upstream full-sync
+- [ ] LTS protected-delta patch
+- [ ] Maintenance docs / CI
+- [ ] Emergency hotfix
+
+## Upstream sync info
+
+- Upstream repo:
+- Upstream branch:
+- Upstream from SHA:
+- Upstream to SHA:
+- Sync branch:
+
+## Protected delta checklist
+
+- [ ] `usage-statistics-enabled` still exists
+- [ ] `internal/usage/` still exists
+- [ ] `/v0/management/usage` still exists
+- [ ] `/v0/management/usage/export` still exists
+- [ ] `/v0/management/usage/import` still exists
+- [ ] CPA-Panel-LTS response shape reviewed
+- [ ] Local auth/config/panel/release/source customizations reviewed
+
+## Conflict resolution notes
+
+Describe any downstream resolution made to preserve LTS behavior.
+
+## Validation
+
+- [ ] `scripts/check-lts-contract.sh`
+- [ ] usage / management contract tests
+- [ ] `go build ./cmd/server`
+- [ ] `go test ./...`
+
+## Optional real runtime smoke
+
+- [ ] Hugging Face Space smoke was run, or explicitly skipped with reason
+- Space:
+- Runtime SHA:
+- CPA-Core-LTS branch/SHA deployed:
+- `/healthz` status:
+- `/management.html` status:
+- `/v0/management/usage*` status:
+
+Do not paste management passwords, API keys, auth files, OAuth tokens, or Hugging Face secrets here.

--- a/.github/workflows/lts-contract.yml
+++ b/.github/workflows/lts-contract.yml
@@ -1,0 +1,47 @@
+name: lts-contract
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  lts-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Check LTS protected sentinels
+        run: scripts/check-lts-contract.sh
+
+      - name: Test usage and management contracts
+        run: |
+          packages="$(go list ./internal/usage ./internal/api/handlers/management ./test 2>/dev/null | tr '\n' ' ')"
+          if [ -z "$packages" ]; then
+            echo "No usage/management contract packages found" >&2
+            exit 1
+          fi
+          go test $packages -run 'Usage|usage'
+
+      - name: Build server
+        run: |
+          go build -o test-output ./cmd/server
+          rm -f test-output
+
+  full-test-observation:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Observe full test suite
+        run: go test ./...

--- a/README.md
+++ b/README.md
@@ -11,17 +11,19 @@ CPA Core LTS is a long-term-maintained fork of `router-for-me/CLIProxyAPI`.
 - Companion Web UI: <https://github.com/BlueSkyXN/CPA-Panel-LTS>
 - Default panel release source: `https://github.com/BlueSkyXN/CPA-Panel-LTS`
 
-## LTS Plan
+## Maintenance Model
 
 This fork exists because upstream releases after the selected baseline changed or removed the full usage statistics flow. The goal of this repository is to keep the CLI proxy core maintainable while preserving the statistics behavior that existed at `v6.9.49`.
 
 Maintenance rules:
 
-- `main` is the LTS line. Do not create a separate "statistics branch" for normal maintenance.
-- Preserve usage collection, `/v0/management/usage`, `/v0/management/usage/export`, `/v0/management/usage/import`, and `usage-statistics-enabled`.
-- Track useful upstream fixes and features selectively by review, cherry-pick, or manual porting.
-- Do not blindly sync the upstream fork if the change removes statistics or breaks `CPA-Panel-LTS` usage pages.
-- Planned cleanup can remove promotional copy, unused features, and non-LTS release machinery, but must not weaken the statistics contract.
+- `main` is the only CPA-Core-LTS product line. Do not create a separate "statistics branch" for normal maintenance.
+- CPA-Core-LTS tracks `router-for-me/CLIProxyAPI` by operator-driven protected full-sync merge PRs, usually prepared by AI agents when maintainers request a sync.
+- Preserve usage collection, `internal/usage/`, `/v0/management/usage`, `/v0/management/usage/export`, `/v0/management/usage/import`, and `usage-statistics-enabled`.
+- Upstream changes are accepted by default. If an upstream change conflicts with a protected delta, adapt the upstream change instead of allowing it to remove or weaken the LTS contract.
+- Do not use GitHub Sync fork, file-level overwrites, or direct `git pull upstream main` on `main`.
+- This repository does not schedule automatic upstream syncs; the documented process is the repeatable method for human/AI-operated sync work.
+- Planned cleanup can remove promotional copy, unused features, and non-LTS release machinery, but must not weaken the statistics contract or `CPA-Panel-LTS` compatibility.
 
 This core service is intended to pair with `CPA-Panel-LTS`, which keeps the matching management panel usage statistics UI. By default, `/management.html` is downloaded from the latest `CPA-Panel-LTS` release asset named `management.html`.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -11,17 +11,19 @@ CPA Core LTS 是基于 `router-for-me/CLIProxyAPI` 的长期维护分支。
 - 配套 Web 管理面板：<https://github.com/BlueSkyXN/CPA-Panel-LTS>
 - 默认面板发布源：`https://github.com/BlueSkyXN/CPA-Panel-LTS`
 
-## LTS 计划
+## 维护模型
 
 本仓库存在的原因是：上游在所选基线之后调整或移除了完整的使用统计链路。本仓库的目标是在继续维护 CLI 代理核心能力的同时，保留 `v6.9.49` 已具备的统计能力。
 
 维护规则：
 
-- `main` 就是 LTS 主线，不再单独维护一个“统计分支”。
-- 必须保留使用统计采集、`/v0/management/usage`、`/v0/management/usage/export`、`/v0/management/usage/import` 和 `usage-statistics-enabled`。
-- 跟进上游新功能时，需要逐项审查、cherry-pick 或手工移植。
-- 不要盲目同步上游 fork；凡是会移除统计或破坏 `CPA-Panel-LTS` 使用统计页面的改动，都不能直接合入。
-- 后续轻量化改造可以移除推广文案、无用功能和非 LTS 发布链路，但不能削弱统计契约。
+- `main` 是 CPA-Core-LTS 的唯一产品主线，不再单独维护一个“统计分支”。
+- CPA-Core-LTS 通过操作者驱动的 protected full-sync merge PR 跟踪 `router-for-me/CLIProxyAPI`，通常由维护者要求 AI agent 执行同步。
+- 必须保留使用统计采集、`internal/usage/`、`/v0/management/usage`、`/v0/management/usage/export`、`/v0/management/usage/import` 和 `usage-statistics-enabled`。
+- 普通上游改动默认吸收。若上游改动与 protected delta 冲突，应改写上游变更以保留 LTS 契约，而不是让上游覆盖或削弱统计功能。
+- 禁止使用 GitHub Sync fork、文件级覆盖，或在 `main` 上直接 `git pull upstream main`。
+- 本仓库不安排自动同步上游；这里沉淀的是可重复执行的人/AI 操作方法。
+- 后续轻量化改造可以移除推广文案、无用功能和非 LTS 发布链路，但不能削弱统计契约或 `CPA-Panel-LTS` 兼容性。
 
 本核心服务应与 `CPA-Panel-LTS` 配套使用，后者保留了与该统计接口匹配的管理面板统计页面。默认情况下，`/management.html` 会从 `CPA-Panel-LTS` 最新 release 中名为 `management.html` 的资产下载。
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -1,6 +1,33 @@
-# CLI Proxy API
+# CPA Core LTS
 
 [English](README.md) | [中文](README_CN.md) | 日本語
+
+CPA Core LTS は `router-for-me/CLIProxyAPI` の長期メンテナンス fork です。
+
+- LTS ベースライン: `v6.9.49`
+- ベースライン commit: `b8bba053fcdafd80abc2152c88c78f4e7713c05a`
+- Upstream source: <https://github.com/router-for-me/CLIProxyAPI>
+- LTS repository: <https://github.com/BlueSkyXN/CPA-Core-LTS>
+- Companion Web UI: <https://github.com/BlueSkyXN/CPA-Panel-LTS>
+- Default panel release source: `https://github.com/BlueSkyXN/CPA-Panel-LTS`
+
+## メンテナンスモデル
+
+この fork は、選択したベースライン以降の upstream が完全な usage statistics フローを変更または削除したため存在します。本リポジトリの目的は、CLI proxy core をメンテナンス可能な状態に保ちながら、`v6.9.49` 時代の統計機能を保持することです。
+
+メンテナンスルール:
+
+- `main` は CPA-Core-LTS の唯一の製品ラインです。通常メンテナンス用に別の「statistics branch」は作りません。
+- CPA-Core-LTS は operator-driven な protected full-sync merge PR によって `router-for-me/CLIProxyAPI` を追跡します。通常はメンテナーが依頼したときに AI agent が同期作業を準備します。
+- usage collection、`internal/usage/`、`/v0/management/usage`、`/v0/management/usage/export`、`/v0/management/usage/import`、`usage-statistics-enabled` を保持します。
+- 通常の upstream 変更はデフォルトで取り込みます。upstream 変更が protected delta と衝突する場合は、LTS 契約を削除または弱体化させるのではなく、upstream 変更を適応させます。
+- GitHub Sync fork、ファイル単位の上書き、`main` 上での直接 `git pull upstream main` は使用しません。
+- このリポジトリでは upstream sync を自動スケジュールしません。ここに記載するのは、人間または AI が操作するための再現可能な手順です。
+- 予定された軽量化では宣伝文、未使用機能、非 LTS release machinery を削除できますが、統計契約や `CPA-Panel-LTS` 互換性を弱めてはいけません。
+
+この core service は、対応する management panel usage statistics UI を保持する `CPA-Panel-LTS` と組み合わせて使用することを想定しています。デフォルトでは、`/management.html` は最新の `CPA-Panel-LTS` release asset `management.html` からダウンロードされます。
+
+## 元プロジェクト概要
 
 CLI向けのOpenAI/Gemini/Claude/Codex互換APIインターフェースを提供するプロキシサーバーです。
 

--- a/docs/lts/protected-deltas.yaml
+++ b/docs/lts/protected-deltas.yaml
@@ -1,0 +1,67 @@
+maintenance_model:
+  type: protected-full-sync
+  product_branch: main
+  operation_mode: manual-ai-assisted
+  scheduled_sync: false
+  cadence_guidance: frequent_small_syncs_when_requested
+  optional_runtime_smoke: manual_huggingface_space
+
+upstream_source:
+  repo: router-for-me/CLIProxyAPI
+  branch: main
+
+protected_deltas:
+  - id: full-usage-statistics
+    must_keep: true
+    markers:
+      - usage-statistics-enabled
+      - internal/usage/
+      - /v0/management/usage
+      - /v0/management/usage/export
+      - /v0/management/usage/import
+    validation:
+      - scripts/check-lts-contract.sh
+      - usage-management-contract-tests
+    conflict_policy: preserve_or_reapply_lts_usage
+
+  - id: cpa-panel-lts-compatibility
+    must_keep: true
+    markers:
+      - CPA-Panel-LTS
+      - management usage response shape
+      - usage page compatibility
+    validation:
+      - panel-response-shape-review
+    conflict_policy: preserve_panel_compatibility
+
+  - id: local-downstream-customizations
+    must_keep: true
+    markers:
+      - auth/config/panel/release/source customizations
+    validation:
+      - manual_review_required
+    conflict_policy: preserve_or_reapply_local_delta
+
+sync_rules:
+  default_mode: protected_full_sync
+  upstream_changes: accept_by_default
+  merge_commit_required: true
+  squash_forbidden: true
+  rebase_forbidden: true
+  forbidden_shortcuts:
+    - GitHub Sync fork
+    - git pull upstream main on main
+    - git checkout upstream/main -- .
+
+runtime_smoke:
+  mode: manual-ai-operated
+  scheduled: false
+  reference_space: BlueSkyXN/CPA-HFS-2026-03
+  requirements:
+    - Build the CPA-Core-LTS branch or exact sync commit being reviewed.
+    - Enable usage-statistics-enabled for the smoke run.
+    - Use the CPA-Panel-LTS management panel release source.
+    - Verify /healthz returns ok.
+    - Verify /management.html is served.
+    - Verify /v0/management/usage and export endpoints exist and require management authentication rather than disappearing.
+    - Do not publish management passwords, API keys, auth files, or Hugging Face secrets in PR text or logs.

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Checking CPA-Core-LTS protected contract sentinels..."
+
+test -d internal/usage
+test -f docs/lts/protected-deltas.yaml
+
+grep -R "usage-statistics-enabled" -n \
+  internal config.example.yaml README.md README_CN.md README_JA.md docs \
+  --exclude-dir=.git \
+  --exclude-dir=local \
+  --exclude-dir=vendor \
+  --exclude-dir=node_modules \
+  >/dev/null
+
+grep -R "/v0/management/usage" -n \
+  internal config.example.yaml README.md README_CN.md README_JA.md docs \
+  --exclude-dir=.git \
+  --exclude-dir=local \
+  --exclude-dir=vendor \
+  --exclude-dir=node_modules \
+  >/dev/null
+
+grep -R "/v0/management/usage/export" -n \
+  internal config.example.yaml README.md README_CN.md README_JA.md docs \
+  --exclude-dir=.git \
+  --exclude-dir=local \
+  --exclude-dir=vendor \
+  --exclude-dir=node_modules \
+  >/dev/null
+
+grep -R "/v0/management/usage/import" -n \
+  internal config.example.yaml README.md README_CN.md README_JA.md docs \
+  --exclude-dir=.git \
+  --exclude-dir=local \
+  --exclude-dir=vendor \
+  --exclude-dir=node_modules \
+  >/dev/null
+
+python3 - <<'PY'
+from pathlib import Path
+import sys
+
+path = Path("docs/lts/protected-deltas.yaml")
+text = path.read_text(encoding="utf-8")
+
+required = [
+    "protected-full-sync",
+    "full-usage-statistics",
+    "usage-statistics-enabled",
+    "internal/usage/",
+    "/v0/management/usage",
+    "/v0/management/usage/export",
+    "/v0/management/usage/import",
+    "cpa-panel-lts-compatibility",
+    "local-downstream-customizations",
+    "preserve_or_reapply_lts_usage",
+]
+
+missing = [item for item in required if item not in text]
+if missing:
+    for item in missing:
+        print(f"missing protected contract marker: {item}", file=sys.stderr)
+    sys.exit(1)
+PY
+
+echo "CPA-Core-LTS protected contract sentinels passed."


### PR DESCRIPTION
## Summary

- define the CPA-Core-LTS protected full-sync maintenance model as operator-driven / AI-assisted, not scheduled automation
- add repository-level protected-delta markers for built-in usage statistics, CPA-Panel-LTS compatibility, and local downstream customizations
- add a lightweight LTS contract sentinel script
- add an LTS contract workflow with targeted usage/management tests and server build
- update README.md / README_CN.md / README_JA.md to replace selective-port wording with protected full-sync wording
- add a PR template for sync and protected-delta reviews
- document manual Hugging Face Space runtime smoke as an optional external verification gate

## HF Space smoke baseline

Reference Space: `BlueSkyXN/CPA-HFS-2026-03`. Current live runtime is running at `1f36a09da1ad8c6c0b94c576dcaea900592baa25`; `/healthz` returns `200`, `/management.html` returns `200`, and `/v0/management/usage*` endpoints exist behind auth.

Important: the current Space Dockerfile still defaults to `router-for-me/CLIProxyAPI` `v6.9.49`, with usage statistics disabled and the upstream panel source. It is a usable runtime carrier, but a staged-sync smoke must deploy the CPA-Core-LTS branch/SHA under review, enable usage statistics, and use CPA-Panel-LTS.

## Validation

- `scripts/check-lts-contract.sh`
- `go list ./internal/usage ./internal/api/handlers/management ./test 2>/dev/null | xargs go test -run 'Usage|usage'`\n- `go build -o test-output ./cmd/server && rm -f test-output`\n- `git diff --check`\n\n## Notes\n\nThis is PR 1 for the CPA-Core-LTS maintenance mode migration. It does not touch AGENTS.md, does not sync upstream code, and does not add any scheduled upstream-sync automation.