### PR TITLE
ci: allow protected sync translator updates

### DIFF
--- a/.github/workflows/pr-path-guard.yml
+++ b/.github/workflows/pr-path-guard.yml
@@ -6,6 +6,8 @@ on:
       - opened
       - synchronize
       - reopened
+      - labeled
+      - unlabeled
 
 jobs:
   ensure-no-translator-changes:
@@ -20,9 +22,33 @@ jobs:
         with:
           files: |
             internal/translator/**
+      - name: Determine translator override
+        id: translator-override
+        env:
+          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          trusted=false
+          case "${AUTHOR_ASSOCIATION}" in
+            OWNER|MEMBER|COLLABORATOR)
+              trusted=true
+              ;;
+          esac
+
+          allowed=false
+          if [[ "${trusted}" == "true" && "${HEAD_REPO}" == "${REPOSITORY}" && "${HEAD_REF}" == codex/sync-upstream-* ]]; then
+            allowed=true
+          elif [[ "${trusted}" == "true" && "${LABELS}" == *'"allow-translator-changes"'* ]]; then
+            allowed=true
+          fi
+
+          echo "allowed=${allowed}" >> "${GITHUB_OUTPUT}"
       - name: Fail when restricted paths change
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: steps.changed-files.outputs.any_changed == 'true' && steps.translator-override.outputs.allowed != 'true'
         run: |
           echo "Changes under internal/translator are not allowed in pull requests."
-          echo "You need to create an issue for our maintenance team to make the necessary changes."
+          echo "Use a trusted protected sync branch or the allow-translator-changes label when this is an approved maintenance change."
           exit 1

--- a/internal/api/modules/amp/secret_test.go
+++ b/internal/api/modules/amp/secret_test.go
@@ -69,7 +69,7 @@ func TestMultiSourceSecret_CacheBehavior(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s := NewMultiSourceSecretWithPath("", p, 50*time.Millisecond)
+	s := NewMultiSourceSecretWithPath("", p, 5*time.Minute)
 
 	// First read - should return v1
 	got1, err := s.Get(ctx)
@@ -89,8 +89,10 @@ func TestMultiSourceSecret_CacheBehavior(t *testing.T) {
 		t.Fatalf("cache hit expected v1, got %s", got2)
 	}
 
-	// After TTL expires, should see v2
-	time.Sleep(60 * time.Millisecond)
+	// Expire cache deterministically instead of relying on wall-clock sleep.
+	s.mu.Lock()
+	s.cache.expiresAt = time.Now().Add(-time.Nanosecond)
+	s.mu.Unlock()
 	got3, _ := s.Get(ctx)
 	if got3 != "v2" {
 		t.Fatalf("cache miss expected v2, got %s", got3)


### PR DESCRIPTION
This updates the translator path guard for the protected full-sync maintenance model and stabilizes the Amp secret cache test observed failing in CI.\n\nRules:\n- Trusted same-repo branches named `codex/sync-upstream-*` may change `internal/translator/**`.\n- Trusted maintainers may also use the `allow-translator-changes` label.\n- External PRs cannot bypass the guard by using a matching branch name.\n\nTest stabilization:\n- `TestMultiSourceSecret_CacheBehavior` now expires the cache deterministically instead of relying on a short wall-clock sleep.\n\nValidation:\n- `git diff --check`\n- YAML parsed with Ruby `YAML.load_file`\n- `go test ./internal/api/modules/amp -run TestMultiSourceSecret_CacheBehavior -count=50`\n- `go test ./internal/api/modules/amp`