### PR TITLE
Codex abnormal reasoning 增加交付策略配置

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -177,6 +177,9 @@ codex:
   # reasoning token counts. Disabled by default.
   abnormal-reasoning-retry:
     enabled: false
+    # Optional action overrides enabled without rewriting existing config files:
+    # "retry" detects and retries; "observe-only" logs matches but returns the original response; "disabled" turns the guard off.
+    # action: "retry"
     model-contains:
       - "gpt-5.5"
     # Optional translated Codex reasoning.effort filter. Empty means any effort.
@@ -203,13 +206,24 @@ codex:
     # Unsupported values are ignored and default to "delivered-only"; the removed "reasoning-fold" mode is not a supported setting.
     max-retries: 2
     exhausted-behavior: "error"
+    # delivery-policy controls mixed pools where at least one non-special success exists:
+    # "best-non-special" (default) keeps 516/1034 responses out when a non-special success exists;
+    # "first-non-special" keeps first-success-wins behavior and minimizes waiting;
+    # "max-output" can choose a retained 516/1034 fallback over a shorter non-special success;
+    # "latest" selects the latest completed non-special winner in quality hedged comparisons.
+    delivery-policy: "best-non-special"
+    # fallback-policy controls all-special pass-through only; delivery-policy is ignored when every candidate is 516/1034.
+    # "best-special" (default) prefers higher special reasoning blocks (1034 over 516), then output_tokens;
+    # "max-output-special" chooses the largest output_tokens special fallback;
+    # "latest-special" chooses the most recently retained special fallback.
+    fallback-policy: "best-special"
     client-usage-aggregation: "delivered-only"
     # Optional hedged retry for abnormal attempts. When enabled, a retry lane starts first;
-    # after hedge-delay-ms, a second parallel lane may start. Default mode is "quality".
-    # mode: "quality" waits for dispatched lanes and selects the largest output_tokens winner; "speed" keeps first-success-wins behavior.
+    # after hedge-delay-ms, a second parallel lane may start. delivery-policy is the winner policy;
+    # mode remains a scheduling hint: "quality" waits for dispatched lanes, while "speed" keeps first-success-wins behavior.
     # quality mode still counts max-retries per dispatched lane; use max-retries: 4 for two full two-lane waves.
     # hedge-delay-ms is not forced to 0; set hedge-delay-ms: 0 when the goal is always to compare two lanes.
-    # When exhausted-behavior is "pass-through", the longest abnormal pass-through fallback in the retry chain is returned.
+    # When exhausted-behavior is "pass-through", fallback-policy selects the abnormal pass-through fallback.
     hedged-retry:
       enabled: false
       mode: "quality"

--- a/docs/lts/core-feature-contracts.yaml
+++ b/docs/lts/core-feature-contracts.yaml
@@ -159,6 +159,7 @@ features:
     reason: CPA-Core-LTS can optionally discard and retry suspicious Codex OAuth responses with attempt-level CPA accounting, default quality hedging, longest abnormal pass-through fallback, and separated client-visible usage modes, without changing plugin ABI.
     config_keys:
       - codex.abnormal-reasoning-retry.enabled
+      - codex.abnormal-reasoning-retry.action
       - codex.abnormal-reasoning-retry.model-contains
       - codex.abnormal-reasoning-retry.reasoning-efforts
       - codex.abnormal-reasoning-retry.reasoning-tokens
@@ -168,6 +169,8 @@ features:
       - codex.abnormal-reasoning-retry.stream-buffer-max-bytes
       - codex.abnormal-reasoning-retry.max-retries
       - codex.abnormal-reasoning-retry.exhausted-behavior
+      - codex.abnormal-reasoning-retry.delivery-policy
+      - codex.abnormal-reasoning-retry.fallback-policy
       - codex.abnormal-reasoning-retry.client-usage-aggregation
       - codex.abnormal-reasoning-retry.hedged-retry.enabled
       - codex.abnormal-reasoning-retry.hedged-retry.mode
@@ -187,12 +190,17 @@ features:
       - config.example.yaml
     required_markers:
       - abnormal-reasoning-retry
+      - observe-only
+      - delivery-policy
+      - fallback-policy
+      - best-non-special
+      - first-non-special
+      - max-output-special
       - hedged-retry
       - client-usage-aggregation
       - delivered-only
       - sum-with-delivered-total
       - quality
-      - longest abnormal pass-through fallback
       - hedge-delay-ms
       - require-distinct-auth
       - stream-buffer-max-bytes

