### PR TITLE
fix(codex): preserve GPT-5.6 Ultra across catalog refreshes

### DIFF
--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -21,6 +21,11 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      - name: Validate GPT-5.6 Ultra compatibility
+        run: |
+          go test ./internal/registry ./internal/thinking \
+            ./internal/runtime/executor ./sdk/api/handlers/openai \
+            -run 'GPT56|Ultra|CodexWire' -count=1
       - name: Build
         run: |
           go build -o test-output ./cmd/server

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,37 @@ env:
   RELEASE_TAG: ${{ github.event.inputs.release_tag || github.ref_name }}
 
 jobs:
+  validate-release-catalog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.release_tag || github.ref }}
+          fetch-depth: 0
+      - name: Refresh models catalog
+        run: |
+          set -euo pipefail
+          git fetch --depth 1 https://github.com/router-for-me/models.git main
+          git show FETCH_HEAD:models.json > internal/registry/models/models.json
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - name: Validate GPT-5.6 Ultra compatibility
+        run: |
+          go test ./internal/registry ./internal/thinking \
+            ./internal/runtime/executor ./sdk/api/handlers/openai \
+            -run 'GPT56|Ultra|CodexWire' -count=1
+      - name: Upload validated models catalog
+        uses: actions/upload-artifact@v4
+        with:
+          name: validated-models-catalog
+          path: internal/registry/models/models.json
+          if-no-files-found: error
+          retention-days: 1
+
   prepare-release:
+    needs: validate-release-catalog
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -145,12 +175,11 @@ jobs:
         with:
           ref: ${{ github.event.inputs.release_tag || github.ref }}
           fetch-depth: 0
-      - name: Refresh models catalog
-        shell: bash
-        run: |
-          set -euo pipefail
-          git fetch --depth 1 https://github.com/router-for-me/models.git main
-          git show FETCH_HEAD:models.json > internal/registry/models/models.json
+      - name: Download validated models catalog
+        uses: actions/download-artifact@v4
+        with:
+          name: validated-models-catalog
+          path: internal/registry/models
       - name: Fetch tags
         shell: bash
         run: git fetch --force --tags
@@ -279,12 +308,11 @@ jobs:
         with:
           ref: ${{ github.event.inputs.release_tag || github.ref }}
           fetch-depth: 0
-      - name: Refresh models catalog
-        shell: bash
-        run: |
-          set -euo pipefail
-          git fetch --depth 1 https://github.com/router-for-me/models.git main
-          git show FETCH_HEAD:models.json > internal/registry/models/models.json
+      - name: Download validated models catalog
+        uses: actions/download-artifact@v4
+        with:
+          name: validated-models-catalog
+          path: internal/registry/models
       - name: Fetch tags
         shell: bash
         run: git fetch --force --tags
@@ -426,12 +454,11 @@ jobs:
         with:
           ref: ${{ github.event.inputs.release_tag || github.ref }}
           fetch-depth: 0
-      - name: Refresh models catalog
-        shell: bash
-        run: |
-          set -euo pipefail
-          git fetch --depth 1 https://github.com/router-for-me/models.git main
-          git show FETCH_HEAD:models.json > internal/registry/models/models.json
+      - name: Download validated models catalog
+        uses: actions/download-artifact@v4
+        with:
+          name: validated-models-catalog
+          path: internal/registry/models
       - name: Fetch tags
         shell: bash
         run: git fetch --force --tags
@@ -573,10 +600,11 @@ jobs:
         with:
           ref: ${{ github.event.inputs.release_tag || github.ref }}
           fetch-depth: 0
-      - name: Refresh models catalog
-        run: |
-          git fetch --depth 1 https://github.com/router-for-me/models.git main
-          git show FETCH_HEAD:models.json > internal/registry/models/models.json
+      - name: Download validated models catalog
+        uses: actions/download-artifact@v4
+        with:
+          name: validated-models-catalog
+          path: internal/registry/models
       - name: Fetch tags
         run: git fetch --force --tags
       - uses: actions/setup-go@v6

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -49,12 +49,19 @@ patches:
     retire_when: Upstream preserves the configured plugin enable default through both YAML parsing and runtime host synthesis, and all listed tests pass without the downstream implementation.
 
   - id: codex-gpt56-ultra-level
