### PR TITLE
收紧 Codex client usage aggregation 正式模式

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -200,6 +200,7 @@ codex:
     # "delivered-only" (default) returns the delivered/fallback attempt's upstream usage unchanged;
     # "sum" adds input/cache/output/reasoning/total fields across all attempts;
     # "sum-with-delivered-total" adds small fields across attempts but keeps total_tokens from the delivered/fallback attempt.
+    # Unsupported values are ignored and default to "delivered-only"; the removed "reasoning-fold" mode is not a supported setting.
     max-retries: 2
     exhausted-behavior: "error"
     client-usage-aggregation: "delivered-only"

--- a/internal/config/codex_websocket_header_defaults_test.go
+++ b/internal/config/codex_websocket_header_defaults_test.go
@@ -305,9 +305,6 @@ func TestCodexAbnormalReasoningRetryClientUsageAggregationNormalization(t *testi
 		{name: "sum", value: "sum", want: CodexAbnormalReasoningRetryClientUsageAggregationSum},
 		{name: "sum with delivered total", value: "sum-with-delivered-total", want: CodexAbnormalReasoningRetryClientUsageAggregationSumWithDeliveredTotal},
 		{name: "sum with delivered total alias", value: "SUM_WITH_DELIVERED_TOTAL", want: CodexAbnormalReasoningRetryClientUsageAggregationSumWithDeliveredTotal},
-		{name: "legacy reasoning fold", value: "reasoning-fold", want: CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly},
-		{name: "legacy reasoning fold alias", value: "reasoning_fold", want: CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly},
-		{name: "legacy fold alias", value: "fold", want: CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly},
 		{name: "unknown", value: "legacy", want: CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly},
 	}
 	for _, tt := range tests {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -449,8 +449,6 @@ func normalizeCodexAbnormalReasoningRetryClientUsageAggregation(value string) st
 		return CodexAbnormalReasoningRetryClientUsageAggregationSum
 	case "sum-with-delivered-total", "sum_with_delivered_total":
 		return CodexAbnormalReasoningRetryClientUsageAggregationSumWithDeliveredTotal
-	case "reasoning-fold", "reasoning_fold", "fold":
-		return CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly
 	default:
 		return CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly
 	}

--- a/internal/runtime/executor/codex_abnormal_reasoning_retry.go
+++ b/internal/runtime/executor/codex_abnormal_reasoning_retry.go
@@ -515,19 +515,8 @@ func addCodexUsageDetail(a, b usage.Detail) usage.Detail {
 	}
 }
 
-func foldedCodexUsageOutputTokens(detail usage.Detail) int64 {
-	detail = normalizeCodexUsageDetail(detail)
-	if detail.OutputTokens >= detail.ReasoningTokens {
-		return detail.OutputTokens
-	}
-	return detail.ReasoningTokens
-}
-
 func normalizeCodexAbnormalReasoningRetryUsageSnapshot(snapshot cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot) cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot {
 	snapshot.Detail = normalizeCodexUsageDetail(snapshot.Detail)
-	if snapshot.FoldedOutputTokens == 0 && hasCodexUsageDetail(snapshot.Detail) {
-		snapshot.FoldedOutputTokens = foldedCodexUsageOutputTokens(snapshot.Detail)
-	}
 	return snapshot
 }
 


### PR DESCRIPTION
## 背景

上一轮 Core PR 已把 `codex.abnormal-reasoning-retry.client-usage-aggregation` 收敛为三个正式模式：`delivered-only`、`sum`、`sum-with-delivered-total`，并取消旧 `reasoning-fold` 的正式行为。

这次是一个 LTS protected delta 的小补丁：进一步把实现和文档语义对齐为“只识别有效枚举；无效值按默认处理”。旧 `reasoning-fold` / `reasoning_fold` / `fold` 不再作为读取兼容 alias 单独声明。

## 变更

- 删除 `normalizeCodexAbnormalReasoningRetryClientUsageAggregation` 中对旧 `reasoning-fold` / `reasoning_fold` / `fold` 的显式 alias 分支。
- 删除配置测试中 legacy alias 被当作兼容值的断言。
- 删除 Codex executor 内已经没有客户端 usage 消费者的本地 fold 补算 helper，避免误读为仍存在 reasoning-fold 聚合路径。
- 更新 `config.example.yaml`：明确只支持列出的三个模式，其他值按默认 `delivered-only` 处理；旧 `reasoning-fold` 不是支持项。

## Protected delta review

- client-visible usage shape：不改变三个正式模式的输出语义。
- config 默认值：仍为 `delivered-only`。
- LTS contract marker：仍保护 `client-usage-aggregation`、`delivered-only`、`sum-with-delivered-total`。
- internal attempt-level usage：不变，discarded retry 成本仍由内部 attempt-level 统计记录。
- SDK `RetryWithoutPenaltyUsageSnapshot.FoldedOutputTokens` 公共字段未删除，本 PR 只清理 Core Codex executor 中的残留补算。

## 兼容性

- `delivered-only` / `sum` / `sum-with-delivered-total` 正常识别。
- 旧 `reasoning-fold` 不再是正式或兼容枚举；如果用户仍写旧值，会和任意 unknown value 一样回落到默认 `delivered-only`。
- HFS 生产配置应直接写 `client-usage-aggregation: delivered-only`，不要写旧值。

## 验证

已通过：

```bash
go test ./internal/config -count=1 -run 'Codex'
go test ./internal/runtime/executor -count=1 -run 'TestCodexExecutorAbnormalReasoningRetry'
scripts/check-lts-contract.sh
go build -o test-output ./cmd/server && rm -f test-output
git diff --check
go list ./... | grep -v '/tmp$' | xargs go test
```

说明：

```bash
go test ./...
```

仍只失败在本地 ignored scratch package `tmp/list_routes.go`，不是产品代码回归；排除 `/tmp` 后产品包全量通过。

## 后续

- 合并后打新 tag `v1-tls-0.0.7`。
- HFS 由用户手动同步配置和 redeploy；本 PR 不部署 HFS、不修改远端 Space。
