### PR TITLE
chore(lts): add taxonomy v2 and downstream patch lifecycle

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,7 @@
 - [ ] Protected upstream full-sync
 - [ ] Staged upstream full-sync
 - [ ] LTS protected-delta patch
+- [ ] LTS feature / downstream patch maintenance
 - [ ] Maintenance docs / CI
 - [ ] Emergency hotfix
 
@@ -22,6 +23,7 @@
 - [ ] `/v0/management/usage/export` still exists
 - [ ] `/v0/management/usage/import` still exists
 - [ ] `docs/lts/core-feature-contracts.yaml` reviewed for touched protected or protected-adjacent features
+- [ ] `docs/lts/downstream-patches.yaml` reviewed for active patch retirement or reapplication
 - [ ] Usage record creation/schema reviewed or tested: API key, auth source, model, token breakdown, latency, success/failure
 - [ ] Management usage response shape reviewed or tested: `usage`, `failed_requests`, `apis`, `models`, `details`
 - [ ] Export/import roundtrip reviewed or tested when usage data shape is touched
@@ -40,6 +42,25 @@ Protected-adjacent upstream changes requiring review even without text conflicts
 - panel asset source / release source
 - registry features listed in `docs/lts/core-feature-contracts.yaml`
 
+## LTS classification review
+
+For a protected full-sync PR, record one conclusion for every non-retired entry in `docs/lts/downstream-patches.yaml`, even when the patch has no textual conflict. For other PR types, record every touched registry or patch item. Use only:
+
+- `preserved`
+- `adapted`
+- `newly-added`
+- `patch-still-required`
+- `upstream-equivalent`
+- `retired`
+
+| Item | Class | Conclusion | Evidence / validation |
+|---|---|---|---|
+|  | retained capability / LTS feature / review seam / downstream patch / validation profile |  |  |
+
+For downstream patches, include the upstream commit or PR checked, the current baseline, and the regression tests used before marking a patch `upstream-equivalent` or `retired`.
+
+- [ ] If this PR creates an implementation/deletion commit named by `introduced_in` or `retired_in`, it will use **Create a merge commit** so that SHA remains reachable; squash/rebase is forbidden. A ledger-only PR referencing a commit already on `main` is exempt.
+
 ## Conflict resolution notes
 
 Describe any downstream resolution made to preserve LTS behavior.
@@ -47,6 +68,7 @@ Describe any downstream resolution made to preserve LTS behavior.
 ## Validation
 
 - [ ] `scripts/check-lts-contract.sh`
+- [ ] `go run ./scripts/ltsregistry --root .`
 - [ ] `go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'`
 - [ ] `go build -o test-output ./cmd/server && rm -f test-output`
 - [ ] `go test ./...`

--- a/.github/workflows/lts-contract.yml
+++ b/.github/workflows/lts-contract.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v5
         with:

--- a/docs/lts/core-feature-contracts.yaml
+++ b/docs/lts/core-feature-contracts.yaml
@@ -1,12 +1,6 @@
-version: 1
+version: 2
 generated_from: docs/lts/sync-runbook.md
 maintenance_model: protected-full-sync-with-contract-registry
-
-status_definitions:
-  protected: LTS identity surface. Must remain present and compatible unless the LTS product direction changes.
-  lts-maintained: Downstream-owned or upstream-deprecated behavior that CPA-Core-LTS still supports.
-  shared: Shared upstream/LTS behavior that can evolve when compatibility is preserved.
-  coexist: Optional or adjacent capability that may coexist with protected LTS behavior but must not replace it.
 
 guard_policy:
   purpose: Keep cheap sentinels around LTS identity surfaces; prove behavior with tests and smoke checks.
@@ -25,21 +19,20 @@ guard_policy:
 
 features:
   - id: full-usage-statistics-core
-    status: protected
-    reason: Built-in request-level usage statistics are the primary CPA-Core-LTS protected delta.
+    kind: retained-capability
+    support: protected
+    owner: cpa-core-lts
+    upstream_relation: removed-upstream
+    reason: Built-in request-level usage statistics are the primary CPA-Core-LTS retained capability.
     core_files:
       - internal/usage/
-      - internal/usage/logger_plugin.go
-      - internal/usage/logger_plugin_test.go
       - internal/runtime/executor/helps/usage_helpers.go
-      - internal/runtime/executor/helps/usage_helpers_test.go
       - internal/api/handlers/management/usage.go
       - internal/api/handlers/management/usage_contract_test.go
       - internal/api/server.go
       - config.example.yaml
     required_markers:
       - usage-statistics-enabled
-      - internal/usage/
       - UsageReporter
       - RequestDetail
       - auth_index
@@ -53,8 +46,11 @@ features:
       - go build -o test-output ./cmd/server && rm -f test-output
 
   - id: management-usage-api
-    status: protected
-    reason: CPA-Panel-LTS and TUI consume these Management API endpoints and response fields.
+    kind: retained-capability
+    support: protected
+    owner: cpa-core-lts
+    upstream_relation: removed-upstream
+    reason: CPA-Panel-LTS and TUI depend on the retained Management usage routes and response fields.
     routes:
       - /v0/management/usage
       - /v0/management/usage/export
@@ -68,10 +64,10 @@ features:
       - internal/tui/client.go
       - internal/tui/usage_tab.go
     required_markers:
-      - mgmt.GET("/usage"
-      - mgmt.GET("/usage/export"
-      - mgmt.POST("/usage/import"
-      - mgmt.GET("/usage-statistics-enabled"
+      - 'mgmt.GET("/usage"'
+      - 'mgmt.GET("/usage/export"'
+      - 'mgmt.POST("/usage/import"'
+      - 'mgmt.GET("/usage-statistics-enabled"'
       - total_requests
       - success_count
       - failure_count
@@ -84,8 +80,11 @@ features:
       - go test ./test -run 'Usage|usage'
 
   - id: panel-release-asset
-    status: protected
-    reason: CPA-Core-LTS must continue serving the CPA-Panel-LTS single-file management panel.
+    kind: retained-capability
+    support: protected
+    owner: cpa-core-lts
+    upstream_relation: divergent
+    reason: CPA-Core-LTS must keep serving the CPA-Panel-LTS single-file management panel and compatible usage views.
     routes:
       - /management.html
     core_files:
@@ -93,9 +92,6 @@ features:
       - internal/managementasset/updater_test.go
       - internal/api/server.go
       - internal/config/config.go
-      - README.md
-      - README_CN.md
-      - README_JA.md
     required_markers:
       - BlueSkyXN/CPA-Panel-LTS
       - management.html
@@ -108,8 +104,11 @@ features:
       - go build -o test-output ./cmd/server && rm -f test-output
 
   - id: auth-identity-attribution
-    status: protected
-    reason: Usage statistics and Panel status views depend on stable API key, auth source, and auth_index attribution.
+    kind: retained-capability
+    support: protected
+    owner: cpa-core-lts
+    upstream_relation: divergent
+    reason: Usage and provider status views require stable API key, auth source, and auth_index attribution.
     core_files:
       - internal/access/
       - internal/api/handlers/management/auth_files.go
@@ -121,7 +120,6 @@ features:
     required_markers:
       - userApiKey
       - auth_index
-      - auth file
       - source
       - api-key
       - APIKey
@@ -129,34 +127,34 @@ features:
       - go test ./internal/api/handlers/management -run 'Auth|auth|Usage|usage'
       - go test ./internal/watcher ./internal/auth/...
 
-  - id: provider-runtime-usage-seams
-    status: shared
-    reason: Upstream provider/runtime changes should be absorbed while preserving usage reporting hooks.
+  - id: config-compatibility-and-hot-reload
+    kind: retained-capability
+    support: protected
+    owner: cpa-core-lts
+    upstream_relation: divergent
+    reason: Existing LTS configuration must keep loading and hot-reloading while the upstream schema evolves.
+    config_keys:
+      - usage-statistics-enabled
+      - remote-management.panel-github-repository
     core_files:
-      - internal/runtime/executor/
-      - internal/runtime/executor/helps/usage_helpers.go
-      - internal/translator/
-      - internal/logging/
-      - internal/api/middleware/
+      - internal/config/
+      - internal/watcher/
+      - internal/api/handlers/management/config_basic.go
+      - config.example.yaml
     required_markers:
-      - UsageReporter
-      - Report
-      - token
-      - latency
-      - failed
-    protected_adjacent_changes:
-      - request lifecycle
-      - streaming final usage
-      - WebSocket fallback
-      - model resolution
-      - token accounting
-      - logging metadata
+      - usage-statistics-enabled
+      - panel-github-repository
+      - UsageStatisticsEnabled
+      - DefaultPanelGitHubRepository
     validation:
-      - go test ./internal/runtime/executor/... ./internal/translator/... ./test -run 'Usage|usage|Translation|translation'
+      - go test ./internal/config ./internal/watcher/... ./internal/api/handlers/management -run 'Config|config|Usage|usage'
 
   - id: codex-abnormal-reasoning-retry
-    status: lts-maintained
-    reason: CPA-Core-LTS can optionally discard and retry suspicious Codex OAuth responses with attempt-level CPA accounting, default quality hedging, longest abnormal pass-through fallback, and separated client-visible usage modes, without changing plugin ABI.
+    kind: lts-feature
+    support: maintained
+    owner: cpa-core-lts
+    upstream_relation: downstream-only
+    reason: CPA-Core-LTS maintains guarded retry and quality hedging for suspicious Codex OAuth reasoning responses.
     config_keys:
       - codex.abnormal-reasoning-retry.enabled
       - codex.abnormal-reasoning-retry.action
@@ -166,12 +164,12 @@ features:
       - codex.abnormal-reasoning-retry.auth-kinds
       - codex.abnormal-reasoning-retry.auth-ids
       - codex.abnormal-reasoning-retry.stream-buffer
-      - codex.abnormal-reasoning-retry.stream-buffer-max-bytes
-      - codex.abnormal-reasoning-retry.max-retries
-      - codex.abnormal-reasoning-retry.exhausted-behavior
       - codex.abnormal-reasoning-retry.delivery-policy
       - codex.abnormal-reasoning-retry.fallback-policy
       - codex.abnormal-reasoning-retry.client-usage-aggregation
+      - codex.abnormal-reasoning-retry.stream-buffer-max-bytes
+      - codex.abnormal-reasoning-retry.max-retries
+      - codex.abnormal-reasoning-retry.exhausted-behavior
       - codex.abnormal-reasoning-retry.hedged-retry.enabled
       - codex.abnormal-reasoning-retry.hedged-retry.mode
       - codex.abnormal-reasoning-retry.hedged-retry.hedge-delay-ms
@@ -179,6 +177,7 @@ features:
     core_files:
       - internal/config/config.go
       - internal/runtime/executor/codex_abnormal_reasoning_retry.go
+      - internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
       - internal/runtime/executor/codex_executor.go
       - internal/runtime/executor/helps/usage_helpers.go
       - internal/usage/logger_plugin.go
@@ -207,8 +206,8 @@ features:
       - max-retries
       - exhausted-behavior
       - reasoning-efforts
-      - ExcludeAuthIDsMetadataKey
       - RetryWithoutPenalty
+      - ExcludeAuthIDsMetadataKey
       - CodexAbnormalReasoningRetryUsageMetadataKey
       - codex_abnormal_reasoning_response
       - codex_abnormal_reasoning_retry_exhausted
@@ -217,13 +216,16 @@ features:
       - gpt-5.5
     validation:
       - go test ./internal/config
-      - go test ./internal/runtime/executor
-      - go test ./sdk/cliproxy/auth
+      - go test ./internal/runtime/executor -run 'Codex.*AbnormalReasoning'
+      - go test ./sdk/cliproxy/auth -run 'HedgedRetry|RetryWithoutPenalty'
       - go test ./internal/watcher/diff
 
   - id: transient-error-cooldown-config
-    status: lts-maintained
-    reason: CPA-Core-LTS exposes transient upstream error cooldown as a stable config key so cloud/HFS deployments and CPA-Panel-LTS can align cooldown behavior with retry windows instead of inheriting an internal 60s default.
+    kind: lts-feature
+    support: maintained
+    owner: cpa-core-lts
+    upstream_relation: downstream-only
+    reason: CPA-Core-LTS exposes transient cooldown as a stable setting that can align provider cooldown with retry windows.
     config_keys:
       - transient-error-cooldown-seconds
     core_files:
@@ -244,27 +246,12 @@ features:
       - go test ./internal/watcher/diff
       - go test ./sdk/cliproxy/auth
 
-  - id: config-compatibility-and-hot-reload
-    status: protected
-    reason: Existing user config must keep reading and hot-reloading while upstream config schema evolves.
-    core_files:
-      - internal/config/
-      - internal/watcher/
-      - internal/api/handlers/management/config_basic.go
-      - config.example.yaml
-    required_markers:
-      - usage-statistics-enabled
-      - panel-github-repository
-      - hot reload
-      - config diff
-      - UsageStatisticsEnabled
-      - DefaultPanelGitHubRepository
-    validation:
-      - go test ./internal/config ./internal/watcher/... ./internal/api/handlers/management -run 'Config|config|Usage|usage'
-
   - id: redis-compatible-usage-queue
-    status: coexist
-    reason: Redis-compatible usage events can support external dashboards without replacing built-in full usage statistics.
+    kind: lts-feature
+    support: maintained
+    owner: cpa-core-lts
+    upstream_relation: downstream-only
+    reason: Redis-compatible usage events are a maintained LTS integration, while built-in full usage remains the protected source of truth.
     routes:
       - /v0/management/usage-queue
     core_files:
@@ -274,15 +261,38 @@ features:
     required_markers:
       - usage-queue
       - redisqueue
-      - usage-statistics-enabled
       - latency_ms
       - auth_index
     validation:
       - go test ./internal/redisqueue ./internal/api -run 'Redis|redis|Usage|usage'
 
+review_seams:
+  - id: provider-runtime-usage-seams
+    support: upstream-shared
+    owner: shared
+    upstream_relation: upstream-equivalent
+    reason: Upstream provider/runtime changes are normally absorbed but require explicit review where they can alter LTS usage attribution or connection ownership.
+    core_files:
+      - internal/runtime/executor/
+      - internal/runtime/executor/helps/usage_helpers.go
+      - internal/translator/
+      - internal/logging/
+      - internal/api/middleware/
+    review_triggers:
+      - request lifecycle
+      - provider runtime
+      - WebSocket connection ownership
+      - model resolution and alias normalization
+      - provider-specific lookup fallback behavior
+      - plan-tier catalog and Codex client metadata consistency
+      - token accounting and final usage aggregation
+      - logging metadata
+    validation:
+      - go test ./internal/runtime/executor/... ./internal/translator/... ./test -run 'Usage|usage|Translation|translation'
+
+validation_profiles:
   - id: hf-space-runtime-smoke
-    status: lts-maintained
-    reason: HF Space smoke is a live deployment check after merge, not a substitute for contract tests.
+    reason: HF Space smoke is live post-merge evidence and is not a product capability or substitute for contract tests.
     reference_space:
       - BlueSkyXN/CPA-HFS-2026-03
     runtime_checks:
@@ -294,5 +304,12 @@ features:
       - CPA_COMMIT
       - CPA_VERSION
       - x-cpa-commit
-      - /management.html
-      - /v0/management/usage
+    validation:
+      - manual post-merge HF Space smoke with exact commit readback
+
+relationships:
+  - id: redis-queue-coexists-with-full-usage
+    type: coexist
+    from: redis-compatible-usage-queue
+    to: full-usage-statistics-core
+    reason: The Redis queue may feed external dashboards but must not replace built-in full usage statistics.

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -1,0 +1,92 @@
+version: 1
+
+patches:
+  - id: codex-image-generation-tool-dedup
+    reason: Codex 0.144+ can send the image_gen namespace, so Core must not inject a duplicate legacy image_generation tool while still preserving the fallback for unrelated namespaces.
+    introduced_in: cb874364950e41e733ab114793af17100f87b06d
+    affected_upstream_range: LTS baseline through 26d45fd46a2d2911adef14772465131066dae465 (v7.2.58); upstream main contains the equivalent change at cfa90f9fbf3f79dabb2eb468d6a098efac8ff06d
+    files:
+      - internal/runtime/executor/codex_executor.go
+      - internal/runtime/executor/codex_executor_imagegen_test.go
+    regression_tests:
+      - TestEnsureImageGenerationTool_ExtensionNamespaceDoesNotInjectLegacyTool
+      - TestEnsureImageGenerationTool_UnrelatedNamespaceStillInjectsLegacyTool
+    upstream_issue_or_pr: router-for-me/CLIProxyAPI#4175
+    state: upstreamed
+    retire_when: The LTS upstream/main baseline contains f9162d391c954446e3519214b51de50d07bf4913 or an equivalent namespace and flattened-function check, and the downstream tests pass after adapting to the upstream implementation.
+
+  - id: plugin-configured-enable-default
+    reason: A configured plugin without an explicit enabled field must inherit the enabled plugin subsystem default instead of being silently disabled during YAML parsing or runtime config synthesis.
+    introduced_in: f3ff2f889026c6a28dc2d14f602c4fef108a0347
+    affected_upstream_range: through cfa90f9fbf3f79dabb2eb468d6a098efac8ff06d (upstream dev checked after v7.2.58)
+    files:
+      - internal/config/config.go
+      - internal/config/plugin_config_test.go
+      - internal/pluginhost/config.go
+      - internal/pluginhost/config_test.go
+    regression_tests:
+      - TestParseConfigBytes_PluginInstanceEmptyRawYAML
+      - TestRuntimeConfigYAMLDefaultsEnabledTrue
+      - TestRuntimeConfigFromConfigDefaultsConfiguredPluginEnabled
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: Upstream preserves the configured plugin enable default through both YAML parsing and runtime host synthesis, and all listed tests pass without the downstream implementation.
+
+  - id: codex-gpt56-ultra-level
+    reason: Upstream v7.2.58 advertises GPT-5.6 catalog entries but does not provide first-class ultra parsing, validation ordering, or Codex client metadata support.
+    introduced_in: 6e12fb1dd6d522ca80a02644d286d765d7a649bd
+    affected_upstream_range: LTS baseline through 26d45fd46a2d2911adef14772465131066dae465 (v7.2.58); upstream main 20e61f281f4b88e150c5cdfa81c3315d9fcfeabe only preserves ultra in Codex client metadata and still lacks the shared thinking level implementation
+    files:
+      - internal/thinking/types.go
+      - internal/thinking/suffix.go
+      - internal/thinking/validate.go
+      - internal/thinking/gpt56_ultra_test.go
+      - sdk/api/handlers/openai/codex_client_models.go
+      - sdk/api/handlers/openai/codex_client_models_test.go
+    regression_tests:
+      - TestParseLevelSuffixUltra
+      - TestGPT56UltraCodexThinking
+      - TestUltraClampsToMaxWhenCrossProviderTargetStopsAtMax
+      - TestCodexClientModelsResponse_GPT56UltraReasoningMetadata
+      - TestCodexClientReasoningDescriptionUltra
+    upstream_issue_or_pr: router-for-me/CLIProxyAPI#4160 (partial client-metadata equivalent only)
+    state: required
+    retire_when: Upstream exposes an equivalent ultra level across suffix parsing, validation/clamping, provider application, and Codex client model metadata, and these regression tests pass after removing the downstream implementation.
+
+  - id: codex-model-header-provider-snapshot
+    reason: Codex model override headers must be resolved from the Codex provider and captured once so the real handshake and connection key cannot disagree or be shadowed by another provider registration.
+    introduced_in: 0877a26d333a3be918f5e48aadf0e4d71709ab2f
+    affected_upstream_range: through 26d45fd46a2d2911adef14772465131066dae465 (v7.2.58)
+    files:
+      - internal/runtime/executor/codex_executor.go
+      - internal/runtime/executor/codex_openai_images.go
+      - internal/runtime/executor/codex_websockets_executor.go
+      - internal/runtime/executor/codex_model_header_profile_test.go
+      - internal/runtime/executor/codex_websockets_executor_test.go
+    regression_tests:
+      - TestResolveCodexModelHeaderProfileUsesCodexProviderRegardlessOfRegistrationOrder
+      - TestCodexModelHeaderProfileIsStableSnapshot
+      - TestCodexModelHeaderProfileDigestNormalizesHeaderKeys
+      - TestCodexWebsocketsEnsureUpstreamConnRedialsForLunaHeaderProfile
+      - TestCodexWebsocketsEnsureUpstreamConnUsesAppliedHeaderProfileSnapshot
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: Upstream resolves model headers by provider-owned immutable snapshot and uses the same snapshot for every Codex transport handshake and connection identity, with all listed regression tests passing after the downstream implementation is removed.
+
+  - id: codex-websocket-reader-generation
+    reason: Reusable Codex WebSocket sessions need generation ownership so a stale reader or shutdown race cannot deliver to, clear, close, or deadlock a newer request.
+    introduced_in: 0877a26d333a3be918f5e48aadf0e4d71709ab2f
+    affected_upstream_range: through 26d45fd46a2d2911adef14772465131066dae465 (v7.2.58)
+    files:
+      - internal/runtime/executor/codex_websockets_executor.go
+      - internal/runtime/executor/codex_websockets_executor_test.go
+    regression_tests:
+      - TestCodexWebsocketHandshakeFailureReleasesExecutionSession
+      - TestCodexWebsocketStaleReaderCannotCloseNewActiveChannel
+      - TestCodexWebsocketGenerationRetryRebindUsesCurrentConnection
+      - TestCodexWebsocketGenerationRetryRebindRejectedAfterSessionClose
+      - TestCodexWebsocketGenerationSessionCloseCancelsActiveRequest
+      - TestCodexWebsocketGenerationSessionCloseDoesNotBlockOnFullActiveChannel
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: Upstream assigns equivalent connection generations, validates reader/request ownership atomically, keeps channels request-owned, and passes every listed concurrency regression after the downstream implementation is removed.

--- a/docs/lts/protected-deltas.yaml
+++ b/docs/lts/protected-deltas.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 maintenance_model:
   type: protected-full-sync
   product_branch: main
@@ -6,13 +8,15 @@ maintenance_model:
   cadence_guidance: frequent_small_syncs_when_requested
   optional_runtime_smoke: manual_huggingface_space
   feature_contract_registry: docs/lts/core-feature-contracts.yaml
+  downstream_patch_ledger: docs/lts/downstream-patches.yaml
 
 upstream_source:
   repo: router-for-me/CLIProxyAPI
   branch: main
 
-protected_deltas:
+retained_capabilities:
   - id: full-usage-statistics
+    registry_feature: full-usage-statistics-core
     must_keep: true
     markers:
       - usage-statistics-enabled
@@ -23,36 +27,104 @@ protected_deltas:
     validation:
       - scripts/check-lts-contract.sh
       - go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'
-      - behavior-contract-tests
     conflict_policy: preserve_or_reapply_lts_usage
-    registry_feature: full-usage-statistics-core
+
+  - id: management-usage-api
+    registry_feature: management-usage-api
+    must_keep: true
+    markers:
+      - /v0/management/usage
+      - /v0/management/usage/export
+      - /v0/management/usage/import
+      - /v0/management/usage-statistics-enabled
+    validation:
+      - management-usage-response-shape-test
+      - export-import-roundtrip-test
+    conflict_policy: preserve_management_usage_contract
 
   - id: cpa-panel-lts-compatibility
+    registry_feature: panel-release-asset
     must_keep: true
     markers:
-      - CPA-Panel-LTS
+      - BlueSkyXN/CPA-Panel-LTS
+      - management.html
       - management usage response shape
-      - usage page compatibility
     validation:
       - panel-response-shape-review
-      - management-usage-response-shape-test
+      - go test ./internal/managementasset
     conflict_policy: preserve_panel_compatibility
-    registry_features:
-      - management-usage-api
-      - panel-release-asset
 
-  - id: local-downstream-customizations
+  - id: auth-identity-attribution
+    registry_feature: auth-identity-attribution
     must_keep: true
     markers:
-      - auth/config/panel/release/source customizations
+      - API key attribution
+      - auth source attribution
+      - auth_index
     validation:
-      - manual_review_required
-    conflict_policy: preserve_or_reapply_local_delta
-    registry_features:
-      - auth-identity-attribution
-      - provider-runtime-usage-seams
-      - config-compatibility-and-hot-reload
-      - redis-compatible-usage-queue
+      - auth-attribution-contract-review
+    conflict_policy: preserve_auth_identity_attribution
+
+  - id: config-and-hot-reload-compatibility
+    registry_feature: config-compatibility-and-hot-reload
+    must_keep: true
+    markers:
+      - usage-statistics-enabled
+      - panel-github-repository
+      - config hot reload
+    validation:
+      - config-compatibility-tests
+      - watcher-diff-tests
+    conflict_policy: preserve_config_compatibility
+
+lts_owned_features:
+  - id: codex-abnormal-reasoning-retry
+    registry_feature: codex-abnormal-reasoning-retry
+    maintenance_policy: long-term-maintained
+    markers:
+      - abnormal-reasoning-retry
+      - hedged-retry
+      - RetryWithoutPenalty
+    validation:
+      - codex-abnormal-reasoning-regression-tests
+      - hedged-retry-race-tests
+    conflict_policy: adapt_lts_feature_to_upstream_runtime
+
+  - id: transient-error-cooldown
+    registry_feature: transient-error-cooldown-config
+    maintenance_policy: long-term-maintained
+    markers:
+      - transient-error-cooldown-seconds
+      - SetTransientErrorCooldownSeconds
+    validation:
+      - transient-cooldown-config-tests
+    conflict_policy: adapt_lts_feature_to_upstream_auth_scheduler
+
+  - id: redis-compatible-usage-queue
+    registry_feature: redis-compatible-usage-queue
+    maintenance_policy: long-term-maintained-optional-integration
+    markers:
+      - /v0/management/usage-queue
+      - internal/redisqueue/
+    validation:
+      - redis-usage-queue-contract-tests
+    conflict_policy: preserve_queue_without_replacing_full_usage
+
+shared_review_seams:
+  - id: provider-runtime-usage-seams
+    registry_seam: provider-runtime-usage-seams
+    review_required: true
+    review_when:
+      - request lifecycle changes
+      - provider runtime or WebSocket ownership changes
+      - model resolution changes
+      - token accounting or final usage changes
+      - logging metadata changes
+    validation:
+      - targeted provider/runtime tests
+      - usage attribution review
+      - go test ./internal/runtime/executor/... ./internal/translator/...
+    conflict_policy: absorb_upstream_and_adapt_lts_hooks
 
 sync_rules:
   default_mode: protected_full_sync
@@ -61,20 +133,12 @@ sync_rules:
   squash_forbidden: true
   rebase_forbidden: true
   contract_registry_required: true
+  downstream_patch_review_required: true
+  patch_provenance_merge_commit_required: true
   forbidden_shortcuts:
     - GitHub Sync fork
     - git pull upstream main on main
     - git checkout upstream/main -- .
 
-runtime_smoke:
-  mode: manual-ai-operated
-  scheduled: false
-  reference_space: BlueSkyXN/CPA-HFS-2026-03
-  requirements:
-    - Build the CPA-Core-LTS branch or exact sync commit being reviewed.
-    - Enable usage-statistics-enabled for the smoke run.
-    - Use the CPA-Panel-LTS management panel release source.
-    - Verify /healthz returns ok.
-    - Verify /management.html is served.
-    - Verify /v0/management/usage and export endpoints exist and require management authentication rather than disappearing.
-    - Do not publish management passwords, API keys, auth files, or Hugging Face secrets in PR text or logs.
+runtime_validation_profiles:
+  - hf-space-runtime-smoke

--- a/docs/lts/sync-runbook.md
+++ b/docs/lts/sync-runbook.md
@@ -18,12 +18,25 @@ CLIProxyAPI upstream/main latest
 
 ## Contract registry
 
-Panel 的实践证明，单靠“这几个文件不能删”的文字规则不够；需要把受保护能力拆成可审查的 registry，再让脚本和 PR checklist 同时引用它。Core 使用 `docs/lts/core-feature-contracts.yaml` 作为 contract registry，定位如下：
+Panel 的实践证明，单靠“这几个文件不能删”的文字规则不够；需要把产品能力、维护功能、临时补丁和审查边界拆开，再让脚本和 PR checklist 同时引用。Core 使用 version 2 contract registry，定位如下：
 
 - `docs/lts/protected-deltas.yaml` 定义 LTS 产品边界和同步策略。
-- `docs/lts/core-feature-contracts.yaml` 定义每个受保护能力的文件、路由、marker、验证命令和 protected-adjacent 改动。
-- `scripts/check-lts-contract.sh` 负责检查 registry 存在、关键 marker 存在、核心源码路径仍然存在。
+- `docs/lts/core-feature-contracts.yaml` 把 `retained-capability`、`lts-feature`、`review_seams`、`validation_profiles` 和能力关系分别登记。
+- `docs/lts/downstream-patches.yaml` 只登记需要随 upstream baseline 复查和退休的下游补丁；普通 upstream model/catalog 吸收不登记为 LTS feature。
+- `go run ./scripts/ltsregistry --root .` 严格解析三份 YAML，检查枚举、引用、路径、marker、补丁测试和退休条件。
+- `scripts/check-lts-contract.sh` 保留少量产品身份 sentinel，并调用结构化 validator。
 - `.github/pull_request_template.md` 负责让评审者显式说明是否按 registry 做了 protected delta review。
+
+分类字段的含义：
+
+- `kind: retained-capability`：LTS 产品身份的一部分，例如完整 usage、Management usage API、Panel 兼容和 auth/config 兼容。
+- `kind: lts-feature`：CPA-Core-LTS 长期维护但不提升为核心身份契约的功能，例如 abnormal reasoning retry、transient cooldown 和 Redis-compatible usage queue。
+- `support`：表达支持强度，使用 `protected / maintained / optional / upstream-shared`，不再用单一 `status` 混合产品重要性和来源关系。
+- `owner`：表达维护归属，使用 `cpa-core-lts / upstream / shared`。
+- `upstream_relation`：表达与 upstream 的关系，使用 `downstream-only / divergent / upstream-equivalent / removed-upstream`。
+- `review_seams`：只表达每次 sync 必须人工审查的边界，不伪装成产品 feature。
+- `validation_profiles`：只表达运行态交付证据，不伪装成长期维护能力。
+- `relationships`：表达 coexist 等能力关系；Redis queue 与 built-in full usage 的关系不再挤进支持级别。
 
 和 Panel 不同，Core 的正确模式仍然是 protected full-sync，不是 selective-port。原因是 Core 的受保护 delta 主要集中在 usage、Management API、panel asset source、auth/config attribution 等明确接口上；普通 provider/runtime/security upstream 变更默认吸收，只在 registry 标出的 protected-adjacent seam 上做保留或适配。
 
@@ -33,6 +46,7 @@ Panel 的实践证明，单靠“这几个文件不能删”的文字规则不�
 - 不为普通函数名、局部变量、临时实现细节增加 marker；这些应该由 tests 或人工 review 覆盖。
 - `scripts/check-lts-contract.sh` 只能证明“保护面没有明显消失”；不能替代 usage schema、response shape、import/export、runtime attribution 的 Go 测试。
 - 每次新增 registry feature，都要写清为什么它是 LTS 产品边界，而不是单次 sync 的临时关注点。
+- 每个 active downstream patch 都必须有 affected upstream range、真实存在的 regression tests 和明确的 `retire_when`。
 
 ## 禁止操作
 
@@ -124,15 +138,39 @@ git merge --no-ff --log <UPSTREAM_STAGE_SHA>
 - `internal/usage/`
 - `/v0/management/usage*`
 
-审查时先对照 `docs/lts/core-feature-contracts.yaml` 的对应 feature：
+审查时先对照 `docs/lts/core-feature-contracts.yaml` 的 retained capability、LTS feature 或 review seam：
 
 - `full-usage-statistics-core`
 - `management-usage-api`
 - `panel-release-asset`
 - `auth-identity-attribution`
-- `provider-runtime-usage-seams`
 - `config-compatibility-and-hot-reload`
 - `redis-compatible-usage-queue`
+- review seam `provider-runtime-usage-seams`
+
+同时逐项检查 `docs/lts/downstream-patches.yaml`。普通 GPT/model catalog 更新属于 upstream/shared absorption；只有 LTS 仍需携带的差异才进入 patch ledger。
+
+## Downstream patch lifecycle
+
+Patch ledger 使用以下状态：
+
+- `required`：当前 upstream baseline 尚无等价实现，本地代码和 regression tests 必须存在。
+- `upstreamed`：upstream 已合并等价实现，但尚未进入当前 LTS sync baseline。
+- `removable`：当前 baseline 已含等价实现；必须先用 ledger 中的 tests 验证，再删除本地实现。
+- `retired`：本地实现已删除；条目保留并记录 `retired_in`，用于历史追溯。
+
+每次 protected full-sync 都执行：
+
+1. 对照 upstream from/to range 搜索 active patch 的等价实现或 upstream PR。
+2. 逐项记录 `patch-still-required / upstream-equivalent / retired`，不能因为无文本冲突而跳过。
+3. 如果等价实现只在 upstream dev 或未进入本轮 baseline，状态改为 `upstreamed`，不能提前删除。
+4. 如果当前 baseline 已包含等价实现，先把状态改为 `removable`，在代码仍存在时运行原 regression tests，并把该状态作为一个独立 PR 或已合并基线。
+5. 后续 retirement PR 先提交删除 downstream 实现的 commit，再提交 ledger commit，把状态从 `removable` 改为 `retired`，并令 `retired_in` 指向前一个删除 commit；最终 PR head 必须重新通过 validator。历史条目不得删除。
+6. 没有等价 upstream 修复时保持 `required`，必要时另行准备 upstream issue/PR，但不把发布 upstream PR 混入 sync 操作。
+
+Validator 会把当前 ledger 与 `--base-ref`（CI 使用 PR base branch）比较，禁止删除历史条目、越级退休、改写 `introduced_in` 或已退休记录。`upstreamed / removable` 可以在 upstream 修复被撤回或等价判断被推翻时保守回退为 `required`，但不能绕过验证直接前进。`upstreamed / removable / retired` 必须提供具体 upstream issue、PR 或 commit。`retired_in` 必须填写实际删除 downstream 实现且可达于当前产品历史的 commit；由于 `required -> retired` 和 `upstreamed -> retired` 都被禁止，补丁发现等价实现、进入 `removable`、最终退休不能压缩成同一个未合并基线。
+
+如果同一 PR 内产生 ledger 引用的实现 commit（`introduced_in`）或删除 commit（`retired_in`），该 downstream patch PR 必须使用 **Create a merge commit**，禁止 squash 或 rebase；否则被引用的 SHA 会被改写并立即失效。若实现 commit 已经在 `main` 上，后续只登记该既有 SHA 的治理 PR 不因此强制使用 merge commit。
 
 ## Conflict policy
 
@@ -153,13 +191,14 @@ sync PR 合入 `main` 前至少运行：
 
 ```bash
 scripts/check-lts-contract.sh
+go run ./scripts/ltsregistry --root .
 go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'
 go build -o test-output ./cmd/server && rm -f test-output
 go test ./...
 git diff --check
 ```
 
-`scripts/check-lts-contract.sh` 必须覆盖 `docs/lts/protected-deltas.yaml` 和 `docs/lts/core-feature-contracts.yaml` 两层文件；如果 guard 只证明单个文件存在，不能视为 contract review 完成。
+`scripts/check-lts-contract.sh` 必须调用结构化 validator，覆盖 registry、protected deltas 和 patch ledger；如果 guard 只证明文件存在或 marker 只存在于 registry 自身，不能视为 contract review 完成。
 
 如果 `go test ./...` 因环境、网络或已知非本次改动原因无法完成，PR body 必须写明实际命令、失败位置和剩余风险。不能把未运行的检查写成通过。
 
@@ -180,6 +219,7 @@ git diff --check
 - 冲突文件列表
 - protected delta review
 - contract registry features reviewed
+- downstream patch ledger conclusions
 - 普通 upstream 改动吸收范围
 - 被覆盖的旧 upstream-port PR 范围，如有
 - validation 命令和结果
@@ -190,23 +230,24 @@ Protected delta review 建议使用固定格式：
 
 ```text
 Protected delta review:
-- usage statistics: preserved / changed / retested
-- management usage API: preserved / changed / retested
-- CPA-Panel-LTS response shape: preserved / changed / retested
-- downstream auth/config/panel/source customizations: preserved / changed / retested
-- contract registry: reviewed features / changed features / skipped features with reason
+- retained capabilities: preserved / adapted / newly-added
+- LTS-owned features: preserved / adapted / newly-added
+- shared review seams: reviewed / adapted / not-touched with reason
+- downstream patches: patch-still-required / upstream-equivalent / retired
+- validation profiles: run / skipped with reason
 - upstream ordinary changes: absorbed
 ```
 
 ## Merge policy
 
-upstream sync PR 合入 `main` 时必须选择 Create a merge commit。
+upstream sync PR，以及在本 PR 内产生 `introduced_in` 或 `retired_in` 所指 commit 的 downstream patch PR，合入 `main` 时必须选择 Create a merge commit。
 
 禁止：
 
 - squash and merge
 - rebase and merge
 - 把 sync PR 拆成文件覆盖 commit
+- squash 或 rebase 在本 PR 内产生 patch provenance commit 的 introduction / retirement PR
 
 原因是 merge commit 会推进 merge-base，让 Git 记住本轮 upstream 历史和冲突解决。否则下一轮 sync 会重新计算已处理过的 upstream commits。
 

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -6,6 +6,7 @@ echo "Checking CPA-Core-LTS protected contract sentinels..."
 test -d internal/usage
 test -f docs/lts/protected-deltas.yaml
 test -f docs/lts/core-feature-contracts.yaml
+test -f docs/lts/downstream-patches.yaml
 
 require_path() {
   local path="$1"
@@ -89,121 +90,17 @@ require_grep "BlueSkyXN/CPA-Panel-LTS" internal/managementasset/updater.go inter
 require_grep "UsageReporter" internal/runtime/executor/helps/usage_helpers.go
 require_grep "auth_index" internal/usage internal/api/handlers/management internal/runtime/executor/helps internal/redisqueue
 require_grep "latency_ms" internal/usage internal/redisqueue internal/tui
-require_grep "abnormal-reasoning-retry" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
-require_grep "observe-only" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
-require_grep "delivery-policy" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
-require_grep "fallback-policy" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
-require_grep "best-non-special" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
-require_grep "first-non-special" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
-require_grep "max-output-special" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
-require_grep "hedged-retry" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
-require_grep "stream-buffer-max-bytes" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
-require_grep "max-retries" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
-require_grep "exhausted-behavior" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
-require_grep "client-usage-aggregation" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
-require_grep "delivered-only" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
-require_grep "sum-with-delivered-total" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
-require_grep "quality" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
-require_grep "reasoning-efforts" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
-require_grep "RetryWithoutPenalty" sdk/cliproxy/auth/conductor.go sdk/cliproxy/auth/retry_without_penalty.go docs/lts/core-feature-contracts.yaml
-require_grep "ExcludeAuthIDsMetadataKey" sdk/cliproxy/executor/types.go docs/lts/core-feature-contracts.yaml
-require_grep "CodexAbnormalReasoningRetryUsageMetadataKey" sdk/cliproxy/executor/types.go docs/lts/core-feature-contracts.yaml
-require_grep "codex_abnormal_reasoning_response" internal/runtime/executor/codex_abnormal_reasoning_retry.go docs/lts/core-feature-contracts.yaml
-require_grep "codex_abnormal_reasoning_retry_exhausted" sdk/cliproxy/auth/retry_without_penalty.go docs/lts/core-feature-contracts.yaml
-require_grep "failure_reason" internal/usage/logger_plugin.go docs/lts/core-feature-contracts.yaml
-require_grep "transient-error-cooldown-seconds" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml
-require_grep "TransientErrorCooldownSeconds" internal/config/config.go internal/api/server.go sdk/cliproxy/service.go docs/lts/core-feature-contracts.yaml
-require_grep "SetTransientErrorCooldownSeconds" cmd/server/main.go internal/api/server.go sdk/cliproxy/auth/conductor.go sdk/cliproxy/service.go docs/lts/core-feature-contracts.yaml
-require_grep "nextTransientErrorRetryAfter" sdk/cliproxy/auth/conductor.go docs/lts/core-feature-contracts.yaml
 
-python3 - <<'PY'
-from pathlib import Path
-import sys
+go test ./scripts/ltsregistry -count=1
 
-path = Path("docs/lts/protected-deltas.yaml")
-text = path.read_text(encoding="utf-8")
-
-required = [
-    "protected-full-sync",
-    "full-usage-statistics",
-    "usage-statistics-enabled",
-    "internal/usage/",
-    "/v0/management/usage",
-    "/v0/management/usage/export",
-    "/v0/management/usage/import",
-    "cpa-panel-lts-compatibility",
-    "local-downstream-customizations",
-    "preserve_or_reapply_lts_usage",
-    "core-feature-contracts.yaml",
-    "contract_registry_required",
-]
-
-missing = [item for item in required if item not in text]
-if missing:
-    for item in missing:
-        print(f"missing protected contract marker: {item}", file=sys.stderr)
-    sys.exit(1)
-
-registry_path = Path("docs/lts/core-feature-contracts.yaml")
-registry_text = registry_path.read_text(encoding="utf-8")
-
-registry_required = [
-    "maintenance_model: protected-full-sync-with-contract-registry",
-    "guard_policy",
-    "sentinel gate",
-    "not a replacement for contract tests",
-    "full-usage-statistics-core",
-    "management-usage-api",
-    "panel-release-asset",
-    "auth-identity-attribution",
-    "provider-runtime-usage-seams",
-    "codex-abnormal-reasoning-retry",
-    "config-compatibility-and-hot-reload",
-    "redis-compatible-usage-queue",
-    "hf-space-runtime-smoke",
-    "usage-statistics-enabled",
-    "/v0/management/usage",
-    "/v0/management/usage/export",
-    "/v0/management/usage/import",
-    "/v0/management/usage-statistics-enabled",
-    "BlueSkyXN/CPA-Panel-LTS",
-    "management.html",
-    "auth_index",
-    "latency_ms",
-    "success_count",
-    "failure_count",
-    "go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'",
-    "abnormal-reasoning-retry",
-    "hedged-retry",
-    "stream-buffer-max-bytes",
-    "hedge-delay-ms",
-    "require-distinct-auth",
-    "max-retries",
-    "exhausted-behavior",
-    "client-usage-aggregation",
-    "delivered-only",
-    "sum-with-delivered-total",
-    "quality",
-    "longest abnormal pass-through fallback",
-    "reasoning-efforts",
-    "ExcludeAuthIDsMetadataKey",
-    "RetryWithoutPenalty",
-    "CodexAbnormalReasoningRetryUsageMetadataKey",
-    "codex_abnormal_reasoning_response",
-    "codex_abnormal_reasoning_retry_exhausted",
-    "failure_reason",
-    "transient-error-cooldown-config",
-    "transient-error-cooldown-seconds",
-    "TransientErrorCooldownSeconds",
-    "SetTransientErrorCooldownSeconds",
-    "nextTransientErrorRetryAfter",
-]
-
-missing_registry = [item for item in registry_required if item not in registry_text]
-if missing_registry:
-    for item in missing_registry:
-        print(f"missing core feature contract marker: {item}", file=sys.stderr)
-    sys.exit(1)
-PY
+validator_args=(--root .)
+if [ -n "${GITHUB_BASE_REF:-}" ]; then
+  base_remote_ref="refs/remotes/origin/${GITHUB_BASE_REF}"
+  if ! git rev-parse --verify --quiet "${base_remote_ref}^{commit}" >/dev/null; then
+    git fetch --no-tags --depth=1 origin "${GITHUB_BASE_REF}:$base_remote_ref"
+  fi
+  validator_args+=(--base-ref "$base_remote_ref")
+fi
+go run ./scripts/ltsregistry "${validator_args[@]}"
 
 echo "CPA-Core-LTS protected contract sentinels passed."

--- a/scripts/ltsregistry/main.go
+++ b/scripts/ltsregistry/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("ltsregistry", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	root := flags.String("root", ".", "repository root containing docs/lts registries")
+	baseRef := flags.String("base-ref", "", "optional git ref used to enforce append-only patch history")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if flags.NArg() != 0 {
+		fmt.Fprintf(stderr, "ltsregistry: unexpected arguments: %v\n", flags.Args())
+		return 2
+	}
+
+	if strings.TrimSpace(*baseRef) == "" {
+		*baseRef = discoverBaseRef(*root)
+	}
+	if err := validateRootAgainst(*root, *baseRef); err != nil {
+		fmt.Fprintf(stderr, "ltsregistry: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintln(stdout, "CPA-Core-LTS registry validation passed.")
+	return 0
+}
+
+func discoverBaseRef(root string) string {
+	if ref := strings.TrimSpace(os.Getenv("LTS_REGISTRY_BASE_REF")); ref != "" {
+		return ref
+	}
+	if err := exec.Command("git", "-C", root, "rev-parse", "--verify", "origin/main^{commit}").Run(); err != nil {
+		return ""
+	}
+	out, err := exec.Command("git", "-C", root, "merge-base", "HEAD", "origin/main").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/scripts/ltsregistry/types.go
+++ b/scripts/ltsregistry/types.go
@@ -1,0 +1,145 @@
+package main
+
+type featureRegistry struct {
+	Version            int                 `yaml:"version"`
+	GeneratedFrom      string              `yaml:"generated_from"`
+	MaintenanceModel   string              `yaml:"maintenance_model"`
+	GuardPolicy        guardPolicy         `yaml:"guard_policy"`
+	Features           []feature           `yaml:"features"`
+	ReviewSeams        []reviewSeam        `yaml:"review_seams"`
+	ValidationProfiles []validationProfile `yaml:"validation_profiles"`
+	Relationships      []relationship      `yaml:"relationships"`
+}
+
+type guardPolicy struct {
+	Purpose         string   `yaml:"purpose"`
+	AddMarkerWhen   []string `yaml:"add_marker_when"`
+	AvoidMarkerWhen []string `yaml:"avoid_marker_when"`
+	BehaviorProof   []string `yaml:"behavior_proof"`
+}
+
+type feature struct {
+	ID               string   `yaml:"id"`
+	Kind             string   `yaml:"kind"`
+	Support          string   `yaml:"support"`
+	Owner            string   `yaml:"owner"`
+	UpstreamRelation string   `yaml:"upstream_relation"`
+	Reason           string   `yaml:"reason"`
+	Routes           []string `yaml:"routes"`
+	ConfigKeys       []string `yaml:"config_keys"`
+	CoreFiles        []string `yaml:"core_files"`
+	RequiredMarkers  []string `yaml:"required_markers"`
+	Validation       []string `yaml:"validation"`
+}
+
+type reviewSeam struct {
+	ID               string   `yaml:"id"`
+	Support          string   `yaml:"support"`
+	Owner            string   `yaml:"owner"`
+	UpstreamRelation string   `yaml:"upstream_relation"`
+	Reason           string   `yaml:"reason"`
+	CoreFiles        []string `yaml:"core_files"`
+	ReviewTriggers   []string `yaml:"review_triggers"`
+	Validation       []string `yaml:"validation"`
+}
+
+type validationProfile struct {
+	ID              string   `yaml:"id"`
+	Reason          string   `yaml:"reason"`
+	ReferenceSpace  []string `yaml:"reference_space"`
+	RuntimeChecks   []string `yaml:"runtime_checks"`
+	RequiredMarkers []string `yaml:"required_markers"`
+	Validation      []string `yaml:"validation"`
+}
+
+type relationship struct {
+	ID     string `yaml:"id"`
+	Type   string `yaml:"type"`
+	From   string `yaml:"from"`
+	To     string `yaml:"to"`
+	Reason string `yaml:"reason"`
+}
+
+type protectedDeltas struct {
+	Version                   int                  `yaml:"version"`
+	MaintenanceModel          maintenanceModel     `yaml:"maintenance_model"`
+	UpstreamSource            upstreamSource       `yaml:"upstream_source"`
+	RetainedCapabilities      []retainedCapability `yaml:"retained_capabilities"`
+	LTSOwnedFeatures          []ltsOwnedFeature    `yaml:"lts_owned_features"`
+	SharedReviewSeams         []sharedReviewSeam   `yaml:"shared_review_seams"`
+	SyncRules                 syncRules            `yaml:"sync_rules"`
+	RuntimeValidationProfiles []string             `yaml:"runtime_validation_profiles"`
+}
+
+type maintenanceModel struct {
+	Type                    string `yaml:"type"`
+	ProductBranch           string `yaml:"product_branch"`
+	OperationMode           string `yaml:"operation_mode"`
+	ScheduledSync           bool   `yaml:"scheduled_sync"`
+	CadenceGuidance         string `yaml:"cadence_guidance"`
+	OptionalRuntimeSmoke    string `yaml:"optional_runtime_smoke"`
+	FeatureContractRegistry string `yaml:"feature_contract_registry"`
+	DownstreamPatchLedger   string `yaml:"downstream_patch_ledger"`
+}
+
+type upstreamSource struct {
+	Repo   string `yaml:"repo"`
+	Branch string `yaml:"branch"`
+}
+
+type retainedCapability struct {
+	ID              string   `yaml:"id"`
+	RegistryFeature string   `yaml:"registry_feature"`
+	MustKeep        bool     `yaml:"must_keep"`
+	Markers         []string `yaml:"markers"`
+	Validation      []string `yaml:"validation"`
+	ConflictPolicy  string   `yaml:"conflict_policy"`
+}
+
+type ltsOwnedFeature struct {
+	ID                string   `yaml:"id"`
+	RegistryFeature   string   `yaml:"registry_feature"`
+	MaintenancePolicy string   `yaml:"maintenance_policy"`
+	Markers           []string `yaml:"markers"`
+	Validation        []string `yaml:"validation"`
+	ConflictPolicy    string   `yaml:"conflict_policy"`
+}
+
+type sharedReviewSeam struct {
+	ID             string   `yaml:"id"`
+	RegistrySeam   string   `yaml:"registry_seam"`
+	ReviewRequired bool     `yaml:"review_required"`
+	ReviewWhen     []string `yaml:"review_when"`
+	Validation     []string `yaml:"validation"`
+	ConflictPolicy string   `yaml:"conflict_policy"`
+}
+
+type syncRules struct {
+	DefaultMode                   string   `yaml:"default_mode"`
+	UpstreamChanges               string   `yaml:"upstream_changes"`
+	MergeCommitRequired           bool     `yaml:"merge_commit_required"`
+	SquashForbidden               bool     `yaml:"squash_forbidden"`
+	RebaseForbidden               bool     `yaml:"rebase_forbidden"`
+	ContractRegistryRequired      bool     `yaml:"contract_registry_required"`
+	DownstreamPatchReviewRequired bool     `yaml:"downstream_patch_review_required"`
+	PatchProvenanceMergeRequired  bool     `yaml:"patch_provenance_merge_commit_required"`
+	ForbiddenShortcuts            []string `yaml:"forbidden_shortcuts"`
+}
+
+type downstreamPatches struct {
+	Version int               `yaml:"version"`
+	Patches []downstreamPatch `yaml:"patches"`
+}
+
+type downstreamPatch struct {
+	ID                    string   `yaml:"id"`
+	Reason                string   `yaml:"reason"`
+	IntroducedIn          string   `yaml:"introduced_in"`
+	AffectedUpstreamRange string   `yaml:"affected_upstream_range"`
+	Files                 []string `yaml:"files"`
+	RegressionTests       []string `yaml:"regression_tests"`
+	UpstreamIssueOrPR     string   `yaml:"upstream_issue_or_pr"`
+	State                 string   `yaml:"state"`
+	RetireWhen            string   `yaml:"retire_when"`
+	RetiredIn             string   `yaml:"retired_in,omitempty"`
+}

--- a/scripts/ltsregistry/validate.go
+++ b/scripts/ltsregistry/validate.go
@@ -1,0 +1,1068 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	featureRegistryPath   = "docs/lts/core-feature-contracts.yaml"
+	protectedDeltasPath   = "docs/lts/protected-deltas.yaml"
+	downstreamPatchesPath = "docs/lts/downstream-patches.yaml"
+)
+
+var (
+	featureKinds          = stringSet("retained-capability", "lts-feature")
+	featureSupports       = stringSet("protected", "maintained", "optional", "upstream-shared")
+	featureOwners         = stringSet("cpa-core-lts", "upstream", "shared")
+	upstreamRelations     = stringSet("downstream-only", "divergent", "upstream-equivalent", "removed-upstream")
+	patchStates           = stringSet("required", "upstreamed", "removable", "retired")
+	registryEvidenceFiles = stringSet(featureRegistryPath, protectedDeltasPath, downstreamPatchesPath)
+	commitSHA             = regexp.MustCompile(`^[0-9a-fA-F]{7,40}$`)
+)
+
+type registryIndex struct {
+	features           map[string]feature
+	reviewSeams        map[string]reviewSeam
+	validationProfiles map[string]validationProfile
+}
+
+type validationErrors []string
+
+func (errs validationErrors) Error() string {
+	items := append([]string(nil), errs...)
+	sort.Strings(items)
+	return "validation failed:\n  - " + strings.Join(items, "\n  - ")
+}
+
+type validator struct {
+	root               string
+	problems           validationErrors
+	configLoaded       bool
+	configExample      map[string]any
+	configErr          error
+	configSchemaLoaded bool
+	configSchema       map[string]map[string]string
+	configSchemaErr    error
+}
+
+func validateRoot(root string) error {
+	return validateRootAgainst(root, "")
+}
+
+func validateRootAgainst(root, baseRef string) error {
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return fmt.Errorf("resolve root: %w", err)
+	}
+	info, err := os.Stat(rootAbs)
+	if err != nil {
+		return fmt.Errorf("stat root: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("root %q is not a directory", rootAbs)
+	}
+
+	var registry featureRegistry
+	if err := decodeStrict(filepath.Join(rootAbs, filepath.FromSlash(featureRegistryPath)), &registry); err != nil {
+		return fmt.Errorf("%s: %w", featureRegistryPath, err)
+	}
+	var deltas protectedDeltas
+	if err := decodeStrict(filepath.Join(rootAbs, filepath.FromSlash(protectedDeltasPath)), &deltas); err != nil {
+		return fmt.Errorf("%s: %w", protectedDeltasPath, err)
+	}
+	var patches downstreamPatches
+	if err := decodeStrict(filepath.Join(rootAbs, filepath.FromSlash(downstreamPatchesPath)), &patches); err != nil {
+		return fmt.Errorf("%s: %w", downstreamPatchesPath, err)
+	}
+
+	v := &validator{root: rootAbs}
+	index := v.validateFeatureRegistry(registry)
+	v.validateProtectedDeltas(deltas, index)
+	v.validateDownstreamPatches(patches)
+	if strings.TrimSpace(baseRef) != "" {
+		v.validatePatchHistory(patches, baseRef)
+	}
+	if len(v.problems) > 0 {
+		return v.problems
+	}
+	v.validateActivePatchTestsWithGo(patches)
+	if len(v.problems) > 0 {
+		return v.problems
+	}
+	return nil
+}
+
+func decodeStrict(path string, out any) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	decoder := yaml.NewDecoder(f)
+	decoder.KnownFields(true)
+	if err := decoder.Decode(out); err != nil {
+		return err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("multiple YAML documents are not supported")
+		}
+		return err
+	}
+	return nil
+}
+
+func (v *validator) validateFeatureRegistry(registry featureRegistry) registryIndex {
+	index := registryIndex{
+		features:           make(map[string]feature),
+		reviewSeams:        make(map[string]reviewSeam),
+		validationProfiles: make(map[string]validationProfile),
+	}
+	if registry.Version != 2 {
+		v.addf("%s: version must be 2, got %d", featureRegistryPath, registry.Version)
+	}
+	v.requireString(featureRegistryPath+".generated_from", registry.GeneratedFrom)
+	if strings.TrimSpace(registry.GeneratedFrom) != "" {
+		v.validatePath(featureRegistryPath+".generated_from", registry.GeneratedFrom, false)
+	}
+	v.requireString(featureRegistryPath+".maintenance_model", registry.MaintenanceModel)
+	v.requireString(featureRegistryPath+".guard_policy.purpose", registry.GuardPolicy.Purpose)
+	v.requireStrings(featureRegistryPath+".guard_policy.add_marker_when", registry.GuardPolicy.AddMarkerWhen, true)
+	v.requireStrings(featureRegistryPath+".guard_policy.avoid_marker_when", registry.GuardPolicy.AvoidMarkerWhen, true)
+	v.requireStrings(featureRegistryPath+".guard_policy.behavior_proof", registry.GuardPolicy.BehaviorProof, true)
+
+	allIDs := make(map[string]string)
+	for i, item := range registry.Features {
+		label := fmt.Sprintf("%s.features[%d]", featureRegistryPath, i)
+		id := v.registerID(allIDs, label, item.ID)
+		v.requireEnum(label+".kind", item.Kind, featureKinds)
+		v.requireEnum(label+".support", item.Support, featureSupports)
+		v.requireEnum(label+".owner", item.Owner, featureOwners)
+		v.requireEnum(label+".upstream_relation", item.UpstreamRelation, upstreamRelations)
+		v.validateFeatureClassification(label, item)
+		v.requireString(label+".reason", item.Reason)
+		v.requireStrings(label+".core_files", item.CoreFiles, true)
+		v.requireStrings(label+".validation", item.Validation, true)
+		v.requireStrings(label+".routes", item.Routes, false)
+		v.requireStrings(label+".config_keys", item.ConfigKeys, false)
+		v.requireStrings(label+".required_markers", item.RequiredMarkers, false)
+		for j, path := range item.CoreFiles {
+			v.validatePath(fmt.Sprintf("%s.core_files[%d]", label, j), path, true)
+		}
+		for j, marker := range item.RequiredMarkers {
+			if strings.TrimSpace(marker) == "" {
+				continue
+			}
+			if !v.markerInPaths(marker, item.CoreFiles) {
+				v.addf("%s.required_markers[%d]: marker %q has no evidence in core_files outside registry YAML", label, j, marker)
+			}
+		}
+		for j, route := range item.Routes {
+			evidence := routeEvidenceToken(route)
+			if evidence != "" && !v.markerInPaths(evidence, item.CoreFiles) {
+				v.addf("%s.routes[%d]: route %q has no evidence token %q in core_files", label, j, route, evidence)
+			}
+		}
+		for j, key := range item.ConfigKeys {
+			exists, err := v.configPathExists(key)
+			if err != nil {
+				v.addf("%s.config_keys[%d]: validate config.example.yaml: %v", label, j, err)
+			} else if !exists {
+				v.addf("%s.config_keys[%d]: config key %q does not exist in config.example.yaml or the internal/config Go schema", label, j, key)
+			}
+		}
+		if id != "" {
+			index.features[id] = item
+		}
+	}
+
+	for i, item := range registry.ReviewSeams {
+		label := fmt.Sprintf("%s.review_seams[%d]", featureRegistryPath, i)
+		id := v.registerID(allIDs, label, item.ID)
+		if item.Support != "upstream-shared" {
+			v.addf("%s.support: must be %q, got %q", label, "upstream-shared", item.Support)
+		}
+		if item.Owner != "shared" {
+			v.addf("%s.owner: must be %q, got %q", label, "shared", item.Owner)
+		}
+		if item.UpstreamRelation != "upstream-equivalent" {
+			v.addf("%s.upstream_relation: must be %q, got %q", label, "upstream-equivalent", item.UpstreamRelation)
+		}
+		v.requireString(label+".reason", item.Reason)
+		v.requireStrings(label+".core_files", item.CoreFiles, true)
+		v.requireStrings(label+".review_triggers", item.ReviewTriggers, true)
+		v.requireStrings(label+".validation", item.Validation, true)
+		for j, path := range item.CoreFiles {
+			v.validatePath(fmt.Sprintf("%s.core_files[%d]", label, j), path, true)
+		}
+		if id != "" {
+			index.reviewSeams[id] = item
+		}
+	}
+
+	for i, item := range registry.ValidationProfiles {
+		label := fmt.Sprintf("%s.validation_profiles[%d]", featureRegistryPath, i)
+		id := v.registerID(allIDs, label, item.ID)
+		v.requireString(label+".reason", item.Reason)
+		v.requireStrings(label+".reference_space", item.ReferenceSpace, false)
+		v.requireStrings(label+".runtime_checks", item.RuntimeChecks, false)
+		v.requireStrings(label+".required_markers", item.RequiredMarkers, false)
+		v.requireStrings(label+".validation", item.Validation, true)
+		for j, marker := range item.RequiredMarkers {
+			if strings.TrimSpace(marker) == "" {
+				continue
+			}
+			if !v.markerInRepository(marker) {
+				v.addf("%s.required_markers[%d]: marker %q has no repository evidence outside registry YAML", label, j, marker)
+			}
+		}
+		if id != "" {
+			index.validationProfiles[id] = item
+		}
+	}
+
+	for i, item := range registry.Relationships {
+		label := fmt.Sprintf("%s.relationships[%d]", featureRegistryPath, i)
+		v.registerID(allIDs, label, item.ID)
+		if item.Type != "coexist" {
+			v.addf("%s.type: must be %q, got %q", label, "coexist", item.Type)
+		}
+		v.requireString(label+".reason", item.Reason)
+		from := strings.TrimSpace(item.From)
+		to := strings.TrimSpace(item.To)
+		if _, ok := index.features[from]; !ok {
+			v.addf("%s.from: unknown feature %q", label, item.From)
+		}
+		if _, ok := index.features[to]; !ok {
+			v.addf("%s.to: unknown feature %q", label, item.To)
+		}
+		if from != "" && from == to {
+			v.addf("%s: relationship endpoints must be different", label)
+		}
+	}
+
+	return index
+}
+
+func (v *validator) validateProtectedDeltas(deltas protectedDeltas, index registryIndex) {
+	if deltas.Version != 2 {
+		v.addf("%s: version must be 2, got %d", protectedDeltasPath, deltas.Version)
+	}
+	v.requireLiteral(protectedDeltasPath+".maintenance_model.type", deltas.MaintenanceModel.Type, "protected-full-sync")
+	v.requireLiteral(protectedDeltasPath+".maintenance_model.product_branch", deltas.MaintenanceModel.ProductBranch, "main")
+	v.requireLiteral(protectedDeltasPath+".maintenance_model.operation_mode", deltas.MaintenanceModel.OperationMode, "manual-ai-assisted")
+	if deltas.MaintenanceModel.ScheduledSync {
+		v.addf("%s.maintenance_model.scheduled_sync: must be false", protectedDeltasPath)
+	}
+	v.requireString(protectedDeltasPath+".maintenance_model.cadence_guidance", deltas.MaintenanceModel.CadenceGuidance)
+	v.requireLiteral(protectedDeltasPath+".maintenance_model.optional_runtime_smoke", deltas.MaintenanceModel.OptionalRuntimeSmoke, "manual_huggingface_space")
+	v.requireString(protectedDeltasPath+".maintenance_model.feature_contract_registry", deltas.MaintenanceModel.FeatureContractRegistry)
+	if strings.TrimSpace(deltas.MaintenanceModel.FeatureContractRegistry) != "" {
+		v.validatePath(protectedDeltasPath+".maintenance_model.feature_contract_registry", deltas.MaintenanceModel.FeatureContractRegistry, false)
+		if filepath.ToSlash(filepath.Clean(deltas.MaintenanceModel.FeatureContractRegistry)) != featureRegistryPath {
+			v.addf("%s.maintenance_model.feature_contract_registry: must reference %q, got %q", protectedDeltasPath, featureRegistryPath, deltas.MaintenanceModel.FeatureContractRegistry)
+		}
+	}
+	v.requireString(protectedDeltasPath+".maintenance_model.downstream_patch_ledger", deltas.MaintenanceModel.DownstreamPatchLedger)
+	if strings.TrimSpace(deltas.MaintenanceModel.DownstreamPatchLedger) != "" {
+		v.validatePath(protectedDeltasPath+".maintenance_model.downstream_patch_ledger", deltas.MaintenanceModel.DownstreamPatchLedger, false)
+		if filepath.ToSlash(filepath.Clean(deltas.MaintenanceModel.DownstreamPatchLedger)) != downstreamPatchesPath {
+			v.addf("%s.maintenance_model.downstream_patch_ledger: must reference %q, got %q", protectedDeltasPath, downstreamPatchesPath, deltas.MaintenanceModel.DownstreamPatchLedger)
+		}
+	}
+	v.requireLiteral(protectedDeltasPath+".upstream_source.repo", deltas.UpstreamSource.Repo, "router-for-me/CLIProxyAPI")
+	v.requireLiteral(protectedDeltasPath+".upstream_source.branch", deltas.UpstreamSource.Branch, "main")
+	v.requireLiteral(protectedDeltasPath+".sync_rules.default_mode", deltas.SyncRules.DefaultMode, "protected_full_sync")
+	v.requireLiteral(protectedDeltasPath+".sync_rules.upstream_changes", deltas.SyncRules.UpstreamChanges, "accept_by_default")
+	if !deltas.SyncRules.MergeCommitRequired {
+		v.addf("%s.sync_rules.merge_commit_required: must be true", protectedDeltasPath)
+	}
+	if !deltas.SyncRules.SquashForbidden {
+		v.addf("%s.sync_rules.squash_forbidden: must be true", protectedDeltasPath)
+	}
+	if !deltas.SyncRules.RebaseForbidden {
+		v.addf("%s.sync_rules.rebase_forbidden: must be true", protectedDeltasPath)
+	}
+	if !deltas.SyncRules.ContractRegistryRequired {
+		v.addf("%s.sync_rules.contract_registry_required: must be true", protectedDeltasPath)
+	}
+	if !deltas.SyncRules.DownstreamPatchReviewRequired {
+		v.addf("%s.sync_rules.downstream_patch_review_required: must be true", protectedDeltasPath)
+	}
+	if !deltas.SyncRules.PatchProvenanceMergeRequired {
+		v.addf("%s.sync_rules.patch_provenance_merge_commit_required: must be true", protectedDeltasPath)
+	}
+	v.requireStrings(protectedDeltasPath+".sync_rules.forbidden_shortcuts", deltas.SyncRules.ForbiddenShortcuts, true)
+	for _, required := range []string{"GitHub Sync fork", "git pull upstream main on main", "git checkout upstream/main -- ."} {
+		if !containsString(deltas.SyncRules.ForbiddenShortcuts, required) {
+			v.addf("%s.sync_rules.forbidden_shortcuts: missing required value %q", protectedDeltasPath, required)
+		}
+	}
+
+	allIDs := make(map[string]string)
+	featureRefs := make(map[string]string)
+	for i, item := range deltas.RetainedCapabilities {
+		label := fmt.Sprintf("%s.retained_capabilities[%d]", protectedDeltasPath, i)
+		v.registerID(allIDs, label, item.ID)
+		v.requireString(label+".registry_feature", item.RegistryFeature)
+		featureItem, ok := index.features[strings.TrimSpace(item.RegistryFeature)]
+		if !ok {
+			v.addf("%s.registry_feature: unknown feature %q", label, item.RegistryFeature)
+		} else if featureItem.Kind != "retained-capability" {
+			v.addf("%s.registry_feature: feature %q has kind %q, want retained-capability", label, item.RegistryFeature, featureItem.Kind)
+		}
+		v.registerReference(featureRefs, label+".registry_feature", item.RegistryFeature)
+		if !item.MustKeep {
+			v.addf("%s.must_keep: retained capability must be true", label)
+		}
+		v.requireStrings(label+".markers", item.Markers, true)
+		v.requireStrings(label+".validation", item.Validation, true)
+		v.requireString(label+".conflict_policy", item.ConflictPolicy)
+	}
+
+	for i, item := range deltas.LTSOwnedFeatures {
+		label := fmt.Sprintf("%s.lts_owned_features[%d]", protectedDeltasPath, i)
+		v.registerID(allIDs, label, item.ID)
+		v.requireString(label+".registry_feature", item.RegistryFeature)
+		featureItem, ok := index.features[strings.TrimSpace(item.RegistryFeature)]
+		if !ok {
+			v.addf("%s.registry_feature: unknown feature %q", label, item.RegistryFeature)
+		} else if featureItem.Kind != "lts-feature" {
+			v.addf("%s.registry_feature: feature %q has kind %q, want lts-feature", label, item.RegistryFeature, featureItem.Kind)
+		}
+		v.registerReference(featureRefs, label+".registry_feature", item.RegistryFeature)
+		v.requireString(label+".maintenance_policy", item.MaintenancePolicy)
+		v.requireStrings(label+".markers", item.Markers, true)
+		v.requireStrings(label+".validation", item.Validation, true)
+		v.requireString(label+".conflict_policy", item.ConflictPolicy)
+	}
+
+	seamRefs := make(map[string]string)
+	for i, item := range deltas.SharedReviewSeams {
+		label := fmt.Sprintf("%s.shared_review_seams[%d]", protectedDeltasPath, i)
+		v.registerID(allIDs, label, item.ID)
+		v.requireString(label+".registry_seam", item.RegistrySeam)
+		if _, ok := index.reviewSeams[strings.TrimSpace(item.RegistrySeam)]; !ok {
+			v.addf("%s.registry_seam: unknown review seam %q", label, item.RegistrySeam)
+		}
+		v.registerReference(seamRefs, label+".registry_seam", item.RegistrySeam)
+		if !item.ReviewRequired {
+			v.addf("%s.review_required: shared review seam must be true", label)
+		}
+		v.requireStrings(label+".review_when", item.ReviewWhen, true)
+		v.requireStrings(label+".validation", item.Validation, true)
+		v.requireString(label+".conflict_policy", item.ConflictPolicy)
+	}
+	for id := range index.features {
+		if _, ok := featureRefs[id]; !ok {
+			v.addf("%s: registry feature %q is not referenced by retained_capabilities or lts_owned_features", protectedDeltasPath, id)
+		}
+	}
+	for id := range index.reviewSeams {
+		if _, ok := seamRefs[id]; !ok {
+			v.addf("%s: registry review seam %q is not referenced by shared_review_seams", protectedDeltasPath, id)
+		}
+	}
+
+	seenProfiles := make(map[string]int)
+	for i, rawID := range deltas.RuntimeValidationProfiles {
+		id := strings.TrimSpace(rawID)
+		if id == "" {
+			v.addf("%s.runtime_validation_profiles[%d]: must not be empty", protectedDeltasPath, i)
+			continue
+		}
+		if first, ok := seenProfiles[id]; ok {
+			v.addf("%s.runtime_validation_profiles[%d]: duplicate id %q (first at index %d)", protectedDeltasPath, i, id, first)
+		} else {
+			seenProfiles[id] = i
+		}
+		if _, ok := index.validationProfiles[id]; !ok {
+			v.addf("%s.runtime_validation_profiles[%d]: unknown validation profile %q", protectedDeltasPath, i, id)
+		}
+	}
+	for id := range index.validationProfiles {
+		if _, ok := seenProfiles[id]; !ok {
+			v.addf("%s: registry validation profile %q is not referenced by runtime_validation_profiles", protectedDeltasPath, id)
+		}
+	}
+}
+
+func (v *validator) validateDownstreamPatches(patches downstreamPatches) {
+	if patches.Version != 1 {
+		v.addf("%s: version must be 1, got %d", downstreamPatchesPath, patches.Version)
+	}
+	if len(patches.Patches) == 0 {
+		v.addf("%s.patches: must contain at least one historical or active patch", downstreamPatchesPath)
+	}
+	seen := make(map[string]string)
+	for i, item := range patches.Patches {
+		label := fmt.Sprintf("%s.patches[%d]", downstreamPatchesPath, i)
+		v.registerID(seen, label, item.ID)
+		v.requireString(label+".reason", item.Reason)
+		v.requireString(label+".introduced_in", item.IntroducedIn)
+		if introducedIn := strings.TrimSpace(item.IntroducedIn); introducedIn != "" && !commitSHA.MatchString(introducedIn) {
+			v.addf("%s.introduced_in: must be a 7-40 character commit SHA, got %q", label, item.IntroducedIn)
+		} else if introducedIn != "" && v.repositoryHasGitHistory() && !v.repositoryIsShallow() {
+			if !v.commitExists(introducedIn) {
+				v.addf("%s.introduced_in: commit %q does not exist in the current repository", label, item.IntroducedIn)
+			} else if !v.commitIsAncestorOfHead(introducedIn) {
+				v.addf("%s.introduced_in: commit %q is not reachable from HEAD", label, item.IntroducedIn)
+			}
+		}
+		v.requireString(label+".upstream_issue_or_pr", item.UpstreamIssueOrPR)
+		v.requireEnum(label+".state", item.State, patchStates)
+		v.requireStrings(label+".files", item.Files, true)
+		v.requireStrings(label+".regression_tests", item.RegressionTests, true)
+		v.requireString(label+".affected_upstream_range", item.AffectedUpstreamRange)
+		v.requireString(label+".retire_when", item.RetireWhen)
+
+		state := strings.TrimSpace(item.State)
+		active := state == "required" || state == "upstreamed" || state == "removable"
+		if active {
+			for j, path := range item.Files {
+				v.validatePath(fmt.Sprintf("%s.files[%d]", label, j), path, false)
+			}
+			for j, testName := range item.RegressionTests {
+				if strings.TrimSpace(testName) == "" {
+					continue
+				}
+				if !strings.HasPrefix(testName, "Test") {
+					v.addf("%s.regression_tests[%d]: %q must start with Test", label, j, testName)
+					continue
+				}
+				if !v.testFunctionInPatchFiles(testName, item.Files) {
+					v.addf("%s.regression_tests[%d]: Go test function %q not found in patch _test.go files", label, j, testName)
+				}
+			}
+		}
+		if state == "retired" {
+			v.requireString(label+".retired_in", item.RetiredIn)
+			if retiredIn := strings.TrimSpace(item.RetiredIn); retiredIn != "" && !commitSHA.MatchString(retiredIn) {
+				v.addf("%s.retired_in: must be a 7-40 character commit SHA, got %q", label, item.RetiredIn)
+			} else if retiredIn != "" && !v.repositoryIsShallow() {
+				if !v.commitExists(retiredIn) {
+					v.addf("%s.retired_in: commit %q does not exist in the current repository", label, item.RetiredIn)
+				} else if !v.commitIsAncestorOfHead(retiredIn) {
+					v.addf("%s.retired_in: commit %q is not reachable from HEAD", label, item.RetiredIn)
+				}
+			}
+		}
+		if (state == "upstreamed" || state == "removable" || state == "retired") && strings.EqualFold(strings.TrimSpace(item.UpstreamIssueOrPR), "not-filed") {
+			v.addf("%s.upstream_issue_or_pr: state %q requires concrete upstream evidence", label, state)
+		}
+		if active && strings.TrimSpace(item.RetiredIn) != "" {
+			v.addf("%s.retired_in: active patch must not declare retired_in", label)
+		}
+	}
+}
+
+func (v *validator) validatePatchHistory(current downstreamPatches, baseRef string) {
+	previous, exists, err := loadPatchesAtRef(v.root, baseRef)
+	if err != nil {
+		v.addf("%s: load patch history from %q: %v", downstreamPatchesPath, baseRef, err)
+		return
+	}
+	if !exists {
+		return
+	}
+	currentByID := make(map[string]downstreamPatch, len(current.Patches))
+	for _, patch := range current.Patches {
+		currentByID[strings.TrimSpace(patch.ID)] = patch
+	}
+	for _, oldPatch := range previous.Patches {
+		id := strings.TrimSpace(oldPatch.ID)
+		newPatch, ok := currentByID[id]
+		if !ok {
+			v.addf("%s: historical patch %q from %s must not be deleted", downstreamPatchesPath, id, baseRef)
+			continue
+		}
+		if !allowedPatchTransition(strings.TrimSpace(oldPatch.State), strings.TrimSpace(newPatch.State)) {
+			v.addf("%s: patch %q has invalid state transition %q -> %q", downstreamPatchesPath, id, oldPatch.State, newPatch.State)
+		}
+		if strings.TrimSpace(oldPatch.IntroducedIn) != strings.TrimSpace(newPatch.IntroducedIn) {
+			v.addf("%s: patch %q must not rewrite introduced_in", downstreamPatchesPath, id)
+		}
+		if strings.TrimSpace(oldPatch.State) == "retired" && !reflect.DeepEqual(oldPatch, newPatch) {
+			v.addf("%s: retired patch %q is immutable", downstreamPatchesPath, id)
+		}
+	}
+}
+
+func loadPatchesAtRef(root, baseRef string) (downstreamPatches, bool, error) {
+	var patches downstreamPatches
+	baseRef = strings.TrimSpace(baseRef)
+	if baseRef == "" {
+		return patches, false, nil
+	}
+	if err := exec.Command("git", "-C", root, "cat-file", "-e", baseRef+"^{commit}").Run(); err != nil {
+		return patches, false, fmt.Errorf("git ref is not a commit: %w", err)
+	}
+	spec := baseRef + ":" + downstreamPatchesPath
+	if err := exec.Command("git", "-C", root, "cat-file", "-e", spec).Run(); err != nil {
+		return patches, false, nil
+	}
+	data, err := exec.Command("git", "-C", root, "show", spec).Output()
+	if err != nil {
+		return patches, false, err
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&patches); err != nil {
+		return patches, false, err
+	}
+	return patches, true, nil
+}
+
+func allowedPatchTransition(from, to string) bool {
+	if from == to {
+		return true
+	}
+	switch from {
+	case "required":
+		return to == "upstreamed" || to == "removable"
+	case "upstreamed":
+		return to == "required" || to == "removable"
+	case "removable":
+		return to == "required" || to == "retired"
+	default:
+		return false
+	}
+}
+
+func (v *validator) commitExists(sha string) bool {
+	return exec.Command("git", "-C", v.root, "cat-file", "-e", strings.TrimSpace(sha)+"^{commit}").Run() == nil
+}
+
+func (v *validator) commitIsAncestorOfHead(sha string) bool {
+	return exec.Command("git", "-C", v.root, "merge-base", "--is-ancestor", strings.TrimSpace(sha), "HEAD").Run() == nil
+}
+
+func (v *validator) repositoryIsShallow() bool {
+	out, err := exec.Command("git", "-C", v.root, "rev-parse", "--is-shallow-repository").Output()
+	return err == nil && strings.TrimSpace(string(out)) == "true"
+}
+
+func (v *validator) repositoryHasGitHistory() bool {
+	return exec.Command("git", "-C", v.root, "rev-parse", "--verify", "HEAD^{commit}").Run() == nil
+}
+
+func (v *validator) validateFeatureClassification(label string, item feature) {
+	switch item.Kind {
+	case "retained-capability":
+		if item.Support != "protected" {
+			v.addf("%s.support: retained-capability must be protected", label)
+		}
+		if item.Owner != "cpa-core-lts" {
+			v.addf("%s.owner: retained-capability must be owned by cpa-core-lts", label)
+		}
+		if item.UpstreamRelation != "divergent" && item.UpstreamRelation != "removed-upstream" {
+			v.addf("%s.upstream_relation: retained-capability must be divergent or removed-upstream", label)
+		}
+	case "lts-feature":
+		if item.Support != "maintained" && item.Support != "optional" {
+			v.addf("%s.support: lts-feature must be maintained or optional", label)
+		}
+		if item.Owner != "cpa-core-lts" {
+			v.addf("%s.owner: lts-feature must be owned by cpa-core-lts", label)
+		}
+		if item.UpstreamRelation != "downstream-only" && item.UpstreamRelation != "divergent" {
+			v.addf("%s.upstream_relation: lts-feature must be downstream-only or divergent", label)
+		}
+	}
+}
+
+func (v *validator) registerReference(seen map[string]string, label, rawID string) {
+	id := strings.TrimSpace(rawID)
+	if id == "" {
+		return
+	}
+	if first, ok := seen[id]; ok {
+		v.addf("%s: duplicate reference to %q (first declared at %s)", label, id, first)
+		return
+	}
+	seen[id] = label
+}
+
+func (v *validator) registerID(seen map[string]string, label, rawID string) string {
+	id := strings.TrimSpace(rawID)
+	if id == "" {
+		v.addf("%s.id: must not be empty", label)
+		return ""
+	}
+	if first, ok := seen[id]; ok {
+		v.addf("%s.id: duplicate id %q (first declared at %s)", label, id, first)
+		return id
+	}
+	seen[id] = label
+	return id
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func routeEvidenceToken(route string) string {
+	route = strings.TrimSpace(route)
+	if strings.HasPrefix(route, "/v0/management/") {
+		return strings.TrimPrefix(route, "/v0/management")
+	}
+	return route
+}
+
+func (v *validator) configPathExists(key string) (bool, error) {
+	if !v.configLoaded {
+		v.configLoaded = true
+		data, err := os.ReadFile(filepath.Join(v.root, "config.example.yaml"))
+		if err != nil {
+			v.configErr = err
+		} else {
+			v.configErr = yaml.Unmarshal(data, &v.configExample)
+		}
+	}
+	if v.configErr != nil {
+		return false, v.configErr
+	}
+	segments := strings.Split(strings.TrimSpace(key), ".")
+	current := any(v.configExample)
+	foundInExample := true
+	for _, segment := range segments {
+		mapping, ok := current.(map[string]any)
+		if !ok {
+			foundInExample = false
+			break
+		}
+		current, ok = mapping[segment]
+		if !ok {
+			foundInExample = false
+			break
+		}
+	}
+	if foundInExample {
+		return true, nil
+	}
+	return v.configSchemaPathExists(segments)
+}
+
+func (v *validator) configSchemaPathExists(segments []string) (bool, error) {
+	if !v.configSchemaLoaded {
+		v.configSchemaLoaded = true
+		v.configSchema = make(map[string]map[string]string)
+		matches, err := filepath.Glob(filepath.Join(v.root, "internal/config/*.go"))
+		if err != nil {
+			v.configSchemaErr = err
+		} else {
+			files := token.NewFileSet()
+			for _, path := range matches {
+				if strings.HasSuffix(path, "_test.go") {
+					continue
+				}
+				file, parseErr := parser.ParseFile(files, path, nil, parser.SkipObjectResolution)
+				if parseErr != nil {
+					v.configSchemaErr = parseErr
+					break
+				}
+				for _, decl := range file.Decls {
+					gen, ok := decl.(*ast.GenDecl)
+					if !ok || gen.Tok != token.TYPE {
+						continue
+					}
+					for _, spec := range gen.Specs {
+						typeSpec, ok := spec.(*ast.TypeSpec)
+						if !ok {
+							continue
+						}
+						structType, ok := typeSpec.Type.(*ast.StructType)
+						if !ok {
+							continue
+						}
+						fields := make(map[string]string)
+						for _, field := range structType.Fields.List {
+							if field.Tag == nil {
+								continue
+							}
+							rawTag, unquoteErr := strconv.Unquote(field.Tag.Value)
+							if unquoteErr != nil {
+								continue
+							}
+							yamlName := strings.Split(reflect.StructTag(rawTag).Get("yaml"), ",")[0]
+							if yamlName == "" || yamlName == "-" {
+								continue
+							}
+							fields[yamlName] = configStructTypeName(field.Type)
+						}
+						v.configSchema[typeSpec.Name.Name] = fields
+					}
+				}
+			}
+		}
+	}
+	if v.configSchemaErr != nil {
+		return false, v.configSchemaErr
+	}
+	typeName := "Config"
+	for index, segment := range segments {
+		fields, ok := v.configSchema[typeName]
+		if !ok {
+			return false, nil
+		}
+		nextType, ok := fields[segment]
+		if !ok {
+			return false, nil
+		}
+		if index == len(segments)-1 {
+			return true, nil
+		}
+		if nextType == "" {
+			return false, nil
+		}
+		typeName = nextType
+	}
+	return false, nil
+}
+
+func configStructTypeName(expr ast.Expr) string {
+	switch value := expr.(type) {
+	case *ast.Ident:
+		return value.Name
+	case *ast.StarExpr:
+		return configStructTypeName(value.X)
+	case *ast.ArrayType:
+		return configStructTypeName(value.Elt)
+	case *ast.MapType:
+		return configStructTypeName(value.Value)
+	default:
+		return ""
+	}
+}
+
+func (v *validator) requireString(label, value string) {
+	if strings.TrimSpace(value) == "" {
+		v.addf("%s: must not be empty", label)
+	}
+}
+
+func (v *validator) requireLiteral(label, value, want string) {
+	if strings.TrimSpace(value) != want {
+		v.addf("%s: must be %q, got %q", label, want, value)
+	}
+}
+
+func (v *validator) requireStrings(label string, values []string, requireNonEmpty bool) {
+	if requireNonEmpty && len(values) == 0 {
+		v.addf("%s: must contain at least one value", label)
+		return
+	}
+	for i, value := range values {
+		if strings.TrimSpace(value) == "" {
+			v.addf("%s[%d]: must not be empty", label, i)
+		}
+	}
+}
+
+func (v *validator) requireEnum(label, value string, allowed map[string]struct{}) {
+	value = strings.TrimSpace(value)
+	if _, ok := allowed[value]; ok {
+		return
+	}
+	choices := make([]string, 0, len(allowed))
+	for choice := range allowed {
+		choices = append(choices, choice)
+	}
+	sort.Strings(choices)
+	v.addf("%s: invalid value %q (allowed: %s)", label, value, strings.Join(choices, ", "))
+}
+
+func (v *validator) validatePath(label, rawPath string, allowDirectory bool) {
+	abs, _, err := v.resolvePath(rawPath)
+	if err != nil {
+		v.addf("%s: %v", label, err)
+		return
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		v.addf("%s: path %q: %v", label, rawPath, err)
+		return
+	}
+	if !allowDirectory && !info.Mode().IsRegular() {
+		v.addf("%s: path %q must be a regular file", label, rawPath)
+	}
+}
+
+func (v *validator) resolvePath(rawPath string) (string, string, error) {
+	rawPath = strings.TrimSpace(rawPath)
+	if rawPath == "" {
+		return "", "", fmt.Errorf("path must not be empty")
+	}
+	if filepath.IsAbs(rawPath) {
+		return "", "", fmt.Errorf("path %q must be repository-relative", rawPath)
+	}
+	clean := filepath.Clean(filepath.FromSlash(rawPath))
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", "", fmt.Errorf("path %q escapes or names the repository root", rawPath)
+	}
+	abs := filepath.Join(v.root, clean)
+	rel, err := filepath.Rel(v.root, abs)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", "", fmt.Errorf("path %q escapes repository root", rawPath)
+	}
+	return abs, filepath.ToSlash(rel), nil
+}
+
+func (v *validator) markerInPaths(marker string, paths []string) bool {
+	markerBytes := []byte(marker)
+	for _, rawPath := range paths {
+		abs, rel, err := v.resolvePath(rawPath)
+		if err != nil || isRegistryEvidencePath(rel) {
+			continue
+		}
+		info, err := os.Stat(abs)
+		if err != nil {
+			continue
+		}
+		if info.IsDir() {
+			found := false
+			_ = filepath.WalkDir(abs, func(path string, entry os.DirEntry, walkErr error) error {
+				if walkErr != nil || found {
+					return nil
+				}
+				relPath, _ := filepath.Rel(v.root, path)
+				if entry.IsDir() && shouldSkipDirectory(filepath.ToSlash(relPath), entry.Name()) {
+					return filepath.SkipDir
+				}
+				if entry.Type().IsRegular() && !isRegistryEvidencePath(filepath.ToSlash(relPath)) && fileContains(path, markerBytes) {
+					found = true
+				}
+				return nil
+			})
+			if found {
+				return true
+			}
+			continue
+		}
+		if info.Mode().IsRegular() && fileContains(abs, markerBytes) {
+			return true
+		}
+	}
+	return false
+}
+
+func (v *validator) markerInRepository(marker string) bool {
+	markerBytes := []byte(marker)
+	found := false
+	_ = filepath.WalkDir(v.root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil || found {
+			return nil
+		}
+		rel, _ := filepath.Rel(v.root, path)
+		rel = filepath.ToSlash(rel)
+		if entry.IsDir() && shouldSkipDirectory(rel, entry.Name()) {
+			return filepath.SkipDir
+		}
+		if entry.Type().IsRegular() && !isRegistryEvidencePath(rel) && fileContains(path, markerBytes) {
+			found = true
+		}
+		return nil
+	})
+	return found
+}
+
+func (v *validator) testFunctionInPatchFiles(testName string, paths []string) bool {
+	_, ok := v.testFunctionPath(testName, paths)
+	return ok
+}
+
+func (v *validator) testFunctionPath(testName string, paths []string) (string, bool) {
+	for _, rawPath := range paths {
+		if !strings.HasSuffix(strings.TrimSpace(rawPath), "_test.go") {
+			continue
+		}
+		abs, _, err := v.resolvePath(rawPath)
+		if err != nil {
+			continue
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), abs, nil, parser.SkipObjectResolution)
+		if err != nil {
+			v.addf("downstream patch test file %q: parse Go AST: %v", rawPath, err)
+			continue
+		}
+		testingImports := testingImportNames(file)
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if ok && isGoTestFunction(fn, testName, testingImports) {
+				return strings.TrimSpace(rawPath), true
+			}
+		}
+	}
+	return "", false
+}
+
+func (v *validator) validateActivePatchTestsWithGo(patches downstreamPatches) {
+	goMod := filepath.Join(v.root, "go.mod")
+	if info, err := os.Stat(goMod); err != nil || !info.Mode().IsRegular() {
+		return
+	}
+
+	expectedByDir := make(map[string]map[string]struct{})
+	for _, patch := range patches.Patches {
+		state := strings.TrimSpace(patch.State)
+		if state != "required" && state != "upstreamed" && state != "removable" {
+			continue
+		}
+		for _, rawName := range patch.RegressionTests {
+			name := strings.TrimSpace(rawName)
+			path, ok := v.testFunctionPath(name, patch.Files)
+			if !ok {
+				continue
+			}
+			dir := filepath.ToSlash(filepath.Dir(filepath.FromSlash(path)))
+			if dir == "." {
+				dir = ""
+			}
+			if expectedByDir[dir] == nil {
+				expectedByDir[dir] = make(map[string]struct{})
+			}
+			expectedByDir[dir][name] = struct{}{}
+		}
+	}
+
+	dirs := make([]string, 0, len(expectedByDir))
+	for dir := range expectedByDir {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+	for _, dir := range dirs {
+		expected := expectedByDir[dir]
+		names := make([]string, 0, len(expected))
+		for name := range expected {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		quoted := make([]string, 0, len(names))
+		for _, name := range names {
+			quoted = append(quoted, regexp.QuoteMeta(name))
+		}
+		pattern := "^(" + strings.Join(quoted, "|") + ")$"
+		pkg := "."
+		if dir != "" {
+			pkg = "./" + dir
+		}
+		cmd := exec.Command("go", "test", "-list", pattern, pkg)
+		cmd.Dir = v.root
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			v.addf("%s: Go tool could not compile/list active patch tests in %s: %v: %s", downstreamPatchesPath, pkg, err, strings.TrimSpace(string(output)))
+			continue
+		}
+		listed := make(map[string]struct{})
+		for _, line := range strings.Split(string(output), "\n") {
+			line = strings.TrimSpace(line)
+			if _, ok := expected[line]; ok {
+				listed[line] = struct{}{}
+			}
+		}
+		for _, name := range names {
+			if _, ok := listed[name]; !ok {
+				v.addf("%s: Go tool did not list active regression test %q in %s", downstreamPatchesPath, name, pkg)
+			}
+		}
+	}
+}
+
+func testingImportNames(file *ast.File) map[string]struct{} {
+	names := make(map[string]struct{})
+	for _, spec := range file.Imports {
+		path, err := strconv.Unquote(spec.Path.Value)
+		if err != nil || path != "testing" {
+			continue
+		}
+		name := "testing"
+		if spec.Name != nil {
+			name = spec.Name.Name
+		}
+		if name != "_" && name != "." {
+			names[name] = struct{}{}
+		}
+	}
+	return names
+}
+
+func isGoTestFunction(fn *ast.FuncDecl, testName string, testingImports map[string]struct{}) bool {
+	if fn == nil || fn.Recv != nil || fn.Name == nil || fn.Name.Name != testName || fn.Type == nil {
+		return false
+	}
+	if fn.Type.TypeParams != nil && len(fn.Type.TypeParams.List) > 0 {
+		return false
+	}
+	if fn.Type.Results != nil && len(fn.Type.Results.List) > 0 {
+		return false
+	}
+	if fn.Type.Params == nil || len(fn.Type.Params.List) != 1 || len(fn.Type.Params.List[0].Names) > 1 {
+		return false
+	}
+	star, ok := fn.Type.Params.List[0].Type.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	selector, ok := star.X.(*ast.SelectorExpr)
+	if !ok || selector.Sel == nil || selector.Sel.Name != "T" {
+		return false
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	_, ok = testingImports[pkg.Name]
+	return ok
+}
+
+func (v *validator) addf(format string, args ...any) {
+	v.problems = append(v.problems, fmt.Sprintf(format, args...))
+}
+
+func fileContains(path string, marker []byte) bool {
+	data, err := os.ReadFile(path)
+	return err == nil && bytes.Contains(data, marker)
+}
+
+func isRegistryEvidencePath(path string) bool {
+	_, ok := registryEvidenceFiles[filepath.ToSlash(path)]
+	return ok
+}
+
+func shouldSkipDirectory(rel, name string) bool {
+	rel = filepath.ToSlash(rel)
+	if rel == ".git" || strings.HasPrefix(rel, ".git/") || rel == "vendor" || strings.HasPrefix(rel, "vendor/") || rel == "local" || strings.HasPrefix(rel, "local/") {
+		return true
+	}
+	return name == ".gocache" || name == ".playwright-mcp" || strings.Contains(name, "worktree") && strings.HasPrefix(name, ".")
+}
+
+func stringSet(values ...string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		out[value] = struct{}{}
+	}
+	return out
+}

--- a/scripts/ltsregistry/validate_test.go
+++ b/scripts/ltsregistry/validate_test.go
@@ -1,0 +1,626 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateRoot(t *testing.T) {
+	root := writeValidFixture(t)
+	if err := validateRoot(root); err != nil {
+		t.Fatalf("validateRoot() unexpected error:\n%v", err)
+	}
+}
+
+func TestRun(t *testing.T) {
+	root := writeValidFixture(t)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if code := run([]string{"--root", root}, &stdout, &stderr); code != 0 {
+		t.Fatalf("run() code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "registry validation passed") {
+		t.Fatalf("run() stdout = %q", stdout.String())
+	}
+}
+
+func TestRetiredPatchMayReferenceDeletedCode(t *testing.T) {
+	root := writeValidFixture(t)
+	retiredIn := initGitRepo(t, root)
+	replaceFile(t, root, downstreamPatchesPath, "state: required", "state: retired")
+	replaceFile(t, root, downstreamPatchesPath, "- internal/demo/demo.go", "- internal/demo/deleted.go")
+	replaceFile(t, root, downstreamPatchesPath, "- internal/demo/demo_test.go", "- internal/demo/deleted_test.go")
+	replaceFile(t, root, downstreamPatchesPath, "- TestDemo", "- TestDeletedBehavior")
+	replaceFile(t, root, downstreamPatchesPath, "upstream_issue_or_pr: not-filed", "upstream_issue_or_pr: example/upstream#123")
+	replaceFile(t, root, downstreamPatchesPath, "retired_in: \"\"", "retired_in: "+retiredIn)
+	if err := validateRoot(root); err != nil {
+		t.Fatalf("validateRoot() retired patch unexpected error:\n%v", err)
+	}
+}
+
+func TestPatchHistoryRejectsDeletionAndSkippedRetirement(t *testing.T) {
+	t.Run("deleted historical id", func(t *testing.T) {
+		root := writeValidFixture(t)
+		baseRef := initGitRepo(t, root)
+		writeFixtureFile(t, root, downstreamPatchesPath, "version: 1\npatches: []\n")
+		err := validateRootAgainst(root, baseRef)
+		if err == nil || !strings.Contains(err.Error(), "historical patch \"patch-a\"") {
+			t.Fatalf("validateRootAgainst() error = %v, want historical patch deletion", err)
+		}
+	})
+
+	t.Run("required directly to retired", func(t *testing.T) {
+		root := writeValidFixture(t)
+		baseRef := initGitRepo(t, root)
+		replaceFile(t, root, downstreamPatchesPath, "state: required", "state: retired")
+		replaceFile(t, root, downstreamPatchesPath, "upstream_issue_or_pr: not-filed", "upstream_issue_or_pr: example/upstream#123")
+		replaceFile(t, root, downstreamPatchesPath, "retired_in: \"\"", "retired_in: "+baseRef)
+		err := validateRootAgainst(root, baseRef)
+		if err == nil || !strings.Contains(err.Error(), "invalid state transition \"required\" -> \"retired\"") {
+			t.Fatalf("validateRootAgainst() error = %v, want skipped retirement rejection", err)
+		}
+	})
+
+	t.Run("introduced commit rewritten", func(t *testing.T) {
+		root := writeValidFixture(t)
+		baseRef := initGitRepo(t, root)
+		replacePrefixedLine(t, root, downstreamPatchesPath, "    introduced_in:", "    introduced_in: deadbeef")
+		err := validateRootAgainst(root, baseRef)
+		if err == nil || !strings.Contains(err.Error(), "must not rewrite introduced_in") {
+			t.Fatalf("validateRootAgainst() error = %v, want introduced_in rewrite rejection", err)
+		}
+	})
+
+	t.Run("retired provenance rewritten", func(t *testing.T) {
+		root := writeValidFixture(t)
+		introducedRef := initGitRepo(t, root)
+		replaceFile(t, root, downstreamPatchesPath, "state: required", "state: retired")
+		replaceFile(t, root, downstreamPatchesPath, "upstream_issue_or_pr: not-filed", "upstream_issue_or_pr: example/upstream#123")
+		replaceFile(t, root, downstreamPatchesPath, "retired_in: \"\"", "retired_in: "+introducedRef)
+		baseRef := commitAll(t, root, "retire fixture patch")
+		replaceFile(t, root, downstreamPatchesPath, "reason: Preserve downstream behavior until upstream matches it.", "reason: Rewritten retired history.")
+		err := validateRootAgainst(root, baseRef)
+		if err == nil || !strings.Contains(err.Error(), "retired patch \"patch-a\" is immutable") {
+			t.Fatalf("validateRootAgainst() error = %v, want retired history immutability rejection", err)
+		}
+	})
+
+	t.Run("upstreamed may conservatively return to required", func(t *testing.T) {
+		root := writeValidFixture(t)
+		replaceFile(t, root, downstreamPatchesPath, "state: required", "state: upstreamed")
+		replaceFile(t, root, downstreamPatchesPath, "upstream_issue_or_pr: not-filed", "upstream_issue_or_pr: example/upstream#123")
+		baseRef := initGitRepo(t, root)
+		replaceFile(t, root, downstreamPatchesPath, "state: upstreamed", "state: required")
+		if err := validateRootAgainst(root, baseRef); err != nil {
+			t.Fatalf("validateRootAgainst() conservative rollback unexpected error:\n%v", err)
+		}
+	})
+}
+
+func TestValidationFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		want       string
+		mutateRoot func(t *testing.T, root string)
+	}{
+		{
+			name: "unknown field",
+			want: "field unexpected not found",
+			mutateRoot: func(t *testing.T, root string) {
+				appendFile(t, root, featureRegistryPath, "\nunexpected: true\n")
+			},
+		},
+		{
+			name: "registry version",
+			want: "version must be 2",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, featureRegistryPath, "version: 2", "version: 1")
+			},
+		},
+		{
+			name: "weakened merge policy",
+			want: "sync_rules.merge_commit_required: must be true",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, protectedDeltasPath, "merge_commit_required: true", "merge_commit_required: false")
+			},
+		},
+		{
+			name: "weakened patch provenance merge policy",
+			want: "sync_rules.patch_provenance_merge_commit_required: must be true",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, protectedDeltasPath, "patch_provenance_merge_commit_required: true", "patch_provenance_merge_commit_required: false")
+			},
+		},
+		{
+			name: "automatic operation mode",
+			want: "maintenance_model.operation_mode: must be \"manual-ai-assisted\"",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, protectedDeltasPath, "operation_mode: manual-ai-assisted", "operation_mode: fully-automatic")
+			},
+		},
+		{
+			name: "missing forbidden shortcut",
+			want: "missing required value \"GitHub Sync fork\"",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, protectedDeltasPath, "- GitHub Sync fork", "- harmless-placeholder")
+			},
+		},
+		{
+			name: "wrong registry reference",
+			want: "must reference \"docs/lts/core-feature-contracts.yaml\"",
+			mutateRoot: func(t *testing.T, root string) {
+				writeFixtureFile(t, root, "docs/lts/other-registry.yaml", "version: 2\n")
+				replaceFile(t, root, protectedDeltasPath, "feature_contract_registry: docs/lts/core-feature-contracts.yaml", "feature_contract_registry: docs/lts/other-registry.yaml")
+			},
+		},
+		{
+			name: "duplicate id",
+			want: "duplicate id \"feature-a\"",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, featureRegistryPath, "  - id: feature-b", "  - id: feature-a")
+			},
+		},
+		{
+			name: "invalid enum",
+			want: "invalid value \"fork\"",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, featureRegistryPath, "kind: retained-capability", "kind: fork")
+			},
+		},
+		{
+			name: "invalid classification combination",
+			want: "retained-capability must be protected",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, featureRegistryPath, "support: protected", "support: optional")
+			},
+		},
+		{
+			name: "dangling feature reference",
+			want: "unknown feature \"missing-feature\"",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, protectedDeltasPath, "registry_feature: feature-a", "registry_feature: missing-feature")
+			},
+		},
+		{
+			name: "duplicate feature reference",
+			want: "duplicate reference to \"feature-a\"",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, protectedDeltasPath, "registry_feature: feature-b", "registry_feature: feature-a")
+			},
+		},
+		{
+			name: "missing validation",
+			want: "features[0].validation: must contain at least one value",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, featureRegistryPath, "    validation:\n      - go test ./internal/demo", "    validation: []")
+			},
+		},
+		{
+			name: "route without source evidence",
+			want: "route \"/v0/missing\" has no evidence token",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, featureRegistryPath, "- /v0/example", "- /v0/missing")
+			},
+		},
+		{
+			name: "config key without source evidence",
+			want: "config key \"demo.nonexistent-key\" does not exist in config.example.yaml or the internal/config Go schema",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, featureRegistryPath, "- demo.enabled", "- demo.nonexistent-key")
+			},
+		},
+		{
+			name: "missing regression test",
+			want: "Go test function \"TestMissing\" not found",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, downstreamPatchesPath, "- TestDemo", "- TestMissing")
+			},
+		},
+		{
+			name: "invalid regression test signature",
+			want: "Go test function \"TestDemo\" not found",
+			mutateRoot: func(t *testing.T, root string) {
+				writeFixtureFile(t, root, "internal/demo/demo_test.go", "package demo\n\nfunc TestDemo() {}\n")
+			},
+		},
+		{
+			name: "regression test parameter is not testing T",
+			want: "Go test function \"TestDemo\" not found",
+			mutateRoot: func(t *testing.T, root string) {
+				writeFixtureFile(t, root, "internal/demo/demo_test.go", "package demo\n\nimport fake \"example.invalid/fake\"\n\nfunc TestDemo(t *fake.T) {}\n")
+			},
+		},
+		{
+			name: "regression test has multiple parameters",
+			want: "Go test function \"TestDemo\" not found",
+			mutateRoot: func(t *testing.T, root string) {
+				writeFixtureFile(t, root, "internal/demo/demo_test.go", "package demo\n\nimport \"testing\"\n\nfunc TestDemo(a, b *testing.T) {}\n")
+			},
+		},
+		{
+			name: "regression test is excluded from Go build",
+			want: "Go tool did not list active regression test \"TestDemo\"",
+			mutateRoot: func(t *testing.T, root string) {
+				writeFixtureFile(t, root, "go.mod", "module example.invalid/ltsregistryfixture\n\ngo 1.23\n")
+				writeFixtureFile(t, root, "internal/demo/demo_test.go", "//go:build never\n\npackage demo\n\nimport \"testing\"\n\nfunc TestDemo(t *testing.T) {}\n")
+			},
+		},
+		{
+			name: "missing retire when",
+			want: ".retire_when: must not be empty",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, downstreamPatchesPath, "retire_when: upstream ships the same behavior", "retire_when: \"\"")
+			},
+		},
+		{
+			name: "missing upstream issue or pr",
+			want: ".upstream_issue_or_pr: must not be empty",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, downstreamPatchesPath, "upstream_issue_or_pr: not-filed", "upstream_issue_or_pr: \"\"")
+			},
+		},
+		{
+			name: "invalid introduced commit",
+			want: ".introduced_in: must be a 7-40 character commit SHA",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, downstreamPatchesPath, "introduced_in: abcdef12", "introduced_in: release-name")
+			},
+		},
+		{
+			name: "missing affected range",
+			want: ".affected_upstream_range: must not be empty",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, downstreamPatchesPath, "affected_upstream_range: v1.0.0..HEAD", "affected_upstream_range: \"\"")
+			},
+		},
+		{
+			name: "empty patch ledger",
+			want: ".patches: must contain at least one historical or active patch",
+			mutateRoot: func(t *testing.T, root string) {
+				writeFixtureFile(t, root, downstreamPatchesPath, "version: 1\npatches: []\n")
+			},
+		},
+		{
+			name: "upstreamed patch missing upstream evidence",
+			want: "state \"upstreamed\" requires concrete upstream evidence",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, downstreamPatchesPath, "state: required", "state: upstreamed")
+			},
+		},
+		{
+			name: "marker only in registry",
+			want: "marker \"registry-only-marker\" has no evidence",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, featureRegistryPath,
+					"    core_files:\n      - internal/demo/demo.go\n    required_markers:\n      - feature-a-marker",
+					"    core_files:\n      - docs/lts/core-feature-contracts.yaml\n    required_markers:\n      - registry-only-marker")
+			},
+		},
+		{
+			name: "marker only in file path",
+			want: "marker \"demo.go\" has no evidence",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, featureRegistryPath, "- feature-a-marker", "- demo.go")
+			},
+		},
+		{
+			name: "missing file",
+			want: "path \"internal/demo/missing.go\"",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, downstreamPatchesPath, "- internal/demo/demo.go", "- internal/demo/missing.go")
+			},
+		},
+		{
+			name: "retired missing retired in",
+			want: ".retired_in: must not be empty",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, downstreamPatchesPath, "state: required", "state: retired")
+			},
+		},
+		{
+			name: "retired invalid commit",
+			want: ".retired_in: must be a 7-40 character commit SHA",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, downstreamPatchesPath, "state: required", "state: retired")
+				replaceFile(t, root, downstreamPatchesPath, "upstream_issue_or_pr: not-filed", "upstream_issue_or_pr: example/upstream#123")
+				replaceFile(t, root, downstreamPatchesPath, "retired_in: \"\"", "retired_in: arbitrary-text")
+			},
+		},
+		{
+			name: "active declares retired in",
+			want: "active patch must not declare retired_in",
+			mutateRoot: func(t *testing.T, root string) {
+				replaceFile(t, root, downstreamPatchesPath, "state: required", "state: removable")
+				replaceFile(t, root, downstreamPatchesPath, "retired_in: \"\"", "retired_in: deadbeef")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := writeValidFixture(t)
+			tt.mutateRoot(t, root)
+			err := validateRoot(root)
+			if err == nil {
+				t.Fatalf("validateRoot() error = nil, want substring %q", tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("validateRoot() error:\n%v\nwant substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func writeValidFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	writeFixtureFile(t, root, "docs/lts/sync-runbook.md", "# Sync runbook\n")
+	writeFixtureFile(t, root, "config.example.yaml", "demo:\n  enabled: true\n")
+	writeFixtureFile(t, root, "internal/demo/demo.go", "package demo\n\nconst FeatureAMarker = \"feature-a-marker\"\nconst FeatureBMarker = \"feature-b-marker\"\nconst ProfileMarker = \"profile-marker\"\nconst ExampleRoute = \"/v0/example\"\nconst DemoConfigKey = \"demo.enabled\"\n")
+	writeFixtureFile(t, root, "internal/demo/demo_test.go", "package demo\n\nimport \"testing\"\n\nfunc TestDemo(t *testing.T) {}\n")
+	writeFixtureFile(t, root, featureRegistryPath, validFeatureRegistryYAML)
+	writeFixtureFile(t, root, protectedDeltasPath, validProtectedDeltasYAML)
+	writeFixtureFile(t, root, downstreamPatchesPath, validDownstreamPatchesYAML)
+	return root
+}
+
+func writeFixtureFile(t *testing.T, root, name, content string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func replaceFile(t *testing.T, root, name, old, replacement string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(name))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if !strings.Contains(string(data), old) {
+		t.Fatalf("fixture %s does not contain %q", name, old)
+	}
+	updated := strings.Replace(string(data), old, replacement, 1)
+	if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func appendFile(t *testing.T, root, name, content string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(name))
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatalf("append %s: %v", path, err)
+	}
+}
+
+func replacePrefixedLine(t *testing.T, root, name, prefix, replacement string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(name))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	lines := strings.Split(string(data), "\n")
+	replaced := false
+	for i, line := range lines {
+		if strings.HasPrefix(line, prefix) {
+			lines[i] = replacement
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		t.Fatalf("fixture %s does not contain line prefix %q", name, prefix)
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func initGitRepo(t *testing.T, root string) string {
+	t.Helper()
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"config", "user.name", "LTS Registry Test"},
+		{"config", "user.email", "lts-registry@example.invalid"},
+		{"commit", "--allow-empty", "-qm", "fixture bootstrap"},
+	} {
+		cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, output)
+		}
+	}
+	bootstrapOutput, err := exec.Command("git", "-C", root, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse bootstrap HEAD: %v", err)
+	}
+	replaceFile(t, root, downstreamPatchesPath, "introduced_in: abcdef12", "introduced_in: "+strings.TrimSpace(string(bootstrapOutput)))
+	for _, args := range [][]string{{"add", "."}, {"commit", "-qm", "fixture baseline"}} {
+		cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, output)
+		}
+	}
+	out, err := exec.Command("git", "-C", root, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func commitAll(t *testing.T, root, message string) string {
+	t.Helper()
+	for _, args := range [][]string{{"add", "."}, {"commit", "-qm", message}} {
+		cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, output)
+		}
+	}
+	out, err := exec.Command("git", "-C", root, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+const validFeatureRegistryYAML = `version: 2
+generated_from: docs/lts/sync-runbook.md
+maintenance_model: protected-full-sync-with-contract-registry
+guard_policy:
+  purpose: Keep cheap sentinels around LTS identity surfaces.
+  add_marker_when:
+    - Marker is stable.
+  avoid_marker_when:
+    - Marker is an implementation detail.
+  behavior_proof:
+    - Behavior requires tests.
+features:
+  - id: feature-a
+    kind: retained-capability
+    support: protected
+    owner: cpa-core-lts
+    upstream_relation: divergent
+    reason: Feature A is retained by the LTS product.
+    routes:
+      - /v0/example
+    config_keys: []
+    core_files:
+      - internal/demo/demo.go
+    required_markers:
+      - feature-a-marker
+    validation:
+      - go test ./internal/demo
+  - id: feature-b
+    kind: lts-feature
+    support: maintained
+    owner: cpa-core-lts
+    upstream_relation: downstream-only
+    reason: Feature B is maintained downstream.
+    routes: []
+    config_keys:
+      - demo.enabled
+    core_files:
+      - internal/demo/demo.go
+    required_markers:
+      - feature-b-marker
+    validation:
+      - go test ./internal/demo
+review_seams:
+  - id: seam-a
+    support: upstream-shared
+    owner: shared
+    upstream_relation: upstream-equivalent
+    reason: Shared request lifecycle requires review.
+    core_files:
+      - internal/demo/demo.go
+    review_triggers:
+      - request lifecycle changes
+    validation:
+      - go test ./internal/demo
+validation_profiles:
+  - id: profile-a
+    reason: Runtime validation is optional after merge.
+    reference_space:
+      - example/space
+    runtime_checks:
+      - /healthz returns ok
+    required_markers:
+      - profile-marker
+    validation:
+      - manual smoke
+relationships:
+  - id: relationship-a
+    type: coexist
+    from: feature-a
+    to: feature-b
+    reason: Both features coexist.
+`
+
+const validProtectedDeltasYAML = `version: 2
+maintenance_model:
+  type: protected-full-sync
+  product_branch: main
+  operation_mode: manual-ai-assisted
+  scheduled_sync: false
+  cadence_guidance: frequent-small-syncs
+  optional_runtime_smoke: manual_huggingface_space
+  feature_contract_registry: docs/lts/core-feature-contracts.yaml
+  downstream_patch_ledger: docs/lts/downstream-patches.yaml
+upstream_source:
+  repo: router-for-me/CLIProxyAPI
+  branch: main
+retained_capabilities:
+  - id: retained-a
+    registry_feature: feature-a
+    must_keep: true
+    markers:
+      - feature-a-marker
+    validation:
+      - go test ./internal/demo
+    conflict_policy: preserve
+lts_owned_features:
+  - id: owned-b
+    registry_feature: feature-b
+    maintenance_policy: maintain downstream
+    markers:
+      - feature-b-marker
+    validation:
+      - go test ./internal/demo
+    conflict_policy: reapply
+shared_review_seams:
+  - id: shared-a
+    registry_seam: seam-a
+    review_required: true
+    review_when:
+      - request lifecycle changes
+    validation:
+      - go test ./internal/demo
+    conflict_policy: review
+sync_rules:
+  default_mode: protected_full_sync
+  upstream_changes: accept_by_default
+  merge_commit_required: true
+  squash_forbidden: true
+  rebase_forbidden: true
+  contract_registry_required: true
+  downstream_patch_review_required: true
+  patch_provenance_merge_commit_required: true
+  forbidden_shortcuts:
+    - GitHub Sync fork
+    - git pull upstream main on main
+    - git checkout upstream/main -- .
+runtime_validation_profiles:
+  - profile-a
+`
+
+const validDownstreamPatchesYAML = `version: 1
+patches:
+  - id: patch-a
+    reason: Preserve downstream behavior until upstream matches it.
+    introduced_in: abcdef12
+    affected_upstream_range: v1.0.0..HEAD
+    files:
+      - internal/demo/demo.go
+      - internal/demo/demo_test.go
+    regression_tests:
+      - TestDemo
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: upstream ships the same behavior
+    retired_in: ""
+`


### PR DESCRIPTION
## Summary

- upgrade the Core LTS contract registry to taxonomy v2, separating retained capabilities, LTS-owned features, shared review seams, runtime validation profiles, and coexist relationships
- add an append-only downstream patch ledger with explicit upstream range, regression tests, lifecycle state, and retirement conditions
- add a strict Go validator and make the blocking LTS contract job validate schema, references, content evidence, patch history, real Go test discovery, and commit provenance
- update the sync runbook and PR template with per-item conclusions and commit-preserving introduction/retirement rules

This PR intentionally changes no runtime code, config/API shape, Management API, Panel response shape, or `AGENTS.md`.

## Current classification

| Class | Items |
|---|---|
| Retained capability / protected | full usage, Management usage API, CPA-Panel-LTS asset compatibility, auth attribution, config/hot reload compatibility |
| LTS feature / maintained | abnormal reasoning and hedged retry, transient cooldown, Redis-compatible usage queue |
| Shared review seam | provider runtime, WebSocket ownership, model resolution, plan-tier metadata, token accounting, logging metadata |
| Validation profile | HF Space runtime smoke |

GPT-5.6 model catalog absorption remains upstream/shared work rather than an LTS feature.

## Downstream patch ledger

| Patch | State | Conclusion |
|---|---|---|
| codex-image-generation-tool-dedup | upstreamed | upstream main contains the equivalent change, current LTS baseline does not |
| plugin-configured-enable-default | required | patch-still-required |
| codex-gpt56-ultra-level | required | upstream PR #4160 is only a partial client-metadata equivalent |
| codex-model-header-provider-snapshot | required | patch-still-required |
| codex-websocket-reader-generation | required | patch-still-required |

The current LTS baseline is `0877a26d` with upstream through `26d45fd4` (v7.2.58). During final verification, upstream main advanced by five commits to `20e61f28`; those runtime/catalog changes are deliberately not mixed into this governance PR.

## Validator behavior

- strict `yaml.v3` known-field decoding and enum/classification checks
- complete registry references plus repository-relative file, route, config-schema, and content-only marker evidence
- active patch AST checks plus blocking `go test -list`, so build-excluded or non-compiling tests cannot satisfy the ledger
- append-only history, controlled state transitions, immutable provenance, and reachable `introduced_in` / `retired_in`
- merge-commit policy when a PR creates a commit named by patch provenance

## Validation

Passed locally:

- `go test ./scripts/ltsregistry -count=1`
- `go vet ./scripts/ltsregistry`
- `go run ./scripts/ltsregistry --root .`
- `scripts/check-lts-contract.sh`
- `go test ./internal/thinking -run 'GPT56|Ultra|ParseLevelSuffixUltra|Clamp' -count=1`
- `go test ./internal/registry ./sdk/api/handlers/openai -run 'GPT56|Ultra|CodexClient|ModelOverrideHeaders' -count=1`
- `go test ./internal/runtime/executor -run 'Codex.*(Profile|Provider|Generation|StaleReader|Retry)' -count=1`
- `go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage' -count=1`
- `go build -o test-output ./cmd/server && rm -f test-output`
- `go test ./... -count=1`
- `actionlint .github/workflows/lts-contract.yml`
- `shellcheck scripts/check-lts-contract.sh`
- `git diff --check`

Independent blocker review found no remaining P0/P1/P2 findings.