-    reason: Temporary downstream compatibility patch after upstream added partial GPT-5.6 Ultra client metadata and then removed Ultra from models.json. CPA-Core-LTS preserves the catalog/client preset boundary while canonicalizing known Sol/Terra Ultra requests to reasoning.effort=max on the final HTTP/WebSocket wire.
+    reason: Temporary downstream compatibility patch after upstream added partial GPT-5.6 Ultra client metadata and then removed Ultra from models.json. The official models catalog refreshed by PR and release builds remains max-only, so CPA-Core-LTS applies a stable non-generated Codex capability overlay for logical Sol/Terra Ultra while keeping Luna max-only, then canonicalizes supported Ultra requests to reasoning.effort=max on the final HTTP/WebSocket wire.
     introduced_in: 6e12fb1dd6d522ca80a02644d286d765d7a649bd
-    affected_upstream_range: LTS baseline through 3554b63721aac9b4202bf2ef88ba7a82b4e5caf8; upstream added partial client metadata at 20e61f281f4b88e150c5cdfa81c3315d9fcfeabe and removed Ultra from models.json at f084eefae6a9aa67c273a697e4c3fdfc15102032, but still lacks the shared thinking level, model-aware custom-model behavior, payload-override-safe final wire canonicalization, usage/retry alignment, and HTTP/WebSocket regression coverage
+    affected_upstream_range: LTS baseline through 3554b63721aac9b4202bf2ef88ba7a82b4e5caf8; upstream added partial client metadata at 20e61f281f4b88e150c5cdfa81c3315d9fcfeabe and removed Ultra from models.json at f084eefae6a9aa67c273a697e4c3fdfc15102032, while router-for-me/models.git main at 9e658ffbc94b0d46392019c59d47d7dc7e5a2b96 still exposes Sol/Terra/Luna only through max; neither source provides the stable provider lookup/tier overlay, model-aware custom-model behavior, payload-override-safe final wire canonicalization, usage/retry alignment, or HTTP/WebSocket regression coverage
     files:
+      - .github/workflows/pr-test-build.yml
+      - .github/workflows/release.yaml
       - config.example.yaml
       - docs/lts/codex-client-context-degradation-defense.md
+      - internal/registry/codex_compatibility.go
+      - internal/registry/codex_gpt56_compatibility_test.go
+      - internal/registry/model_definitions.go
+      - internal/registry/model_registry.go
+      - internal/registry/models/models.json
       - internal/thinking/types.go
       - internal/thinking/suffix.go
       - internal/thinking/validate.go
@@ -75,8 +82,13 @@ patches:
       - TestGPT56MaxCodexThinkingPreserved
       - TestUnknownCustomCodexModelPreservesLiteralUltra
       - TestUltraClampsToMaxWhenCrossProviderTargetStopsAtMax
+      - TestCodexGPT56UltraCompatibilityCoversStaticTierModels
+      - TestLookupModelInfoAppliesCodexGPT56UltraCompatibility
+      - TestLookupModelInfoAppliesCodexGPT56UltraCompatibilityToDynamicProviderInfo
+      - TestLookupModelInfoDoesNotApplyCodexGPT56UltraCompatibilityToOtherProviders
       - TestCanonicalCodexWireEffortIsModelAware
       - TestNormalizeCodexReasoningEffortForWire
+      - TestNormalizeCodexReasoningEffortForWirePreservesUserDefinedGPT56Ultra
       - TestCodexExecutorExecuteCanonicalizesGPT56UltraFinalWire
       - TestCodexExecutorExecutePreservesGPT56MaxFinalWire
       - TestCodexExecutorExecuteStreamCanonicalizesGPT56UltraSuffixFinalWire

