### PR TITLE
fix(codex): finalize OAuth identity and scope model-not-found 404s

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -386,8 +386,11 @@ nonstream-keepalive-interval: 0
 # These are used only for file-backed/OAuth Codex requests when the client
 # does not send the header. `user-agent` applies to HTTP and websocket requests;
 # `beta-features` only applies to websocket requests. They do not apply to codex-api-key entries.
+# Final outbound OAuth requests derive `originator` from the selected official Codex
+# `user-agent`; an explicitly supplied `Version` lower than that UA's engine version
+# is raised to match, while an omitted `Version` remains omitted.
 # codex-header-defaults:
-#   user-agent: "codex_cli_rs/0.114.0 (Mac OS 14.2.0; x86_64) vscode/1.111.0"
+#   user-agent: "codex_cli_rs/0.144.1 (Mac OS 14.2.0; x86_64) vscode/1.111.0"
 #   beta-features: "multi_agent"
 
 # OpenAI compatibility providers

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -126,6 +126,42 @@ patches:
     state: required
     retire_when: Upstream resolves model headers by provider-owned immutable snapshot and uses the same snapshot for every Codex transport handshake and connection identity, with all listed regression tests passing after the downstream implementation is removed.
 
+  - id: codex-oauth-client-identity-finalization
+    reason: Codex OAuth requests must finalize the official Originator, User-Agent, optional Version floor, and macOS Session_id after model-specific header overrides; otherwise the backend can reject a valid model route with a misleading 404 Model not found response.
+    introduced_in: ded0314d23dc38656e2fb02220504bd98373813c
+    affected_upstream_range: LTS baseline through 3554b63721aac9b4202bf2ef88ba7a82b4e5caf8 (v7.2.62); upstream/main through e99a2056baa981345f4a93600039725363ffca46 (v7.2.66) has no equivalent final identity pass shared by HTTP, compact, streaming, WebSocket, and image paths
+    files:
+      - config.example.yaml
+      - internal/runtime/executor/codex_client_identity.go
+      - internal/runtime/executor/codex_client_identity_test.go
+      - internal/runtime/executor/codex_executor.go
+      - internal/runtime/executor/codex_openai_images.go
+      - internal/runtime/executor/codex_websockets_executor.go
+    regression_tests:
+      - TestCodexExecutorFinalizesLunaClientIdentityVersion
+      - TestCodexWebsocketsExecutorFinalizesClientIdentity
+      - TestFinalizeCodexClientIdentityHeaders
+      - TestCodexDirectImageOAuthFinalizesClientIdentity
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: Upstream finalizes one coherent official Codex OAuth identity after every model/header override across HTTP, compact, streaming, WebSocket, and image transports; preserves API-key requests and omitted Version headers; and all listed regressions pass after removing the downstream implementation.
+
+  - id: codex-model-not-found-request-scope
+    reason: An OpenAI-style 404 with error.type invalid_request_error and error.param model is a request/model routing failure, not evidence of unhealthy Codex credentials; retrying every auth or applying the generic 12-hour model cooldown can suspend the entire model pool.
+    introduced_in: ded0314d23dc38656e2fb02220504bd98373813c
+    affected_upstream_range: LTS baseline through 3554b63721aac9b4202bf2ef88ba7a82b4e5caf8 (v7.2.62); upstream/main through e99a2056baa981345f4a93600039725363ffca46 (v7.2.66) still applies generic 404 retry and cooldown handling without this typed request-scope boundary
+    files:
+      - sdk/cliproxy/auth/conductor.go
+      - sdk/cliproxy/auth/conductor_overrides_test.go
+    regression_tests:
+      - TestManager_MarkResult_CodexModelNotFoundDoesNotCooldownAuth
+      - TestManager_CodexModelNotFoundStopsRetryWithoutSuspendingAuth
+      - TestIsRequestScopedModelNotFoundMessage
+      - TestManager_MarkResult_GenericNotFoundStillCooldownsModel
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: Upstream recognizes only the typed invalid_request_error model 404 as request-scoped, stops futile cross-auth retries without marking credentials or the model unavailable, preserves generic 404 cooldown behavior, and all listed regressions pass after removing the downstream implementation.
+
   - id: codex-websocket-reader-generation
     reason: Reusable Codex WebSocket sessions need generation ownership so a stale reader or shutdown race cannot deliver to, clear, close, or deadlock a newer request.
     introduced_in: 0877a26d333a3be918f5e48aadf0e4d71709ab2f

