### PR TITLE
fix(codex): isolate model header snapshots and websocket generations

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -43,6 +43,68 @@ const (
 
 var dataTag = []byte("data:")
 
+type codexModelHeaderProfile struct {
+	overrides map[string]string
+	digest    [sha256.Size]byte
+}
+
+func resolveCodexModelHeaderProfile(modelName string) codexModelHeaderProfile {
+	rawOverrides := registry.ModelOverrideHeaders(strings.TrimSpace(modelName), "codex")
+	if len(rawOverrides) == 0 {
+		return codexModelHeaderProfile{}
+	}
+
+	type headerEntry struct {
+		key   string
+		value string
+	}
+	entries := make([]headerEntry, 0, len(rawOverrides))
+	for key, value := range rawOverrides {
+		key = http.CanonicalHeaderKey(strings.TrimSpace(key))
+		if key == "" {
+			continue
+		}
+		entries = append(entries, headerEntry{key: key, value: value})
+	}
+	if len(entries) == 0 {
+		return codexModelHeaderProfile{}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		leftKey := strings.ToLower(entries[i].key)
+		rightKey := strings.ToLower(entries[j].key)
+		if leftKey != rightKey {
+			return leftKey < rightKey
+		}
+		return entries[i].value < entries[j].value
+	})
+
+	overrides := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		// Duplicate keys that differ only by case resolve deterministically.
+		overrides[entry.key] = entry.value
+	}
+
+	keys := make([]string, 0, len(overrides))
+	for key := range overrides {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return strings.ToLower(keys[i]) < strings.ToLower(keys[j])
+	})
+
+	var serialized strings.Builder
+	for _, key := range keys {
+		value := overrides[key]
+		normalizedKey := strings.ToLower(key)
+		_, _ = fmt.Fprintf(&serialized, "%d:%s%d:%s", len(normalizedKey), normalizedKey, len(value), value)
+	}
+
+	return codexModelHeaderProfile{
+		overrides: overrides,
+		digest:    sha256.Sum256([]byte(serialized.String())),
+	}
+}
+
 // Streamed Codex responses may emit response.output_item.done events while leaving
 // response.completed.response.output empty. Keep the stream path aligned with the
 // already-patched non-stream path by reconstructing response.output from those items.
@@ -748,6 +810,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		return e.executeOpenAIImage(ctx, auth, req, opts)
 	}
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	modelHeaderProfile := resolveCodexModelHeaderProfile(baseModel)
 
 	apiKey, baseURL := codexCreds(auth)
 	if baseURL == "" {
@@ -805,7 +868,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		return resp, err
 	}
 	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
-	applyModelHeaderOverrides(httpReq.Header, baseModel)
+	applyModelHeaderOverrides(httpReq.Header, modelHeaderProfile)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
@@ -946,6 +1009,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 
 func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	modelHeaderProfile := resolveCodexModelHeaderProfile(baseModel)
 
 	apiKey, baseURL := codexCreds(auth)
 	if baseURL == "" {
@@ -994,7 +1058,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 		return resp, err
 	}
 	applyCodexHeaders(httpReq, auth, apiKey, false, e.cfg)
-	applyModelHeaderOverrides(httpReq.Header, baseModel)
+	applyModelHeaderOverrides(httpReq.Header, modelHeaderProfile)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
@@ -1058,6 +1122,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		return e.executeOpenAIImageStream(ctx, auth, req, opts)
 	}
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	modelHeaderProfile := resolveCodexModelHeaderProfile(baseModel)
 
 	apiKey, baseURL := codexCreds(auth)
 	if baseURL == "" {
@@ -1114,7 +1179,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		return nil, err
 	}
 	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
-	applyModelHeaderOverrides(httpReq.Header, baseModel)
+	applyModelHeaderOverrides(httpReq.Header, modelHeaderProfile)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
@@ -1723,16 +1788,15 @@ func applyCodexHeaders(r *http.Request, auth *cliproxyauth.Auth, token string, s
 	applyCodexHeadersFromSources(r, auth, token, stream, cfg, ginHeaders)
 }
 