--- a/internal/registry/codex_compatibility.go
+++ b/internal/registry/codex_compatibility.go
@@ -1,0 +1,44 @@
+package registry
+
+import "strings"
+
+var codexGPT56UltraCompatibilityLevels = []string{"low", "medium", "high", "xhigh", "max", "ultra"}
+
+// withCodexCompatibility applies LTS client compatibility metadata to cloned
+// Codex model definitions. The remote models catalog remains authoritative for
+// server wire capabilities; this overlay only preserves logical client presets
+// that CPA-Core-LTS canonicalizes before the request reaches Codex upstream.
+func withCodexCompatibility(models []*ModelInfo) []*ModelInfo {
+	for _, model := range models {
+		applyCodexCompatibility(model)
+	}
+	return models
+}
+
+// applyCodexCompatibility mutates a cloned model definition in place.
+func applyCodexCompatibility(model *ModelInfo) *ModelInfo {
+	if model == nil || model.UserDefined {
+		return model
+	}
+	if model.ID != "gpt-5.6-sol" && model.ID != "gpt-5.6-terra" {
+		return model
+	}
+
+	if model.Thinking == nil {
+		model.Thinking = &ThinkingSupport{
+			Levels: append([]string(nil), codexGPT56UltraCompatibilityLevels...),
+		}
+		return model
+	}
+	if len(model.Thinking.Levels) == 0 {
+		model.Thinking.Levels = append([]string(nil), codexGPT56UltraCompatibilityLevels...)
+		return model
+	}
+	for _, level := range model.Thinking.Levels {
+		if strings.EqualFold(strings.TrimSpace(level), "ultra") {
+			return model
+		}
+	}
+	model.Thinking.Levels = append(model.Thinking.Levels, "ultra")
+	return model
+}

