### PR TITLE
[codex] 异常重试新增 quality hedge 模式与 usage reasoning-fold 聚合

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -195,13 +195,19 @@ codex:
     # This limit is independent of the global request-retry setting.
     # Set to 0 to record the abnormal attempt as failed usage and apply exhausted-behavior immediately.
     # exhausted-behavior: "error" returns 502 (default); "pass-through" returns the exhausted abnormal response.
-    # CPA usage is attempt-level; successful client response usage includes discarded attempts plus the delivered attempt.
+    # CPA usage is attempt-level. successful client response usage includes discarded attempts plus the delivered attempt.
+    # client-usage-aggregation: "reasoning-fold" (default) folds discarded output into reasoning tokens so visible output remains the delivered attempt only; "sum" preserves the legacy field-sum shape.
     max-retries: 2
     exhausted-behavior: "error"
+    client-usage-aggregation: "reasoning-fold"
     # Optional V1 hedged retry for abnormal attempts. When enabled, a retry lane starts first;
     # after hedge-delay-ms, a second parallel lane may start to reduce tail latency. First success wins.
+    # mode: "speed" keeps first-success-wins behavior. "quality" waits for dispatched lanes and selects the largest output_tokens winner.
+    # quality mode still counts max-retries per dispatched lane; use max-retries: 4 for two full two-lane waves.
+    # For quality mode, hedge-delay-ms: 0 is recommended when the goal is always to compare two lanes.
     hedged-retry:
       enabled: false
+      mode: "speed"
       hedge-delay-ms: 1000
       require-distinct-auth: true
 

--- a/docs/lts/core-feature-contracts.yaml
+++ b/docs/lts/core-feature-contracts.yaml
@@ -168,7 +168,9 @@ features:
       - codex.abnormal-reasoning-retry.stream-buffer-max-bytes
       - codex.abnormal-reasoning-retry.max-retries
       - codex.abnormal-reasoning-retry.exhausted-behavior
+      - codex.abnormal-reasoning-retry.client-usage-aggregation
       - codex.abnormal-reasoning-retry.hedged-retry.enabled
+      - codex.abnormal-reasoning-retry.hedged-retry.mode
       - codex.abnormal-reasoning-retry.hedged-retry.hedge-delay-ms
       - codex.abnormal-reasoning-retry.hedged-retry.require-distinct-auth
     core_files:
@@ -186,6 +188,9 @@ features:
     required_markers:
       - abnormal-reasoning-retry
       - hedged-retry
+      - client-usage-aggregation
+      - reasoning-fold
+      - quality
       - hedge-delay-ms
       - require-distinct-auth
       - stream-buffer-max-bytes