-// applyModelHeaderOverrides forces models.json config.override_header onto upstream headers.
-func applyModelHeaderOverrides(headers http.Header, modelName string) {
+// applyModelHeaderOverrides forces a resolved model profile onto upstream headers.
+func applyModelHeaderOverrides(headers http.Header, profile codexModelHeaderProfile) {
 	if headers == nil {
 		return
 	}
-	overrides := registry.ModelOverrideHeaders(modelName)
-	if len(overrides) == 0 {
+	if len(profile.overrides) == 0 {
 		return
 	}
-	for key, value := range overrides {
+	for key, value := range profile.overrides {
 		headers.Set(key, value)
 	}
 	if strings.Contains(headers.Get("User-Agent"), "Mac OS") && codexSessionHeaderValue(headers) == "" {

--- a/internal/runtime/executor/codex_model_header_profile_test.go
+++ b/internal/runtime/executor/codex_model_header_profile_test.go
@@ -1,0 +1,136 @@
+package executor
+
+import (
+	"crypto/sha256"
+	"net/http"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+func TestResolveCodexModelHeaderProfileUsesCodexProviderRegardlessOfRegistrationOrder(t *testing.T) {
+	tests := []struct {
+		name       string
+		providers  []string
+		modelID    string
+		clientBase string
+	}{
+		{
+			name:       "codex-first",
+			providers:  []string{"codex", "openai-compatibility"},
+			modelID:    "test-codex-header-profile-order-a",
+			clientBase: "test-codex-header-profile-order-a",
+		},
+		{
+			name:       "codex-last",
+			providers:  []string{"openai-compatibility", "codex"},
+			modelID:    "test-codex-header-profile-order-b",
+			clientBase: "test-codex-header-profile-order-b",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := registry.GetGlobalRegistry()
+			clientIDs := make([]string, 0, len(tt.providers))
+			for _, provider := range tt.providers {
+				clientID := tt.clientBase + "-" + provider
+				clientIDs = append(clientIDs, clientID)
+				userAgent := "other-provider/1.0"
+				if provider == "codex" {
+					userAgent = "codex-provider/1.0"
+				}
+				reg.RegisterClient(clientID, provider, []*registry.ModelInfo{{
+					ID: tt.modelID,
+					Config: &registry.ModelConfig{OverrideHeader: map[string]string{
+						"user-agent": userAgent,
+					}},
+				}})
+			}
+			defer func() {
+				for _, clientID := range clientIDs {
+					reg.UnregisterClient(clientID)
+				}
+			}()
+
+			profile := resolveCodexModelHeaderProfile(tt.modelID)
+			headers := http.Header{}
+			applyModelHeaderOverrides(headers, profile)
+
+			if got := headers.Get("User-Agent"); got != "codex-provider/1.0" {
+				t.Fatalf("User-Agent = %q, want Codex provider override", got)
+			}
+			if profile.digest == ([sha256.Size]byte{}) {
+				t.Fatal("profile digest is empty, want resolved override digest")
+			}
+		})
+	}
+}
+
+func TestCodexModelHeaderProfileIsStableSnapshot(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	clientID := "test-codex-header-profile-snapshot"
+	modelID := "test-codex-header-profile-snapshot-model"
+	defer reg.UnregisterClient(clientID)
+
+	register := func(userAgent string) {
+		reg.RegisterClient(clientID, "codex", []*registry.ModelInfo{{
+			ID: modelID,
+			Config: &registry.ModelConfig{OverrideHeader: map[string]string{
+				"user-agent": userAgent,
+			}},
+		}})
+	}
+
+	register("snapshot-a/1.0")
+	profileA := resolveCodexModelHeaderProfile(modelID)
+	register("snapshot-b/1.0")
+	profileB := resolveCodexModelHeaderProfile(modelID)
+
+	headers := http.Header{}
+	applyModelHeaderOverrides(headers, profileA)
+	if got := headers.Get("User-Agent"); got != "snapshot-a/1.0" {
+		t.Fatalf("snapshot A User-Agent = %q, want snapshot-a/1.0", got)
+	}
+	if profileA.digest == profileB.digest {
+		t.Fatal("profile digest did not change after override update")
+	}
+
+	applyModelHeaderOverrides(headers, profileB)
+	if got := headers.Get("User-Agent"); got != "snapshot-b/1.0" {
+		t.Fatalf("snapshot B User-Agent = %q, want snapshot-b/1.0", got)
+	}
+	applyModelHeaderOverrides(http.Header{}, profileA)
+	if got := profileA.overrides["User-Agent"]; got != "snapshot-a/1.0" {
+		t.Fatalf("applying profile mutated snapshot: User-Agent = %q", got)
+	}
+}
+
+func TestCodexModelHeaderProfileDigestNormalizesHeaderKeys(t *testing.T) {
+	reg := registry.GetGlobalRegistry()
+	clientID := "test-codex-header-profile-normalization"
+	defer reg.UnregisterClient(clientID)
+
+	reg.RegisterClient(clientID, "codex", []*registry.ModelInfo{
+		{
+			ID: "test-codex-header-profile-normalization-a",
+			Config: &registry.ModelConfig{OverrideHeader: map[string]string{
+				"user-agent": "normalized/1.0",
+				"ORIGINATOR": "codex",
+			}},
+		},
+		{
+			ID: "test-codex-header-profile-normalization-b",
+			Config: &registry.ModelConfig{OverrideHeader: map[string]string{
+				"User-Agent": "normalized/1.0",
+				"originator": "codex",
+			}},
+		},
+	})
+
+	profileA := resolveCodexModelHeaderProfile("test-codex-header-profile-normalization-a")
+	profileB := resolveCodexModelHeaderProfile("test-codex-header-profile-normalization-b")
+	if profileA.digest != profileB.digest {
+		t.Fatalf("equivalent header profiles have different digests: %x != %x", profileA.digest, profileB.digest)
+	}
+}

--- a/internal/runtime/executor/codex_openai_images.go
+++ b/internal/runtime/executor/codex_openai_images.go
@@ -97,6 +97,7 @@ func (e *CodexExecutor) executeOpenAIImage(ctx context.Context, auth *cliproxyau
 	}
 
 	mainModel := e.resolveGPTImage2BaseModel()
+	modelHeaderProfile := resolveCodexModelHeaderProfile(mainModel)
 	reporter := helps.NewExecutorUsageReporter(ctx, e, mainModel, auth)
 	defer reporter.TrackFailure(ctx, &err)
 
@@ -113,7 +114,7 @@ func (e *CodexExecutor) executeOpenAIImage(ctx context.Context, auth *cliproxyau
 		return resp, errCache
 	}
 	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
-	applyModelHeaderOverrides(httpReq.Header, mainModel)
+	applyModelHeaderOverrides(httpReq.Header, modelHeaderProfile)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
 	recordCodexOpenAIImageRequest(ctx, e.cfg, e.Identifier(), auth, url, httpReq.Header.Clone(), body)
 
@@ -194,6 +195,7 @@ func (e *CodexExecutor) executeOpenAIImageStream(ctx context.Context, auth *clip
 	}
 
 	mainModel := e.resolveGPTImage2BaseModel()
+	modelHeaderProfile := resolveCodexModelHeaderProfile(mainModel)
 	reporter := helps.NewExecutorUsageReporter(ctx, e, mainModel, auth)
 	defer reporter.TrackFailure(ctx, &err)
 
@@ -210,7 +212,7 @@ func (e *CodexExecutor) executeOpenAIImageStream(ctx context.Context, auth *clip
 		return nil, errCache
 	}
 	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
-	applyModelHeaderOverrides(httpReq.Header, mainModel)
+	applyModelHeaderOverrides(httpReq.Header, modelHeaderProfile)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
 	recordCodexOpenAIImageRequest(ctx, e.cfg, e.Identifier(), auth, url, httpReq.Header.Clone(), body)
 
@@ -320,6 +322,7 @@ func (e *CodexExecutor) executeDirectOpenAIImage(ctx context.Context, auth *clip
 	if errPrepare != nil {
 		return resp, errPrepare
 	}
+	modelHeaderProfile := resolveCodexModelHeaderProfile(model)
 
 	apiKey, baseURL := codexCreds(auth)
 	if baseURL == "" {
@@ -337,7 +340,7 @@ func (e *CodexExecutor) executeDirectOpenAIImage(ctx context.Context, auth *clip
 		return resp, errCache
 	}
 	applyCodexDirectImageHeaders(httpReq, auth, apiKey, false, e.cfg)
-	applyModelHeaderOverrides(httpReq.Header, model)
+	applyModelHeaderOverrides(httpReq.Header, modelHeaderProfile)
 	if contentType != "" {
 		httpReq.Header.Set("Content-Type", contentType)
 	}
@@ -381,6 +384,7 @@ func (e *CodexExecutor) executeDirectOpenAIImageStream(ctx context.Context, auth
 	if errPrepare != nil {
 		return nil, errPrepare
 	}
+	modelHeaderProfile := resolveCodexModelHeaderProfile(model)
 
 	apiKey, baseURL := codexCreds(auth)
 	if baseURL == "" {
@@ -398,7 +402,7 @@ func (e *CodexExecutor) executeDirectOpenAIImageStream(ctx context.Context, auth
 		return nil, errCache
 	}
 	applyCodexDirectImageHeaders(httpReq, auth, apiKey, true, e.cfg)
-	applyModelHeaderOverrides(httpReq.Header, model)
+	applyModelHeaderOverrides(httpReq.Header, modelHeaderProfile)
 	if contentType != "" {
 		httpReq.Header.Set("Content-Type", contentType)
 	}

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -12,7 +12,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -23,7 +22,6 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
-	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
@@ -191,6 +189,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	}
 
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	modelHeaderProfile := resolveCodexModelHeaderProfile(baseModel)
 	apiKey, baseURL := codexCreds(auth)
 	if baseURL == "" {
 		baseURL = "https://chatgpt.com/backend-api/codex"
@@ -242,7 +241,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	upstreamBody, identityState := applyCodexIdentityConfuseBody(e.cfg, auth, originalPayloadSource, body)
 	reporter.SetTranslatedReasoningEffort(clientBody, to.String())
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
-	applyModelHeaderOverrides(wsHeaders, baseModel)
+	applyModelHeaderOverrides(wsHeaders, modelHeaderProfile)
 	applyCodexIdentityConfuseHeaders(wsHeaders, &identityState)
 
 	var authID, authLabel, authType, authValue string
@@ -274,7 +273,8 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	}
 	helps.RecordAPIWebsocketRequest(ctx, e.cfg, wsReqLog)
 
-	conn, respHS, errDial := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, baseModel, wsHeaders)
+	connectionKey := newCodexWebsocketConnectionKey(authID, wsURL, baseModel, modelHeaderProfile.digest)
+	conn, respHS, errDial := e.ensureUpstreamConn(ctx, auth, sess, connectionKey, wsHeaders)
 	if errDial != nil {
 		bodyErr := websocketHandshakeBody(respHS)
 		if respHS != nil {
@@ -319,7 +319,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 			// Retry once with a fresh websocket connection. This is mainly to handle
 			// upstream closing the socket between sequential requests within the same
 			// execution session.
-			connRetry, respHSRetry, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, baseModel, wsHeaders)
+			connRetry, respHSRetry, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, connectionKey, wsHeaders)
 			if errDialRetry == nil && connRetry != nil {
 				wsReqBodyRetry := buildCodexWebsocketRequestBody(upstreamBody)
 				helps.RecordAPIWebsocketRequest(ctx, e.cfg, helps.UpstreamRequestLog{
@@ -417,6 +417,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	}
 
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	modelHeaderProfile := resolveCodexModelHeaderProfile(baseModel)
 	apiKey, baseURL := codexCreds(auth)
 	if baseURL == "" {
 		baseURL = "https://chatgpt.com/backend-api/codex"
@@ -464,7 +465,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	upstreamBody, identityState := applyCodexIdentityConfuseBody(e.cfg, auth, userPayload, body)
 	reporter.SetTranslatedReasoningEffort(clientBody, to.String())
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
-	applyModelHeaderOverrides(wsHeaders, baseModel)
+	applyModelHeaderOverrides(wsHeaders, modelHeaderProfile)
 	applyCodexIdentityConfuseHeaders(wsHeaders, &identityState)
 
 	var authID, authLabel, authType, authValue string
@@ -495,7 +496,8 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	}
 	helps.RecordAPIWebsocketRequest(ctx, e.cfg, wsReqLog)
 
-	conn, respHS, errDial := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, baseModel, wsHeaders)
+	connectionKey := newCodexWebsocketConnectionKey(authID, wsURL, baseModel, modelHeaderProfile.digest)
+	conn, respHS, errDial := e.ensureUpstreamConn(ctx, auth, sess, connectionKey, wsHeaders)
 	var upstreamHeaders http.Header
 	if respHS != nil {
 		upstreamHeaders = respHS.Header.Clone()
@@ -536,7 +538,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			e.invalidateUpstreamConn(sess, conn, "send_error", errSend)
 
 			// Retry once with a new websocket connection for the same execution session.
-			connRetry, respHSRetry, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, authID, wsURL, baseModel, wsHeaders)
+			connRetry, respHSRetry, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, connectionKey, wsHeaders)
 			if errDialRetry != nil || connRetry == nil {
 				closeHTTPResponseBody(respHSRetry, "codex websockets executor: close handshake response body error")
 				helps.RecordAPIWebsocketError(ctx, e.cfg, "dial_retry", errDialRetry)
@@ -1404,52 +1406,20 @@ func (e *CodexWebsocketsExecutor) UpstreamDisconnectChan(sessionID string) <-cha
 	return sess.upstreamDisconnectCh
 }
 
-func newCodexWebsocketConnectionKey(authID string, wsURL string, baseModel string) codexWebsocketConnectionKey {
+func newCodexWebsocketConnectionKey(authID string, wsURL string, baseModel string, overrideHeaderProfile [sha256.Size]byte) codexWebsocketConnectionKey {
 	return codexWebsocketConnectionKey{
 		authID:                strings.TrimSpace(authID),
 		wsURL:                 strings.TrimSpace(wsURL),
 		baseModel:             strings.TrimSpace(baseModel),
-		overrideHeaderProfile: codexModelOverrideHeaderProfile(baseModel),
+		overrideHeaderProfile: overrideHeaderProfile,
 	}
 }
 
-func codexModelOverrideHeaderProfile(baseModel string) [sha256.Size]byte {
-	overrides := registry.ModelOverrideHeaders(strings.TrimSpace(baseModel))
-	if len(overrides) == 0 {
-		return [sha256.Size]byte{}
-	}
-
-	type headerEntry struct {
-		key   string
-		value string
-	}
-	entries := make([]headerEntry, 0, len(overrides))
-	for key, value := range overrides {
-		entries = append(entries, headerEntry{
-			key:   strings.ToLower(strings.TrimSpace(key)),
-			value: value,
-		})
-	}
-	sort.Slice(entries, func(i, j int) bool {
-		if entries[i].key != entries[j].key {
-			return entries[i].key < entries[j].key
-		}
-		return entries[i].value < entries[j].value
-	})
-
-	var profile strings.Builder
-	for i := range entries {
-		_, _ = fmt.Fprintf(&profile, "%d:%s%d:%s", len(entries[i].key), entries[i].key, len(entries[i].value), entries[i].value)
-	}
-	return sha256.Sum256([]byte(profile.String()))
-}
-
-func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *cliproxyauth.Auth, sess *codexWebsocketSession, authID string, wsURL string, baseModel string, headers http.Header) (*websocket.Conn, *http.Response, error) {
+func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *cliproxyauth.Auth, sess *codexWebsocketSession, wantedKey codexWebsocketConnectionKey, headers http.Header) (*websocket.Conn, *http.Response, error) {
 	if sess == nil {
-		return e.dialCodexWebsocket(ctx, auth, wsURL, headers)
+		return e.dialCodexWebsocket(ctx, auth, wantedKey.wsURL, headers)
 	}
 
-	wantedKey := newCodexWebsocketConnectionKey(authID, wsURL, baseModel)
 	sess.connMu.Lock()
 	conn := sess.conn
 	readerConn := sess.readerConn
@@ -1480,7 +1450,7 @@ func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *
 		}
 	}
 
-	conn, resp, errDial := e.dialCodexWebsocket(ctx, auth, wsURL, headers)
+	conn, resp, errDial := e.dialCodexWebsocket(ctx, auth, wantedKey.wsURL, headers)
 	if errDial != nil {
 		return nil, resp, errDial
 	}
@@ -1500,14 +1470,14 @@ func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *
 	}
 	sess.conn = conn
 	sess.connKey = wantedKey
-	sess.wsURL = wsURL
-	sess.authID = authID
+	sess.wsURL = wantedKey.wsURL
+	sess.authID = wantedKey.authID
 	sess.readerConn = conn
 	sess.connMu.Unlock()
 
 	sess.configureConn(conn)
 	go e.readUpstreamLoop(sess, conn)
-	logCodexWebsocketConnected(sess.sessionID, authID, wsURL)
+	logCodexWebsocketConnected(sess.sessionID, wantedKey.authID, wantedKey.wsURL)
 	return conn, resp, nil
 }
 

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -67,18 +67,22 @@ type codexWebsocketSession struct {
 
 	connMu  sync.Mutex
 	conn    *websocket.Conn
+	connGen uint64
 	connKey codexWebsocketConnectionKey
 	wsURL   string
 	authID  string
+	closed  bool
 
 	writeMu sync.Mutex
 
 	activeMu     sync.Mutex
+	active       codexWebsocketActive
 	activeCh     chan codexWebsocketRead
 	activeDone   <-chan struct{}
 	activeCancel context.CancelFunc
 
 	readerConn *websocket.Conn
+	readerGen  uint64
 
 	upstreamDisconnectOnce sync.Once
 	upstreamDisconnectCh   chan error
@@ -91,6 +95,27 @@ type codexWebsocketConnectionKey struct {
 	overrideHeaderProfile [sha256.Size]byte
 }
 
+type codexWebsocketConnectionRef struct {
+	conn       *websocket.Conn
+	generation uint64
+}
+
+type codexWebsocketRequestSignal struct {
+	ctx    context.Context
+	cancel context.CancelCauseFunc
+}
+
+func newCodexWebsocketRequestSignal() *codexWebsocketRequestSignal {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	return &codexWebsocketRequestSignal{ctx: ctx, cancel: cancel}
+}
+
+type codexWebsocketActive struct {
+	connection codexWebsocketConnectionRef
+	ch         chan codexWebsocketRead
+	signal     *codexWebsocketRequestSignal
+}
+
 func NewCodexWebsocketsExecutor(cfg *config.Config) *CodexWebsocketsExecutor {
 	return &CodexWebsocketsExecutor{
 		CodexExecutor: NewCodexExecutor(cfg),
@@ -99,12 +124,114 @@ func NewCodexWebsocketsExecutor(cfg *config.Config) *CodexWebsocketsExecutor {
 }
 
 type codexWebsocketRead struct {
-	conn    *websocket.Conn
-	msgType int
-	payload []byte
-	err     error
+	connection codexWebsocketConnectionRef
+	conn       *websocket.Conn
+	msgType    int
+	payload    []byte
+	err        error
 }
 
+func (s *codexWebsocketSession) setActiveConnection(connection codexWebsocketConnectionRef, ch chan codexWebsocketRead) (*codexWebsocketRequestSignal, error) {
+	if s == nil {
+		return nil, fmt.Errorf("codex websockets executor: session is nil")
+	}
+	s.connMu.Lock()
+	if s.closed {
+		s.connMu.Unlock()
+		return nil, fmt.Errorf("codex websockets executor: session is closed")
+	}
+	if connection.conn == nil || s.conn != connection.conn || s.connGen != connection.generation {
+		s.connMu.Unlock()
+		return nil, fmt.Errorf("codex websockets executor: connection generation is no longer current")
+	}
+	signal := newCodexWebsocketRequestSignal()
+	s.activeMu.Lock()
+	if s.active.signal != nil {
+		s.active.signal.cancel(context.Canceled)
+	}
+	s.active = codexWebsocketActive{connection: connection, ch: ch, signal: signal}
+	s.activeMu.Unlock()
+	s.connMu.Unlock()
+	return signal, nil
+}
+
+func (s *codexWebsocketSession) clearActiveConnection(connection codexWebsocketConnectionRef, ch chan codexWebsocketRead) {
+	if s == nil {
+		return
+	}
+	s.activeMu.Lock()
+	if s.active.connection == connection && s.active.ch == ch {
+		if s.active.signal != nil {
+			s.active.signal.cancel(context.Canceled)
+		}
+		s.active = codexWebsocketActive{}
+	}
+	s.activeMu.Unlock()
+}
+
+func (s *codexWebsocketSession) cancelActiveConnection(cause error) {
+	if s == nil {
+		return
+	}
+	if cause == nil {
+		cause = context.Canceled
+	}
+	s.activeMu.Lock()
+	if s.active.signal != nil {
+		s.active.signal.cancel(cause)
+	}
+	s.active = codexWebsocketActive{}
+	s.activeMu.Unlock()
+}
+
+func (s *codexWebsocketSession) activeFor(connection codexWebsocketConnectionRef) (chan codexWebsocketRead, *codexWebsocketRequestSignal, bool) {
+	if s == nil {
+		return nil, nil, false
+	}
+	s.activeMu.Lock()
+	defer s.activeMu.Unlock()
+	if s.active.connection != connection || s.active.ch == nil || s.active.signal == nil {
+		return nil, nil, false
+	}
+	return s.active.ch, s.active.signal, true
+}
+
+func (s *codexWebsocketSession) dispatchRead(connection codexWebsocketConnectionRef, event codexWebsocketRead, terminal bool) bool {
+	event.connection = connection
+	if terminal {
+		s.activeMu.Lock()
+		defer s.activeMu.Unlock()
+		if s.active.connection != connection || s.active.ch == nil || s.active.signal == nil {
+			return false
+		}
+		select {
+		case s.active.ch <- event:
+		default:
+		}
+		cause := event.err
+		if cause == nil {
+			cause = context.Canceled
+		}
+		s.active.signal.cancel(cause)
+		s.active = codexWebsocketActive{}
+		return true
+	}
+
+	ch, signal, ok := s.activeFor(connection)
+	if !ok {
+		return false
+	}
+	select {
+	case ch <- event:
+	case <-signal.ctx.Done():
+		return false
+	}
+	return true
+}
+
+// setActive and clearActive retain the legacy active-channel contract used by
+// the independent xAI websocket session store. Codex sessions use the
+// generation-aware variants above.
 func (s *codexWebsocketSession) setActive(ch chan codexWebsocketRead) {
 	if s == nil {
 		return
@@ -138,6 +265,16 @@ func (s *codexWebsocketSession) clearActive(ch chan codexWebsocketRead) {
 		s.activeDone = nil
 	}
 	s.activeMu.Unlock()
+}
+
+func (s *codexWebsocketSession) isCurrentConnection(connection codexWebsocketConnectionRef) bool {
+	if s == nil || connection.conn == nil {
+		return false
+	}
+	s.connMu.Lock()
+	current := s.conn == connection.conn && s.connGen == connection.generation
+	s.connMu.Unlock()
+	return current
 }
 
 func (s *codexWebsocketSession) writeMessage(conn *websocket.Conn, msgType int, payload []byte) error {
@@ -274,7 +411,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	helps.RecordAPIWebsocketRequest(ctx, e.cfg, wsReqLog)
 
 	connectionKey := newCodexWebsocketConnectionKey(authID, wsURL, baseModel, modelHeaderProfile.digest)
-	conn, respHS, errDial := e.ensureUpstreamConn(ctx, auth, sess, connectionKey, wsHeaders)
+	connection, respHS, errDial := e.ensureUpstreamConn(ctx, auth, sess, connectionKey, wsHeaders)
 	if errDial != nil {
 		bodyErr := websocketHandshakeBody(respHS)
 		if respHS != nil {
@@ -299,28 +436,33 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 				reason = "error"
 			}
 			logCodexWebsocketDisconnected(executionSessionID, authID, wsURL, reason, err)
-			if errClose := conn.Close(); errClose != nil {
+			if errClose := connection.conn.Close(); errClose != nil {
 				log.Errorf("codex websockets executor: close websocket error: %v", errClose)
 			}
 		}()
 	}
 
 	var readCh chan codexWebsocketRead
+	var requestSignal *codexWebsocketRequestSignal
 	if sess != nil {
 		readCh = make(chan codexWebsocketRead, 4096)
-		sess.setActive(readCh)
-		defer sess.clearActive(readCh)
+		var errActive error
+		requestSignal, errActive = sess.setActiveConnection(connection, readCh)
+		if errActive != nil {
+			return resp, errActive
+		}
+		defer func() { sess.clearActiveConnection(connection, readCh) }()
 	}
 
-	if errSend := writeCodexWebsocketMessage(sess, conn, wsReqBody); errSend != nil {
+	if errSend := writeCodexWebsocketMessage(sess, connection.conn, wsReqBody); errSend != nil {
 		if sess != nil {
-			e.invalidateUpstreamConn(sess, conn, "send_error", errSend)
+			e.invalidateUpstreamConn(sess, connection, "send_error", errSend)
 
 			// Retry once with a fresh websocket connection. This is mainly to handle
 			// upstream closing the socket between sequential requests within the same
 			// execution session.
-			connRetry, respHSRetry, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, connectionKey, wsHeaders)
-			if errDialRetry == nil && connRetry != nil {
+			connectionRetry, respHSRetry, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, connectionKey, wsHeaders)
+			if errDialRetry == nil && connectionRetry.conn != nil {
 				wsReqBodyRetry := buildCodexWebsocketRequestBody(upstreamBody)
 				helps.RecordAPIWebsocketRequest(ctx, e.cfg, helps.UpstreamRequestLog{
 					URL:       wsURL,
@@ -335,11 +477,16 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 				})
 				recordAPIWebsocketHandshake(ctx, e.cfg, respHSRetry)
 				reporter.StartResponseTTFT()
-				if errSendRetry := writeCodexWebsocketMessage(sess, connRetry, wsReqBodyRetry); errSendRetry == nil {
-					conn = connRetry
+				retrySignal, errActive := sess.setActiveConnection(connectionRetry, readCh)
+				if errActive != nil {
+					return resp, errActive
+				}
+				connection = connectionRetry
+				requestSignal = retrySignal
+				if errSendRetry := writeCodexWebsocketMessage(sess, connection.conn, wsReqBodyRetry); errSendRetry == nil {
 					wsReqBody = wsReqBodyRetry
 				} else {
-					e.invalidateUpstreamConn(sess, connRetry, "send_error", errSendRetry)
+					e.invalidateUpstreamConn(sess, connection, "send_error", errSendRetry)
 					helps.RecordAPIWebsocketError(ctx, e.cfg, "send_retry", errSendRetry)
 					return resp, errSendRetry
 				}
@@ -358,7 +505,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		if ctx != nil && ctx.Err() != nil {
 			return resp, ctx.Err()
 		}
-		msgType, payload, errRead := readCodexWebsocketMessage(ctx, sess, conn, readCh)
+		msgType, payload, errRead := readCodexWebsocketMessage(ctx, sess, connection, readCh, requestSignal)
 		if errRead != nil {
 			mappedErr := mapCodexWebsocketReadError(errRead)
 			helps.RecordAPIWebsocketError(ctx, e.cfg, "read", mappedErr)
@@ -368,7 +515,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 			if msgType == websocket.BinaryMessage {
 				err = fmt.Errorf("codex websockets executor: unexpected binary message")
 				if sess != nil {
-					e.invalidateUpstreamConn(sess, conn, "unexpected_binary", err)
+					e.invalidateUpstreamConn(sess, connection, "unexpected_binary", err)
 				}
 				helps.RecordAPIWebsocketError(ctx, e.cfg, "unexpected_binary", err)
 				return resp, err
@@ -386,7 +533,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 
 		if wsErr, ok := parseCodexWebsocketError(payload); ok {
 			if sess != nil {
-				e.invalidateUpstreamConn(sess, conn, "upstream_error", wsErr)
+				e.invalidateUpstreamConn(sess, connection, "upstream_error", wsErr)
 			}
 			helps.RecordAPIWebsocketError(ctx, e.cfg, "upstream_error", wsErr)
 			return resp, wsErr
@@ -497,7 +644,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	helps.RecordAPIWebsocketRequest(ctx, e.cfg, wsReqLog)
 
 	connectionKey := newCodexWebsocketConnectionKey(authID, wsURL, baseModel, modelHeaderProfile.digest)
-	conn, respHS, errDial := e.ensureUpstreamConn(ctx, auth, sess, connectionKey, wsHeaders)
+	connection, respHS, errDial := e.ensureUpstreamConn(ctx, auth, sess, connectionKey, wsHeaders)
 	var upstreamHeaders http.Header
 	if respHS != nil {
 		upstreamHeaders = respHS.Header.Clone()
@@ -508,9 +655,15 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			helps.RecordAPIWebsocketUpgradeRejection(ctx, e.cfg, websocketUpgradeRequestLog(wsReqLog), respHS.StatusCode, respHS.Header.Clone(), bodyErr)
 		}
 		if respHS != nil && respHS.StatusCode == http.StatusUpgradeRequired {
+			if sess != nil {
+				sess.reqMu.Unlock()
+			}
 			return e.CodexExecutor.ExecuteStream(ctx, auth, req, opts)
 		}
 		if respHS != nil && respHS.StatusCode > 0 {
+			if sess != nil {
+				sess.reqMu.Unlock()
+			}
 			return nil, statusErr{code: respHS.StatusCode, msg: string(bodyErr)}
 		}
 		helps.RecordAPIWebsocketError(ctx, e.cfg, "dial", errDial)
@@ -527,22 +680,28 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	}
 
 	var readCh chan codexWebsocketRead
+	var requestSignal *codexWebsocketRequestSignal
 	if sess != nil {
 		readCh = make(chan codexWebsocketRead, 4096)
-		sess.setActive(readCh)
+		var errActive error
+		requestSignal, errActive = sess.setActiveConnection(connection, readCh)
+		if errActive != nil {
+			sess.reqMu.Unlock()
+			return nil, errActive
+		}
 	}
 
-	if errSend := writeCodexWebsocketMessage(sess, conn, wsReqBody); errSend != nil {
+	if errSend := writeCodexWebsocketMessage(sess, connection.conn, wsReqBody); errSend != nil {
 		helps.RecordAPIWebsocketError(ctx, e.cfg, "send", errSend)
 		if sess != nil {
-			e.invalidateUpstreamConn(sess, conn, "send_error", errSend)
+			e.invalidateUpstreamConn(sess, connection, "send_error", errSend)
 
 			// Retry once with a new websocket connection for the same execution session.
-			connRetry, respHSRetry, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, connectionKey, wsHeaders)
-			if errDialRetry != nil || connRetry == nil {
+			connectionRetry, respHSRetry, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, connectionKey, wsHeaders)
+			if errDialRetry != nil || connectionRetry.conn == nil {
 				closeHTTPResponseBody(respHSRetry, "codex websockets executor: close handshake response body error")
 				helps.RecordAPIWebsocketError(ctx, e.cfg, "dial_retry", errDialRetry)
-				sess.clearActive(readCh)
+				sess.clearActiveConnection(connection, readCh)
 				sess.reqMu.Unlock()
 				return nil, errDialRetry
 			}
@@ -560,18 +719,25 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			})
 			recordAPIWebsocketHandshake(ctx, e.cfg, respHSRetry)
 			reporter.StartResponseTTFT()
-			if errSendRetry := writeCodexWebsocketMessage(sess, connRetry, wsReqBodyRetry); errSendRetry != nil {
+			retrySignal, errActive := sess.setActiveConnection(connectionRetry, readCh)
+			if errActive != nil {
+				sess.clearActiveConnection(connection, readCh)
+				sess.reqMu.Unlock()
+				return nil, errActive
+			}
+			connection = connectionRetry
+			requestSignal = retrySignal
+			if errSendRetry := writeCodexWebsocketMessage(sess, connection.conn, wsReqBodyRetry); errSendRetry != nil {
 				helps.RecordAPIWebsocketError(ctx, e.cfg, "send_retry", errSendRetry)
-				e.invalidateUpstreamConn(sess, connRetry, "send_error", errSendRetry)
-				sess.clearActive(readCh)
+				e.invalidateUpstreamConn(sess, connection, "send_error", errSendRetry)
+				sess.clearActiveConnection(connection, readCh)
 				sess.reqMu.Unlock()
 				return nil, errSendRetry
 			}
-			conn = connRetry
 			wsReqBody = wsReqBodyRetry
 		} else {
 			logCodexWebsocketDisconnected(executionSessionID, authID, wsURL, "send_error", errSend)
-			if errClose := conn.Close(); errClose != nil {
+			if errClose := connection.conn.Close(); errClose != nil {
 				log.Errorf("codex websockets executor: close websocket error: %v", errClose)
 			}
 			return nil, errSend
@@ -586,12 +752,12 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		defer close(out)
 		defer func() {
 			if sess != nil {
-				sess.clearActive(readCh)
+				sess.clearActiveConnection(connection, readCh)
 				sess.reqMu.Unlock()
 				return
 			}
 			logCodexWebsocketDisconnected(executionSessionID, authID, wsURL, terminateReason, terminateErr)
-			if errClose := conn.Close(); errClose != nil {
+			if errClose := connection.conn.Close(); errClose != nil {
 				log.Errorf("codex websockets executor: close websocket error: %v", errClose)
 			}
 		}()
@@ -617,7 +783,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 				_ = send(cliproxyexecutor.StreamChunk{Err: ctx.Err()})
 				return
 			}
-			msgType, payload, errRead := readCodexWebsocketMessage(ctx, sess, conn, readCh)
+			msgType, payload, errRead := readCodexWebsocketMessage(ctx, sess, connection, readCh, requestSignal)
 			if errRead != nil {
 				if sess != nil && ctx != nil && ctx.Err() != nil {
 					terminateReason = "context_done"
@@ -641,7 +807,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 					helps.RecordAPIWebsocketError(ctx, e.cfg, "unexpected_binary", err)
 					reporter.PublishFailure(ctx, err)
 					if sess != nil {
-						e.invalidateUpstreamConn(sess, conn, "unexpected_binary", err)
+						e.invalidateUpstreamConn(sess, connection, "unexpected_binary", err)
 					}
 					_ = send(cliproxyexecutor.StreamChunk{Err: err})
 					return
@@ -663,7 +829,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 				helps.RecordAPIWebsocketError(ctx, e.cfg, "upstream_error", wsErr)
 				reporter.PublishFailure(ctx, wsErr)
 				if sess != nil {
-					e.invalidateUpstreamConn(sess, conn, "upstream_error", wsErr)
+					e.invalidateUpstreamConn(sess, connection, "upstream_error", wsErr)
 				}
 				_ = send(cliproxyexecutor.StreamChunk{Err: wsErr})
 				return
@@ -770,30 +936,39 @@ func buildCodexWebsocketRequestBody(body []byte) []byte {
 	return fallback
 }
 
-func readCodexWebsocketMessage(ctx context.Context, sess *codexWebsocketSession, conn *websocket.Conn, readCh chan codexWebsocketRead) (int, []byte, error) {
+func readCodexWebsocketMessage(ctx context.Context, sess *codexWebsocketSession, connection codexWebsocketConnectionRef, readCh chan codexWebsocketRead, requestSignal *codexWebsocketRequestSignal) (int, []byte, error) {
 	if sess == nil {
-		if conn == nil {
+		if connection.conn == nil {
 			return 0, nil, fmt.Errorf("codex websockets executor: websocket conn is nil")
 		}
-		_ = conn.SetReadDeadline(time.Now().Add(codexResponsesWebsocketIdleTimeout))
-		msgType, payload, errRead := conn.ReadMessage()
+		_ = connection.conn.SetReadDeadline(time.Now().Add(codexResponsesWebsocketIdleTimeout))
+		msgType, payload, errRead := connection.conn.ReadMessage()
 		return msgType, payload, errRead
 	}
-	if conn == nil {
+	if connection.conn == nil {
 		return 0, nil, fmt.Errorf("codex websockets executor: websocket conn is nil")
 	}
 	if readCh == nil {
 		return 0, nil, fmt.Errorf("codex websockets executor: session read channel is nil")
 	}
+	if requestSignal == nil || requestSignal.ctx == nil {
+		return 0, nil, fmt.Errorf("codex websockets executor: session request signal is nil")
+	}
 	for {
 		select {
 		case <-ctx.Done():
 			return 0, nil, ctx.Err()
+		case <-requestSignal.ctx.Done():
+			cause := context.Cause(requestSignal.ctx)
+			if cause == nil {
+				cause = context.Canceled
+			}
+			return 0, nil, cause
 		case ev, ok := <-readCh:
 			if !ok {
 				return 0, nil, fmt.Errorf("codex websockets executor: session read channel closed")
 			}
-			if ev.conn != conn {
+			if ev.connection != connection {
 				continue
 			}
 			if ev.err != nil {
@@ -1415,49 +1590,63 @@ func newCodexWebsocketConnectionKey(authID string, wsURL string, baseModel strin
 	}
 }
 
-func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *cliproxyauth.Auth, sess *codexWebsocketSession, wantedKey codexWebsocketConnectionKey, headers http.Header) (*websocket.Conn, *http.Response, error) {
+func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *cliproxyauth.Auth, sess *codexWebsocketSession, wantedKey codexWebsocketConnectionKey, headers http.Header) (codexWebsocketConnectionRef, *http.Response, error) {
 	if sess == nil {
-		return e.dialCodexWebsocket(ctx, auth, wantedKey.wsURL, headers)
+		conn, resp, errDial := e.dialCodexWebsocket(ctx, auth, wantedKey.wsURL, headers)
+		return codexWebsocketConnectionRef{conn: conn}, resp, errDial
 	}
 
 	sess.connMu.Lock()
-	conn := sess.conn
-	readerConn := sess.readerConn
-	if conn != nil && sess.connKey == wantedKey {
-		startReader := readerConn != conn
+	if sess.closed {
+		sess.connMu.Unlock()
+		return codexWebsocketConnectionRef{}, nil, fmt.Errorf("codex websockets executor: session is closed")
+	}
+	connection := codexWebsocketConnectionRef{conn: sess.conn, generation: sess.connGen}
+	reader := codexWebsocketConnectionRef{conn: sess.readerConn, generation: sess.readerGen}
+	if connection.conn != nil && sess.connKey == wantedKey {
+		startReader := reader != connection
 		if startReader {
-			sess.readerConn = conn
+			sess.readerConn = connection.conn
+			sess.readerGen = connection.generation
 		}
 		sess.connMu.Unlock()
 		if startReader {
-			sess.configureConn(conn)
-			go e.readUpstreamLoop(sess, conn)
+			sess.configureConn(connection.conn)
+			go e.readUpstreamLoop(sess, connection)
 		}
-		return conn, nil, nil
+		return connection, nil, nil
 	}
-	if conn != nil {
+	if connection.conn != nil {
 		sess.conn = nil
-		if sess.readerConn == conn {
+		if reader == connection {
 			sess.readerConn = nil
+			sess.readerGen = 0
 		}
 	}
 	sess.connKey = codexWebsocketConnectionKey{}
 	sess.connMu.Unlock()
 
-	if conn != nil {
-		if errClose := conn.Close(); errClose != nil {
+	if connection.conn != nil {
+		if errClose := connection.conn.Close(); errClose != nil {
 			log.Errorf("codex websockets executor: close websocket error: %v", errClose)
 		}
 	}
 
 	conn, resp, errDial := e.dialCodexWebsocket(ctx, auth, wantedKey.wsURL, headers)
 	if errDial != nil {
-		return nil, resp, errDial
+		return codexWebsocketConnectionRef{}, resp, errDial
 	}
 
 	sess.connMu.Lock()
+	if sess.closed {
+		sess.connMu.Unlock()
+		if errClose := conn.Close(); errClose != nil {
+			log.Errorf("codex websockets executor: close websocket error: %v", errClose)
+		}
+		return codexWebsocketConnectionRef{}, nil, fmt.Errorf("codex websockets executor: session closed while dialing")
+	}
 	if sess.conn != nil {
-		previous := sess.conn
+		previous := codexWebsocketConnectionRef{conn: sess.conn, generation: sess.connGen}
 		previousKey := sess.connKey
 		sess.connMu.Unlock()
 		if errClose := conn.Close(); errClose != nil {
@@ -1466,84 +1655,59 @@ func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *
 		if previousKey == wantedKey {
 			return previous, nil, nil
 		}
-		return nil, nil, fmt.Errorf("codex websockets executor: session connection profile changed while dialing")
+		return codexWebsocketConnectionRef{}, nil, fmt.Errorf("codex websockets executor: session connection profile changed while dialing")
 	}
+	sess.connGen++
+	if sess.connGen == 0 {
+		sess.connGen++
+	}
+	connection = codexWebsocketConnectionRef{conn: conn, generation: sess.connGen}
 	sess.conn = conn
 	sess.connKey = wantedKey
 	sess.wsURL = wantedKey.wsURL
 	sess.authID = wantedKey.authID
 	sess.readerConn = conn
+	sess.readerGen = connection.generation
 	sess.connMu.Unlock()
 
 	sess.configureConn(conn)
-	go e.readUpstreamLoop(sess, conn)
+	go e.readUpstreamLoop(sess, connection)
 	logCodexWebsocketConnected(sess.sessionID, wantedKey.authID, wantedKey.wsURL)
-	return conn, resp, nil
+	return connection, resp, nil
 }
 
-func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, conn *websocket.Conn) {
-	if e == nil || sess == nil || conn == nil {
+func (e *CodexWebsocketsExecutor) readUpstreamLoop(sess *codexWebsocketSession, connection codexWebsocketConnectionRef) {
+	if e == nil || sess == nil || connection.conn == nil {
 		return
 	}
 	for {
-		_ = conn.SetReadDeadline(time.Now().Add(codexResponsesWebsocketIdleTimeout))
-		msgType, payload, errRead := conn.ReadMessage()
+		_ = connection.conn.SetReadDeadline(time.Now().Add(codexResponsesWebsocketIdleTimeout))
+		msgType, payload, errRead := connection.conn.ReadMessage()
+		if !sess.isCurrentConnection(connection) {
+			return
+		}
 		if errRead != nil {
-			sess.activeMu.Lock()
-			ch := sess.activeCh
-			done := sess.activeDone
-			sess.activeMu.Unlock()
-			if ch != nil {
-				select {
-				case ch <- codexWebsocketRead{conn: conn, err: errRead}:
-				case <-done:
-				default:
-				}
-				sess.clearActive(ch)
-				close(ch)
-			}
-			e.invalidateUpstreamConn(sess, conn, "upstream_disconnected", errRead)
+			sess.dispatchRead(connection, codexWebsocketRead{err: errRead}, true)
+			e.invalidateUpstreamConn(sess, connection, "upstream_disconnected", errRead)
 			return
 		}
 
 		if msgType != websocket.TextMessage {
 			if msgType == websocket.BinaryMessage {
 				errBinary := fmt.Errorf("codex websockets executor: unexpected binary message")
-				sess.activeMu.Lock()
-				ch := sess.activeCh
-				done := sess.activeDone
-				sess.activeMu.Unlock()
-				if ch != nil {
-					select {
-					case ch <- codexWebsocketRead{conn: conn, err: errBinary}:
-					case <-done:
-					default:
-					}
-					sess.clearActive(ch)
-					close(ch)
-				}
-				e.invalidateUpstreamConn(sess, conn, "unexpected_binary", errBinary)
+				sess.dispatchRead(connection, codexWebsocketRead{err: errBinary}, true)
+				e.invalidateUpstreamConn(sess, connection, "unexpected_binary", errBinary)
 				return
 			}
 			continue
 		}
 
-		sess.activeMu.Lock()
-		ch := sess.activeCh
-		done := sess.activeDone
-		sess.activeMu.Unlock()
-		if ch == nil {
-			continue
-		}
-		select {
-		case ch <- codexWebsocketRead{conn: conn, msgType: msgType, payload: payload}:
-		case <-done:
-		}
+		sess.dispatchRead(connection, codexWebsocketRead{msgType: msgType, payload: payload}, false)
 	}
 }
 
-func (e *CodexWebsocketsExecutor) invalidateUpstreamConn(sess *codexWebsocketSession, conn *websocket.Conn, reason string, err error) {
-	if sess == nil || conn == nil {
+func (e *CodexWebsocketsExecutor) invalidateUpstreamConn(sess *codexWebsocketSession, connection codexWebsocketConnectionRef, reason string, err error) {
+	if sess == nil || connection.conn == nil {
 		return
 	}
 
@@ -1552,20 +1716,21 @@ func (e *CodexWebsocketsExecutor) invalidateUpstreamConn(sess *codexWebsocketSes
 	authID := sess.authID
 	wsURL := sess.wsURL
 	sessionID := sess.sessionID
-	if current == nil || current != conn {
+	if current == nil || current != connection.conn || sess.connGen != connection.generation {
 		sess.connMu.Unlock()
 		return
 	}
 	sess.conn = nil
 	sess.connKey = codexWebsocketConnectionKey{}
-	if sess.readerConn == conn {
+	if sess.readerConn == connection.conn && sess.readerGen == connection.generation {
 		sess.readerConn = nil
+		sess.readerGen = 0
 	}
 	sess.connMu.Unlock()
 
 	logCodexWebsocketDisconnected(sessionID, authID, wsURL, reason, err)
 	sess.notifyUpstreamDisconnect(err)
-	if errClose := conn.Close(); errClose != nil {
+	if errClose := connection.conn.Close(); errClose != nil {
 		log.Errorf("codex websockets executor: close websocket error: %v", errClose)
 	}
 }
@@ -1635,22 +1800,37 @@ func closeCodexWebsocketSession(sess *codexWebsocketSession, reason string) {
 	}
 
 	sess.connMu.Lock()
-	conn := sess.conn
+	connection := codexWebsocketConnectionRef{conn: sess.conn, generation: sess.connGen}
 	authID := sess.authID
 	wsURL := sess.wsURL
+	sessionID := sess.sessionID
+	sess.closed = true
 	sess.conn = nil
 	sess.connKey = codexWebsocketConnectionKey{}
-	if sess.readerConn == conn {
-		sess.readerConn = nil
+	sess.connGen++
+	if sess.connGen == 0 {
+		sess.connGen++
 	}
-	sessionID := sess.sessionID
+	if sess.readerConn == connection.conn && sess.readerGen == connection.generation {
+		sess.readerConn = nil
+		sess.readerGen = 0
+	}
 	sess.connMu.Unlock()
 
-	if conn == nil {
+	closeErr := fmt.Errorf("codex websockets executor: session closed: %s", reason)
+	if connection.conn == nil {
+		sess.cancelActiveConnection(closeErr)
 		return
 	}
+
+	if delivered := sess.dispatchRead(connection, codexWebsocketRead{
+		err: closeErr,
+	}, true); !delivered {
+		sess.cancelActiveConnection(closeErr)
+	}
+
 	logCodexWebsocketDisconnected(sessionID, authID, wsURL, reason, nil)
-	if errClose := conn.Close(); errClose != nil {
+	if errClose := connection.conn.Close(); errClose != nil {
 		log.Errorf("codex websockets executor: close websocket error: %v", errClose)
 	}
 }

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -383,14 +383,18 @@ func TestCodexWebsocketsEnsureUpstreamConnRedialsForLunaHeaderProfile(t *testing
 	auth := &cliproxyauth.Auth{ID: "auth-1"}
 
 	normalHeaders := http.Header{"User-Agent": []string{normalUA}}
-	firstConn, _, err := exec.ensureUpstreamConn(context.Background(), auth, sess, auth.ID, wsURL, normalModel, normalHeaders)
+	normalProfile := resolveCodexModelHeaderProfile(normalModel)
+	normalKey := newCodexWebsocketConnectionKey(auth.ID, wsURL, normalModel, normalProfile.digest)
+	firstConn, _, err := exec.ensureUpstreamConn(context.Background(), auth, sess, normalKey, normalHeaders)
 	if err != nil {
 		t.Fatalf("ensureUpstreamConn(normal) error = %v", err)
 	}
 
 	lunaHeaders := http.Header{"User-Agent": []string{normalUA}}
-	applyModelHeaderOverrides(lunaHeaders, lunaModel)
-	secondConn, _, err := exec.ensureUpstreamConn(context.Background(), auth, sess, auth.ID, wsURL, lunaModel, lunaHeaders)
+	lunaProfile := resolveCodexModelHeaderProfile(lunaModel)
+	applyModelHeaderOverrides(lunaHeaders, lunaProfile)
+	lunaKey := newCodexWebsocketConnectionKey(auth.ID, wsURL, lunaModel, lunaProfile.digest)
+	secondConn, _, err := exec.ensureUpstreamConn(context.Background(), auth, sess, lunaKey, lunaHeaders)
 	if err != nil {
 		t.Fatalf("ensureUpstreamConn(luna) error = %v", err)
 	}
@@ -413,6 +417,87 @@ func TestCodexWebsocketsEnsureUpstreamConnRedialsForLunaHeaderProfile(t *testing
 	case errDisconnect, ok := <-disconnectCh:
 		t.Fatalf("planned connection profile change signaled upstream disconnect: err=%v ok=%v", errDisconnect, ok)
 	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestCodexWebsocketsEnsureUpstreamConnUsesAppliedHeaderProfileSnapshot(t *testing.T) {
+	const (
+		modelID  = "test-codex-websocket-profile-snapshot"
+		clientID = "test-codex-websocket-profile-snapshot-client"
+	)
+
+	reg := registry.GetGlobalRegistry()
+	registerProfile := func(userAgent string) {
+		reg.RegisterClient(clientID, "codex", []*registry.ModelInfo{{
+			ID: modelID,
+			Config: &registry.ModelConfig{OverrideHeader: map[string]string{
+				"user-agent": userAgent,
+			}},
+		}})
+	}
+	registerProfile("snapshot-a/1.0")
+	t.Cleanup(func() { reg.UnregisterClient(clientID) })
+
+	profileA := resolveCodexModelHeaderProfile(modelID)
+	headersA := http.Header{}
+	applyModelHeaderOverrides(headersA, profileA)
+
+	// Change the live registry after request headers and their connection key
+	// profile have been captured. The first dial must still use snapshot A.
+	registerProfile("snapshot-b/1.0")
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	handshakes := make(chan string, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handshakes <- r.UserAgent()
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		for {
+			if _, _, errRead := conn.ReadMessage(); errRead != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{})
+	sessionID := "sess-applied-header-profile-snapshot"
+	defer exec.CloseExecutionSession(sessionID)
+	sess := exec.getOrCreateSession(sessionID)
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	auth := &cliproxyauth.Auth{ID: "auth-profile-snapshot"}
+
+	keyA := newCodexWebsocketConnectionKey(auth.ID, wsURL, modelID, profileA.digest)
+	firstConn, _, err := exec.ensureUpstreamConn(context.Background(), auth, sess, keyA, headersA)
+	if err != nil {
+		t.Fatalf("ensureUpstreamConn(snapshot A) error = %v", err)
+	}
+
+	profileB := resolveCodexModelHeaderProfile(modelID)
+	headersB := http.Header{}
+	applyModelHeaderOverrides(headersB, profileB)
+	keyB := newCodexWebsocketConnectionKey(auth.ID, wsURL, modelID, profileB.digest)
+	secondConn, _, err := exec.ensureUpstreamConn(context.Background(), auth, sess, keyB, headersB)
+	if err != nil {
+		t.Fatalf("ensureUpstreamConn(snapshot B) error = %v", err)
+	}
+	if secondConn == firstConn {
+		t.Fatal("updated applied profile reused the snapshot A websocket; want redial")
+	}
+
+	for index, wantUserAgent := range []string{"snapshot-a/1.0", "snapshot-b/1.0"} {
+		select {
+		case gotUserAgent := <-handshakes:
+			if gotUserAgent != wantUserAgent {
+				t.Fatalf("handshake %d User-Agent = %q, want %q", index+1, gotUserAgent, wantUserAgent)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for handshake %d", index+1)
+		}
 	}
 }
 
@@ -446,13 +531,15 @@ func TestCodexWebsocketsEnsureUpstreamConnReusesMatchingConnectionKey(t *testing
 		"X-Client-Request-Id": []string{"request-1"},
 	}
 
-	firstConn, _, err := exec.ensureUpstreamConn(context.Background(), auth, sess, auth.ID, wsURL, "gpt-5.4", headers)
+	profile := resolveCodexModelHeaderProfile("gpt-5.4")
+	connectionKey := newCodexWebsocketConnectionKey(auth.ID, wsURL, "gpt-5.4", profile.digest)
+	firstConn, _, err := exec.ensureUpstreamConn(context.Background(), auth, sess, connectionKey, headers)
 	if err != nil {
 		t.Fatalf("ensureUpstreamConn(first) error = %v", err)
 	}
 	secondHeaders := headers.Clone()
 	secondHeaders.Set("X-Client-Request-Id", "request-2")
-	secondConn, _, err := exec.ensureUpstreamConn(context.Background(), auth, sess, auth.ID, wsURL, "gpt-5.4", secondHeaders)
+	secondConn, _, err := exec.ensureUpstreamConn(context.Background(), auth, sess, connectionKey, secondHeaders)
 	if err != nil {
 		t.Fatalf("ensureUpstreamConn(second) error = %v", err)
 	}
@@ -1011,7 +1098,7 @@ func TestApplyModelHeaderOverridesFromModelConfig(t *testing.T) {
 	}
 
 	applyCodexHeaders(req, auth, "oauth-token", true, cfg)
-	applyModelHeaderOverrides(req.Header, "gpt-5.6-luna")
+	applyModelHeaderOverrides(req.Header, resolveCodexModelHeaderProfile("gpt-5.6-luna"))
 
 	if got := req.Header.Get("User-Agent"); got != wantUA {
 		t.Fatalf("User-Agent = %q, want %q", got, wantUA)
@@ -1020,7 +1107,7 @@ func TestApplyModelHeaderOverridesFromModelConfig(t *testing.T) {
 		t.Fatal("expected Session_id to be set for Mac OS User-Agent override")
 	}
 
-	applyModelHeaderOverrides(req.Header, "gpt-5.4")
+	applyModelHeaderOverrides(req.Header, resolveCodexModelHeaderProfile("gpt-5.4"))
 	if got := req.Header.Get("User-Agent"); got != wantUA {
 		t.Fatalf("User-Agent after no-op override = %q, want %q", got, wantUA)
 	}
@@ -1046,7 +1133,7 @@ func TestApplyModelHeaderOverridesMultipleHeaders(t *testing.T) {
 	headers.Set("Originator", "old-origin")
 	headers.Set("X-Test-Header", "old-value")
 
-	applyModelHeaderOverrides(headers, "test-override-headers-model")
+	applyModelHeaderOverrides(headers, resolveCodexModelHeaderProfile("test-override-headers-model"))
 
 	if got := headers.Get("User-Agent"); got != "custom-ua/1.0" {
 		t.Fatalf("User-Agent = %q, want custom-ua/1.0", got)

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -290,6 +290,72 @@ func TestCodexWebsocketsExecuteStreamMapsMessageTooBigClose(t *testing.T) {
 	}
 }
 
+func TestCodexWebsocketHandshakeFailureReleasesExecutionSession(t *testing.T) {
+	tests := []struct {
+		name            string
+		handshakeStatus int
+	}{
+		{name: "upgrade-required-fallback", handshakeStatus: http.StatusUpgradeRequired},
+		{name: "upstream-status-error", handshakeStatus: http.StatusTooManyRequests},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if websocket.IsWebSocketUpgrade(r) {
+					w.WriteHeader(tt.handshakeStatus)
+					_, _ = w.Write([]byte(`{"error":{"message":"websocket rejected"}}`))
+					return
+				}
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"error":{"message":"http fallback stopped"}}`))
+			}))
+			defer server.Close()
+
+			exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+			auth := &cliproxyauth.Auth{
+				ID:         "auth-handshake-" + tt.name,
+				Provider:   "codex",
+				Attributes: map[string]string{"api_key": "sk-test", "base_url": server.URL},
+			}
+			sessionID := "session-handshake-" + tt.name
+			req := cliproxyexecutor.Request{
+				Model:   "gpt-5.4",
+				Payload: []byte(`{"model":"gpt-5.4","input":[{"type":"message","role":"user","content":"hello"}]}`),
+			}
+			opts := cliproxyexecutor.Options{
+				SourceFormat: sdktranslator.FromString("openai-response"),
+				Metadata: map[string]any{
+					cliproxyexecutor.ExecutionSessionMetadataKey: sessionID,
+				},
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			result, _ := exec.ExecuteStream(ctx, auth, req, opts)
+			if result != nil {
+				for range result.Chunks {
+				}
+			}
+
+			sess := exec.getOrCreateSession(sessionID)
+			acquired := make(chan struct{})
+			go func() {
+				sess.reqMu.Lock()
+				close(acquired)
+				sess.reqMu.Unlock()
+			}()
+			select {
+			case <-acquired:
+			case <-time.After(2 * time.Second):
+				t.Fatal("websocket handshake failure left the execution session locked")
+			}
+			exec.CloseExecutionSession(sessionID)
+		})
+	}
+}
+
 func TestCodexWebsocketsUpstreamDisconnectChanSignalsOnInvalidate(t *testing.T) {
 	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -327,13 +393,15 @@ func TestCodexWebsocketsUpstreamDisconnectChanSignalsOnInvalidate(t *testing.T) 
 	}
 	sess.connMu.Lock()
 	sess.conn = conn
+	sess.connGen = 1
 	sess.authID = "auth-1"
 	sess.wsURL = "ws://example.test/responses"
 	sess.readerConn = conn
+	sess.readerGen = 1
 	sess.connMu.Unlock()
 
 	upstreamErr := errors.New("upstream gone")
-	exec.invalidateUpstreamConn(sess, conn, "test_invalidate", upstreamErr)
+	exec.invalidateUpstreamConn(sess, codexWebsocketConnectionRef{conn: conn, generation: 1}, "test_invalidate", upstreamErr)
 
 	select {
 	case errRead, ok := <-disconnectCh:
@@ -345,6 +413,314 @@ func TestCodexWebsocketsUpstreamDisconnectChanSignalsOnInvalidate(t *testing.T) 
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for disconnect signal")
+	}
+}
+
+func TestCodexWebsocketStaleReaderCannotCloseNewActiveChannel(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	serverReady := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		serverReady <- struct{}{}
+		_, _, _ = conn.ReadMessage()
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	oldConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	select {
+	case <-serverReady:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for websocket server")
+	}
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{})
+	sess := &codexWebsocketSession{sessionID: "stale-reader-generation"}
+	oldConnection := codexWebsocketConnectionRef{conn: oldConn, generation: 1}
+	newConnection := codexWebsocketConnectionRef{conn: &websocket.Conn{}, generation: 2}
+
+	sess.connMu.Lock()
+	sess.conn = oldConnection.conn
+	sess.connGen = oldConnection.generation
+	sess.readerConn = oldConnection.conn
+	sess.readerGen = oldConnection.generation
+	sess.connMu.Unlock()
+
+	readerDone := make(chan struct{})
+	go func() {
+		exec.readUpstreamLoop(sess, oldConnection)
+		close(readerDone)
+	}()
+
+	readCh := make(chan codexWebsocketRead, 4)
+	sess.connMu.Lock()
+	sess.conn = newConnection.conn
+	sess.connGen = newConnection.generation
+	sess.readerConn = newConnection.conn
+	sess.readerGen = newConnection.generation
+	sess.connMu.Unlock()
+	requestSignal, errActive := sess.setActiveConnection(newConnection, readCh)
+	if errActive != nil {
+		t.Fatalf("install new active connection: %v", errActive)
+	}
+	if requestSignal == nil {
+		t.Fatal("install new active connection returned a nil request signal")
+	}
+
+	if errClose := oldConn.Close(); errClose != nil {
+		t.Fatalf("close old websocket: %v", errClose)
+	}
+	select {
+	case <-readerDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stale reader did not exit")
+	}
+
+	if activeCh, _, ok := sess.activeFor(newConnection); !ok || activeCh != readCh {
+		t.Fatal("stale reader cleared the new connection active channel")
+	}
+	select {
+	case event, ok := <-readCh:
+		if !ok {
+			t.Fatal("stale reader closed the new connection active channel")
+		}
+		t.Fatalf("stale reader delivered an event to the new connection: %#v", event)
+	default:
+	}
+
+	sess.clearActiveConnection(newConnection, readCh)
+	sess.connMu.Lock()
+	sess.conn = nil
+	sess.readerConn = nil
+	sess.connMu.Unlock()
+}
+
+func TestCodexWebsocketGenerationRetryRebindUsesCurrentConnection(t *testing.T) {
+	sess := &codexWebsocketSession{sessionID: "retry-generation-rebind"}
+	oldConnection := codexWebsocketConnectionRef{conn: &websocket.Conn{}, generation: 1}
+	newConnection := codexWebsocketConnectionRef{conn: &websocket.Conn{}, generation: 2}
+	readCh := make(chan codexWebsocketRead, 4)
+
+	sess.conn = oldConnection.conn
+	sess.connGen = oldConnection.generation
+	_, errActive := sess.setActiveConnection(oldConnection, readCh)
+	if errActive != nil {
+		t.Fatalf("install initial retry connection: %v", errActive)
+	}
+	sess.connMu.Lock()
+	sess.conn = newConnection.conn
+	sess.connGen = newConnection.generation
+	sess.connMu.Unlock()
+	requestSignal, errActive := sess.setActiveConnection(newConnection, readCh)
+	if errActive != nil {
+		t.Fatalf("rebind retry connection: %v", errActive)
+	}
+
+	if delivered := sess.dispatchRead(oldConnection, codexWebsocketRead{err: errors.New("stale retry error")}, true); delivered {
+		t.Fatal("stale connection delivered an error after retry rebind")
+	}
+	wantPayload := []byte(`{"type":"response.completed"}`)
+	if delivered := sess.dispatchRead(newConnection, codexWebsocketRead{msgType: websocket.TextMessage, payload: wantPayload}, false); !delivered {
+		t.Fatal("current retry connection did not deliver its response")
+	}
+
+	msgType, payload, errRead := readCodexWebsocketMessage(context.Background(), sess, newConnection, readCh, requestSignal)
+	if errRead != nil {
+		t.Fatalf("read current retry response: %v", errRead)
+	}
+	if msgType != websocket.TextMessage || !bytes.Equal(payload, wantPayload) {
+		t.Fatalf("retry response = type %d payload %s, want type %d payload %s", msgType, payload, websocket.TextMessage, wantPayload)
+	}
+	sess.clearActiveConnection(newConnection, readCh)
+}
+
+func TestCodexWebsocketGenerationRetryRebindRejectedAfterSessionClose(t *testing.T) {
+	sess := &codexWebsocketSession{sessionID: "retry-rebind-after-close"}
+	oldConnection := codexWebsocketConnectionRef{conn: &websocket.Conn{}, generation: 11}
+	retryConnection := codexWebsocketConnectionRef{conn: &websocket.Conn{}, generation: 12}
+	readCh := make(chan codexWebsocketRead, 1)
+
+	sess.conn = oldConnection.conn
+	sess.connGen = oldConnection.generation
+	_, errActive := sess.setActiveConnection(oldConnection, readCh)
+	if errActive != nil {
+		t.Fatalf("install initial retry active connection: %v", errActive)
+	}
+
+	// Simulate a successful retry dial followed by session shutdown before the
+	// request can rebind its active channel to the returned generation.
+	sess.connMu.Lock()
+	sess.conn = nil
+	sess.connGen = retryConnection.generation + 1
+	sess.closed = true
+	sess.connMu.Unlock()
+	sess.cancelActiveConnection(errors.New("test session closed"))
+
+	if _, errActive := sess.setActiveConnection(retryConnection, readCh); errActive == nil {
+		t.Fatal("closed session accepted a retry generation rebind")
+	}
+	if _, _, active := sess.activeFor(oldConnection); active {
+		t.Fatal("closed session retained the pre-retry active connection")
+	}
+	if _, _, active := sess.activeFor(retryConnection); active {
+		t.Fatal("closed session installed the retry active connection")
+	}
+}
+
+func TestCodexWebsocketGenerationSessionCloseCancelsActiveRequest(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_, _, _ = conn.ReadMessage()
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+
+	sess := &codexWebsocketSession{
+		sessionID:  "generation-session-close",
+		conn:       conn,
+		connGen:    7,
+		readerConn: conn,
+		readerGen:  7,
+		wsURL:      wsURL,
+		authID:     "auth-session-close",
+	}
+	connection := codexWebsocketConnectionRef{conn: conn, generation: 7}
+	readCh := make(chan codexWebsocketRead, 1)
+	requestSignal, errActive := sess.setActiveConnection(connection, readCh)
+	if errActive != nil {
+		t.Fatalf("install session close active connection: %v", errActive)
+	}
+
+	closeCodexWebsocketSession(sess, "test_close")
+
+	_, _, errRead := readCodexWebsocketMessage(context.Background(), sess, connection, readCh, requestSignal)
+	if errRead == nil || !strings.Contains(errRead.Error(), "test_close") {
+		t.Fatalf("session close read error = %v, want generation-scoped close error", errRead)
+	}
+	if _, _, active := sess.activeFor(connection); active {
+		t.Fatal("session close left the active request installed")
+	}
+	sess.connMu.Lock()
+	currentConn := sess.conn
+	currentGeneration := sess.connGen
+	sess.connMu.Unlock()
+	if currentConn != nil || currentGeneration == connection.generation {
+		t.Fatalf("session close state = conn %p generation %d, want nil and a new generation", currentConn, currentGeneration)
+	}
+	exec := NewCodexWebsocketsExecutor(&config.Config{})
+	connectionKey := newCodexWebsocketConnectionKey("auth-session-close", wsURL, "gpt-5.4", codexModelHeaderProfile{}.digest)
+	if _, _, errEnsure := exec.ensureUpstreamConn(context.Background(), nil, sess, connectionKey, http.Header{}); errEnsure == nil {
+		t.Fatal("closed session accepted a replacement connection")
+	}
+	lateReadCh := make(chan codexWebsocketRead, 1)
+	if _, errActive := sess.setActiveConnection(connection, lateReadCh); errActive == nil {
+		t.Fatal("closed session accepted an active request after connection setup")
+	}
+	if _, _, active := sess.activeFor(connection); active {
+		t.Fatal("closed session retained a late active request")
+	}
+	select {
+	case event, ok := <-readCh:
+		if !ok {
+			t.Fatal("session close closed the request-owned channel after delivering the error")
+		}
+		if event.connection != connection || event.err == nil || !strings.Contains(event.err.Error(), "test_close") {
+			t.Fatalf("queued session close event = %#v, want generation-scoped close error", event)
+		}
+	default:
+	}
+	select {
+	case _, ok := <-readCh:
+		if !ok {
+			t.Fatal("session close closed the request-owned channel")
+		}
+		t.Fatal("session close delivered more than one terminal event")
+	default:
+	}
+}
+
+func TestCodexWebsocketGenerationSessionCloseDoesNotBlockOnFullActiveChannel(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_, _, _ = conn.ReadMessage()
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	connection := codexWebsocketConnectionRef{conn: conn, generation: 17}
+	sess := &codexWebsocketSession{
+		sessionID:  "generation-session-close-full-channel",
+		conn:       conn,
+		connGen:    connection.generation,
+		readerConn: conn,
+		readerGen:  connection.generation,
+		wsURL:      wsURL,
+		authID:     "auth-session-close-full-channel",
+	}
+	readCh := make(chan codexWebsocketRead, 1)
+	readCh <- codexWebsocketRead{connection: connection, msgType: websocket.TextMessage, payload: []byte(`{"type":"response.output_text.delta"}`)}
+	requestSignal, errActive := sess.setActiveConnection(connection, readCh)
+	if errActive != nil {
+		t.Fatalf("install full-channel active connection: %v", errActive)
+	}
+
+	closed := make(chan struct{})
+	go func() {
+		closeCodexWebsocketSession(sess, "full_channel_close")
+		close(closed)
+	}()
+	select {
+	case <-closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("session close blocked while the request-owned channel was full")
+	}
+	select {
+	case <-requestSignal.ctx.Done():
+		if cause := context.Cause(requestSignal.ctx); cause == nil || !strings.Contains(cause.Error(), "full_channel_close") {
+			t.Fatalf("request cancellation cause = %v, want full_channel_close", cause)
+		}
+	default:
+		t.Fatal("session close did not cancel the request signal")
+	}
+	if _, _, active := sess.activeFor(connection); active {
+		t.Fatal("session close left the full-channel request active")
+	}
+	select {
+	case _, ok := <-readCh:
+		if !ok {
+			t.Fatal("session close closed the request-owned channel")
+		}
+	default:
+		t.Fatal("session close unexpectedly drained the request-owned channel")
 	}
 }
 


### PR DESCRIPTION
## Context

PR #140 was merged at `9949bb79` before its two planned concurrency fixes were pushed. This follow-up contains exactly those two reviewed commits on top of the #140 code baseline:

- `7aba08b8 fix(codex): scope model header profiles to provider snapshots`
- `8be91f85 fix(codex): isolate websocket readers by connection generation`

This PR must use **Create a merge commit**. Do not squash or rebase the two auditable downstream patch commits.

## Classification

- GPT-5.6 Sol/Terra/Luna catalog and model metadata: ordinary upstream/shared absorption already merged in #140.
- `codex-gpt56-ultra-level`: downstream patch already merged in #140.
- `codex-model-header-provider-snapshot`: downstream patch in this PR.
- `codex-websocket-reader-generation`: downstream patch in this PR.

No LTS taxonomy, Management API, config schema, Panel response shape, usage schema, release, deployment, or `AGENTS.md` changes are included.

## Model header provider snapshot

- Add an immutable `codexModelHeaderProfile` with normalized override headers and a stable SHA-256 digest.
- Resolve model overrides once and explicitly for provider `codex`, avoiding global last-registered model collisions.
- Reuse the same profile resolver across Codex HTTP, image, and WebSocket paths.
- Apply the captured snapshot to the real WebSocket handshake and place the same digest in the connection key.
- Keep request-scoped headers such as `X-Client-Request-Id` out of the reuse key.
- Redial when auth ID, URL, base model, or the model header profile changes.

## WebSocket generation ownership

- Assign each installed session connection a monotonically increasing generation.
- Bind active request state to `connection + generation + channel + cancel-cause signal`.
- Require connection and generation matches for active installation, cleanup, invalidation, and reader delivery.
- Make stale readers exit silently without delivering errors to, clearing, or closing a newer request channel.
- Rebind the request channel to the retry generation before the retry write.
- Keep request-owned channels under request-owner control; readers and session close never close them.
- Make terminal delivery non-blocking and wake the request through a cancel-cause signal even when its channel is full.
- Reject reconnect and late active installation after session shutdown.
- Release `reqMu` on WebSocket handshake `426` fallback and other HTTP status error returns.

## Regression coverage

- Same model ID registered by two providers in either order still resolves Codex override headers.
- Captured profile A is used by both handshake and key after the registry changes to B; the next B request redials.
- Matching keys reuse the current connection; Luna/model profile changes redial.
- A stale reader cannot deliver to, clear, or close a newer active channel.
- Retry rebind accepts only the current generation and delivers the retry response.
- Session close cancels active requests, prevents reconnect, and does not block on a full request channel.
- Handshake `426` and non-upgrade status failures release the execution-session lock.

## Protected delta review

- Full usage statistics: unchanged.
- Management usage routes and response shapes: unchanged.
- CPA-Panel-LTS compatibility and management asset source: unchanged.
- Auth attribution, config/hot reload, translator, plugin ABI/host, and Redis usage queue: unchanged.
- Runtime review seam: Codex model resolution and WebSocket lifecycle are intentionally changed and covered by regression/race tests.
- Logging continues to use the existing redaction path; no credentials or raw auth files are added.

## Validation

Passed locally:

- `go test -race ./internal/runtime/executor -run 'Codex.*(Profile|Provider|Generation|StaleReader|Retry|Handshake)' -count=100`
- `go test ./internal/registry ./internal/runtime/executor ./sdk/api/handlers/openai -count=1`
- `scripts/check-lts-contract.sh`
- `go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage' -count=1`
- `go build -o test-output ./cmd/server && rm -f test-output`
- `go test ./... -count=1`
- `git diff --check`

The first full-suite run observed one scheduling-order failure in the pre-existing hedged-retry test. The exact test then passed `-count=100` both normally and under `-race`, and the full suite passed on a clean rerun. No unrelated test code was changed.

## Delivery boundary

- No merge, release, tag, deployment, or HF Space update is performed by this PR preparation.
- LTS Taxonomy V2 remains a separate governance PR after this fix PR is merged, so its patch ledger can reference the actual merge baseline.
