### PR TITLE
ci: make lts-contract workflow shell-safe

### DIFF
--- a/.github/workflows/lts-contract.yml
+++ b/.github/workflows/lts-contract.yml
@@ -21,12 +21,12 @@ jobs:
 
       - name: Test usage and management contracts
         run: |
-          packages="$(go list ./internal/usage ./internal/api/handlers/management ./test 2>/dev/null | tr '\n' ' ')"
+          packages="$(go list ./internal/usage ./internal/api/handlers/management ./test 2>/dev/null)"
           if [ -z "$packages" ]; then
             echo "No usage/management contract packages found" >&2
             exit 1
           fi
-          go test $packages -run 'Usage|usage'
+          printf '%s\n' "$packages" | xargs go test -run 'Usage|usage'
 
       - name: Build server
         run: |


### PR DESCRIPTION
## Summary
- keep the targeted LTS contract package set line-oriented instead of flattening it with unquoted shell expansion
- run the same usage/management package list through xargs so actionlint and shellcheck stay clean

## Validation
- scripts/check-lts-contract.sh
- actionlint .github/workflows/docker-image.yml .github/workflows/release.yaml .github/workflows/lts-contract.yml .github/workflows/agents-md-guard.yml
- bash -lc 'packages="github.com/router-for-me/CLIProxyAPI/v6/internal/usage
github.com/router-for-me/CLIProxyAPI/v6/internal/api/handlers/management
github.com/router-for-me/CLIProxyAPI/v6/test"; if [ -z "" ]; then echo "No usage/management contract packages found" >&2; exit 1; fi; printf "%s\n" "" | xargs go test -run "Usage|usage"'
- git diff --check
- git diff --cached --check