--- a/internal/config/codex_websocket_header_defaults_test.go
+++ b/internal/config/codex_websocket_header_defaults_test.go
@@ -96,8 +96,14 @@ func TestLoadConfigOptional_CodexAbnormalReasoningRetryDefaults(t *testing.T) {
 	if effective.ExhaustedBehavior != CodexAbnormalReasoningRetryExhaustedBehaviorError {
 		t.Fatalf("ExhaustedBehavior = %q, want %q", effective.ExhaustedBehavior, CodexAbnormalReasoningRetryExhaustedBehaviorError)
 	}
+	if effective.ClientUsageAggregation != CodexAbnormalReasoningRetryClientUsageAggregationReasoningFold {
+		t.Fatalf("ClientUsageAggregation = %q, want %q", effective.ClientUsageAggregation, CodexAbnormalReasoningRetryClientUsageAggregationReasoningFold)
+	}
 	if effective.HedgedRetry.Enabled {
 		t.Fatal("HedgedRetry.Enabled = true, want false")
+	}
+	if effective.HedgedRetry.Mode != CodexAbnormalReasoningHedgedRetryModeSpeed {
+		t.Fatalf("HedgedRetry.Mode = %q, want %q", effective.HedgedRetry.Mode, CodexAbnormalReasoningHedgedRetryModeSpeed)
 	}
 	if effective.HedgedRetry.HedgeDelayMS != 1000 {
 		t.Fatalf("HedgedRetry.HedgeDelayMS = %d, want 1000", effective.HedgedRetry.HedgeDelayMS)
@@ -136,8 +142,10 @@ codex:
     stream-buffer-max-bytes: 4096
     max-retries: 0
     exhausted-behavior: "passthrough"
+    client-usage-aggregation: "sum"
     hedged-retry:
       enabled: true
+      mode: "quality"
       hedge-delay-ms: 250
       require-distinct-auth: false
 `)
@@ -181,8 +189,14 @@ codex:
 	if effective.ExhaustedBehavior != CodexAbnormalReasoningRetryExhaustedBehaviorPassThrough {
 		t.Fatalf("ExhaustedBehavior = %q, want %q", effective.ExhaustedBehavior, CodexAbnormalReasoningRetryExhaustedBehaviorPassThrough)
 	}
+	if effective.ClientUsageAggregation != CodexAbnormalReasoningRetryClientUsageAggregationSum {
+		t.Fatalf("ClientUsageAggregation = %q, want %q", effective.ClientUsageAggregation, CodexAbnormalReasoningRetryClientUsageAggregationSum)
+	}
 	if !effective.HedgedRetry.Enabled {
 		t.Fatal("HedgedRetry.Enabled = false, want true")
+	}
+	if effective.HedgedRetry.Mode != CodexAbnormalReasoningHedgedRetryModeQuality {
+		t.Fatalf("HedgedRetry.Mode = %q, want %q", effective.HedgedRetry.Mode, CodexAbnormalReasoningHedgedRetryModeQuality)
 	}
 	if effective.HedgedRetry.HedgeDelayMS != 250 {
 		t.Fatalf("HedgedRetry.HedgeDelayMS = %d, want 250", effective.HedgedRetry.HedgeDelayMS)
@@ -246,6 +260,35 @@ codex:
 	effective := cfg.Codex.AbnormalReasoningRetry.Effective()
 	if effective.ExhaustedBehavior != CodexAbnormalReasoningRetryExhaustedBehaviorError {
 		t.Fatalf("ExhaustedBehavior = %q, want %q", effective.ExhaustedBehavior, CodexAbnormalReasoningRetryExhaustedBehaviorError)
+	}
+}
+
+func TestLoadConfigOptional_CodexAbnormalReasoningRetryInvalidV2ModesDefault(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	configYAML := []byte(`
+codex:
+  abnormal-reasoning-retry:
+    enabled: true
+    client-usage-aggregation: "legacy"
+    hedged-retry:
+      mode: "latency"
+`)
+	if err := os.WriteFile(configPath, configYAML, 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := LoadConfigOptional(configPath, false)
+	if err != nil {
+		t.Fatalf("LoadConfigOptional() error = %v", err)
+	}
+
+	effective := cfg.Codex.AbnormalReasoningRetry.Effective()
+	if effective.ClientUsageAggregation != CodexAbnormalReasoningRetryClientUsageAggregationReasoningFold {
+		t.Fatalf("ClientUsageAggregation = %q, want %q", effective.ClientUsageAggregation, CodexAbnormalReasoningRetryClientUsageAggregationReasoningFold)
+	}
+	if effective.HedgedRetry.Mode != CodexAbnormalReasoningHedgedRetryModeSpeed {
+		t.Fatalf("HedgedRetry.Mode = %q, want %q", effective.HedgedRetry.Mode, CodexAbnormalReasoningHedgedRetryModeSpeed)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -316,55 +316,63 @@ type CodexConfig struct {
 }
 
 const (
-	CodexAbnormalReasoningRetryExhaustedBehaviorError       = "error"
-	CodexAbnormalReasoningRetryExhaustedBehaviorPassThrough = "pass-through"
+	CodexAbnormalReasoningRetryExhaustedBehaviorError              = "error"
+	CodexAbnormalReasoningRetryExhaustedBehaviorPassThrough        = "pass-through"
+	CodexAbnormalReasoningRetryClientUsageAggregationReasoningFold = "reasoning-fold"
+	CodexAbnormalReasoningRetryClientUsageAggregationSum           = "sum"
+	CodexAbnormalReasoningHedgedRetryModeSpeed                     = "speed"
+	CodexAbnormalReasoningHedgedRetryModeQuality                   = "quality"
 )
 
 // CodexAbnormalReasoningRetryConfig controls the CPA-Core-LTS retry guard for
 // suspicious Codex successful responses.
 type CodexAbnormalReasoningRetryConfig struct {
-	Enabled              bool                                    `yaml:"enabled" json:"enabled"`
-	ModelContains        []string                                `yaml:"model-contains" json:"model-contains"`
-	ReasoningEfforts     []string                                `yaml:"reasoning-efforts" json:"reasoning-efforts"`
-	ReasoningTokens      []int64                                 `yaml:"reasoning-tokens" json:"reasoning-tokens"`
-	AuthKinds            []string                                `yaml:"auth-kinds" json:"auth-kinds"`
-	AuthIDs              []string                                `yaml:"auth-ids" json:"auth-ids"`
-	StreamBuffer         *bool                                   `yaml:"stream-buffer,omitempty" json:"stream-buffer,omitempty"`
-	StreamBufferMaxBytes *int64                                  `yaml:"stream-buffer-max-bytes,omitempty" json:"stream-buffer-max-bytes,omitempty"`
-	MaxRetries           *int                                    `yaml:"max-retries,omitempty" json:"max-retries,omitempty"`
-	ExhaustedBehavior    string                                  `yaml:"exhausted-behavior,omitempty" json:"exhausted-behavior,omitempty"`
-	HedgedRetry          CodexAbnormalReasoningHedgedRetryConfig `yaml:"hedged-retry" json:"hedged-retry"`
+	Enabled                bool                                    `yaml:"enabled" json:"enabled"`
+	ModelContains          []string                                `yaml:"model-contains" json:"model-contains"`
+	ReasoningEfforts       []string                                `yaml:"reasoning-efforts" json:"reasoning-efforts"`
+	ReasoningTokens        []int64                                 `yaml:"reasoning-tokens" json:"reasoning-tokens"`
+	AuthKinds              []string                                `yaml:"auth-kinds" json:"auth-kinds"`
+	AuthIDs                []string                                `yaml:"auth-ids" json:"auth-ids"`
+	StreamBuffer           *bool                                   `yaml:"stream-buffer,omitempty" json:"stream-buffer,omitempty"`
+	StreamBufferMaxBytes   *int64                                  `yaml:"stream-buffer-max-bytes,omitempty" json:"stream-buffer-max-bytes,omitempty"`
+	MaxRetries             *int                                    `yaml:"max-retries,omitempty" json:"max-retries,omitempty"`
+	ExhaustedBehavior      string                                  `yaml:"exhausted-behavior,omitempty" json:"exhausted-behavior,omitempty"`
+	ClientUsageAggregation string                                  `yaml:"client-usage-aggregation,omitempty" json:"client-usage-aggregation,omitempty"`
+	HedgedRetry            CodexAbnormalReasoningHedgedRetryConfig `yaml:"hedged-retry" json:"hedged-retry"`
 }
 
 // CodexAbnormalReasoningHedgedRetryConfig controls the optional hedged retry
 // lane launched after an abnormal reasoning retry has already been triggered.
 type CodexAbnormalReasoningHedgedRetryConfig struct {
-	Enabled             bool  `yaml:"enabled" json:"enabled"`
-	HedgeDelayMS        *int  `yaml:"hedge-delay-ms,omitempty" json:"hedge-delay-ms,omitempty"`
-	RequireDistinctAuth *bool `yaml:"require-distinct-auth,omitempty" json:"require-distinct-auth,omitempty"`
+	Enabled             bool   `yaml:"enabled" json:"enabled"`
+	Mode                string `yaml:"mode,omitempty" json:"mode,omitempty"`
+	HedgeDelayMS        *int   `yaml:"hedge-delay-ms,omitempty" json:"hedge-delay-ms,omitempty"`
+	RequireDistinctAuth *bool  `yaml:"require-distinct-auth,omitempty" json:"require-distinct-auth,omitempty"`
 }
 
 // EffectiveCodexAbnormalReasoningRetryConfig is the sanitized runtime view of
 // CodexAbnormalReasoningRetryConfig. It is intentionally derived in memory so
 // existing config.yaml files are not rewritten to add default values.
 type EffectiveCodexAbnormalReasoningRetryConfig struct {
-	Enabled              bool
-	ModelContains        []string
-	ReasoningEfforts     []string
-	ReasoningTokens      []int64
-	AuthKinds            []string
-	AuthIDs              []string
-	StreamBuffer         bool
-	StreamBufferMaxBytes int64
-	MaxRetries           int
-	ExhaustedBehavior    string
-	HedgedRetry          EffectiveCodexAbnormalReasoningHedgedRetryConfig
+	Enabled                bool
+	ModelContains          []string
+	ReasoningEfforts       []string
+	ReasoningTokens        []int64
+	AuthKinds              []string
+	AuthIDs                []string
+	StreamBuffer           bool
+	StreamBufferMaxBytes   int64
+	MaxRetries             int
+	ExhaustedBehavior      string
+	ClientUsageAggregation string
+	HedgedRetry            EffectiveCodexAbnormalReasoningHedgedRetryConfig
 }
 
 // EffectiveCodexAbnormalReasoningHedgedRetryConfig is the sanitized runtime view
 // of CodexAbnormalReasoningHedgedRetryConfig.
 type EffectiveCodexAbnormalReasoningHedgedRetryConfig struct {
 	Enabled             bool
+	Mode                string
 	HedgeDelayMS        int
 	RequireDistinctAuth bool
 }
@@ -401,18 +409,20 @@ func (c CodexAbnormalReasoningRetryConfig) Effective() EffectiveCodexAbnormalRea
 		requireDistinctAuth = *c.HedgedRetry.RequireDistinctAuth
 	}
 	return EffectiveCodexAbnormalReasoningRetryConfig{
-		Enabled:              c.Enabled,
-		ModelContains:        defaultedTrimmedStringList(c.ModelContains, []string{"gpt-5.5"}, false),
-		ReasoningEfforts:     defaultedTrimmedStringList(c.ReasoningEfforts, nil, true),
-		ReasoningTokens:      defaultedPositiveInt64List(c.ReasoningTokens, []int64{516, 1034}),
-		AuthKinds:            defaultedTrimmedStringList(c.AuthKinds, []string{"oauth"}, true),
-		AuthIDs:              defaultedTrimmedStringList(c.AuthIDs, nil, false),
-		StreamBuffer:         streamBuffer,
-		StreamBufferMaxBytes: streamBufferMaxBytes,
-		MaxRetries:           maxRetries,
-		ExhaustedBehavior:    normalizeCodexAbnormalReasoningRetryExhaustedBehavior(c.ExhaustedBehavior),
+		Enabled:                c.Enabled,
+		ModelContains:          defaultedTrimmedStringList(c.ModelContains, []string{"gpt-5.5"}, false),
+		ReasoningEfforts:       defaultedTrimmedStringList(c.ReasoningEfforts, nil, true),
+		ReasoningTokens:        defaultedPositiveInt64List(c.ReasoningTokens, []int64{516, 1034}),
+		AuthKinds:              defaultedTrimmedStringList(c.AuthKinds, []string{"oauth"}, true),
+		AuthIDs:                defaultedTrimmedStringList(c.AuthIDs, nil, false),
+		StreamBuffer:           streamBuffer,
+		StreamBufferMaxBytes:   streamBufferMaxBytes,
+		MaxRetries:             maxRetries,
+		ExhaustedBehavior:      normalizeCodexAbnormalReasoningRetryExhaustedBehavior(c.ExhaustedBehavior),
+		ClientUsageAggregation: normalizeCodexAbnormalReasoningRetryClientUsageAggregation(c.ClientUsageAggregation),
 		HedgedRetry: EffectiveCodexAbnormalReasoningHedgedRetryConfig{
 			Enabled:             c.HedgedRetry.Enabled,
+			Mode:                normalizeCodexAbnormalReasoningHedgedRetryMode(c.HedgedRetry.Mode),
 			HedgeDelayMS:        hedgeDelayMS,
 			RequireDistinctAuth: requireDistinctAuth,
 		},
@@ -427,6 +437,28 @@ func normalizeCodexAbnormalReasoningRetryExhaustedBehavior(value string) string 
 		return CodexAbnormalReasoningRetryExhaustedBehaviorPassThrough
 	default:
 		return CodexAbnormalReasoningRetryExhaustedBehaviorError
+	}
+}
+
+func normalizeCodexAbnormalReasoningRetryClientUsageAggregation(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "reasoning-fold", "reasoning_fold", "fold":
+		return CodexAbnormalReasoningRetryClientUsageAggregationReasoningFold
+	case "sum":
+		return CodexAbnormalReasoningRetryClientUsageAggregationSum
+	default:
+		return CodexAbnormalReasoningRetryClientUsageAggregationReasoningFold
+	}
+}
+
+func normalizeCodexAbnormalReasoningHedgedRetryMode(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "speed":
+		return CodexAbnormalReasoningHedgedRetryModeSpeed
+	case "quality":
+		return CodexAbnormalReasoningHedgedRetryModeQuality
+	default:
+		return CodexAbnormalReasoningHedgedRetryModeSpeed
 	}
 }
 

--- a/internal/runtime/executor/codex_abnormal_reasoning_retry.go
+++ b/internal/runtime/executor/codex_abnormal_reasoning_retry.go
@@ -18,31 +18,35 @@ import (
 )
 
 type codexAbnormalReasoningRetryPolicy struct {
-	enabled           bool
-	streamBuffer      bool
-	streamBufferMax   int64
-	maxRetries        int
-	exhaustedBehavior string
-	hedgeEnabled      bool
-	hedgeDelay        time.Duration
-	requireDistinct   bool
-	authID            string
-	modelContains     []string
-	reasoningEfforts  map[string]struct{}
-	reasoningTokens   map[int64]struct{}
+	enabled                bool
+	streamBuffer           bool
+	streamBufferMax        int64
+	maxRetries             int
+	exhaustedBehavior      string
+	clientUsageAggregation string
+	hedgeEnabled           bool
+	hedgeMode              string
+	hedgeDelay             time.Duration
+	requireDistinct        bool
+	authID                 string
+	modelContains          []string
+	reasoningEfforts       map[string]struct{}
+	reasoningTokens        map[int64]struct{}
 }
 
 type codexAbnormalReasoningRetryError struct {
-	detail                usage.Detail
-	maxRetries            int
-	exhaustedBehavior     string
-	hedgeEnabled          bool
-	hedgeDelay            time.Duration
-	requireDistinctAuth   bool
-	authID                string
-	fallbackResponse      *cliproxyexecutor.Response
-	fallbackStreamHeaders http.Header
-	fallbackStreamChunks  []cliproxyexecutor.StreamChunk
+	detail                 usage.Detail
+	maxRetries             int
+	exhaustedBehavior      string
+	clientUsageAggregation string
+	hedgeEnabled           bool
+	hedgeMode              string
+	hedgeDelay             time.Duration
+	requireDistinctAuth    bool
+	authID                 string
+	fallbackResponse       *cliproxyexecutor.Response
+	fallbackStreamHeaders  http.Header
+	fallbackStreamChunks   []cliproxyexecutor.StreamChunk
 }
 
 const (
@@ -87,6 +91,13 @@ func (e *codexAbnormalReasoningRetryError) RetryWithoutPenaltyHedgePolicy() (boo
 		return false, 0, true
 	}
 	return e.hedgeEnabled, e.hedgeDelay, e.requireDistinctAuth
+}
+
+func (e *codexAbnormalReasoningRetryError) RetryWithoutPenaltyHedgeMode() string {
+	if e == nil || strings.TrimSpace(e.hedgeMode) == "" {
+		return config.CodexAbnormalReasoningHedgedRetryModeSpeed
+	}
+	return e.hedgeMode
 }
 
 func (e *codexAbnormalReasoningRetryError) RetryWithoutPenaltyAuthID() string {
@@ -163,18 +174,20 @@ func newCodexAbnormalReasoningRetryPolicy(cfg *config.Config, auth *cliproxyauth
 		}
 	}
 	return codexAbnormalReasoningRetryPolicy{
-		enabled:           true,
-		streamBuffer:      effective.StreamBuffer,
-		streamBufferMax:   effective.StreamBufferMaxBytes,
-		maxRetries:        effective.MaxRetries,
-		exhaustedBehavior: effective.ExhaustedBehavior,
-		hedgeEnabled:      effective.HedgedRetry.Enabled,
-		hedgeDelay:        time.Duration(effective.HedgedRetry.HedgeDelayMS) * time.Millisecond,
-		requireDistinct:   effective.HedgedRetry.RequireDistinctAuth,
-		authID:            strings.TrimSpace(auth.ID),
-		modelContains:     modelContains,
-		reasoningEfforts:  efforts,
-		reasoningTokens:   tokens,
+		enabled:                true,
+		streamBuffer:           effective.StreamBuffer,
+		streamBufferMax:        effective.StreamBufferMaxBytes,
+		maxRetries:             effective.MaxRetries,
+		exhaustedBehavior:      effective.ExhaustedBehavior,
+		clientUsageAggregation: effective.ClientUsageAggregation,
+		hedgeEnabled:           effective.HedgedRetry.Enabled,
+		hedgeMode:              effective.HedgedRetry.Mode,
+		hedgeDelay:             time.Duration(effective.HedgedRetry.HedgeDelayMS) * time.Millisecond,
+		requireDistinct:        effective.HedgedRetry.RequireDistinctAuth,
+		authID:                 strings.TrimSpace(auth.ID),
+		modelContains:          modelContains,
+		reasoningEfforts:       efforts,
+		reasoningTokens:        tokens,
 	}
 }
 
@@ -218,13 +231,15 @@ func (p codexAbnormalReasoningRetryPolicy) retryError(detail usage.Detail, reaso
 		}
 	}
 	err := &codexAbnormalReasoningRetryError{
-		detail:              detail,
-		maxRetries:          p.maxRetries,
-		exhaustedBehavior:   p.exhaustedBehavior,
-		hedgeEnabled:        p.hedgeEnabled,
-		hedgeDelay:          p.hedgeDelay,
-		requireDistinctAuth: p.requireDistinct,
-		authID:              p.authID,
+		detail:                 detail,
+		maxRetries:             p.maxRetries,
+		exhaustedBehavior:      p.exhaustedBehavior,
+		clientUsageAggregation: p.clientUsageAggregation,
+		hedgeEnabled:           p.hedgeEnabled,
+		hedgeMode:              p.hedgeMode,
+		hedgeDelay:             p.hedgeDelay,
+		requireDistinctAuth:    p.requireDistinct,
+		authID:                 p.authID,
 	}
 	if fallbackResponse != nil {
 		resp := cloneCodexAbnormalReasoningRetryResponse(*fallbackResponse)
@@ -372,16 +387,20 @@ func stringListContains(values []string, needle string, fold bool) bool {
 	return false
 }
 
-func patchCodexAbnormalReasoningClientUsage(eventData []byte, metadata map[string]any) []byte {
-	previous, ok := codexAbnormalReasoningRetryUsageFromMetadata(metadata)
+func patchCodexAbnormalReasoningClientUsage(eventData []byte, metadata map[string]any, aggregation string) []byte {
+	previous, ok := codexAbnormalReasoningRetryUsageSnapshotFromMetadata(metadata)
 	if !ok {
 		return eventData
 	}
+	return patchCodexAbnormalReasoningClientUsageWithSnapshot(eventData, previous, aggregation)
+}
+
+func patchCodexAbnormalReasoningClientUsageWithSnapshot(eventData []byte, previous cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot, aggregation string) []byte {
 	current, ok := helps.ParseCodexUsage(eventData)
 	if !ok {
 		return eventData
 	}
-	total := addCodexUsageDetail(previous, current)
+	total := codexAbnormalReasoningRetryAggregateClientUsage(previous, current, aggregation)
 	usageNode := gjson.GetBytes(eventData, "response.usage")
 	if !usageNode.Exists() {
 		return eventData
@@ -407,23 +426,77 @@ func patchCodexAbnormalReasoningClientUsage(eventData []byte, metadata map[strin
 }
 
 func codexAbnormalReasoningRetryUsageFromMetadata(metadata map[string]any) (usage.Detail, bool) {
-	if len(metadata) == 0 {
+	snapshot, ok := codexAbnormalReasoningRetryUsageSnapshotFromMetadata(metadata)
+	if !ok {
 		return usage.Detail{}, false
+	}
+	return snapshot.Detail, hasCodexUsageDetail(snapshot.Detail)
+}
+
+func codexAbnormalReasoningRetryUsageSnapshotFromMetadata(metadata map[string]any) (cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot, bool) {
+	if len(metadata) == 0 {
+		return cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot{}, false
 	}
 	raw := metadata[cliproxyexecutor.CodexAbnormalReasoningRetryUsageMetadataKey]
 	switch detail := raw.(type) {
+	case cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot:
+		return detail, hasCodexUsageDetail(detail.Detail)
+	case *cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot:
+		if detail == nil {
+			return cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot{}, false
+		}
+		return *detail, hasCodexUsageDetail(detail.Detail)
 	case usage.Detail:
-		return detail, hasCodexUsageDetail(detail)
+		if !hasCodexUsageDetail(detail) {
+			return cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot{}, false
+		}
+		return cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot{
+			Detail:             detail,
+			FoldedOutputTokens: foldedCodexUsageOutputTokens(detail),
+		}, true
 	case *usage.Detail:
 		if detail == nil {
-			return usage.Detail{}, false
+			return cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot{}, false
 		}
-		return *detail, hasCodexUsageDetail(*detail)
+		if !hasCodexUsageDetail(*detail) {
+			return cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot{}, false
+		}
+		return cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot{
+			Detail:             *detail,
+			FoldedOutputTokens: foldedCodexUsageOutputTokens(*detail),
+		}, true
 	case *cliproxyexecutor.UsageAccumulator:
-		snapshot := detail.Snapshot()
-		return snapshot, hasCodexUsageDetail(snapshot)
+		snapshot := detail.RetryWithoutPenaltySnapshot()
+		return snapshot, hasCodexUsageDetail(snapshot.Detail)
 	default:
-		return usage.Detail{}, false
+		return cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot{}, false
+	}
+}
+
+func codexAbnormalReasoningRetryAggregateClientUsage(previous cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot, current usage.Detail, aggregation string) usage.Detail {
+	if aggregation == config.CodexAbnormalReasoningRetryClientUsageAggregationSum {
+		return addCodexUsageDetail(previous.Detail, current)
+	}
+	previousDetail := normalizeCodexUsageDetail(previous.Detail)
+	current = normalizeCodexUsageDetail(current)
+	foldedPreviousOutput := previous.FoldedOutputTokens
+	if foldedPreviousOutput == 0 && hasCodexUsageDetail(previousDetail) {
+		foldedPreviousOutput = foldedCodexUsageOutputTokens(previousDetail)
+	}
+	deliveredOutput := current.OutputTokens
+	if current.ReasoningTokens > deliveredOutput {
+		deliveredOutput = current.ReasoningTokens
+	}
+	input := previousDetail.InputTokens + current.InputTokens
+	output := deliveredOutput + foldedPreviousOutput
+	return usage.Detail{
+		InputTokens:         input,
+		OutputTokens:        output,
+		ReasoningTokens:     current.ReasoningTokens + foldedPreviousOutput,
+		CachedTokens:        previousDetail.CachedTokens + current.CachedTokens,
+		CacheReadTokens:     previousDetail.CacheReadTokens + current.CacheReadTokens,
+		CacheCreationTokens: previousDetail.CacheCreationTokens + current.CacheCreationTokens,
+		TotalTokens:         input + output,
 	}
 }
 
@@ -439,6 +512,77 @@ func addCodexUsageDetail(a, b usage.Detail) usage.Detail {
 		CacheCreationTokens: a.CacheCreationTokens + b.CacheCreationTokens,
 		TotalTokens:         a.TotalTokens + b.TotalTokens,
 	}
+}
+
+func foldedCodexUsageOutputTokens(detail usage.Detail) int64 {
+	detail = normalizeCodexUsageDetail(detail)
+	if detail.OutputTokens >= detail.ReasoningTokens {
+		return detail.OutputTokens
+	}
+	return detail.ReasoningTokens
+}
+
+func codexAbnormalReasoningRetryResponseMetadata(detail usage.Detail, finalizer cliproxyexecutor.RetryWithoutPenaltyResponseFinalizer) map[string]any {
+	meta := map[string]any{
+		cliproxyexecutor.RetryWithoutPenaltyUsageDetailMetadataKey: detail,
+		cliproxyexecutor.RetryWithoutPenaltyHedgeScoreMetadataKey:  detail.OutputTokens,
+	}
+	if finalizer != nil {
+		meta[cliproxyexecutor.RetryWithoutPenaltyResponseFinalizerMetadataKey] = finalizer
+	}
+	return meta
+}
+
+func codexAbnormalReasoningRetryStreamMetadata(streamUsage *cliproxyexecutor.RetryWithoutPenaltyStreamUsage, finalizer cliproxyexecutor.RetryWithoutPenaltyStreamFinalizer) map[string]any {
+	meta := map[string]any{}
+	if streamUsage != nil {
+		meta[cliproxyexecutor.RetryWithoutPenaltyStreamUsageMetadataKey] = streamUsage
+	}
+	if finalizer != nil {
+		meta[cliproxyexecutor.RetryWithoutPenaltyStreamFinalizerMetadataKey] = finalizer
+	}
+	if len(meta) == 0 {
+		return nil
+	}
+	return meta
+}
+
+func finalizeCodexAbnormalReasoningRetryStream(headers http.Header, chunks []cliproxyexecutor.StreamChunk, previous cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot, aggregation string) *cliproxyexecutor.StreamResult {
+	out := make(chan cliproxyexecutor.StreamChunk, len(chunks))
+	for i := range chunks {
+		chunk := chunks[i]
+		if chunk.Err == nil && len(chunk.Payload) > 0 {
+			chunk.Payload = patchCodexAbnormalReasoningStreamPayload(chunk.Payload, previous, aggregation)
+		}
+		if len(chunk.Payload) > 0 {
+			chunk.Payload = bytes.Clone(chunk.Payload)
+		}
+		out <- chunk
+	}
+	close(out)
+	return &cliproxyexecutor.StreamResult{
+		Headers: cloneCodexAbnormalReasoningRetryHeader(headers),
+		Chunks:  out,
+	}
+}
+
+func patchCodexAbnormalReasoningStreamPayload(payload []byte, previous cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot, aggregation string) []byte {
+	trimmed := bytes.TrimSpace(payload)
+	if len(trimmed) == 0 {
+		return payload
+	}
+	if bytes.HasPrefix(trimmed, []byte("data:")) {
+		data := bytes.TrimSpace(trimmed[len("data:"):])
+		if !gjson.GetBytes(data, "response.usage").Exists() {
+			return payload
+		}
+		patched := patchCodexAbnormalReasoningClientUsageWithSnapshot(data, previous, aggregation)
+		return append([]byte("data: "), patched...)
+	}
+	if !gjson.GetBytes(trimmed, "response.usage").Exists() {
+		return payload
+	}
+	return patchCodexAbnormalReasoningClientUsageWithSnapshot(trimmed, previous, aggregation)
 }
 
 func normalizeCodexUsageDetail(detail usage.Detail) usage.Detail {

--- a/internal/runtime/executor/codex_abnormal_reasoning_retry.go
+++ b/internal/runtime/executor/codex_abnormal_reasoning_retry.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -204,6 +206,11 @@ func (p codexAbnormalReasoningRetryPolicy) StreamBufferMaxBytes() int64 {
 		return 0
 	}
 	return p.streamBufferMax
+}
+
+func (p codexAbnormalReasoningRetryPolicy) QualityHedgeStreamRewrite() bool {
+	return p.enabled && p.hedgeEnabled &&
+		strings.EqualFold(strings.TrimSpace(p.hedgeMode), config.CodexAbnormalReasoningHedgedRetryModeQuality)
 }
 
 func (p codexAbnormalReasoningRetryPolicy) RetryError(detail usage.Detail, reasoningEffort string) error {
@@ -545,6 +552,91 @@ func codexAbnormalReasoningRetryStreamMetadata(streamUsage *cliproxyexecutor.Ret
 		return nil
 	}
 	return meta
+}
+
+// codexAbnormalReasoningRetryStreamRecorder captures the raw upstream SSE lines
+// fed into stream translation so a quality-hedge finalizer can re-patch the
+// completed usage with the final discarded-attempt snapshot and re-translate the
+// whole stream. The completed event is kept in its usage-unpatched form; every
+// other line is kept exactly as it entered translation.
+type codexAbnormalReasoningRetryStreamRecorder struct {
+	lines          [][]byte
+	completedIndex int
+	completedData  []byte
+	recordedBytes  int64
+	maxBytes       int64
+	dropped        bool
+}
+
+func newCodexAbnormalReasoningRetryStreamRecorder(maxBytes int64) *codexAbnormalReasoningRetryStreamRecorder {
+	return &codexAbnormalReasoningRetryStreamRecorder{completedIndex: -1, maxBytes: maxBytes}
+}
+
+func (r *codexAbnormalReasoningRetryStreamRecorder) recordLine(line []byte) {
+	if r == nil || r.dropped || !r.reserve(int64(len(line))) {
+		return
+	}
+	r.lines = append(r.lines, bytes.Clone(line))
+}
+
+func (r *codexAbnormalReasoningRetryStreamRecorder) recordCompleted(completedData []byte) {
+	if r == nil || r.dropped || !r.reserve(int64(len(completedData))) {
+		return
+	}
+	r.completedData = bytes.Clone(completedData)
+	r.completedIndex = len(r.lines)
+	r.lines = append(r.lines, nil)
+}
+
+func (r *codexAbnormalReasoningRetryStreamRecorder) reserve(size int64) bool {
+	if r.maxBytes > 0 && r.recordedBytes+size > r.maxBytes {
+		r.dropped = true
+		r.lines = nil
+		r.completedData = nil
+		r.completedIndex = -1
+		return false
+	}
+	r.recordedBytes += size
+	return true
+}
+
+func (r *codexAbnormalReasoningRetryStreamRecorder) ready() bool {
+	return r != nil && !r.dropped && r.completedIndex >= 0
+}
+
+// finalizeCodexAbnormalReasoningRetryStreamFromRaw rebuilds the winning stream
+// from recorded raw upstream lines, mirroring the non-stream finalizer: the
+// completed event usage is re-patched with the final discarded-attempt snapshot
+// before the whole stream is re-translated, so the folded usage survives
+// translation into any downstream response format. Returns nil when no usable
+// recording exists and the caller must fall back to patching translated chunks.
+func finalizeCodexAbnormalReasoningRetryStreamFromRaw(ctx context.Context, to, responseFormat sdktranslator.Format, model string, originalPayload, body []byte, identityState codexIdentityConfuseState, recorder *codexAbnormalReasoningRetryStreamRecorder, headers http.Header, previous cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot, aggregation string) *cliproxyexecutor.StreamResult {
+	if !recorder.ready() {
+		return nil
+	}
+	var param any
+	var patched []cliproxyexecutor.StreamChunk
+	for i := range recorder.lines {
+		line := recorder.lines[i]
+		if i == recorder.completedIndex {
+			data := patchCodexAbnormalReasoningClientUsageWithSnapshot(recorder.completedData, previous, aggregation)
+			line = append([]byte("data: "), data...)
+			line = applyCodexIdentityExposeResponsePayload(line, identityState)
+		}
+		chunks := sdktranslator.TranslateStream(ctx, to, responseFormat, model, originalPayload, body, line, &param)
+		for j := range chunks {
+			patched = append(patched, cliproxyexecutor.StreamChunk{Payload: bytes.Clone(chunks[j])})
+		}
+	}
+	out := make(chan cliproxyexecutor.StreamChunk, len(patched))
+	for i := range patched {
+		out <- patched[i]
+	}
+	close(out)
+	return &cliproxyexecutor.StreamResult{
+		Headers: cloneCodexAbnormalReasoningRetryHeader(headers),
+		Chunks:  out,
+	}
 }
 
 func finalizeCodexAbnormalReasoningRetryStream(headers http.Header, chunks []cliproxyexecutor.StreamChunk, previous cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot, aggregation string) *cliproxyexecutor.StreamResult {

--- a/internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
+++ b/internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
@@ -350,14 +350,14 @@ func TestCodexExecutorAbnormalReasoningRetry_ManagerRecordsAttemptLevelUsageAndA
 	if calls != 2 {
 		t.Fatalf("upstream calls = %d, want 2", calls)
 	}
-	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 15 {
-		t.Fatalf("client response usage.total_tokens = %d, want abnormal plus final total 15; payload=%s", got, resp.Payload)
+	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 650 {
+		t.Fatalf("client response usage.total_tokens = %d, want reasoning-fold total 650; payload=%s", got, resp.Payload)
 	}
 	if got := gjson.GetBytes(resp.Payload, "usage.input_tokens").Int(); got != 6 {
 		t.Fatalf("client response usage.input_tokens = %d, want abnormal plus final input 6; payload=%s", got, resp.Payload)
 	}
-	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens").Int(); got != 9 {
-		t.Fatalf("client response usage.output_tokens = %d, want abnormal plus final output 9; payload=%s", got, resp.Payload)
+	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens").Int(); got != 644 {
+		t.Fatalf("client response usage.output_tokens = %d, want folded output 644; payload=%s", got, resp.Payload)
 	}
 	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens_details.reasoning_tokens").Int(); got != 644 {
 		t.Fatalf("client response usage.reasoning_tokens = %d, want abnormal plus final reasoning 644; payload=%s", got, resp.Payload)
@@ -388,6 +388,55 @@ func TestCodexExecutorAbnormalReasoningRetry_ManagerRecordsAttemptLevelUsageAndA
 	}
 	if successRecord.Detail.TotalTokens != 12 || successRecord.Detail.ReasoningTokens != 128 {
 		t.Fatalf("success record detail = %+v, want final attempt total=12 reasoning=128", successRecord.Detail)
+	}
+}
+
+func TestCodexExecutorAbnormalReasoningRetry_ClientUsageAggregationSumKeepsLegacyShape(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "text/event-stream")
+		if calls == 1 {
+			_, _ = w.Write([]byte(codexCompletedSSEWithUsage("gpt-5.5", 516, 1, 2, 3)))
+			return
+		}
+		_, _ = w.Write([]byte(codexCompletedSSEWithUsage("gpt-5.5", 128, 5, 7, 12)))
+	}))
+	defer server.Close()
+
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(NewCodexExecutor(codexAbnormalReasoningRetryTestConfigWithAggregation(config.CodexAbnormalReasoningRetryClientUsageAggregationSum)))
+	manager.SetRetryConfig(1, 0, 0)
+
+	auth := codexAbnormalReasoningRetryTestAuth(server.URL)
+	auth.ID = "codex-oauth-sum-aggregate"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, "codex", []*registry.ModelInfo{{ID: "gpt-5.5"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(auth.ID)
+	})
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"hello"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error = %v, want nil", err)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 15 {
+		t.Fatalf("client response usage.total_tokens = %d, want legacy total 15; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens").Int(); got != 9 {
+		t.Fatalf("client response usage.output_tokens = %d, want legacy output 9; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens_details.reasoning_tokens").Int(); got != 644 {
+		t.Fatalf("client response usage.reasoning_tokens = %d, want legacy reasoning 644; payload=%s", got, resp.Payload)
 	}
 }
 
@@ -441,14 +490,14 @@ func TestCodexExecutorAbnormalReasoningRetry_DefaultMaxRetriesAggregatesTwoAbnor
 	if calls != 3 {
 		t.Fatalf("upstream calls = %d, want 3", calls)
 	}
-	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 25 {
-		t.Fatalf("client response usage.total_tokens = %d, want abnormal attempts plus final total 25; payload=%s", got, resp.Payload)
+	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 1688 {
+		t.Fatalf("client response usage.total_tokens = %d, want folded total 1688; payload=%s", got, resp.Payload)
 	}
 	if got := gjson.GetBytes(resp.Payload, "usage.input_tokens").Int(); got != 10 {
 		t.Fatalf("client response usage.input_tokens = %d, want abnormal attempts plus final input 10; payload=%s", got, resp.Payload)
 	}
-	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens").Int(); got != 15 {
-		t.Fatalf("client response usage.output_tokens = %d, want abnormal attempts plus final output 15; payload=%s", got, resp.Payload)
+	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens").Int(); got != 1678 {
+		t.Fatalf("client response usage.output_tokens = %d, want folded output 1678; payload=%s", got, resp.Payload)
 	}
 	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens_details.reasoning_tokens").Int(); got != 1678 {
 		t.Fatalf("client response usage.reasoning_tokens = %d, want abnormal attempts plus final reasoning 1678; payload=%s", got, resp.Payload)
@@ -524,8 +573,8 @@ func TestCodexExecutorAbnormalReasoningRetry_ManagerMaxRetriesIndependentFromReq
 	if calls != 2 {
 		t.Fatalf("upstream calls = %d, want 2 despite request-retry=0", calls)
 	}
-	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 15 {
-		t.Fatalf("client response usage.total_tokens = %d, want abnormal plus final total 15; payload=%s", got, resp.Payload)
+	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 650 {
+		t.Fatalf("client response usage.total_tokens = %d, want folded total 650; payload=%s", got, resp.Payload)
 	}
 }
 
@@ -632,8 +681,8 @@ func TestCodexExecutorAbnormalReasoningRetry_PassThroughAggregatesDiscardedUsage
 	if calls != 2 {
 		t.Fatalf("upstream calls = %d, want 2", calls)
 	}
-	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 13 {
-		t.Fatalf("client response usage.total_tokens = %d, want discarded plus delivered total 13; payload=%s", got, resp.Payload)
+	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 1555 {
+		t.Fatalf("client response usage.total_tokens = %d, want folded pass-through total 1555; payload=%s", got, resp.Payload)
 	}
 	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens_details.reasoning_tokens").Int(); got != 1550 {
 		t.Fatalf("client response reasoning_tokens = %d, want discarded plus delivered reasoning 1550; payload=%s", got, resp.Payload)
@@ -688,8 +737,8 @@ func TestCodexExecutorAbnormalReasoningRetry_ManagerAggregatesStreamingClientUsa
 	if calls != 2 {
 		t.Fatalf("upstream calls = %d, want 2", calls)
 	}
-	if !bytes.Contains(payload, []byte(`"total_tokens":15`)) {
-		t.Fatalf("stream payload missing aggregated total_tokens=15: %s", payload)
+	if !bytes.Contains(payload, []byte(`"total_tokens":650`)) {
+		t.Fatalf("stream payload missing folded total_tokens=650: %s", payload)
 	}
 	if !bytes.Contains(payload, []byte(`"reasoning_tokens":644`)) {
 		t.Fatalf("stream payload missing aggregated reasoning_tokens=644: %s", payload)
@@ -906,6 +955,12 @@ func codexAbnormalReasoningRetryTestConfig(authIDs []string, streamBuffer *bool)
 func codexAbnormalReasoningRetryTestConfigWithEfforts(efforts []string) *config.Config {
 	cfg := codexAbnormalReasoningRetryTestConfig(nil, nil)
 	cfg.Codex.AbnormalReasoningRetry.ReasoningEfforts = efforts
+	return cfg
+}
+
+func codexAbnormalReasoningRetryTestConfigWithAggregation(aggregation string) *config.Config {
+	cfg := codexAbnormalReasoningRetryTestConfig(nil, nil)
+	cfg.Codex.AbnormalReasoningRetry.ClientUsageAggregation = aggregation
 	return cfg
 }
 

--- a/internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
+++ b/internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
@@ -745,6 +745,82 @@ func TestCodexExecutorAbnormalReasoningRetry_ManagerAggregatesStreamingClientUsa
 	}
 }
 
+func TestCodexExecutorAbnormalReasoningRetry_QualityStreamFoldsUsageIntoChatCompletionsFormat(t *testing.T) {
+	var mu sync.Mutex
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		calls++
+		n := calls
+		mu.Unlock()
+		w.Header().Set("Content-Type", "text/event-stream")
+		switch n {
+		case 1:
+			_, _ = w.Write([]byte(codexCompletedSSEWithUsage("gpt-5.5", 516, 1, 2, 3)))
+		case 2:
+			_, _ = w.Write([]byte(`data: {"type":"response.output_text.delta","delta":"clean"}` + "\n\n"))
+			_, _ = w.Write([]byte(codexCompletedSSEWithUsage("gpt-5.5", 128, 5, 200, 205)))
+		default:
+			_, _ = w.Write([]byte(codexCompletedSSEWithUsage("gpt-5.5", 516, 2, 4, 6)))
+		}
+	}))
+	defer server.Close()
+
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(NewCodexExecutor(codexAbnormalReasoningRetryTestConfigWithQualityHedge(2)))
+	manager.SetRetryConfig(0, 0, 0)
+
+	auth := codexAbnormalReasoningRetryTestAuth(server.URL)
+	auth.ID = "codex-oauth-quality-chat-fold"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, "codex", []*registry.ModelInfo{{ID: "gpt-5.5"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(auth.ID)
+	})
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	result, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","messages":[{"role":"user","content":"hello"}],"stream":true}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error = %v, want nil", err)
+	}
+	var payload []byte
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v, want nil", chunk.Err)
+		}
+		payload = append(payload, chunk.Payload...)
+	}
+	mu.Lock()
+	gotCalls := calls
+	mu.Unlock()
+	if gotCalls != 3 {
+		t.Fatalf("upstream calls = %d, want trigger plus two quality lanes", gotCalls)
+	}
+	if !bytes.Contains(payload, []byte("clean")) {
+		t.Fatalf("stream payload missing winner delta text: %s", payload)
+	}
+	// reasoning-fold 折算：trigger(1/2/516) 与 quality 波内 abnormal lane(2/4/516)
+	// 折入胜者(5/200/128)，并且必须以下游 chat-completions 的 usage 形状交付。
+	for _, want := range []string{
+		`"prompt_tokens":8`,
+		`"completion_tokens":1232`,
+		`"total_tokens":1240`,
+		`"reasoning_tokens":1160`,
+	} {
+		if !bytes.Contains(payload, []byte(want)) {
+			t.Fatalf("stream payload missing folded chat usage %s: %s", want, payload)
+		}
+	}
+}
+
 func TestCodexExecutorAbnormalReasoningRetry_PassThroughWhenExhaustedStreaming(t *testing.T) {
 	recorder := &codexAbnormalReasoningRetryUsageRecorder{}
 	usage.RegisterNamedPlugin("codex-abnormal-reasoning-retry-test", recorder)
@@ -961,6 +1037,20 @@ func codexAbnormalReasoningRetryTestConfigWithEfforts(efforts []string) *config.
 func codexAbnormalReasoningRetryTestConfigWithAggregation(aggregation string) *config.Config {
 	cfg := codexAbnormalReasoningRetryTestConfig(nil, nil)
 	cfg.Codex.AbnormalReasoningRetry.ClientUsageAggregation = aggregation
+	return cfg
+}
+
+func codexAbnormalReasoningRetryTestConfigWithQualityHedge(maxRetries int) *config.Config {
+	cfg := codexAbnormalReasoningRetryTestConfig(nil, nil)
+	cfg.Codex.AbnormalReasoningRetry.MaxRetries = &maxRetries
+	hedgeDelayMS := 0
+	requireDistinctAuth := false
+	cfg.Codex.AbnormalReasoningRetry.HedgedRetry = config.CodexAbnormalReasoningHedgedRetryConfig{
+		Enabled:             true,
+		Mode:                config.CodexAbnormalReasoningHedgedRetryModeQuality,
+		HedgeDelayMS:        &hedgeDelayMS,
+		RequireDistinctAuth: &requireDistinctAuth,
+	}
 	return cfg
 }
 

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -933,10 +933,14 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		}
 
 		completedData := patchCodexCompletedOutput(eventData, outputItemsByIndex, outputItemsFallback)
+		var completedUsage usage.Detail
+		var completedUsageOK bool
 		if detail, ok := helps.ParseCodexUsage(eventData); ok {
+			completedUsage = detail
+			completedUsageOK = true
 			if errRetry := abnormalRetry.RetryError(detail, reporter.ReasoningEffort()); errRetry != nil {
 				var param any
-				clientCompletedData := patchCodexAbnormalReasoningClientUsage(completedData, opts.Metadata)
+				clientCompletedData := patchCodexAbnormalReasoningClientUsage(completedData, opts.Metadata, abnormalRetry.clientUsageAggregation)
 				clientCompletedData = applyCodexIdentityExposeResponsePayload(clientCompletedData, identityState)
 				out := sdktranslator.TranslateNonStream(ctx, to, responseFormat, req.Model, originalPayload, body, clientCompletedData, &param)
 				fallbackResp := cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
@@ -954,10 +958,19 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		cacheCodexReasoningReplayFromCompleted(replayScope, completedData)
 
 		var param any
-		clientCompletedData := patchCodexAbnormalReasoningClientUsage(completedData, opts.Metadata)
+		clientCompletedData := patchCodexAbnormalReasoningClientUsage(completedData, opts.Metadata, abnormalRetry.clientUsageAggregation)
 		clientCompletedData = applyCodexIdentityExposeResponsePayload(clientCompletedData, identityState)
 		out := sdktranslator.TranslateNonStream(ctx, to, responseFormat, req.Model, originalPayload, body, clientCompletedData, &param)
 		resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
+		if completedUsageOK {
+			resp.Metadata = codexAbnormalReasoningRetryResponseMetadata(completedUsage, func(base cliproxyexecutor.Response, previous cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot) cliproxyexecutor.Response {
+				var finalizerParam any
+				finalCompletedData := patchCodexAbnormalReasoningClientUsageWithSnapshot(completedData, previous, abnormalRetry.clientUsageAggregation)
+				finalCompletedData = applyCodexIdentityExposeResponsePayload(finalCompletedData, identityState)
+				base.Payload = sdktranslator.TranslateNonStream(ctx, to, responseFormat, req.Model, originalPayload, body, finalCompletedData, &finalizerParam)
+				return base
+			})
+		}
 		return resp, nil
 	}
 	err = statusErr{code: 408, msg: "stream error: stream disconnected before completion: stream closed before response.completed"}
@@ -1177,6 +1190,10 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		return nil, err
 	}
 	out := make(chan cliproxyexecutor.StreamChunk)
+	streamUsage := &cliproxyexecutor.RetryWithoutPenaltyStreamUsage{}
+	streamFinalizer := cliproxyexecutor.RetryWithoutPenaltyStreamFinalizer(func(headers http.Header, chunks []cliproxyexecutor.StreamChunk, previous cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot) *cliproxyexecutor.StreamResult {
+		return finalizeCodexAbnormalReasoningRetryStream(headers, chunks, previous, abnormalRetry.clientUsageAggregation)
+	})
 	go func() {
 		defer close(out)
 		defer func() {
@@ -1277,7 +1294,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 						}
 					}
 					completedData = patchCodexCompletedOutput(data, outputItemsByIndex, outputItemsFallback)
-					data = patchCodexAbnormalReasoningClientUsage(completedData, opts.Metadata)
+					data = patchCodexAbnormalReasoningClientUsage(completedData, opts.Metadata, abnormalRetry.clientUsageAggregation)
 					translatedLine = append([]byte("data: "), data...)
 					flushAfterLine = buffering
 				}
@@ -1301,6 +1318,9 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 				return
 			}
 			if usageDetailOK {
+				streamUsage.Detail = usageDetail
+				streamUsage.HedgeScore = usageDetail.OutputTokens
+				streamUsage.OK = true
 				reporter.Publish(ctx, usageDetail)
 			}
 			if len(completedData) > 0 {
@@ -1328,7 +1348,11 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 			_ = flushBuffered()
 		}
 	}()
-	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+	return &cliproxyexecutor.StreamResult{
+		Headers:  httpResp.Header.Clone(),
+		Chunks:   out,
+		Metadata: codexAbnormalReasoningRetryStreamMetadata(streamUsage, streamFinalizer),
+	}, nil
 }
 
 func (e *CodexExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -1191,7 +1191,14 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	}
 	out := make(chan cliproxyexecutor.StreamChunk)
 	streamUsage := &cliproxyexecutor.RetryWithoutPenaltyStreamUsage{}
+	var qualityRecorder *codexAbnormalReasoningRetryStreamRecorder
+	if abnormalRetry.StreamBuffer() && abnormalRetry.QualityHedgeStreamRewrite() {
+		qualityRecorder = newCodexAbnormalReasoningRetryStreamRecorder(abnormalRetry.StreamBufferMaxBytes())
+	}
 	streamFinalizer := cliproxyexecutor.RetryWithoutPenaltyStreamFinalizer(func(headers http.Header, chunks []cliproxyexecutor.StreamChunk, previous cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot) *cliproxyexecutor.StreamResult {
+		if result := finalizeCodexAbnormalReasoningRetryStreamFromRaw(ctx, to, responseFormat, req.Model, originalPayload, body, identityState, qualityRecorder, headers, previous, abnormalRetry.clientUsageAggregation); result != nil {
+			return result
+		}
 		return finalizeCodexAbnormalReasoningRetryStream(headers, chunks, previous, abnormalRetry.clientUsageAggregation)
 	})
 	go func() {
@@ -1301,6 +1308,11 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 			}
 
 			translatedLine = applyCodexIdentityExposeResponsePayload(translatedLine, identityState)
+			if len(completedData) > 0 {
+				qualityRecorder.recordCompleted(completedData)
+			} else {
+				qualityRecorder.recordLine(translatedLine)
+			}
 			chunks := sdktranslator.TranslateStream(ctx, to, responseFormat, req.Model, originalPayload, body, translatedLine, &param)
 			if retryErr != nil {
 				fallbackChunks := cloneCodexAbnormalReasoningRetryStreamChunks(bufferedChunks)

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -394,8 +394,14 @@ func appendCodexAbnormalReasoningRetryChanges(changes []string, oldCfg, newCfg c
 	if oldCfg.ExhaustedBehavior != newCfg.ExhaustedBehavior {
 		changes = append(changes, fmt.Sprintf("codex.abnormal-reasoning-retry.exhausted-behavior: %s -> %s", oldCfg.ExhaustedBehavior, newCfg.ExhaustedBehavior))
 	}
+	if oldCfg.ClientUsageAggregation != newCfg.ClientUsageAggregation {
+		changes = append(changes, fmt.Sprintf("codex.abnormal-reasoning-retry.client-usage-aggregation: %s -> %s", oldCfg.ClientUsageAggregation, newCfg.ClientUsageAggregation))
+	}
 	if oldCfg.HedgedRetry.Enabled != newCfg.HedgedRetry.Enabled {
 		changes = append(changes, fmt.Sprintf("codex.abnormal-reasoning-retry.hedged-retry.enabled: %t -> %t", oldCfg.HedgedRetry.Enabled, newCfg.HedgedRetry.Enabled))
+	}
+	if oldCfg.HedgedRetry.Mode != newCfg.HedgedRetry.Mode {
+		changes = append(changes, fmt.Sprintf("codex.abnormal-reasoning-retry.hedged-retry.mode: %s -> %s", oldCfg.HedgedRetry.Mode, newCfg.HedgedRetry.Mode))
 	}
 	if oldCfg.HedgedRetry.HedgeDelayMS != newCfg.HedgedRetry.HedgeDelayMS {
 		changes = append(changes, fmt.Sprintf("codex.abnormal-reasoning-retry.hedged-retry.hedge-delay-ms: %d -> %d", oldCfg.HedgedRetry.HedgeDelayMS, newCfg.HedgedRetry.HedgeDelayMS))

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -186,18 +186,20 @@ func TestBuildConfigChangeDetails_CodexAbnormalReasoningRetry(t *testing.T) {
 	newCfg := &config.Config{
 		Codex: config.CodexConfig{
 			AbnormalReasoningRetry: config.CodexAbnormalReasoningRetryConfig{
-				Enabled:              true,
-				ModelContains:        []string{"gpt-5.5", "custom"},
-				ReasoningEfforts:     []string{"xhigh"},
-				ReasoningTokens:      []int64{516},
-				AuthKinds:            []string{"oauth", "api-key"},
-				AuthIDs:              []string{"auth-1"},
-				StreamBuffer:         &streamBuffer,
-				StreamBufferMaxBytes: &streamBufferMaxBytes,
-				MaxRetries:           &maxRetries,
-				ExhaustedBehavior:    config.CodexAbnormalReasoningRetryExhaustedBehaviorPassThrough,
+				Enabled:                true,
+				ModelContains:          []string{"gpt-5.5", "custom"},
+				ReasoningEfforts:       []string{"xhigh"},
+				ReasoningTokens:        []int64{516},
+				AuthKinds:              []string{"oauth", "api-key"},
+				AuthIDs:                []string{"auth-1"},
+				StreamBuffer:           &streamBuffer,
+				StreamBufferMaxBytes:   &streamBufferMaxBytes,
+				MaxRetries:             &maxRetries,
+				ExhaustedBehavior:      config.CodexAbnormalReasoningRetryExhaustedBehaviorPassThrough,
+				ClientUsageAggregation: config.CodexAbnormalReasoningRetryClientUsageAggregationSum,
 				HedgedRetry: config.CodexAbnormalReasoningHedgedRetryConfig{
 					Enabled:             true,
+					Mode:                config.CodexAbnormalReasoningHedgedRetryModeQuality,
 					HedgeDelayMS:        &hedgeDelayMS,
 					RequireDistinctAuth: &requireDistinctAuth,
 				},
@@ -212,7 +214,9 @@ func TestBuildConfigChangeDetails_CodexAbnormalReasoningRetry(t *testing.T) {
 	expectContains(t, details, "codex.abnormal-reasoning-retry.stream-buffer-max-bytes: 0 -> 4096")
 	expectContains(t, details, "codex.abnormal-reasoning-retry.max-retries: 2 -> 0")
 	expectContains(t, details, "codex.abnormal-reasoning-retry.exhausted-behavior: error -> pass-through")
+	expectContains(t, details, "codex.abnormal-reasoning-retry.client-usage-aggregation: reasoning-fold -> sum")
 	expectContains(t, details, "codex.abnormal-reasoning-retry.hedged-retry.enabled: false -> true")
+	expectContains(t, details, "codex.abnormal-reasoning-retry.hedged-retry.mode: speed -> quality")
 	expectContains(t, details, "codex.abnormal-reasoning-retry.hedged-retry.hedge-delay-ms: 1000 -> 250")
 	expectContains(t, details, "codex.abnormal-reasoning-retry.hedged-retry.require-distinct-auth: true -> false")
 	expectContains(t, details, "codex.abnormal-reasoning-retry.model-contains: updated (1 -> 2 entries)")

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -94,6 +94,9 @@ require_grep "hedged-retry" internal/config/config.go config.example.yaml docs/l
 require_grep "stream-buffer-max-bytes" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
 require_grep "max-retries" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
 require_grep "exhausted-behavior" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
+require_grep "client-usage-aggregation" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
+require_grep "reasoning-fold" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
+require_grep "quality" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
 require_grep "reasoning-efforts" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
 require_grep "RetryWithoutPenalty" sdk/cliproxy/auth/conductor.go sdk/cliproxy/auth/retry_without_penalty.go docs/lts/core-feature-contracts.yaml
 require_grep "ExcludeAuthIDsMetadataKey" sdk/cliproxy/executor/types.go docs/lts/core-feature-contracts.yaml
@@ -170,6 +173,9 @@ registry_required = [
     "require-distinct-auth",
     "max-retries",
     "exhausted-behavior",
+    "client-usage-aggregation",
+    "reasoning-fold",
+    "quality",
     "reasoning-efforts",
     "ExcludeAuthIDsMetadataKey",
     "RetryWithoutPenalty",

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1192,7 +1192,7 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: true})
 		}
 	}()
-		return &cliproxyexecutor.StreamResult{Headers: headers, Chunks: out, Metadata: cloneSchedulerAnyMap(metadata)}
+	return &cliproxyexecutor.StreamResult{Headers: headers, Chunks: out, Metadata: cloneSchedulerAnyMap(metadata)}
 }
 
 func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor ProviderExecutor, auth *Auth, provider string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, routeModel string, execModels []string, pooled bool) (*cliproxyexecutor.StreamResult, error) {
@@ -1290,7 +1290,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			close(closedCh)
 			remaining = closedCh
 		}
-			return m.wrapStreamResult(ctx, auth.Clone(), provider, resultModel, streamResult.Headers, streamResult.Metadata, buffered, remaining), nil
+		return m.wrapStreamResult(ctx, auth.Clone(), provider, resultModel, streamResult.Headers, streamResult.Metadata, buffered, remaining), nil
 	}
 	if lastErr == nil {
 		lastErr = &Error{Code: "auth_not_found", Message: "no upstream model available"}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1144,7 +1144,7 @@ func readStreamBootstrap(ctx context.Context, ch <-chan cliproxyexecutor.StreamC
 	}
 }
 
-func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, resultModel string, headers http.Header, buffered []cliproxyexecutor.StreamChunk, remaining <-chan cliproxyexecutor.StreamChunk) *cliproxyexecutor.StreamResult {
+func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, resultModel string, headers http.Header, metadata map[string]any, buffered []cliproxyexecutor.StreamChunk, remaining <-chan cliproxyexecutor.StreamChunk) *cliproxyexecutor.StreamResult {
 	out := make(chan cliproxyexecutor.StreamChunk)
 	go func() {
 		defer close(out)
@@ -1192,7 +1192,7 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: true})
 		}
 	}()
-	return &cliproxyexecutor.StreamResult{Headers: headers, Chunks: out}
+		return &cliproxyexecutor.StreamResult{Headers: headers, Chunks: out, Metadata: cloneSchedulerAnyMap(metadata)}
 }
 
 func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor ProviderExecutor, auth *Auth, provider string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, routeModel string, execModels []string, pooled bool) (*cliproxyexecutor.StreamResult, error) {
@@ -1290,7 +1290,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			close(closedCh)
 			remaining = closedCh
 		}
-		return m.wrapStreamResult(ctx, auth.Clone(), provider, resultModel, streamResult.Headers, buffered, remaining), nil
+			return m.wrapStreamResult(ctx, auth.Clone(), provider, resultModel, streamResult.Headers, streamResult.Metadata, buffered, remaining), nil
 	}
 	if lastErr == nil {
 		lastErr = &Error{Code: "auth_not_found", Message: "no upstream model available"}

--- a/sdk/cliproxy/auth/hedged_retry_without_penalty.go
+++ b/sdk/cliproxy/auth/hedged_retry_without_penalty.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"bytes"
 	"context"
+	"net/http"
 	"net/url"
 	"sort"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 )
 
 type retryWithoutPenaltyHedgeRequestState struct {
@@ -30,6 +32,9 @@ type retryWithoutPenaltyHedgeLaneResult struct {
 	authID         string
 	response       cliproxyexecutor.Response
 	stream         *cliproxyexecutor.StreamResult
+	streamHeaders  http.Header
+	streamChunks   []cliproxyexecutor.StreamChunk
+	streamMetadata map[string]any
 	err            error
 	dispatched     bool
 	usageAccounted bool
@@ -156,6 +161,9 @@ func (c *retryWithoutPenaltyHedgeLaneCoordinator) release(laneName string) {
 func (m *Manager) executeRetryWithoutPenaltyHedged(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int, class string, policy retryWithoutPenaltyHedgePolicy, remainingRetries int, accumulator *cliproxyexecutor.UsageAccumulator, state *retryWithoutPenaltyHedgeRequestState) retryWithoutPenaltyHedgeOutcome {
 	if remainingRetries <= 0 {
 		return retryWithoutPenaltyHedgeOutcome{}
+	}
+	if policy.mode == retryWithoutPenaltyHedgeModeQuality {
+		return m.executeRetryWithoutPenaltyHedgedQuality(ctx, providers, req, opts, maxRetryCredentials, class, policy, remainingRetries, accumulator, state)
 	}
 	attempts := 0
 	reservedAttempts := 0
@@ -318,6 +326,9 @@ func (m *Manager) executeStreamRetryWithoutPenaltyHedged(ctx context.Context, pr
 	if remainingRetries <= 0 {
 		return retryWithoutPenaltyHedgeOutcome{}
 	}
+	if policy.mode == retryWithoutPenaltyHedgeModeQuality {
+		return m.executeStreamRetryWithoutPenaltyHedgedQuality(ctx, providers, req, opts, maxRetryCredentials, class, policy, remainingRetries, accumulator, state)
+	}
 	attempts := 0
 	reservedAttempts := 0
 	usageAccounted := false
@@ -475,6 +486,348 @@ func (m *Manager) executeStreamRetryWithoutPenaltyHedged(ctx context.Context, pr
 	return retryWithoutPenaltyHedgeOutcome{err: err, attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
 }
 
+func (m *Manager) executeRetryWithoutPenaltyHedgedQuality(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int, class string, policy retryWithoutPenaltyHedgePolicy, remainingRetries int, accumulator *cliproxyexecutor.UsageAccumulator, state *retryWithoutPenaltyHedgeRequestState) retryWithoutPenaltyHedgeOutcome {
+	attempts := 0
+	reservedAttempts := 0
+	usageAccounted := false
+	disableSecondLane := false
+	var lastAbnormalErr error
+	var lastAbnormalAuthID string
+	var lastZeroDispatchErr error
+	selectedCallback := retryWithoutPenaltyHedgeSelectedAuthCallback(opts)
+	var coordinator *retryWithoutPenaltyHedgeLaneCoordinator
+	if policy.requireDistinctAuth {
+		coordinator = newRetryWithoutPenaltyHedgeLaneCoordinator()
+	}
+
+	startLane := func(resultCh chan<- retryWithoutPenaltyHedgeLaneResult, handles map[string]retryWithoutPenaltyHedgeLaneHandle, pending *int, name string, excludeAuthIDs []string, onAcceptedAuth func(string)) *retryWithoutPenaltyHedgeLaneTracker {
+		if reservedAttempts >= remainingRetries {
+			return nil
+		}
+		laneCtx, cancel := context.WithCancel(ctx)
+		tracker := newRetryWithoutPenaltyHedgeLaneTracker()
+		laneSelectedCallback := tracker.selectedCallback()
+		if coordinator != nil {
+			laneSelectedCallback = func(authID string) {
+				if !coordinator.claim(name, authID) {
+					cancel()
+					return
+				}
+				tracker.markSelected(authID)
+				if onAcceptedAuth != nil {
+					onAcceptedAuth(authID)
+				}
+			}
+		}
+		laneOpts := retryWithoutPenaltyHedgeOptions(opts, accumulator, excludeAuthIDs, laneSelectedCallback)
+		laneReq := cloneRetryWithoutPenaltyHedgeRequest(req)
+		handles[name] = retryWithoutPenaltyHedgeLaneHandle{name: name, cancel: cancel}
+		(*pending)++
+		reservedAttempts++
+		go func() {
+			defer coordinator.release(name)
+			resp, err := m.executeMixedOnce(laneCtx, providers, laneReq, laneOpts, maxRetryCredentials)
+			dispatched := tracker.dispatched()
+			accounted := false
+			if err != nil && accumulator != nil {
+				if detail, ok := retryWithoutPenaltyUsageDetail(err); ok {
+					accumulator.Add(detail)
+					accounted = true
+				}
+			}
+			resultCh <- retryWithoutPenaltyHedgeLaneResult{
+				name:           name,
+				authID:         tracker.selectedAuthID(),
+				response:       resp,
+				err:            err,
+				dispatched:     dispatched,
+				usageAccounted: accounted,
+			}
+		}()
+		return tracker
+	}
+
+	cancelAll := func(handles map[string]retryWithoutPenaltyHedgeLaneHandle) {
+		for _, handle := range handles {
+			if handle.cancel != nil {
+				handle.cancel()
+			}
+		}
+	}
+
+	for attempts < remainingRetries {
+		resultCh := make(chan retryWithoutPenaltyHedgeLaneResult, 2)
+		handles := make(map[string]retryWithoutPenaltyHedgeLaneHandle, 2)
+		pending := 0
+		waveRemaining := remainingRetries - attempts
+		var results []retryWithoutPenaltyHedgeLaneResult
+
+		primaryTracker := startLane(resultCh, handles, &pending, "primary", nil, nil)
+		if primaryTracker == nil {
+			break
+		}
+		secondAllowed := !disableSecondLane && retryWithoutPenaltySecondLaneAllowed(policy, waveRemaining, state)
+		var timer *time.Timer
+		var timerC <-chan time.Time
+		if secondAllowed {
+			timer = time.NewTimer(policy.hedgeDelay)
+			timerC = timer.C
+		}
+
+		for pending > 0 {
+			select {
+			case <-ctx.Done():
+				if timer != nil {
+					timer.Stop()
+				}
+				cancelAll(handles)
+				return retryWithoutPenaltyHedgeOutcome{err: ctx.Err(), attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
+			case res := <-resultCh:
+				pending--
+				if res.dispatched {
+					attempts++
+				} else if res.name == "secondary" {
+					disableSecondLane = true
+				}
+				if !res.dispatched && reservedAttempts > 0 {
+					reservedAttempts--
+				}
+				if res.usageAccounted {
+					usageAccounted = true
+				}
+				results = append(results, res)
+			case <-timerC:
+				timerC = nil
+				if pending <= 0 || reservedAttempts >= remainingRetries {
+					continue
+				}
+				exclude := retryWithoutPenaltySecondLaneExcludes(policy, primaryTracker.selectedAuthID())
+				primaryCancel := handles["primary"].cancel
+				startLane(resultCh, handles, &pending, "secondary", exclude, func(string) {
+					if policy.requireDistinctAuth && primaryTracker.selectedAuthID() == "" && primaryCancel != nil {
+						primaryCancel()
+					}
+				})
+			}
+		}
+		if timer != nil {
+			timer.Stop()
+		}
+
+		if winner := retryWithoutPenaltySelectQualityResponseWinner(results); winner >= 0 {
+			if retryWithoutPenaltyAddQualityResponseLosers(results, winner, accumulator) {
+				usageAccounted = true
+			}
+			resp := retryWithoutPenaltyFinalizeQualityResponse(results[winner].response, accumulator)
+			retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, results[winner].authID)
+			return retryWithoutPenaltyHedgeOutcome{response: resp, attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
+		}
+
+		waveHadAbnormal, waveOrdinaryErr := retryWithoutPenaltySummarizeQualityErrors(results, &lastAbnormalErr, &lastAbnormalAuthID, &lastZeroDispatchErr)
+		if waveHadAbnormal {
+			if attempts >= remainingRetries {
+				out := retryWithoutPenaltyExecuteHedgeExhaustedOutcome(class, lastAbnormalErr, attempts, disableSecondLane, usageAccounted)
+				if out.err == nil {
+					retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, lastAbnormalAuthID)
+				}
+				return out
+			}
+			continue
+		}
+		if waveOrdinaryErr != nil {
+			return retryWithoutPenaltyHedgeOutcome{err: waveOrdinaryErr, attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
+		}
+		if lastZeroDispatchErr != nil {
+			return retryWithoutPenaltyHedgeOutcome{err: lastZeroDispatchErr, attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
+		}
+	}
+
+	if lastAbnormalErr != nil {
+		out := retryWithoutPenaltyExecuteHedgeExhaustedOutcome(class, lastAbnormalErr, attempts, disableSecondLane, usageAccounted)
+		if out.err == nil {
+			retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, lastAbnormalAuthID)
+		}
+		return out
+	}
+	return retryWithoutPenaltyHedgeOutcome{err: lastZeroDispatchErr, attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
+}
+
+func (m *Manager) executeStreamRetryWithoutPenaltyHedgedQuality(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int, class string, policy retryWithoutPenaltyHedgePolicy, remainingRetries int, accumulator *cliproxyexecutor.UsageAccumulator, state *retryWithoutPenaltyHedgeRequestState) retryWithoutPenaltyHedgeOutcome {
+	attempts := 0
+	reservedAttempts := 0
+	usageAccounted := false
+	disableSecondLane := false
+	var lastAbnormalErr error
+	var lastAbnormalAuthID string
+	var lastZeroDispatchErr error
+	selectedCallback := retryWithoutPenaltyHedgeSelectedAuthCallback(opts)
+	var coordinator *retryWithoutPenaltyHedgeLaneCoordinator
+	if policy.requireDistinctAuth {
+		coordinator = newRetryWithoutPenaltyHedgeLaneCoordinator()
+	}
+
+	startLane := func(resultCh chan<- retryWithoutPenaltyHedgeLaneResult, handles map[string]retryWithoutPenaltyHedgeLaneHandle, pending *int, name string, excludeAuthIDs []string, onAcceptedAuth func(string)) *retryWithoutPenaltyHedgeLaneTracker {
+		if reservedAttempts >= remainingRetries {
+			return nil
+		}
+		laneCtx, cancel := context.WithCancel(ctx)
+		tracker := newRetryWithoutPenaltyHedgeLaneTracker()
+		laneSelectedCallback := tracker.selectedCallback()
+		if coordinator != nil {
+			laneSelectedCallback = func(authID string) {
+				if !coordinator.claim(name, authID) {
+					cancel()
+					return
+				}
+				tracker.markSelected(authID)
+				if onAcceptedAuth != nil {
+					onAcceptedAuth(authID)
+				}
+			}
+		}
+		laneOpts := retryWithoutPenaltyHedgeOptions(opts, accumulator, excludeAuthIDs, laneSelectedCallback)
+		laneReq := cloneRetryWithoutPenaltyHedgeRequest(req)
+		handles[name] = retryWithoutPenaltyHedgeLaneHandle{name: name, cancel: cancel}
+		(*pending)++
+		reservedAttempts++
+		go func() {
+			defer coordinator.release(name)
+			stream, err := m.executeStreamMixedOnce(laneCtx, providers, laneReq, laneOpts, maxRetryCredentials)
+			var headers http.Header
+			var chunks []cliproxyexecutor.StreamChunk
+			var metadata map[string]any
+			if err == nil && stream != nil {
+				headers = cloneHTTPHeader(stream.Headers)
+				metadata = cloneSchedulerAnyMap(stream.Metadata)
+				chunks, err = collectRetryWithoutPenaltyStreamChunks(laneCtx, stream.Chunks)
+			}
+			dispatched := tracker.dispatched()
+			accounted := false
+			if err != nil && accumulator != nil {
+				if detail, ok := retryWithoutPenaltyUsageDetail(err); ok {
+					accumulator.Add(detail)
+					accounted = true
+				}
+			}
+			resultCh <- retryWithoutPenaltyHedgeLaneResult{
+				name:           name,
+				authID:         tracker.selectedAuthID(),
+				streamHeaders:  headers,
+				streamChunks:   chunks,
+				streamMetadata: metadata,
+				err:            err,
+				dispatched:     dispatched,
+				usageAccounted: accounted,
+			}
+		}()
+		return tracker
+	}
+
+	cancelAll := func(handles map[string]retryWithoutPenaltyHedgeLaneHandle) {
+		for _, handle := range handles {
+			if handle.cancel != nil {
+				handle.cancel()
+			}
+		}
+	}
+
+	for attempts < remainingRetries {
+		resultCh := make(chan retryWithoutPenaltyHedgeLaneResult, 2)
+		handles := make(map[string]retryWithoutPenaltyHedgeLaneHandle, 2)
+		pending := 0
+		waveRemaining := remainingRetries - attempts
+		var results []retryWithoutPenaltyHedgeLaneResult
+
+		primaryTracker := startLane(resultCh, handles, &pending, "primary", nil, nil)
+		if primaryTracker == nil {
+			break
+		}
+		secondAllowed := !disableSecondLane && retryWithoutPenaltySecondLaneAllowed(policy, waveRemaining, state)
+		var timer *time.Timer
+		var timerC <-chan time.Time
+		if secondAllowed {
+			timer = time.NewTimer(policy.hedgeDelay)
+			timerC = timer.C
+		}
+
+		for pending > 0 {
+			select {
+			case <-ctx.Done():
+				if timer != nil {
+					timer.Stop()
+				}
+				cancelAll(handles)
+				return retryWithoutPenaltyHedgeOutcome{err: ctx.Err(), attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
+			case res := <-resultCh:
+				pending--
+				if res.dispatched {
+					attempts++
+				} else if res.name == "secondary" {
+					disableSecondLane = true
+				}
+				if !res.dispatched && reservedAttempts > 0 {
+					reservedAttempts--
+				}
+				if res.usageAccounted {
+					usageAccounted = true
+				}
+				results = append(results, res)
+			case <-timerC:
+				timerC = nil
+				if pending <= 0 || reservedAttempts >= remainingRetries {
+					continue
+				}
+				exclude := retryWithoutPenaltySecondLaneExcludes(policy, primaryTracker.selectedAuthID())
+				primaryCancel := handles["primary"].cancel
+				startLane(resultCh, handles, &pending, "secondary", exclude, func(string) {
+					if policy.requireDistinctAuth && primaryTracker.selectedAuthID() == "" && primaryCancel != nil {
+						primaryCancel()
+					}
+				})
+			}
+		}
+		if timer != nil {
+			timer.Stop()
+		}
+
+		if winner := retryWithoutPenaltySelectQualityStreamWinner(results); winner >= 0 {
+			if retryWithoutPenaltyAddQualityStreamLosers(results, winner, accumulator) {
+				usageAccounted = true
+			}
+			stream := retryWithoutPenaltyFinalizeQualityStream(results[winner], accumulator)
+			retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, results[winner].authID)
+			return retryWithoutPenaltyHedgeOutcome{stream: stream, attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
+		}
+
+		waveHadAbnormal, waveOrdinaryErr := retryWithoutPenaltySummarizeQualityErrors(results, &lastAbnormalErr, &lastAbnormalAuthID, &lastZeroDispatchErr)
+		if waveHadAbnormal {
+			if attempts >= remainingRetries {
+				out := retryWithoutPenaltyStreamHedgeExhaustedOutcome(class, lastAbnormalErr, attempts, disableSecondLane, usageAccounted)
+				if out.err == nil {
+					retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, lastAbnormalAuthID)
+				}
+				return out
+			}
+			continue
+		}
+		if waveOrdinaryErr != nil {
+			return retryWithoutPenaltyHedgeOutcome{err: waveOrdinaryErr, attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
+		}
+		if lastZeroDispatchErr != nil {
+			return retryWithoutPenaltyHedgeOutcome{err: lastZeroDispatchErr, attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
+		}
+	}
+
+	if lastAbnormalErr != nil {
+		out := retryWithoutPenaltyStreamHedgeExhaustedOutcome(class, lastAbnormalErr, attempts, disableSecondLane, usageAccounted)
+		if out.err == nil {
+			retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, lastAbnormalAuthID)
+		}
+		return out
+	}
+	return retryWithoutPenaltyHedgeOutcome{err: lastZeroDispatchErr, attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
+}
+
 func processRetryWithoutPenaltyExecuteHedgeResult(res retryWithoutPenaltyHedgeLaneResult, attempts *int, reservedAttempts *int, usageAccounted *bool, disableSecondLane *bool, waveHadAbnormal *bool, waveOrdinaryErr *error, lastAbnormalErr *error, lastAbnormalAuthID *string, lastZeroDispatchErr *error) (retryWithoutPenaltyHedgeOutcome, bool) {
 	if res.dispatched {
 		(*attempts)++
@@ -563,6 +916,235 @@ func drainRetryWithoutPenaltyStreamHedgeResults(resultCh <-chan retryWithoutPena
 			}
 		}
 	}()
+}
+
+func collectRetryWithoutPenaltyStreamChunks(ctx context.Context, ch <-chan cliproxyexecutor.StreamChunk) ([]cliproxyexecutor.StreamChunk, error) {
+	var chunks []cliproxyexecutor.StreamChunk
+	for {
+		var (
+			chunk cliproxyexecutor.StreamChunk
+			ok    bool
+		)
+		if ctx != nil {
+			select {
+			case <-ctx.Done():
+				discardStreamChunks(ch)
+				return nil, ctx.Err()
+			case chunk, ok = <-ch:
+			}
+		} else {
+			chunk, ok = <-ch
+		}
+		if !ok {
+			return chunks, nil
+		}
+		if chunk.Err != nil {
+			discardStreamChunks(ch)
+			return nil, chunk.Err
+		}
+		if len(chunk.Payload) > 0 {
+			chunk.Payload = bytes.Clone(chunk.Payload)
+		}
+		chunks = append(chunks, chunk)
+	}
+}
+
+func retryWithoutPenaltySelectQualityResponseWinner(results []retryWithoutPenaltyHedgeLaneResult) int {
+	winner := -1
+	var winnerScore int64
+	for i, res := range results {
+		if !res.dispatched || res.err != nil {
+			continue
+		}
+		score := retryWithoutPenaltyHedgeScore(res.response.Metadata)
+		if winner < 0 || score > winnerScore {
+			winner = i
+			winnerScore = score
+		}
+	}
+	return winner
+}
+
+func retryWithoutPenaltySelectQualityStreamWinner(results []retryWithoutPenaltyHedgeLaneResult) int {
+	winner := -1
+	var winnerScore int64
+	for i, res := range results {
+		if !res.dispatched || res.err != nil {
+			continue
+		}
+		_, score, ok := retryWithoutPenaltyStreamUsage(res.streamMetadata)
+		if !ok {
+			score = retryWithoutPenaltyHedgeScore(res.streamMetadata)
+		}
+		if winner < 0 || score > winnerScore {
+			winner = i
+			winnerScore = score
+		}
+	}
+	return winner
+}
+
+func retryWithoutPenaltyAddQualityResponseLosers(results []retryWithoutPenaltyHedgeLaneResult, winner int, accumulator *cliproxyexecutor.UsageAccumulator) bool {
+	if accumulator == nil {
+		return false
+	}
+	accounted := false
+	for i, res := range results {
+		if i == winner || !res.dispatched || res.err != nil {
+			continue
+		}
+		if detail, ok := retryWithoutPenaltyResponseUsage(res.response.Metadata); ok {
+			accumulator.Add(detail)
+			accounted = true
+		}
+	}
+	return accounted
+}
+
+func retryWithoutPenaltyAddQualityStreamLosers(results []retryWithoutPenaltyHedgeLaneResult, winner int, accumulator *cliproxyexecutor.UsageAccumulator) bool {
+	if accumulator == nil {
+		return false
+	}
+	accounted := false
+	for i, res := range results {
+		if i == winner || !res.dispatched || res.err != nil {
+			continue
+		}
+		if detail, _, ok := retryWithoutPenaltyStreamUsage(res.streamMetadata); ok {
+			accumulator.Add(detail)
+			accounted = true
+		}
+	}
+	return accounted
+}
+
+func retryWithoutPenaltySummarizeQualityErrors(results []retryWithoutPenaltyHedgeLaneResult, lastAbnormalErr *error, lastAbnormalAuthID *string, lastZeroDispatchErr *error) (bool, error) {
+	waveHadAbnormal := false
+	var waveOrdinaryErr error
+	for _, res := range results {
+		if res.err == nil {
+			continue
+		}
+		if res.dispatched {
+			if isRetryWithoutPenaltyError(res.err) {
+				waveHadAbnormal = true
+				if lastAbnormalErr != nil {
+					*lastAbnormalErr = res.err
+				}
+				if lastAbnormalAuthID != nil {
+					*lastAbnormalAuthID = res.authID
+				}
+			} else if waveOrdinaryErr == nil {
+				waveOrdinaryErr = res.err
+			}
+			continue
+		}
+		if lastZeroDispatchErr != nil {
+			*lastZeroDispatchErr = res.err
+		}
+	}
+	return waveHadAbnormal, waveOrdinaryErr
+}
+
+func retryWithoutPenaltyFinalizeQualityResponse(resp cliproxyexecutor.Response, accumulator *cliproxyexecutor.UsageAccumulator) cliproxyexecutor.Response {
+	finalizer, _ := resp.Metadata[cliproxyexecutor.RetryWithoutPenaltyResponseFinalizerMetadataKey].(cliproxyexecutor.RetryWithoutPenaltyResponseFinalizer)
+	if finalizer == nil {
+		return resp
+	}
+	return finalizer(resp, retryWithoutPenaltyAccumulatorSnapshot(accumulator))
+}
+
+func retryWithoutPenaltyFinalizeQualityStream(res retryWithoutPenaltyHedgeLaneResult, accumulator *cliproxyexecutor.UsageAccumulator) *cliproxyexecutor.StreamResult {
+	finalizer, _ := res.streamMetadata[cliproxyexecutor.RetryWithoutPenaltyStreamFinalizerMetadataKey].(cliproxyexecutor.RetryWithoutPenaltyStreamFinalizer)
+	if finalizer != nil {
+		return finalizer(res.streamHeaders, res.streamChunks, retryWithoutPenaltyAccumulatorSnapshot(accumulator))
+	}
+	ch := make(chan cliproxyexecutor.StreamChunk, len(res.streamChunks))
+	for i := range res.streamChunks {
+		chunk := res.streamChunks[i]
+		if len(chunk.Payload) > 0 {
+			chunk.Payload = bytes.Clone(chunk.Payload)
+		}
+		ch <- chunk
+	}
+	close(ch)
+	return &cliproxyexecutor.StreamResult{
+		Headers:  cloneHTTPHeader(res.streamHeaders),
+		Chunks:   ch,
+		Metadata: cloneSchedulerAnyMap(res.streamMetadata),
+	}
+}
+
+func retryWithoutPenaltyAccumulatorSnapshot(accumulator *cliproxyexecutor.UsageAccumulator) cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot {
+	if accumulator == nil {
+		return cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot{}
+	}
+	return accumulator.RetryWithoutPenaltySnapshot()
+}
+
+func retryWithoutPenaltyResponseUsage(meta map[string]any) (coreusage.Detail, bool) {
+	return retryWithoutPenaltyUsageFromMetadata(meta)
+}
+
+func retryWithoutPenaltyStreamUsage(meta map[string]any) (coreusage.Detail, int64, bool) {
+	if len(meta) == 0 {
+		return coreusage.Detail{}, 0, false
+	}
+	switch value := meta[cliproxyexecutor.RetryWithoutPenaltyStreamUsageMetadataKey].(type) {
+	case *cliproxyexecutor.RetryWithoutPenaltyStreamUsage:
+		if value == nil || !value.OK || !hasRetryWithoutPenaltyUsageDetail(value.Detail) {
+			return coreusage.Detail{}, 0, false
+		}
+		return value.Detail, value.HedgeScore, true
+	case cliproxyexecutor.RetryWithoutPenaltyStreamUsage:
+		if !value.OK || !hasRetryWithoutPenaltyUsageDetail(value.Detail) {
+			return coreusage.Detail{}, 0, false
+		}
+		return value.Detail, value.HedgeScore, true
+	default:
+		detail, ok := retryWithoutPenaltyUsageFromMetadata(meta)
+		return detail, retryWithoutPenaltyHedgeScore(meta), ok
+	}
+}
+
+func retryWithoutPenaltyUsageFromMetadata(meta map[string]any) (coreusage.Detail, bool) {
+	if len(meta) == 0 {
+		return coreusage.Detail{}, false
+	}
+	switch detail := meta[cliproxyexecutor.RetryWithoutPenaltyUsageDetailMetadataKey].(type) {
+	case coreusage.Detail:
+		return detail, hasRetryWithoutPenaltyUsageDetail(detail)
+	case *coreusage.Detail:
+		if detail == nil {
+			return coreusage.Detail{}, false
+		}
+		return *detail, hasRetryWithoutPenaltyUsageDetail(*detail)
+	default:
+		return coreusage.Detail{}, false
+	}
+}
+
+func retryWithoutPenaltyHedgeScore(meta map[string]any) int64 {
+	if len(meta) == 0 {
+		return 0
+	}
+	switch score := meta[cliproxyexecutor.RetryWithoutPenaltyHedgeScoreMetadataKey].(type) {
+	case int:
+		return int64(score)
+	case int64:
+		return score
+	case int32:
+		return int64(score)
+	case float64:
+		return int64(score)
+	case float32:
+		return int64(score)
+	default:
+		if detail, ok := retryWithoutPenaltyUsageFromMetadata(meta); ok {
+			return detail.OutputTokens
+		}
+		return 0
+	}
 }
 
 func retryWithoutPenaltySecondLaneAllowed(policy retryWithoutPenaltyHedgePolicy, remainingRetries int, state *retryWithoutPenaltyHedgeRequestState) bool {
@@ -701,7 +1283,8 @@ func retryWithoutPenaltyStreamResultWithCancel(result *cliproxyexecutor.StreamRe
 		}
 	}()
 	return &cliproxyexecutor.StreamResult{
-		Headers: cloneHTTPHeader(result.Headers),
-		Chunks:  out,
+		Headers:  cloneHTTPHeader(result.Headers),
+		Chunks:   out,
+		Metadata: cloneSchedulerAnyMap(result.Metadata),
 	}
 }

--- a/sdk/cliproxy/auth/hedged_retry_without_penalty_test.go
+++ b/sdk/cliproxy/auth/hedged_retry_without_penalty_test.go
@@ -17,6 +17,7 @@ import (
 type hedgedRetryTestError struct {
 	maxRetries         int
 	hedgeEnabled       bool
+	hedgeMode          string
 	hedgeDelay         time.Duration
 	requireDistinct    bool
 	authID             string
@@ -47,6 +48,10 @@ func (e hedgedRetryTestError) RetryWithoutPenaltyExhaustedBehavior() string {
 
 func (e hedgedRetryTestError) RetryWithoutPenaltyHedgePolicy() (bool, time.Duration, bool) {
 	return e.hedgeEnabled, e.hedgeDelay, e.requireDistinct
+}
+
+func (e hedgedRetryTestError) RetryWithoutPenaltyHedgeMode() string {
+	return e.hedgeMode
 }
 
 func (e hedgedRetryTestError) RetryWithoutPenaltyAuthID() string {
@@ -89,10 +94,12 @@ func (e hedgedRetryRateLimitError) RetryAfter() *time.Duration {
 }
 
 type hedgedRetryBehavior struct {
-	kind    string
-	delay   time.Duration
-	payload string
-	barrier *hedgedRetryBarrier
+	kind     string
+	delay    time.Duration
+	payload  string
+	usage    coreusage.Detail
+	finalize bool
+	barrier  *hedgedRetryBarrier
 }
 
 type hedgedRetryBarrier struct {
@@ -174,6 +181,7 @@ type hedgedRetryTestExecutor struct {
 	behaviors          map[string][]hedgedRetryBehavior
 	streamBehaviors    map[string][]hedgedRetryBehavior
 	maxRetries         int
+	hedgeMode          string
 	hedgeDelay         time.Duration
 	requireDistinct    bool
 	disableHedge       bool
@@ -207,7 +215,7 @@ func (e *hedgedRetryTestExecutor) Execute(ctx context.Context, auth *Auth, _ cli
 		if payload == "" {
 			payload = "ok"
 		}
-		return cliproxyexecutor.Response{Payload: []byte(payload)}, nil
+		return cliproxyexecutor.Response{Payload: []byte(payload), Metadata: hedgedRetryTestResponseMetadata(behavior)}, nil
 	}
 }
 
@@ -234,7 +242,54 @@ func (e *hedgedRetryTestExecutor) ExecuteStream(ctx context.Context, auth *Auth,
 		ch <- cliproxyexecutor.StreamChunk{Payload: []byte(payload)}
 	}
 	close(ch)
-	return &cliproxyexecutor.StreamResult{Chunks: ch}, nil
+	return &cliproxyexecutor.StreamResult{Chunks: ch, Metadata: hedgedRetryTestStreamMetadata(behavior)}, nil
+}
+
+func hedgedRetryTestResponseMetadata(behavior hedgedRetryBehavior) map[string]any {
+	if !hasRetryWithoutPenaltyUsageDetail(behavior.usage) && !behavior.finalize {
+		return nil
+	}
+	meta := map[string]any{}
+	if hasRetryWithoutPenaltyUsageDetail(behavior.usage) {
+		meta[cliproxyexecutor.RetryWithoutPenaltyUsageDetailMetadataKey] = behavior.usage
+		meta[cliproxyexecutor.RetryWithoutPenaltyHedgeScoreMetadataKey] = behavior.usage.OutputTokens
+	}
+	if behavior.finalize {
+		meta[cliproxyexecutor.RetryWithoutPenaltyResponseFinalizerMetadataKey] = cliproxyexecutor.RetryWithoutPenaltyResponseFinalizer(func(resp cliproxyexecutor.Response, previous cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot) cliproxyexecutor.Response {
+			resp.Payload = []byte(fmt.Sprintf("%s|fold:%d|discarded:%d", resp.Payload, previous.FoldedOutputTokens, previous.Detail.TotalTokens))
+			return resp
+		})
+	}
+	return meta
+}
+
+func hedgedRetryTestStreamMetadata(behavior hedgedRetryBehavior) map[string]any {
+	if !hasRetryWithoutPenaltyUsageDetail(behavior.usage) && !behavior.finalize {
+		return nil
+	}
+	meta := map[string]any{}
+	if hasRetryWithoutPenaltyUsageDetail(behavior.usage) {
+		meta[cliproxyexecutor.RetryWithoutPenaltyStreamUsageMetadataKey] = &cliproxyexecutor.RetryWithoutPenaltyStreamUsage{
+			Detail:     behavior.usage,
+			HedgeScore: behavior.usage.OutputTokens,
+			OK:         true,
+		}
+	}
+	if behavior.finalize {
+		meta[cliproxyexecutor.RetryWithoutPenaltyStreamFinalizerMetadataKey] = cliproxyexecutor.RetryWithoutPenaltyStreamFinalizer(func(headers http.Header, chunks []cliproxyexecutor.StreamChunk, previous cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot) *cliproxyexecutor.StreamResult {
+			out := make(chan cliproxyexecutor.StreamChunk, len(chunks))
+			for i := range chunks {
+				chunk := chunks[i]
+				if chunk.Err == nil {
+					chunk.Payload = []byte(fmt.Sprintf("%s|fold:%d|discarded:%d", chunk.Payload, previous.FoldedOutputTokens, previous.Detail.TotalTokens))
+				}
+				out <- chunk
+			}
+			close(out)
+			return &cliproxyexecutor.StreamResult{Headers: headers, Chunks: out}
+		})
+	}
+	return meta
 }
 
 func (e *hedgedRetryTestExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
@@ -293,6 +348,7 @@ func (e *hedgedRetryTestExecutor) retryError(authID string) error {
 	return hedgedRetryTestError{
 		maxRetries:         e.maxRetries,
 		hedgeEnabled:       !e.disableHedge,
+		hedgeMode:          e.hedgeMode,
 		hedgeDelay:         e.hedgeDelay,
 		requireDistinct:    e.requireDistinct,
 		authID:             authID,
@@ -619,6 +675,138 @@ func TestManagerExecute_HedgedRetrySelectedAuthCallbackReportsWinner(t *testing.
 	callbackMu.Unlock()
 	if len(got) == 0 || got[len(got)-1] != "auth-b" {
 		t.Fatalf("selected auth callbacks = %#v, want final winner auth-b", got)
+	}
+}
+
+func TestManagerExecute_HedgedRetryQualityWaitsForAbnormalAndFinalizesWinnerUsage(t *testing.T) {
+	executor := &hedgedRetryTestExecutor{
+		behaviors: map[string][]hedgedRetryBehavior{
+			"auth-a": {
+				{kind: "retry"},
+				{kind: "success", payload: "winner-ok", usage: coreusage.Detail{InputTokens: 5, OutputTokens: 20, ReasoningTokens: 8, TotalTokens: 25}, finalize: true},
+			},
+			"auth-b": {{kind: "retry"}},
+		},
+		maxRetries:      2,
+		hedgeMode:       retryWithoutPenaltyHedgeModeQuality,
+		hedgeDelay:      0,
+		requireDistinct: false,
+	}
+	manager, _ := newHedgedRetryTestManager(t, executor, "auth-a", "auth-b")
+	manager.SetRetryConfig(0, 0, 0)
+
+	var callbackMu sync.Mutex
+	var callbackAuthIDs []string
+	opts := cliproxyexecutor.Options{
+		Metadata: map[string]any{
+			cliproxyexecutor.SelectedAuthCallbackMetadataKey: func(authID string) {
+				callbackMu.Lock()
+				defer callbackMu.Unlock()
+				callbackAuthIDs = append(callbackAuthIDs, authID)
+			},
+		},
+	}
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5.5"}, opts)
+	if err != nil {
+		t.Fatalf("Execute error = %v, want nil", err)
+	}
+	if string(resp.Payload) != "winner-ok|fold:1032|discarded:6" {
+		t.Fatalf("payload = %q, want finalized winner usage", resp.Payload)
+	}
+	callbackMu.Lock()
+	gotCallbacks := append([]string(nil), callbackAuthIDs...)
+	callbackMu.Unlock()
+	if len(gotCallbacks) == 0 || gotCallbacks[len(gotCallbacks)-1] != "auth-a" {
+		t.Fatalf("selected auth callbacks = %#v, want final winner auth-a", gotCallbacks)
+	}
+	if got := executor.callsSnapshot(); len(got) != 3 || got[0] != "auth-a" || got[1] != "auth-b" || got[2] != "auth-a" {
+		t.Fatalf("calls = %#v, want auth-a trigger, auth-b abnormal, auth-a winner", got)
+	}
+}
+
+func TestManagerExecute_HedgedRetryQualityChoosesLargestOutputAndFoldsLoser(t *testing.T) {
+	executor := &hedgedRetryTestExecutor{
+		behaviors: map[string][]hedgedRetryBehavior{
+			"auth-a": {
+				{kind: "retry"},
+				{kind: "success", payload: "big", usage: coreusage.Detail{InputTokens: 5, OutputTokens: 30, ReasoningTokens: 8, TotalTokens: 35}, finalize: true},
+			},
+			"auth-b": {{kind: "success", payload: "small", usage: coreusage.Detail{InputTokens: 3, OutputTokens: 10, ReasoningTokens: 2, TotalTokens: 13}, finalize: true}},
+		},
+		maxRetries:      2,
+		hedgeMode:       retryWithoutPenaltyHedgeModeQuality,
+		hedgeDelay:      0,
+		requireDistinct: false,
+	}
+	manager, _ := newHedgedRetryTestManager(t, executor, "auth-a", "auth-b")
+	manager.SetRetryConfig(0, 0, 0)
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5.5"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute error = %v, want nil", err)
+	}
+	if string(resp.Payload) != "big|fold:526|discarded:16" {
+		t.Fatalf("payload = %q, want big winner with trigger plus loser folded", resp.Payload)
+	}
+}
+
+func TestManagerExecute_HedgedRetryQualityBudgetCountsDispatchedLanes(t *testing.T) {
+	executor := &hedgedRetryTestExecutor{
+		behaviors: map[string][]hedgedRetryBehavior{
+			"auth-a": {{kind: "retry"}, {kind: "retry"}},
+			"auth-b": {{kind: "retry"}},
+		},
+		maxRetries:      2,
+		hedgeMode:       retryWithoutPenaltyHedgeModeQuality,
+		hedgeDelay:      0,
+		requireDistinct: false,
+	}
+	manager, _ := newHedgedRetryTestManager(t, executor, "auth-a", "auth-b")
+	manager.SetRetryConfig(0, 0, 0)
+
+	_, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5.5"}, cliproxyexecutor.Options{})
+	if err == nil {
+		t.Fatal("Execute error = nil, want exhausted error")
+	}
+	if statusCodeFromError(err) != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; err=%v", statusCodeFromError(err), err)
+	}
+	if calls := executor.callCount(); calls != 3 {
+		t.Fatalf("calls = %d, want initial trigger plus exactly two quality lanes", calls)
+	}
+}
+
+func TestManagerExecuteStream_HedgedRetryQualityReplaysWinnerOnly(t *testing.T) {
+	executor := &hedgedRetryTestExecutor{
+		streamBehaviors: map[string][]hedgedRetryBehavior{
+			"auth-a": {
+				{kind: "retry"},
+				{kind: "success", payload: "big-stream", usage: coreusage.Detail{InputTokens: 5, OutputTokens: 30, ReasoningTokens: 8, TotalTokens: 35}, finalize: true},
+			},
+			"auth-b": {{kind: "success", payload: "small-stream", usage: coreusage.Detail{InputTokens: 3, OutputTokens: 10, ReasoningTokens: 2, TotalTokens: 13}, finalize: true}},
+		},
+		maxRetries:      2,
+		hedgeMode:       retryWithoutPenaltyHedgeModeQuality,
+		hedgeDelay:      0,
+		requireDistinct: false,
+	}
+	manager, _ := newHedgedRetryTestManager(t, executor, "auth-a", "auth-b")
+	manager.SetRetryConfig(0, 0, 0)
+
+	result, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5.5"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("ExecuteStream error = %v, want nil", err)
+	}
+	var payload []byte
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v, want nil", chunk.Err)
+		}
+		payload = append(payload, chunk.Payload...)
+	}
+	if string(payload) != "big-stream|fold:526|discarded:16" {
+		t.Fatalf("payload = %q, want finalized big stream winner only", payload)
 	}
 }
 

--- a/sdk/cliproxy/auth/hedged_retry_without_penalty_test.go
+++ b/sdk/cliproxy/auth/hedged_retry_without_penalty_test.go
@@ -810,6 +810,104 @@ func TestManagerExecuteStream_HedgedRetryQualityReplaysWinnerOnly(t *testing.T) 
 	}
 }
 
+// Mixed-wave semantics: per the V1 hedged retry plan, an ordinary error only
+// becomes the wave error when the wave produced no abnormal signal ("两路都普通
+// 失败" case). When one lane is abnormal and another fails with an ordinary
+// error and no lane succeeded, the anti-degradation guard keeps retrying while
+// budget remains instead of surfacing the ordinary error.
+// maxRetryCredentials=1 keeps the ordinary error at lane level instead of
+// letting the lane rotate onto the other credential.
+func TestManagerExecute_HedgedRetryQualityMixedAbnormalAndOrdinaryContinuesWaves(t *testing.T) {
+	executor := &hedgedRetryTestExecutor{
+		behaviors: map[string][]hedgedRetryBehavior{
+			"auth-a": {
+				{kind: "retry"},
+				{kind: "retry"},
+				{kind: "success", delay: 25 * time.Millisecond, payload: "after-mixed", usage: coreusage.Detail{InputTokens: 5, OutputTokens: 30, TotalTokens: 35}},
+			},
+			"auth-b": {{kind: "rate_limit", delay: 25 * time.Millisecond}},
+		},
+		maxRetries:      4,
+		hedgeMode:       retryWithoutPenaltyHedgeModeQuality,
+		hedgeDelay:      0,
+		requireDistinct: false,
+	}
+	manager, _ := newHedgedRetryTestManager(t, executor, "auth-a", "auth-b")
+	manager.SetRetryConfig(0, 0, 1)
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5.5"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute error = %v, want mixed wave to continue retrying", err)
+	}
+	if string(resp.Payload) != "after-mixed" {
+		t.Fatalf("payload = %q, want after-mixed winner from the follow-up wave", resp.Payload)
+	}
+	if calls := executor.callCount(); calls != 5 {
+		t.Fatalf("calls = %d, want trigger plus two waves of two lanes", calls)
+	}
+}
+
+func TestManagerExecute_HedgedRetryQualityMixedAbnormalAndOrdinaryExhaustsToExhaustedError(t *testing.T) {
+	executor := &hedgedRetryTestExecutor{
+		behaviors: map[string][]hedgedRetryBehavior{
+			"auth-a": {
+				{kind: "retry"},
+				{kind: "retry", delay: 25 * time.Millisecond},
+				{kind: "rate_limit"},
+			},
+		},
+		maxRetries:      2,
+		hedgeMode:       retryWithoutPenaltyHedgeModeQuality,
+		hedgeDelay:      0,
+		requireDistinct: false,
+	}
+	manager, _ := newHedgedRetryTestManager(t, executor, "auth-a")
+	manager.SetRetryConfig(0, 0, 1)
+
+	_, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5.5"}, cliproxyexecutor.Options{})
+	assertRetryWithoutPenaltyExhausted(t, err, "codex_abnormal_reasoning_retry_exhausted")
+	if statusCodeFromError(err) != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502 exhausted rather than the ordinary lane error; err=%v", statusCodeFromError(err), err)
+	}
+	if calls := executor.callCount(); calls != 3 {
+		t.Fatalf("calls = %d, want initial trigger plus one mixed wave", calls)
+	}
+}
+
+func TestManagerExecuteStream_HedgedRetryQualityMixedAbnormalAndOrdinaryContinuesWaves(t *testing.T) {
+	executor := &hedgedRetryTestExecutor{
+		streamBehaviors: map[string][]hedgedRetryBehavior{
+			"auth-a": {
+				{kind: "retry"},
+				{kind: "retry"},
+				{kind: "success", delay: 25 * time.Millisecond, payload: "after-mixed-stream", usage: coreusage.Detail{InputTokens: 5, OutputTokens: 30, TotalTokens: 35}},
+			},
+			"auth-b": {{kind: "rate_limit", delay: 25 * time.Millisecond}},
+		},
+		maxRetries:      4,
+		hedgeMode:       retryWithoutPenaltyHedgeModeQuality,
+		hedgeDelay:      0,
+		requireDistinct: false,
+	}
+	manager, _ := newHedgedRetryTestManager(t, executor, "auth-a", "auth-b")
+	manager.SetRetryConfig(0, 0, 1)
+
+	result, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5.5"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("ExecuteStream error = %v, want mixed wave to continue retrying", err)
+	}
+	var payload []byte
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v, want nil", chunk.Err)
+		}
+		payload = append(payload, chunk.Payload...)
+	}
+	if string(payload) != "after-mixed-stream" {
+		t.Fatalf("payload = %q, want after-mixed-stream winner from the follow-up wave", payload)
+	}
+}
+
 func TestManagerExecute_HedgedRetryCleanLoserCompletedCountsAsSuccess(t *testing.T) {
 	barrier := newHedgedRetryBarrier(2)
 	executor := &hedgedRetryTestExecutor{

--- a/sdk/cliproxy/auth/retry_without_penalty.go
+++ b/sdk/cliproxy/auth/retry_without_penalty.go
@@ -15,6 +15,8 @@ import (
 const (
 	retryWithoutPenaltyExhaustedBehaviorError       = "error"
 	retryWithoutPenaltyExhaustedBehaviorPassThrough = "pass-through"
+	retryWithoutPenaltyHedgeModeSpeed               = "speed"
+	retryWithoutPenaltyHedgeModeQuality             = "quality"
 )
 
 func withRetryWithoutPenaltyUsageMetadata(opts cliproxyexecutor.Options, accumulator *cliproxyexecutor.UsageAccumulator) cliproxyexecutor.Options {
@@ -105,6 +107,7 @@ func retryWithoutPenaltyExhaustedBehavior(err error) string {
 
 type retryWithoutPenaltyHedgePolicy struct {
 	enabled             bool
+	mode                string
 	hedgeDelay          time.Duration
 	requireDistinctAuth bool
 	triggerAuthID       string
@@ -126,8 +129,15 @@ func retryWithoutPenaltyHedgePolicyFromError(err error) (retryWithoutPenaltyHedg
 	}
 	policy := retryWithoutPenaltyHedgePolicy{
 		enabled:             enabled,
+		mode:                retryWithoutPenaltyHedgeModeSpeed,
 		hedgeDelay:          hedgeDelay,
 		requireDistinctAuth: requireDistinctAuth,
+	}
+	var withMode interface {
+		RetryWithoutPenaltyHedgeMode() string
+	}
+	if errors.As(err, &withMode) {
+		policy.mode = normalizeRetryWithoutPenaltyHedgeMode(withMode.RetryWithoutPenaltyHedgeMode())
 	}
 	var withAuthID interface {
 		RetryWithoutPenaltyAuthID() string
@@ -136,6 +146,15 @@ func retryWithoutPenaltyHedgePolicyFromError(err error) (retryWithoutPenaltyHedg
 		policy.triggerAuthID = strings.TrimSpace(withAuthID.RetryWithoutPenaltyAuthID())
 	}
 	return policy, true
+}
+
+func normalizeRetryWithoutPenaltyHedgeMode(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "quality":
+		return retryWithoutPenaltyHedgeModeQuality
+	default:
+		return retryWithoutPenaltyHedgeModeSpeed
+	}
 }
 
 func normalizeRetryWithoutPenaltyExhaustedBehavior(value string) string {

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -29,6 +29,16 @@ const ServiceTierMetadataKey = "service_tier"
 const (
 	// CodexAbnormalReasoningRetryUsageMetadataKey carries discarded abnormal attempt usage for client-visible aggregate usage only.
 	CodexAbnormalReasoningRetryUsageMetadataKey = "codex_abnormal_reasoning_retry_usage"
+	// RetryWithoutPenaltyUsageDetailMetadataKey carries attempt usage for retry-without-penalty hedge selection and client aggregation.
+	RetryWithoutPenaltyUsageDetailMetadataKey = "retry_without_penalty_usage_detail"
+	// RetryWithoutPenaltyHedgeScoreMetadataKey carries the score used to choose a quality-mode hedge winner.
+	RetryWithoutPenaltyHedgeScoreMetadataKey = "retry_without_penalty_hedge_score"
+	// RetryWithoutPenaltyResponseFinalizerMetadataKey carries a response finalizer for post-hedge client usage aggregation.
+	RetryWithoutPenaltyResponseFinalizerMetadataKey = "retry_without_penalty_response_finalizer"
+	// RetryWithoutPenaltyStreamFinalizerMetadataKey carries a stream finalizer for post-hedge client usage aggregation.
+	RetryWithoutPenaltyStreamFinalizerMetadataKey = "retry_without_penalty_stream_finalizer"
+	// RetryWithoutPenaltyStreamUsageMetadataKey carries mutable stream usage captured while chunks are produced.
+	RetryWithoutPenaltyStreamUsageMetadataKey = "retry_without_penalty_stream_usage"
 	// ExcludeAuthIDsMetadataKey instructs auth selection to skip the listed auth IDs.
 	ExcludeAuthIDsMetadataKey = "exclude_auth_ids"
 	// PinnedAuthMetadataKey locks execution to a specific auth ID.
@@ -41,10 +51,34 @@ const (
 	ExecutionSessionMetadataKey = "execution_session_id"
 )
 
+// RetryWithoutPenaltyUsageSnapshot carries discarded-attempt usage in both the
+// legacy field-sum shape and the folded output-token shape needed by clients.
+type RetryWithoutPenaltyUsageSnapshot struct {
+	Detail             coreusage.Detail
+	FoldedOutputTokens int64
+}
+
+// RetryWithoutPenaltyResponseFinalizer rewrites a delivered non-stream response
+// after hedge selection has the final discarded-attempt usage snapshot.
+type RetryWithoutPenaltyResponseFinalizer func(Response, RetryWithoutPenaltyUsageSnapshot) Response
+
+// RetryWithoutPenaltyStreamFinalizer rewrites buffered stream chunks after hedge
+// selection has the final discarded-attempt usage snapshot.
+type RetryWithoutPenaltyStreamFinalizer func(http.Header, []StreamChunk, RetryWithoutPenaltyUsageSnapshot) *StreamResult
+
+// RetryWithoutPenaltyStreamUsage carries completed usage discovered while a
+// stream is produced. Producers set it before emitting the terminal usage chunk.
+type RetryWithoutPenaltyStreamUsage struct {
+	Detail     coreusage.Detail
+	HedgeScore int64
+	OK         bool
+}
+
 // UsageAccumulator is a thread-safe request-local usage accumulator carried in Options.Metadata.
 type UsageAccumulator struct {
-	mu     sync.Mutex
-	detail coreusage.Detail
+	mu                 sync.Mutex
+	detail             coreusage.Detail
+	foldedOutputTokens int64
 }
 
 // NewUsageAccumulator creates a UsageAccumulator seeded with initial usage.
@@ -60,9 +94,11 @@ func (a *UsageAccumulator) Add(detail coreusage.Detail) {
 		return
 	}
 	detail = normalizeUsageAccumulatorDetail(detail)
+	foldedOutputTokens := foldedUsageAccumulatorOutputTokens(detail)
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.detail = addUsageAccumulatorDetail(a.detail, detail)
+	a.foldedOutputTokens += foldedOutputTokens
 }
 
 // Snapshot returns the current accumulated usage.
@@ -73,6 +109,20 @@ func (a *UsageAccumulator) Snapshot() coreusage.Detail {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return a.detail
+}
+
+// RetryWithoutPenaltySnapshot returns the field-sum and folded discarded usage
+// snapshots used by retry-without-penalty response finalizers.
+func (a *UsageAccumulator) RetryWithoutPenaltySnapshot() RetryWithoutPenaltyUsageSnapshot {
+	if a == nil {
+		return RetryWithoutPenaltyUsageSnapshot{}
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return RetryWithoutPenaltyUsageSnapshot{
+		Detail:             a.detail,
+		FoldedOutputTokens: a.foldedOutputTokens,
+	}
 }
 
 func addUsageAccumulatorDetail(a, b coreusage.Detail) coreusage.Detail {
@@ -87,6 +137,13 @@ func addUsageAccumulatorDetail(a, b coreusage.Detail) coreusage.Detail {
 		CacheCreationTokens: a.CacheCreationTokens + b.CacheCreationTokens,
 		TotalTokens:         a.TotalTokens + b.TotalTokens,
 	}
+}
+
+func foldedUsageAccumulatorOutputTokens(detail coreusage.Detail) int64 {
+	if detail.OutputTokens >= detail.ReasoningTokens {
+		return detail.OutputTokens
+	}
+	return detail.ReasoningTokens
 }
 
 func normalizeUsageAccumulatorDetail(detail coreusage.Detail) coreusage.Detail {
@@ -210,6 +267,8 @@ type StreamResult struct {
 	Headers http.Header
 	// Chunks is the channel of streaming payload units.
 	Chunks <-chan StreamChunk
+	// Metadata exposes optional structured data for stream translators and retry helpers.
+	Metadata map[string]any
 }
 
 // StatusError represents an error that carries an HTTP-like status code.


### PR DESCRIPTION
## 概述
- 为 Codex 异常 reasoning 重试新增 V2 控制项：客户端可见 usage 聚合方式与 hedged retry 模式。
- 普通请求行为完全不变：新行为仅在 `codex.abnormal-reasoning-retry.enabled: true` 且异常 reasoning 守卫触发重试路径后生效。
- 保持 hedging 当前默认运行时行为（`hedged-retry.mode: "speed"`）；新增可选 `"quality"` 模式，在同一波并发 lane 内按最大成功 `output_tokens` 选择胜者。

## 新增 Config Keys
- `codex.abnormal-reasoning-retry.client-usage-aggregation`
  - 允许值：`"reasoning-fold" | "sum"`
  - 默认值：`"reasoning-fold"`
  - 非法值归一化为 `"reasoning-fold"`
- `codex.abnormal-reasoning-retry.hedged-retry.mode`
  - 允许值：`"speed" | "quality"`
  - 默认值：`"speed"`
  - 非法值归一化为 `"speed"`

## Usage 聚合语义
- `sum`：沿用旧行为，对客户端可见的重试 usage payload 逐字段相加。
- `reasoning-fold`：被丢弃的尝试继续累计 `input/cache`；被丢弃的 `output_tokens` 仍计入总 output，同时将被丢弃尝试的 `max(output_tokens, reasoning_tokens)` 折叠进最终 `reasoning_tokens`。
- 客户端可见的 `total_tokens` 重新按 `input_tokens + output_tokens` 计算。
- 客户端可见的重试 usage 保证 `reasoning_tokens <= output_tokens`；`output_tokens - reasoning_tokens` 即最终交付尝试的可见输出。
- Management 侧按尝试（per-attempt）的 usage 统计刻意保持不变；本 PR 只改变客户端可见的重试 payload 聚合方式。

## Quality Hedge 语义
- `speed` 模式保持现有行为：第一个成功的 lane 胜出，另一个 lane 被取消。
- `quality` 模式等待同一波内所有已派发的 lane，剔除异常 lane 后，选择 `output_tokens` 最大的成功 lane；平局时选择先完成的 lane。
- 成功但落选的 lane，其 usage 通过 executor metadata/finalizer 回传，折叠进客户端累加器，且不会向 Management usage 统计重复发布。
- 流式 quality 模式会缓冲成功 lane 的输出，仅回放胜者的 chunk，并在选出胜者后重写选中的 usage chunk。
- `max-retries` 仍按实际派发的 lane 计数，而不是按波（wave）计数。quality 模式下一波双 lane 会消耗 2 个重试额度；如需两轮完整的双 lane 对比，请把 `max-retries` 从 `2` 提高到 `4`。
- `quality` 模式遵循已配置的 `hedge-delay-ms`，不会强制将其置为 `0`。

## Protected Delta Review
- Request lifecycle：quality 与 usage-fold 新行为仅作用于异常守卫触发后的 Codex 异常重试路径；普通请求不会双重派发，usage 行为不变。
- Token accounting：客户端可见的重试聚合新增 `reasoning-fold` 支持；Management per-attempt 记账与 usage record 发布保持不变。
- Management usage response shape：无变化。未删除或重命名任何 `/v0/management/usage*` 响应字段。
- Config hot reload：watcher diff 已覆盖新增 config keys。
- Panel 契约影响：Core 的 config/API 面有所扩展，建议在后续 PR 中更新 `CPA-Panel-LTS` 可视化配置编辑器，使这些 keys 可展示/可编辑。

## 验证
- [x] `go test ./internal/config`
- [x] `go test ./internal/watcher/diff`
- [x] `go test -count=1 ./sdk/cliproxy/auth`
- [x] `go test -race -count=1 ./sdk/cliproxy/auth`
- [x] `go test ./internal/runtime/executor`
- [x] `go test -race -count=1 ./internal/runtime/executor -run 'CodexExecutorAbnormalReasoningRetry|CodexAbnormalReasoningRetry'`
- [x] `scripts/check-lts-contract.sh`
- [x] `go build -o test-output ./cmd/server && rm -f test-output`
- [x] `git diff --check`
- [x] `go test ./...`

## 发布说明
- 仅 draft PR。本 PR 流程不执行 tag、release、HFS 部署、Docker 发布或合并。


---

## Follow-up（4e954156）：流式 quality usage 折算的多下游格式修复

### 问题
流式 quality 模式选出胜者后的 usage 重写（stream finalizer）只识别 codex 原生形状 `response.usage`；但胜者 chunk 在缓冲时已被 `sdktranslator.TranslateStream` 翻译成客户端格式。下游为 OpenAI Chat（top-level `usage.*`）、Claude（`message_delta.usage`）、Gemini（`usageMetadata`）时，被淘汰 lane 的 usage 无法折入最终交付的 usage chunk（非流式路径不受影响，其 finalizer 本就采用"重打 raw usage 后重新翻译"的设计）。

### 修复
- quality hedge 生效时，executor 在流式读取中记录 raw 上游行（`response.completed` 保留 usage 未打补丁版本）。
- stream finalizer 用最终 discarded-usage snapshot 重打 raw completed usage，然后整体重新翻译回放，对齐非流式 finalizer 设计，天然覆盖全部下游格式。
- 无可用记录（如 `stream-buffer-max-bytes` 超限）时回退到原 translated-chunk patch 行为。
- 新增端到端回归测试：OpenAI Chat 下游格式的 quality 流式折算精确值（修复前该测试失败，且失败输出同时证实了旧路径存在 winner patch 时刻的 accumulator 竞态）。

### Mixed-wave 语义裁定（不改行为，补测试锁定）
复核"quality 无成功 lane 时 ordinary error 应优先于 abnormal 返回"的审查意见：与 V1 设计文档原文（普通错误在 lane 内消化；仅"两路都普通失败"才把普通错误返回外层）及已合入 main 的 speed 模式行为相矛盾，且提前返回瞬时普通错误会中断对抗降智的重试链。维持现状：同 wave 内 abnormal 优先继续重试，预算耗尽走 exhausted 语义。新增 3 个回归测试锁定该语义（继续重试、耗尽 502、流式路径）。

### Follow-up 验证
- [x] `go test ./internal/runtime/executor`（含 `-race` 定向）
- [x] `go test -count=1 ./sdk/cliproxy/auth` / `go test -race -count=1 ./sdk/cliproxy/auth`
- [x] 新增 mixed-wave 测试 `-count=10` 与 `-race -count=5` 稳定通过
- [x] `go build -o test-output ./cmd/server`
- [x] `scripts/check-lts-contract.sh`
- [x] `git diff --check`
- [x] `go test ./...`
