### PR TITLE
sync(lts): absorb upstream post-v7.2.61 fixes

### DIFF
--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -33,9 +33,9 @@ patches:
     retire_when: Upstream preserves the configured plugin enable default through both YAML parsing and runtime host synthesis, and all listed tests pass without the downstream implementation.
 
   - id: codex-gpt56-ultra-level
-    reason: Upstream v7.2.58 advertises GPT-5.6 catalog entries but does not provide first-class ultra parsing, validation ordering, or Codex client metadata support.
+    reason: CPA-Core-LTS preserves GPT-5.6 Ultra as a client compatibility level while upstream no longer advertises Ultra in models.json and still lacks first-class parsing, validation ordering, and complete Codex client semantics.
     introduced_in: 6e12fb1dd6d522ca80a02644d286d765d7a649bd
-    affected_upstream_range: LTS baseline through ca67caf0872eef65f8eaedf2e127cf214a49621d (v7.2.61); upstream main 20e61f281f4b88e150c5cdfa81c3315d9fcfeabe only preserves ultra in Codex client metadata and still lacks the shared thinking level implementation
+    affected_upstream_range: LTS baseline through 3554b63721aac9b4202bf2ef88ba7a82b4e5caf8; upstream added partial client metadata at 20e61f281f4b88e150c5cdfa81c3315d9fcfeabe, then removed Ultra from models.json at f084eefae6a9aa67c273a697e4c3fdfc15102032, while LTS retains the catalog level and shared thinking implementation
     files:
       - internal/thinking/types.go
       - internal/thinking/suffix.go

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -2627,8 +2627,12 @@ func (h *Handler) GetAuthStatus(c *gin.Context) {
 		return
 	}
 
-	provider, status, isPlugin, metadata, ok := GetOAuthSessionDetails(state)
+	provider, status, isPlugin, metadata, completed, ok := GetOAuthSessionDetails(state)
 	if !ok {
+		c.JSON(http.StatusOK, gin.H{"status": "error", "error": "unknown or expired state"})
+		return
+	}
+	if completed {
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
 		return
 	}

--- a/internal/api/handlers/management/oauth_callback.go
+++ b/internal/api/handlers/management/oauth_callback.go
@@ -86,9 +86,13 @@ func (h *Handler) handleOAuthCallback(c *gin.Context, req oauthCallbackRequest) 
 		return
 	}
 
-	sessionProvider, sessionStatus, isPlugin, _, ok := GetOAuthSessionDetails(state)
+	sessionProvider, sessionStatus, isPlugin, _, completed, ok := GetOAuthSessionDetails(state)
 	if !ok {
 		c.JSON(http.StatusNotFound, gin.H{"status": "error", "error": "unknown or expired state"})
+		return
+	}
+	if completed {
+		c.JSON(http.StatusConflict, gin.H{"status": "error", "error": "oauth flow is already completed"})
 		return
 	}
 	provider := strings.TrimSpace(req.Provider)

