### PR TITLE
拆分 Codex abnormal retry client usage 聚合模式

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -195,11 +195,14 @@ codex:
     # This limit is independent of the global request-retry setting.
     # Set to 0 to record the abnormal attempt as failed usage and apply exhausted-behavior immediately.
     # exhausted-behavior: "error" returns 502 (default); "pass-through" returns the exhausted abnormal response.
-    # CPA usage is attempt-level. successful client response usage includes discarded attempts plus the delivered attempt.
-    # client-usage-aggregation: "reasoning-fold" (default) folds discarded output into reasoning tokens so visible output remains the delivered attempt only; "sum" preserves the legacy field-sum shape.
+    # CPA internal usage remains attempt-level and records discarded retry costs separately.
+    # client-usage-aggregation only controls the client-visible response.usage shape:
+    # "delivered-only" (default) returns the delivered/fallback attempt's upstream usage unchanged;
+    # "sum" adds input/cache/output/reasoning/total fields across all attempts;
+    # "sum-with-delivered-total" adds small fields across attempts but keeps total_tokens from the delivered/fallback attempt.
     max-retries: 2
     exhausted-behavior: "error"
-    client-usage-aggregation: "reasoning-fold"
+    client-usage-aggregation: "delivered-only"
     # Optional hedged retry for abnormal attempts. When enabled, a retry lane starts first;
     # after hedge-delay-ms, a second parallel lane may start. Default mode is "quality".
     # mode: "quality" waits for dispatched lanes and selects the largest output_tokens winner; "speed" keeps first-success-wins behavior.

--- a/docs/lts/core-feature-contracts.yaml
+++ b/docs/lts/core-feature-contracts.yaml
@@ -156,7 +156,7 @@ features:
 
   - id: codex-abnormal-reasoning-retry
     status: lts-maintained
-    reason: CPA-Core-LTS can optionally discard and retry suspicious Codex OAuth responses with attempt-level CPA accounting, default quality hedging, longest abnormal pass-through fallback, and aggregate client-visible usage, without changing plugin ABI or Panel UI.
+    reason: CPA-Core-LTS can optionally discard and retry suspicious Codex OAuth responses with attempt-level CPA accounting, default quality hedging, longest abnormal pass-through fallback, and separated client-visible usage modes, without changing plugin ABI.
     config_keys:
       - codex.abnormal-reasoning-retry.enabled
       - codex.abnormal-reasoning-retry.model-contains
@@ -189,7 +189,8 @@ features:
       - abnormal-reasoning-retry
       - hedged-retry
       - client-usage-aggregation
-      - reasoning-fold
+      - delivered-only
+      - sum-with-delivered-total
       - quality
       - longest abnormal pass-through fallback
       - hedge-delay-ms