--- a/internal/config/codex_websocket_header_defaults_test.go
+++ b/internal/config/codex_websocket_header_defaults_test.go
@@ -69,6 +69,9 @@ func TestLoadConfigOptional_CodexAbnormalReasoningRetryDefaults(t *testing.T) {
 	if effective.Enabled {
 		t.Fatal("Enabled = true, want false")
 	}
+	if effective.Action != CodexAbnormalReasoningRetryActionDisabled {
+		t.Fatalf("Action = %q, want %q", effective.Action, CodexAbnormalReasoningRetryActionDisabled)
+	}
 	if got, want := effective.ModelContains, []string{"gpt-5.5"}; !equalStringSlices(got, want) {
 		t.Fatalf("ModelContains = %#v, want %#v", got, want)
 	}
@@ -99,6 +102,12 @@ func TestLoadConfigOptional_CodexAbnormalReasoningRetryDefaults(t *testing.T) {
 	if effective.ClientUsageAggregation != CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly {
 		t.Fatalf("ClientUsageAggregation = %q, want %q", effective.ClientUsageAggregation, CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly)
 	}
+	if effective.DeliveryPolicy != CodexAbnormalReasoningRetryDeliveryPolicyBestNonSpecial {
+		t.Fatalf("DeliveryPolicy = %q, want %q", effective.DeliveryPolicy, CodexAbnormalReasoningRetryDeliveryPolicyBestNonSpecial)
+	}
+	if effective.FallbackPolicy != CodexAbnormalReasoningRetryFallbackPolicyBestSpecial {
+		t.Fatalf("FallbackPolicy = %q, want %q", effective.FallbackPolicy, CodexAbnormalReasoningRetryFallbackPolicyBestSpecial)
+	}
 	if effective.HedgedRetry.Enabled {
 		t.Fatal("HedgedRetry.Enabled = true, want false")
 	}
@@ -120,6 +129,7 @@ func TestLoadConfigOptional_CodexAbnormalReasoningRetryExplicit(t *testing.T) {
 codex:
   abnormal-reasoning-retry:
     enabled: true
+    action: "observe-only"
     model-contains:
       - "  gpt-5.5  "
       - "gpt-5.5"
@@ -143,6 +153,8 @@ codex:
     max-retries: 0
     exhausted-behavior: "passthrough"
     client-usage-aggregation: "sum"
+    delivery-policy: "max-output"
+    fallback-policy: "latest-special"
     hedged-retry:
       enabled: true
       mode: "quality"
@@ -161,6 +173,9 @@ codex:
 	effective := cfg.Codex.AbnormalReasoningRetry.Effective()
 	if !effective.Enabled {
 		t.Fatal("Enabled = false, want true")
+	}
+	if effective.Action != CodexAbnormalReasoningRetryActionObserveOnly {
+		t.Fatalf("Action = %q, want %q", effective.Action, CodexAbnormalReasoningRetryActionObserveOnly)
 	}
 	if got, want := effective.ModelContains, []string{"gpt-5.5", "custom"}; !equalStringSlices(got, want) {
 		t.Fatalf("ModelContains = %#v, want %#v", got, want)
@@ -191,6 +206,12 @@ codex:
 	}
 	if effective.ClientUsageAggregation != CodexAbnormalReasoningRetryClientUsageAggregationSum {
 		t.Fatalf("ClientUsageAggregation = %q, want %q", effective.ClientUsageAggregation, CodexAbnormalReasoningRetryClientUsageAggregationSum)
+	}
+	if effective.DeliveryPolicy != CodexAbnormalReasoningRetryDeliveryPolicyMaxOutput {
+		t.Fatalf("DeliveryPolicy = %q, want %q", effective.DeliveryPolicy, CodexAbnormalReasoningRetryDeliveryPolicyMaxOutput)
+	}
+	if effective.FallbackPolicy != CodexAbnormalReasoningRetryFallbackPolicyLatestSpecial {
+		t.Fatalf("FallbackPolicy = %q, want %q", effective.FallbackPolicy, CodexAbnormalReasoningRetryFallbackPolicyLatestSpecial)
 	}
 	if !effective.HedgedRetry.Enabled {
 		t.Fatal("HedgedRetry.Enabled = false, want true")
@@ -270,7 +291,10 @@ func TestLoadConfigOptional_CodexAbnormalReasoningRetryInvalidV2ModesDefault(t *
 codex:
   abnormal-reasoning-retry:
     enabled: true
+    action: "unexpected"
     client-usage-aggregation: "legacy"
+    delivery-policy: "salvage-collapsed"
+    fallback-policy: "longest"
     hedged-retry:
       mode: "latency"
 `)
@@ -286,6 +310,15 @@ codex:
 	effective := cfg.Codex.AbnormalReasoningRetry.Effective()
 	if effective.ClientUsageAggregation != CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly {
 		t.Fatalf("ClientUsageAggregation = %q, want %q", effective.ClientUsageAggregation, CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly)
+	}
+	if effective.Action != CodexAbnormalReasoningRetryActionRetry {
+		t.Fatalf("Action = %q, want %q", effective.Action, CodexAbnormalReasoningRetryActionRetry)
+	}
+	if effective.DeliveryPolicy != CodexAbnormalReasoningRetryDeliveryPolicyBestNonSpecial {
+		t.Fatalf("DeliveryPolicy = %q, want %q", effective.DeliveryPolicy, CodexAbnormalReasoningRetryDeliveryPolicyBestNonSpecial)
+	}
+	if effective.FallbackPolicy != CodexAbnormalReasoningRetryFallbackPolicyMaxOutputSpecial {
+		t.Fatalf("FallbackPolicy = %q, want %q", effective.FallbackPolicy, CodexAbnormalReasoningRetryFallbackPolicyMaxOutputSpecial)
 	}
 	if effective.HedgedRetry.Mode != CodexAbnormalReasoningHedgedRetryModeQuality {
 		t.Fatalf("HedgedRetry.Mode = %q, want %q", effective.HedgedRetry.Mode, CodexAbnormalReasoningHedgedRetryModeQuality)
@@ -311,6 +344,74 @@ func TestCodexAbnormalReasoningRetryClientUsageAggregationNormalization(t *testi
 		t.Run(tt.name, func(t *testing.T) {
 			if got := normalizeCodexAbnormalReasoningRetryClientUsageAggregation(tt.value); got != tt.want {
 				t.Fatalf("normalizeCodexAbnormalReasoningRetryClientUsageAggregation(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCodexAbnormalReasoningRetryActionNormalization(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		enabled bool
+		want    string
+	}{
+		{name: "empty disabled", value: "", enabled: false, want: CodexAbnormalReasoningRetryActionDisabled},
+		{name: "empty retry", value: "", enabled: true, want: CodexAbnormalReasoningRetryActionRetry},
+		{name: "retry", value: "retry", enabled: false, want: CodexAbnormalReasoningRetryActionRetry},
+		{name: "observe only", value: "observe_only", enabled: false, want: CodexAbnormalReasoningRetryActionObserveOnly},
+		{name: "disabled", value: "off", enabled: true, want: CodexAbnormalReasoningRetryActionDisabled},
+		{name: "unknown derives enabled", value: "unexpected", enabled: true, want: CodexAbnormalReasoningRetryActionRetry},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeCodexAbnormalReasoningRetryAction(tt.value, tt.enabled); got != tt.want {
+				t.Fatalf("normalizeCodexAbnormalReasoningRetryAction(%q, %v) = %q, want %q", tt.value, tt.enabled, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCodexAbnormalReasoningRetryDeliveryPolicyNormalization(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "empty", value: "", want: CodexAbnormalReasoningRetryDeliveryPolicyBestNonSpecial},
+		{name: "best", value: "best-non-special", want: CodexAbnormalReasoningRetryDeliveryPolicyBestNonSpecial},
+		{name: "best alias", value: "normal_first", want: CodexAbnormalReasoningRetryDeliveryPolicyBestNonSpecial},
+		{name: "first", value: "first_non_special", want: CodexAbnormalReasoningRetryDeliveryPolicyFirstNonSpecial},
+		{name: "max output", value: "longest", want: CodexAbnormalReasoningRetryDeliveryPolicyMaxOutput},
+		{name: "latest", value: "last", want: CodexAbnormalReasoningRetryDeliveryPolicyLatest},
+		{name: "unsupported salvage", value: "salvage-collapsed", want: CodexAbnormalReasoningRetryDeliveryPolicyBestNonSpecial},
+		{name: "unknown", value: "unexpected", want: CodexAbnormalReasoningRetryDeliveryPolicyBestNonSpecial},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeCodexAbnormalReasoningRetryDeliveryPolicy(tt.value); got != tt.want {
+				t.Fatalf("normalizeCodexAbnormalReasoningRetryDeliveryPolicy(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCodexAbnormalReasoningRetryFallbackPolicyNormalization(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "empty", value: "", want: CodexAbnormalReasoningRetryFallbackPolicyBestSpecial},
+		{name: "best", value: "best_special", want: CodexAbnormalReasoningRetryFallbackPolicyBestSpecial},
+		{name: "max output", value: "longest", want: CodexAbnormalReasoningRetryFallbackPolicyMaxOutputSpecial},
+		{name: "latest", value: "last", want: CodexAbnormalReasoningRetryFallbackPolicyLatestSpecial},
+		{name: "unknown", value: "unexpected", want: CodexAbnormalReasoningRetryFallbackPolicyBestSpecial},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeCodexAbnormalReasoningRetryFallbackPolicy(tt.value); got != tt.want {
+				t.Fatalf("normalizeCodexAbnormalReasoningRetryFallbackPolicy(%q) = %q, want %q", tt.value, got, tt.want)
 			}
 		})
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -316,11 +316,21 @@ type CodexConfig struct {
 }
 
 const (
+	CodexAbnormalReasoningRetryActionRetry                                 = "retry"
+	CodexAbnormalReasoningRetryActionObserveOnly                           = "observe-only"
+	CodexAbnormalReasoningRetryActionDisabled                              = "disabled"
 	CodexAbnormalReasoningRetryExhaustedBehaviorError                      = "error"
 	CodexAbnormalReasoningRetryExhaustedBehaviorPassThrough                = "pass-through"
 	CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly         = "delivered-only"
 	CodexAbnormalReasoningRetryClientUsageAggregationSum                   = "sum"
 	CodexAbnormalReasoningRetryClientUsageAggregationSumWithDeliveredTotal = "sum-with-delivered-total"
+	CodexAbnormalReasoningRetryDeliveryPolicyBestNonSpecial                = "best-non-special"
+	CodexAbnormalReasoningRetryDeliveryPolicyFirstNonSpecial               = "first-non-special"
+	CodexAbnormalReasoningRetryDeliveryPolicyMaxOutput                     = "max-output"
+	CodexAbnormalReasoningRetryDeliveryPolicyLatest                        = "latest"
+	CodexAbnormalReasoningRetryFallbackPolicyBestSpecial                   = "best-special"
+	CodexAbnormalReasoningRetryFallbackPolicyMaxOutputSpecial              = "max-output-special"
+	CodexAbnormalReasoningRetryFallbackPolicyLatestSpecial                 = "latest-special"
 	CodexAbnormalReasoningHedgedRetryModeSpeed                             = "speed"
 	CodexAbnormalReasoningHedgedRetryModeQuality                           = "quality"
 )
@@ -329,6 +339,7 @@ const (
 // suspicious Codex successful responses.
 type CodexAbnormalReasoningRetryConfig struct {
 	Enabled                bool                                    `yaml:"enabled" json:"enabled"`
+	Action                 string                                  `yaml:"action,omitempty" json:"action,omitempty"`
 	ModelContains          []string                                `yaml:"model-contains" json:"model-contains"`
 	ReasoningEfforts       []string                                `yaml:"reasoning-efforts" json:"reasoning-efforts"`
 	ReasoningTokens        []int64                                 `yaml:"reasoning-tokens" json:"reasoning-tokens"`
@@ -339,6 +350,8 @@ type CodexAbnormalReasoningRetryConfig struct {
 	MaxRetries             *int                                    `yaml:"max-retries,omitempty" json:"max-retries,omitempty"`
 	ExhaustedBehavior      string                                  `yaml:"exhausted-behavior,omitempty" json:"exhausted-behavior,omitempty"`
 	ClientUsageAggregation string                                  `yaml:"client-usage-aggregation,omitempty" json:"client-usage-aggregation,omitempty"`
+	DeliveryPolicy         string                                  `yaml:"delivery-policy,omitempty" json:"delivery-policy,omitempty"`
+	FallbackPolicy         string                                  `yaml:"fallback-policy,omitempty" json:"fallback-policy,omitempty"`
 	HedgedRetry            CodexAbnormalReasoningHedgedRetryConfig `yaml:"hedged-retry" json:"hedged-retry"`
 }
 
@@ -356,6 +369,7 @@ type CodexAbnormalReasoningHedgedRetryConfig struct {
 // existing config.yaml files are not rewritten to add default values.
 type EffectiveCodexAbnormalReasoningRetryConfig struct {
 	Enabled                bool
+	Action                 string
 	ModelContains          []string
 	ReasoningEfforts       []string
 	ReasoningTokens        []int64
@@ -366,6 +380,8 @@ type EffectiveCodexAbnormalReasoningRetryConfig struct {
 	MaxRetries             int
 	ExhaustedBehavior      string
 	ClientUsageAggregation string
+	DeliveryPolicy         string
+	FallbackPolicy         string
 	HedgedRetry            EffectiveCodexAbnormalReasoningHedgedRetryConfig
 }
 
@@ -409,8 +425,10 @@ func (c CodexAbnormalReasoningRetryConfig) Effective() EffectiveCodexAbnormalRea
 	if c.HedgedRetry.RequireDistinctAuth != nil {
 		requireDistinctAuth = *c.HedgedRetry.RequireDistinctAuth
 	}
+	action := normalizeCodexAbnormalReasoningRetryAction(c.Action, c.Enabled)
 	return EffectiveCodexAbnormalReasoningRetryConfig{
-		Enabled:                c.Enabled,
+		Enabled:                action == CodexAbnormalReasoningRetryActionRetry || action == CodexAbnormalReasoningRetryActionObserveOnly,
+		Action:                 action,
 		ModelContains:          defaultedTrimmedStringList(c.ModelContains, []string{"gpt-5.5"}, false),
 		ReasoningEfforts:       defaultedTrimmedStringList(c.ReasoningEfforts, nil, true),
 		ReasoningTokens:        defaultedPositiveInt64List(c.ReasoningTokens, []int64{516, 1034}),
@@ -421,12 +439,30 @@ func (c CodexAbnormalReasoningRetryConfig) Effective() EffectiveCodexAbnormalRea
 		MaxRetries:             maxRetries,
 		ExhaustedBehavior:      normalizeCodexAbnormalReasoningRetryExhaustedBehavior(c.ExhaustedBehavior),
 		ClientUsageAggregation: normalizeCodexAbnormalReasoningRetryClientUsageAggregation(c.ClientUsageAggregation),
+		DeliveryPolicy:         normalizeCodexAbnormalReasoningRetryDeliveryPolicy(c.DeliveryPolicy),
+		FallbackPolicy:         normalizeCodexAbnormalReasoningRetryFallbackPolicy(c.FallbackPolicy),
 		HedgedRetry: EffectiveCodexAbnormalReasoningHedgedRetryConfig{
 			Enabled:             c.HedgedRetry.Enabled,
 			Mode:                normalizeCodexAbnormalReasoningHedgedRetryMode(c.HedgedRetry.Mode),
 			HedgeDelayMS:        hedgeDelayMS,
 			RequireDistinctAuth: requireDistinctAuth,
 		},
+	}
+}
+
+func normalizeCodexAbnormalReasoningRetryAction(value string, enabled bool) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case CodexAbnormalReasoningRetryActionRetry:
+		return CodexAbnormalReasoningRetryActionRetry
+	case "observe_only", "observe-only", "observe":
+		return CodexAbnormalReasoningRetryActionObserveOnly
+	case CodexAbnormalReasoningRetryActionDisabled, "disable", "off":
+		return CodexAbnormalReasoningRetryActionDisabled
+	default:
+		if enabled {
+			return CodexAbnormalReasoningRetryActionRetry
+		}
+		return CodexAbnormalReasoningRetryActionDisabled
 	}
 }
 
@@ -451,6 +487,34 @@ func normalizeCodexAbnormalReasoningRetryClientUsageAggregation(value string) st
 		return CodexAbnormalReasoningRetryClientUsageAggregationSumWithDeliveredTotal
 	default:
 		return CodexAbnormalReasoningRetryClientUsageAggregationDeliveredOnly
+	}
+}
+
+func normalizeCodexAbnormalReasoningRetryDeliveryPolicy(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "best-non-special", "best_non_special", "normal-first", "normal_first":
+		return CodexAbnormalReasoningRetryDeliveryPolicyBestNonSpecial
+	case "first-non-special", "first_non_special", "first-normal", "first_normal":
+		return CodexAbnormalReasoningRetryDeliveryPolicyFirstNonSpecial
+	case "max-output", "max_output", "longest":
+		return CodexAbnormalReasoningRetryDeliveryPolicyMaxOutput
+	case "latest", "last":
+		return CodexAbnormalReasoningRetryDeliveryPolicyLatest
+	default:
+		return CodexAbnormalReasoningRetryDeliveryPolicyBestNonSpecial
+	}
+}
+
+func normalizeCodexAbnormalReasoningRetryFallbackPolicy(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "best-special", "best_special":
+		return CodexAbnormalReasoningRetryFallbackPolicyBestSpecial
+	case "max-output-special", "max_output_special", "max-output", "max_output", "longest":
+		return CodexAbnormalReasoningRetryFallbackPolicyMaxOutputSpecial
+	case "latest-special", "latest_special", "latest", "last":
+		return CodexAbnormalReasoningRetryFallbackPolicyLatestSpecial
+	default:
+		return CodexAbnormalReasoningRetryFallbackPolicyBestSpecial
 	}
 }
 

--- a/internal/runtime/executor/codex_abnormal_reasoning_retry.go
+++ b/internal/runtime/executor/codex_abnormal_reasoning_retry.go
@@ -15,6 +15,7 @@ import (
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -23,9 +24,12 @@ type codexAbnormalReasoningRetryPolicy struct {
 	enabled                bool
 	streamBuffer           bool
 	streamBufferMax        int64
+	action                 string
 	maxRetries             int
 	exhaustedBehavior      string
 	clientUsageAggregation string
+	deliveryPolicy         string
+	fallbackPolicy         string
 	hedgeEnabled           bool
 	hedgeMode              string
 	hedgeDelay             time.Duration
@@ -41,6 +45,8 @@ type codexAbnormalReasoningRetryError struct {
 	maxRetries              int
 	exhaustedBehavior       string
 	clientUsageAggregation  string
+	deliveryPolicy          string
+	fallbackPolicy          string
 	hedgeEnabled            bool
 	hedgeMode               string
 	hedgeDelay              time.Duration
@@ -101,6 +107,27 @@ func (e *codexAbnormalReasoningRetryError) RetryWithoutPenaltyHedgeMode() string
 		return config.CodexAbnormalReasoningHedgedRetryModeQuality
 	}
 	return e.hedgeMode
+}
+
+func (e *codexAbnormalReasoningRetryError) RetryWithoutPenaltyDeliveryPolicy() string {
+	if e == nil {
+		return ""
+	}
+	return e.deliveryPolicy
+}
+
+func (e *codexAbnormalReasoningRetryError) RetryWithoutPenaltyFallbackPolicy() string {
+	if e == nil {
+		return ""
+	}
+	return e.fallbackPolicy
+}
+
+func (e *codexAbnormalReasoningRetryError) RetryWithoutPenaltyCandidatePolicy() cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy {
+	if e == nil {
+		return cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy{}
+	}
+	return codexAbnormalReasoningRetryCandidatePolicy(e.detail, e.deliveryPolicy, e.fallbackPolicy, cliproxyexecutor.RetryWithoutPenaltyCandidateKindSpecial)
 }
 
 func (e *codexAbnormalReasoningRetryError) RetryWithoutPenaltyAuthID() string {
@@ -187,9 +214,12 @@ func newCodexAbnormalReasoningRetryPolicy(cfg *config.Config, auth *cliproxyauth
 		enabled:                true,
 		streamBuffer:           effective.StreamBuffer,
 		streamBufferMax:        effective.StreamBufferMaxBytes,
+		action:                 effective.Action,
 		maxRetries:             effective.MaxRetries,
 		exhaustedBehavior:      effective.ExhaustedBehavior,
 		clientUsageAggregation: effective.ClientUsageAggregation,
+		deliveryPolicy:         effective.DeliveryPolicy,
+		fallbackPolicy:         effective.FallbackPolicy,
 		hedgeEnabled:           effective.HedgedRetry.Enabled,
 		hedgeMode:              effective.HedgedRetry.Mode,
 		hedgeDelay:             time.Duration(effective.HedgedRetry.HedgeDelayMS) * time.Millisecond,
@@ -245,11 +275,29 @@ func (p codexAbnormalReasoningRetryPolicy) retryError(detail usage.Detail, reaso
 			return nil
 		}
 	}
+	if p.action == config.CodexAbnormalReasoningRetryActionObserveOnly {
+		visibleTokens := detail.OutputTokens - detail.ReasoningTokens
+		if visibleTokens < 0 {
+			visibleTokens = 0
+		}
+		log.WithFields(log.Fields{
+			"auth_id":          p.authID,
+			"reasoning_effort": normalizeCodexAbnormalReasoningRetryEffort(reasoningEffort),
+			"reasoning_tokens": detail.ReasoningTokens,
+			"output_tokens":    detail.OutputTokens,
+			"visible_tokens":   visibleTokens,
+			"total_tokens":     detail.TotalTokens,
+			"action":           p.action,
+		}).Info("codex abnormal reasoning retry observe-only match")
+		return nil
+	}
 	err := &codexAbnormalReasoningRetryError{
 		detail:                 detail,
 		maxRetries:             p.maxRetries,
 		exhaustedBehavior:      p.exhaustedBehavior,
 		clientUsageAggregation: p.clientUsageAggregation,
+		deliveryPolicy:         p.deliveryPolicy,
+		fallbackPolicy:         p.fallbackPolicy,
 		hedgeEnabled:           p.hedgeEnabled,
 		hedgeMode:              p.hedgeMode,
 		hedgeDelay:             p.hedgeDelay,
@@ -520,11 +568,29 @@ func normalizeCodexAbnormalReasoningRetryUsageSnapshot(snapshot cliproxyexecutor
 	return snapshot
 }
 
-func codexAbnormalReasoningRetryResponseMetadata(detail usage.Detail, finalizer cliproxyexecutor.RetryWithoutPenaltyResponseFinalizer) map[string]any {
+func codexAbnormalReasoningRetryCandidatePolicy(detail usage.Detail, deliveryPolicy, fallbackPolicy, candidateKind string) cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy {
 	detail = normalizeCodexUsageDetail(detail)
+	visibleTokens := detail.OutputTokens - detail.ReasoningTokens
+	if visibleTokens < 0 {
+		visibleTokens = 0
+	}
+	return cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy{
+		DeliveryPolicy:  deliveryPolicy,
+		FallbackPolicy:  fallbackPolicy,
+		CandidateKind:   candidateKind,
+		ReasoningTokens: detail.ReasoningTokens,
+		OutputTokens:    detail.OutputTokens,
+		VisibleTokens:   visibleTokens,
+	}
+}
+
+func codexAbnormalReasoningRetryResponseMetadata(detail usage.Detail, finalizer cliproxyexecutor.RetryWithoutPenaltyResponseFinalizer, policy codexAbnormalReasoningRetryPolicy) map[string]any {
+	detail = normalizeCodexUsageDetail(detail)
+	candidatePolicy := codexAbnormalReasoningRetryCandidatePolicy(detail, policy.deliveryPolicy, policy.fallbackPolicy, cliproxyexecutor.RetryWithoutPenaltyCandidateKindNonSpecial)
 	meta := map[string]any{
-		cliproxyexecutor.RetryWithoutPenaltyUsageDetailMetadataKey: detail,
-		cliproxyexecutor.RetryWithoutPenaltyHedgeScoreMetadataKey:  detail.OutputTokens,
+		cliproxyexecutor.RetryWithoutPenaltyUsageDetailMetadataKey:     detail,
+		cliproxyexecutor.RetryWithoutPenaltyHedgeScoreMetadataKey:      detail.OutputTokens,
+		cliproxyexecutor.RetryWithoutPenaltyCandidatePolicyMetadataKey: candidatePolicy,
 	}
 	if finalizer != nil {
 		meta[cliproxyexecutor.RetryWithoutPenaltyResponseFinalizerMetadataKey] = finalizer

--- a/internal/runtime/executor/codex_abnormal_reasoning_retry.go
+++ b/internal/runtime/executor/codex_abnormal_reasoning_retry.go
@@ -236,7 +236,11 @@ func (p codexAbnormalReasoningRetryPolicy) Enabled() bool {
 }
 
 func (p codexAbnormalReasoningRetryPolicy) StreamBuffer() bool {
-	return p.enabled && p.streamBuffer
+	return p.enabled && p.action == config.CodexAbnormalReasoningRetryActionRetry && p.streamBuffer
+}
+
+func (p codexAbnormalReasoningRetryPolicy) ObserveOnly() bool {
+	return p.enabled && p.action == config.CodexAbnormalReasoningRetryActionObserveOnly
 }
 
 func (p codexAbnormalReasoningRetryPolicy) StreamBufferMaxBytes() int64 {

--- a/internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
+++ b/internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
@@ -1366,6 +1366,69 @@ func TestCodexExecutorAbnormalReasoningRetry_StreamingBufferDisabledDoesNotRetry
 	}
 }
 
+func TestCodexExecutorAbnormalReasoningRetry_ObserveOnlyStreamingDoesNotBufferUntilCompleted(t *testing.T) {
+	allowCompleted := make(chan struct{})
+	var releaseCompleted sync.Once
+	release := func() {
+		releaseCompleted.Do(func() {
+			close(allowCompleted)
+		})
+	}
+	defer release()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(`data: {"type":"response.output_text.delta","delta":"visible"}` + "\n\n"))
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		select {
+		case <-allowCompleted:
+		case <-r.Context().Done():
+			return
+		}
+		_, _ = w.Write([]byte(codexCompletedSSE("gpt-5.5", 516)))
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(codexAbnormalReasoningRetryTestConfigWithAction(config.CodexAbnormalReasoningRetryActionObserveOnly))
+	result, err := executor.ExecuteStream(context.Background(), codexAbnormalReasoningRetryTestAuth(server.URL), cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"hello"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error = %v", err)
+	}
+
+	select {
+	case chunk, ok := <-result.Chunks:
+		if !ok {
+			t.Fatal("stream closed before first payload")
+		}
+		if chunk.Err != nil {
+			t.Fatalf("first stream chunk error = %v, want nil", chunk.Err)
+		}
+		if !bytes.Contains(chunk.Payload, []byte("visible")) {
+			t.Fatalf("first stream payload = %s, want visible delta before completed", chunk.Payload)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("observe-only stream buffered first payload until response.completed")
+	}
+
+	release()
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v, want nil", chunk.Err)
+		}
+	}
+}
+
 func TestCodexExecutorAbnormalReasoningRetry_StreamingBufferMaxBytesFlushesAndDisablesRetry(t *testing.T) {
 	streamBufferMaxBytes := int64(1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
+++ b/internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
@@ -56,6 +56,12 @@ func TestCodexExecutorAbnormalReasoningRetry_NonStreaming(t *testing.T) {
 			reasoning: 128,
 		},
 		{
+			name:      "observe only does not retry",
+			cfg:       codexAbnormalReasoningRetryTestConfigWithAction(config.CodexAbnormalReasoningRetryActionObserveOnly),
+			model:     "gpt-5.5",
+			reasoning: 516,
+		},
+		{
 			name:      "model mismatch",
 			cfg:       codexAbnormalReasoningRetryTestConfig(nil, nil),
 			model:     "gpt-5.4",
@@ -388,6 +394,92 @@ func TestCodexExecutorAbnormalReasoningRetry_ManagerRecordsAttemptLevelUsageAndD
 	}
 	if successRecord.Detail.TotalTokens != 12 || successRecord.Detail.ReasoningTokens != 128 {
 		t.Fatalf("success record detail = %+v, want final attempt total=12 reasoning=128", successRecord.Detail)
+	}
+}
+
+func TestCodexExecutorAbnormalReasoningRetry_BestNonSpecialKeepsShorterSuccess(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "text/event-stream")
+		if calls == 1 {
+			_, _ = w.Write([]byte(codexCompletedSSEWithTextAndUsage("gpt-5.5", "special", 516, 1, 80, 81)))
+			return
+		}
+		_, _ = w.Write([]byte(codexCompletedSSEWithTextAndUsage("gpt-5.5", "non-special", 128, 5, 20, 25)))
+	}))
+	defer server.Close()
+
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(NewCodexExecutor(codexAbnormalReasoningRetryTestConfigWithDeliveryPolicy(config.CodexAbnormalReasoningRetryDeliveryPolicyBestNonSpecial)))
+	manager.SetRetryConfig(1, 0, 0)
+
+	auth := codexAbnormalReasoningRetryTestAuth(server.URL)
+	auth.ID = "codex-oauth-best-non-special"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, "codex", []*registry.ModelInfo{{ID: "gpt-5.5"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(auth.ID)
+	})
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"hello"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error = %v, want nil", err)
+	}
+	if !bytes.Contains(resp.Payload, []byte("non-special")) || bytes.Contains(resp.Payload, []byte(`"text":"special"`)) {
+		t.Fatalf("payload = %s, want non-special success", resp.Payload)
+	}
+}
+
+func TestCodexExecutorAbnormalReasoningRetry_MaxOutputCanReturnLongerSpecial(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "text/event-stream")
+		if calls == 1 {
+			_, _ = w.Write([]byte(codexCompletedSSEWithTextAndUsage("gpt-5.5", "special", 516, 1, 80, 81)))
+			return
+		}
+		_, _ = w.Write([]byte(codexCompletedSSEWithTextAndUsage("gpt-5.5", "short-success", 128, 5, 20, 25)))
+	}))
+	defer server.Close()
+
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(NewCodexExecutor(codexAbnormalReasoningRetryTestConfigWithDeliveryPolicy(config.CodexAbnormalReasoningRetryDeliveryPolicyMaxOutput)))
+	manager.SetRetryConfig(1, 0, 0)
+
+	auth := codexAbnormalReasoningRetryTestAuth(server.URL)
+	auth.ID = "codex-oauth-max-output-special"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, "codex", []*registry.ModelInfo{{ID: "gpt-5.5"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(auth.ID)
+	})
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{
+		Model:   "gpt-5.5",
+		Payload: []byte(`{"model":"gpt-5.5","input":"hello"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute error = %v, want nil", err)
+	}
+	if !bytes.Contains(resp.Payload, []byte(`"text":"special"`)) || bytes.Contains(resp.Payload, []byte("short-success")) {
+		t.Fatalf("payload = %s, want longer special fallback", resp.Payload)
 	}
 }
 
@@ -1327,9 +1419,21 @@ func codexAbnormalReasoningRetryTestConfigWithEfforts(efforts []string) *config.
 	return cfg
 }
 
+func codexAbnormalReasoningRetryTestConfigWithAction(action string) *config.Config {
+	cfg := codexAbnormalReasoningRetryTestConfig(nil, nil)
+	cfg.Codex.AbnormalReasoningRetry.Action = action
+	return cfg
+}
+
 func codexAbnormalReasoningRetryTestConfigWithAggregation(aggregation string) *config.Config {
 	cfg := codexAbnormalReasoningRetryTestConfig(nil, nil)
 	cfg.Codex.AbnormalReasoningRetry.ClientUsageAggregation = aggregation
+	return cfg
+}
+
+func codexAbnormalReasoningRetryTestConfigWithDeliveryPolicy(deliveryPolicy string) *config.Config {
+	cfg := codexAbnormalReasoningRetryTestConfig(nil, nil)
+	cfg.Codex.AbnormalReasoningRetry.DeliveryPolicy = deliveryPolicy
 	return cfg
 }
 

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -1304,6 +1304,8 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 						usageDetailOK = true
 						if buffering {
 							retryErr = abnormalRetry.RetryError(detail, reporter.ReasoningEffort())
+						} else if abnormalRetry.ObserveOnly() {
+							_ = abnormalRetry.RetryError(detail, reporter.ReasoningEffort())
 						}
 					}
 					completedData = patchCodexCompletedOutput(data, outputItemsByIndex, outputItemsFallback)

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -954,7 +954,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 				fallbackResp := cliproxyexecutor.Response{
 					Payload:  out,
 					Headers:  httpResp.Header.Clone(),
-					Metadata: codexAbnormalReasoningRetryResponseMetadata(detail, responseFinalizer),
+					Metadata: codexAbnormalReasoningRetryResponseMetadata(detail, responseFinalizer, abnormalRetry),
 				}
 				if errWithFallback := abnormalRetry.RetryErrorWithFallbackResponse(detail, reporter.ReasoningEffort(), fallbackResp); errWithFallback != nil {
 					errRetry = errWithFallback
@@ -975,7 +975,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		out := sdktranslator.TranslateNonStream(ctx, to, responseFormat, req.Model, originalPayload, body, clientCompletedData, &param)
 		resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
 		if completedUsageOK {
-			resp.Metadata = codexAbnormalReasoningRetryResponseMetadata(completedUsage, responseFinalizer)
+			resp.Metadata = codexAbnormalReasoningRetryResponseMetadata(completedUsage, responseFinalizer, abnormalRetry)
 		}
 		return resp, nil
 	}
@@ -1338,6 +1338,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 			if usageDetailOK {
 				streamUsage.Detail = normalizeCodexUsageDetail(usageDetail)
 				streamUsage.HedgeScore = usageDetail.OutputTokens
+				streamUsage.CandidatePolicy = codexAbnormalReasoningRetryCandidatePolicy(usageDetail, abnormalRetry.deliveryPolicy, abnormalRetry.fallbackPolicy, cliproxyexecutor.RetryWithoutPenaltyCandidateKindNonSpecial)
 				streamUsage.OK = true
 				reporter.Publish(ctx, usageDetail)
 			}

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -382,6 +382,9 @@ func appendCodexAbnormalReasoningRetryChanges(changes []string, oldCfg, newCfg c
 	if oldCfg.Enabled != newCfg.Enabled {
 		changes = append(changes, fmt.Sprintf("codex.abnormal-reasoning-retry.enabled: %t -> %t", oldCfg.Enabled, newCfg.Enabled))
 	}
+	if oldCfg.Action != newCfg.Action {
+		changes = append(changes, fmt.Sprintf("codex.abnormal-reasoning-retry.action: %s -> %s", oldCfg.Action, newCfg.Action))
+	}
 	if oldCfg.StreamBuffer != newCfg.StreamBuffer {
 		changes = append(changes, fmt.Sprintf("codex.abnormal-reasoning-retry.stream-buffer: %t -> %t", oldCfg.StreamBuffer, newCfg.StreamBuffer))
 	}
@@ -393,6 +396,12 @@ func appendCodexAbnormalReasoningRetryChanges(changes []string, oldCfg, newCfg c
 	}
 	if oldCfg.ExhaustedBehavior != newCfg.ExhaustedBehavior {
 		changes = append(changes, fmt.Sprintf("codex.abnormal-reasoning-retry.exhausted-behavior: %s -> %s", oldCfg.ExhaustedBehavior, newCfg.ExhaustedBehavior))
+	}
+	if oldCfg.DeliveryPolicy != newCfg.DeliveryPolicy {
+		changes = append(changes, fmt.Sprintf("codex.abnormal-reasoning-retry.delivery-policy: %s -> %s", oldCfg.DeliveryPolicy, newCfg.DeliveryPolicy))
+	}
+	if oldCfg.FallbackPolicy != newCfg.FallbackPolicy {
+		changes = append(changes, fmt.Sprintf("codex.abnormal-reasoning-retry.fallback-policy: %s -> %s", oldCfg.FallbackPolicy, newCfg.FallbackPolicy))
 	}
 	if oldCfg.ClientUsageAggregation != newCfg.ClientUsageAggregation {
 		changes = append(changes, fmt.Sprintf("codex.abnormal-reasoning-retry.client-usage-aggregation: %s -> %s", oldCfg.ClientUsageAggregation, newCfg.ClientUsageAggregation))

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -204,6 +204,8 @@ func TestBuildConfigChangeDetails_CodexAbnormalReasoningRetry(t *testing.T) {
 				StreamBufferMaxBytes:   &streamBufferMaxBytes,
 				MaxRetries:             &maxRetries,
 				ExhaustedBehavior:      config.CodexAbnormalReasoningRetryExhaustedBehaviorPassThrough,
+				DeliveryPolicy:         config.CodexAbnormalReasoningRetryDeliveryPolicyMaxOutput,
+				FallbackPolicy:         config.CodexAbnormalReasoningRetryFallbackPolicyLatestSpecial,
 				ClientUsageAggregation: config.CodexAbnormalReasoningRetryClientUsageAggregationSum,
 				HedgedRetry: config.CodexAbnormalReasoningHedgedRetryConfig{
 					Enabled:             true,
@@ -218,10 +220,13 @@ func TestBuildConfigChangeDetails_CodexAbnormalReasoningRetry(t *testing.T) {
 	details := BuildConfigChangeDetails(oldCfg, newCfg)
 
 	expectContains(t, details, "codex.abnormal-reasoning-retry.enabled: false -> true")
+	expectContains(t, details, "codex.abnormal-reasoning-retry.action: disabled -> retry")
 	expectContains(t, details, "codex.abnormal-reasoning-retry.stream-buffer: true -> false")
 	expectContains(t, details, "codex.abnormal-reasoning-retry.stream-buffer-max-bytes: 0 -> 4096")
 	expectContains(t, details, "codex.abnormal-reasoning-retry.max-retries: 2 -> 0")
 	expectContains(t, details, "codex.abnormal-reasoning-retry.exhausted-behavior: error -> pass-through")
+	expectContains(t, details, "codex.abnormal-reasoning-retry.delivery-policy: best-non-special -> max-output")
+	expectContains(t, details, "codex.abnormal-reasoning-retry.fallback-policy: best-special -> latest-special")
 	expectContains(t, details, "codex.abnormal-reasoning-retry.client-usage-aggregation: delivered-only -> sum")
 	expectContains(t, details, "codex.abnormal-reasoning-retry.hedged-retry.enabled: false -> true")
 	expectContains(t, details, "codex.abnormal-reasoning-retry.hedged-retry.mode: speed -> quality")

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -90,6 +90,12 @@ require_grep "UsageReporter" internal/runtime/executor/helps/usage_helpers.go
 require_grep "auth_index" internal/usage internal/api/handlers/management internal/runtime/executor/helps internal/redisqueue
 require_grep "latency_ms" internal/usage internal/redisqueue internal/tui
 require_grep "abnormal-reasoning-retry" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
+require_grep "observe-only" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
+require_grep "delivery-policy" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
+require_grep "fallback-policy" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
+require_grep "best-non-special" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
+require_grep "first-non-special" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
+require_grep "max-output-special" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
 require_grep "hedged-retry" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
 require_grep "stream-buffer-max-bytes" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
 require_grep "max-retries" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
@@ -98,7 +104,6 @@ require_grep "client-usage-aggregation" internal/config/config.go config.example
 require_grep "delivered-only" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
 require_grep "sum-with-delivered-total" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
 require_grep "quality" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
-require_grep "longest abnormal pass-through fallback" config.example.yaml docs/lts/core-feature-contracts.yaml
 require_grep "reasoning-efforts" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
 require_grep "RetryWithoutPenalty" sdk/cliproxy/auth/conductor.go sdk/cliproxy/auth/retry_without_penalty.go docs/lts/core-feature-contracts.yaml
 require_grep "ExcludeAuthIDsMetadataKey" sdk/cliproxy/executor/types.go docs/lts/core-feature-contracts.yaml

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1642,6 +1642,9 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 		attemptOpts := withRetryWithoutPenaltyUsageMetadata(opts, retryWithoutPenaltyUsage)
 		resp, errExec := m.executeMixedOnce(ctx, normalized, req, attemptOpts, maxRetryCredentials)
 		if errExec == nil {
+			if fallbackResp, ok := retryWithoutPenaltyMaybeSelectFallbackResponse(resp, retryWithoutPenaltyFallback, retryWithoutPenaltyUsage); ok {
+				return fallbackResp, nil
+			}
 			return resp, nil
 		}
 		lastErr = errExec
@@ -1782,6 +1785,9 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 		attemptOpts := withRetryWithoutPenaltyUsageMetadata(opts, retryWithoutPenaltyUsage)
 		result, errStream := m.executeStreamMixedOnce(ctx, normalized, req, attemptOpts, maxRetryCredentials)
 		if errStream == nil {
+			if fallbackResult, ok := retryWithoutPenaltyMaybeSelectFallbackStreamResult(result, retryWithoutPenaltyFallback, retryWithoutPenaltyUsage); ok {
+				return fallbackResult, nil
+			}
 			return result, nil
 		}
 		lastErr = errStream

--- a/sdk/cliproxy/auth/hedged_retry_without_penalty.go
+++ b/sdk/cliproxy/auth/hedged_retry_without_penalty.go
@@ -614,11 +614,17 @@ func (m *Manager) executeRetryWithoutPenaltyHedgedQuality(ctx context.Context, p
 			timer.Stop()
 		}
 
+		retryWithoutPenaltyConsiderQualityFallbackCandidates(results, fallbackCandidate)
+
 		if winner := retryWithoutPenaltySelectQualityResponseWinner(results); winner >= 0 {
 			if retryWithoutPenaltyAddQualityResponseLosers(results, winner, accumulator) {
 				usageAccounted = true
 			}
 			resp := retryWithoutPenaltyFinalizeQualityResponse(results[winner].response, accumulator)
+			if fallbackResp, ok := retryWithoutPenaltyMaybeSelectFallbackResponse(resp, fallbackCandidate, accumulator); ok {
+				retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, fallbackCandidate.AuthID(lastAbnormalAuthID))
+				return retryWithoutPenaltyHedgeOutcome{response: fallbackResp, attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
+			}
 			retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, results[winner].authID)
 			return retryWithoutPenaltyHedgeOutcome{response: resp, attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
 		}
@@ -790,11 +796,17 @@ func (m *Manager) executeStreamRetryWithoutPenaltyHedgedQuality(ctx context.Cont
 			timer.Stop()
 		}
 
+		retryWithoutPenaltyConsiderQualityFallbackCandidates(results, fallbackCandidate)
+
 		if winner := retryWithoutPenaltySelectQualityStreamWinner(results); winner >= 0 {
 			if retryWithoutPenaltyAddQualityStreamLosers(results, winner, accumulator) {
 				usageAccounted = true
 			}
 			stream := retryWithoutPenaltyFinalizeQualityStream(results[winner], accumulator)
+			if fallbackStream, ok := retryWithoutPenaltyMaybeSelectFallbackStreamResult(stream, fallbackCandidate, accumulator); ok {
+				retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, fallbackCandidate.AuthID(lastAbnormalAuthID))
+				return retryWithoutPenaltyHedgeOutcome{stream: fallbackStream, attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
+			}
 			retryWithoutPenaltyHedgePublishSelectedAuthCallback(selectedCallback, results[winner].authID)
 			return retryWithoutPenaltyHedgeOutcome{stream: stream, attempts: attempts, disableSecondLane: disableSecondLane, usageAccounted: usageAccounted}
 		}
@@ -954,14 +966,24 @@ func collectRetryWithoutPenaltyStreamChunks(ctx context.Context, ch <-chan clipr
 func retryWithoutPenaltySelectQualityResponseWinner(results []retryWithoutPenaltyHedgeLaneResult) int {
 	winner := -1
 	var winnerScore int64
+	var winnerPolicy cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy
 	for i, res := range results {
 		if !res.dispatched || res.err != nil {
 			continue
 		}
+		detail, _ := retryWithoutPenaltyResponseUsage(res.response.Metadata)
+		policy, hasPolicy := retryWithoutPenaltyCandidatePolicyFromMetadata(res.response.Metadata, detail)
+		if hasPolicy && policy.DeliveryPolicy == retryWithoutPenaltyDeliveryPolicyLatest {
+			winner = i
+			winnerScore = retryWithoutPenaltyHedgeScore(res.response.Metadata)
+			winnerPolicy = policy
+			continue
+		}
 		score := retryWithoutPenaltyHedgeScore(res.response.Metadata)
-		if winner < 0 || score > winnerScore {
+		if winner < 0 || retryWithoutPenaltyResponseCandidateBetter(winnerScore, winnerPolicy, score, policy, hasPolicy) {
 			winner = i
 			winnerScore = score
+			winnerPolicy = policy
 		}
 	}
 	return winner
@@ -970,17 +992,26 @@ func retryWithoutPenaltySelectQualityResponseWinner(results []retryWithoutPenalt
 func retryWithoutPenaltySelectQualityStreamWinner(results []retryWithoutPenaltyHedgeLaneResult) int {
 	winner := -1
 	var winnerScore int64
+	var winnerPolicy cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy
 	for i, res := range results {
 		if !res.dispatched || res.err != nil {
 			continue
 		}
-		_, score, ok := retryWithoutPenaltyStreamUsage(res.streamMetadata)
+		detail, score, ok := retryWithoutPenaltyStreamUsage(res.streamMetadata)
 		if !ok {
 			score = retryWithoutPenaltyHedgeScore(res.streamMetadata)
 		}
-		if winner < 0 || score > winnerScore {
+		policy, hasPolicy := retryWithoutPenaltyCandidatePolicyFromMetadata(res.streamMetadata, detail)
+		if hasPolicy && policy.DeliveryPolicy == retryWithoutPenaltyDeliveryPolicyLatest {
 			winner = i
 			winnerScore = score
+			winnerPolicy = policy
+			continue
+		}
+		if winner < 0 || retryWithoutPenaltyResponseCandidateBetter(winnerScore, winnerPolicy, score, policy, hasPolicy) {
+			winner = i
+			winnerScore = score
+			winnerPolicy = policy
 		}
 	}
 	return winner
@@ -1018,6 +1049,18 @@ func retryWithoutPenaltyAddQualityStreamLosers(results []retryWithoutPenaltyHedg
 		}
 	}
 	return accounted
+}
+
+func retryWithoutPenaltyConsiderQualityFallbackCandidates(results []retryWithoutPenaltyHedgeLaneResult, fallbackCandidate *retryWithoutPenaltyFallbackCandidate) {
+	if fallbackCandidate == nil {
+		return
+	}
+	for _, res := range results {
+		if res.err == nil || !res.dispatched || !isRetryWithoutPenaltyError(res.err) {
+			continue
+		}
+		fallbackCandidate.Consider(res.err, res.authID)
+	}
 }
 
 func retryWithoutPenaltySummarizeQualityErrors(results []retryWithoutPenaltyHedgeLaneResult, lastAbnormalErr *error, lastAbnormalAuthID *string, lastZeroDispatchErr *error, fallbackCandidate *retryWithoutPenaltyFallbackCandidate) (bool, error) {
@@ -1124,6 +1167,72 @@ func retryWithoutPenaltyUsageFromMetadata(meta map[string]any) (coreusage.Detail
 		return *detail, hasRetryWithoutPenaltyUsageDetail(*detail)
 	default:
 		return coreusage.Detail{}, false
+	}
+}
+
+func retryWithoutPenaltyCandidatePolicyFromMetadata(meta map[string]any, detail coreusage.Detail) (cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy, bool) {
+	if len(meta) == 0 {
+		return cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy{}, false
+	}
+	var policy cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy
+	switch value := meta[cliproxyexecutor.RetryWithoutPenaltyCandidatePolicyMetadataKey].(type) {
+	case cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy:
+		policy = value
+	case *cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy:
+		if value == nil {
+			return cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy{}, false
+		}
+		policy = *value
+	default:
+		switch value := meta[cliproxyexecutor.RetryWithoutPenaltyStreamUsageMetadataKey].(type) {
+		case *cliproxyexecutor.RetryWithoutPenaltyStreamUsage:
+			if value == nil {
+				return cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy{}, false
+			}
+			policy = value.CandidatePolicy
+		case cliproxyexecutor.RetryWithoutPenaltyStreamUsage:
+			policy = value.CandidatePolicy
+		default:
+			return cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy{}, false
+		}
+	}
+	policy = normalizeRetryWithoutPenaltyCandidatePolicy(policy, detail)
+	if policy.DeliveryPolicy == "" && policy.FallbackPolicy == "" && policy.CandidateKind == "" {
+		return cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy{}, false
+	}
+	return policy, true
+}
+
+func retryWithoutPenaltyResponseCandidateBetter(currentScore int64, currentPolicy cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy, nextScore int64, nextPolicy cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy, hasNextPolicy bool) bool {
+	if !hasNextPolicy {
+		return nextScore > currentScore
+	}
+	switch nextPolicy.DeliveryPolicy {
+	case retryWithoutPenaltyDeliveryPolicyLatest:
+		return true
+	case retryWithoutPenaltyDeliveryPolicyFirstNonSpecial:
+		return false
+	case retryWithoutPenaltyDeliveryPolicyBestNonSpecial:
+		if currentPolicy.CandidateKind != nextPolicy.CandidateKind {
+			return nextPolicy.CandidateKind == cliproxyexecutor.RetryWithoutPenaltyCandidateKindNonSpecial
+		}
+		fallthrough
+	case retryWithoutPenaltyDeliveryPolicyMaxOutput:
+		if nextScore != currentScore {
+			return nextScore > currentScore
+		}
+		if nextPolicy.VisibleTokens != currentPolicy.VisibleTokens {
+			return nextPolicy.VisibleTokens > currentPolicy.VisibleTokens
+		}
+		return false
+	default:
+		if nextScore != currentScore {
+			return nextScore > currentScore
+		}
+		if nextPolicy.VisibleTokens != currentPolicy.VisibleTokens {
+			return nextPolicy.VisibleTokens > currentPolicy.VisibleTokens
+		}
+		return false
 	}
 }
 

--- a/sdk/cliproxy/auth/hedged_retry_without_penalty_test.go
+++ b/sdk/cliproxy/auth/hedged_retry_without_penalty_test.go
@@ -196,6 +196,28 @@ func (s *delayedPrimaryHedgeSelector) callCount() int {
 	return s.calls
 }
 
+type sequenceHedgeSelector struct {
+	mu      sync.Mutex
+	authIDs []string
+}
+
+func (s *sequenceHedgeSelector) Pick(_ context.Context, _ string, _ string, _ cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	s.mu.Lock()
+	var authID string
+	if len(s.authIDs) > 0 {
+		authID = s.authIDs[0]
+		s.authIDs = s.authIDs[1:]
+	}
+	s.mu.Unlock()
+	if authID != "" {
+		return pickHedgedRetryTestAuth(auths, authID)
+	}
+	if len(auths) == 0 {
+		return nil, &Error{Code: "no_auth", Message: "test auth unavailable"}
+	}
+	return auths[0], nil
+}
+
 func pickHedgedRetryTestAuth(auths []*Auth, authID string) (*Auth, error) {
 	for _, auth := range auths {
 		if auth != nil && auth.ID == authID {
@@ -789,6 +811,50 @@ func TestManagerExecute_RetryWithoutPenaltyMaxOutputCanReturnLongerSpecialInMixe
 	}
 	if string(resp.Payload) != "special" {
 		t.Fatalf("payload = %q, want longer special fallback", resp.Payload)
+	}
+}
+
+func TestManagerExecute_HedgedRetrySpeedModeIgnoresDeliveryPolicySelector(t *testing.T) {
+	executor := &hedgedRetryTestExecutor{
+		behaviors: map[string][]hedgedRetryBehavior{
+			"auth-a": {
+				{kind: "retry", payload: "trigger", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 5, ReasoningTokens: 516, TotalTokens: 6}},
+			},
+			"auth-b": {
+				{
+					kind:    "success",
+					payload: "fast-short",
+					delay:   10 * time.Millisecond,
+					usage:   coreusage.Detail{InputTokens: 5, OutputTokens: 20, ReasoningTokens: 8, TotalTokens: 25},
+					policy:  hedgedRetryTestCandidatePolicy(retryWithoutPenaltyDeliveryPolicyMaxOutput),
+				},
+			},
+			"auth-c": {
+				{
+					kind:    "success",
+					payload: "slow-long",
+					delay:   50 * time.Millisecond,
+					usage:   coreusage.Detail{InputTokens: 5, OutputTokens: 80, ReasoningTokens: 8, TotalTokens: 85},
+					policy:  hedgedRetryTestCandidatePolicy(retryWithoutPenaltyDeliveryPolicyMaxOutput),
+				},
+			},
+		},
+		maxRetries:      2,
+		hedgeMode:       retryWithoutPenaltyHedgeModeSpeed,
+		hedgeDelay:      0,
+		requireDistinct: true,
+		deliveryPolicy:  retryWithoutPenaltyDeliveryPolicyMaxOutput,
+	}
+	selector := &sequenceHedgeSelector{authIDs: []string{"auth-a", "auth-b", "auth-c"}}
+	manager, _ := newHedgedRetryTestManagerWithSelector(t, selector, executor, "auth-a", "auth-b", "auth-c")
+	manager.SetRetryConfig(0, 0, 0)
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5.5"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute error = %v, want nil", err)
+	}
+	if string(resp.Payload) != "fast-short" {
+		t.Fatalf("payload = %q, want speed mode first-success result; calls=%v", resp.Payload, executor.callsSnapshot())
 	}
 }
 

--- a/sdk/cliproxy/auth/hedged_retry_without_penalty_test.go
+++ b/sdk/cliproxy/auth/hedged_retry_without_penalty_test.go
@@ -23,6 +23,8 @@ type hedgedRetryTestError struct {
 	authID             string
 	usage              coreusage.Detail
 	exhaustedBehavior  string
+	deliveryPolicy     string
+	fallbackPolicy     string
 	fallbackPayload    []byte
 	fallbackStreamData []cliproxyexecutor.StreamChunk
 }
@@ -53,6 +55,30 @@ func (e hedgedRetryTestError) RetryWithoutPenaltyHedgePolicy() (bool, time.Durat
 
 func (e hedgedRetryTestError) RetryWithoutPenaltyHedgeMode() string {
 	return e.hedgeMode
+}
+
+func (e hedgedRetryTestError) RetryWithoutPenaltyDeliveryPolicy() string {
+	return e.deliveryPolicy
+}
+
+func (e hedgedRetryTestError) RetryWithoutPenaltyFallbackPolicy() string {
+	return e.fallbackPolicy
+}
+
+func (e hedgedRetryTestError) RetryWithoutPenaltyCandidatePolicy() cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy {
+	detail := e.RetryWithoutPenaltyUsageDetail()
+	visible := detail.OutputTokens - detail.ReasoningTokens
+	if visible < 0 {
+		visible = 0
+	}
+	return cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy{
+		DeliveryPolicy:  e.deliveryPolicy,
+		FallbackPolicy:  e.fallbackPolicy,
+		CandidateKind:   cliproxyexecutor.RetryWithoutPenaltyCandidateKindSpecial,
+		ReasoningTokens: detail.ReasoningTokens,
+		OutputTokens:    detail.OutputTokens,
+		VisibleTokens:   visible,
+	}
 }
 
 func (e hedgedRetryTestError) RetryWithoutPenaltyAuthID() string {
@@ -104,6 +130,7 @@ type hedgedRetryBehavior struct {
 	usage    coreusage.Detail
 	finalize bool
 	barrier  *hedgedRetryBarrier
+	policy   cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy
 }
 
 type hedgedRetryBarrier struct {
@@ -190,6 +217,8 @@ type hedgedRetryTestExecutor struct {
 	requireDistinct    bool
 	disableHedge       bool
 	exhaustedBehavior  string
+	deliveryPolicy     string
+	fallbackPolicy     string
 	fallbackPayload    []byte
 	fallbackStreamData []cliproxyexecutor.StreamChunk
 }
@@ -257,6 +286,19 @@ func hedgedRetryTestResponseMetadata(behavior hedgedRetryBehavior) map[string]an
 	if hasRetryWithoutPenaltyUsageDetail(behavior.usage) {
 		meta[cliproxyexecutor.RetryWithoutPenaltyUsageDetailMetadataKey] = behavior.usage
 		meta[cliproxyexecutor.RetryWithoutPenaltyHedgeScoreMetadataKey] = behavior.usage.OutputTokens
+		if behavior.policy.DeliveryPolicy != "" || behavior.policy.FallbackPolicy != "" || behavior.policy.CandidateKind != "" {
+			policy := behavior.policy
+			if policy.ReasoningTokens == 0 {
+				policy.ReasoningTokens = behavior.usage.ReasoningTokens
+			}
+			if policy.OutputTokens == 0 {
+				policy.OutputTokens = behavior.usage.OutputTokens
+			}
+			if policy.VisibleTokens == 0 && policy.OutputTokens > policy.ReasoningTokens {
+				policy.VisibleTokens = policy.OutputTokens - policy.ReasoningTokens
+			}
+			meta[cliproxyexecutor.RetryWithoutPenaltyCandidatePolicyMetadataKey] = policy
+		}
 	}
 	if behavior.finalize {
 		meta[cliproxyexecutor.RetryWithoutPenaltyResponseFinalizerMetadataKey] = cliproxyexecutor.RetryWithoutPenaltyResponseFinalizer(func(resp cliproxyexecutor.Response, previous cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot) cliproxyexecutor.Response {
@@ -273,11 +315,25 @@ func hedgedRetryTestStreamMetadata(behavior hedgedRetryBehavior) map[string]any 
 	}
 	meta := map[string]any{}
 	if hasRetryWithoutPenaltyUsageDetail(behavior.usage) {
-		meta[cliproxyexecutor.RetryWithoutPenaltyStreamUsageMetadataKey] = &cliproxyexecutor.RetryWithoutPenaltyStreamUsage{
+		streamUsage := &cliproxyexecutor.RetryWithoutPenaltyStreamUsage{
 			Detail:     behavior.usage,
 			HedgeScore: behavior.usage.OutputTokens,
 			OK:         true,
 		}
+		if behavior.policy.DeliveryPolicy != "" || behavior.policy.FallbackPolicy != "" || behavior.policy.CandidateKind != "" {
+			policy := behavior.policy
+			if policy.ReasoningTokens == 0 {
+				policy.ReasoningTokens = behavior.usage.ReasoningTokens
+			}
+			if policy.OutputTokens == 0 {
+				policy.OutputTokens = behavior.usage.OutputTokens
+			}
+			if policy.VisibleTokens == 0 && policy.OutputTokens > policy.ReasoningTokens {
+				policy.VisibleTokens = policy.OutputTokens - policy.ReasoningTokens
+			}
+			streamUsage.CandidatePolicy = policy
+		}
+		meta[cliproxyexecutor.RetryWithoutPenaltyStreamUsageMetadataKey] = streamUsage
 	}
 	if behavior.finalize {
 		meta[cliproxyexecutor.RetryWithoutPenaltyStreamFinalizerMetadataKey] = cliproxyexecutor.RetryWithoutPenaltyStreamFinalizer(func(headers http.Header, chunks []cliproxyexecutor.StreamChunk, previous cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot) *cliproxyexecutor.StreamResult {
@@ -370,6 +426,8 @@ func (e *hedgedRetryTestExecutor) retryError(authID string, behavior hedgedRetry
 		authID:             authID,
 		usage:              usageDetail,
 		exhaustedBehavior:  e.exhaustedBehavior,
+		deliveryPolicy:     e.deliveryPolicy,
+		fallbackPolicy:     e.fallbackPolicy,
 		fallbackPayload:    fallbackPayload,
 		fallbackStreamData: fallbackStreamData,
 	}
@@ -415,6 +473,13 @@ func collectHedgedRetryStreamPayload(t *testing.T, result *cliproxyexecutor.Stre
 		payload = append(payload, chunk.Payload...)
 	}
 	return payload
+}
+
+func hedgedRetryTestCandidatePolicy(deliveryPolicy string) cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy {
+	return cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy{
+		DeliveryPolicy: deliveryPolicy,
+		CandidateKind:  cliproxyexecutor.RetryWithoutPenaltyCandidateKindNonSpecial,
+	}
 }
 
 func newHedgedRetryTestManager(t *testing.T, executor *hedgedRetryTestExecutor, authIDs ...string) (*Manager, []string) {
@@ -669,6 +734,116 @@ func TestManagerExecute_RetryWithoutPenaltyPassThroughReturnsLongestSerialAbnorm
 	}
 }
 
+func TestManagerExecute_RetryWithoutPenaltyBestNonSpecialKeepsSuccessOverLongerSpecial(t *testing.T) {
+	executor := &hedgedRetryTestExecutor{
+		behaviors: map[string][]hedgedRetryBehavior{
+			"auth-a": {
+				{kind: "retry", payload: "special", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 80, ReasoningTokens: 516, TotalTokens: 81}},
+				{
+					kind:    "success",
+					payload: "non-special",
+					usage:   coreusage.Detail{InputTokens: 5, OutputTokens: 20, ReasoningTokens: 8, TotalTokens: 25},
+					policy:  hedgedRetryTestCandidatePolicy(retryWithoutPenaltyDeliveryPolicyBestNonSpecial),
+				},
+			},
+		},
+		maxRetries:     1,
+		disableHedge:   true,
+		deliveryPolicy: retryWithoutPenaltyDeliveryPolicyBestNonSpecial,
+	}
+	manager, _ := newHedgedRetryTestManager(t, executor, "auth-a")
+	manager.SetRetryConfig(0, 0, 0)
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5.5"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute error = %v, want nil", err)
+	}
+	if string(resp.Payload) != "non-special" {
+		t.Fatalf("payload = %q, want non-special success", resp.Payload)
+	}
+}
+
+func TestManagerExecute_RetryWithoutPenaltyMaxOutputCanReturnLongerSpecialInMixedPool(t *testing.T) {
+	executor := &hedgedRetryTestExecutor{
+		behaviors: map[string][]hedgedRetryBehavior{
+			"auth-a": {
+				{kind: "retry", payload: "special", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 80, ReasoningTokens: 516, TotalTokens: 81}},
+				{
+					kind:    "success",
+					payload: "non-special",
+					usage:   coreusage.Detail{InputTokens: 5, OutputTokens: 20, ReasoningTokens: 8, TotalTokens: 25},
+					policy:  hedgedRetryTestCandidatePolicy(retryWithoutPenaltyDeliveryPolicyMaxOutput),
+				},
+			},
+		},
+		maxRetries:     1,
+		disableHedge:   true,
+		deliveryPolicy: retryWithoutPenaltyDeliveryPolicyMaxOutput,
+	}
+	manager, _ := newHedgedRetryTestManager(t, executor, "auth-a")
+	manager.SetRetryConfig(0, 0, 0)
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5.5"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute error = %v, want nil", err)
+	}
+	if string(resp.Payload) != "special" {
+		t.Fatalf("payload = %q, want longer special fallback", resp.Payload)
+	}
+}
+
+func TestManagerExecute_RetryWithoutPenaltyFallbackPolicyBestSpecialPrefersReasoningBlock(t *testing.T) {
+	executor := &hedgedRetryTestExecutor{
+		behaviors: map[string][]hedgedRetryBehavior{
+			"auth-a": {
+				{kind: "retry", payload: "trigger", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 5, ReasoningTokens: 516, TotalTokens: 6}},
+				{kind: "retry", payload: "reasoning-1034", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 30, ReasoningTokens: 1034, TotalTokens: 31}},
+				{kind: "retry", payload: "long-516", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 80, ReasoningTokens: 516, TotalTokens: 81}},
+			},
+		},
+		maxRetries:        2,
+		disableHedge:      true,
+		exhaustedBehavior: retryWithoutPenaltyExhaustedBehaviorPassThrough,
+		fallbackPolicy:    retryWithoutPenaltyFallbackPolicyBestSpecial,
+	}
+	manager, _ := newHedgedRetryTestManager(t, executor, "auth-a")
+	manager.SetRetryConfig(0, 0, 0)
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5.5"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute error = %v, want nil pass-through", err)
+	}
+	if string(resp.Payload) != "reasoning-1034" {
+		t.Fatalf("payload = %q, want best-special 1034 fallback", resp.Payload)
+	}
+}
+
+func TestManagerExecute_RetryWithoutPenaltyFallbackPolicyMaxOutputSpecialPrefersLongest(t *testing.T) {
+	executor := &hedgedRetryTestExecutor{
+		behaviors: map[string][]hedgedRetryBehavior{
+			"auth-a": {
+				{kind: "retry", payload: "trigger", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 5, ReasoningTokens: 516, TotalTokens: 6}},
+				{kind: "retry", payload: "reasoning-1034", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 30, ReasoningTokens: 1034, TotalTokens: 31}},
+				{kind: "retry", payload: "long-516", usage: coreusage.Detail{InputTokens: 1, OutputTokens: 80, ReasoningTokens: 516, TotalTokens: 81}},
+			},
+		},
+		maxRetries:        2,
+		disableHedge:      true,
+		exhaustedBehavior: retryWithoutPenaltyExhaustedBehaviorPassThrough,
+		fallbackPolicy:    retryWithoutPenaltyFallbackPolicyMaxOutputSpecial,
+	}
+	manager, _ := newHedgedRetryTestManager(t, executor, "auth-a")
+	manager.SetRetryConfig(0, 0, 0)
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5.5"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute error = %v, want nil pass-through", err)
+	}
+	if string(resp.Payload) != "long-516" {
+		t.Fatalf("payload = %q, want max-output-special fallback", resp.Payload)
+	}
+}
+
 func TestManagerExecute_HedgedRetrySpeedPassThroughReturnsLongestAbnormal(t *testing.T) {
 	executor := &hedgedRetryTestExecutor{
 		behaviors: map[string][]hedgedRetryBehavior{
@@ -755,7 +930,7 @@ func TestManagerExecute_HedgedRetryPassThroughIgnoresOrdinaryErrors(t *testing.T
 	}
 }
 
-func TestManagerExecute_HedgedRetryPassThroughTieKeepsFirstCompletedAbnormal(t *testing.T) {
+func TestManagerExecute_HedgedRetryPassThroughTieKeepsLatestAbnormal(t *testing.T) {
 	executor := &hedgedRetryTestExecutor{
 		behaviors: map[string][]hedgedRetryBehavior{
 			"auth-a": {
@@ -778,8 +953,8 @@ func TestManagerExecute_HedgedRetryPassThroughTieKeepsFirstCompletedAbnormal(t *
 	if err != nil {
 		t.Fatalf("Execute error = %v, want nil pass-through", err)
 	}
-	if string(resp.Payload) != "tie-first" {
-		t.Fatalf("payload = %q, want first completed tied abnormal fallback", resp.Payload)
+	if string(resp.Payload) != "tie-second" {
+		t.Fatalf("payload = %q, want latest tied abnormal fallback", resp.Payload)
 	}
 }
 

--- a/sdk/cliproxy/auth/retry_without_penalty.go
+++ b/sdk/cliproxy/auth/retry_without_penalty.go
@@ -264,11 +264,6 @@ func retryWithoutPenaltyHedgePolicyFromError(err error) (retryWithoutPenaltyHedg
 	}
 	if deliveryPolicy := retryWithoutPenaltyDeliveryPolicyFromError(err); deliveryPolicy != "" {
 		policy.deliveryPolicy = deliveryPolicy
-		if deliveryPolicy == retryWithoutPenaltyDeliveryPolicyFirstNonSpecial {
-			policy.mode = retryWithoutPenaltyHedgeModeSpeed
-		} else {
-			policy.mode = retryWithoutPenaltyHedgeModeQuality
-		}
 	}
 	if fallbackPolicy := retryWithoutPenaltyFallbackPolicyFromError(err); fallbackPolicy != "" {
 		policy.fallbackPolicy = fallbackPolicy

--- a/sdk/cliproxy/auth/retry_without_penalty.go
+++ b/sdk/cliproxy/auth/retry_without_penalty.go
@@ -13,10 +13,17 @@ import (
 )
 
 const (
-	retryWithoutPenaltyExhaustedBehaviorError       = "error"
-	retryWithoutPenaltyExhaustedBehaviorPassThrough = "pass-through"
-	retryWithoutPenaltyHedgeModeSpeed               = "speed"
-	retryWithoutPenaltyHedgeModeQuality             = "quality"
+	retryWithoutPenaltyExhaustedBehaviorError         = "error"
+	retryWithoutPenaltyExhaustedBehaviorPassThrough   = "pass-through"
+	retryWithoutPenaltyHedgeModeSpeed                 = "speed"
+	retryWithoutPenaltyHedgeModeQuality               = "quality"
+	retryWithoutPenaltyDeliveryPolicyBestNonSpecial   = "best-non-special"
+	retryWithoutPenaltyDeliveryPolicyFirstNonSpecial  = "first-non-special"
+	retryWithoutPenaltyDeliveryPolicyMaxOutput        = "max-output"
+	retryWithoutPenaltyDeliveryPolicyLatest           = "latest"
+	retryWithoutPenaltyFallbackPolicyBestSpecial      = "best-special"
+	retryWithoutPenaltyFallbackPolicyMaxOutputSpecial = "max-output-special"
+	retryWithoutPenaltyFallbackPolicyLatestSpecial    = "latest-special"
 )
 
 func withRetryWithoutPenaltyUsageMetadata(opts cliproxyexecutor.Options, accumulator *cliproxyexecutor.UsageAccumulator) cliproxyexecutor.Options {
@@ -121,6 +128,8 @@ func retryWithoutPenaltyExhaustedBehavior(err error) string {
 type retryWithoutPenaltyHedgePolicy struct {
 	enabled             bool
 	mode                string
+	deliveryPolicy      string
+	fallbackPolicy      string
 	hedgeDelay          time.Duration
 	requireDistinctAuth bool
 	triggerAuthID       string
@@ -133,6 +142,7 @@ type retryWithoutPenaltyFallbackCandidate struct {
 	authID string
 	score  int64
 	detail coreusage.Detail
+	policy cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy
 }
 
 func newRetryWithoutPenaltyFallbackCandidate(stream bool) *retryWithoutPenaltyFallbackCandidate {
@@ -143,19 +153,17 @@ func (c *retryWithoutPenaltyFallbackCandidate) Consider(err error, authID string
 	if c == nil || err == nil || !isRetryWithoutPenaltyError(err) {
 		return
 	}
-	if retryWithoutPenaltyExhaustedBehavior(err) != retryWithoutPenaltyExhaustedBehaviorPassThrough {
-		return
-	}
 	if c.stream {
-		if _, ok := retryWithoutPenaltyFallbackStreamResult(err); !ok {
+		if _, _, ok := retryWithoutPenaltyRawFallbackStreamChunks(err); !ok {
 			return
 		}
-	} else if _, ok := retryWithoutPenaltyFallbackResponse(err); !ok {
+	} else if _, ok := retryWithoutPenaltyRawFallbackResponse(err); !ok {
 		return
 	}
 	detail, _ := retryWithoutPenaltyUsageDetail(err)
-	score := detail.OutputTokens
-	if c.set && score <= c.score {
+	policy := retryWithoutPenaltyCandidatePolicyFromError(err, detail)
+	score := retryWithoutPenaltyFallbackScore(detail, policy)
+	if c.set && !retryWithoutPenaltyFallbackCandidateBetter(c.detail, c.policy, c.score, detail, policy, score) {
 		return
 	}
 	c.set = true
@@ -163,6 +171,7 @@ func (c *retryWithoutPenaltyFallbackCandidate) Consider(err error, authID string
 	c.authID = strings.TrimSpace(authID)
 	c.score = score
 	c.detail = detail
+	c.policy = policy
 }
 
 func (c *retryWithoutPenaltyFallbackCandidate) Err(fallback error) error {
@@ -242,6 +251,8 @@ func retryWithoutPenaltyHedgePolicyFromError(err error) (retryWithoutPenaltyHedg
 	policy := retryWithoutPenaltyHedgePolicy{
 		enabled:             enabled,
 		mode:                retryWithoutPenaltyHedgeModeSpeed,
+		deliveryPolicy:      retryWithoutPenaltyDeliveryPolicyBestNonSpecial,
+		fallbackPolicy:      retryWithoutPenaltyFallbackPolicyBestSpecial,
 		hedgeDelay:          hedgeDelay,
 		requireDistinctAuth: requireDistinctAuth,
 	}
@@ -251,6 +262,17 @@ func retryWithoutPenaltyHedgePolicyFromError(err error) (retryWithoutPenaltyHedg
 	if errors.As(err, &withMode) {
 		policy.mode = normalizeRetryWithoutPenaltyHedgeMode(withMode.RetryWithoutPenaltyHedgeMode())
 	}
+	if deliveryPolicy := retryWithoutPenaltyDeliveryPolicyFromError(err); deliveryPolicy != "" {
+		policy.deliveryPolicy = deliveryPolicy
+		if deliveryPolicy == retryWithoutPenaltyDeliveryPolicyFirstNonSpecial {
+			policy.mode = retryWithoutPenaltyHedgeModeSpeed
+		} else {
+			policy.mode = retryWithoutPenaltyHedgeModeQuality
+		}
+	}
+	if fallbackPolicy := retryWithoutPenaltyFallbackPolicyFromError(err); fallbackPolicy != "" {
+		policy.fallbackPolicy = fallbackPolicy
+	}
 	var withAuthID interface {
 		RetryWithoutPenaltyAuthID() string
 	}
@@ -258,6 +280,60 @@ func retryWithoutPenaltyHedgePolicyFromError(err error) (retryWithoutPenaltyHedg
 		policy.triggerAuthID = strings.TrimSpace(withAuthID.RetryWithoutPenaltyAuthID())
 	}
 	return policy, true
+}
+
+func retryWithoutPenaltyDeliveryPolicyFromError(err error) string {
+	if err == nil {
+		return ""
+	}
+	var withPolicy interface {
+		RetryWithoutPenaltyDeliveryPolicy() string
+	}
+	if !errors.As(err, &withPolicy) {
+		return ""
+	}
+	return normalizeRetryWithoutPenaltyDeliveryPolicy(withPolicy.RetryWithoutPenaltyDeliveryPolicy())
+}
+
+func retryWithoutPenaltyFallbackPolicyFromError(err error) string {
+	if err == nil {
+		return ""
+	}
+	var withPolicy interface {
+		RetryWithoutPenaltyFallbackPolicy() string
+	}
+	if !errors.As(err, &withPolicy) {
+		return ""
+	}
+	return normalizeRetryWithoutPenaltyFallbackPolicy(withPolicy.RetryWithoutPenaltyFallbackPolicy())
+}
+
+func normalizeRetryWithoutPenaltyDeliveryPolicy(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case retryWithoutPenaltyDeliveryPolicyFirstNonSpecial:
+		return retryWithoutPenaltyDeliveryPolicyFirstNonSpecial
+	case retryWithoutPenaltyDeliveryPolicyMaxOutput:
+		return retryWithoutPenaltyDeliveryPolicyMaxOutput
+	case retryWithoutPenaltyDeliveryPolicyLatest:
+		return retryWithoutPenaltyDeliveryPolicyLatest
+	case retryWithoutPenaltyDeliveryPolicyBestNonSpecial:
+		return retryWithoutPenaltyDeliveryPolicyBestNonSpecial
+	default:
+		return ""
+	}
+}
+
+func normalizeRetryWithoutPenaltyFallbackPolicy(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case retryWithoutPenaltyFallbackPolicyMaxOutputSpecial:
+		return retryWithoutPenaltyFallbackPolicyMaxOutputSpecial
+	case retryWithoutPenaltyFallbackPolicyLatestSpecial:
+		return retryWithoutPenaltyFallbackPolicyLatestSpecial
+	case retryWithoutPenaltyFallbackPolicyBestSpecial:
+		return retryWithoutPenaltyFallbackPolicyBestSpecial
+	default:
+		return ""
+	}
 }
 
 func normalizeRetryWithoutPenaltyHedgeMode(value string) string {
@@ -275,6 +351,93 @@ func normalizeRetryWithoutPenaltyExhaustedBehavior(value string) string {
 		return retryWithoutPenaltyExhaustedBehaviorPassThrough
 	default:
 		return retryWithoutPenaltyExhaustedBehaviorError
+	}
+}
+
+func retryWithoutPenaltyCandidatePolicyFromError(err error, detail coreusage.Detail) cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy {
+	var policy cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy
+	if err != nil {
+		var withPolicy interface {
+			RetryWithoutPenaltyCandidatePolicy() cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy
+		}
+		if errors.As(err, &withPolicy) {
+			policy = withPolicy.RetryWithoutPenaltyCandidatePolicy()
+		}
+	}
+	policy = normalizeRetryWithoutPenaltyCandidatePolicy(policy, detail)
+	if policy.CandidateKind == "" {
+		policy.CandidateKind = cliproxyexecutor.RetryWithoutPenaltyCandidateKindSpecial
+	}
+	if policy.FallbackPolicy == "" {
+		if fallbackPolicy := retryWithoutPenaltyFallbackPolicyFromError(err); fallbackPolicy != "" {
+			policy.FallbackPolicy = fallbackPolicy
+		} else {
+			policy.FallbackPolicy = retryWithoutPenaltyFallbackPolicyBestSpecial
+		}
+	}
+	return policy
+}
+
+func normalizeRetryWithoutPenaltyCandidatePolicy(policy cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy, detail coreusage.Detail) cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy {
+	if hasRetryWithoutPenaltyUsageDetail(detail) {
+		detail = normalizeRetryWithoutPenaltyUsageDetail(detail)
+		if policy.ReasoningTokens == 0 {
+			policy.ReasoningTokens = detail.ReasoningTokens
+		}
+		if policy.OutputTokens == 0 {
+			policy.OutputTokens = detail.OutputTokens
+		}
+	}
+	if policy.VisibleTokens == 0 && policy.OutputTokens > policy.ReasoningTokens {
+		policy.VisibleTokens = policy.OutputTokens - policy.ReasoningTokens
+	}
+	policy.DeliveryPolicy = normalizeRetryWithoutPenaltyDeliveryPolicy(policy.DeliveryPolicy)
+	policy.FallbackPolicy = normalizeRetryWithoutPenaltyFallbackPolicy(policy.FallbackPolicy)
+	switch strings.ToLower(strings.TrimSpace(policy.CandidateKind)) {
+	case cliproxyexecutor.RetryWithoutPenaltyCandidateKindNonSpecial:
+		policy.CandidateKind = cliproxyexecutor.RetryWithoutPenaltyCandidateKindNonSpecial
+	case cliproxyexecutor.RetryWithoutPenaltyCandidateKindSpecial:
+		policy.CandidateKind = cliproxyexecutor.RetryWithoutPenaltyCandidateKindSpecial
+	default:
+		policy.CandidateKind = ""
+	}
+	return policy
+}
+
+func retryWithoutPenaltyFallbackScore(detail coreusage.Detail, policy cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy) int64 {
+	policy = normalizeRetryWithoutPenaltyCandidatePolicy(policy, detail)
+	if policy.OutputTokens > 0 {
+		return policy.OutputTokens
+	}
+	detail = normalizeRetryWithoutPenaltyUsageDetail(detail)
+	return detail.OutputTokens
+}
+
+func retryWithoutPenaltyFallbackCandidateBetter(currentDetail coreusage.Detail, currentPolicy cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy, currentScore int64, nextDetail coreusage.Detail, nextPolicy cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy, nextScore int64) bool {
+	currentPolicy = normalizeRetryWithoutPenaltyCandidatePolicy(currentPolicy, currentDetail)
+	nextPolicy = normalizeRetryWithoutPenaltyCandidatePolicy(nextPolicy, nextDetail)
+	switch nextPolicy.FallbackPolicy {
+	case retryWithoutPenaltyFallbackPolicyLatestSpecial:
+		return true
+	case retryWithoutPenaltyFallbackPolicyMaxOutputSpecial:
+		if nextScore != currentScore {
+			return nextScore > currentScore
+		}
+		if nextPolicy.VisibleTokens != currentPolicy.VisibleTokens {
+			return nextPolicy.VisibleTokens > currentPolicy.VisibleTokens
+		}
+		return true
+	default:
+		if nextPolicy.ReasoningTokens != currentPolicy.ReasoningTokens {
+			return nextPolicy.ReasoningTokens > currentPolicy.ReasoningTokens
+		}
+		if nextScore != currentScore {
+			return nextScore > currentScore
+		}
+		if nextPolicy.VisibleTokens != currentPolicy.VisibleTokens {
+			return nextPolicy.VisibleTokens > currentPolicy.VisibleTokens
+		}
+		return true
 	}
 }
 
@@ -307,6 +470,47 @@ func retryWithoutPenaltyCandidateFallbackResponse(err error, candidate *retryWit
 	return finalizer(resp, candidate.PreviousUsageSnapshot(accumulator)), true
 }
 
+func retryWithoutPenaltyMaybeSelectFallbackResponse(resp cliproxyexecutor.Response, candidate *retryWithoutPenaltyFallbackCandidate, accumulator *cliproxyexecutor.UsageAccumulator) (cliproxyexecutor.Response, bool) {
+	if candidate == nil || !candidate.set || candidate.err == nil {
+		return cliproxyexecutor.Response{}, false
+	}
+	detail, ok := retryWithoutPenaltyResponseUsage(resp.Metadata)
+	if !ok {
+		return cliproxyexecutor.Response{}, false
+	}
+	score := retryWithoutPenaltyHedgeScore(resp.Metadata)
+	policy, hasPolicy := retryWithoutPenaltyCandidatePolicyFromMetadata(resp.Metadata, detail)
+	if !hasPolicy {
+		return cliproxyexecutor.Response{}, false
+	}
+	if !retryWithoutPenaltyFallbackShouldReplaceDelivered(detail, policy, score, candidate) {
+		return cliproxyexecutor.Response{}, false
+	}
+	fallbackResp, ok := retryWithoutPenaltyRawFallbackResponse(candidate.err)
+	if !ok {
+		return cliproxyexecutor.Response{}, false
+	}
+	finalizer, _ := fallbackResp.Metadata[cliproxyexecutor.RetryWithoutPenaltyResponseFinalizerMetadataKey].(cliproxyexecutor.RetryWithoutPenaltyResponseFinalizer)
+	if finalizer == nil {
+		return fallbackResp, true
+	}
+	return finalizer(fallbackResp, retryWithoutPenaltyMixedFallbackSnapshot(candidate, accumulator, detail)), true
+}
+
+func retryWithoutPenaltyRawFallbackResponse(err error) (cliproxyexecutor.Response, bool) {
+	var withFallback interface {
+		RetryWithoutPenaltyFallbackResponse() (cliproxyexecutor.Response, bool)
+	}
+	if !errors.As(err, &withFallback) {
+		return cliproxyexecutor.Response{}, false
+	}
+	resp, ok := withFallback.RetryWithoutPenaltyFallbackResponse()
+	if !ok {
+		return cliproxyexecutor.Response{}, false
+	}
+	return cloneRetryWithoutPenaltyResponse(resp), true
+}
+
 func retryWithoutPenaltyFallbackStreamResult(err error) (*cliproxyexecutor.StreamResult, bool) {
 	if retryWithoutPenaltyExhaustedBehavior(err) != retryWithoutPenaltyExhaustedBehaviorPassThrough {
 		return nil, false
@@ -334,17 +538,37 @@ func retryWithoutPenaltyFallbackStreamResult(err error) (*cliproxyexecutor.Strea
 	}, true
 }
 
+func retryWithoutPenaltyMaybeSelectFallbackStreamResult(result *cliproxyexecutor.StreamResult, candidate *retryWithoutPenaltyFallbackCandidate, accumulator *cliproxyexecutor.UsageAccumulator) (*cliproxyexecutor.StreamResult, bool) {
+	if result == nil || candidate == nil || !candidate.set || candidate.err == nil {
+		return nil, false
+	}
+	detail, score, ok := retryWithoutPenaltyStreamUsage(result.Metadata)
+	if !ok {
+		return nil, false
+	}
+	policy, hasPolicy := retryWithoutPenaltyCandidatePolicyFromMetadata(result.Metadata, detail)
+	if !hasPolicy {
+		return nil, false
+	}
+	if !retryWithoutPenaltyFallbackShouldReplaceDelivered(detail, policy, score, candidate) {
+		return nil, false
+	}
+	return retryWithoutPenaltyRawCandidateFallbackStreamResultWithSnapshot(candidate.err, retryWithoutPenaltyMixedFallbackSnapshot(candidate, accumulator, detail))
+}
+
 func retryWithoutPenaltyCandidateFallbackStreamResult(err error, candidate *retryWithoutPenaltyFallbackCandidate, accumulator *cliproxyexecutor.UsageAccumulator) (*cliproxyexecutor.StreamResult, bool) {
 	if retryWithoutPenaltyExhaustedBehavior(err) != retryWithoutPenaltyExhaustedBehaviorPassThrough {
 		return nil, false
 	}
-	var withFallback interface {
-		RetryWithoutPenaltyFallbackStreamChunks() (http.Header, []cliproxyexecutor.StreamChunk, bool)
-	}
-	if !errors.As(err, &withFallback) {
-		return nil, false
-	}
-	headers, chunks, ok := withFallback.RetryWithoutPenaltyFallbackStreamChunks()
+	return retryWithoutPenaltyRawCandidateFallbackStreamResult(err, candidate, accumulator)
+}
+
+func retryWithoutPenaltyRawCandidateFallbackStreamResult(err error, candidate *retryWithoutPenaltyFallbackCandidate, accumulator *cliproxyexecutor.UsageAccumulator) (*cliproxyexecutor.StreamResult, bool) {
+	return retryWithoutPenaltyRawCandidateFallbackStreamResultWithSnapshot(err, candidate.PreviousUsageSnapshot(accumulator))
+}
+
+func retryWithoutPenaltyRawCandidateFallbackStreamResultWithSnapshot(err error, previous cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot) (*cliproxyexecutor.StreamResult, bool) {
+	headers, chunks, ok := retryWithoutPenaltyRawFallbackStreamChunks(err)
 	if !ok || len(chunks) == 0 {
 		return nil, false
 	}
@@ -353,7 +577,7 @@ func retryWithoutPenaltyCandidateFallbackStreamResult(err error, candidate *retr
 	}
 	if errors.As(err, &withFinalizer) {
 		if finalizer := withFinalizer.RetryWithoutPenaltyFallbackStreamFinalizer(); finalizer != nil {
-			if result := finalizer(headers, chunks, candidate.PreviousUsageSnapshot(accumulator)); result != nil {
+			if result := finalizer(headers, chunks, previous); result != nil {
 				return result, true
 			}
 		}
@@ -369,6 +593,52 @@ func retryWithoutPenaltyCandidateFallbackStreamResult(err error, candidate *retr
 		Headers: cloneRetryWithoutPenaltyHeader(headers),
 		Chunks:  out,
 	}, true
+}
+
+func retryWithoutPenaltyRawFallbackStreamChunks(err error) (http.Header, []cliproxyexecutor.StreamChunk, bool) {
+	var withFallback interface {
+		RetryWithoutPenaltyFallbackStreamChunks() (http.Header, []cliproxyexecutor.StreamChunk, bool)
+	}
+	if !errors.As(err, &withFallback) {
+		return nil, nil, false
+	}
+	headers, chunks, ok := withFallback.RetryWithoutPenaltyFallbackStreamChunks()
+	if !ok || len(chunks) == 0 {
+		return nil, nil, false
+	}
+	return headers, chunks, true
+}
+
+func retryWithoutPenaltyFallbackShouldReplaceDelivered(deliveredDetail coreusage.Detail, deliveredPolicy cliproxyexecutor.RetryWithoutPenaltyCandidatePolicy, deliveredScore int64, candidate *retryWithoutPenaltyFallbackCandidate) bool {
+	if candidate == nil || !candidate.set {
+		return false
+	}
+	deliveredPolicy = normalizeRetryWithoutPenaltyCandidatePolicy(deliveredPolicy, deliveredDetail)
+	candidatePolicy := normalizeRetryWithoutPenaltyCandidatePolicy(candidate.policy, candidate.detail)
+	deliveryPolicy := deliveredPolicy.DeliveryPolicy
+	if deliveryPolicy == "" {
+		deliveryPolicy = candidatePolicy.DeliveryPolicy
+	}
+	if deliveryPolicy != retryWithoutPenaltyDeliveryPolicyMaxOutput {
+		return false
+	}
+	if candidate.score != deliveredScore {
+		return candidate.score > deliveredScore
+	}
+	if candidatePolicy.VisibleTokens != deliveredPolicy.VisibleTokens {
+		return candidatePolicy.VisibleTokens > deliveredPolicy.VisibleTokens
+	}
+	return false
+}
+
+func retryWithoutPenaltyMixedFallbackSnapshot(candidate *retryWithoutPenaltyFallbackCandidate, accumulator *cliproxyexecutor.UsageAccumulator, deliveredDetail coreusage.Detail) cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot {
+	snapshot := candidate.PreviousUsageSnapshot(accumulator)
+	if hasRetryWithoutPenaltyUsageDetail(deliveredDetail) {
+		delivered := normalizeRetryWithoutPenaltyUsageDetail(deliveredDetail)
+		snapshot.Detail = addRetryWithoutPenaltyUsageDetail(snapshot.Detail, delivered)
+		snapshot.FoldedOutputTokens += foldedRetryWithoutPenaltyUsageOutputTokens(delivered)
+	}
+	return snapshot
 }
 
 func cloneRetryWithoutPenaltyResponse(resp cliproxyexecutor.Response) cliproxyexecutor.Response {

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -33,6 +33,8 @@ const (
 	RetryWithoutPenaltyUsageDetailMetadataKey = "retry_without_penalty_usage_detail"
 	// RetryWithoutPenaltyHedgeScoreMetadataKey carries the score used to choose a quality-mode hedge winner.
 	RetryWithoutPenaltyHedgeScoreMetadataKey = "retry_without_penalty_hedge_score"
+	// RetryWithoutPenaltyCandidatePolicyMetadataKey carries policy-aware candidate selection metadata.
+	RetryWithoutPenaltyCandidatePolicyMetadataKey = "retry_without_penalty_candidate_policy"
 	// RetryWithoutPenaltyResponseFinalizerMetadataKey carries a response finalizer for post-hedge client usage aggregation.
 	RetryWithoutPenaltyResponseFinalizerMetadataKey = "retry_without_penalty_response_finalizer"
 	// RetryWithoutPenaltyStreamFinalizerMetadataKey carries a stream finalizer for post-hedge client usage aggregation.
@@ -51,11 +53,28 @@ const (
 	ExecutionSessionMetadataKey = "execution_session_id"
 )
 
+const (
+	RetryWithoutPenaltyCandidateKindNonSpecial = "non-special"
+	RetryWithoutPenaltyCandidateKindSpecial    = "special"
+)
+
 // RetryWithoutPenaltyUsageSnapshot carries discarded-attempt usage in both the
 // legacy field-sum shape and the folded output-token shape needed by clients.
 type RetryWithoutPenaltyUsageSnapshot struct {
 	Detail             coreusage.Detail
 	FoldedOutputTokens int64
+}
+
+// RetryWithoutPenaltyCandidatePolicy carries policy-aware candidate selection
+// metadata for retry-without-penalty results. It is additive metadata: callers
+// that do not understand it can keep using RetryWithoutPenaltyHedgeScore.
+type RetryWithoutPenaltyCandidatePolicy struct {
+	DeliveryPolicy  string
+	FallbackPolicy  string
+	CandidateKind   string
+	ReasoningTokens int64
+	OutputTokens    int64
+	VisibleTokens   int64
 }
 
 // RetryWithoutPenaltyResponseFinalizer rewrites a delivered non-stream response
@@ -69,9 +88,10 @@ type RetryWithoutPenaltyStreamFinalizer func(http.Header, []StreamChunk, RetryWi
 // RetryWithoutPenaltyStreamUsage carries completed usage discovered while a
 // stream is produced. Producers set it before emitting the terminal usage chunk.
 type RetryWithoutPenaltyStreamUsage struct {
-	Detail     coreusage.Detail
-	HedgeScore int64
-	OK         bool
+	Detail          coreusage.Detail
+	HedgeScore      int64
+	CandidatePolicy RetryWithoutPenaltyCandidatePolicy
+	OK              bool
 }
 
 // UsageAccumulator is a thread-safe request-local usage accumulator carried in Options.Metadata.


### PR DESCRIPTION
## 背景

这次 PR 继续收敛 Codex abnormal reasoning retry 的候选选择语义。前面已经把客户端可见 `response.usage.total_tokens` 和内部成本账拆开，本 PR 处理另一个问题：`reasoning_tokens == 516/1034` 的 abnormal attempt 被保留为 fallback 时，不能再只用 `output_tokens` 作为唯一交付/透传选择信号。

这会影响两类场景：

- mixed pool：已经有至少一次 non-special success，同时也保留了 special fallback。
- all-special pool：多次尝试都命中 516/1034，只能在报错和 pass-through fallback 之间选择。

## 变更

- 新增 `codex.abnormal-reasoning-retry.action`：
  - `retry`：检测并重试。
  - `observe-only`：只记录命中日志，原样返回响应。
  - `disabled`：关闭检测。
- 新增 `delivery-policy`，用于 mixed pool：
  - `best-non-special`：默认；有 non-special success 时不交付 516/1034。
  - `first-non-special`：低延迟 first-success-wins。
  - `max-output`：允许保留的 special fallback 凭更大 `output_tokens` 反选。
  - `latest`：quality hedged success 候选中选择最后完成者。
- 新增 `fallback-policy`，用于 all-special + `exhausted-behavior: pass-through`：
  - `best-special`：默认；优先更高 special reasoning block（1034 > 516），再比 output。
  - `max-output-special`：选择 output 最大的 special fallback。
  - `latest-special`：选择最新保留的 special fallback。
- SDK `RetryWithoutPenalty` metadata 增加 candidate policy 元数据，让 executor 和 auth conductor 使用同一套候选选择语义。
- `hedged-retry.mode` 保留为调度开关：`quality` 等待已派发 lane，`speed` 保持 first-success-wins；winner policy 不再靠 mode 隐含表达。
- 修复 review 发现的语义偏差：`delivery-policy` 不再反向覆盖 `hedged-retry.mode`，并新增 `mode: speed + delivery-policy: max-output` 的 runtime 回归测试。
- `config.example.yaml`、`docs/lts/core-feature-contracts.yaml`、`scripts/check-lts-contract.sh` 已同步更新。

## Protected Delta Review

- Config schema：新增 `action`、`delivery-policy`、`fallback-policy`，不自动重写用户配置。
- Client-visible usage：不改变 `client-usage-aggregation` 三模式语义。
- Internal usage：attempt-level usage 记录保持不变；discarded attempt 仍由内部 usage/Management 统计承载。
- SDK auth conductor：新增 policy-aware fallback candidate，保留 all-special 时 `exhausted-behavior` 的边界；`delivery-policy` 不再影响 hedge speed/quality 调度。
- Executor stream/non-stream：成功响应标记为 non-special candidate，被拦截 fallback 标记为 special candidate。
- LTS contract：新增配置 key 与 marker，contract guard 已更新。

## 不包含

- 不实现 `salvage-collapsed`；该策略需要跨池内容质量验证和更大的 conductor 改动，本 PR 不伪装成已支持。
- 不改 Management usage schema。
- 不改 HFS 配置，不做部署。
- Panel 配置面由 CPA-Panel-LTS #8 单独处理。

## 验证

已本地通过：

```bash
go test ./sdk/cliproxy/auth -count=1 -run 'TestManagerExecute_HedgedRetrySpeedModeIgnoresDeliveryPolicySelector' -timeout 120s -v
go test ./sdk/cliproxy/auth -count=1 -run 'RetryWithoutPenalty|Hedged' -timeout 120s
go test ./sdk/cliproxy/auth -count=1 -timeout 120s
go test ./internal/config -count=1 -run 'Codex'
go test ./internal/runtime/executor -count=1 -run 'TestCodexExecutorAbnormalReasoningRetry' -timeout 180s
go test ./internal/watcher/diff -count=1
scripts/check-lts-contract.sh
go build -o test-output ./cmd/server && rm -f test-output
git diff --check
go list ./... | grep -v '/tmp$' | xargs go test -timeout 240s
```

`go test ./... -timeout 240s` 仍会失败在本地 scratch 包 `tmp/list_routes.go`，错误是该 ignored scratch package 引用过期 API；排除 `/tmp` 后全产品包测试通过。

## GitHub Actions

已通过：

- `agents-md-guard / guard-agents-md-changes`
- `lts-contract / lts-contract`
- `pr-test-build / build`
- `translator-path-guard / ensure-no-translator-changes`
- `lts-contract / full-test-observation`

## 合并评估

review blocker 已修复。当前 PR 为 `CLEAN / MERGEABLE`，checks 全绿。Panel follow-up PR #8 也为 `CLEAN / MERGEABLE` 且 checks 全绿。建议合并顺序为 Core #138 -> Panel #8。

## 后续

- HFS 由部署侧手动设置运行配置，例如当前建议：

```yaml
codex:
  abnormal-reasoning-retry:
    enabled: true
    action: retry
    delivery-policy: best-non-special
    exhausted-behavior: pass-through
    fallback-policy: best-special
```