--- a/internal/runtime/executor/codex_client_identity.go
+++ b/internal/runtime/executor/codex_client_identity.go
@@ -1,0 +1,202 @@
+package executor
+
+import (
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+const codexClientIdentityMaxLength = 64
+
+var codexClientVersionPattern = regexp.MustCompile(`^[vV]?(\d+)\.(\d+)\.(\d+)`)
+
+// codexOfficialClientOriginators mirrors Codex first-party originators plus
+// currently observed official CLI, extension, desktop, exec, and SDK variants.
+var codexOfficialClientOriginators = map[string]string{
+	"codex_cli_rs":          "codex_cli_rs",
+	"codex-tui":             "codex-tui",
+	"codex_vscode":          "codex_vscode",
+	"codex_vscode_copilot":  "codex_vscode_copilot",
+	"codex_app":             "codex_app",
+	"codex_chatgpt_desktop": "codex_chatgpt_desktop",
+	"codex_atlas":           "codex_atlas",
+	"codex_exec":            "codex_exec",
+	"codex_sdk_ts":          "codex_sdk_ts",
+}
+
+// applyFinalCodexClientHeaders applies model-specific overrides first and then
+// normalizes the resulting OAuth identity. Keeping the order in one helper
+// prevents new HTTP, streaming, websocket, or image paths from finalizing a
+// pre-profile header set by mistake.
+func applyFinalCodexClientHeaders(headers http.Header, profile codexModelHeaderProfile, auth *cliproxyauth.Auth) {
+	applyModelHeaderOverrides(headers, profile)
+	finalizeCodexClientIdentityHeaders(headers, auth)
+}
+
+// finalizeCodexClientIdentityHeaders normalizes the final ChatGPT Codex OAuth
+// client identity after downstream headers, config defaults, custom auth headers,
+// and model-specific header profiles have all been applied.
+//
+// The upstream Codex backend validates originator together with the first
+// User-Agent segment. A mismatch can be reported as a misleading 404 Model not
+// found response. When Version is present, keep it at least as new as the engine
+// version advertised by the final User-Agent. Requests that omit Version keep it
+// omitted because the backend does not require the header unconditionally.
+func finalizeCodexClientIdentityHeaders(headers http.Header, auth *cliproxyauth.Auth) {
+	if headers == nil || codexAuthUsesAPIKey(auth) {
+		return
+	}
+	if strings.TrimSpace(headers.Get("Originator")) == "" {
+		return
+	}
+
+	originator, userAgent, ok := pairCodexClientIdentity(headers.Get("User-Agent"))
+	if !ok {
+		originator = codexOriginator
+		userAgent = codexUserAgent
+	}
+	headers.Set("Originator", originator)
+	headers.Set("User-Agent", userAgent)
+	alignCodexClientVersion(headers, userAgent)
+	if strings.Contains(userAgent, "Mac OS") && codexSessionHeaderValue(headers) == "" {
+		headers.Set("Session_id", uuid.NewString())
+	}
+}
+
+// pairCodexClientIdentity derives the upstream originator from the final
+// User-Agent. It also restores the real client identity from the trailing
+// codex-rs `(name; version)` group when an originator override changed only the
+// leading User-Agent segment.
+func pairCodexClientIdentity(userAgent string) (originator string, pairedUserAgent string, ok bool) {
+	userAgent = strings.TrimSpace(userAgent)
+	slash := strings.IndexByte(userAgent, '/')
+	if slash <= 0 {
+		return "", "", false
+	}
+
+	if leading, valid := canonicalCodexClientOriginator(strings.TrimSpace(userAgent[:slash])); valid {
+		return leading, leading + userAgent[slash:], true
+	}
+
+	trailer := codexUserAgentTrailerOriginator(userAgent)
+	if strings.ContainsRune(trailer, '/') {
+		return "", "", false
+	}
+	if trailer, valid := canonicalCodexClientOriginator(trailer); valid {
+		return trailer, trailer + userAgent[slash:], true
+	}
+	return "", "", false
+}
+
+func canonicalCodexClientOriginator(originator string) (string, bool) {
+	originator = strings.TrimSpace(originator)
+	if !isSaneCodexClientOriginator(originator) {
+		return "", false
+	}
+	if canonical, ok := codexOfficialClientOriginators[strings.ToLower(originator)]; ok {
+		return canonical, true
+	}
+	if strings.HasPrefix(originator, "Codex ") {
+		return originator, true
+	}
+	return "", false
+}
+
+func isSaneCodexClientOriginator(originator string) bool {
+	if originator == "" || len(originator) > codexClientIdentityMaxLength {
+		return false
+	}
+	for i := 0; i < len(originator); i++ {
+		if originator[i] < 0x20 || originator[i] > 0x7e {
+			return false
+		}
+	}
+	return true
+}
+
+func codexUserAgentTrailerOriginator(userAgent string) string {
+	lastOpen := strings.LastIndex(userAgent, "(")
+	if lastOpen < 0 {
+		return ""
+	}
+	rest := userAgent[lastOpen+1:]
+	closeIndex := strings.IndexByte(rest, ')')
+	if closeIndex < 0 {
+		return ""
+	}
+	inner := strings.TrimSpace(rest[:closeIndex])
+	if semicolon := strings.IndexByte(inner, ';'); semicolon >= 0 {
+		inner = strings.TrimSpace(inner[:semicolon])
+	}
+	return inner
+}
+
+func alignCodexClientVersion(headers http.Header, userAgent string) {
+	version := strings.TrimSpace(headers.Get("Version"))
+	if version == "" {
+		return
+	}
+
+	engineVersion, engineParts, ok := codexEngineReleaseVersion(userAgent)
+	if !ok {
+		return
+	}
+	currentParts, comparable := parseCodexReleaseVersion(version)
+	if !comparable || compareCodexReleaseVersions(currentParts, engineParts) < 0 {
+		headers.Set("Version", engineVersion)
+	}
+}
+
+func codexEngineReleaseVersion(userAgent string) (string, [3]int64, bool) {
+	userAgent = strings.TrimSpace(userAgent)
+	slash := strings.IndexByte(userAgent, '/')
+	if slash < 0 || slash+1 >= len(userAgent) {
+		return "", [3]int64{}, false
+	}
+	rest := strings.TrimSpace(userAgent[slash+1:])
+	matches := codexClientVersionPattern.FindStringSubmatch(rest)
+	if len(matches) != 4 {
+		return "", [3]int64{}, false
+	}
+	parts, ok := parseCodexVersionMatches(matches)
+	if !ok {
+		return "", [3]int64{}, false
+	}
+	return strings.Join(matches[1:4], "."), parts, true
+}
+
+func parseCodexReleaseVersion(version string) ([3]int64, bool) {
+	matches := codexClientVersionPattern.FindStringSubmatch(strings.TrimSpace(version))
+	if len(matches) != 4 {
+		return [3]int64{}, false
+	}
+	return parseCodexVersionMatches(matches)
+}
+
+func parseCodexVersionMatches(matches []string) ([3]int64, bool) {
+	var parts [3]int64
+	for i := range parts {
+		value, err := strconv.ParseInt(matches[i+1], 10, 64)
+		if err != nil || value < 0 {
+			return [3]int64{}, false
+		}
+		parts[i] = value
+	}
+	return parts, true
+}
+
+func compareCodexReleaseVersions(left, right [3]int64) int {
+	for i := range left {
+		if left[i] < right[i] {
+			return -1
+		}
+		if left[i] > right[i] {
+			return 1
+		}
+	}
+	return 0
+}

--- a/internal/runtime/executor/codex_client_identity_test.go
+++ b/internal/runtime/executor/codex_client_identity_test.go
@@ -1,0 +1,324 @@
+package executor
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+func TestCodexExecutorFinalizesLunaClientIdentityVersion(t *testing.T) {
+	capturedHeaders := make(chan http.Header, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeaders <- r.Header.Clone()
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\",\"object\":\"response\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":0,\"output_tokens\":0,\"total_tokens\":0}}}\n\n"))
+	}))
+	defer server.Close()
+
+	exec := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Attributes: map[string]string{
+			"base_url":  server.URL,
+			"plan_type": "pro",
+		},
+		Metadata: map[string]any{
+			"access_token": "test-token",
+		},
+	}
+	ctx := contextWithGinHeaders(map[string]string{
+		"Originator": "Codex Desktop",
+		"User-Agent": "codex_cli_rs/0.115.0 (Mac OS 14.2.0; arm64) iTerm.app",
+		"Version":    "0.115.0-alpha.27",
+	})
+
+	_, err := exec.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.6-luna",
+		Payload: []byte(`{"model":"gpt-5.6-luna","input":"hello","store":false}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	select {
+	case headers := <-capturedHeaders:
+		const wantUA = "codex-tui/0.144.0 (Mac OS 26.5.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.144.0)"
+		if got := headers.Get("User-Agent"); got != wantUA {
+			t.Fatalf("User-Agent = %q, want %q", got, wantUA)
+		}
+		if got := headers.Get("Originator"); got != "codex-tui" {
+			t.Fatalf("Originator = %q, want codex-tui", got)
+		}
+		if got := headers.Get("Version"); got != "0.144.0" {
+			t.Fatalf("Version = %q, want 0.144.0", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Codex HTTP request")
+	}
+}
+
+func TestCodexWebsocketsExecutorFinalizesClientIdentity(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	capturedHeaders := make(chan http.Header, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeaders <- r.Header.Clone()
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		_, payload, errRead := conn.ReadMessage()
+		if errRead != nil {
+			t.Errorf("read upstream websocket message: %v", errRead)
+			return
+		}
+		if !bytes.Contains(payload, []byte(`"model":"gpt-5.4"`)) {
+			t.Errorf("upstream payload missing model: %s", payload)
+			return
+		}
+		completed := []byte(`{"type":"response.completed","response":{"id":"resp-2","output":[],"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0}}}`)
+		if errWrite := conn.WriteMessage(websocket.TextMessage, completed); errWrite != nil {
+			t.Errorf("write completed websocket message: %v", errWrite)
+		}
+	}))
+	defer server.Close()
+
+	exec := NewCodexWebsocketsExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Attributes: map[string]string{
+			"base_url":  server.URL,
+			"plan_type": "pro",
+		},
+		Metadata: map[string]any{
+			"access_token": "test-token",
+		},
+	}
+	ctx := contextWithGinHeaders(map[string]string{
+		"Originator": "Codex Desktop",
+		"User-Agent": "codex_cli_rs/0.144.1 (Mac OS 14.2.0; arm64) iTerm.app",
+		"Version":    "0.115.0-alpha.27",
+	})
+
+	_, err := exec.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.4",
+		Payload: []byte(`{"model":"gpt-5.4","input":"hello","store":false}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("codex")})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	select {
+	case headers := <-capturedHeaders:
+		if got := headers.Get("User-Agent"); got != "codex_cli_rs/0.144.1 (Mac OS 14.2.0; arm64) iTerm.app" {
+			t.Fatalf("User-Agent = %q, want preserved official CLI UA", got)
+		}
+		if got := headers.Get("Originator"); got != "codex_cli_rs" {
+			t.Fatalf("Originator = %q, want codex_cli_rs", got)
+		}
+		if got := headers.Get("Version"); got != "0.144.1" {
+			t.Fatalf("Version = %q, want 0.144.1", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Codex websocket request")
+	}
+}
+
+func TestFinalizeCodexClientIdentityHeaders(t *testing.T) {
+	tests := []struct {
+		name           string
+		auth           *cliproxyauth.Auth
+		originator     string
+		userAgent      string
+		version        string
+		wantOriginator string
+		wantUserAgent  string
+		wantVersion    string
+		wantSession    bool
+	}{
+		{
+			name:           "pairs official CLI and raises old version",
+			auth:           &cliproxyauth.Auth{Provider: "codex"},
+			originator:     "Codex Desktop",
+			userAgent:      "codex_cli_rs/0.144.1 (Mac OS 14.2.0; arm64) iTerm.app",
+			version:        "0.115.0-alpha.27",
+			wantOriginator: "codex_cli_rs",
+			wantUserAgent:  "codex_cli_rs/0.144.1 (Mac OS 14.2.0; arm64) iTerm.app",
+			wantVersion:    "0.144.1",
+			wantSession:    true,
+		},
+		{
+			name:           "keeps omitted version omitted",
+			auth:           &cliproxyauth.Auth{Provider: "codex"},
+			originator:     "codex_cli_rs",
+			userAgent:      "codex-tui/0.144.0 (Linux 6.8; x86_64) xterm",
+			wantOriginator: "codex-tui",
+			wantUserAgent:  "codex-tui/0.144.0 (Linux 6.8; x86_64) xterm",
+		},
+		{
+			name:           "preserves higher explicit version",
+			auth:           &cliproxyauth.Auth{Provider: "codex"},
+			originator:     "codex-tui",
+			userAgent:      "codex-tui/0.144.0 (Linux 6.8; x86_64) xterm",
+			version:        "0.145.0-beta.1",
+			wantOriginator: "codex-tui",
+			wantUserAgent:  "codex-tui/0.144.0 (Linux 6.8; x86_64) xterm",
+			wantVersion:    "0.145.0-beta.1",
+		},
+		{
+			name:           "restores originator override from trailer",
+			auth:           &cliproxyauth.Auth{Provider: "codex"},
+			originator:     "cccc",
+			userAgent:      "cccc/0.144.1 (Linux 6.8; x86_64) xterm (codex-tui; 0.144.1)",
+			version:        "invalid",
+			wantOriginator: "codex-tui",
+			wantUserAgent:  "codex-tui/0.144.1 (Linux 6.8; x86_64) xterm (codex-tui; 0.144.1)",
+			wantVersion:    "0.144.1",
+		},
+		{
+			name:           "preserves Codex family identity",
+			auth:           &cliproxyauth.Auth{Provider: "codex"},
+			originator:     "codex_cli_rs",
+			userAgent:      "Codex Desktop/1.2.3 (Mac OS 14.2.0; arm64)",
+			version:        "1.0.0",
+			wantOriginator: "Codex Desktop",
+			wantUserAgent:  "Codex Desktop/1.2.3 (Mac OS 14.2.0; arm64)",
+			wantVersion:    "1.2.3",
+			wantSession:    true,
+		},
+		{
+			name:           "falls back from third party identity",
+			auth:           &cliproxyauth.Auth{Provider: "codex"},
+			originator:     "opencode",
+			userAgent:      "third-party/9.9.9",
+			version:        "0.1.0",
+			wantOriginator: codexOriginator,
+			wantUserAgent:  codexUserAgent,
+			wantVersion:    "0.135.0",
+			wantSession:    true,
+		},
+		{
+			name:           "rejects control characters in Codex family identity",
+			auth:           &cliproxyauth.Auth{Provider: "codex"},
+			originator:     "Codex Desktop",
+			userAgent:      "Codex \x01evil/9.9.9",
+			version:        "0.1.0",
+			wantOriginator: codexOriginator,
+			wantUserAgent:  codexUserAgent,
+			wantVersion:    "0.135.0",
+			wantSession:    true,
+		},
+		{
+			name: "does not rewrite API key requests",
+			auth: &cliproxyauth.Auth{Provider: "codex", Attributes: map[string]string{
+				"api_key": "sk-test",
+			}},
+			originator:     "custom-origin",
+			userAgent:      "custom-client/1.0.0",
+			version:        "0.1.0",
+			wantOriginator: "custom-origin",
+			wantUserAgent:  "custom-client/1.0.0",
+			wantVersion:    "0.1.0",
+		},
+		{
+			name:          "does not inject a missing originator",
+			auth:          &cliproxyauth.Auth{Provider: "codex"},
+			userAgent:     "third-party/1.0.0",
+			version:       "0.1.0",
+			wantUserAgent: "third-party/1.0.0",
+			wantVersion:   "0.1.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			headers := make(http.Header)
+			if tt.originator != "" {
+				headers.Set("Originator", tt.originator)
+			}
+			if tt.userAgent != "" {
+				headers.Set("User-Agent", tt.userAgent)
+			}
+			if tt.version != "" {
+				headers.Set("Version", tt.version)
+			}
+
+			finalizeCodexClientIdentityHeaders(headers, tt.auth)
+
+			if got := headers.Get("Originator"); got != tt.wantOriginator {
+				t.Fatalf("Originator = %q, want %q", got, tt.wantOriginator)
+			}
+			if got := headers.Get("User-Agent"); got != tt.wantUserAgent {
+				t.Fatalf("User-Agent = %q, want %q", got, tt.wantUserAgent)
+			}
+			if got := headers.Get("Version"); got != tt.wantVersion {
+				t.Fatalf("Version = %q, want %q", got, tt.wantVersion)
+			}
+			if gotSession := codexSessionHeaderValue(headers) != ""; gotSession != tt.wantSession {
+				t.Fatalf("Session_id present = %v, want %v", gotSession, tt.wantSession)
+			}
+		})
+	}
+}
+
+func TestCodexDirectImageOAuthFinalizesClientIdentity(t *testing.T) {
+	capturedHeaders := make(chan http.Header, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeaders <- r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"created":1713833628,"data":[{"b64_json":"AA=="}]}`))
+	}))
+	defer server.Close()
+
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Attributes: map[string]string{
+			"base_url":  server.URL,
+			"plan_type": "pro",
+		},
+		Metadata: map[string]any{
+			"access_token": "test-token",
+		},
+	}
+	ctx := contextWithGinHeaders(map[string]string{
+		"Originator": "Codex Desktop",
+		"User-Agent": "third-party/9.9.9",
+		"Version":    "0.115.0-alpha.27",
+	})
+
+	exec := NewCodexExecutor(&config.Config{})
+	_, err := exec.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "codex/gpt-image-1.5",
+		Payload: []byte(`{"model":"codex/gpt-image-1.5","prompt":"hello","n":1,"size":"1024x1024"}`),
+	}, codexOpenAIImageTestOptions(codexImagesGenerationsPath, false))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	select {
+	case headers := <-capturedHeaders:
+		if got := headers.Get("User-Agent"); got != codexUserAgent {
+			t.Fatalf("User-Agent = %q, want %q", got, codexUserAgent)
+		}
+		if got := headers.Get("Originator"); got != codexOriginator {
+			t.Fatalf("Originator = %q, want %q", got, codexOriginator)
+		}
+		if got := headers.Get("Version"); got != "0.135.0" {
+			t.Fatalf("Version = %q, want 0.135.0", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for direct image request")
+	}
+}

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -895,7 +895,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		return resp, err
 	}
 	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