--- a/internal/registry/codex_gpt56_compatibility_test.go
+++ b/internal/registry/codex_gpt56_compatibility_test.go
@@ -1,0 +1,133 @@
+package registry
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCodexGPT56UltraCompatibilityCoversStaticTierModels(t *testing.T) {
+	tiers := map[string]func() []*ModelInfo{
+		"free": GetCodexFreeModels,
+		"team": GetCodexTeamModels,
+		"plus": GetCodexPlusModels,
+		"pro":  GetCodexProModels,
+	}
+	seen := map[string]bool{}
+
+	for tier, getModels := range tiers {
+		for _, model := range getModels() {
+			if model == nil {
+				continue
+			}
+			switch model.ID {
+			case "gpt-5.6-sol", "gpt-5.6-terra":
+				seen[model.ID] = true
+				if !modelHasThinkingLevel(model, "ultra") {
+					t.Errorf("%s tier %s levels = %v, want logical ultra compatibility", tier, model.ID, thinkingLevels(model))
+				}
+			case "gpt-5.6-luna":
+				seen[model.ID] = true
+				if modelHasThinkingLevel(model, "ultra") {
+					t.Errorf("%s tier %s levels = %v, want max-only", tier, model.ID, thinkingLevels(model))
+				}
+			}
+		}
+	}
+
+	for _, modelID := range []string{"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"} {
+		if !seen[modelID] {
+			t.Fatalf("Codex tier models missing %s", modelID)
+		}
+	}
+}
+
+func TestLookupModelInfoAppliesCodexGPT56UltraCompatibility(t *testing.T) {
+	tests := []struct {
+		modelID   string
+		wantUltra bool
+	}{
+		{modelID: "gpt-5.6-sol", wantUltra: true},
+		{modelID: "gpt-5.6-terra", wantUltra: true},
+		{modelID: "gpt-5.6-luna", wantUltra: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.modelID, func(t *testing.T) {
+			info := LookupModelInfo(tt.modelID, "codex")
+			if info == nil {
+				t.Fatalf("LookupModelInfo(%q, codex) = nil", tt.modelID)
+			}
+			if got := modelHasThinkingLevel(info, "ultra"); got != tt.wantUltra {
+				t.Fatalf("LookupModelInfo(%q, codex) levels = %v, ultra=%t want %t", tt.modelID, thinkingLevels(info), got, tt.wantUltra)
+			}
+		})
+	}
+}
+
+func TestLookupModelInfoAppliesCodexGPT56UltraCompatibilityToDynamicProviderInfo(t *testing.T) {
+	registryRef := GetGlobalRegistry()
+	clientID := "test-codex-gpt56-ultra-compatibility"
+	registryRef.RegisterClient(clientID, "codex", []*ModelInfo{
+		maxOnlyGPT56Model("gpt-5.6-sol"),
+		maxOnlyGPT56Model("gpt-5.6-terra"),
+		maxOnlyGPT56Model("gpt-5.6-luna"),
+	})
+	t.Cleanup(func() { registryRef.UnregisterClient(clientID) })
+
+	for _, tt := range []struct {
+		modelID   string
+		wantUltra bool
+	}{
+		{modelID: "gpt-5.6-sol", wantUltra: true},
+		{modelID: "gpt-5.6-terra", wantUltra: true},
+		{modelID: "gpt-5.6-luna", wantUltra: false},
+	} {
+		info := LookupModelInfo(tt.modelID, "codex")
+		if info == nil {
+			t.Fatalf("dynamic LookupModelInfo(%q, codex) = nil", tt.modelID)
+		}
+		if got := modelHasThinkingLevel(info, "ultra"); got != tt.wantUltra {
+			t.Fatalf("dynamic LookupModelInfo(%q, codex) levels = %v, ultra=%t want %t", tt.modelID, thinkingLevels(info), got, tt.wantUltra)
+		}
+	}
+}
+
+func TestLookupModelInfoDoesNotApplyCodexGPT56UltraCompatibilityToOtherProviders(t *testing.T) {
+	registryRef := GetGlobalRegistry()
+	clientID := "test-openai-gpt56-no-ultra-compatibility"
+	registryRef.RegisterClient(clientID, "openai", []*ModelInfo{maxOnlyGPT56Model("gpt-5.6-sol")})
+	t.Cleanup(func() { registryRef.UnregisterClient(clientID) })
+
+	info := LookupModelInfo("gpt-5.6-sol", "openai")
+	if info == nil {
+		t.Fatal("LookupModelInfo(gpt-5.6-sol, openai) = nil")
+	}
+	if modelHasThinkingLevel(info, "ultra") {
+		t.Fatalf("non-Codex provider levels = %v, want no logical ultra overlay", thinkingLevels(info))
+	}
+}
+
+func maxOnlyGPT56Model(modelID string) *ModelInfo {
+	return &ModelInfo{
+		ID: modelID,
+		Thinking: &ThinkingSupport{
+			Levels: []string{"low", "medium", "high", "xhigh", "max"},
+		},
+	}
+}
+
+func modelHasThinkingLevel(model *ModelInfo, want string) bool {
+	for _, level := range thinkingLevels(model) {
+		if strings.EqualFold(strings.TrimSpace(level), want) {
+			return true
+		}
+	}
+	return false
+}
+
+func thinkingLevels(model *ModelInfo) []string {
+	if model == nil || model.Thinking == nil {
+		return nil
+	}
+	return model.Thinking.Levels
+}

