### PR TITLE
Codex abnormal retry default quality and longest pass-through

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -200,14 +200,15 @@ codex:
     max-retries: 2
     exhausted-behavior: "error"
     client-usage-aggregation: "reasoning-fold"
-    # Optional V1 hedged retry for abnormal attempts. When enabled, a retry lane starts first;
-    # after hedge-delay-ms, a second parallel lane may start to reduce tail latency. First success wins.
-    # mode: "speed" keeps first-success-wins behavior. "quality" waits for dispatched lanes and selects the largest output_tokens winner.
+    # Optional hedged retry for abnormal attempts. When enabled, a retry lane starts first;
+    # after hedge-delay-ms, a second parallel lane may start. Default mode is "quality".
+    # mode: "quality" waits for dispatched lanes and selects the largest output_tokens winner; "speed" keeps first-success-wins behavior.
     # quality mode still counts max-retries per dispatched lane; use max-retries: 4 for two full two-lane waves.
-    # For quality mode, hedge-delay-ms: 0 is recommended when the goal is always to compare two lanes.
+    # hedge-delay-ms is not forced to 0; set hedge-delay-ms: 0 when the goal is always to compare two lanes.
+    # When exhausted-behavior is "pass-through", the longest abnormal pass-through fallback in the retry chain is returned.
     hedged-retry:
       enabled: false
-      mode: "speed"
+      mode: "quality"
       hedge-delay-ms: 1000
       require-distinct-auth: true
 

--- a/docs/lts/core-feature-contracts.yaml
+++ b/docs/lts/core-feature-contracts.yaml
@@ -156,7 +156,7 @@ features:
 
   - id: codex-abnormal-reasoning-retry
     status: lts-maintained
-    reason: CPA-Core-LTS can optionally discard and retry suspicious Codex OAuth responses with attempt-level CPA accounting and aggregate client-visible usage, without changing plugin ABI or Panel UI.
+    reason: CPA-Core-LTS can optionally discard and retry suspicious Codex OAuth responses with attempt-level CPA accounting, default quality hedging, longest abnormal pass-through fallback, and aggregate client-visible usage, without changing plugin ABI or Panel UI.
     config_keys:
       - codex.abnormal-reasoning-retry.enabled
       - codex.abnormal-reasoning-retry.model-contains
@@ -191,6 +191,7 @@ features:
       - client-usage-aggregation
       - reasoning-fold
       - quality
+      - longest abnormal pass-through fallback
       - hedge-delay-ms
       - require-distinct-auth
       - stream-buffer-max-bytes

--- a/internal/config/codex_websocket_header_defaults_test.go
+++ b/internal/config/codex_websocket_header_defaults_test.go
@@ -102,8 +102,8 @@ func TestLoadConfigOptional_CodexAbnormalReasoningRetryDefaults(t *testing.T) {
 	if effective.HedgedRetry.Enabled {
 		t.Fatal("HedgedRetry.Enabled = true, want false")
 	}
-	if effective.HedgedRetry.Mode != CodexAbnormalReasoningHedgedRetryModeSpeed {
-		t.Fatalf("HedgedRetry.Mode = %q, want %q", effective.HedgedRetry.Mode, CodexAbnormalReasoningHedgedRetryModeSpeed)
+	if effective.HedgedRetry.Mode != CodexAbnormalReasoningHedgedRetryModeQuality {
+		t.Fatalf("HedgedRetry.Mode = %q, want %q", effective.HedgedRetry.Mode, CodexAbnormalReasoningHedgedRetryModeQuality)
 	}
 	if effective.HedgedRetry.HedgeDelayMS != 1000 {
 		t.Fatalf("HedgedRetry.HedgeDelayMS = %d, want 1000", effective.HedgedRetry.HedgeDelayMS)
@@ -287,6 +287,31 @@ codex:
 	if effective.ClientUsageAggregation != CodexAbnormalReasoningRetryClientUsageAggregationReasoningFold {
 		t.Fatalf("ClientUsageAggregation = %q, want %q", effective.ClientUsageAggregation, CodexAbnormalReasoningRetryClientUsageAggregationReasoningFold)
 	}
+	if effective.HedgedRetry.Mode != CodexAbnormalReasoningHedgedRetryModeQuality {
+		t.Fatalf("HedgedRetry.Mode = %q, want %q", effective.HedgedRetry.Mode, CodexAbnormalReasoningHedgedRetryModeQuality)
+	}
+}
+
+func TestLoadConfigOptional_CodexAbnormalReasoningRetryExplicitSpeedMode(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	configYAML := []byte(`
+codex:
+  abnormal-reasoning-retry:
+    enabled: true
+    hedged-retry:
+      mode: "speed"
+`)
+	if err := os.WriteFile(configPath, configYAML, 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := LoadConfigOptional(configPath, false)
+	if err != nil {
+		t.Fatalf("LoadConfigOptional() error = %v", err)
+	}
+
+	effective := cfg.Codex.AbnormalReasoningRetry.Effective()
 	if effective.HedgedRetry.Mode != CodexAbnormalReasoningHedgedRetryModeSpeed {
 		t.Fatalf("HedgedRetry.Mode = %q, want %q", effective.HedgedRetry.Mode, CodexAbnormalReasoningHedgedRetryModeSpeed)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -453,12 +453,12 @@ func normalizeCodexAbnormalReasoningRetryClientUsageAggregation(value string) st
 
 func normalizeCodexAbnormalReasoningHedgedRetryMode(value string) string {
 	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "", "speed":
+	case "speed":
 		return CodexAbnormalReasoningHedgedRetryModeSpeed
 	case "quality":
 		return CodexAbnormalReasoningHedgedRetryModeQuality
 	default:
-		return CodexAbnormalReasoningHedgedRetryModeSpeed
+		return CodexAbnormalReasoningHedgedRetryModeQuality
 	}
 }
 

--- a/internal/runtime/executor/codex_abnormal_reasoning_retry.go
+++ b/internal/runtime/executor/codex_abnormal_reasoning_retry.go
@@ -37,18 +37,19 @@ type codexAbnormalReasoningRetryPolicy struct {
 }
 
 type codexAbnormalReasoningRetryError struct {
-	detail                 usage.Detail
-	maxRetries             int
-	exhaustedBehavior      string
-	clientUsageAggregation string
-	hedgeEnabled           bool
-	hedgeMode              string
-	hedgeDelay             time.Duration
-	requireDistinctAuth    bool
-	authID                 string
-	fallbackResponse       *cliproxyexecutor.Response
-	fallbackStreamHeaders  http.Header
-	fallbackStreamChunks   []cliproxyexecutor.StreamChunk
+	detail                  usage.Detail
+	maxRetries              int
+	exhaustedBehavior       string
+	clientUsageAggregation  string
+	hedgeEnabled            bool
+	hedgeMode               string
+	hedgeDelay              time.Duration
+	requireDistinctAuth     bool
+	authID                  string
+	fallbackResponse        *cliproxyexecutor.Response
+	fallbackStreamHeaders   http.Header
+	fallbackStreamChunks    []cliproxyexecutor.StreamChunk
+	fallbackStreamFinalizer cliproxyexecutor.RetryWithoutPenaltyStreamFinalizer
 }
 
 const (
@@ -97,7 +98,7 @@ func (e *codexAbnormalReasoningRetryError) RetryWithoutPenaltyHedgePolicy() (boo
 
 func (e *codexAbnormalReasoningRetryError) RetryWithoutPenaltyHedgeMode() string {
 	if e == nil || strings.TrimSpace(e.hedgeMode) == "" {
-		return config.CodexAbnormalReasoningHedgedRetryModeSpeed
+		return config.CodexAbnormalReasoningHedgedRetryModeQuality
 	}
 	return e.hedgeMode
 }
@@ -121,6 +122,13 @@ func (e *codexAbnormalReasoningRetryError) RetryWithoutPenaltyFallbackStreamChun
 		return nil, nil, false
 	}
 	return cloneCodexAbnormalReasoningRetryHeader(e.fallbackStreamHeaders), cloneCodexAbnormalReasoningRetryStreamChunks(e.fallbackStreamChunks), true
+}
+
+func (e *codexAbnormalReasoningRetryError) RetryWithoutPenaltyFallbackStreamFinalizer() cliproxyexecutor.RetryWithoutPenaltyStreamFinalizer {
+	if e == nil {
+		return nil
+	}
+	return e.fallbackStreamFinalizer
 }
 
 func (e *codexAbnormalReasoningRetryError) UsageFailureCode() string {
@@ -208,24 +216,23 @@ func (p codexAbnormalReasoningRetryPolicy) StreamBufferMaxBytes() int64 {
 	return p.streamBufferMax
 }
 
-func (p codexAbnormalReasoningRetryPolicy) QualityHedgeStreamRewrite() bool {
-	return p.enabled && p.hedgeEnabled &&
-		strings.EqualFold(strings.TrimSpace(p.hedgeMode), config.CodexAbnormalReasoningHedgedRetryModeQuality)
-}
-
 func (p codexAbnormalReasoningRetryPolicy) RetryError(detail usage.Detail, reasoningEffort string) error {
-	return p.retryError(detail, reasoningEffort, nil, nil, nil)
+	return p.retryError(detail, reasoningEffort, nil, nil, nil, nil)
 }
 
 func (p codexAbnormalReasoningRetryPolicy) RetryErrorWithFallbackResponse(detail usage.Detail, reasoningEffort string, fallback cliproxyexecutor.Response) error {
-	return p.retryError(detail, reasoningEffort, &fallback, nil, nil)
+	return p.retryError(detail, reasoningEffort, &fallback, nil, nil, nil)
 }
 
 func (p codexAbnormalReasoningRetryPolicy) RetryErrorWithFallbackStreamChunks(detail usage.Detail, reasoningEffort string, headers http.Header, chunks []cliproxyexecutor.StreamChunk) error {
-	return p.retryError(detail, reasoningEffort, nil, headers, chunks)
+	return p.retryError(detail, reasoningEffort, nil, headers, chunks, nil)
 }
 
-func (p codexAbnormalReasoningRetryPolicy) retryError(detail usage.Detail, reasoningEffort string, fallbackResponse *cliproxyexecutor.Response, fallbackStreamHeaders http.Header, fallbackStreamChunks []cliproxyexecutor.StreamChunk) error {
+func (p codexAbnormalReasoningRetryPolicy) RetryErrorWithFallbackStreamChunksAndFinalizer(detail usage.Detail, reasoningEffort string, headers http.Header, chunks []cliproxyexecutor.StreamChunk, finalizer cliproxyexecutor.RetryWithoutPenaltyStreamFinalizer) error {
+	return p.retryError(detail, reasoningEffort, nil, headers, chunks, finalizer)
+}
+
+func (p codexAbnormalReasoningRetryPolicy) retryError(detail usage.Detail, reasoningEffort string, fallbackResponse *cliproxyexecutor.Response, fallbackStreamHeaders http.Header, fallbackStreamChunks []cliproxyexecutor.StreamChunk, fallbackStreamFinalizer cliproxyexecutor.RetryWithoutPenaltyStreamFinalizer) error {
 	if !p.enabled || detail.ReasoningTokens <= 0 {
 		return nil
 	}
@@ -255,6 +262,7 @@ func (p codexAbnormalReasoningRetryPolicy) retryError(detail usage.Detail, reaso
 	if len(fallbackStreamChunks) > 0 {
 		err.fallbackStreamHeaders = cloneCodexAbnormalReasoningRetryHeader(fallbackStreamHeaders)
 		err.fallbackStreamChunks = cloneCodexAbnormalReasoningRetryStreamChunks(fallbackStreamChunks)
+		err.fallbackStreamFinalizer = fallbackStreamFinalizer
 	}
 	return err
 }

--- a/internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
+++ b/internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
@@ -621,8 +621,8 @@ func TestCodexExecutorAbnormalReasoningRetry_PassThroughWhenExhaustedNonStreamin
 	if calls != 1 {
 		t.Fatalf("upstream calls = %d, want 1", calls)
 	}
-	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 3 {
-		t.Fatalf("client response usage.total_tokens = %d, want delivered abnormal total 3; payload=%s", got, resp.Payload)
+	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 517 {
+		t.Fatalf("client response usage.total_tokens = %d, want folded abnormal total 517; payload=%s", got, resp.Payload)
 	}
 	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens_details.reasoning_tokens").Int(); got != 516 {
 		t.Fatalf("client response reasoning_tokens = %d, want 516; payload=%s", got, resp.Payload)
@@ -686,6 +686,58 @@ func TestCodexExecutorAbnormalReasoningRetry_PassThroughAggregatesDiscardedUsage
 	}
 	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens_details.reasoning_tokens").Int(); got != 1550 {
 		t.Fatalf("client response reasoning_tokens = %d, want discarded plus delivered reasoning 1550; payload=%s", got, resp.Payload)
+	}
+}
+
+func TestCodexExecutorAbnormalReasoningRetry_PassThroughReturnsLongestNonStreamingFallback(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "text/event-stream")
+		switch calls {
+		case 1:
+			_, _ = w.Write([]byte(codexCompletedSSEWithTextAndUsage("gpt-5.5", "trigger", 516, 1, 5, 6)))
+		case 2:
+			_, _ = w.Write([]byte(codexCompletedSSEWithTextAndUsage("gpt-5.5", "long", 516, 1, 80, 81)))
+		default:
+			_, _ = w.Write([]byte(codexCompletedSSEWithTextAndUsage("gpt-5.5", "short", 516, 1, 20, 21)))
+		}
+	}))
+	defer server.Close()
+
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(NewCodexExecutor(codexAbnormalReasoningRetryTestConfigWithMaxAndExhausted(2, config.CodexAbnormalReasoningRetryExhaustedBehaviorPassThrough)))
+	manager.SetRetryConfig(0, 0, 0)
+
+	auth := codexAbnormalReasoningRetryTestAuth(server.URL)
+	auth.ID = "codex-oauth-pass-through-longest"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, "codex", []*registry.ModelInfo{{ID: "gpt-5.5"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(auth.ID)
+	})
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"hello"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error = %v, want nil pass-through", err)
+	}
+	if calls != 3 {
+		t.Fatalf("upstream calls = %d, want 3", calls)
+	}
+	if !bytes.Contains(resp.Payload, []byte("long")) || bytes.Contains(resp.Payload, []byte("short")) {
+		t.Fatalf("client response payload = %s, want longest fallback only", resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 1551 {
+		t.Fatalf("client response usage.total_tokens = %d, want final folded total 1551; payload=%s", got, resp.Payload)
 	}
 }
 
@@ -884,6 +936,68 @@ func TestCodexExecutorAbnormalReasoningRetry_PassThroughWhenExhaustedStreaming(t
 	})
 	if !record.Failed {
 		t.Fatalf("record.Failed = false, want true")
+	}
+}
+
+func TestCodexExecutorAbnormalReasoningRetry_PassThroughReturnsLongestStreamingFallback(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "text/event-stream")
+		switch calls {
+		case 1:
+			_, _ = w.Write([]byte(`data: {"type":"response.output_text.delta","delta":"trigger"}` + "\n\n"))
+			_, _ = w.Write([]byte(codexCompletedSSEWithTextAndUsage("gpt-5.5", "trigger", 516, 1, 5, 6)))
+		case 2:
+			_, _ = w.Write([]byte(`data: {"type":"response.output_text.delta","delta":"long"}` + "\n\n"))
+			_, _ = w.Write([]byte(codexCompletedSSEWithTextAndUsage("gpt-5.5", "long", 516, 1, 80, 81)))
+		default:
+			_, _ = w.Write([]byte(`data: {"type":"response.output_text.delta","delta":"short"}` + "\n\n"))
+			_, _ = w.Write([]byte(codexCompletedSSEWithTextAndUsage("gpt-5.5", "short", 516, 1, 20, 21)))
+		}
+	}))
+	defer server.Close()
+
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(NewCodexExecutor(codexAbnormalReasoningRetryTestConfigWithMaxAndExhausted(2, config.CodexAbnormalReasoningRetryExhaustedBehaviorPassThrough)))
+	manager.SetRetryConfig(0, 0, 0)
+
+	auth := codexAbnormalReasoningRetryTestAuth(server.URL)
+	auth.ID = "codex-oauth-stream-pass-through-longest"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, "codex", []*registry.ModelInfo{{ID: "gpt-5.5"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(auth.ID)
+	})
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	result, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"hello","stream":true}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error = %v, want nil pass-through", err)
+	}
+	var payload []byte
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v, want nil", chunk.Err)
+		}
+		payload = append(payload, chunk.Payload...)
+	}
+	if calls != 3 {
+		t.Fatalf("upstream calls = %d, want 3", calls)
+	}
+	if !bytes.Contains(payload, []byte("long")) || bytes.Contains(payload, []byte("short")) {
+		t.Fatalf("stream payload = %s, want longest fallback only", payload)
+	}
+	if !bytes.Contains(payload, []byte(`"total_tokens":1551`)) {
+		t.Fatalf("stream payload missing final folded total_tokens=1551: %s", payload)
 	}
 }
 