--- a/internal/api/handlers/management/oauth_sessions.go
+++ b/internal/api/handlers/management/oauth_sessions.go
@@ -155,7 +155,7 @@ func (s *oauthSessionStore) Complete(state string) {
 
 	s.purgeExpiredLocked(now)
 	session, ok := s.sessions[state]
-	if !ok {
+	if !ok || session.Completed {
 		return
 	}
 	session.Status = ""
@@ -179,7 +179,7 @@ func (s *oauthSessionStore) CompleteProvider(provider string, source string) int
 	s.purgeExpiredLocked(now)
 	removed := 0
 	for state, session := range s.sessions {
-		if strings.EqualFold(session.Provider, provider) && (source == "" || session.Source == source) {
+		if !session.Completed && strings.EqualFold(session.Provider, provider) && (source == "" || session.Source == source) {
 			session.Status = ""
 			session.Metadata = nil
 			session.Completed = true

--- a/internal/api/handlers/management/oauth_sessions.go
+++ b/internal/api/handlers/management/oauth_sessions.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	oauthSessionTTL     = 10 * time.Minute
-	maxOAuthStateLength = 128
+	oauthSessionTTL          = 10 * time.Minute
+	oauthCompletedSessionTTL = time.Minute
+	maxOAuthStateLength      = 128
 )
 
 const (
@@ -33,23 +34,30 @@ type oauthSession struct {
 	Status    string
 	Source    string
 	Metadata  map[string]any
+	Completed bool
 	CreatedAt time.Time
 	ExpiresAt time.Time
 }
 
 type oauthSessionStore struct {
-	mu       sync.RWMutex
-	ttl      time.Duration
-	sessions map[string]oauthSession
+	mu           sync.RWMutex
+	ttl          time.Duration
+	completedTTL time.Duration
+	sessions     map[string]oauthSession
 }
 
 func newOAuthSessionStore(ttl time.Duration) *oauthSessionStore {
 	if ttl <= 0 {
 		ttl = oauthSessionTTL
 	}
+	completedTTL := oauthCompletedSessionTTL
+	if ttl < completedTTL {
+		completedTTL = ttl
+	}
 	return &oauthSessionStore{
-		ttl:      ttl,
-		sessions: make(map[string]oauthSession),
+		ttl:          ttl,
+		completedTTL: completedTTL,
+		sessions:     make(map[string]oauthSession),
 	}
 }
 
@@ -127,7 +135,7 @@ func (s *oauthSessionStore) SetError(state, message string) {
 
 	s.purgeExpiredLocked(now)
 	session, ok := s.sessions[state]
-	if !ok {
+	if !ok || session.Completed {
 		return
 	}
 	session.Status = message
@@ -146,7 +154,15 @@ func (s *oauthSessionStore) Complete(state string) {
 	defer s.mu.Unlock()
 
 	s.purgeExpiredLocked(now)
-	delete(s.sessions, state)
+	session, ok := s.sessions[state]
+	if !ok {
+		return
+	}
+	session.Status = ""
+	session.Metadata = nil
+	session.Completed = true
+	session.ExpiresAt = now.Add(s.completedTTL)
+	s.sessions[state] = session
 }
 
 func (s *oauthSessionStore) CompleteProvider(provider string, source string) int {
@@ -164,7 +180,11 @@ func (s *oauthSessionStore) CompleteProvider(provider string, source string) int
 	removed := 0
 	for state, session := range s.sessions {
 		if strings.EqualFold(session.Provider, provider) && (source == "" || session.Source == source) {
-			delete(s.sessions, state)
+			session.Status = ""
+			session.Metadata = nil
+			session.Completed = true
+			session.ExpiresAt = now.Add(s.completedTTL)
+			s.sessions[state] = session
 			removed++
 		}
 	}
@@ -197,7 +217,7 @@ func (s *oauthSessionStore) IsPending(state, provider string) bool {
 	if !ok {
 		return false
 	}
-	if session.Status != "" {
+	if session.Completed || session.Status != "" {
 		return false
 	}
 	if provider == "" {
@@ -245,12 +265,12 @@ func GetOAuthSession(state string) (provider string, status string, ok bool) {
 	return session.Provider, session.Status, true
 }
 
-func GetOAuthSessionDetails(state string) (provider string, status string, isPlugin bool, metadata map[string]any, ok bool) {
+func GetOAuthSessionDetails(state string) (provider string, status string, isPlugin bool, metadata map[string]any, completed bool, ok bool) {
 	session, ok := oauthSessions.Get(state)
 	if !ok {
-		return "", "", false, nil, false
+		return "", "", false, nil, false, false
 	}
-	return session.Provider, session.Status, session.Source == oauthSessionSourcePlugin, cloneOAuthSessionMetadata(session.Metadata), true
+	return session.Provider, session.Status, session.Source == oauthSessionSourcePlugin, cloneOAuthSessionMetadata(session.Metadata), session.Completed, true
 }
 
 func IsOAuthSessionPending(state, provider string) bool {

--- a/internal/api/handlers/management/oauth_sessions.go
+++ b/internal/api/handlers/management/oauth_sessions.go
@@ -259,7 +259,7 @@ func CompletePluginOAuthSessionsByProvider(provider string) int {
 
 func GetOAuthSession(state string) (provider string, status string, ok bool) {
 	session, ok := oauthSessions.Get(state)
-	if !ok {
+	if !ok || session.Completed {
 		return "", "", false
 	}
 	return session.Provider, session.Status, true

--- a/internal/api/handlers/management/oauth_sessions_test.go
+++ b/internal/api/handlers/management/oauth_sessions_test.go
@@ -1,0 +1,102 @@
+package management
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestOAuthSessionStoreCompleteKeepsShortLivedSession(t *testing.T) {
+	store := newOAuthSessionStore(time.Minute)
+	store.Register("completed-state", "codex")
+
+	store.Complete("completed-state")
+
+	if _, ok := store.Get("completed-state"); !ok {
+		t.Fatal("completed OAuth session was deleted instead of retained as a tombstone")
+	}
+	if store.IsPending("completed-state", "codex") {
+		t.Fatal("completed OAuth session remained pending")
+	}
+}
+
+func TestGetAuthStatusRejectsUnknownStateAndAcceptsCompletedState(t *testing.T) {
+	store := newOAuthSessionStore(time.Minute)
+	replaceOAuthSessionStoreForTest(t, store)
+
+	handler := &Handler{}
+	router := gin.New()
+	router.GET("/status", handler.GetAuthStatus)
+
+	unknown := performOAuthStatusRequest(t, router, "unknown-state")
+	if unknown.Status != "error" || unknown.Error != "unknown or expired state" {
+		t.Fatalf("unknown state response = %#v, want unknown/expired error", unknown)
+	}
+
+	store.Register("completed-state", "codex")
+	store.Complete("completed-state")
+	completed := performOAuthStatusRequest(t, router, "completed-state")
+	if completed.Status != "ok" || completed.Error != "" {
+		t.Fatalf("completed state response = %#v, want success", completed)
+	}
+}
+
+func TestOAuthCallbackRejectsCompletedSession(t *testing.T) {
+	store := newOAuthSessionStore(time.Minute)
+	replaceOAuthSessionStoreForTest(t, store)
+	store.Register("completed-state", "codex")
+	store.Complete("completed-state")
+
+	handler := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, nil)
+	router := gin.New()
+	router.POST("/oauth-callback", handler.PostOAuthCallback)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/oauth-callback",
+		strings.NewReader(`{"provider":"codex","state":"completed-state","code":"test-code"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("completed callback status = %d, want %d; body=%s", w.Code, http.StatusConflict, w.Body.String())
+	}
+}
+
+type oauthStatusResponse struct {
+	Status string `json:"status"`
+	Error  string `json:"error"`
+}
+
+func performOAuthStatusRequest(t *testing.T, router http.Handler, state string) oauthStatusResponse {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/status?state="+state, nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status request returned %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var response oauthStatusResponse
+	if errDecode := json.Unmarshal(w.Body.Bytes(), &response); errDecode != nil {
+		t.Fatalf("decode status response: %v", errDecode)
+	}
+	return response
+}
+
+func replaceOAuthSessionStoreForTest(t *testing.T, store *oauthSessionStore) {
+	t.Helper()
+	original := oauthSessions
+	oauthSessions = store
+	t.Cleanup(func() {
+		oauthSessions = original
+	})
+}

--- a/internal/api/handlers/management/oauth_sessions_test.go
+++ b/internal/api/handlers/management/oauth_sessions_test.go
@@ -26,6 +26,53 @@ func TestOAuthSessionStoreCompleteKeepsShortLivedSession(t *testing.T) {
 	}
 }
 
+func TestOAuthSessionStoreCompleteDoesNotExtendCompletedSession(t *testing.T) {
+	store := newOAuthSessionStore(time.Minute)
+	store.Register("completed-state", "codex")
+	store.Complete("completed-state")
+	before, ok := store.Get("completed-state")
+	if !ok {
+		t.Fatal("completed OAuth session tombstone is missing")
+	}
+
+	store.completedTTL = 2 * time.Minute
+	store.Complete("completed-state")
+	after, ok := store.Get("completed-state")
+	if !ok {
+		t.Fatal("completed OAuth session tombstone is missing after repeated completion")
+	}
+	if !after.ExpiresAt.Equal(before.ExpiresAt) {
+		t.Fatalf("repeated completion extended expiry from %s to %s", before.ExpiresAt, after.ExpiresAt)
+	}
+}
+
+func TestOAuthSessionStoreCompleteProviderSkipsCompletedSessions(t *testing.T) {
+	store := newOAuthSessionStore(time.Minute)
+	store.Register("completed-state", "codex")
+	store.Register("pending-state", "codex")
+	store.Complete("completed-state")
+	completedBefore, ok := store.Get("completed-state")
+	if !ok {
+		t.Fatal("completed OAuth session tombstone is missing")
+	}
+
+	store.completedTTL = 2 * time.Minute
+	if got := store.CompleteProvider("codex", oauthSessionSourceBuiltin); got != 1 {
+		t.Fatalf("CompleteProvider() = %d, want 1 newly completed session", got)
+	}
+	completedAfter, ok := store.Get("completed-state")
+	if !ok {
+		t.Fatal("completed OAuth session tombstone is missing after provider completion")
+	}
+	if !completedAfter.ExpiresAt.Equal(completedBefore.ExpiresAt) {
+		t.Fatalf("provider completion extended existing tombstone from %s to %s", completedBefore.ExpiresAt, completedAfter.ExpiresAt)
+	}
+	pendingAfter, ok := store.Get("pending-state")
+	if !ok || !pendingAfter.Completed {
+		t.Fatalf("pending session completed/ok = %t/%t, want true/true", pendingAfter.Completed, ok)
+	}
+}
+
 func TestGetOAuthSessionHidesCompletedSession(t *testing.T) {
 	store := newOAuthSessionStore(time.Minute)
 	replaceOAuthSessionStoreForTest(t, store)

--- a/internal/api/handlers/management/oauth_sessions_test.go
+++ b/internal/api/handlers/management/oauth_sessions_test.go
@@ -26,6 +26,23 @@ func TestOAuthSessionStoreCompleteKeepsShortLivedSession(t *testing.T) {
 	}
 }
 
+func TestGetOAuthSessionHidesCompletedSession(t *testing.T) {
+	store := newOAuthSessionStore(time.Minute)
+	replaceOAuthSessionStoreForTest(t, store)
+	store.Register("completed-state", "codex")
+	store.Complete("completed-state")
+
+	provider, status, ok := GetOAuthSession("completed-state")
+	if ok {
+		t.Fatalf("GetOAuthSession() = (%q, %q, true), want completed session hidden", provider, status)
+	}
+
+	_, _, _, _, completed, detailsOK := GetOAuthSessionDetails("completed-state")
+	if !detailsOK || !completed {
+		t.Fatalf("GetOAuthSessionDetails() completed/ok = %t/%t, want true/true", completed, detailsOK)
+	}
+}
+
 func TestGetAuthStatusRejectsUnknownStateAndAcceptsCompletedState(t *testing.T) {
 	store := newOAuthSessionStore(time.Minute)
 	replaceOAuthSessionStoreForTest(t, store)

--- a/internal/api/handlers/management/plugin_store.go
+++ b/internal/api/handlers/management/plugin_store.go
@@ -59,32 +59,34 @@ type pluginStoreSourceErr struct {
 }
 
 type pluginStoreListEntry struct {
-	StoreID          string                `json:"store_id"`
-	SourceID         string                `json:"source_id"`
-	SourceName       string                `json:"source_name"`
-	SourceURL        string                `json:"source_url"`
-	ID               string                `json:"id"`
-	Name             string                `json:"name"`
-	Description      string                `json:"description"`
-	Author           string                `json:"author"`
-	Version          string                `json:"version"`
-	Repository       string                `json:"repository"`
-	InstallType      string                `json:"install_type"`
-	AuthRequired     bool                  `json:"auth_required"`
-	AuthConfigured   bool                  `json:"auth_configured"`
-	Platforms        []pluginStorePlatform `json:"platforms,omitempty"`
-	Logo             string                `json:"logo,omitempty"`
-	Homepage         string                `json:"homepage,omitempty"`
-	License          string                `json:"license,omitempty"`
-	Tags             []string              `json:"tags,omitempty"`
-	Installed        bool                  `json:"installed"`
-	InstalledVersion string                `json:"installed_version"`
-	Path             string                `json:"path"`
-	Configured       bool                  `json:"configured"`
-	Registered       bool                  `json:"registered"`
-	Enabled          bool                  `json:"enabled"`
-	EffectiveEnabled bool                  `json:"effective_enabled"`
-	UpdateAvailable  bool                  `json:"update_available"`
+	StoreID             string                `json:"store_id"`
+	SourceID            string                `json:"source_id"`
+	SourceName          string                `json:"source_name"`
+	SourceURL           string                `json:"source_url"`
+	ID                  string                `json:"id"`
+	Name                string                `json:"name"`
+	Description         string                `json:"description"`
+	Author              string                `json:"author"`
+	Version             string                `json:"version"`
+	Repository          string                `json:"repository"`
+	InstallType         string                `json:"install_type"`
+	AuthRequired        bool                  `json:"auth_required"`
+	AuthConfigured      bool                  `json:"auth_configured"`
+	Platforms           []pluginStorePlatform `json:"platforms,omitempty"`
+	Logo                string                `json:"logo,omitempty"`
+	Homepage            string                `json:"homepage,omitempty"`
+	License             string                `json:"license,omitempty"`
+	Tags                []string              `json:"tags,omitempty"`
+	Installed           bool                  `json:"installed"`
+	InstalledVersion    string                `json:"installed_version"`
+	InstalledSourceID   string                `json:"installed_source_id,omitempty"`
+	InstallSourceStatus string                `json:"install_source_status,omitempty"`
+	Path                string                `json:"path"`
+	Configured          bool                  `json:"configured"`
+	Registered          bool                  `json:"registered"`
+	Enabled             bool                  `json:"enabled"`
+	EffectiveEnabled    bool                  `json:"effective_enabled"`
+	UpdateAvailable     bool                  `json:"update_available"`
 }
 
 type pluginStorePlatform struct {
@@ -110,13 +112,16 @@ type pluginInstallRequest struct {
 }
 
 type pluginLocalStatus struct {
-	Installed        bool
-	InstalledVersion string
-	Path             string
-	Configured       bool
-	Registered       bool
-	Enabled          bool
-	EffectiveEnabled bool
+	Installed          bool
+	InstalledVersion   string
+	StoreManaged       bool
+	InstalledSourceID  string
+	InstalledSourceURL string
+	Path               string
+	Configured         bool
+	Registered         bool
+	Enabled            bool
+	EffectiveEnabled   bool
 }
 
 type sourcedPlugin struct {
@@ -148,11 +153,21 @@ func (h *Handler) ListPluginStore(c *gin.Context) {
 	}
 	client := h.newPluginStoreClient(proxyURL, "", storeAuth)
 	latestVersions := h.latestPluginVersions(c.Request.Context(), client, latestInput)
+	pluginSourceCounts := make(map[string]int, len(plugins))
+	for _, item := range plugins {
+		pluginSourceCounts[item.plugin.ID]++
+	}
 
 	entries := make([]pluginStoreListEntry, 0, len(plugins))
 	for index, item := range plugins {
 		plugin := item.plugin
 		status := statuses[plugin.ID]
+		installedSourceID, installSourceStatus, sourceAllowsUpdate := pluginStoreInstallSourceStatus(
+			status,
+			sources,
+			item.source.ID,
+			pluginSourceCounts[plugin.ID],
+		)
 		installedVersion := status.InstalledVersion
 		// Fall back to the registry version when the latest release is unknown.
 		storeVersion := plugin.Version
@@ -160,32 +175,34 @@ func (h *Handler) ListPluginStore(c *gin.Context) {
 			storeVersion = latestVersions[index]
 		}
 		entries = append(entries, pluginStoreListEntry{
-			StoreID:          htmlsanitize.String(item.source.ID + "/" + plugin.ID),
-			SourceID:         htmlsanitize.String(item.source.ID),
-			SourceName:       htmlsanitize.String(item.source.Name),
-			SourceURL:        htmlsanitize.String(item.source.URL),
-			ID:               htmlsanitize.String(plugin.ID),
-			Name:             htmlsanitize.String(plugin.Name),
-			Description:      htmlsanitize.String(plugin.Description),
-			Author:           htmlsanitize.String(plugin.Author),
-			Version:          htmlsanitize.String(storeVersion),
-			Repository:       htmlsanitize.String(plugin.Repository),
-			InstallType:      htmlsanitize.String(pluginstore.PluginInstallType(plugin)),
-			AuthRequired:     plugin.AuthRequired,
-			AuthConfigured:   pluginAuthConfigured(item.source, plugin, storeAuth),
-			Platforms:        sanitizePluginStorePlatforms(pluginstore.PluginPlatforms(plugin)),
-			Logo:             htmlsanitize.String(plugin.Logo),
-			Homepage:         htmlsanitize.String(plugin.Homepage),
-			License:          htmlsanitize.String(plugin.License),
-			Tags:             htmlsanitize.Strings(plugin.Tags),
-			Installed:        status.Installed,
-			InstalledVersion: htmlsanitize.String(installedVersion),
-			Path:             htmlsanitize.String(status.Path),
-			Configured:       status.Configured,
-			Registered:       status.Registered,
-			Enabled:          status.Enabled,
-			EffectiveEnabled: status.EffectiveEnabled,
-			UpdateAvailable:  pluginstore.UpdateAvailable(installedVersion, storeVersion),
+			StoreID:             htmlsanitize.String(item.source.ID + "/" + plugin.ID),
+			SourceID:            htmlsanitize.String(item.source.ID),
+			SourceName:          htmlsanitize.String(item.source.Name),
+			SourceURL:           htmlsanitize.String(item.source.URL),
+			ID:                  htmlsanitize.String(plugin.ID),
+			Name:                htmlsanitize.String(plugin.Name),
+			Description:         htmlsanitize.String(plugin.Description),
+			Author:              htmlsanitize.String(plugin.Author),
+			Version:             htmlsanitize.String(storeVersion),
+			Repository:          htmlsanitize.String(plugin.Repository),
+			InstallType:         htmlsanitize.String(pluginstore.PluginInstallType(plugin)),
+			AuthRequired:        plugin.AuthRequired,
+			AuthConfigured:      pluginAuthConfigured(item.source, plugin, storeAuth),
+			Platforms:           sanitizePluginStorePlatforms(pluginstore.PluginPlatforms(plugin)),
+			Logo:                htmlsanitize.String(plugin.Logo),
+			Homepage:            htmlsanitize.String(plugin.Homepage),
+			License:             htmlsanitize.String(plugin.License),
+			Tags:                htmlsanitize.Strings(plugin.Tags),
+			Installed:           status.Installed,
+			InstalledVersion:    htmlsanitize.String(installedVersion),
+			InstalledSourceID:   htmlsanitize.String(installedSourceID),
+			InstallSourceStatus: htmlsanitize.String(installSourceStatus),
+			Path:                htmlsanitize.String(status.Path),
+			Configured:          status.Configured,
+			Registered:          status.Registered,
+			Enabled:             status.Enabled,
+			EffectiveEnabled:    status.EffectiveEnabled,
+			UpdateAvailable:     sourceAllowsUpdate && pluginstore.UpdateAvailable(installedVersion, storeVersion),
 		})
 	}
 
@@ -213,7 +230,7 @@ func (h *Handler) installPluginFromStore(c *gin.Context, goos, goarch string) {
 		return
 	}
 	installCtx := c.Request.Context()
-	pluginsEnabled, pluginsDir, proxyURL, sourceConfigs, storeAuth, _, host := h.pluginStoreSnapshot()
+	pluginsEnabled, pluginsDir, proxyURL, sourceConfigs, storeAuth, configs, host := h.pluginStoreSnapshot()
 	sources, errSources := h.pluginStoreSources(sourceConfigs)
 	if errSources != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "plugin_store_source_invalid", "message": errSources.Error()})
@@ -221,6 +238,9 @@ func (h *Handler) installPluginFromStore(c *gin.Context, goos, goarch string) {
 	}
 	source, plugin, client, okPlugin := h.findPluginStoreInstallTarget(installCtx, proxyURL, storeAuth, sources, id, c.Query("source"), c)
 	if !okPlugin {
+		return
+	}
+	if !validatePluginStoreInstallSource(c, configs, sources, id, source.ID) {
 		return
 	}
 	pluginIsBusy := func() bool { return pluginBusy(host, id) }
@@ -717,6 +737,7 @@ func pluginLocalStatuses(pluginsEnabled bool, pluginsDir string, configs map[str
 		status := statuses[id]
 		status.Configured = true
 		status.Enabled = pluginInstanceEnabled(item)
+		status.InstalledSourceID, status.InstalledSourceURL, status.StoreManaged = pluginStoreConfiguredSource(item)
 		statuses[id] = status
 	}
 	if host != nil {
@@ -736,6 +757,95 @@ func pluginLocalStatuses(pluginsEnabled bool, pluginsDir string, configs map[str
 		statuses[id] = status
 	}
 	return statuses, nil
+}
+
+func pluginStoreConfiguredSource(item config.PluginInstanceConfig) (sourceID string, sourceURL string, managed bool) {
+	storeNode := pluginStoreConfigNode(item)
+	if storeNode == nil {
+		return "", "", false
+	}
+	var manifest pluginstore.Manifest
+	if errDecode := storeNode.Decode(&manifest); errDecode != nil {
+		return "", "", true
+	}
+	return strings.TrimSpace(manifest.SourceID), strings.TrimSpace(manifest.SourceURL), true
+}
+
+func pluginStoreResolveInstalledSource(status pluginLocalStatus, sources []pluginstore.Source) (string, bool) {
+	sourceID := strings.TrimSpace(status.InstalledSourceID)
+	sourceURL := strings.TrimSpace(status.InstalledSourceURL)
+	if sourceID != "" {
+		for _, source := range sources {
+			if strings.TrimSpace(source.ID) != sourceID {
+				continue
+			}
+			if sourceURL != "" && strings.TrimSpace(source.URL) != sourceURL {
+				return "", false
+			}
+			return sourceID, true
+		}
+		return sourceID, true
+	}
+	if sourceURL == "" {
+		return "", false
+	}
+	for _, source := range sources {
+		if strings.TrimSpace(source.URL) == sourceURL {
+			return strings.TrimSpace(source.ID), true
+		}
+	}
+	return "", false
+}
+
+func pluginStoreInstallSourceStatus(status pluginLocalStatus, sources []pluginstore.Source, entrySourceID string, sourceCount int) (installedSourceID string, sourceStatus string, allowUpdate bool) {
+	if !status.Installed && !status.Configured && !status.Registered {
+		return "", "", true
+	}
+	if sourceID, known := pluginStoreResolveInstalledSource(status, sources); known {
+		if sourceID == strings.TrimSpace(entrySourceID) {
+			return sourceID, "matched", true
+		}
+		return sourceID, "different", false
+	}
+	if status.StoreManaged || sourceCount > 1 {
+		return "", "unknown", false
+	}
+	return "", "assumed", true
+}
+
+func validatePluginStoreInstallSource(c *gin.Context, configs map[string]config.PluginInstanceConfig, sources []pluginstore.Source, id string, requestedSourceID string) bool {
+	item, configured := configs[id]
+	if !configured {
+		return true
+	}
+	installedSourceID, installedSourceURL, managed := pluginStoreConfiguredSource(item)
+	if !managed {
+		return true
+	}
+	status := pluginLocalStatus{
+		StoreManaged:       true,
+		InstalledSourceID:  installedSourceID,
+		InstalledSourceURL: installedSourceURL,
+	}
+	resolvedSourceID, known := pluginStoreResolveInstalledSource(status, sources)
+	if !known {
+		c.JSON(http.StatusConflict, gin.H{
+			"error":               "plugin_store_installed_source_unknown",
+			"message":             "installed plugin source cannot be verified; uninstall it before reinstalling from the store",
+			"requested_source_id": strings.TrimSpace(requestedSourceID),
+		})
+		return false
+	}
+	if resolvedSourceID != strings.TrimSpace(requestedSourceID) {
+		c.JSON(http.StatusConflict, gin.H{
+			"error":               "plugin_store_source_conflict",
+			"message":             "installed plugin belongs to a different store source; uninstall it before switching sources",
+			"installed_source_id": resolvedSourceID,
+			"requested_source_id": strings.TrimSpace(requestedSourceID),
+		})
+		return false
+	}
+	return true
 }
 
 func pluginStoreDesiredVersions(configs map[string]config.PluginInstanceConfig) map[string]string {

--- a/internal/api/handlers/management/plugin_store_test.go
+++ b/internal/api/handlers/management/plugin_store_test.go
@@ -402,6 +402,154 @@ func TestListPluginStoreIncludesThirdPartySources(t *testing.T) {
 	}
 }
 
+func TestListPluginStoreMatchesInstalledStatusToManifestSource(t *testing.T) {
+	t.Parallel()
+
+	pluginsDir := t.TempDir()
+	archDir := filepath.Join(pluginsDir, runtime.GOOS, runtime.GOARCH)
+	if errMkdirAll := os.MkdirAll(archDir, 0o755); errMkdirAll != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", archDir, errMkdirAll)
+	}
+	pluginPath := filepath.Join(archDir, "sample-provider-v0.0.1"+managementPluginExtension(runtime.GOOS))
+	if errWriteFile := os.WriteFile(pluginPath, []byte("x"), 0o644); errWriteFile != nil {
+		t.Fatalf("WriteFile(%s) error = %v", pluginPath, errWriteFile)
+	}
+
+	communityURL := "https://community.example/registry.json"
+	h := &Handler{
+		cfg: &config.Config{
+			Plugins: config.PluginsConfig{
+				Enabled:      true,
+				Dir:          pluginsDir,
+				StoreSources: []string{communityURL},
+				Configs: map[string]config.PluginInstanceConfig{
+					"sample-provider": pluginConfigWithStoreSource(t, pluginstore.DefaultSourceID, pluginstore.DefaultRegistryURL),
+				},
+			},
+		},
+		configFilePath: writeTestConfigFile(t),
+		pluginStoreHTTPClient: fakePluginStoreHTTPClient{
+			pluginstore.DefaultRegistryURL: registryJSON(t),
+			communityURL:                   thirdPartySampleRegistryJSON(t),
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v0/management/plugin-store", nil)
+	h.ListPluginStore(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var body struct {
+		Plugins []struct {
+			SourceID            string `json:"source_id"`
+			InstalledSourceID   string `json:"installed_source_id"`
+			InstallSourceStatus string `json:"install_source_status"`
+			UpdateAvailable     bool   `json:"update_available"`
+		} `json:"plugins"`
+	}
+	if errDecode := json.Unmarshal(rec.Body.Bytes(), &body); errDecode != nil {
+		t.Fatalf("Unmarshal() error = %v; body=%s", errDecode, rec.Body.String())
+	}
+	if len(body.Plugins) != 2 {
+		t.Fatalf("plugins len = %d, want 2", len(body.Plugins))
+	}
+	entries := make(map[string]struct {
+		InstalledSourceID   string
+		InstallSourceStatus string
+		UpdateAvailable     bool
+	}, len(body.Plugins))
+	for _, entry := range body.Plugins {
+		entries[entry.SourceID] = struct {
+			InstalledSourceID   string
+			InstallSourceStatus string
+			UpdateAvailable     bool
+		}{entry.InstalledSourceID, entry.InstallSourceStatus, entry.UpdateAvailable}
+	}
+	official := entries[pluginstore.DefaultSourceID]
+	if official.InstalledSourceID != pluginstore.DefaultSourceID || official.InstallSourceStatus != "matched" || !official.UpdateAvailable {
+		t.Fatalf("official entry = %#v, want matched update", official)
+	}
+	communitySourceID := pluginstore.SourceID(communityURL)
+	community := entries[communitySourceID]
+	if community.InstalledSourceID != pluginstore.DefaultSourceID || community.InstallSourceStatus != "different" || community.UpdateAvailable {
+		t.Fatalf("community entry = %#v, want different source without update", community)
+	}
+}
+
+func TestInstallPluginFromStoreRejectsImplicitSourceSwitch(t *testing.T) {
+	t.Parallel()
+
+	communityURL := "https://community.example/registry.json"
+	h := &Handler{
+		cfg: &config.Config{
+			Plugins: config.PluginsConfig{
+				Enabled:      true,
+				Dir:          writeManagementPluginFile(t, "sample-provider"),
+				StoreSources: []string{communityURL},
+				Configs: map[string]config.PluginInstanceConfig{
+					"sample-provider": pluginConfigWithStoreSource(t, pluginstore.DefaultSourceID, pluginstore.DefaultRegistryURL),
+				},
+			},
+		},
+		configFilePath: writeTestConfigFile(t),
+		pluginStoreHTTPClient: fakePluginStoreHTTPClient{
+			pluginstore.DefaultRegistryURL: registryJSON(t),
+			communityURL:                   thirdPartySampleRegistryJSON(t),
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Params = gin.Params{{Key: "id", Value: "sample-provider"}}
+	communitySourceID := pluginstore.SourceID(communityURL)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/plugin-store/sample-provider/install?source="+communitySourceID, nil)
+	h.InstallPluginFromStore(c)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusConflict, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "plugin_store_source_conflict") || !strings.Contains(rec.Body.String(), pluginstore.DefaultSourceID) {
+		t.Fatalf("body = %s, want source conflict with installed source", rec.Body.String())
+	}
+}
+
+func TestInstallPluginFromStoreRejectsUnknownManagedSource(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		cfg: &config.Config{
+			Plugins: config.PluginsConfig{
+				Enabled: true,
+				Dir:     writeManagementPluginFile(t, "sample-provider"),
+				Configs: map[string]config.PluginInstanceConfig{
+					"sample-provider": pluginConfigWithStoreSource(t, "", ""),
+				},
+			},
+		},
+		configFilePath:         writeTestConfigFile(t),
+		pluginStoreRegistryURL: "https://registry.example/registry.json",
+		pluginStoreHTTPClient: fakePluginStoreHTTPClient{
+			"https://registry.example/registry.json": registryJSON(t),
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Params = gin.Params{{Key: "id", Value: "sample-provider"}}
+	c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/plugin-store/sample-provider/install", nil)
+	h.InstallPluginFromStore(c)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusConflict, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "plugin_store_installed_source_unknown") {
+		t.Fatalf("body = %s, want unknown installed source error", rec.Body.String())
+	}
+}
+
 func TestListPluginStoreIncludesDirectMetadataAndAuth(t *testing.T) {
 	t.Setenv("PLUGIN_STORE_TOKEN", "secret-token")
 
@@ -1145,6 +1293,18 @@ func testStoreManifest() pluginstore.Manifest {
 		Repository:  "https://github.com/author-name/cliproxy-sample-provider-plugin",
 		Install:     pluginstore.InstallPlan{Type: pluginstore.InstallTypeGitHubRelease},
 	}
+}
+
+func pluginConfigWithStoreSource(t *testing.T, sourceID string, sourceURL string) config.PluginInstanceConfig {
+	t.Helper()
+	sourceFields := ""
+	if sourceID != "" {
+		sourceFields += "  source-id: " + sourceID + "\n"
+	}
+	if sourceURL != "" {
+		sourceFields += "  source-url: " + sourceURL + "\n"
+	}
+	return pluginConfigFromYAML(t, "enabled: true\nstore:\n  schema-version: 1\n  id: sample-provider\n  version: 0.0.1\n  release-tag: v0.0.1\n  repository: https://github.com/author-name/cliproxy-sample-provider-plugin\n"+sourceFields+"  install:\n    type: github-release\n")
 }
 
 func pluginStoreManifestFromConfig(t *testing.T, item config.PluginInstanceConfig) pluginstore.Manifest {

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -1449,8 +1449,7 @@
           "medium",
           "high",
           "xhigh",
-          "max",
-          "ultra"
+          "max"
         ]
       }
     },
@@ -1598,8 +1597,7 @@
           "medium",
           "high",
           "xhigh",
-          "max",
-          "ultra"
+          "max"
         ]
       }
     },
@@ -1623,8 +1621,7 @@
           "medium",
           "high",
           "xhigh",
-          "max",
-          "ultra"
+          "max"
         ]
       }
     },
@@ -1795,8 +1792,7 @@
           "medium",
           "high",
           "xhigh",
-          "max",
-          "ultra"
+          "max"
         ]
       }
     },
@@ -1820,8 +1816,7 @@
           "medium",
           "high",
           "xhigh",
-          "max",
-          "ultra"
+          "max"
         ]
       }
     },
@@ -1992,8 +1987,7 @@
           "medium",
           "high",
           "xhigh",
-          "max",
-          "ultra"
+          "max"
         ]
       }
     },
@@ -2017,8 +2011,7 @@
           "medium",
           "high",
           "xhigh",
-          "max",
-          "ultra"
+          "max"
         ]
       }
     },

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -1449,7 +1449,8 @@
           "medium",
           "high",
           "xhigh",
-          "max"
+          "max",
+          "ultra"
         ]
       }
     },
@@ -1597,7 +1598,8 @@
           "medium",
           "high",
           "xhigh",
-          "max"
+          "max",
+          "ultra"
         ]
       }
     },
@@ -1621,7 +1623,8 @@
           "medium",
           "high",
           "xhigh",
-          "max"
+          "max",
+          "ultra"
         ]
       }
     },
@@ -1792,7 +1795,8 @@
           "medium",
           "high",
           "xhigh",
-          "max"
+          "max",
+          "ultra"
         ]
       }
     },
@@ -1816,7 +1820,8 @@
           "medium",
           "high",
           "xhigh",
-          "max"
+          "max",
+          "ultra"
         ]
       }
     },
@@ -1987,7 +1992,8 @@
           "medium",
           "high",
           "xhigh",
-          "max"
+          "max",
+          "ultra"
         ]
       }
     },
@@ -2011,7 +2017,8 @@
           "medium",
           "high",
           "xhigh",
-          "max"
+          "max",
+          "ultra"
         ]
       }
     },

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -38,6 +38,8 @@ const (
 	codexUserAgent             = "codex-tui/0.135.0 (Mac OS 26.5.0; arm64) iTerm.app/3.6.10 (codex-tui; 0.135.0)"
 	codexOriginator            = "codex-tui"
 	codexDefaultImageToolModel = "gpt-image-2"
+	codexResponsesLiteHeader   = "X-OpenAI-Internal-Codex-Responses-Lite"
+	codexResponsesLiteMetadata = "client_metadata.ws_request_header_x_openai_internal_codex_responses_lite"
 )
 
 var dataTag = []byte("data:")
@@ -782,7 +784,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	body, _ = sjson.DeleteBytes(body, "stream_options")
 	body = normalizeCodexInstructions(body)
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
-		body = ensureImageGenerationTool(body, baseModel, auth)
+		body = ensureImageGenerationTool(body, baseModel, auth, opts.Headers)
 	}
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex executor", body)
 	body = normalizeCodexParallelToolCallsForTools(body)
@@ -959,7 +961,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	body, _ = sjson.DeleteBytes(body, "stream")
 	body = normalizeCodexInstructions(body)
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
-		body = ensureImageGenerationTool(body, baseModel, auth)
+		body = ensureImageGenerationTool(body, baseModel, auth, opts.Headers)
 	}
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex executor", body)
 	body = normalizeCodexParallelToolCallsForTools(body)
@@ -1070,7 +1072,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 	body = normalizeCodexInstructions(body)
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
-		body = ensureImageGenerationTool(body, baseModel, auth)
+		body = ensureImageGenerationTool(body, baseModel, auth, opts.Headers)
 	}
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex executor", body)
 	body = normalizeCodexParallelToolCallsForTools(body)
@@ -1767,7 +1769,22 @@ func isImageGenerationFunctionTool(tool gjson.Result) bool {
 	return false
 }
 
-func ensureImageGenerationTool(body []byte, baseModel string, auth *cliproxyauth.Auth) []byte {
+func isCodexResponsesLiteRequest(body []byte, headers http.Header) bool {
+	if strings.EqualFold(strings.TrimSpace(headers.Get(codexResponsesLiteHeader)), "true") {
+		return true
+	}
+	// Codex Desktop mirrors websocket-only request headers into client_metadata.
+	value := gjson.GetBytes(body, codexResponsesLiteMetadata)
+	if !value.Exists() {
+		return false
+	}
+	return value.Type == gjson.True || value.Type == gjson.String && strings.EqualFold(strings.TrimSpace(value.String()), "true")
+}
+
+func ensureImageGenerationTool(body []byte, baseModel string, auth *cliproxyauth.Auth, headers http.Header) []byte {
+	if isCodexResponsesLiteRequest(body, headers) {
+		return body
+	}
 	if strings.HasSuffix(baseModel, "spark") {
 		return body
 	}

--- a/internal/runtime/executor/codex_executor_imagegen_test.go
+++ b/internal/runtime/executor/codex_executor_imagegen_test.go
@@ -1,15 +1,103 @@
 package executor
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	"github.com/tidwall/gjson"
 )
 
+func TestCodexExecutorExecuteResponsesLiteHeaderDoesNotInjectImageGenerationTool(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read request body: %v", errRead)
+		}
+		gotBody = body
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":0,\"output_tokens\":0,\"total_tokens\":0}}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Attributes: map[string]string{
+			"api_key":   "test",
+			"base_url":  server.URL,
+			"plan_type": "pro",
+		},
+	}
+	headers := make(http.Header)
+	headers.Set("X-OpenAI-Internal-Codex-Responses-Lite", "true")
+
+	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.6-sol",
+		Payload: []byte(`{"model":"gpt-5.6-sol","input":"hello"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Headers:      headers,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if tools := gjson.GetBytes(gotBody, "tools"); tools.Exists() {
+		t.Fatalf("unexpected tools in responses-lite upstream payload: %s", tools.Raw)
+	}
+}
+
+func TestEnsureImageGenerationTool_ResponsesLiteMetadataDoesNotInjectTool(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-sol","client_metadata":{"ws_request_header_x_openai_internal_codex_responses_lite":"true"},"input":[{"role":"user","content":"hello"}]}`)
+	result := ensureImageGenerationTool(body, "gpt-5.6-sol", nil, nil)
+
+	if string(result) != string(body) {
+		t.Fatalf("expected responses-lite body to be unchanged, got %s", string(result))
+	}
+	if gjson.GetBytes(result, "tools").Exists() {
+		t.Fatalf("expected no injected tools for responses-lite request, got %s", gjson.GetBytes(result, "tools").Raw)
+	}
+}
+
+func TestEnsureImageGenerationTool_ResponsesLiteBooleanMetadataDoesNotInjectTool(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-sol","client_metadata":{"ws_request_header_x_openai_internal_codex_responses_lite":true},"input":"hello"}`)
+	result := ensureImageGenerationTool(body, "gpt-5.6-sol", nil, nil)
+
+	if string(result) != string(body) {
+		t.Fatalf("expected responses-lite body to be unchanged, got %s", string(result))
+	}
+}
+
+func TestEnsureImageGenerationTool_ResponsesLiteHeaderDoesNotInjectTool(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-sol","input":"hello"}`)
+	headers := make(http.Header)
+	headers.Set("X-OpenAI-Internal-Codex-Responses-Lite", "true")
+	result := ensureImageGenerationTool(body, "gpt-5.6-sol", nil, headers)
+
+	if string(result) != string(body) {
+		t.Fatalf("expected responses-lite body to be unchanged, got %s", string(result))
+	}
+}
+
+func TestEnsureImageGenerationTool_ResponsesLiteFalseMetadataStillInjectsTool(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-sol","client_metadata":{"ws_request_header_x_openai_internal_codex_responses_lite":"false"},"input":"hello"}`)
+	result := ensureImageGenerationTool(body, "gpt-5.6-sol", nil, nil)
+
+	if got := gjson.GetBytes(result, "tools.0.type").String(); got != "image_generation" {
+		t.Fatalf("tools.0.type = %q, want image_generation; body=%s", got, result)
+	}
+}
+
 func TestEnsureImageGenerationTool_NoTools(t *testing.T) {
 	body := []byte(`{"model":"gpt-5.4","input":"draw a cat"}`)
-	result := ensureImageGenerationTool(body, "gpt-5.4", nil)
+	result := ensureImageGenerationTool(body, "gpt-5.4", nil, nil)
 
 	tools := gjson.GetBytes(result, "tools")
 	if !tools.IsArray() {
@@ -29,7 +117,7 @@ func TestEnsureImageGenerationTool_NoTools(t *testing.T) {
 
 func TestEnsureImageGenerationTool_ExistingToolsWithoutImageGen(t *testing.T) {
 	body := []byte(`{"model":"gpt-5.4","tools":[{"type":"function","name":"get_weather","parameters":{}}]}`)
-	result := ensureImageGenerationTool(body, "gpt-5.4", nil)
+	result := ensureImageGenerationTool(body, "gpt-5.4", nil, nil)
 
 	tools := gjson.GetBytes(result, "tools")
 	arr := tools.Array()
@@ -46,7 +134,7 @@ func TestEnsureImageGenerationTool_ExistingToolsWithoutImageGen(t *testing.T) {
 
 func TestEnsureImageGenerationTool_AlreadyPresent(t *testing.T) {
 	body := []byte(`{"model":"gpt-5.4","tools":[{"type":"image_generation","output_format":"webp"},{"type":"function","name":"f1"}]}`)
-	result := ensureImageGenerationTool(body, "gpt-5.4", nil)
+	result := ensureImageGenerationTool(body, "gpt-5.4", nil, nil)
 
 	tools := gjson.GetBytes(result, "tools")
 	arr := tools.Array()
@@ -60,7 +148,7 @@ func TestEnsureImageGenerationTool_AlreadyPresent(t *testing.T) {
 
 func TestEnsureImageGenerationTool_ImageGenNamespaceDoesNotInjectTool(t *testing.T) {
 	body := []byte(`{"model":"gpt-5.4","tools":[{"type":"namespace","name":"image_gen","tools":[{"type":"function","name":"imagegen","parameters":{}}]}]}`)
-	result := ensureImageGenerationTool(body, "gpt-5.4", nil)
+	result := ensureImageGenerationTool(body, "gpt-5.4", nil, nil)
 
 	if string(result) != string(body) {
 		t.Fatalf("expected body to be unchanged, got %s", string(result))
@@ -69,7 +157,7 @@ func TestEnsureImageGenerationTool_ImageGenNamespaceDoesNotInjectTool(t *testing
 
 func TestEnsureImageGenerationTool_FlattenedImageGenFunctionDoesNotInjectTool(t *testing.T) {
 	body := []byte(`{"model":"gpt-5.4","tools":[{"type":"function","name":"image_gen.imagegen","parameters":{}}]}`)
-	result := ensureImageGenerationTool(body, "gpt-5.4", nil)
+	result := ensureImageGenerationTool(body, "gpt-5.4", nil, nil)
 
 	if string(result) != string(body) {
 		t.Fatalf("expected body to be unchanged, got %s", string(result))
@@ -78,7 +166,7 @@ func TestEnsureImageGenerationTool_FlattenedImageGenFunctionDoesNotInjectTool(t 
 
 func TestEnsureImageGenerationTool_SimilarNamespaceStillInjectsTool(t *testing.T) {
 	body := []byte(`{"model":"gpt-5.4","tools":[{"type":"namespace","name":"image_tools","tools":[{"type":"function","name":"imagegen","parameters":{}}]}]}`)
-	result := ensureImageGenerationTool(body, "gpt-5.4", nil)
+	result := ensureImageGenerationTool(body, "gpt-5.4", nil, nil)
 
 	tools := gjson.GetBytes(result, "tools").Array()
 	if len(tools) != 2 {
@@ -91,7 +179,7 @@ func TestEnsureImageGenerationTool_SimilarNamespaceStillInjectsTool(t *testing.T
 
 func TestEnsureImageGenerationTool_EmptyToolsArray(t *testing.T) {
 	body := []byte(`{"model":"gpt-5.4","tools":[]}`)
-	result := ensureImageGenerationTool(body, "gpt-5.4", nil)
+	result := ensureImageGenerationTool(body, "gpt-5.4", nil, nil)
 
 	tools := gjson.GetBytes(result, "tools")
 	arr := tools.Array()
@@ -105,7 +193,7 @@ func TestEnsureImageGenerationTool_EmptyToolsArray(t *testing.T) {
 
 func TestEnsureImageGenerationTool_WebSearchAndImageGen(t *testing.T) {
 	body := []byte(`{"model":"gpt-5.4","tools":[{"type":"web_search"}]}`)
-	result := ensureImageGenerationTool(body, "gpt-5.4", nil)
+	result := ensureImageGenerationTool(body, "gpt-5.4", nil, nil)
 
 	tools := gjson.GetBytes(result, "tools")
 	arr := tools.Array()
@@ -122,7 +210,7 @@ func TestEnsureImageGenerationTool_WebSearchAndImageGen(t *testing.T) {
 
 func TestEnsureImageGenerationTool_GPT53CodexSparkDoesNotInjectTool(t *testing.T) {
 	body := []byte(`{"model":"gpt-5.3-codex-spark","input":"draw a cat"}`)
-	result := ensureImageGenerationTool(body, "gpt-5.3-codex-spark", nil)
+	result := ensureImageGenerationTool(body, "gpt-5.3-codex-spark", nil, nil)
 
 	if string(result) != string(body) {
 		t.Fatalf("expected body to be unchanged, got %s", string(result))
@@ -138,7 +226,7 @@ func TestEnsureImageGenerationTool_FreeCodexAuthDoesNotInjectTool(t *testing.T) 
 		Provider:   "codex",
 		Attributes: map[string]string{"plan_type": "free"},
 	}
-	result := ensureImageGenerationTool(body, "gpt-5.4", freeAuth)
+	result := ensureImageGenerationTool(body, "gpt-5.4", freeAuth, nil)
 
 	if string(result) != string(body) {
 		t.Fatalf("expected body to be unchanged, got %s", string(result))

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -212,7 +212,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
 	body = normalizeCodexInstructions(body)
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
-		body = ensureImageGenerationTool(body, baseModel, auth)
+		body = ensureImageGenerationTool(body, baseModel, auth, opts.Headers)
 	}
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex websockets executor", body)
 
@@ -434,7 +434,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	body, _ = sjson.SetBytes(body, "model", baseModel)
 	body = normalizeCodexInstructions(body)
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {
-		body = ensureImageGenerationTool(body, baseModel, auth)
+		body = ensureImageGenerationTool(body, baseModel, auth, opts.Headers)
 	}
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex websockets executor", body)
 

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -40,6 +40,64 @@ func TestBuildCodexWebsocketRequestBodyPreservesPreviousResponseID(t *testing.T)
 	}
 }
 
+func TestCodexWebsocketsExecuteResponsesLiteDoesNotInjectImageGenerationTool(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	capturedPayload := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade websocket: %v", err)
+		}
+		defer func() { _ = conn.Close() }()
+
+		_, payload, errRead := conn.ReadMessage()
+		if errRead != nil {
+			t.Fatalf("read upstream websocket message: %v", errRead)
+		}
+		capturedPayload <- bytes.Clone(payload)
+
+		completed := []byte(`{"type":"response.completed","response":{"id":"resp-1","output":[],"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0}}}`)
+		if errWrite := conn.WriteMessage(websocket.TextMessage, completed); errWrite != nil {
+			t.Fatalf("write completed websocket message: %v", errWrite)
+		}
+	}))
+	defer server.Close()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Attributes: map[string]string{
+			"api_key":   "sk-test",
+			"base_url":  server.URL,
+			"plan_type": "pro",
+		},
+	}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5.6-sol",
+		Payload: []byte(`{"model":"gpt-5.6-sol","input":[{"type":"additional_tools","role":"developer","tools":[{"type":"custom","name":"exec"}]},{"role":"user","content":"hello"}],"client_metadata":{"ws_request_header_x_openai_internal_codex_responses_lite":"true"}}`),
+	}
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("codex")}
+
+	if _, err := exec.Execute(context.Background(), auth, req, opts); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	select {
+	case payload := <-capturedPayload:
+		if tools := gjson.GetBytes(payload, "tools"); tools.Exists() {
+			t.Fatalf("unexpected tools in responses-lite upstream payload: %s", tools.Raw)
+		}
+		if got := gjson.GetBytes(payload, "input.0.type").String(); got != "additional_tools" {
+			t.Fatalf("input.0.type = %q, want additional_tools; payload=%s", got, payload)
+		}
+		if got := gjson.GetBytes(payload, "client_metadata.ws_request_header_x_openai_internal_codex_responses_lite").String(); got != "true" {
+			t.Fatalf("responses-lite metadata = %q, want true; payload=%s", got, payload)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for upstream websocket payload")
+	}
+}
+
 func TestCodexWebsocketsExecutePreservesPreviousResponseIDUpstream(t *testing.T) {
 	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
 	capturedPayload := make(chan []byte, 1)


### PR DESCRIPTION
## Type

- [x] Protected upstream full-sync
- [ ] Staged upstream full-sync
- [x] LTS protected-delta patch
- [x] LTS feature / downstream patch maintenance
- [ ] Maintenance docs / CI
- [ ] Emergency hotfix

## Upstream sync info

- Upstream repo: `router-for-me/CLIProxyAPI`
- Upstream branch: `main`
- Upstream from SHA: `ca67caf0872eef65f8eaedf2e127cf214a49621d` (`v7.2.61`)
- Upstream to SHA: `3554b63721aac9b4202bf2ef88ba7a82b4e5caf8`
- Sync branch: `codex/sync-upstream-post-v7.2.61-20260710`
- Stage: single stage; only 8 upstream commits, with one focused test conflict

## Summary

Absorbs the eight upstream commits after `v7.2.61`:

- responses-lite image-generation tool handling
- idempotent OAuth session completion and legacy getter cleanup
- plugin-store installed source identity preservation
- upstream model catalog removal of Ultra

The upstream Ultra catalog removal failed the existing LTS Ultra regressions. This PR therefore restores the LTS Ultra catalog entries and records the divergence in the downstream patch ledger.

## Protected delta checklist

- [x] `usage-statistics-enabled` still exists
- [x] `internal/usage/` still exists
- [x] `/v0/management/usage` still exists
- [x] `/v0/management/usage/export` still exists
- [x] `/v0/management/usage/import` still exists
- [x] `docs/lts/core-feature-contracts.yaml` reviewed
- [x] `docs/lts/downstream-patches.yaml` reviewed
- [x] Usage record creation/schema tested
- [x] Management usage response shape tested
- [x] Export/import behavior tests passed
- [x] Current CPA-Panel-LTS response shape remains backward compatible
- [x] Local auth/config/panel/release/source customizations reviewed

## LTS classification review

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| full-usage-statistics-core | retained capability | preserved | usage/Management contract tests and full test suite |
| management-usage-api | retained capability | preserved | management usage tests and route sentinels |
| panel-release-asset | retained capability | preserved | contract sentinels; source untouched |
| auth-identity-attribution | retained capability | adapted | OAuth session changes reviewed; auth and full tests passed |
| config-compatibility-and-hot-reload | retained capability | preserved | upstream range did not change config schema |
| codex-abnormal-reasoning-retry | LTS feature | preserved | executor and full tests passed |
| transient-error-cooldown-config | LTS feature | preserved | not touched |
| redis-compatible-usage-queue | LTS feature | preserved | usage/full tests passed |
| provider-runtime-usage-seams | review seam | reviewed | Codex HTTP/WebSocket image-tool changes tested |
| hf-space-runtime-smoke | validation profile | skipped | user scope ends at Core main; no HFS deployment |
| redis-queue-coexists-with-full-usage | relationship | preserved | full test suite |
| codex-image-generation-tool-dedup | downstream patch | upstream-equivalent | upstream `f9162d39` / `cfa90f9f`; state advanced to `removable`, named LTS tests retained |
| plugin-configured-enable-default | downstream patch | patch-still-required | no upstream equivalent in target range |
| codex-gpt56-ultra-level | downstream patch | adapted / patch-still-required | upstream `f084eefa` removed Ultra; LTS catalog restored and Ultra regressions passed |
| codex-model-header-provider-snapshot | downstream patch | patch-still-required | no upstream equivalent in target range |
| codex-websocket-reader-generation | downstream patch | patch-still-required | no upstream equivalent in target range |

- [x] This sync PR will use **Create a merge commit**; squash/rebase is forbidden.

## Conflict resolution notes

One textual conflict occurred in `internal/runtime/executor/codex_executor_imagegen_test.go`.

Resolution:

- retained the ledger-referenced LTS test names and stronger namespace assertions
- updated those tests for the upstream `headers http.Header` argument
- retained upstream responses-lite header/metadata tests
- retained the unrelated-namespace legacy fallback regression

The first full test run exposed a protected-delta regression: `f084eefa` removed Ultra from `models.json`, causing four `TestGPT56UltraCodexThinking` cases to fail. The LTS Ultra entries were restored in `47a12d5d`, the patch ledger was updated, and the complete suite then passed.

## Validation

- [x] `scripts/check-lts-contract.sh`
- [x] `go run ./scripts/ltsregistry --root .`
- [x] `go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'`
- [x] `go test ./internal/auth/...`
- [x] `go test ./internal/pluginstore ./internal/pluginhost`
- [x] `go test ./internal/runtime/executor`
- [x] `go test ./internal/translator/...`
- [x] `go test ./internal/registry`
- [x] `go test ./internal/thinking/... -count=1`
- [x] `go build -o test-output ./cmd/server && rm -f test-output`
- [x] `go test ./...`
- [x] `git diff --check`

## Optional real runtime smoke

- [x] Hugging Face Space smoke explicitly skipped
- Reason: this task is scoped to Core PR/main merge only; no release or HFS mutation is authorized.