--- a/internal/registry/model_definitions.go
+++ b/internal/registry/model_definitions.go
@@ -52,22 +52,22 @@ func GetAIStudioModels() []*ModelInfo {
 
 // GetCodexFreeModels returns model definitions for the Codex free plan tier.
 func GetCodexFreeModels() []*ModelInfo {
-	return WithCodexBuiltins(cloneModelInfos(getModels().CodexFree))
+	return withCodexCompatibility(WithCodexBuiltins(cloneModelInfos(getModels().CodexFree)))
 }
 
 // GetCodexTeamModels returns model definitions for the Codex team plan tier.
 func GetCodexTeamModels() []*ModelInfo {
-	return WithCodexBuiltins(cloneModelInfos(getModels().CodexTeam))
+	return withCodexCompatibility(WithCodexBuiltins(cloneModelInfos(getModels().CodexTeam)))
 }
 
 // GetCodexPlusModels returns model definitions for the Codex plus plan tier.
 func GetCodexPlusModels() []*ModelInfo {
-	return WithCodexBuiltins(cloneModelInfos(getModels().CodexPlus))
+	return withCodexCompatibility(WithCodexBuiltins(cloneModelInfos(getModels().CodexPlus)))
 }
 
 // GetCodexProModels returns model definitions for the Codex pro plan tier.
 func GetCodexProModels() []*ModelInfo {
-	return WithCodexBuiltins(cloneModelInfos(getModels().CodexPro))
+	return withCodexCompatibility(WithCodexBuiltins(cloneModelInfos(getModels().CodexPro)))
 }
 
 // GetKimiModels returns the standard Kimi (Moonshot AI) model definitions.

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -192,9 +192,17 @@ func LookupModelInfo(modelID string, provider ...string) *ModelInfo {
 	}
 
 	if info := GetGlobalRegistry().GetModelInfo(modelID, p); info != nil {
-		return cloneModelInfo(info)
+		info = cloneModelInfo(info)
+		if p == "codex" {
+			return applyCodexCompatibility(info)
+		}
+		return info
 	}
-	return cloneModelInfo(LookupStaticModelInfo(modelID))
+	info := cloneModelInfo(LookupStaticModelInfo(modelID))
+	if p == "codex" {
+		return applyCodexCompatibility(info)
+	}
+	return info
 }
 
 // ModelOverrideHeaders returns models.json config.override_header for the model, if any.

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -1449,8 +1449,7 @@
           "medium",
           "high",
           "xhigh",
-          "max",
-          "ultra"
+          "max"
         ]
       }
     },
@@ -1598,8 +1597,7 @@
           "medium",
           "high",
           "xhigh",
-          "max",
-          "ultra"
+          "max"
         ]
       }
     },
@@ -1623,8 +1621,7 @@
           "medium",
           "high",
           "xhigh",
-          "max",
-          "ultra"
+          "max"
         ]
       }
     },
@@ -1795,8 +1792,7 @@
           "medium",
           "high",
           "xhigh",
-          "max",
-          "ultra"
+          "max"
         ]
       }
     },
@@ -1820,8 +1816,7 @@
           "medium",
           "high",
           "xhigh",
-          "max",
-          "ultra"
+          "max"
         ]
       }
     },
@@ -1992,8 +1987,7 @@
           "medium",
           "high",
           "xhigh",
-          "max",
-          "ultra"
+          "max"
         ]
       }
     },
@@ -2017,8 +2011,7 @@
           "medium",
           "high",
           "xhigh",
-          "max",
-          "ultra"
+          "max"
         ]
       }
     },