--- a/internal/config/codex_websocket_header_defaults_test.go
+++ b/internal/config/codex_websocket_header_defaults_test.go
@@ -96,8 +96,8 @@ func TestLoadConfigOptional_CodexAbnormalReasoningRetryDefaults(t *testing.T) {
 	if effective.ExhaustedBehavior != CodexAbnormalReasoningRetryExhaustedBehaviorError {
 		t.Fatalf("ExhaustedBehavior = %q, want %q", effective.ExhaustedBehavior, CodexAbnormalReasoningRetryExhaustedBehaviorError)
 	}
-	if effective.ClientUsageAggregation != CodexAbnormalReasoningRetryClientUsageAggregationReasoningFold {
-		t.Fatalf("ClientUsageAggregation = %q, want %q", effective.ClientUsageAggregation, CodexAbnormalReasoningRetryClientUsageAggregationReasoningFold)
+	if effective.ClientUsageAggregation != CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly {
+		t.Fatalf("ClientUsageAggregation = %q, want %q", effective.ClientUsageAggregation, CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly)
 	}
 	if effective.HedgedRetry.Enabled {
 		t.Fatal("HedgedRetry.Enabled = true, want false")
@@ -284,11 +284,38 @@ codex:
 	}
 
 	effective := cfg.Codex.AbnormalReasoningRetry.Effective()
-	if effective.ClientUsageAggregation != CodexAbnormalReasoningRetryClientUsageAggregationReasoningFold {
-		t.Fatalf("ClientUsageAggregation = %q, want %q", effective.ClientUsageAggregation, CodexAbnormalReasoningRetryClientUsageAggregationReasoningFold)
+	if effective.ClientUsageAggregation != CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly {
+		t.Fatalf("ClientUsageAggregation = %q, want %q", effective.ClientUsageAggregation, CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly)
 	}
 	if effective.HedgedRetry.Mode != CodexAbnormalReasoningHedgedRetryModeQuality {
 		t.Fatalf("HedgedRetry.Mode = %q, want %q", effective.HedgedRetry.Mode, CodexAbnormalReasoningHedgedRetryModeQuality)
+	}
+}
+
+func TestCodexAbnormalReasoningRetryClientUsageAggregationNormalization(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "empty", value: "", want: CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly},
+		{name: "delivered only", value: "delivered-only", want: CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly},
+		{name: "delivered only alias", value: "Delivered_Only", want: CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly},
+		{name: "delivered alias", value: " delivered ", want: CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly},
+		{name: "sum", value: "sum", want: CodexAbnormalReasoningRetryClientUsageAggregationSum},
+		{name: "sum with delivered total", value: "sum-with-delivered-total", want: CodexAbnormalReasoningRetryClientUsageAggregationSumWithDeliveredTotal},
+		{name: "sum with delivered total alias", value: "SUM_WITH_DELIVERED_TOTAL", want: CodexAbnormalReasoningRetryClientUsageAggregationSumWithDeliveredTotal},
+		{name: "legacy reasoning fold", value: "reasoning-fold", want: CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly},
+		{name: "legacy reasoning fold alias", value: "reasoning_fold", want: CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly},
+		{name: "legacy fold alias", value: "fold", want: CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly},
+		{name: "unknown", value: "legacy", want: CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeCodexAbnormalReasoningRetryClientUsageAggregation(tt.value); got != tt.want {
+				t.Fatalf("normalizeCodexAbnormalReasoningRetryClientUsageAggregation(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -316,12 +316,13 @@ type CodexConfig struct {
 }
 
 const (
-	CodexAbnormalReasoningRetryExhaustedBehaviorError              = "error"
-	CodexAbnormalReasoningRetryExhaustedBehaviorPassThrough        = "pass-through"
-	CodexAbnormalReasoningRetryClientUsageAggregationReasoningFold = "reasoning-fold"
-	CodexAbnormalReasoningRetryClientUsageAggregationSum           = "sum"
-	CodexAbnormalReasoningHedgedRetryModeSpeed                     = "speed"
-	CodexAbnormalReasoningHedgedRetryModeQuality                   = "quality"
+	CodexAbnormalReasoningRetryExhaustedBehaviorError                      = "error"
+	CodexAbnormalReasoningRetryExhaustedBehaviorPassThrough                = "pass-through"
+	CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly         = "delivered-only"
+	CodexAbnormalReasoningRetryClientUsageAggregationSum                   = "sum"
+	CodexAbnormalReasoningRetryClientUsageAggregationSumWithDeliveredTotal = "sum-with-delivered-total"
+	CodexAbnormalReasoningHedgedRetryModeSpeed                             = "speed"
+	CodexAbnormalReasoningHedgedRetryModeQuality                           = "quality"
 )
 
 // CodexAbnormalReasoningRetryConfig controls the CPA-Core-LTS retry guard for
@@ -442,12 +443,16 @@ func normalizeCodexAbnormalReasoningRetryExhaustedBehavior(value string) string 
 
 func normalizeCodexAbnormalReasoningRetryClientUsageAggregation(value string) string {
 	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "", "reasoning-fold", "reasoning_fold", "fold":
-		return CodexAbnormalReasoningRetryClientUsageAggregationReasoningFold
+	case "", "delivered-only", "delivered_only", "delivered":
+		return CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly
 	case "sum":
 		return CodexAbnormalReasoningRetryClientUsageAggregationSum
+	case "sum-with-delivered-total", "sum_with_delivered_total":
+		return CodexAbnormalReasoningRetryClientUsageAggregationSumWithDeliveredTotal
+	case "reasoning-fold", "reasoning_fold", "fold":
+		return CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly
 	default:
-		return CodexAbnormalReasoningRetryClientUsageAggregationReasoningFold
+		return CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly
 	}
 }
 

--- a/internal/runtime/executor/codex_abnormal_reasoning_retry.go
+++ b/internal/runtime/executor/codex_abnormal_reasoning_retry.go
@@ -233,6 +233,7 @@ func (p codexAbnormalReasoningRetryPolicy) RetryErrorWithFallbackStreamChunksAnd
 }
 
 func (p codexAbnormalReasoningRetryPolicy) retryError(detail usage.Detail, reasoningEffort string, fallbackResponse *cliproxyexecutor.Response, fallbackStreamHeaders http.Header, fallbackStreamChunks []cliproxyexecutor.StreamChunk, fallbackStreamFinalizer cliproxyexecutor.RetryWithoutPenaltyStreamFinalizer) error {
+	detail = normalizeCodexUsageDetail(detail)
 	if !p.enabled || detail.ReasoningTokens <= 0 {
 		return nil
 	}
@@ -411,6 +412,9 @@ func patchCodexAbnormalReasoningClientUsage(eventData []byte, metadata map[strin
 }
 
 func patchCodexAbnormalReasoningClientUsageWithSnapshot(eventData []byte, previous cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot, aggregation string) []byte {
+	if aggregation == config.CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly {
+		return eventData
+	}
 	current, ok := helps.ParseCodexUsage(eventData)
 	if !ok {
 		return eventData
@@ -455,20 +459,19 @@ func codexAbnormalReasoningRetryUsageSnapshotFromMetadata(metadata map[string]an
 	raw := metadata[cliproxyexecutor.CodexAbnormalReasoningRetryUsageMetadataKey]
 	switch detail := raw.(type) {
 	case cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot:
-		return detail, hasCodexUsageDetail(detail.Detail)
+		snapshot := normalizeCodexAbnormalReasoningRetryUsageSnapshot(detail)
+		return snapshot, hasCodexUsageDetail(snapshot.Detail)
 	case *cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot:
 		if detail == nil {
 			return cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot{}, false
 		}
-		return *detail, hasCodexUsageDetail(detail.Detail)
+		snapshot := normalizeCodexAbnormalReasoningRetryUsageSnapshot(*detail)
+		return snapshot, hasCodexUsageDetail(snapshot.Detail)
 	case usage.Detail:
 		if !hasCodexUsageDetail(detail) {
 			return cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot{}, false
 		}
-		return cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot{
-			Detail:             detail,
-			FoldedOutputTokens: foldedCodexUsageOutputTokens(detail),
-		}, true
+		return normalizeCodexAbnormalReasoningRetryUsageSnapshot(cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot{Detail: detail}), true
 	case *usage.Detail:
 		if detail == nil {
 			return cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot{}, false
@@ -476,12 +479,10 @@ func codexAbnormalReasoningRetryUsageSnapshotFromMetadata(metadata map[string]an
 		if !hasCodexUsageDetail(*detail) {
 			return cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot{}, false
 		}
-		return cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot{
-			Detail:             *detail,
-			FoldedOutputTokens: foldedCodexUsageOutputTokens(*detail),
-		}, true
+		return normalizeCodexAbnormalReasoningRetryUsageSnapshot(cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot{Detail: *detail}), true
 	case *cliproxyexecutor.UsageAccumulator:
 		snapshot := detail.RetryWithoutPenaltySnapshot()
+		snapshot = normalizeCodexAbnormalReasoningRetryUsageSnapshot(snapshot)
 		return snapshot, hasCodexUsageDetail(snapshot.Detail)
 	default:
 		return cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot{}, false
@@ -492,27 +493,12 @@ func codexAbnormalReasoningRetryAggregateClientUsage(previous cliproxyexecutor.R
 	if aggregation == config.CodexAbnormalReasoningRetryClientUsageAggregationSum {
 		return addCodexUsageDetail(previous.Detail, current)
 	}
-	previousDetail := normalizeCodexUsageDetail(previous.Detail)
-	current = normalizeCodexUsageDetail(current)
-	foldedPreviousOutput := previous.FoldedOutputTokens
-	if foldedPreviousOutput == 0 && hasCodexUsageDetail(previousDetail) {
-		foldedPreviousOutput = foldedCodexUsageOutputTokens(previousDetail)
+	if aggregation == config.CodexAbnormalReasoningRetryClientUsageAggregationSumWithDeliveredTotal {
+		total := addCodexUsageDetail(previous.Detail, current)
+		total.TotalTokens = normalizeCodexUsageDetail(current).TotalTokens
+		return total
 	}
-	deliveredOutput := current.OutputTokens
-	if current.ReasoningTokens > deliveredOutput {
-		deliveredOutput = current.ReasoningTokens
-	}
-	input := previousDetail.InputTokens + current.InputTokens
-	output := deliveredOutput + foldedPreviousOutput
-	return usage.Detail{
-		InputTokens:         input,
-		OutputTokens:        output,
-		ReasoningTokens:     current.ReasoningTokens + foldedPreviousOutput,
-		CachedTokens:        previousDetail.CachedTokens + current.CachedTokens,
-		CacheReadTokens:     previousDetail.CacheReadTokens + current.CacheReadTokens,
-		CacheCreationTokens: previousDetail.CacheCreationTokens + current.CacheCreationTokens,
-		TotalTokens:         input + output,
-	}
+	return normalizeCodexUsageDetail(current)
 }
 
 func addCodexUsageDetail(a, b usage.Detail) usage.Detail {
@@ -537,7 +523,16 @@ func foldedCodexUsageOutputTokens(detail usage.Detail) int64 {
 	return detail.ReasoningTokens
 }
 
+func normalizeCodexAbnormalReasoningRetryUsageSnapshot(snapshot cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot) cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot {
+	snapshot.Detail = normalizeCodexUsageDetail(snapshot.Detail)
+	if snapshot.FoldedOutputTokens == 0 && hasCodexUsageDetail(snapshot.Detail) {
+		snapshot.FoldedOutputTokens = foldedCodexUsageOutputTokens(snapshot.Detail)
+	}
+	return snapshot
+}
+
 func codexAbnormalReasoningRetryResponseMetadata(detail usage.Detail, finalizer cliproxyexecutor.RetryWithoutPenaltyResponseFinalizer) map[string]any {
+	detail = normalizeCodexUsageDetail(detail)
 	meta := map[string]any{
 		cliproxyexecutor.RetryWithoutPenaltyUsageDetailMetadataKey: detail,
 		cliproxyexecutor.RetryWithoutPenaltyHedgeScoreMetadataKey:  detail.OutputTokens,
@@ -615,9 +610,9 @@ func (r *codexAbnormalReasoningRetryStreamRecorder) ready() bool {
 // finalizeCodexAbnormalReasoningRetryStreamFromRaw rebuilds the winning stream
 // from recorded raw upstream lines, mirroring the non-stream finalizer: the
 // completed event usage is re-patched with the final discarded-attempt snapshot
-// before the whole stream is re-translated, so the folded usage survives
-// translation into any downstream response format. Returns nil when no usable
-// recording exists and the caller must fall back to patching translated chunks.
+// before the whole stream is re-translated, so the configured client usage
+// survives translation into any downstream response format. Returns nil when no
+// usable recording exists and the caller must fall back to patching translated chunks.
 func finalizeCodexAbnormalReasoningRetryStreamFromRaw(ctx context.Context, to, responseFormat sdktranslator.Format, model string, originalPayload, body []byte, identityState codexIdentityConfuseState, recorder *codexAbnormalReasoningRetryStreamRecorder, headers http.Header, previous cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot, aggregation string) *cliproxyexecutor.StreamResult {
 	if !recorder.ready() {
 		return nil
@@ -687,7 +682,7 @@ func patchCodexAbnormalReasoningStreamPayload(payload []byte, previous cliproxye
 
 func normalizeCodexUsageDetail(detail usage.Detail) usage.Detail {
 	if detail.TotalTokens == 0 {
-		total := detail.InputTokens + detail.OutputTokens + detail.ReasoningTokens
+		total := detail.InputTokens + detail.OutputTokens
 		if total > 0 {
 			detail.TotalTokens = total
 		}

--- a/internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
+++ b/internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
@@ -303,7 +303,7 @@ func TestCodexExecutorAbnormalReasoningRetry_PublishesFailedUsageForInterceptedA
 	}
 }
 
-func TestCodexExecutorAbnormalReasoningRetry_ManagerRecordsAttemptLevelUsageAndAggregatesClientUsage(t *testing.T) {
+func TestCodexExecutorAbnormalReasoningRetry_ManagerRecordsAttemptLevelUsageAndDeliversRawClientUsage(t *testing.T) {
 	recorder := &codexAbnormalReasoningRetryUsageRecorder{}
 	usage.RegisterNamedPlugin("codex-abnormal-reasoning-retry-test", recorder)
 	t.Cleanup(func() {
@@ -350,17 +350,17 @@ func TestCodexExecutorAbnormalReasoningRetry_ManagerRecordsAttemptLevelUsageAndA
 	if calls != 2 {
 		t.Fatalf("upstream calls = %d, want 2", calls)
 	}
-	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 650 {
-		t.Fatalf("client response usage.total_tokens = %d, want reasoning-fold total 650; payload=%s", got, resp.Payload)
+	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 12 {
+		t.Fatalf("client response usage.total_tokens = %d, want delivered total 12; payload=%s", got, resp.Payload)
 	}
-	if got := gjson.GetBytes(resp.Payload, "usage.input_tokens").Int(); got != 6 {
-		t.Fatalf("client response usage.input_tokens = %d, want abnormal plus final input 6; payload=%s", got, resp.Payload)
+	if got := gjson.GetBytes(resp.Payload, "usage.input_tokens").Int(); got != 5 {
+		t.Fatalf("client response usage.input_tokens = %d, want delivered input 5; payload=%s", got, resp.Payload)
 	}
-	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens").Int(); got != 644 {
-		t.Fatalf("client response usage.output_tokens = %d, want folded output 644; payload=%s", got, resp.Payload)
+	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens").Int(); got != 7 {
+		t.Fatalf("client response usage.output_tokens = %d, want delivered output 7; payload=%s", got, resp.Payload)
 	}
-	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens_details.reasoning_tokens").Int(); got != 644 {
-		t.Fatalf("client response usage.reasoning_tokens = %d, want abnormal plus final reasoning 644; payload=%s", got, resp.Payload)
+	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens_details.reasoning_tokens").Int(); got != 128 {
+		t.Fatalf("client response usage.reasoning_tokens = %d, want delivered reasoning 128; payload=%s", got, resp.Payload)
 	}
 
 	records := recorder.waitForRecords(t, func(record usage.Record) bool {
@@ -391,7 +391,7 @@ func TestCodexExecutorAbnormalReasoningRetry_ManagerRecordsAttemptLevelUsageAndA
 	}
 }
 
-func TestCodexExecutorAbnormalReasoningRetry_ClientUsageAggregationSumKeepsLegacyShape(t *testing.T) {
+func TestCodexExecutorAbnormalReasoningRetry_ClientUsageAggregationSumSumsFields(t *testing.T) {
 	var calls int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls++
@@ -430,17 +430,124 @@ func TestCodexExecutorAbnormalReasoningRetry_ClientUsageAggregationSumKeepsLegac
 		t.Fatalf("Execute error = %v, want nil", err)
 	}
 	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 15 {
-		t.Fatalf("client response usage.total_tokens = %d, want legacy total 15; payload=%s", got, resp.Payload)
+		t.Fatalf("client response usage.total_tokens = %d, want summed total 15; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.input_tokens").Int(); got != 6 {
+		t.Fatalf("client response usage.input_tokens = %d, want summed input 6; payload=%s", got, resp.Payload)
 	}
 	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens").Int(); got != 9 {
-		t.Fatalf("client response usage.output_tokens = %d, want legacy output 9; payload=%s", got, resp.Payload)
+		t.Fatalf("client response usage.output_tokens = %d, want summed output 9; payload=%s", got, resp.Payload)
 	}
 	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens_details.reasoning_tokens").Int(); got != 644 {
-		t.Fatalf("client response usage.reasoning_tokens = %d, want legacy reasoning 644; payload=%s", got, resp.Payload)
+		t.Fatalf("client response usage.reasoning_tokens = %d, want summed reasoning 644; payload=%s", got, resp.Payload)
 	}
 }
 
-func TestCodexExecutorAbnormalReasoningRetry_DefaultMaxRetriesAggregatesTwoAbnormalAttempts(t *testing.T) {
+func TestCodexExecutorAbnormalReasoningRetry_ClientUsageAggregationSumUsesCodexFallbackWhenPreviousTotalMissing(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "text/event-stream")
+		if calls == 1 {
+			_, _ = w.Write([]byte(codexCompletedSSEWithUsageNoTotal("gpt-5.5", 516, 1, 2)))
+			return
+		}
+		_, _ = w.Write([]byte(codexCompletedSSEWithUsage("gpt-5.5", 128, 5, 7, 12)))
+	}))
+	defer server.Close()
+
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(NewCodexExecutor(codexAbnormalReasoningRetryTestConfigWithAggregation(config.CodexAbnormalReasoningRetryClientUsageAggregationSum)))
+	manager.SetRetryConfig(1, 0, 0)
+
+	auth := codexAbnormalReasoningRetryTestAuth(server.URL)
+	auth.ID = "codex-oauth-sum-missing-previous-total"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, "codex", []*registry.ModelInfo{{ID: "gpt-5.5"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(auth.ID)
+	})
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"hello"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error = %v, want nil", err)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 15 {
+		t.Fatalf("client response usage.total_tokens = %d, want summed Codex fallback total 15; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.input_tokens").Int(); got != 6 {
+		t.Fatalf("client response usage.input_tokens = %d, want summed input 6; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens").Int(); got != 9 {
+		t.Fatalf("client response usage.output_tokens = %d, want summed output 9; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens_details.reasoning_tokens").Int(); got != 644 {
+		t.Fatalf("client response usage.reasoning_tokens = %d, want summed reasoning 644; payload=%s", got, resp.Payload)
+	}
+}
+
+func TestCodexExecutorAbnormalReasoningRetry_ClientUsageAggregationSumWithDeliveredTotal(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "text/event-stream")
+		if calls == 1 {
+			_, _ = w.Write([]byte(codexCompletedSSEWithUsage("gpt-5.5", 516, 1, 2, 3)))
+			return
+		}
+		_, _ = w.Write([]byte(codexCompletedSSEWithUsage("gpt-5.5", 128, 5, 7, 12)))
+	}))
+	defer server.Close()
+
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(NewCodexExecutor(codexAbnormalReasoningRetryTestConfigWithAggregation(config.CodexAbnormalReasoningRetryClientUsageAggregationSumWithDeliveredTotal)))
+	manager.SetRetryConfig(1, 0, 0)
+
+	auth := codexAbnormalReasoningRetryTestAuth(server.URL)
+	auth.ID = "codex-oauth-sum-delivered-total"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, "codex", []*registry.ModelInfo{{ID: "gpt-5.5"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(auth.ID)
+	})
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"hello"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error = %v, want nil", err)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 12 {
+		t.Fatalf("client response usage.total_tokens = %d, want delivered total 12; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.input_tokens").Int(); got != 6 {
+		t.Fatalf("client response usage.input_tokens = %d, want summed input 6; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens").Int(); got != 9 {
+		t.Fatalf("client response usage.output_tokens = %d, want summed output 9; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens_details.reasoning_tokens").Int(); got != 644 {
+		t.Fatalf("client response usage.reasoning_tokens = %d, want summed reasoning 644; payload=%s", got, resp.Payload)
+	}
+}
+
+func TestCodexExecutorAbnormalReasoningRetry_DefaultMaxRetriesDeliversFinalUsageWithTwoAbnormalAttempts(t *testing.T) {
 	recorder := &codexAbnormalReasoningRetryUsageRecorder{}
 	usage.RegisterNamedPlugin("codex-abnormal-reasoning-retry-test", recorder)
 	t.Cleanup(func() {
@@ -490,17 +597,17 @@ func TestCodexExecutorAbnormalReasoningRetry_DefaultMaxRetriesAggregatesTwoAbnor
 	if calls != 3 {
 		t.Fatalf("upstream calls = %d, want 3", calls)
 	}
-	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 1688 {
-		t.Fatalf("client response usage.total_tokens = %d, want folded total 1688; payload=%s", got, resp.Payload)
+	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 12 {
+		t.Fatalf("client response usage.total_tokens = %d, want delivered total 12; payload=%s", got, resp.Payload)
 	}
-	if got := gjson.GetBytes(resp.Payload, "usage.input_tokens").Int(); got != 10 {
-		t.Fatalf("client response usage.input_tokens = %d, want abnormal attempts plus final input 10; payload=%s", got, resp.Payload)
+	if got := gjson.GetBytes(resp.Payload, "usage.input_tokens").Int(); got != 5 {
+		t.Fatalf("client response usage.input_tokens = %d, want delivered input 5; payload=%s", got, resp.Payload)
 	}
-	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens").Int(); got != 1678 {
-		t.Fatalf("client response usage.output_tokens = %d, want folded output 1678; payload=%s", got, resp.Payload)
+	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens").Int(); got != 7 {
+		t.Fatalf("client response usage.output_tokens = %d, want delivered output 7; payload=%s", got, resp.Payload)
 	}
-	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens_details.reasoning_tokens").Int(); got != 1678 {
-		t.Fatalf("client response usage.reasoning_tokens = %d, want abnormal attempts plus final reasoning 1678; payload=%s", got, resp.Payload)
+	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens_details.reasoning_tokens").Int(); got != 128 {
+		t.Fatalf("client response usage.reasoning_tokens = %d, want delivered reasoning 128; payload=%s", got, resp.Payload)
 	}
 
 	records := recorder.waitForRecords(t, func(record usage.Record) bool {
@@ -573,8 +680,8 @@ func TestCodexExecutorAbnormalReasoningRetry_ManagerMaxRetriesIndependentFromReq
 	if calls != 2 {
 		t.Fatalf("upstream calls = %d, want 2 despite request-retry=0", calls)
 	}
-	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 650 {
-		t.Fatalf("client response usage.total_tokens = %d, want folded total 650; payload=%s", got, resp.Payload)
+	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 12 {
+		t.Fatalf("client response usage.total_tokens = %d, want delivered total 12; payload=%s", got, resp.Payload)
 	}
 }
 
@@ -621,8 +728,14 @@ func TestCodexExecutorAbnormalReasoningRetry_PassThroughWhenExhaustedNonStreamin
 	if calls != 1 {
 		t.Fatalf("upstream calls = %d, want 1", calls)
 	}
-	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 517 {
-		t.Fatalf("client response usage.total_tokens = %d, want folded abnormal total 517; payload=%s", got, resp.Payload)
+	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 3 {
+		t.Fatalf("client response usage.total_tokens = %d, want delivered abnormal total 3; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.input_tokens").Int(); got != 1 {
+		t.Fatalf("client response usage.input_tokens = %d, want delivered abnormal input 1; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens").Int(); got != 2 {
+		t.Fatalf("client response usage.output_tokens = %d, want delivered abnormal output 2; payload=%s", got, resp.Payload)
 	}
 	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens_details.reasoning_tokens").Int(); got != 516 {
 		t.Fatalf("client response reasoning_tokens = %d, want 516; payload=%s", got, resp.Payload)
@@ -639,7 +752,7 @@ func TestCodexExecutorAbnormalReasoningRetry_PassThroughWhenExhaustedNonStreamin
 	}
 }
 
-func TestCodexExecutorAbnormalReasoningRetry_PassThroughAggregatesDiscardedUsageWhenExhausted(t *testing.T) {
+func TestCodexExecutorAbnormalReasoningRetry_PassThroughDeliversSelectedFallbackUsageWhenExhausted(t *testing.T) {
 	var calls int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls++
@@ -681,11 +794,76 @@ func TestCodexExecutorAbnormalReasoningRetry_PassThroughAggregatesDiscardedUsage
 	if calls != 2 {
 		t.Fatalf("upstream calls = %d, want 2", calls)
 	}
-	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 1555 {
-		t.Fatalf("client response usage.total_tokens = %d, want folded pass-through total 1555; payload=%s", got, resp.Payload)
+	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 10 {
+		t.Fatalf("client response usage.total_tokens = %d, want selected fallback total 10; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.input_tokens").Int(); got != 4 {
+		t.Fatalf("client response usage.input_tokens = %d, want selected fallback input 4; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens").Int(); got != 6 {
+		t.Fatalf("client response usage.output_tokens = %d, want selected fallback output 6; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens_details.reasoning_tokens").Int(); got != 1034 {
+		t.Fatalf("client response reasoning_tokens = %d, want selected fallback reasoning 1034; payload=%s", got, resp.Payload)
+	}
+}
+
+func TestCodexExecutorAbnormalReasoningRetry_PassThroughSumWithDeliveredTotalKeepsFallbackTotal(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "text/event-stream")
+		switch calls {
+		case 1:
+			_, _ = w.Write([]byte(codexCompletedSSEWithUsage("gpt-5.5", 516, 1, 2, 3)))
+		default:
+			_, _ = w.Write([]byte(codexCompletedSSEWithUsage("gpt-5.5", 1034, 4, 6, 10)))
+		}
+	}))
+	defer server.Close()
+
+	cfg := codexAbnormalReasoningRetryTestConfigWithMaxAndExhausted(1, config.CodexAbnormalReasoningRetryExhaustedBehaviorPassThrough)
+	cfg.Codex.AbnormalReasoningRetry.ClientUsageAggregation = config.CodexAbnormalReasoningRetryClientUsageAggregationSumWithDeliveredTotal
+
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(NewCodexExecutor(cfg))
+	manager.SetRetryConfig(0, 0, 0)
+
+	auth := codexAbnormalReasoningRetryTestAuth(server.URL)
+	auth.ID = "codex-oauth-pass-through-sum-delivered-total"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, "codex", []*registry.ModelInfo{{ID: "gpt-5.5"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(auth.ID)
+	})
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"hello"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error = %v, want nil pass-through", err)
+	}
+	if calls != 2 {
+		t.Fatalf("upstream calls = %d, want 2", calls)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 10 {
+		t.Fatalf("client response usage.total_tokens = %d, want selected fallback total 10; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.input_tokens").Int(); got != 5 {
+		t.Fatalf("client response usage.input_tokens = %d, want summed input 5; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens").Int(); got != 8 {
+		t.Fatalf("client response usage.output_tokens = %d, want summed output 8; payload=%s", got, resp.Payload)
 	}
 	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens_details.reasoning_tokens").Int(); got != 1550 {
-		t.Fatalf("client response reasoning_tokens = %d, want discarded plus delivered reasoning 1550; payload=%s", got, resp.Payload)
+		t.Fatalf("client response reasoning_tokens = %d, want summed reasoning 1550; payload=%s", got, resp.Payload)
 	}
 }
 
@@ -736,12 +914,12 @@ func TestCodexExecutorAbnormalReasoningRetry_PassThroughReturnsLongestNonStreami
 	if !bytes.Contains(resp.Payload, []byte("long")) || bytes.Contains(resp.Payload, []byte("short")) {
 		t.Fatalf("client response payload = %s, want longest fallback only", resp.Payload)
 	}
-	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 1551 {
-		t.Fatalf("client response usage.total_tokens = %d, want final folded total 1551; payload=%s", got, resp.Payload)
+	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 81 {
+		t.Fatalf("client response usage.total_tokens = %d, want longest fallback total 81; payload=%s", got, resp.Payload)
 	}
 }
 
-func TestCodexExecutorAbnormalReasoningRetry_ManagerAggregatesStreamingClientUsage(t *testing.T) {
+func TestCodexExecutorAbnormalReasoningRetry_ManagerDeliversStreamingClientUsage(t *testing.T) {
 	var calls int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls++
@@ -789,15 +967,15 @@ func TestCodexExecutorAbnormalReasoningRetry_ManagerAggregatesStreamingClientUsa
 	if calls != 2 {
 		t.Fatalf("upstream calls = %d, want 2", calls)
 	}
-	if !bytes.Contains(payload, []byte(`"total_tokens":650`)) {
-		t.Fatalf("stream payload missing folded total_tokens=650: %s", payload)
+	if !bytes.Contains(payload, []byte(`"total_tokens":12`)) {
+		t.Fatalf("stream payload missing delivered total_tokens=12: %s", payload)
 	}
-	if !bytes.Contains(payload, []byte(`"reasoning_tokens":644`)) {
-		t.Fatalf("stream payload missing aggregated reasoning_tokens=644: %s", payload)
+	if !bytes.Contains(payload, []byte(`"reasoning_tokens":128`)) {
+		t.Fatalf("stream payload missing delivered reasoning_tokens=128: %s", payload)
 	}
 }
 
-func TestCodexExecutorAbnormalReasoningRetry_QualityStreamFoldsUsageIntoChatCompletionsFormat(t *testing.T) {
+func TestCodexExecutorAbnormalReasoningRetry_QualityStreamDeliversWinnerUsageIntoChatCompletionsFormat(t *testing.T) {
 	var mu sync.Mutex
 	calls := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -823,7 +1001,7 @@ func TestCodexExecutorAbnormalReasoningRetry_QualityStreamFoldsUsageIntoChatComp
 	manager.SetRetryConfig(0, 0, 0)
 
 	auth := codexAbnormalReasoningRetryTestAuth(server.URL)
-	auth.ID = "codex-oauth-quality-chat-fold"
+	auth.ID = "codex-oauth-quality-chat-delivered"
 	reg := registry.GetGlobalRegistry()
 	reg.RegisterClient(auth.ID, "codex", []*registry.ModelInfo{{ID: "gpt-5.5"}})
 	t.Cleanup(func() {
@@ -859,16 +1037,14 @@ func TestCodexExecutorAbnormalReasoningRetry_QualityStreamFoldsUsageIntoChatComp
 	if !bytes.Contains(payload, []byte("clean")) {
 		t.Fatalf("stream payload missing winner delta text: %s", payload)
 	}
-	// reasoning-fold 折算：trigger(1/2/516) 与 quality 波内 abnormal lane(2/4/516)
-	// 折入胜者(5/200/128)，并且必须以下游 chat-completions 的 usage 形状交付。
 	for _, want := range []string{
-		`"prompt_tokens":8`,
-		`"completion_tokens":1232`,
-		`"total_tokens":1240`,
-		`"reasoning_tokens":1160`,
+		`"prompt_tokens":5`,
+		`"completion_tokens":200`,
+		`"total_tokens":205`,
+		`"reasoning_tokens":128`,
 	} {
 		if !bytes.Contains(payload, []byte(want)) {
-			t.Fatalf("stream payload missing folded chat usage %s: %s", want, payload)
+			t.Fatalf("stream payload missing delivered chat usage %s: %s", want, payload)
 		}
 	}
 }
@@ -926,6 +1102,9 @@ func TestCodexExecutorAbnormalReasoningRetry_PassThroughWhenExhaustedStreaming(t
 	}
 	if !bytes.Contains(payload, []byte("visible")) {
 		t.Fatalf("stream payload missing buffered visible delta: %s", payload)
+	}
+	if !bytes.Contains(payload, []byte(`"total_tokens":3`)) {
+		t.Fatalf("stream payload missing delivered abnormal total_tokens=3: %s", payload)
 	}
 	if !bytes.Contains(payload, []byte(`"reasoning_tokens":516`)) {
 		t.Fatalf("stream payload missing delivered abnormal reasoning_tokens=516: %s", payload)
@@ -996,8 +1175,8 @@ func TestCodexExecutorAbnormalReasoningRetry_PassThroughReturnsLongestStreamingF
 	if !bytes.Contains(payload, []byte("long")) || bytes.Contains(payload, []byte("short")) {
 		t.Fatalf("stream payload = %s, want longest fallback only", payload)
 	}
-	if !bytes.Contains(payload, []byte(`"total_tokens":1551`)) {
-		t.Fatalf("stream payload missing final folded total_tokens=1551: %s", payload)
+	if !bytes.Contains(payload, []byte(`"total_tokens":81`)) {
+		t.Fatalf("stream payload missing longest fallback total_tokens=81: %s", payload)
 	}
 }
 
@@ -1204,6 +1383,10 @@ func codexCompletedSSE(model string, reasoning int) string {
 
 func codexCompletedSSEWithUsage(model string, reasoning, input, output, total int) string {
 	return codexCompletedSSEWithTextAndUsage(model, "ok", reasoning, input, output, total)
+}
+
+func codexCompletedSSEWithUsageNoTotal(model string, reasoning, input, output int) string {
+	return `data: {"type":"response.completed","response":{"id":"resp_1","object":"response","created_at":1775555723,"status":"completed","model":"` + model + `","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":` + strconv.Itoa(input) + `,"output_tokens":` + strconv.Itoa(output) + `,"output_tokens_details":{"reasoning_tokens":` + strconv.Itoa(reasoning) + `}}}}` + "\n\n"
 }
 
 func codexCompletedSSEWithTextAndUsage(model, text string, reasoning, input, output, total int) string {

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -1336,7 +1336,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 				return
 			}
 			if usageDetailOK {
-				streamUsage.Detail = usageDetail
+				streamUsage.Detail = normalizeCodexUsageDetail(usageDetail)
 				streamUsage.HedgeScore = usageDetail.OutputTokens
 				streamUsage.OK = true
 				reporter.Publish(ctx, usageDetail)

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -222,7 +222,7 @@ func TestBuildConfigChangeDetails_CodexAbnormalReasoningRetry(t *testing.T) {
 	expectContains(t, details, "codex.abnormal-reasoning-retry.stream-buffer-max-bytes: 0 -> 4096")
 	expectContains(t, details, "codex.abnormal-reasoning-retry.max-retries: 2 -> 0")
 	expectContains(t, details, "codex.abnormal-reasoning-retry.exhausted-behavior: error -> pass-through")
-	expectContains(t, details, "codex.abnormal-reasoning-retry.client-usage-aggregation: reasoning-fold -> sum")
+	expectContains(t, details, "codex.abnormal-reasoning-retry.client-usage-aggregation: delivered-only -> sum")
 	expectContains(t, details, "codex.abnormal-reasoning-retry.hedged-retry.enabled: false -> true")
 	expectContains(t, details, "codex.abnormal-reasoning-retry.hedged-retry.mode: speed -> quality")
 	expectContains(t, details, "codex.abnormal-reasoning-retry.hedged-retry.hedge-delay-ms: 1000 -> 250")

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -95,7 +95,8 @@ require_grep "stream-buffer-max-bytes" internal/config/config.go config.example.
 require_grep "max-retries" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
 require_grep "exhausted-behavior" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
 require_grep "client-usage-aggregation" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
-require_grep "reasoning-fold" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
+require_grep "delivered-only" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
+require_grep "sum-with-delivered-total" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
 require_grep "quality" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
 require_grep "longest abnormal pass-through fallback" config.example.yaml docs/lts/core-feature-contracts.yaml
 require_grep "reasoning-efforts" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
@@ -175,7 +176,8 @@ registry_required = [
     "max-retries",
     "exhausted-behavior",
     "client-usage-aggregation",
-    "reasoning-fold",
+    "delivered-only",
+    "sum-with-delivered-total",
     "quality",
     "longest abnormal pass-through fallback",
     "reasoning-efforts",


### PR DESCRIPTION
## 背景

Codex CLI/App 使用客户端可见的 `response.usage.total_tokens` 判断上下文占用和 auto compact。CPA-Core-LTS 的 abnormal-reasoning-retry 已经在内部 attempt-level usage 中记录 discarded retry 成本；继续把隐藏重试成本折进客户端 `response.usage` 会把成本账误导成上下文账。

## 变更

- 将 `codex.abnormal-reasoning-retry.client-usage-aggregation` 重定义为 3 个正式模式：`delivered-only`、`sum`、`sum-with-delivered-total`。
- 默认改为 `delivered-only`：客户端 usage 全字段使用最终 delivered/fallback attempt 的上游原始 usage。
- `sum` 改为按同名字段相加 `input/cache/output/reasoning/total`，不再把失败 attempt 的 output 搬进 reasoning。
- `sum-with-delivered-total` 复用 `sum` 的小项相加，但 `total_tokens` 使用最终 delivered/fallback attempt 的原始 total。
- `reasoning-fold` / `reasoning_fold` / `fold` 只保留读取兼容，统一归一到 `delivered-only`；example、docs、contract 不再展示旧模式。
- `total_tokens` 缺失时只兜底为 `input + output`，不额外加 reasoning，避免把 reasoning 明细重复计入 total。
- Codex retry metadata 在进入 retry-without-penalty accumulator / hedge metadata 前按 Codex total 语义归一，覆盖 discarded attempt 缺失 `total_tokens` 的 `sum` 回归。

## Protected Delta Review

- client-visible usage shape：有意变更，默认只暴露 delivered/fallback attempt usage，避免客户端把 hidden retry cost 当上下文占用。
- config 默认值：`client-usage-aggregation` 默认从旧 fold 语义改为 `delivered-only`，legacy 配置读取兼容但不保留正式行为。
- LTS contract marker：更新 `docs/lts/core-feature-contracts.yaml` 和 `scripts/check-lts-contract.sh`，保护 `delivered-only` 与 `sum-with-delivered-total`。
- internal attempt-level usage：不改 `UsageAccumulator` 的 generic 规则、不改 Management usage；Codex retry 只规范化 client aggregation / hedge metadata 通道。executor 测试继续断言 discarded attempt 被记录为 failed usage。
- retry/pass-through/hedge：不改 abnormal 触发、重试预算、quality hedge、longest fallback 选择逻辑。
- Panel/HFS：本 PR 只改 Core；Panel 枚举支持和 HFS 配置/部署不在本 PR 范围内。

## 兼容性

旧配置值 `reasoning-fold`、`reasoning_fold`、`fold` 仍可读取，但 runtime 归一为 `delivered-only`。未知值也回落到 `delivered-only`。

## 验证

- `go test ./internal/config -count=1 -run Codex` 通过。
- `go test ./internal/runtime/executor -count=1 -run TestCodexExecutorAbnormalReasoningRetry` 通过。
- `go test ./internal/runtime/executor -count=1 -run TestCodexExecutorAbnormalReasoningRetry_ClientUsageAggregationSumUsesCodexFallbackWhenPreviousTotalMissing` 通过；该测试修复前复现为 `total_tokens=531`，修复后为 `15`。
- `go test ./internal/watcher/diff -count=1` 通过。
- `scripts/check-lts-contract.sh` 通过。
- `go build -o test-output ./cmd/server && rm -f test-output` 通过。
- `git diff --check` 通过。
- `go list ./... | grep -v /tmp$ | xargs go test` 通过。
- `go test ./...` 额外跑过，唯一失败是 ignored 本地 scratch package `tmp/list_routes.go`；`git check-ignore -v tmp/list_routes.go` 确认为 `.gitignore:63:/tmp`。

## 后续

- CPA-Panel-LTS 需要单独 PR 支持新枚举，避免 Panel 保存配置时把新值回写丢失。
- HFS 由用户手动配置和部署，可按运行目标选择 `delivered-only` 或 `sum-with-delivered-total`；本 PR 不修改 HFS 配置、不部署。