@@ -1089,7 +1203,11 @@ func codexCompletedSSE(model string, reasoning int) string {
 }
 
 func codexCompletedSSEWithUsage(model string, reasoning, input, output, total int) string {
-	return `data: {"type":"response.completed","response":{"id":"resp_1","object":"response","created_at":1775555723,"status":"completed","model":"` + model + `","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":` + strconv.Itoa(input) + `,"output_tokens":` + strconv.Itoa(output) + `,"total_tokens":` + strconv.Itoa(total) + `,"output_tokens_details":{"reasoning_tokens":` + strconv.Itoa(reasoning) + `}}}}` + "\n\n"
+	return codexCompletedSSEWithTextAndUsage(model, "ok", reasoning, input, output, total)
+}
+
+func codexCompletedSSEWithTextAndUsage(model, text string, reasoning, input, output, total int) string {
+	return `data: {"type":"response.completed","response":{"id":"resp_1","object":"response","created_at":1775555723,"status":"completed","model":"` + model + `","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"` + text + `"}]}],"usage":{"input_tokens":` + strconv.Itoa(input) + `,"output_tokens":` + strconv.Itoa(output) + `,"total_tokens":` + strconv.Itoa(total) + `,"output_tokens_details":{"reasoning_tokens":` + strconv.Itoa(reasoning) + `}}}}` + "\n\n"
 }
 
 func assertRetryWithoutPenaltyError(t *testing.T, err error) {

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -935,15 +935,27 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		completedData := patchCodexCompletedOutput(eventData, outputItemsByIndex, outputItemsFallback)
 		var completedUsage usage.Detail
 		var completedUsageOK bool
+		var responseFinalizer cliproxyexecutor.RetryWithoutPenaltyResponseFinalizer
 		if detail, ok := helps.ParseCodexUsage(eventData); ok {
 			completedUsage = detail
 			completedUsageOK = true
+			responseFinalizer = cliproxyexecutor.RetryWithoutPenaltyResponseFinalizer(func(base cliproxyexecutor.Response, previous cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot) cliproxyexecutor.Response {
+				var finalizerParam any
+				finalCompletedData := patchCodexAbnormalReasoningClientUsageWithSnapshot(completedData, previous, abnormalRetry.clientUsageAggregation)
+				finalCompletedData = applyCodexIdentityExposeResponsePayload(finalCompletedData, identityState)
+				base.Payload = sdktranslator.TranslateNonStream(ctx, to, responseFormat, req.Model, originalPayload, body, finalCompletedData, &finalizerParam)
+				return base
+			})
 			if errRetry := abnormalRetry.RetryError(detail, reporter.ReasoningEffort()); errRetry != nil {
 				var param any
 				clientCompletedData := patchCodexAbnormalReasoningClientUsage(completedData, opts.Metadata, abnormalRetry.clientUsageAggregation)
 				clientCompletedData = applyCodexIdentityExposeResponsePayload(clientCompletedData, identityState)
 				out := sdktranslator.TranslateNonStream(ctx, to, responseFormat, req.Model, originalPayload, body, clientCompletedData, &param)
-				fallbackResp := cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
+				fallbackResp := cliproxyexecutor.Response{
+					Payload:  out,
+					Headers:  httpResp.Header.Clone(),
+					Metadata: codexAbnormalReasoningRetryResponseMetadata(detail, responseFinalizer),
+				}
 				if errWithFallback := abnormalRetry.RetryErrorWithFallbackResponse(detail, reporter.ReasoningEffort(), fallbackResp); errWithFallback != nil {
 					errRetry = errWithFallback
 				}
@@ -963,13 +975,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		out := sdktranslator.TranslateNonStream(ctx, to, responseFormat, req.Model, originalPayload, body, clientCompletedData, &param)
 		resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
 		if completedUsageOK {
-			resp.Metadata = codexAbnormalReasoningRetryResponseMetadata(completedUsage, func(base cliproxyexecutor.Response, previous cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot) cliproxyexecutor.Response {
-				var finalizerParam any
-				finalCompletedData := patchCodexAbnormalReasoningClientUsageWithSnapshot(completedData, previous, abnormalRetry.clientUsageAggregation)
-				finalCompletedData = applyCodexIdentityExposeResponsePayload(finalCompletedData, identityState)
-				base.Payload = sdktranslator.TranslateNonStream(ctx, to, responseFormat, req.Model, originalPayload, body, finalCompletedData, &finalizerParam)
-				return base
-			})
+			resp.Metadata = codexAbnormalReasoningRetryResponseMetadata(completedUsage, responseFinalizer)
 		}
 		return resp, nil
 	}
@@ -1192,7 +1198,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	out := make(chan cliproxyexecutor.StreamChunk)
 	streamUsage := &cliproxyexecutor.RetryWithoutPenaltyStreamUsage{}
 	var qualityRecorder *codexAbnormalReasoningRetryStreamRecorder
-	if abnormalRetry.StreamBuffer() && abnormalRetry.QualityHedgeStreamRewrite() {
+	if abnormalRetry.StreamBuffer() {
 		qualityRecorder = newCodexAbnormalReasoningRetryStreamRecorder(abnormalRetry.StreamBufferMaxBytes())
 	}
 	streamFinalizer := cliproxyexecutor.RetryWithoutPenaltyStreamFinalizer(func(headers http.Header, chunks []cliproxyexecutor.StreamChunk, previous cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot) *cliproxyexecutor.StreamResult {
@@ -1320,7 +1326,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 					fallbackChunks = append(fallbackChunks, cliproxyexecutor.StreamChunk{Payload: bytes.Clone(chunks[i])})
 				}
 				if usageDetailOK {
-					if errWithFallback := abnormalRetry.RetryErrorWithFallbackStreamChunks(usageDetail, reporter.ReasoningEffort(), httpResp.Header.Clone(), fallbackChunks); errWithFallback != nil {
+					if errWithFallback := abnormalRetry.RetryErrorWithFallbackStreamChunksAndFinalizer(usageDetail, reporter.ReasoningEffort(), httpResp.Header.Clone(), fallbackChunks, streamFinalizer); errWithFallback != nil {
 						retryErr = errWithFallback
 					}
 					reporter.PublishFailureWithDetail(ctx, usageDetail, retryErr)

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -182,7 +182,15 @@ func TestBuildConfigChangeDetails_CodexAbnormalReasoningRetry(t *testing.T) {
 	maxRetries := 0
 	hedgeDelayMS := 250
 	requireDistinctAuth := false
-	oldCfg := &config.Config{}
+	oldCfg := &config.Config{
+		Codex: config.CodexConfig{
+			AbnormalReasoningRetry: config.CodexAbnormalReasoningRetryConfig{
+				HedgedRetry: config.CodexAbnormalReasoningHedgedRetryConfig{
+					Mode: config.CodexAbnormalReasoningHedgedRetryModeSpeed,
+				},
+			},
+		},
+	}
 	newCfg := &config.Config{
 		Codex: config.CodexConfig{
 			AbnormalReasoningRetry: config.CodexAbnormalReasoningRetryConfig{

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -97,6 +97,7 @@ require_grep "exhausted-behavior" internal/config/config.go config.example.yaml 
 require_grep "client-usage-aggregation" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
 require_grep "reasoning-fold" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
 require_grep "quality" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
+require_grep "longest abnormal pass-through fallback" config.example.yaml docs/lts/core-feature-contracts.yaml
 require_grep "reasoning-efforts" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
 require_grep "RetryWithoutPenalty" sdk/cliproxy/auth/conductor.go sdk/cliproxy/auth/retry_without_penalty.go docs/lts/core-feature-contracts.yaml
 require_grep "ExcludeAuthIDsMetadataKey" sdk/cliproxy/executor/types.go docs/lts/core-feature-contracts.yaml
@@ -176,6 +177,7 @@ registry_required = [
     "client-usage-aggregation",
     "reasoning-fold",
     "quality",
+    "longest abnormal pass-through fallback",
     "reasoning-efforts",
     "ExcludeAuthIDsMetadataKey",
     "RetryWithoutPenalty",

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1637,6 +1637,7 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 	retryWithoutPenaltyCounts := make(map[string]int)
 	retryWithoutPenaltyUsage := cliproxyexecutor.NewUsageAccumulator(coreusage.Detail{})
 	retryWithoutPenaltyHedgeState := &retryWithoutPenaltyHedgeRequestState{}
+	retryWithoutPenaltyFallback := newRetryWithoutPenaltyFallbackCandidate(false)
 	for attempt := 0; ; {
 		attemptOpts := withRetryWithoutPenaltyUsageMetadata(opts, retryWithoutPenaltyUsage)
 		resp, errExec := m.executeMixedOnce(ctx, normalized, req, attemptOpts, maxRetryCredentials)
@@ -1647,17 +1648,18 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 		if detail, ok := retryWithoutPenaltyUsageDetail(errExec); ok {
 			retryWithoutPenaltyUsage.Add(detail)
 		}
+		retryWithoutPenaltyFallback.Consider(errExec, retryWithoutPenaltyAuthIDFromError(errExec))
 		if policy, ok := retryWithoutPenaltyHedgePolicyFromError(errExec); ok && policy.enabled && !m.HomeEnabled() {
 			class, remaining, terminalErr, limited := retryWithoutPenaltyRemainingRetries(errExec, retryWithoutPenaltyCounts)
 			if terminalErr != nil {
-				if resp, ok := retryWithoutPenaltyFallbackResponse(errExec); ok {
+				if resp, ok := retryWithoutPenaltyCandidateFallbackResponse(retryWithoutPenaltyFallback.Err(errExec), retryWithoutPenaltyFallback, retryWithoutPenaltyUsage); ok {
 					return resp, nil
 				}
 				lastErr = terminalErr
 				break
 			}
 			if limited && remaining > 0 {
-				outcome := m.executeRetryWithoutPenaltyHedged(ctx, normalized, req, opts, maxRetryCredentials, class, policy, remaining, retryWithoutPenaltyUsage, retryWithoutPenaltyHedgeState)
+				outcome := m.executeRetryWithoutPenaltyHedged(ctx, normalized, req, opts, maxRetryCredentials, class, policy, remaining, retryWithoutPenaltyUsage, retryWithoutPenaltyHedgeState, retryWithoutPenaltyFallback)
 				if outcome.disableSecondLane {
 					retryWithoutPenaltyHedgeState.secondLaneDisabled = true
 				}
@@ -1676,7 +1678,7 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 				}
 				wait, shouldRetry, terminalErr := m.shouldRetryAfterError(outcome.err, attempt, normalized, req.Model, maxWait, retryWithoutPenaltyCounts)
 				if terminalErr != nil {
-					if resp, ok := retryWithoutPenaltyFallbackResponse(outcome.err); ok {
+					if resp, ok := retryWithoutPenaltyCandidateFallbackResponse(retryWithoutPenaltyFallback.Err(outcome.err), retryWithoutPenaltyFallback, retryWithoutPenaltyUsage); ok {
 						return resp, nil
 					}
 					lastErr = terminalErr
@@ -1693,7 +1695,7 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 		}
 		wait, shouldRetry, terminalErr := m.shouldRetryAfterError(errExec, attempt, normalized, req.Model, maxWait, retryWithoutPenaltyCounts)
 		if terminalErr != nil {
-			if resp, ok := retryWithoutPenaltyFallbackResponse(errExec); ok {
+			if resp, ok := retryWithoutPenaltyCandidateFallbackResponse(retryWithoutPenaltyFallback.Err(errExec), retryWithoutPenaltyFallback, retryWithoutPenaltyUsage); ok {
 				return resp, nil
 			}
 			lastErr = terminalErr
@@ -1775,6 +1777,7 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 	retryWithoutPenaltyCounts := make(map[string]int)
 	retryWithoutPenaltyUsage := cliproxyexecutor.NewUsageAccumulator(coreusage.Detail{})
 	retryWithoutPenaltyHedgeState := &retryWithoutPenaltyHedgeRequestState{}
+	retryWithoutPenaltyFallback := newRetryWithoutPenaltyFallbackCandidate(true)
 	for attempt := 0; ; {
 		attemptOpts := withRetryWithoutPenaltyUsageMetadata(opts, retryWithoutPenaltyUsage)
 		result, errStream := m.executeStreamMixedOnce(ctx, normalized, req, attemptOpts, maxRetryCredentials)
@@ -1785,17 +1788,18 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 		if detail, ok := retryWithoutPenaltyUsageDetail(errStream); ok {
 			retryWithoutPenaltyUsage.Add(detail)
 		}
+		retryWithoutPenaltyFallback.Consider(errStream, retryWithoutPenaltyAuthIDFromError(errStream))
 		if policy, ok := retryWithoutPenaltyHedgePolicyFromError(errStream); ok && policy.enabled && !m.HomeEnabled() {
 			class, remaining, terminalErr, limited := retryWithoutPenaltyRemainingRetries(errStream, retryWithoutPenaltyCounts)
 			if terminalErr != nil {
-				if result, ok := retryWithoutPenaltyFallbackStreamResult(errStream); ok {
+				if result, ok := retryWithoutPenaltyCandidateFallbackStreamResult(retryWithoutPenaltyFallback.Err(errStream), retryWithoutPenaltyFallback, retryWithoutPenaltyUsage); ok {
 					return result, nil
 				}
 				lastErr = terminalErr
 				break
 			}
 			if limited && remaining > 0 {
-				outcome := m.executeStreamRetryWithoutPenaltyHedged(ctx, normalized, req, opts, maxRetryCredentials, class, policy, remaining, retryWithoutPenaltyUsage, retryWithoutPenaltyHedgeState)
+				outcome := m.executeStreamRetryWithoutPenaltyHedged(ctx, normalized, req, opts, maxRetryCredentials, class, policy, remaining, retryWithoutPenaltyUsage, retryWithoutPenaltyHedgeState, retryWithoutPenaltyFallback)
 				if outcome.disableSecondLane {
 					retryWithoutPenaltyHedgeState.secondLaneDisabled = true
 				}
@@ -1814,7 +1818,7 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 				}
 				wait, shouldRetry, terminalErr := m.shouldRetryAfterError(outcome.err, attempt, normalized, req.Model, maxWait, retryWithoutPenaltyCounts)
 				if terminalErr != nil {
-					if result, ok := retryWithoutPenaltyFallbackStreamResult(outcome.err); ok {
+					if result, ok := retryWithoutPenaltyCandidateFallbackStreamResult(retryWithoutPenaltyFallback.Err(outcome.err), retryWithoutPenaltyFallback, retryWithoutPenaltyUsage); ok {
 						return result, nil
 					}
 					lastErr = terminalErr
@@ -1831,7 +1835,7 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 		}
 		wait, shouldRetry, terminalErr := m.shouldRetryAfterError(errStream, attempt, normalized, req.Model, maxWait, retryWithoutPenaltyCounts)
 		if terminalErr != nil {
-			if result, ok := retryWithoutPenaltyFallbackStreamResult(errStream); ok {
+			if result, ok := retryWithoutPenaltyCandidateFallbackStreamResult(retryWithoutPenaltyFallback.Err(errStream), retryWithoutPenaltyFallback, retryWithoutPenaltyUsage); ok {
 				return result, nil
 			}
 			lastErr = terminalErr

--- a/sdk/cliproxy/auth/hedged_retry_without_penalty.go
+++ b/sdk/cliproxy/auth/hedged_retry_without_penalty.go
@@ -158,12 +158,12 @@ func (c *retryWithoutPenaltyHedgeLaneCoordinator) release(laneName string) {
 	delete(c.laneAuth, laneName)
 }
 
-func (m *Manager) executeRetryWithoutPenaltyHedged(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int, class string, policy retryWithoutPenaltyHedgePolicy, remainingRetries int, accumulator *cliproxyexecutor.UsageAccumulator, state *retryWithoutPenaltyHedgeRequestState) retryWithoutPenaltyHedgeOutcome {
+func (m *Manager) executeRetryWithoutPenaltyHedged(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int, class string, policy retryWithoutPenaltyHedgePolicy, remainingRetries int, accumulator *cliproxyexecutor.UsageAccumulator, state *retryWithoutPenaltyHedgeRequestState, fallbackCandidate *retryWithoutPenaltyFallbackCandidate) retryWithoutPenaltyHedgeOutcome {
 	if remainingRetries <= 0 {
 		return retryWithoutPenaltyHedgeOutcome{}
 	}
 	if policy.mode == retryWithoutPenaltyHedgeModeQuality {
-		return m.executeRetryWithoutPenaltyHedgedQuality(ctx, providers, req, opts, maxRetryCredentials, class, policy, remainingRetries, accumulator, state)
+		return m.executeRetryWithoutPenaltyHedgedQuality(ctx, providers, req, opts, maxRetryCredentials, class, policy, remainingRetries, accumulator, state, fallbackCandidate)
 	}
 	attempts := 0
 	reservedAttempts := 0
@@ -263,7 +263,7 @@ func (m *Manager) executeRetryWithoutPenaltyHedged(ctx context.Context, provider
 				return retryWithoutPenaltyHedgeOutcome{err: ctx.Err(), attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
 			case res := <-resultCh:
 				pending--
-				if out, done := processRetryWithoutPenaltyExecuteHedgeResult(res, &attempts, &reservedAttempts, &usageAccounted, &disableSecondLane, &waveHadAbnormal, &waveOrdinaryErr, &lastAbnormalErr, &lastAbnormalAuthID, &lastZeroDispatchErr); done {
+				if out, done := processRetryWithoutPenaltyExecuteHedgeResult(res, &attempts, &reservedAttempts, &usageAccounted, &disableSecondLane, &waveHadAbnormal, &waveOrdinaryErr, &lastAbnormalErr, &lastAbnormalAuthID, &lastZeroDispatchErr, fallbackCandidate); done {
 					if timer != nil {
 						timer.Stop()
 					}
@@ -295,9 +295,9 @@ func (m *Manager) executeRetryWithoutPenaltyHedged(ctx context.Context, provider
 		}
 		if waveHadAbnormal {
 			if attempts >= remainingRetries {
-				out := retryWithoutPenaltyExecuteHedgeExhaustedOutcome(class, lastAbnormalErr, attempts, disableSecondLane, usageAccounted)
+				out := retryWithoutPenaltyExecuteHedgeExhaustedOutcome(class, fallbackCandidate.Err(lastAbnormalErr), attempts, disableSecondLane, usageAccounted, fallbackCandidate, accumulator)
 				if out.err == nil {
-					retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, lastAbnormalAuthID)
+					retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, fallbackCandidate.AuthID(lastAbnormalAuthID))
 				}
 				return out
 			}
@@ -312,9 +312,9 @@ func (m *Manager) executeRetryWithoutPenaltyHedged(ctx context.Context, provider
 	}
 
 	if lastAbnormalErr != nil {
-		out := retryWithoutPenaltyExecuteHedgeExhaustedOutcome(class, lastAbnormalErr, attempts, disableSecondLane, usageAccounted)
+		out := retryWithoutPenaltyExecuteHedgeExhaustedOutcome(class, fallbackCandidate.Err(lastAbnormalErr), attempts, disableSecondLane, usageAccounted, fallbackCandidate, accumulator)
 		if out.err == nil {
-			retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, lastAbnormalAuthID)
+			retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, fallbackCandidate.AuthID(lastAbnormalAuthID))
 		}
 		return out
 	}
@@ -322,12 +322,12 @@ func (m *Manager) executeRetryWithoutPenaltyHedged(ctx context.Context, provider
 	return retryWithoutPenaltyHedgeOutcome{err: err, attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
 }
 
-func (m *Manager) executeStreamRetryWithoutPenaltyHedged(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int, class string, policy retryWithoutPenaltyHedgePolicy, remainingRetries int, accumulator *cliproxyexecutor.UsageAccumulator, state *retryWithoutPenaltyHedgeRequestState) retryWithoutPenaltyHedgeOutcome {
+func (m *Manager) executeStreamRetryWithoutPenaltyHedged(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int, class string, policy retryWithoutPenaltyHedgePolicy, remainingRetries int, accumulator *cliproxyexecutor.UsageAccumulator, state *retryWithoutPenaltyHedgeRequestState, fallbackCandidate *retryWithoutPenaltyFallbackCandidate) retryWithoutPenaltyHedgeOutcome {
 	if remainingRetries <= 0 {
 		return retryWithoutPenaltyHedgeOutcome{}
 	}
 	if policy.mode == retryWithoutPenaltyHedgeModeQuality {
-		return m.executeStreamRetryWithoutPenaltyHedgedQuality(ctx, providers, req, opts, maxRetryCredentials, class, policy, remainingRetries, accumulator, state)
+		return m.executeStreamRetryWithoutPenaltyHedgedQuality(ctx, providers, req, opts, maxRetryCredentials, class, policy, remainingRetries, accumulator, state, fallbackCandidate)
 	}
 	attempts := 0
 	reservedAttempts := 0
@@ -427,7 +427,7 @@ func (m *Manager) executeStreamRetryWithoutPenaltyHedged(ctx context.Context, pr
 				return retryWithoutPenaltyHedgeOutcome{err: ctx.Err(), attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
 			case res := <-resultCh:
 				pending--
-				if out, done := processRetryWithoutPenaltyStreamHedgeResult(res, handles[res.name].cancel, &attempts, &reservedAttempts, &usageAccounted, &disableSecondLane, &waveHadAbnormal, &waveOrdinaryErr, &lastAbnormalErr, &lastAbnormalAuthID, &lastZeroDispatchErr); done {
+				if out, done := processRetryWithoutPenaltyStreamHedgeResult(res, handles[res.name].cancel, &attempts, &reservedAttempts, &usageAccounted, &disableSecondLane, &waveHadAbnormal, &waveOrdinaryErr, &lastAbnormalErr, &lastAbnormalAuthID, &lastZeroDispatchErr, fallbackCandidate); done {
 					if timer != nil {
 						timer.Stop()
 					}
@@ -460,9 +460,9 @@ func (m *Manager) executeStreamRetryWithoutPenaltyHedged(ctx context.Context, pr
 		}
 		if waveHadAbnormal {
 			if attempts >= remainingRetries {
-				out := retryWithoutPenaltyStreamHedgeExhaustedOutcome(class, lastAbnormalErr, attempts, disableSecondLane, usageAccounted)
+				out := retryWithoutPenaltyStreamHedgeExhaustedOutcome(class, fallbackCandidate.Err(lastAbnormalErr), attempts, disableSecondLane, usageAccounted, fallbackCandidate, accumulator)
 				if out.err == nil {
-					retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, lastAbnormalAuthID)
+					retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, fallbackCandidate.AuthID(lastAbnormalAuthID))
 				}
 				return out
 			}
@@ -476,9 +476,9 @@ func (m *Manager) executeStreamRetryWithoutPenaltyHedged(ctx context.Context, pr
 		}
 	}
 	if lastAbnormalErr != nil {
-		out := retryWithoutPenaltyStreamHedgeExhaustedOutcome(class, lastAbnormalErr, attempts, disableSecondLane, usageAccounted)
+		out := retryWithoutPenaltyStreamHedgeExhaustedOutcome(class, fallbackCandidate.Err(lastAbnormalErr), attempts, disableSecondLane, usageAccounted, fallbackCandidate, accumulator)
 		if out.err == nil {
-			retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, lastAbnormalAuthID)
+			retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, fallbackCandidate.AuthID(lastAbnormalAuthID))
 		}
 		return out
 	}
@@ -486,7 +486,7 @@ func (m *Manager) executeStreamRetryWithoutPenaltyHedged(ctx context.Context, pr
 	return retryWithoutPenaltyHedgeOutcome{err: err, attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
 }
 
-func (m *Manager) executeRetryWithoutPenaltyHedgedQuality(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int, class string, policy retryWithoutPenaltyHedgePolicy, remainingRetries int, accumulator *cliproxyexecutor.UsageAccumulator, state *retryWithoutPenaltyHedgeRequestState) retryWithoutPenaltyHedgeOutcome {
+func (m *Manager) executeRetryWithoutPenaltyHedgedQuality(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int, class string, policy retryWithoutPenaltyHedgePolicy, remainingRetries int, accumulator *cliproxyexecutor.UsageAccumulator, state *retryWithoutPenaltyHedgeRequestState, fallbackCandidate *retryWithoutPenaltyFallbackCandidate) retryWithoutPenaltyHedgeOutcome {
 	attempts := 0
 	reservedAttempts := 0
 	usageAccounted := false
@@ -623,12 +623,12 @@ func (m *Manager) executeRetryWithoutPenaltyHedgedQuality(ctx context.Context, p
 			return retryWithoutPenaltyHedgeOutcome{response: resp, attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
 		}
 
-		waveHadAbnormal, waveOrdinaryErr := retryWithoutPenaltySummarizeQualityErrors(results, &lastAbnormalErr, &lastAbnormalAuthID, &lastZeroDispatchErr)
+		waveHadAbnormal, waveOrdinaryErr := retryWithoutPenaltySummarizeQualityErrors(results, &lastAbnormalErr, &lastAbnormalAuthID, &lastZeroDispatchErr, fallbackCandidate)
 		if waveHadAbnormal {
 			if attempts >= remainingRetries {
-				out := retryWithoutPenaltyExecuteHedgeExhaustedOutcome(class, lastAbnormalErr, attempts, disableSecondLane, usageAccounted)
+				out := retryWithoutPenaltyExecuteHedgeExhaustedOutcome(class, fallbackCandidate.Err(lastAbnormalErr), attempts, disableSecondLane, usageAccounted, fallbackCandidate, accumulator)
 				if out.err == nil {
-					retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, lastAbnormalAuthID)
+					retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, fallbackCandidate.AuthID(lastAbnormalAuthID))
 				}
 				return out
 			}
@@ -643,16 +643,16 @@ func (m *Manager) executeRetryWithoutPenaltyHedgedQuality(ctx context.Context, p
 	}
 
 	if lastAbnormalErr != nil {
-		out := retryWithoutPenaltyExecuteHedgeExhaustedOutcome(class, lastAbnormalErr, attempts, disableSecondLane, usageAccounted)
+		out := retryWithoutPenaltyExecuteHedgeExhaustedOutcome(class, fallbackCandidate.Err(lastAbnormalErr), attempts, disableSecondLane, usageAccounted, fallbackCandidate, accumulator)
 		if out.err == nil {
-			retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, lastAbnormalAuthID)
+			retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, fallbackCandidate.AuthID(lastAbnormalAuthID))
 		}
 		return out
 	}
 	return retryWithoutPenaltyHedgeOutcome{err: lastZeroDispatchErr, attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
 }
 
-func (m *Manager) executeStreamRetryWithoutPenaltyHedgedQuality(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int, class string, policy retryWithoutPenaltyHedgePolicy, remainingRetries int, accumulator *cliproxyexecutor.UsageAccumulator, state *retryWithoutPenaltyHedgeRequestState) retryWithoutPenaltyHedgeOutcome {
+func (m *Manager) executeStreamRetryWithoutPenaltyHedgedQuality(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int, class string, policy retryWithoutPenaltyHedgePolicy, remainingRetries int, accumulator *cliproxyexecutor.UsageAccumulator, state *retryWithoutPenaltyHedgeRequestState, fallbackCandidate *retryWithoutPenaltyFallbackCandidate) retryWithoutPenaltyHedgeOutcome {
 	attempts := 0
 	reservedAttempts := 0
 	usageAccounted := false
@@ -799,12 +799,12 @@ func (m *Manager) executeStreamRetryWithoutPenaltyHedgedQuality(ctx context.Cont
 			return retryWithoutPenaltyHedgeOutcome{stream: stream, attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
 		}
 
-		waveHadAbnormal, waveOrdinaryErr := retryWithoutPenaltySummarizeQualityErrors(results, &lastAbnormalErr, &lastAbnormalAuthID, &lastZeroDispatchErr)
+		waveHadAbnormal, waveOrdinaryErr := retryWithoutPenaltySummarizeQualityErrors(results, &lastAbnormalErr, &lastAbnormalAuthID, &lastZeroDispatchErr, fallbackCandidate)
 		if waveHadAbnormal {
 			if attempts >= remainingRetries {
-				out := retryWithoutPenaltyStreamHedgeExhaustedOutcome(class, lastAbnormalErr, attempts, disableSecondLane, usageAccounted)
+				out := retryWithoutPenaltyStreamHedgeExhaustedOutcome(class, fallbackCandidate.Err(lastAbnormalErr), attempts, disableSecondLane, usageAccounted, fallbackCandidate, accumulator)
 				if out.err == nil {
-					retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, lastAbnormalAuthID)
+					retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, fallbackCandidate.AuthID(lastAbnormalAuthID))
 				}
 				return out
 			}
@@ -819,16 +819,16 @@ func (m *Manager) executeStreamRetryWithoutPenaltyHedgedQuality(ctx context.Cont
 	}
 
 	if lastAbnormalErr != nil {
-		out := retryWithoutPenaltyStreamHedgeExhaustedOutcome(class, lastAbnormalErr, attempts, disableSecondLane, usageAccounted)
+		out := retryWithoutPenaltyStreamHedgeExhaustedOutcome(class, fallbackCandidate.Err(lastAbnormalErr), attempts, disableSecondLane, usageAccounted, fallbackCandidate, accumulator)
 		if out.err == nil {
-			retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, lastAbnormalAuthID)
+			retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, fallbackCandidate.AuthID(lastAbnormalAuthID))
 		}
 		return out
 	}
 	return retryWithoutPenaltyHedgeOutcome{err: lastZeroDispatchErr, attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
 }
 
-func processRetryWithoutPenaltyExecuteHedgeResult(res retryWithoutPenaltyHedgeLaneResult, attempts *int, reservedAttempts *int, usageAccounted *bool, disableSecondLane *bool, waveHadAbnormal *bool, waveOrdinaryErr *error, lastAbnormalErr *error, lastAbnormalAuthID *string, lastZeroDispatchErr *error) (retryWithoutPenaltyHedgeOutcome, bool) {
+func processRetryWithoutPenaltyExecuteHedgeResult(res retryWithoutPenaltyHedgeLaneResult, attempts *int, reservedAttempts *int, usageAccounted *bool, disableSecondLane *bool, waveHadAbnormal *bool, waveOrdinaryErr *error, lastAbnormalErr *error, lastAbnormalAuthID *string, lastZeroDispatchErr *error, fallbackCandidate *retryWithoutPenaltyFallbackCandidate) (retryWithoutPenaltyHedgeOutcome, bool) {
 	if res.dispatched {
 		(*attempts)++
 	} else if res.name == "secondary" {
@@ -846,6 +846,7 @@ func processRetryWithoutPenaltyExecuteHedgeResult(res retryWithoutPenaltyHedgeLa
 	if res.dispatched {
 		if isRetryWithoutPenaltyError(res.err) {
 			*waveHadAbnormal = true
+			fallbackCandidate.Consider(res.err, res.authID)
 			*lastAbnormalErr = res.err
 			if lastAbnormalAuthID != nil {
 				*lastAbnormalAuthID = res.authID
@@ -859,7 +860,7 @@ func processRetryWithoutPenaltyExecuteHedgeResult(res retryWithoutPenaltyHedgeLa
 	return retryWithoutPenaltyHedgeOutcome{}, false
 }
 
-func processRetryWithoutPenaltyStreamHedgeResult(res retryWithoutPenaltyHedgeLaneResult, winnerCancel context.CancelFunc, attempts *int, reservedAttempts *int, usageAccounted *bool, disableSecondLane *bool, waveHadAbnormal *bool, waveOrdinaryErr *error, lastAbnormalErr *error, lastAbnormalAuthID *string, lastZeroDispatchErr *error) (retryWithoutPenaltyHedgeOutcome, bool) {
+func processRetryWithoutPenaltyStreamHedgeResult(res retryWithoutPenaltyHedgeLaneResult, winnerCancel context.CancelFunc, attempts *int, reservedAttempts *int, usageAccounted *bool, disableSecondLane *bool, waveHadAbnormal *bool, waveOrdinaryErr *error, lastAbnormalErr *error, lastAbnormalAuthID *string, lastZeroDispatchErr *error, fallbackCandidate *retryWithoutPenaltyFallbackCandidate) (retryWithoutPenaltyHedgeOutcome, bool) {
 	if res.dispatched {
 		(*attempts)++
 	} else if res.name == "secondary" {
@@ -877,6 +878,7 @@ func processRetryWithoutPenaltyStreamHedgeResult(res retryWithoutPenaltyHedgeLan
 	if res.dispatched {
 		if isRetryWithoutPenaltyError(res.err) {
 			*waveHadAbnormal = true
+			fallbackCandidate.Consider(res.err, res.authID)
 			*lastAbnormalErr = res.err
 			if lastAbnormalAuthID != nil {
 				*lastAbnormalAuthID = res.authID
@@ -890,15 +892,15 @@ func processRetryWithoutPenaltyStreamHedgeResult(res retryWithoutPenaltyHedgeLan
 	return retryWithoutPenaltyHedgeOutcome{}, false
 }
 
-func retryWithoutPenaltyExecuteHedgeExhaustedOutcome(class string, err error, attempts int, disableSecondLane bool, usageAccounted bool) retryWithoutPenaltyHedgeOutcome {
-	if resp, ok := retryWithoutPenaltyFallbackResponse(err); ok {
+func retryWithoutPenaltyExecuteHedgeExhaustedOutcome(class string, err error, attempts int, disableSecondLane bool, usageAccounted bool, fallbackCandidate *retryWithoutPenaltyFallbackCandidate, accumulator *cliproxyexecutor.UsageAccumulator) retryWithoutPenaltyHedgeOutcome {
+	if resp, ok := retryWithoutPenaltyCandidateFallbackResponse(err, fallbackCandidate, accumulator); ok {
 		return retryWithoutPenaltyHedgeOutcome{response: resp, attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
 	}
 	return retryWithoutPenaltyHedgeOutcome{err: newRetryWithoutPenaltyExhaustedError(err, class), attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
 }
 
-func retryWithoutPenaltyStreamHedgeExhaustedOutcome(class string, err error, attempts int, disableSecondLane bool, usageAccounted bool) retryWithoutPenaltyHedgeOutcome {
-	if stream, ok := retryWithoutPenaltyFallbackStreamResult(err); ok {
+func retryWithoutPenaltyStreamHedgeExhaustedOutcome(class string, err error, attempts int, disableSecondLane bool, usageAccounted bool, fallbackCandidate *retryWithoutPenaltyFallbackCandidate, accumulator *cliproxyexecutor.UsageAccumulator) retryWithoutPenaltyHedgeOutcome {
+	if stream, ok := retryWithoutPenaltyCandidateFallbackStreamResult(err, fallbackCandidate, accumulator); ok {
 		return retryWithoutPenaltyHedgeOutcome{stream: stream, attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
 	}
 	return retryWithoutPenaltyHedgeOutcome{err: newRetryWithoutPenaltyExhaustedError(err, class), attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
@@ -1018,7 +1020,7 @@ func retryWithoutPenaltyAddQualityStreamLosers(results []retryWithoutPenaltyHedg
 	return accounted
 }
 
-func retryWithoutPenaltySummarizeQualityErrors(results []retryWithoutPenaltyHedgeLaneResult, lastAbnormalErr *error, lastAbnormalAuthID *string, lastZeroDispatchErr *error) (bool, error) {
+func retryWithoutPenaltySummarizeQualityErrors(results []retryWithoutPenaltyHedgeLaneResult, lastAbnormalErr *error, lastAbnormalAuthID *string, lastZeroDispatchErr *error, fallbackCandidate *retryWithoutPenaltyFallbackCandidate) (bool, error) {
 	waveHadAbnormal := false
 	var waveOrdinaryErr error
 	for _, res := range results {
@@ -1028,6 +1030,7 @@ func retryWithoutPenaltySummarizeQualityErrors(results []retryWithoutPenaltyHedg
 		if res.dispatched {
 			if isRetryWithoutPenaltyError(res.err) {
 				waveHadAbnormal = true
+				fallbackCandidate.Consider(res.err, res.authID)
 				if lastAbnormalErr != nil {
 					*lastAbnormalErr = res.err
 				}

--- a/sdk/cliproxy/auth/hedged_retry_without_penalty_test.go
+++ b/sdk/cliproxy/auth/hedged_retry_without_penalty_test.go
@@ -21,6 +21,7 @@ type hedgedRetryTestError struct {
 	hedgeDelay         time.Duration
 	requireDistinct    bool
 	authID             string
+	usage              coreusage.Detail
 	exhaustedBehavior  string
 	fallbackPayload    []byte
 	fallbackStreamData []cliproxyexecutor.StreamChunk
@@ -59,6 +60,9 @@ func (e hedgedRetryTestError) RetryWithoutPenaltyAuthID() string {
 }
 
 func (e hedgedRetryTestError) RetryWithoutPenaltyUsageDetail() coreusage.Detail {
+	if hasRetryWithoutPenaltyUsageDetail(e.usage) {
+		return e.usage
+	}
 	return coreusage.Detail{InputTokens: 1, OutputTokens: 2, ReasoningTokens: 516, TotalTokens: 3}
 }
 
@@ -202,7 +206,7 @@ func (e *hedgedRetryTestExecutor) Execute(ctx context.Context, auth *Auth, _ cli
 	}
 	switch behavior.kind {
 	case "retry":
-		return cliproxyexecutor.Response{}, e.retryError(authID)
+		return cliproxyexecutor.Response{}, e.retryError(authID, behavior)
 	case "rate_limit":
 		return cliproxyexecutor.Response{}, hedgedRetryRateLimitError{retryAfter: time.Millisecond}
 	case "wait_cancel":
@@ -228,7 +232,7 @@ func (e *hedgedRetryTestExecutor) ExecuteStream(ctx context.Context, auth *Auth,
 	ch := make(chan cliproxyexecutor.StreamChunk, 1)
 	switch behavior.kind {
 	case "retry":
-		ch <- cliproxyexecutor.StreamChunk{Err: e.retryError(authID)}
+		ch <- cliproxyexecutor.StreamChunk{Err: e.retryError(authID, behavior)}
 	case "rate_limit":
 		return nil, hedgedRetryRateLimitError{retryAfter: time.Millisecond}
 	case "wait_cancel":
@@ -344,7 +348,19 @@ func (e *hedgedRetryTestExecutor) wait(ctx context.Context, behavior hedgedRetry
 	}
 }
 
-func (e *hedgedRetryTestExecutor) retryError(authID string) error {
+func (e *hedgedRetryTestExecutor) retryError(authID string, behavior hedgedRetryBehavior) error {
+	usageDetail := behavior.usage
+	if !hasRetryWithoutPenaltyUsageDetail(usageDetail) {
+		usageDetail = coreusage.Detail{InputTokens: 1, OutputTokens: 2, ReasoningTokens: 516, TotalTokens: 3}
+	}
+	fallbackPayload := e.fallbackPayload
+	if behavior.payload != "" {
+		fallbackPayload = []byte(behavior.payload)
+	}
+	fallbackStreamData := e.fallbackStreamData
+	if behavior.payload != "" {
+		fallbackStreamData = []cliproxyexecutor.StreamChunk{{Payload: []byte(behavior.payload)}}
+	}
 	return hedgedRetryTestError{
 		maxRetries:         e.maxRetries,
 		hedgeEnabled:       !e.disableHedge,
@@ -352,9 +368,10 @@ func (e *hedgedRetryTestExecutor) retryError(authID string) error {
 		hedgeDelay:         e.hedgeDelay,
 		requireDistinct:    e.requireDistinct,
 		authID:             authID,
+		usage:              usageDetail,
 		exhaustedBehavior:  e.exhaustedBehavior,
-		fallbackPayload:    e.fallbackPayload,
-		fallbackStreamData: e.fallbackStreamData,
+		fallbackPayload:    fallbackPayload,
+		fallbackStreamData: fallbackStreamData,
 	}
 }
 
@@ -383,6 +400,21 @@ func (e *hedgedRetryTestExecutor) streamCallCount() int {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	return len(e.streamCalls)
+}
+
+func collectHedgedRetryStreamPayload(t *testing.T, result *cliproxyexecutor.StreamResult) []byte {
+	t.Helper()
+	if result == nil {
+		t.Fatal("stream result = nil")
+	}
+	var payload []byte
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v, want nil", chunk.Err)
+		}
+		payload = append(payload, chunk.Payload...)
+	}
+	return payload
 }
 
 func newHedgedRetryTestManager(t *testing.T, executor *hedgedRetryTestExecutor, authIDs ...string) (*Manager, []string) {
@@ -612,6 +644,161 @@ func TestManagerExecute_HedgedRetryPassThroughAfterDoubleAbnormal(t *testing.T) 
 	}
 }
 
+func TestManagerExecute_RetryWithoutPenaltyPassThroughReturnsLongestSerialAbnormal(t *testing.T) {
+	executor := &hedgedRetryTestExecutor{
+		behaviors: map[string][]hedgedRetryBehavior{
+			"auth-a": {
+				{kind: "retry", payload: "trigger", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 5, ReasoningTokens: 516, TotalTokens: 6}},
+				{kind: "retry", payload: "long", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 80, ReasoningTokens: 516, TotalTokens: 81}},
+				{kind: "retry", payload: "short", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 20, ReasoningTokens: 516, TotalTokens: 21}},
+			},
+		},
+		maxRetries:        2,
+		disableHedge:      true,
+		exhaustedBehavior: retryWithoutPenaltyExhaustedBehaviorPassThrough,
+	}
+	manager, _ := newHedgedRetryTestManager(t, executor, "auth-a")
+	manager.SetRetryConfig(0, 0, 0)
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5.5"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute error = %v, want nil pass-through", err)
+	}
+	if string(resp.Payload) != "long" {
+		t.Fatalf("payload = %q, want longest serial abnormal fallback", resp.Payload)
+	}
+}
+
+func TestManagerExecute_HedgedRetrySpeedPassThroughReturnsLongestAbnormal(t *testing.T) {
+	executor := &hedgedRetryTestExecutor{
+		behaviors: map[string][]hedgedRetryBehavior{
+			"auth-a": {
+				{kind: "retry", payload: "trigger", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 5, ReasoningTokens: 516, TotalTokens: 6}},
+				{kind: "retry", payload: "short", delay: 5 * time.Millisecond, usage: coreusage.Detail{InputTokens: 1, OutputTokens: 20, ReasoningTokens: 516, TotalTokens: 21}},
+			},
+			"auth-b": {
+				{kind: "retry", payload: "long", delay: 25 * time.Millisecond, usage: coreusage.Detail{InputTokens: 1, OutputTokens: 80, ReasoningTokens: 516, TotalTokens: 81}},
+			},
+		},
+		maxRetries:        2,
+		hedgeDelay:        0,
+		requireDistinct:   false,
+		exhaustedBehavior: retryWithoutPenaltyExhaustedBehaviorPassThrough,
+	}
+	manager, _ := newHedgedRetryTestManager(t, executor, "auth-a", "auth-b")
+	manager.SetRetryConfig(0, 0, 0)
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5.5"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute error = %v, want nil pass-through", err)
+	}
+	if string(resp.Payload) != "long" {
+		t.Fatalf("payload = %q, want longest speed hedge abnormal fallback", resp.Payload)
+	}
+}
+
+func TestManagerExecute_HedgedRetryQualityPassThroughReturnsLongestAbnormal(t *testing.T) {
+	executor := &hedgedRetryTestExecutor{
+		behaviors: map[string][]hedgedRetryBehavior{
+			"auth-a": {
+				{kind: "retry", payload: "trigger", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 5, ReasoningTokens: 516, TotalTokens: 6}},
+				{kind: "retry", payload: "short", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 20, ReasoningTokens: 516, TotalTokens: 21}},
+			},
+			"auth-b": {
+				{kind: "retry", payload: "long", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 80, ReasoningTokens: 516, TotalTokens: 81}},
+			},
+		},
+		maxRetries:        2,
+		hedgeMode:         retryWithoutPenaltyHedgeModeQuality,
+		hedgeDelay:        0,
+		requireDistinct:   false,
+		exhaustedBehavior: retryWithoutPenaltyExhaustedBehaviorPassThrough,
+	}
+	manager, _ := newHedgedRetryTestManager(t, executor, "auth-a", "auth-b")
+	manager.SetRetryConfig(0, 0, 0)
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5.5"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute error = %v, want nil pass-through", err)
+	}
+	if string(resp.Payload) != "long" {
+		t.Fatalf("payload = %q, want longest quality hedge abnormal fallback", resp.Payload)
+	}
+}
+
+func TestManagerExecute_HedgedRetryPassThroughIgnoresOrdinaryErrors(t *testing.T) {
+	executor := &hedgedRetryTestExecutor{
+		behaviors: map[string][]hedgedRetryBehavior{
+			"auth-a": {
+				{kind: "retry", payload: "trigger", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 5, ReasoningTokens: 516, TotalTokens: 6}},
+				{kind: "rate_limit"},
+			},
+			"auth-b": {
+				{kind: "retry", payload: "abnormal", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 50, ReasoningTokens: 516, TotalTokens: 51}},
+			},
+		},
+		maxRetries:        2,
+		hedgeMode:         retryWithoutPenaltyHedgeModeQuality,
+		hedgeDelay:        0,
+		requireDistinct:   false,
+		exhaustedBehavior: retryWithoutPenaltyExhaustedBehaviorPassThrough,
+	}
+	manager, _ := newHedgedRetryTestManager(t, executor, "auth-a", "auth-b")
+	manager.SetRetryConfig(0, 0, 1)
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5.5"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute error = %v, want abnormal pass-through", err)
+	}
+	if string(resp.Payload) != "abnormal" {
+		t.Fatalf("payload = %q, want abnormal fallback rather than ordinary error", resp.Payload)
+	}
+}
+
+func TestManagerExecute_HedgedRetryPassThroughTieKeepsFirstCompletedAbnormal(t *testing.T) {
+	executor := &hedgedRetryTestExecutor{
+		behaviors: map[string][]hedgedRetryBehavior{
+			"auth-a": {
+				{kind: "retry", payload: "trigger", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 5, ReasoningTokens: 516, TotalTokens: 6}},
+				{kind: "retry", payload: "tie-second", delay: 25 * time.Millisecond, usage: coreusage.Detail{InputTokens: 1, OutputTokens: 50, ReasoningTokens: 516, TotalTokens: 51}},
+			},
+			"auth-b": {
+				{kind: "retry", payload: "tie-first", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 50, ReasoningTokens: 516, TotalTokens: 51}},
+			},
+		},
+		maxRetries:        2,
+		hedgeDelay:        0,
+		requireDistinct:   false,
+		exhaustedBehavior: retryWithoutPenaltyExhaustedBehaviorPassThrough,
+	}
+	manager, _ := newHedgedRetryTestManager(t, executor, "auth-a", "auth-b")
+	manager.SetRetryConfig(0, 0, 0)
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5.5"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute error = %v, want nil pass-through", err)
+	}
+	if string(resp.Payload) != "tie-first" {
+		t.Fatalf("payload = %q, want first completed tied abnormal fallback", resp.Payload)
+	}
+}
+
+func TestManagerExecute_HedgedRetryErrorExhaustedIgnoresFallbackCandidate(t *testing.T) {
+	executor := &hedgedRetryTestExecutor{
+		behaviors: map[string][]hedgedRetryBehavior{
+			"auth-a": {{kind: "retry", payload: "abnormal", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 80, ReasoningTokens: 516, TotalTokens: 81}}},
+		},
+		maxRetries:      0,
+		disableHedge:    true,
+		requireDistinct: false,
+	}
+	manager, _ := newHedgedRetryTestManager(t, executor, "auth-a")
+	manager.SetRetryConfig(0, 0, 0)
+
+	_, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5.5"}, cliproxyexecutor.Options{})
+	assertRetryWithoutPenaltyExhausted(t, err, "codex_abnormal_reasoning_retry_exhausted")
+}
+
 func TestManagerExecute_HedgedRetryWinnerSeesTriggerAndPrimaryAbnormalUsage(t *testing.T) {
 	executor := &hedgedRetryTestExecutor{
 		behaviors: map[string][]hedgedRetryBehavior{
@@ -807,6 +994,91 @@ func TestManagerExecuteStream_HedgedRetryQualityReplaysWinnerOnly(t *testing.T) 
 	}
 	if string(payload) != "big-stream|fold:526|discarded:16" {
 		t.Fatalf("payload = %q, want finalized big stream winner only", payload)
+	}
+}
+
+func TestManagerExecuteStream_RetryWithoutPenaltyPassThroughReturnsLongestSerialAbnormal(t *testing.T) {
+	executor := &hedgedRetryTestExecutor{
+		streamBehaviors: map[string][]hedgedRetryBehavior{
+			"auth-a": {
+				{kind: "retry", payload: "trigger-stream", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 5, ReasoningTokens: 516, TotalTokens: 6}},
+				{kind: "retry", payload: "long-stream", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 80, ReasoningTokens: 516, TotalTokens: 81}},
+				{kind: "retry", payload: "short-stream", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 20, ReasoningTokens: 516, TotalTokens: 21}},
+			},
+		},
+		maxRetries:        2,
+		disableHedge:      true,
+		exhaustedBehavior: retryWithoutPenaltyExhaustedBehaviorPassThrough,
+	}
+	manager, _ := newHedgedRetryTestManager(t, executor, "auth-a")
+	manager.SetRetryConfig(0, 0, 0)
+
+	result, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5.5"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("ExecuteStream error = %v, want nil pass-through", err)
+	}
+	payload := collectHedgedRetryStreamPayload(t, result)
+	if string(payload) != "long-stream" {
+		t.Fatalf("payload = %q, want longest serial abnormal stream", payload)
+	}
+}
+
+func TestManagerExecuteStream_HedgedRetrySpeedPassThroughReturnsLongestAbnormal(t *testing.T) {
+	executor := &hedgedRetryTestExecutor{
+		streamBehaviors: map[string][]hedgedRetryBehavior{
+			"auth-a": {
+				{kind: "retry", payload: "trigger-stream", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 5, ReasoningTokens: 516, TotalTokens: 6}},
+				{kind: "retry", payload: "short-stream", delay: 5 * time.Millisecond, usage: coreusage.Detail{InputTokens: 1, OutputTokens: 20, ReasoningTokens: 516, TotalTokens: 21}},
+			},
+			"auth-b": {
+				{kind: "retry", payload: "long-stream", delay: 25 * time.Millisecond, usage: coreusage.Detail{InputTokens: 1, OutputTokens: 80, ReasoningTokens: 516, TotalTokens: 81}},
+			},
+		},
+		maxRetries:        2,
+		hedgeDelay:        0,
+		requireDistinct:   false,
+		exhaustedBehavior: retryWithoutPenaltyExhaustedBehaviorPassThrough,
+	}
+	manager, _ := newHedgedRetryTestManager(t, executor, "auth-a", "auth-b")
+	manager.SetRetryConfig(0, 0, 0)
+
+	result, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5.5"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("ExecuteStream error = %v, want nil pass-through", err)
+	}
+	payload := collectHedgedRetryStreamPayload(t, result)
+	if string(payload) != "long-stream" {
+		t.Fatalf("payload = %q, want longest speed hedge abnormal stream", payload)
+	}
+}
+
+func TestManagerExecuteStream_HedgedRetryQualityPassThroughReturnsLongestAbnormal(t *testing.T) {
+	executor := &hedgedRetryTestExecutor{
+		streamBehaviors: map[string][]hedgedRetryBehavior{
+			"auth-a": {
+				{kind: "retry", payload: "trigger-stream", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 5, ReasoningTokens: 516, TotalTokens: 6}},
+				{kind: "retry", payload: "short-stream", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 20, ReasoningTokens: 516, TotalTokens: 21}},
+			},
+			"auth-b": {
+				{kind: "retry", payload: "long-stream", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 80, ReasoningTokens: 516, TotalTokens: 81}},
+			},
+		},
+		maxRetries:        2,
+		hedgeMode:         retryWithoutPenaltyHedgeModeQuality,
+		hedgeDelay:        0,
+		requireDistinct:   false,
+		exhaustedBehavior: retryWithoutPenaltyExhaustedBehaviorPassThrough,
+	}
+	manager, _ := newHedgedRetryTestManager(t, executor, "auth-a", "auth-b")
+	manager.SetRetryConfig(0, 0, 0)
+
+	result, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5.5"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("ExecuteStream error = %v, want nil pass-through", err)
+	}
+	payload := collectHedgedRetryStreamPayload(t, result)
+	if string(payload) != "long-stream" {
+		t.Fatalf("payload = %q, want longest quality hedge abnormal stream", payload)
 	}
 }
 

--- a/sdk/cliproxy/auth/retry_without_penalty.go
+++ b/sdk/cliproxy/auth/retry_without_penalty.go
@@ -92,6 +92,19 @@ func retryWithoutPenaltyUsageDetail(err error) (coreusage.Detail, bool) {
 	return detail, hasRetryWithoutPenaltyUsageDetail(detail)
 }
 
+func retryWithoutPenaltyAuthIDFromError(err error) string {
+	if err == nil {
+		return ""
+	}
+	var withAuthID interface {
+		RetryWithoutPenaltyAuthID() string
+	}
+	if !errors.As(err, &withAuthID) {
+		return ""
+	}
+	return strings.TrimSpace(withAuthID.RetryWithoutPenaltyAuthID())
+}
+
 func retryWithoutPenaltyExhaustedBehavior(err error) string {
 	if err == nil {
 		return retryWithoutPenaltyExhaustedBehaviorError
@@ -111,6 +124,105 @@ type retryWithoutPenaltyHedgePolicy struct {
 	hedgeDelay          time.Duration
 	requireDistinctAuth bool
 	triggerAuthID       string
+}
+
+type retryWithoutPenaltyFallbackCandidate struct {
+	stream bool
+	set    bool
+	err    error
+	authID string
+	score  int64
+	detail coreusage.Detail
+}
+
+func newRetryWithoutPenaltyFallbackCandidate(stream bool) *retryWithoutPenaltyFallbackCandidate {
+	return &retryWithoutPenaltyFallbackCandidate{stream: stream}
+}
+
+func (c *retryWithoutPenaltyFallbackCandidate) Consider(err error, authID string) {
+	if c == nil || err == nil || !isRetryWithoutPenaltyError(err) {
+		return
+	}
+	if retryWithoutPenaltyExhaustedBehavior(err) != retryWithoutPenaltyExhaustedBehaviorPassThrough {
+		return
+	}
+	if c.stream {
+		if _, ok := retryWithoutPenaltyFallbackStreamResult(err); !ok {
+			return
+		}
+	} else if _, ok := retryWithoutPenaltyFallbackResponse(err); !ok {
+		return
+	}
+	detail, _ := retryWithoutPenaltyUsageDetail(err)
+	score := detail.OutputTokens
+	if c.set && score <= c.score {
+		return
+	}
+	c.set = true
+	c.err = err
+	c.authID = strings.TrimSpace(authID)
+	c.score = score
+	c.detail = detail
+}
+
+func (c *retryWithoutPenaltyFallbackCandidate) Err(fallback error) error {
+	if c != nil && c.set && c.err != nil {
+		return c.err
+	}
+	return fallback
+}
+
+func (c *retryWithoutPenaltyFallbackCandidate) AuthID(fallback string) string {
+	if c != nil && c.set && c.authID != "" {
+		return c.authID
+	}
+	return fallback
+}
+
+func (c *retryWithoutPenaltyFallbackCandidate) PreviousUsageSnapshot(accumulator *cliproxyexecutor.UsageAccumulator) cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot {
+	if accumulator == nil {
+		return cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot{}
+	}
+	snapshot := accumulator.RetryWithoutPenaltySnapshot()
+	if c == nil || !c.set || !hasRetryWithoutPenaltyUsageDetail(c.detail) {
+		return snapshot
+	}
+	selected := normalizeRetryWithoutPenaltyUsageDetail(c.detail)
+	snapshot.Detail = subtractRetryWithoutPenaltyUsageDetail(snapshot.Detail, selected)
+	snapshot.FoldedOutputTokens -= foldedRetryWithoutPenaltyUsageOutputTokens(selected)
+	if snapshot.FoldedOutputTokens < 0 {
+		snapshot.FoldedOutputTokens = 0
+	}
+	return snapshot
+}
+
+func subtractRetryWithoutPenaltyUsageDetail(total, selected coreusage.Detail) coreusage.Detail {
+	total = normalizeRetryWithoutPenaltyUsageDetail(total)
+	selected = normalizeRetryWithoutPenaltyUsageDetail(selected)
+	return coreusage.Detail{
+		InputTokens:         subtractRetryWithoutPenaltyInt64(total.InputTokens, selected.InputTokens),
+		OutputTokens:        subtractRetryWithoutPenaltyInt64(total.OutputTokens, selected.OutputTokens),
+		ReasoningTokens:     subtractRetryWithoutPenaltyInt64(total.ReasoningTokens, selected.ReasoningTokens),
+		CachedTokens:        subtractRetryWithoutPenaltyInt64(total.CachedTokens, selected.CachedTokens),
+		CacheReadTokens:     subtractRetryWithoutPenaltyInt64(total.CacheReadTokens, selected.CacheReadTokens),
+		CacheCreationTokens: subtractRetryWithoutPenaltyInt64(total.CacheCreationTokens, selected.CacheCreationTokens),
+		TotalTokens:         subtractRetryWithoutPenaltyInt64(total.TotalTokens, selected.TotalTokens),
+	}
+}
+
+func subtractRetryWithoutPenaltyInt64(total, selected int64) int64 {
+	if total <= selected {
+		return 0
+	}
+	return total - selected
+}
+
+func foldedRetryWithoutPenaltyUsageOutputTokens(detail coreusage.Detail) int64 {
+	detail = normalizeRetryWithoutPenaltyUsageDetail(detail)
+	if detail.OutputTokens >= detail.ReasoningTokens {
+		return detail.OutputTokens
+	}
+	return detail.ReasoningTokens
 }
 
 func retryWithoutPenaltyHedgePolicyFromError(err error) (retryWithoutPenaltyHedgePolicy, bool) {
@@ -183,6 +295,18 @@ func retryWithoutPenaltyFallbackResponse(err error) (cliproxyexecutor.Response, 
 	return cloneRetryWithoutPenaltyResponse(resp), true
 }
 
+func retryWithoutPenaltyCandidateFallbackResponse(err error, candidate *retryWithoutPenaltyFallbackCandidate, accumulator *cliproxyexecutor.UsageAccumulator) (cliproxyexecutor.Response, bool) {
+	resp, ok := retryWithoutPenaltyFallbackResponse(err)
+	if !ok {
+		return cliproxyexecutor.Response{}, false
+	}
+	finalizer, _ := resp.Metadata[cliproxyexecutor.RetryWithoutPenaltyResponseFinalizerMetadataKey].(cliproxyexecutor.RetryWithoutPenaltyResponseFinalizer)
+	if finalizer == nil {
+		return resp, true
+	}
+	return finalizer(resp, candidate.PreviousUsageSnapshot(accumulator)), true
+}
+
 func retryWithoutPenaltyFallbackStreamResult(err error) (*cliproxyexecutor.StreamResult, bool) {
 	if retryWithoutPenaltyExhaustedBehavior(err) != retryWithoutPenaltyExhaustedBehaviorPassThrough {
 		return nil, false
@@ -196,6 +320,43 @@ func retryWithoutPenaltyFallbackStreamResult(err error) (*cliproxyexecutor.Strea
 	headers, chunks, ok := withFallback.RetryWithoutPenaltyFallbackStreamChunks()
 	if !ok || len(chunks) == 0 {
 		return nil, false
+	}
+	out := make(chan cliproxyexecutor.StreamChunk, len(chunks))
+	for i := range chunks {
+		chunk := chunks[i]
+		chunk.Payload = bytes.Clone(chunk.Payload)
+		out <- chunk
+	}
+	close(out)
+	return &cliproxyexecutor.StreamResult{
+		Headers: cloneRetryWithoutPenaltyHeader(headers),
+		Chunks:  out,
+	}, true
+}
+
+func retryWithoutPenaltyCandidateFallbackStreamResult(err error, candidate *retryWithoutPenaltyFallbackCandidate, accumulator *cliproxyexecutor.UsageAccumulator) (*cliproxyexecutor.StreamResult, bool) {
+	if retryWithoutPenaltyExhaustedBehavior(err) != retryWithoutPenaltyExhaustedBehaviorPassThrough {
+		return nil, false
+	}
+	var withFallback interface {
+		RetryWithoutPenaltyFallbackStreamChunks() (http.Header, []cliproxyexecutor.StreamChunk, bool)
+	}
+	if !errors.As(err, &withFallback) {
+		return nil, false
+	}
+	headers, chunks, ok := withFallback.RetryWithoutPenaltyFallbackStreamChunks()
+	if !ok || len(chunks) == 0 {
+		return nil, false
+	}
+	var withFinalizer interface {
+		RetryWithoutPenaltyFallbackStreamFinalizer() cliproxyexecutor.RetryWithoutPenaltyStreamFinalizer
+	}
+	if errors.As(err, &withFinalizer) {
+		if finalizer := withFinalizer.RetryWithoutPenaltyFallbackStreamFinalizer(); finalizer != nil {
+			if result := finalizer(headers, chunks, candidate.PreviousUsageSnapshot(accumulator)); result != nil {
+				return result, true
+			}
+		}
 	}
 	out := make(chan cliproxyexecutor.StreamChunk, len(chunks))
 	for i := range chunks {


### PR DESCRIPTION
## Summary
- Change `codex.abnormal-reasoning-retry.hedged-retry.mode` default and invalid-value normalization from `speed` to `quality`; explicit `speed` and `quality` remain supported.
- Keep `hedged-retry.enabled` default unchanged (`false`) and keep `hedge-delay-ms` default unchanged (`1000`); quality users still need `hedge-delay-ms: 0` to always dispatch two lanes for comparison.
- When abnormal retry budget is exhausted with `exhausted-behavior: pass-through`, return the abnormal fallback with the largest `RetryWithoutPenaltyUsageDetail().OutputTokens` across the request-local retry chain; ties keep the first completed candidate.
- Apply longest pass-through to serial retry, `speed` hedge, `quality` hedge, non-stream, and stream paths.

## Behavior Notes
- `exhausted-behavior: error` is unchanged and still returns `codex_abnormal_reasoning_retry_exhausted` / 502.
- `max-retries` still counts dispatched retry lanes, not waves. With quality hedge, `max-retries: 2` allows one two-lane wave; use `max-retries: 4` for two full two-lane waves.
- Ordinary errors do not participate in longest pass-through candidate selection.
- Management usage remains per-attempt and unchanged; the longest fallback choice only affects the final client-visible pass-through payload.
- Client-visible fallback usage is finalized with the request-local accumulator minus the selected delivered fallback, preserving existing `reasoning-fold` / `sum` aggregation semantics and keeping `reasoning_tokens <= output_tokens` for folded Codex payloads.

## Config / Contract
- `codex.abnormal-reasoning-retry.hedged-retry.mode` default: `quality`.
- Explicit `mode: "speed"`: preserved as first-success-wins mode.
- Explicit `mode: "quality"`: waits for dispatched lanes and selects the largest successful `output_tokens` winner.
- Invalid / empty `mode`: normalized to `quality`.
- Updated `config.example.yaml`, watcher diff tests, LTS feature contract markers, and `scripts/check-lts-contract.sh`.
- `CPA-Panel-LTS` visual config surface should be checked separately so labels/default hints match the new Core default; Core runtime behavior does not depend on Panel.

## Protected Delta Review
- Request lifecycle: only the abnormal-reasoning retry-without-penalty path changes after the guard has already fired; normal requests are not double-dispatched and hedge remains disabled by default.
- Token accounting: Management per-attempt usage is unchanged. Client final pass-through usage is re-finalized from the selected fallback plus discarded-attempt accumulator.
- Management usage response shape: unchanged.
- Config hot reload: effective config normalization changes empty/invalid `hedged-retry.mode` to `quality`; watcher diff still reports explicit `speed -> quality` changes.
- Panel contract impact: config key is unchanged, but Panel copy/default display should be synchronized in a separate Panel PR if needed.

## Validation
- `go test ./internal/config` passed.
- `go test ./internal/watcher/diff` passed.
- `go test -count=1 ./sdk/cliproxy/auth` passed.
- `go test -race -count=1 ./sdk/cliproxy/auth` passed.
- `go test ./internal/runtime/executor` passed.
- `go test -race -count=1 ./internal/runtime/executor -run 'CodexExecutorAbnormalReasoningRetry|CodexAbnormalReasoningRetry'` passed.
- `scripts/check-lts-contract.sh` passed.
- `go build -o test-output ./cmd/server && rm -f test-output` passed.
- `git diff --check` passed.
- `go test ./...` passed.

No tag, release, HFS deploy, Docker publish, or merge was performed.