-	applyModelHeaderOverrides(httpReq.Header, modelHeaderProfile)
+	applyFinalCodexClientHeaders(httpReq.Header, modelHeaderProfile, auth)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
@@ -1090,7 +1090,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 		return resp, err
 	}
 	applyCodexHeaders(httpReq, auth, apiKey, false, e.cfg)
-	applyModelHeaderOverrides(httpReq.Header, modelHeaderProfile)
+	applyFinalCodexClientHeaders(httpReq.Header, modelHeaderProfile, auth)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
@@ -1216,7 +1216,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		return nil, err
 	}
 	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
-	applyModelHeaderOverrides(httpReq.Header, modelHeaderProfile)
+	applyFinalCodexClientHeaders(httpReq.Header, modelHeaderProfile, auth)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {

--- a/internal/runtime/executor/codex_openai_images.go
+++ b/internal/runtime/executor/codex_openai_images.go
@@ -114,7 +114,7 @@ func (e *CodexExecutor) executeOpenAIImage(ctx context.Context, auth *cliproxyau
 		return resp, errCache
 	}
 	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
-	applyModelHeaderOverrides(httpReq.Header, modelHeaderProfile)
+	applyFinalCodexClientHeaders(httpReq.Header, modelHeaderProfile, auth)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
 	recordCodexOpenAIImageRequest(ctx, e.cfg, e.Identifier(), auth, url, httpReq.Header.Clone(), body)
 
@@ -212,7 +212,7 @@ func (e *CodexExecutor) executeOpenAIImageStream(ctx context.Context, auth *clip
 		return nil, errCache
 	}
 	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
-	applyModelHeaderOverrides(httpReq.Header, modelHeaderProfile)
+	applyFinalCodexClientHeaders(httpReq.Header, modelHeaderProfile, auth)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
 	recordCodexOpenAIImageRequest(ctx, e.cfg, e.Identifier(), auth, url, httpReq.Header.Clone(), body)
 
@@ -340,7 +340,7 @@ func (e *CodexExecutor) executeDirectOpenAIImage(ctx context.Context, auth *clip
 		return resp, errCache
 	}
 	applyCodexDirectImageHeaders(httpReq, auth, apiKey, false, e.cfg)
-	applyModelHeaderOverrides(httpReq.Header, modelHeaderProfile)
+	applyFinalCodexClientHeaders(httpReq.Header, modelHeaderProfile, auth)
 	if contentType != "" {
 		httpReq.Header.Set("Content-Type", contentType)
 	}
@@ -402,7 +402,7 @@ func (e *CodexExecutor) executeDirectOpenAIImageStream(ctx context.Context, auth
 		return nil, errCache
 	}
 	applyCodexDirectImageHeaders(httpReq, auth, apiKey, true, e.cfg)
-	applyModelHeaderOverrides(httpReq.Header, modelHeaderProfile)
+	applyFinalCodexClientHeaders(httpReq.Header, modelHeaderProfile, auth)
 	if contentType != "" {
 		httpReq.Header.Set("Content-Type", contentType)
 	}

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -383,7 +383,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	upstreamBody, identityState := applyCodexIdentityConfuseBody(e.cfg, auth, originalPayloadSource, body)
 	reporter.SetTranslatedReasoningEffort(clientBody, to.String())
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
-	applyModelHeaderOverrides(wsHeaders, modelHeaderProfile)
+	applyFinalCodexClientHeaders(wsHeaders, modelHeaderProfile, auth)
 	applyCodexIdentityConfuseHeaders(wsHeaders, &identityState)
 
 	var authID, authLabel, authType, authValue string
@@ -622,7 +622,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	upstreamBody, identityState := applyCodexIdentityConfuseBody(e.cfg, auth, userPayload, body)
 	reporter.SetTranslatedReasoningEffort(clientBody, to.String())
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
-	applyModelHeaderOverrides(wsHeaders, modelHeaderProfile)
+	applyFinalCodexClientHeaders(wsHeaders, modelHeaderProfile, auth)
 	applyCodexIdentityConfuseHeaders(wsHeaders, &identityState)
 
 	var authID, authLabel, authType, authValue string

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -4617,9 +4617,37 @@ func isRequestScopedNotFoundMessage(message string) bool {
 		return false
 	}
 	lower := strings.ToLower(message)
-	return strings.Contains(lower, "item with id") &&
+	if strings.Contains(lower, "item with id") &&
 		strings.Contains(lower, "not found") &&
-		strings.Contains(lower, "items are not persisted when `store` is set to false")
+		strings.Contains(lower, "items are not persisted when `store` is set to false") {
+		return true
+	}
+	return isRequestScopedModelNotFoundMessage(message)
+}
+
+// isRequestScopedModelNotFoundMessage identifies the OpenAI-style 404 emitted
+// when request/model routing or Codex client identity is rejected. This shape
+// is not evidence of unhealthy credentials, and penalizing each auth can
+// otherwise suspend an entire model pool for hours.
+func isRequestScopedModelNotFoundMessage(message string) bool {
+	lower := strings.ToLower(strings.TrimSpace(message))
+	if !strings.Contains(lower, "model not found") || !strings.Contains(lower, "invalid_request_error") {
+		return false
+	}
+
+	var payload struct {
+		Error struct {
+			Type  string `json:"type"`
+			Param any    `json:"param"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(message), &payload); err == nil {
+		return strings.EqualFold(strings.TrimSpace(payload.Error.Type), "invalid_request_error") &&
+			strings.EqualFold(strings.TrimSpace(fmt.Sprint(payload.Error.Param)), "model")
+	}
+
+	compact := strings.NewReplacer(" ", "", "\t", "", "\r", "", "\n", "").Replace(lower)
+	return strings.Contains(compact, `"param":"model"`) || strings.Contains(compact, "param=model")
 }
 
 func isRequestScopedNotFoundResultError(err *Error) bool {
@@ -4632,9 +4660,10 @@ func isRequestScopedNotFoundResultError(err *Error) bool {
 // isRequestInvalidError returns true if the error represents a client request
 // error that should not be retried. Specifically, it treats 400 responses with
 // "invalid_request_error", request-scoped 404 item misses caused by `store=false`,
-// and all 422 responses as request-shape failures, where switching auths or
-// pooled upstream models will not help. Model-support errors are excluded so
-// routing can fall through to another auth or upstream.
+// OpenAI-style 404 model-routing failures, and all 422 responses as request-shape
+// failures, where switching auths or pooled upstream models will not help.
+// Model-support errors are excluded so routing can fall through to another auth
+// or upstream.
 func isRequestInvalidError(err error) bool {
 	if err == nil {
 		return false

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -15,6 +15,8 @@ import (
 
 const requestScopedNotFoundMessage = "Item with id 'rs_0b5f3eb6f51f175c0169ca74e4a85881998539920821603a74' not found. Items are not persisted when `store` is set to false. Try again with `store` set to true, or remove this item from your input."
 
+const codexModelNotFoundMessage = `{"error":{"message":"Model not found gpt-5.6-luna","type":"invalid_request_error","param":"model"}}`
+
 func TestManager_ShouldRetryAfterError_RespectsAuthRequestRetryOverride(t *testing.T) {
 	m := NewManager(nil, nil, nil)
 	m.SetRetryConfig(3, 30*time.Second, 0)
@@ -1270,5 +1272,186 @@ func TestManager_RequestScopedNotFoundStopsRetryWithoutSuspendingAuth(t *testing
 	}
 	if state := updatedBad.ModelStates[model]; state != nil {
 		t.Fatalf("expected request-scoped 404 to avoid bad auth model cooldown state, got %#v", state)
+	}
+}
+
+func TestManager_MarkResult_CodexModelNotFoundDoesNotCooldownAuth(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+
+	auth := &Auth{
+		ID:       "codex-auth-1",
+		Provider: "codex",
+	}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	model := "gpt-5.6-luna"
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    model,
+		Success:  false,
+		Error: &Error{
+			HTTPStatus: http.StatusNotFound,
+			Message:    codexModelNotFoundMessage,
+		},
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be present")
+	}
+	if updated.Unavailable {
+		t.Fatalf("expected Codex model-not-found 404 to keep auth available")
+	}
+	if !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("expected Codex model-not-found 404 to keep auth cooldown unset, got %v", updated.NextRetryAfter)
+	}
+	if state := updated.ModelStates[model]; state != nil {
+		t.Fatalf("expected Codex model-not-found 404 to avoid model cooldown state, got %#v", state)
+	}
+}
+
+func TestManager_CodexModelNotFoundStopsRetryWithoutSuspendingAuth(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	executor := &authFallbackExecutor{
+		id: "codex",
+		executeErrors: map[string]error{
+			"aa-bad-auth": &Error{
+				HTTPStatus: http.StatusNotFound,
+				Message:    codexModelNotFoundMessage,
+			},
+		},
+	}
+	m.RegisterExecutor(executor)
+
+	model := "gpt-5.6-luna"
+	badAuth := &Auth{ID: "aa-bad-auth", Provider: "codex"}
+	goodAuth := &Auth{ID: "bb-good-auth", Provider: "codex"}
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(badAuth.ID, "codex", []*registry.ModelInfo{{ID: model}})
+	reg.RegisterClient(goodAuth.ID, "codex", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(badAuth.ID)
+		reg.UnregisterClient(goodAuth.ID)
+	})
+
+	if _, errRegister := m.Register(context.Background(), badAuth); errRegister != nil {
+		t.Fatalf("register bad auth: %v", errRegister)
+	}
+	if _, errRegister := m.Register(context.Background(), goodAuth); errRegister != nil {
+		t.Fatalf("register good auth: %v", errRegister)
+	}
+
+	_, errExecute := m.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if errExecute == nil {
+		t.Fatal("expected model-not-found error")
+	}
+	if statusCodeFromError(errExecute) != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", statusCodeFromError(errExecute), http.StatusNotFound)
+	}
+
+	got := executor.ExecuteCalls()
+	want := []string{badAuth.ID}
+	if len(got) != len(want) {
+		t.Fatalf("execute calls = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("execute call %d auth = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	updatedBad, ok := m.GetByID(badAuth.ID)
+	if !ok || updatedBad == nil {
+		t.Fatalf("expected bad auth to remain registered")
+	}
+	if updatedBad.Unavailable {
+		t.Fatalf("expected model-not-found auth to remain available")
+	}
+	if !updatedBad.NextRetryAfter.IsZero() {
+		t.Fatalf("expected model-not-found auth cooldown unset, got %v", updatedBad.NextRetryAfter)
+	}
+	if state := updatedBad.ModelStates[model]; state != nil {
+		t.Fatalf("expected model-not-found error to avoid model state, got %#v", state)
+	}
+}
+
+func TestIsRequestScopedModelNotFoundMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+		want    bool
+	}{
+		{
+			name:    "Codex identity routing error",
+			message: codexModelNotFoundMessage,
+			want:    true,
+		},
+		{
+			name:    "formatted JSON",
+			message: "{\n  \"error\": {\n    \"message\": \"Model not found gpt-5.6-luna\",\n    \"type\": \"invalid_request_error\",\n    \"param\": \"model\"\n  }\n}",
+			want:    true,
+		},
+		{
+			name:    "wrapped status error",
+			message: "status 404: " + codexModelNotFoundMessage,
+			want:    true,
+		},
+		{
+			name:    "plain missing route lacks typed param",
+			message: "Model not found gpt-5.6-luna",
+		},
+		{
+			name:    "different invalid parameter",
+			message: `{"error":{"message":"Model not found gpt-5.6-luna","type":"invalid_request_error","param":"input"}}`,
+		},
+		{
+			name:    "explicit account model support error",
+			message: `{"detail":"The 'gpt-5.6-luna' model is not supported when using Codex with a ChatGPT account."}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRequestScopedModelNotFoundMessage(tt.message); got != tt.want {
+				t.Fatalf("isRequestScopedModelNotFoundMessage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestManager_MarkResult_GenericNotFoundStillCooldownsModel(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "generic-404-auth", Provider: "codex"}
+	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	model := "gpt-5.6-luna"
+	before := time.Now()
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    model,
+		Success:  false,
+		Error: &Error{
+			HTTPStatus: http.StatusNotFound,
+			Message:    `{"error":{"message":"resource not found","type":"server_error"}}`,
+		},
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatal("expected auth to remain registered")
+	}
+	state := updated.ModelStates[model]
+	if state == nil || !state.Unavailable {
+		t.Fatalf("generic 404 model state = %#v, want unavailable", state)
+	}
+	if state.NextRetryAfter.Before(before.Add(11 * time.Hour)) {
+		t.Fatalf("generic 404 retry time = %v, want roughly 12 hours", state.NextRetryAfter)
 	}
 }


### PR DESCRIPTION
## Outcome

Fixes two coupled Codex OAuth failure modes that can surface as a misleading `404 Model not found` response and then unnecessarily suspend the model pool:

- Final outbound client identity could become inconsistent after model-specific header overrides (`Originator`, `User-Agent`, and an explicit older `Version` no longer described one official Codex client).
- The exact OpenAI-style model-routing 404 was handled like a generic provider/auth failure, allowing futile cross-auth retries and the generic 12-hour model cooldown.

**Merge requirement:** use **Create a merge commit**. The two new downstream-patch ledger entries reference implementation commit `ded0314d23dc38656e2fb02220504bd98373813c`; squash or rebase would invalidate that provenance.

## Root cause

Codex HTTP, compact, streaming, WebSocket, and image paths applied model header profiles after the earlier base-header logic, but there was no shared final identity pass. Separately, `sdk/cliproxy/auth` only recognized the persisted-item 404 as request-scoped and otherwise applied generic 404 retry/cooldown behavior.

## Changes

- Add one final Codex OAuth identity helper, called after model-specific overrides by every HTTP/WebSocket/image path.
- Pair supported official first-party `Originator` and `User-Agent` values, recover a real official identity from the Codex trailer when only the leading segment was overridden, and fall back to the repository's official default for unsupported third-party identities.
- Raise an explicitly supplied stale `Version` to the final client engine version while preserving an omitted or already newer version.
- Preserve API-key request headers and add a macOS `Session_id` only when no session header is already present.
- Treat only an OpenAI-style `404` containing `error.type=invalid_request_error` and `error.param=model` as request-scoped; stop futile auth fallback without marking the auth/model unavailable.
- Preserve the existing generic 404 cooldown boundary and add regressions for both the narrow exception and the generic case.
- Register `codex-oauth-client-identity-finalization` and `codex-model-not-found-request-scope` as independent `required` downstream patches after checking upstream through `e99a2056baa981345f4a93600039725363ffca46` (`v7.2.66`).

## Compatibility and boundaries

- No config key or default changes; `config.example.yaml` only documents final identity behavior and refreshes the example client version.
- No Management usage schema, usage attribution field, API route, Panel response shape, or release source changes.
- No change to generic 404 cooldown behavior.
- No release, tag, or runtime deployment is included in this PR.

## Protected delta review

| Item | Class | Conclusion | Evidence |
|---|---|---|---|
| `auth-identity-attribution` | retained capability | adapted | OAuth client identity is finalized after all model/header overrides; API-key requests remain untouched |
| `transient-error-cooldown-config` | LTS feature | adapted | narrow typed model-routing exception added; configured and generic cooldown behavior preserved |
| `provider-runtime-usage-seams` | review seam | preserved | request paths changed only at final header application; usage emission and attribution remain in place and repo-wide tests pass |
| `codex-image-generation-tool-dedup` | downstream patch | preserved | image paths retain the existing tool behavior; direct and translated image identity regressions pass |
| `codex-gpt56-ultra-level` | downstream patch | preserved | final reasoning wire canonicalization is unchanged; full executor/thinking/registry tests pass |
| `codex-model-header-provider-snapshot` | downstream patch | adapted | the same resolved immutable profile is applied inside the new final helper before identity normalization |
| `codex-websocket-reader-generation` | downstream patch | preserved | no reader ownership/session lifecycle changes; full WebSocket executor tests pass |
| `codex-spark-reasoning-summary-compat` | downstream patch | preserved | payload sanitization order and regressions remain unchanged |
| `codex-oauth-client-identity-finalization` | downstream patch | newly-added | implementation commit plus HTTP/WebSocket/image regression coverage |
| `codex-model-not-found-request-scope` | downstream patch | newly-added | exact typed-404 parsing, retry stop, no-cooldown, and generic-404 boundary regressions |

Protected delta summary:

- retained capabilities: adapted and preserved
- LTS-owned features: adapted and preserved
- shared review seams: reviewed and preserved
- downstream patches: two newly-added; overlapping active patches preserved/adapted
- validation profiles: local contract, focused, build, and repo-wide checks run; runtime smoke skipped because deployment is out of scope
- upstream ordinary changes: not applicable; this is not an upstream sync PR

## Validation

- [x] `scripts/check-lts-contract.sh`
- [x] `go run ./scripts/ltsregistry --root . --base-ref origin/main`
- [x] `go test -count=1 ./internal/runtime/executor`
- [x] `go test -count=1 ./sdk/cliproxy/auth`
- [x] `go test -count=1 ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'`
- [x] `go build -o test-output ./cmd/server && rm -f test-output`
- [x] `go list ./... | rg -v '/tmp$' | xargs go test -count=1`
- [x] `git diff --check origin/main...HEAD`
- [ ] `go test ./...` — observed the known ignored scratch-package failure in `tmp/list_routes.go` (`RemoteManagementConfig`, `NewManager`, and `Server.Routes` stale helper APIs); all non-`tmp` packages passed with the command above
- [ ] Hugging Face runtime smoke — skipped; this PR is not merged or deployed

## Review focus

- Official-client allowlist/fallback behavior and `Version` floor semantics in `internal/runtime/executor/codex_client_identity.go`.
- The intentionally narrow JSON/error-shape check in `sdk/cliproxy/auth/conductor.go`.
- Merge-method compliance so the ledger's `introduced_in` SHA remains reachable.