--- a/internal/thinking/codex_wire_test.go
+++ b/internal/thinking/codex_wire_test.go
@@ -90,3 +90,25 @@ func TestNormalizeCodexReasoningEffortForWire(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeCodexReasoningEffortForWirePreservesUserDefinedGPT56Ultra(t *testing.T) {
+	registryRef := registry.GetGlobalRegistry()
+	clientID := "test-user-defined-gpt56-ultra-passthrough"
+	registryRef.RegisterClient(clientID, "codex", []*registry.ModelInfo{{
+		ID:          "gpt-5.6-sol",
+		UserDefined: true,
+		Thinking: &registry.ThinkingSupport{
+			Levels: []string{"low", "medium", "high", "xhigh", "max"},
+		},
+	}})
+	t.Cleanup(func() { registryRef.UnregisterClient(clientID) })
+
+	body := []byte(`{"reasoning":{"effort":"ultra"}}`)
+	out, err := thinking.NormalizeCodexReasoningEffortForWire(body, "gpt-5.6-sol")
+	if err != nil {
+		t.Fatalf("NormalizeCodexReasoningEffortForWire() error = %v", err)
+	}
+	if got := gjson.GetBytes(out, "reasoning.effort").String(); got != "ultra" {
+		t.Fatalf("reasoning.effort = %q, want literal ultra for user-defined model; body=%s", got, out)
+	}
+}


### PR DESCRIPTION
## Outcome and critical release boundary

This patch makes the existing GPT-5.6 logical Ultra compatibility survive the exact model-catalog refresh used by PR and release builds.

- `router-for-me/models.git/main@9e658ffbc94b0d46392019c59d47d7dc7e5a2b96` advertises Sol, Terra, and Luna only through `max`.
- CPA-Core-LTS now applies a stable code overlay only for known, non-user-defined Codex `gpt-5.6-sol` and `gpt-5.6-terra`, then keeps the existing final-wire mapping `ultra -> max`.
- `gpt-5.6-luna` remains max-only. Other providers, unknown/custom models, and `UserDefined` Codex models remain literal passthrough.
- The generated `models.json` is restored to the official max-only content instead of carrying a hand-maintained Ultra edit.
- Release validation now runs before a GitHub release is created, and every platform build consumes the same validated catalog artifact.
- Merge with **Create a merge commit**. This PR does not create a release or tag and does not deploy HFS.

## Type

- [ ] Protected upstream full-sync
- [ ] Staged upstream full-sync
- [ ] LTS protected-delta patch
- [x] LTS feature / downstream patch maintenance
- [ ] Maintenance docs / CI
- [ ] Emergency hotfix

## Root cause and red evidence

The final-wire guard resolves capability through `registry.LookupModelInfo(model, "codex")` and requires the model's `Thinking.Levels` to include logical `ultra`. PR/release builds replace the checked-in model catalog with the official max-only catalog, so the previous hand-edited metadata disappeared from the actual build tree.

After restoring the official catalog and before adding the overlay, the release-path command failed across the real behavior surface:

```text
level "ultra" not supported, valid levels: low, medium, high, xhigh, max
```

Failures included:

- static Codex tier models and provider-specific dynamic lookup;
- thinking body/suffix shaping for Sol and Terra;
- HTTP, compact, CountTokens, abnormal retry, and WebSocket execution;
- the SDK client metadata test still passed, proving that `codex_client_models.json` alone did not protect runtime behavior.

## Changes

### Stable Codex compatibility overlay

- Add a registry compatibility helper that appends logical `ultra` only to non-user-defined Sol/Terra metadata.
- Apply it to all Codex free/team/plus/pro tier getters.
- Apply it after provider-specific dynamic lookup and static fallback in `LookupModelInfo(..., "codex")`.
- Preserve Luna, other providers, unknown models, and UserDefined behavior.
- Add registry regressions for tier models, static lookup, dynamic provider lookup, cross-provider isolation, and Luna.
- Add an end-to-end UserDefined same-ID passthrough regression.

### Generated catalog and patch ledger

- Remove the seven hand-restored `ultra` entries from `internal/registry/models/models.json`.
- Keep the checked-in file byte-identical to current official `models.git/main` for the exercised snapshot.
- Update `codex-gpt56-ultra-level` in the downstream patch ledger with the stable overlay, workflow seams, current models.git evidence, and new regressions.

### PR and release gates

- PR build: refresh `models.json`, run the GPT-5.6 Ultra/Max behavior suite, then build.
- Release: refresh and test the catalog in a dedicated validation job **before** `prepare-release` can create/edit a release.
- Upload the exact tested `models.json` as a short-lived workflow artifact.
- Replace per-platform re-fetches with downloads of that same validated artifact, preventing catalog drift between validation and platform builds.

## Compatibility

- Final upstream wire semantics remain unchanged: supported Sol/Terra logical Ultra is sent as `reasoning.effort=max`.
- Existing literal `max` is unchanged and never remapped twice.
- Luna Ultra remains locally rejected.
- Unknown/custom/UserDefined models preserve literal Ultra.
- No Management API, usage/export/import, auth, config, Panel response shape, dependency, release asset name, or binary packaging format changes.
- The release workflow graph changes, but no release trigger, tag pattern, upload target, or permission is broadened.

## Protected delta checklist

- [x] `usage-statistics-enabled` and full built-in usage remain present and unchanged
- [x] `/v0/management/usage*` and usage queue remain present and unchanged
- [x] `docs/lts/core-feature-contracts.yaml` reviewed; no new brittle sentinel is needed
- [x] `docs/lts/downstream-patches.yaml` adapted for `codex-gpt56-ultra-level`
- [x] Model resolution, payload override, retry, HTTP/WebSocket, and final usage alignment reviewed and tested
- [x] Management usage response shape reviewed and unaffected
- [x] CPA-Panel-LTS compatibility reviewed; final recorded wire effort remains `max`
- [x] Release source, asset names, tag trigger, and upload paths reviewed and preserved

## LTS classification review

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| `codex-gpt56-ultra-level` | downstream patch | adapted | Stable registry overlay replaces generated-catalog dependence; full Ultra/Max regressions pass after official refresh |
| Codex provider model lookup | review seam | adapted | Static tier and provider-specific dynamic lookup tests cover Sol/Terra/Luna and other-provider isolation |
| PR catalog refresh gate | validation profile | newly-added | Current official catalog is refreshed before the focused behavior suite and build |
| Release catalog/build coupling | validation profile | newly-added | Release creation depends on validation; all platform jobs download the exact validated catalog artifact |
| usage and Redis accounting | retained capability | preserved | Usage and Redis package tests plus full suite pass; no schema or aggregation change |

## Conflict resolution notes

No upstream merge or conflict resolution is included. New upstream Core drift is intentionally excluded. The generated catalog is aligned to the independent official models repository rather than used as the durable LTS compatibility source.

## Validation

Passed on the final branch tree:

- [x] Official catalog readback: `models.git/main@9e658ffbc94b0d46392019c59d47d7dc7e5a2b96` is max-only for Sol/Terra/Luna
- [x] Release rehearsal: refresh the latest official catalog, run the focused behavior suite, then build the server
- [x] `go test ./internal/registry ./internal/thinking ./internal/runtime/executor ./sdk/api/handlers/openai -run 'GPT56|Ultra|CodexWire' -count=1`
- [x] `go test ./internal/registry -count=1`
- [x] `go test ./internal/thinking/... -count=1`
- [x] `go test ./internal/runtime/executor -run 'Ultra|Max|Reasoning|Retry|Websocket|WebSocket' -count=1`
- [x] `go test ./internal/runtime/executor -count=1`
- [x] `go test ./sdk/api/handlers/openai -run 'GPT56|Ultra|Max|CodexClient' -count=1`
- [x] `go test ./internal/usage ./internal/redisqueue -count=1`
- [x] `go test -race ./internal/registry ./internal/thinking -run 'GPT56|Ultra|CodexWire' -count=1`
- [x] `scripts/check-lts-contract.sh`
- [x] `go run ./scripts/ltsregistry --root .`
- [x] `go build -o test-output ./cmd/server && rm -f test-output`
- [x] `go test ./...`
- [x] `actionlint .github/workflows/pr-test-build.yml .github/workflows/release.yaml`
- [x] YAML parse and `git diff --check`

## Remaining release-context boundary

The real tag-triggered release workflow was not executed because this PR intentionally creates no tag or release. Local rehearsal proves the refreshed catalog and behavior/build commands; `actionlint` and YAML parsing prove workflow structure. GitHub Actions must still confirm the PR refresh gate on this exact head.

## Review focus

1. Confirm the registry overlay is limited to Codex non-UserDefined Sol/Terra and cannot broaden Luna or other providers.
2. Confirm both tier lists and provider-specific dynamic lookup receive the overlay.
3. Confirm the release job cannot create a release before catalog behavior validation succeeds.
4. Confirm every platform build receives the same validated catalog artifact rather than re-fetching a moving target.

Draft only. Not merged, released, tagged, or deployed.
