### PR TITLE
fix(usage): deduplicate cross-version cache imports

### DIFF
--- a/internal/api/handlers/management/usage_contract_test.go
+++ b/internal/api/handlers/management/usage_contract_test.go
@@ -227,6 +227,93 @@ func TestUsageManagementImportLegacyExportKeepsServiceTierUnknown(t *testing.T) 
 	}
 }
 
+func TestUsageManagementImportDeduplicatesLegacyAndCanonicalCacheCreation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	timestamp := time.Date(2026, 7, 11, 9, 30, 0, 0, time.UTC)
+	legacy := usageCacheCreationSnapshot(timestamp, usage.TokenStats{
+		InputTokens:         1200,
+		OutputTokens:        10,
+		CachedTokens:        1024,
+		CacheCreationTokens: 1024,
+		TotalTokens:         1210,
+	})
+	canonical := usageCacheCreationSnapshot(timestamp, usage.TokenStats{
+		InputTokens:         1200,
+		OutputTokens:        10,
+		CacheCreationTokens: 1024,
+		TotalTokens:         2234,
+	})
+
+	tests := []struct {
+		name            string
+		first           usage.StatisticsSnapshot
+		second          usage.StatisticsSnapshot
+		wantTotalTokens int64
+	}{
+		{
+			name:            "legacy then canonical",
+			first:           legacy,
+			second:          canonical,
+			wantTotalTokens: 1210,
+		},
+		{
+			name:            "canonical then legacy",
+			first:           canonical,
+			second:          legacy,
+			wantTotalTokens: 2234,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stats := usage.NewRequestStatistics()
+			h := &Handler{}
+			h.SetUsageStatistics(stats)
+
+			firstResult := importUsageStatistics(t, h, tt.first)
+			if firstResult.Added != 1 || firstResult.Skipped != 0 || firstResult.TotalRequests != 1 {
+				t.Fatalf("first import result = %+v, want added=1 skipped=0 total_requests=1", firstResult)
+			}
+
+			secondResult := importUsageStatistics(t, h, tt.second)
+			if secondResult.Added != 0 || secondResult.Skipped != 1 || secondResult.TotalRequests != 1 {
+				t.Fatalf("second import result = %+v, want added=0 skipped=1 total_requests=1", secondResult)
+			}
+
+			snapshot := stats.Snapshot()
+			model := snapshot.APIs["cache-key"].Models["gpt-5.6-sol"]
+			if snapshot.TotalRequests != 1 || snapshot.TotalTokens != tt.wantTotalTokens || len(model.Details) != 1 {
+				t.Fatalf("snapshot after imports = requests:%d tokens:%d details:%d, want 1/%d/1", snapshot.TotalRequests, snapshot.TotalTokens, len(model.Details), tt.wantTotalTokens)
+			}
+			if snapshot.RequestsByDay["2026-07-11"] != 1 || snapshot.RequestsByHour["09"] != 1 {
+				t.Fatalf("request buckets after imports = day:%v hour:%v, want one request", snapshot.RequestsByDay, snapshot.RequestsByHour)
+			}
+			if snapshot.TokensByDay["2026-07-11"] != tt.wantTotalTokens || snapshot.TokensByHour["09"] != tt.wantTotalTokens {
+				t.Fatalf("token buckets after imports = day:%v hour:%v, want %d", snapshot.TokensByDay, snapshot.TokensByHour, tt.wantTotalTokens)
+			}
+		})
+	}
+}
+
+func usageCacheCreationSnapshot(timestamp time.Time, tokens usage.TokenStats) usage.StatisticsSnapshot {
+	return usage.StatisticsSnapshot{
+		APIs: map[string]usage.APISnapshot{
+			"cache-key": {
+				Models: map[string]usage.ModelSnapshot{
+					"gpt-5.6-sol": {
+						Details: []usage.RequestDetail{{
+							Timestamp: timestamp,
+							Source:    "auths/codex.json",
+							AuthIndex: "0",
+							Tokens:    tokens,
+						}},
+					},
+				},
+			},
+		},
+	}
+}
+
 func recordPanelContractUsage(stats *usage.RequestStatistics) {
 	stats.Record(context.Background(), coreusage.Record{
 		APIKey:          "panel-client-key",

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -396,8 +396,25 @@ func (s *RequestStatistics) recordImported(apiName, modelName string, stats *api
 func dedupKey(apiName, modelName string, detail RequestDetail) string {
 	timestamp := detail.Timestamp.UTC().Format(time.RFC3339Nano)
 	tokens := normaliseTokenStats(detail.Tokens)
+	cacheReadTokens := tokens.CacheReadTokens
+	legacyCacheCreationAlias := tokens.CacheCreationTokens > 0 &&
+		cacheReadTokens == 0 &&
+		tokens.CachedTokens == tokens.CacheCreationTokens
+	if cacheReadTokens == 0 && !legacyCacheCreationAlias {
+		cacheReadTokens = tokens.CachedTokens
+	}
+
+	totalTokensFallback := int64(0)
+	if tokens.InputTokens == 0 &&
+		tokens.OutputTokens == 0 &&
+		tokens.ReasoningTokens == 0 &&
+		cacheReadTokens == 0 &&
+		tokens.CacheCreationTokens == 0 {
+		totalTokensFallback = tokens.TotalTokens
+	}
+
 	return fmt.Sprintf(
-		"%s|%s|%s|%s|%s|%t|%s|%d|%d|%d|%d|%d|%d",
+		"%s|%s|%s|%s|%s|%t|%s|%d|%d|%d|%d|%d|%d|%d",
 		apiName,
 		modelName,
 		timestamp,
@@ -409,8 +426,9 @@ func dedupKey(apiName, modelName string, detail RequestDetail) string {
 		tokens.InputTokens,
 		tokens.OutputTokens,
 		tokens.ReasoningTokens,
-		tokens.CachedTokens,
-		tokens.TotalTokens,
+		cacheReadTokens,
+		tokens.CacheCreationTokens,
+		totalTokensFallback,
 	)
 }
 

--- a/internal/usage/logger_plugin_test.go
+++ b/internal/usage/logger_plugin_test.go
@@ -306,3 +306,146 @@ func TestRequestStatisticsMergeSnapshotDedupIgnoresLatencyAndServiceTier(t *test
 		t.Fatalf("service_tier = %q, want legacy unknown to remain empty", details[0].ServiceTier)
 	}
 }
+
+func TestRequestStatisticsMergeSnapshotDeduplicatesLegacyAndCanonicalCacheCreation(t *testing.T) {
+	timestamp := time.Date(2026, 7, 11, 9, 30, 0, 0, time.UTC)
+	legacy := cacheCreationSnapshot(timestamp, TokenStats{
+		InputTokens:         1200,
+		OutputTokens:        10,
+		CachedTokens:        1024,
+		CacheCreationTokens: 1024,
+		TotalTokens:         1210,
+	})
+	canonical := cacheCreationSnapshot(timestamp, TokenStats{
+		InputTokens:         1200,
+		OutputTokens:        10,
+		CacheCreationTokens: 1024,
+		TotalTokens:         2234,
+	})
+
+	tests := []struct {
+		name            string
+		first           StatisticsSnapshot
+		second          StatisticsSnapshot
+		wantTotalTokens int64
+	}{
+		{
+			name:            "legacy then canonical",
+			first:           legacy,
+			second:          canonical,
+			wantTotalTokens: 1210,
+		},
+		{
+			name:            "canonical then legacy",
+			first:           canonical,
+			second:          legacy,
+			wantTotalTokens: 2234,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stats := NewRequestStatistics()
+
+			result := stats.MergeSnapshot(tt.first)
+			if result.Added != 1 || result.Skipped != 0 {
+				t.Fatalf("first merge = %+v, want added=1 skipped=0", result)
+			}
+
+			result = stats.MergeSnapshot(tt.second)
+			if result.Added != 0 || result.Skipped != 1 {
+				t.Fatalf("second merge = %+v, want added=0 skipped=1", result)
+			}
+
+			snapshot := stats.Snapshot()
+			model := snapshot.APIs["cache-key"].Models["gpt-5.6-sol"]
+			if snapshot.TotalRequests != 1 || snapshot.SuccessCount != 1 || snapshot.FailureCount != 0 {
+				t.Fatalf("snapshot request totals = requests:%d success:%d failure:%d, want 1/1/0", snapshot.TotalRequests, snapshot.SuccessCount, snapshot.FailureCount)
+			}
+			if snapshot.TotalTokens != tt.wantTotalTokens || model.TotalTokens != tt.wantTotalTokens {
+				t.Fatalf("snapshot token totals = total:%d model:%d, want %d", snapshot.TotalTokens, model.TotalTokens, tt.wantTotalTokens)
+			}
+			if len(model.Details) != 1 {
+				t.Fatalf("details len = %d, want 1", len(model.Details))
+			}
+			if snapshot.RequestsByDay["2026-07-11"] != 1 || snapshot.RequestsByHour["09"] != 1 {
+				t.Fatalf("request buckets = day:%v hour:%v, want one request", snapshot.RequestsByDay, snapshot.RequestsByHour)
+			}
+			if snapshot.TokensByDay["2026-07-11"] != tt.wantTotalTokens || snapshot.TokensByHour["09"] != tt.wantTotalTokens {
+				t.Fatalf("token buckets = day:%v hour:%v, want %d", snapshot.TokensByDay, snapshot.TokensByHour, tt.wantTotalTokens)
+			}
+		})
+	}
+}
+
+func TestRequestStatisticsMergeSnapshotCacheCreationAliasDoesNotHideCacheReadAndWrite(t *testing.T) {
+	timestamp := time.Date(2026, 7, 11, 9, 30, 0, 0, time.UTC)
+	creationOnly := cacheCreationSnapshot(timestamp, TokenStats{
+		InputTokens:         1200,
+		OutputTokens:        10,
+		CachedTokens:        1024,
+		CacheCreationTokens: 1024,
+		TotalTokens:         1210,
+	})
+	readAndWrite := cacheCreationSnapshot(timestamp, TokenStats{
+		InputTokens:         1200,
+		OutputTokens:        10,
+		CachedTokens:        1024,
+		CacheReadTokens:     1024,
+		CacheCreationTokens: 1024,
+		TotalTokens:         3258,
+	})
+
+	stats := NewRequestStatistics()
+	if result := stats.MergeSnapshot(creationOnly); result.Added != 1 || result.Skipped != 0 {
+		t.Fatalf("creation-only merge = %+v, want added=1 skipped=0", result)
+	}
+	if result := stats.MergeSnapshot(readAndWrite); result.Added != 1 || result.Skipped != 0 {
+		t.Fatalf("read-and-write merge = %+v, want added=1 skipped=0", result)
+	}
+
+	snapshot := stats.Snapshot()
+	details := snapshot.APIs["cache-key"].Models["gpt-5.6-sol"].Details
+	if snapshot.TotalRequests != 2 || len(details) != 2 {
+		t.Fatalf("merged requests = total:%d details:%d, want 2/2", snapshot.TotalRequests, len(details))
+	}
+}
+
+func TestRequestStatisticsMergeSnapshotTotalOnlyIdentityRemainsDistinct(t *testing.T) {
+	timestamp := time.Date(2026, 7, 11, 9, 30, 0, 0, time.UTC)
+	first := cacheCreationSnapshot(timestamp, TokenStats{TotalTokens: 100})
+	second := cacheCreationSnapshot(timestamp, TokenStats{TotalTokens: 200})
+
+	stats := NewRequestStatistics()
+	if result := stats.MergeSnapshot(first); result.Added != 1 || result.Skipped != 0 {
+		t.Fatalf("first total-only merge = %+v, want added=1 skipped=0", result)
+	}
+	if result := stats.MergeSnapshot(second); result.Added != 1 || result.Skipped != 0 {
+		t.Fatalf("second total-only merge = %+v, want added=1 skipped=0", result)
+	}
+
+	snapshot := stats.Snapshot()
+	details := snapshot.APIs["cache-key"].Models["gpt-5.6-sol"].Details
+	if snapshot.TotalRequests != 2 || snapshot.TotalTokens != 300 || len(details) != 2 {
+		t.Fatalf("total-only snapshot = requests:%d tokens:%d details:%d, want 2/300/2", snapshot.TotalRequests, snapshot.TotalTokens, len(details))
+	}
+}
+
+func cacheCreationSnapshot(timestamp time.Time, tokens TokenStats) StatisticsSnapshot {
+	return StatisticsSnapshot{
+		APIs: map[string]APISnapshot{
+			"cache-key": {
+				Models: map[string]ModelSnapshot{
+					"gpt-5.6-sol": {
+						Details: []RequestDetail{{
+							Timestamp: timestamp,
+							Source:    "auths/codex.json",
+							AuthIndex: "0",
+							Tokens:    tokens,
+						}},
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Outcome and critical boundary

This patch prevents the same cache-creation request from being counted twice when usage snapshots cross the legacy and current cache token representations.

- Legacy creation-only records may carry `cached_tokens == cache_creation_tokens` while current records keep cache writes only in `cache_creation_tokens`.
- Their derived `total_tokens` can also differ even though they describe the same request.
- This change canonicalizes only the import dedup identity. It does **not** rewrite imported details, alter the export/import payload, enrich an already stored record, or change the Management response shape.
- Historical duplicates that were already imported are not retroactively collapsed.
- Merge with **Create a merge commit**. This PR is not released or deployed.

## Type

- [ ] Protected upstream full-sync
- [ ] Staged upstream full-sync
- [x] LTS protected-delta patch
- [ ] LTS feature / downstream patch maintenance
- [ ] Maintenance docs / CI
- [ ] Emergency hotfix

## Root cause

`dedupKey` used legacy `cached_tokens` and derived `total_tokens`, but did not canonicalize `cache_read_tokens` and `cache_creation_tokens`. The same creation-only request therefore produced different identities before and after the cache-write accounting correction.

The regression loop failed in both directions before the implementation change:

```text
legacy -> canonical: second merge {Added:1 Skipped:0}
canonical -> legacy: second merge {Added:1 Skipped:0}
```

The Management import path likewise returned `total_requests: 2` for the same request.

## Changes

- Treat the legacy creation alias (`cache_creation_tokens > 0`, no explicit cache read, and `cached_tokens == cache_creation_tokens`) as zero canonical cache-read tokens.
- Prefer explicit `cache_read_tokens`; otherwise retain legacy `cached_tokens` as the canonical read value.
- Include canonical cache-read and cache-creation values in the dedup identity.
- Ignore derived `total_tokens` when any token component is available; retain it as a fallback identity only for total-only legacy details.
- Add bidirectional unit and Management JSON import regressions.
- Prove that a real cache read plus cache write does not collide with a creation-only alias, and that distinct total-only records remain distinct.

## Compatibility and data integrity

- The first imported representation remains stored exactly as normalized by the existing import path; a later equivalent representation is skipped.
- Request totals, token totals, day/hour buckets, success/failure state, auth attribution, `service_tier`, and export shape are unchanged.
- `/v0/management/usage`, `/usage/export`, and `/usage/import` keep their existing response and payload contracts.
- Redis queue behavior is untouched and its package tests pass.
- CPA-Panel-LTS remains compatible. Its advisory preflight remains useful for older Core versions that do not contain this fix.

## Protected delta checklist

- [x] `usage-statistics-enabled` still exists
- [x] `internal/usage/` still exists
- [x] `/v0/management/usage` still exists
- [x] `/v0/management/usage/export` still exists
- [x] `/v0/management/usage/import` still exists
- [x] `docs/lts/core-feature-contracts.yaml` reviewed; behavior tests cover the stable contract and no brittle marker is needed
- [x] `docs/lts/downstream-patches.yaml` reviewed; no downstream patch entry changes
- [x] Usage record creation/schema reviewed and tested
- [x] Management usage response shape and JSON import reviewed and tested
- [x] Export/import compatibility reviewed and tested
- [x] CPA-Panel-LTS compatibility reviewed
- [x] Auth/config/panel/release/source customizations reviewed and unaffected

## LTS classification review

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| `full-usage-statistics-core` | LTS feature | adapted | Canonical import identity plus bidirectional unit regressions; full usage tests pass |
| `management-usage-api` | LTS feature | adapted | `/usage/import` JSON regressions prove `added`, `skipped`, and `total_requests` |
| `redis-compatible-usage-queue` | LTS feature | preserved | No wire change; `go test ./internal/redisqueue -count=1` passes |

## Conflict resolution notes

No merge conflict or upstream sync is included. The branch is based directly on the current `origin/main`; upstream drift is intentionally out of scope.

## Validation

Passed on the final branch tree:

- [x] `go test ./internal/usage -count=1`
- [x] `go test ./internal/api/handlers/management -run 'Usage|usage' -count=1`
- [x] `go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage' -count=1`
- [x] `go test ./internal/redisqueue -count=1`
- [x] `scripts/check-lts-contract.sh`
- [x] `go run ./scripts/ltsregistry --root .`
- [x] `go build -o test-output ./cmd/server && rm -f test-output`
- [x] `go test ./...`
- [x] `git diff --check`

## Optional real runtime smoke

- [x] Skipped intentionally: this is an in-memory import identity fix covered through the real Management handler; no release, tag, HFS deployment, or runtime mutation is in scope.

## Review focus

1. Confirm the legacy creation alias cannot hide an explicit cache read plus cache write.
2. Confirm ignoring derived totals is limited to records with a component breakdown.
3. Confirm stored details and external JSON shapes remain unchanged.

Draft only. Not merged, released, or deployed.
