### PR TITLE
docs(lts): add core maintenance contract registry

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,7 @@
 - [ ] `/v0/management/usage` still exists
 - [ ] `/v0/management/usage/export` still exists
 - [ ] `/v0/management/usage/import` still exists
+- [ ] `docs/lts/core-feature-contracts.yaml` reviewed for touched protected or protected-adjacent features
 - [ ] Usage record creation/schema reviewed or tested: API key, auth source, model, token breakdown, latency, success/failure
 - [ ] Management usage response shape reviewed or tested: `usage`, `failed_requests`, `apis`, `models`, `details`
 - [ ] Export/import roundtrip reviewed or tested when usage data shape is touched
@@ -37,6 +38,7 @@ Protected-adjacent upstream changes requiring review even without text conflicts
 - Management usage response shape
 - config schema / hot reload
 - panel asset source / release source
+- registry features listed in `docs/lts/core-feature-contracts.yaml`
 
 ## Conflict resolution notes
 

--- a/docs/lts/core-feature-contracts.yaml
+++ b/docs/lts/core-feature-contracts.yaml
@@ -1,0 +1,208 @@
+version: 1
+generated_from: docs/lts/sync-runbook.md
+maintenance_model: protected-full-sync-with-contract-registry
+
+status_definitions:
+  protected: LTS identity surface. Must remain present and compatible unless the LTS product direction changes.
+  lts-maintained: Downstream-owned or upstream-deprecated behavior that CPA-Core-LTS still supports.
+  shared: Shared upstream/LTS behavior that can evolve when compatibility is preserved.
+  coexist: Optional or adjacent capability that may coexist with protected LTS behavior but must not replace it.
+
+guard_policy:
+  purpose: Keep cheap sentinels around LTS identity surfaces; prove behavior with tests and smoke checks.
+  add_marker_when:
+    - The marker is a stable route, config key, exported field, release asset name, or directory boundary.
+    - A missing marker would make a sync PR unsafe to review without manual rediscovery.
+    - The marker can be checked without network, secrets, generated assets, or provider credentials.
+  avoid_marker_when:
+    - The marker is only a local implementation detail that can be renamed without contract drift.
+    - The check duplicates an existing behavior-level test without improving review clarity.
+    - The marker would make normal upstream refactors fail unless an LTS contract actually changed.
+  behavior_proof:
+    - scripts/check-lts-contract.sh is a sentinel gate, not a replacement for contract tests.
+    - Usage schema, response shape, import/export roundtrip, and runtime attribution require Go tests.
+    - HF Space smoke is optional post-merge evidence and must not expose secrets in logs or PR text.
+
+features:
+  - id: full-usage-statistics-core
+    status: protected
+    reason: Built-in request-level usage statistics are the primary CPA-Core-LTS protected delta.
+    core_files:
+      - internal/usage/
+      - internal/usage/logger_plugin.go
+      - internal/usage/logger_plugin_test.go
+      - internal/runtime/executor/helps/usage_helpers.go
+      - internal/runtime/executor/helps/usage_helpers_test.go
+      - internal/api/handlers/management/usage.go
+      - internal/api/handlers/management/usage_contract_test.go
+      - internal/api/server.go
+      - config.example.yaml
+    required_markers:
+      - usage-statistics-enabled
+      - internal/usage/
+      - UsageReporter
+      - RequestDetail
+      - auth_index
+      - latency_ms
+      - success_count
+      - failure_count
+      - failed_requests
+    validation:
+      - scripts/check-lts-contract.sh
+      - go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'
+      - go build -o test-output ./cmd/server && rm -f test-output
+
+  - id: management-usage-api
+    status: protected
+    reason: CPA-Panel-LTS and TUI consume these Management API endpoints and response fields.
+    routes:
+      - /v0/management/usage
+      - /v0/management/usage/export
+      - /v0/management/usage/import
+      - /v0/management/usage-statistics-enabled
+    core_files:
+      - internal/api/server.go
+      - internal/api/handlers/management/usage.go
+      - internal/api/handlers/management/config_basic.go
+      - internal/api/handlers/management/usage_contract_test.go
+      - internal/tui/client.go
+      - internal/tui/usage_tab.go
+    required_markers:
+      - mgmt.GET("/usage"
+      - mgmt.GET("/usage/export"
+      - mgmt.POST("/usage/import"
+      - mgmt.GET("/usage-statistics-enabled"
+      - total_requests
+      - success_count
+      - failure_count
+      - total_tokens
+      - apis
+      - models
+      - details
+    validation:
+      - go test ./internal/api/handlers/management -run 'Usage|usage'
+      - go test ./test -run 'Usage|usage'
+
+  - id: panel-release-asset
+    status: protected
+    reason: CPA-Core-LTS must continue serving the CPA-Panel-LTS single-file management panel.
+    routes:
+      - /management.html
+    core_files:
+      - internal/managementasset/updater.go
+      - internal/managementasset/updater_test.go
+      - internal/api/server.go
+      - internal/config/config.go
+      - README.md
+      - README_CN.md
+      - README_JA.md
+    required_markers:
+      - BlueSkyXN/CPA-Panel-LTS
+      - management.html
+      - DefaultPanelGitHubRepository
+      - defaultManagementReleaseURL
+      - defaultManagementFallbackURL
+      - serveManagementControlPanel
+    validation:
+      - go test ./internal/managementasset
+      - go build -o test-output ./cmd/server && rm -f test-output
+
+  - id: auth-identity-attribution
+    status: protected
+    reason: Usage statistics and Panel status views depend on stable API key, auth source, and auth_index attribution.
+    core_files:
+      - internal/access/
+      - internal/api/handlers/management/auth_files.go
+      - internal/api/handlers/management/config_lists.go
+      - internal/auth/
+      - internal/runtime/executor/helps/usage_helpers.go
+      - internal/watcher/
+      - internal/pluginhost/auth_callbacks.go
+    required_markers:
+      - userApiKey
+      - auth_index
+      - auth file
+      - source
+      - api-key
+      - APIKey
+    validation:
+      - go test ./internal/api/handlers/management -run 'Auth|auth|Usage|usage'
+      - go test ./internal/watcher ./internal/auth/...
+
+  - id: provider-runtime-usage-seams
+    status: shared
+    reason: Upstream provider/runtime changes should be absorbed while preserving usage reporting hooks.
+    core_files:
+      - internal/runtime/executor/
+      - internal/runtime/executor/helps/usage_helpers.go
+      - internal/translator/
+      - internal/logging/
+      - internal/api/middleware/
+    required_markers:
+      - UsageReporter
+      - Report
+      - token
+      - latency
+      - failed
+    protected_adjacent_changes:
+      - request lifecycle
+      - streaming final usage
+      - WebSocket fallback
+      - model resolution
+      - token accounting
+      - logging metadata
+    validation:
+      - go test ./internal/runtime/executor/... ./internal/translator/... ./test -run 'Usage|usage|Translation|translation'
+
+  - id: config-compatibility-and-hot-reload
+    status: protected
+    reason: Existing user config must keep reading and hot-reloading while upstream config schema evolves.
+    core_files:
+      - internal/config/
+      - internal/watcher/
+      - internal/api/handlers/management/config_basic.go
+      - config.example.yaml
+    required_markers:
+      - usage-statistics-enabled
+      - panel-github-repository
+      - hot reload
+      - config diff
+      - UsageStatisticsEnabled
+      - DefaultPanelGitHubRepository
+    validation:
+      - go test ./internal/config ./internal/watcher/... ./internal/api/handlers/management -run 'Config|config|Usage|usage'
+
+  - id: redis-compatible-usage-queue
+    status: coexist
+    reason: Redis-compatible usage events can support external dashboards without replacing built-in full usage statistics.
+    routes:
+      - /v0/management/usage-queue
+    core_files:
+      - internal/redisqueue/
+      - internal/api/server.go
+      - internal/api/redis_queue_protocol_integration_test.go
+    required_markers:
+      - usage-queue
+      - redisqueue
+      - usage-statistics-enabled
+      - latency_ms
+      - auth_index
+    validation:
+      - go test ./internal/redisqueue ./internal/api -run 'Redis|redis|Usage|usage'
+
+  - id: hf-space-runtime-smoke
+    status: lts-maintained
+    reason: HF Space smoke is a live deployment check after merge, not a substitute for contract tests.
+    reference_space:
+      - BlueSkyXN/CPA-HFS-2026-03
+    runtime_checks:
+      - /healthz returns ok
+      - /management.html is served
+      - /v0/management/usage requires management auth rather than disappearing
+      - x-cpa-commit matches the intended Core commit when the Space exposes it
+    required_markers:
+      - CPA_COMMIT
+      - CPA_VERSION
+      - x-cpa-commit
+      - /management.html
+      - /v0/management/usage

--- a/docs/lts/protected-deltas.yaml
+++ b/docs/lts/protected-deltas.yaml
@@ -5,6 +5,7 @@ maintenance_model:
   scheduled_sync: false
   cadence_guidance: frequent_small_syncs_when_requested
   optional_runtime_smoke: manual_huggingface_space
+  feature_contract_registry: docs/lts/core-feature-contracts.yaml
 
 upstream_source:
   repo: router-for-me/CLIProxyAPI
@@ -24,6 +25,7 @@ protected_deltas:
       - go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'
       - behavior-contract-tests
     conflict_policy: preserve_or_reapply_lts_usage
+    registry_feature: full-usage-statistics-core
 
   - id: cpa-panel-lts-compatibility
     must_keep: true
@@ -35,6 +37,9 @@ protected_deltas:
       - panel-response-shape-review
       - management-usage-response-shape-test
     conflict_policy: preserve_panel_compatibility
+    registry_features:
+      - management-usage-api
+      - panel-release-asset
 
   - id: local-downstream-customizations
     must_keep: true
@@ -43,6 +48,11 @@ protected_deltas:
     validation:
       - manual_review_required
     conflict_policy: preserve_or_reapply_local_delta
+    registry_features:
+      - auth-identity-attribution
+      - provider-runtime-usage-seams
+      - config-compatibility-and-hot-reload
+      - redis-compatible-usage-queue
 
 sync_rules:
   default_mode: protected_full_sync
@@ -50,6 +60,7 @@ sync_rules:
   merge_commit_required: true
   squash_forbidden: true
   rebase_forbidden: true
+  contract_registry_required: true
   forbidden_shortcuts:
     - GitHub Sync fork
     - git pull upstream main on main

--- a/docs/lts/sync-runbook.md
+++ b/docs/lts/sync-runbook.md
@@ -16,6 +16,24 @@ CLIProxyAPI upstream/main latest
 
 本仓库不是普通 mirror fork。`main` 是唯一产品主线；`upstream/main` 只是只读同步坐标。正常维护方式是 manual / AI-operated protected full-sync，不安排自动同步。
 
+## Contract registry
+
+Panel 的实践证明，单靠“这几个文件不能删”的文字规则不够；需要把受保护能力拆成可审查的 registry，再让脚本和 PR checklist 同时引用它。Core 使用 `docs/lts/core-feature-contracts.yaml` 作为 contract registry，定位如下：
+
+- `docs/lts/protected-deltas.yaml` 定义 LTS 产品边界和同步策略。
+- `docs/lts/core-feature-contracts.yaml` 定义每个受保护能力的文件、路由、marker、验证命令和 protected-adjacent 改动。
+- `scripts/check-lts-contract.sh` 负责检查 registry 存在、关键 marker 存在、核心源码路径仍然存在。
+- `.github/pull_request_template.md` 负责让评审者显式说明是否按 registry 做了 protected delta review。
+
+和 Panel 不同，Core 的正确模式仍然是 protected full-sync，不是 selective-port。原因是 Core 的受保护 delta 主要集中在 usage、Management API、panel asset source、auth/config attribution 等明确接口上；普通 provider/runtime/security upstream 变更默认吸收，只在 registry 标出的 protected-adjacent seam 上做保留或适配。
+
+保持这套方案轻量的规则：
+
+- 只为稳定 contract 增加 sentinel：route、config key、JSON 字段、release asset、目录边界。
+- 不为普通函数名、局部变量、临时实现细节增加 marker；这些应该由 tests 或人工 review 覆盖。
+- `scripts/check-lts-contract.sh` 只能证明“保护面没有明显消失”；不能替代 usage schema、response shape、import/export、runtime attribution 的 Go 测试。
+- 每次新增 registry feature，都要写清为什么它是 LTS 产品边界，而不是单次 sync 的临时关注点。
+
 ## 禁止操作
 
 - 不使用 GitHub `Sync fork`。
@@ -41,6 +59,7 @@ git rev-list --count origin/main..upstream/main
 git worktree list --porcelain
 git branch --list 'codex/*'
 git for-each-ref refs/remotes/origin/codex --format='%(refname:short)'
+scripts/check-lts-contract.sh
 ```
 
 如果工作区不干净，先确认改动来源。不要覆盖或丢弃用户改动。
@@ -105,6 +124,16 @@ git merge --no-ff --log <UPSTREAM_STAGE_SHA>
 - `internal/usage/`
 - `/v0/management/usage*`
 
+审查时先对照 `docs/lts/core-feature-contracts.yaml` 的对应 feature：
+
+- `full-usage-statistics-core`
+- `management-usage-api`
+- `panel-release-asset`
+- `auth-identity-attribution`
+- `provider-runtime-usage-seams`
+- `config-compatibility-and-hot-reload`
+- `redis-compatible-usage-queue`
+
 ## Conflict policy
 
 冲突解决原则：
@@ -130,6 +159,8 @@ go test ./...
 git diff --check
 ```
 
+`scripts/check-lts-contract.sh` 必须覆盖 `docs/lts/protected-deltas.yaml` 和 `docs/lts/core-feature-contracts.yaml` 两层文件；如果 guard 只证明单个文件存在，不能视为 contract review 完成。
+
 如果 `go test ./...` 因环境、网络或已知非本次改动原因无法完成，PR body 必须写明实际命令、失败位置和剩余风险。不能把未运行的检查写成通过。
 
 最小行为级 contract tests 必须覆盖：
@@ -148,6 +179,7 @@ git diff --check
 - stage 编号和分段理由
 - 冲突文件列表
 - protected delta review
+- contract registry features reviewed
 - 普通 upstream 改动吸收范围
 - 被覆盖的旧 upstream-port PR 范围，如有
 - validation 命令和结果
@@ -162,6 +194,7 @@ Protected delta review:
 - management usage API: preserved / changed / retested
 - CPA-Panel-LTS response shape: preserved / changed / retested
 - downstream auth/config/panel/source customizations: preserved / changed / retested
+- contract registry: reviewed features / changed features / skipped features with reason
 - upstream ordinary changes: absorbed
 ```
 

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -5,6 +5,24 @@ echo "Checking CPA-Core-LTS protected contract sentinels..."
 
 test -d internal/usage
 test -f docs/lts/protected-deltas.yaml
+test -f docs/lts/core-feature-contracts.yaml
+
+require_path() {
+  local path="$1"
+  if [ ! -e "$path" ]; then
+    echo "missing required LTS contract path: $path" >&2
+    exit 1
+  fi
+}
+
+require_grep() {
+  local pattern="$1"
+  shift
+  if ! git grep -n -- "$pattern" -- "$@" >/dev/null; then
+    echo "missing required LTS contract marker '$pattern' in: $*" >&2
+    exit 1
+  fi
+}
 
 module_path="$(sed -n 's/^module //p' go.mod)"
 if [ "$module_path" != "github.com/router-for-me/CLIProxyAPI/v7" ]; then
@@ -49,6 +67,29 @@ grep -R "/v0/management/usage/import" -n \
   --exclude-dir=node_modules \
   >/dev/null
 
+require_path internal/api/handlers/management/usage.go
+require_path internal/api/handlers/management/usage_contract_test.go
+require_path internal/runtime/executor/helps/usage_helpers.go
+require_path internal/managementasset/updater.go
+require_path internal/config/config.go
+require_path internal/redisqueue
+require_path config.example.yaml
+
+require_grep "mgmt.GET(\"/usage\"" internal/api/server.go
+require_grep "mgmt.GET(\"/usage/export\"" internal/api/server.go
+require_grep "mgmt.POST(\"/usage/import\"" internal/api/server.go
+require_grep "mgmt.GET(\"/usage-queue\"" internal/api/server.go
+require_grep "mgmt.GET(\"/usage-statistics-enabled\"" internal/api/server.go
+require_grep "DefaultPanelGitHubRepository" internal/config/config.go
+require_grep "defaultManagementReleaseURL" internal/managementasset/updater.go
+require_grep "defaultManagementFallbackURL" internal/managementasset/updater.go
+require_grep "managementAssetName" internal/managementasset/updater.go
+require_grep "serveManagementControlPanel" internal/api/server.go
+require_grep "BlueSkyXN/CPA-Panel-LTS" internal/managementasset/updater.go internal/managementasset/updater_test.go internal/config/config.go
+require_grep "UsageReporter" internal/runtime/executor/helps/usage_helpers.go
+require_grep "auth_index" internal/usage internal/api/handlers/management internal/runtime/executor/helps internal/redisqueue
+require_grep "latency_ms" internal/usage internal/redisqueue internal/tui
+
 python3 - <<'PY'
 from pathlib import Path
 import sys
@@ -67,12 +108,50 @@ required = [
     "cpa-panel-lts-compatibility",
     "local-downstream-customizations",
     "preserve_or_reapply_lts_usage",
+    "core-feature-contracts.yaml",
+    "contract_registry_required",
 ]
 
 missing = [item for item in required if item not in text]
 if missing:
     for item in missing:
         print(f"missing protected contract marker: {item}", file=sys.stderr)
+    sys.exit(1)
+
+registry_path = Path("docs/lts/core-feature-contracts.yaml")
+registry_text = registry_path.read_text(encoding="utf-8")
+
+registry_required = [
+    "maintenance_model: protected-full-sync-with-contract-registry",
+    "guard_policy",
+    "sentinel gate",
+    "not a replacement for contract tests",
+    "full-usage-statistics-core",
+    "management-usage-api",
+    "panel-release-asset",
+    "auth-identity-attribution",
+    "provider-runtime-usage-seams",
+    "config-compatibility-and-hot-reload",
+    "redis-compatible-usage-queue",
+    "hf-space-runtime-smoke",
+    "usage-statistics-enabled",
+    "/v0/management/usage",
+    "/v0/management/usage/export",
+    "/v0/management/usage/import",
+    "/v0/management/usage-statistics-enabled",
+    "BlueSkyXN/CPA-Panel-LTS",
+    "management.html",
+    "auth_index",
+    "latency_ms",
+    "success_count",
+    "failure_count",
+    "go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'",
+]
+
+missing_registry = [item for item in registry_required if item not in registry_text]
+if missing_registry:
+    for item in missing_registry:
+        print(f"missing core feature contract marker: {item}", file=sys.stderr)
     sys.exit(1)
 PY
 


### PR DESCRIPTION
## Summary

- Add `docs/lts/core-feature-contracts.yaml` as the Core-side LTS contract registry, modeled after the Panel maintenance approach but keeping Core on protected full-sync.
- Link `protected-deltas.yaml`, `sync-runbook.md`, `scripts/check-lts-contract.sh`, and the PR template to the new registry.
- Strengthen the LTS guard so it checks registry presence, protected routes, panel release source, usage attribution markers, usage-queue presence, and core source paths.
- Add guard policy guidance so the registry stays lightweight: use stable contract markers as sentinels, and rely on Go tests for behavior proof.

## Validation

- `scripts/check-lts-contract.sh`
- `shellcheck scripts/check-lts-contract.sh`
- `go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'`
- `go build -o test-output ./cmd/server && rm -f test-output`
- `go test ./...`
- `git diff --check -- . ':!AGENTS.md'`

## Notes

- This PR intentionally does not include the existing local `AGENTS.md` working-tree change, keeping the review scoped to LTS maintenance docs and guardrails.
- No runtime release or HF Space deployment was performed.
