### PR TITLE
chore(lts): retire upstream-equivalent Codex image tool dedup patch

### DIFF
--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -28,7 +28,8 @@ patches:
       - TestEnsureImageGenerationTool_ExtensionNamespaceDoesNotInjectLegacyTool
       - TestEnsureImageGenerationTool_UnrelatedNamespaceStillInjectsLegacyTool
     upstream_issue_or_pr: router-for-me/CLIProxyAPI#4175
-    state: removable
+    state: retired
+    retired_in: 087804e59a07141401809bc25d06a1ff244bdb8f
     retire_when: After this removable state is merged, remove the downstream helper while retaining the upstream namespace and flattened-function behavior; the listed regressions and the responses-lite image-tool regressions must pass, and the removal commit must be recorded in retired_in.
 
   - id: plugin-configured-enable-default

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -1988,7 +1988,18 @@ func isImageGenerationFunctionTool(tool gjson.Result) bool {
 	case "function":
 		return tool.Get("name").String() == "image_gen.imagegen"
 	case "namespace":
-		return isCodexExtensionImageGenerationTool(tool)
+		if tool.Get("name").String() != "image_gen" {
+			return false
+		}
+		tools := tool.Get("tools")
+		if !tools.IsArray() {
+			return false
+		}
+		for _, nestedTool := range tools.Array() {
+			if nestedTool.Get("type").String() == "function" && nestedTool.Get("name").String() == "imagegen" {
+				return true
+			}
+		}
 	}
 	return false
 }
@@ -2028,23 +2039,6 @@ func ensureImageGenerationTool(body []byte, baseModel string, auth *cliproxyauth
 	}
 	body, _ = sjson.SetRawBytes(body, "tools.-1", imageGenToolJSON)
 	return body
-}
-
-func isCodexExtensionImageGenerationTool(tool gjson.Result) bool {
-	// Codex 0.144+ replaces hosted image_generation with this extension-backed namespace when available.
-	if tool.Get("type").String() != "namespace" || tool.Get("name").String() != "image_gen" {
-		return false
-	}
-	nestedTools := tool.Get("tools")
-	if !nestedTools.IsArray() {
-		return false
-	}
-	for _, nestedTool := range nestedTools.Array() {
-		if nestedTool.Get("type").String() == "function" && nestedTool.Get("name").String() == "imagegen" {
-			return true
-		}
-	}
-	return false
 }
 
 func normalizeCodexParallelToolCallsForTools(body []byte) []byte {

--- a/internal/runtime/executor/codex_executor_imagegen_test.go
+++ b/internal/runtime/executor/codex_executor_imagegen_test.go
@@ -146,32 +146,6 @@ func TestEnsureImageGenerationTool_AlreadyPresent(t *testing.T) {
 	}
 }
 
-func TestEnsureImageGenerationTool_ExtensionNamespaceDoesNotInjectLegacyTool(t *testing.T) {
-	body := []byte(`{"model":"gpt-5.5","tools":[{"type":"namespace","name":"image_gen","description":"Tools in the image_gen namespace.","tools":[{"type":"function","name":"imagegen","parameters":{"type":"object","properties":{"prompt":{"type":"string"}},"required":["prompt"]}}]}]}`)
-	result := ensureImageGenerationTool(body, "gpt-5.5", nil, nil)
-
-	if string(result) != string(body) {
-		t.Fatalf("expected extension-backed image generation request to remain unchanged, got %s", string(result))
-	}
-	tools := gjson.GetBytes(result, "tools").Array()
-	if len(tools) != 1 {
-		t.Fatalf("expected only the client image_gen namespace, got %d tools: %s", len(tools), string(result))
-	}
-}
-
-func TestEnsureImageGenerationTool_UnrelatedNamespaceStillInjectsLegacyTool(t *testing.T) {
-	body := []byte(`{"model":"gpt-5.5","tools":[{"type":"namespace","name":"weather","tools":[{"type":"function","name":"forecast","parameters":{"type":"object"}}]}]}`)
-	result := ensureImageGenerationTool(body, "gpt-5.5", nil, nil)
-
-	tools := gjson.GetBytes(result, "tools").Array()
-	if len(tools) != 2 {
-		t.Fatalf("expected unrelated namespace plus legacy image generation tool, got %d tools: %s", len(tools), string(result))
-	}
-	if got := tools[1].Get("type").String(); got != "image_generation" {
-		t.Fatalf("expected injected legacy image generation tool, got type %q: %s", got, string(result))
-	}
-}
-
 func TestEnsureImageGenerationTool_FlattenedImageGenFunctionDoesNotInjectTool(t *testing.T) {
 	body := []byte(`{"model":"gpt-5.4","tools":[{"type":"function","name":"image_gen.imagegen","parameters":{}}]}`)
 	result := ensureImageGenerationTool(body, "gpt-5.4", nil, nil)


### PR DESCRIPTION
## Outcome

Retires the now-upstream-equivalent `codex-image-generation-tool-dedup` downstream patch after the LTS baseline advanced through upstream `v7.2.66`.

The PR removes only the downstream namespace shim and its duplicate regression tests. The upstream implementation remains authoritative for both:

- `image_gen` namespace detection
- flattened `image_gen.imagegen` function detection

**Merge requirement:** use **Create a merge commit**. The retired ledger entry references implementation-removal commit `087804e59a07141401809bc25d06a1ff244bdb8f`; squash/rebase would invalidate `retired_in` provenance.

## Why retirement is valid

- Upstream commit `f9162d391c954446e3519214b51de50d07bf4913` added namespace and flattened image-generation tool detection.
- Upstream merge `cfa90f9fbf3f79dabb2eb468d6a098efac8ff06d` brought that behavior into the baseline.
- Upstream commit `aa05fb27f34d9a669db0faf00e9c42ae1bd7a83f` additionally stopped compact requests from injecting the image tool.
- PR #154 advanced CPA-Core-LTS ancestry to `e99a2056baa981345f4a93600039725363ffca46` (`v7.2.66`) and revalidated the overlapping executor behavior.

## Changes and provenance

1. `087804e59a07141401809bc25d06a1ff244bdb8f` — remove the downstream `isCodexExtensionImageGenerationTool` helper, restore upstream's inline namespace implementation, and remove the two duplicate downstream tests.
2. `501c096a` — change `codex-image-generation-tool-dedup` from `removable` to `retired` and set `retired_in` to the implementation-removal commit above.

The historical ledger entry, original `introduced_in`, affected range, upstream evidence, and retirement criteria remain preserved.

## Compatibility and boundaries

Preserved behavior:

- no duplicate legacy tool for an `image_gen` namespace
- no duplicate legacy tool for flattened `image_gen.imagegen`
- legacy `image_generation` fallback still added for missing tools and unrelated namespaces
- responses-lite, Spark, free-plan, existing hosted image tool, and compact-request boundaries remain intact
- `disable-image-generation` behavior and config schema are unchanged

No usage schema, Management API, auth, Panel, release, or runtime-deployment change is included.

## LTS classification review

| Item | Class | Conclusion | Evidence |
|---|---|---|---|
| `codex-image-generation-tool-dedup` | downstream patch | retired | upstream-equivalent behavior in `f9162d39` / `cfa90f9f`, compact reinforcement in `aa05fb27`, removal commit `087804e5`, validator-approved `retired_in` |
| `codex-gpt56-ultra-level` | downstream patch | preserved | shared executor file changed only in image-tool detection; executor and repo-wide tests pass |
| `codex-model-header-provider-snapshot` | downstream patch | preserved | no header-profile code changed |
| `codex-oauth-client-identity-finalization` | downstream patch | preserved | no final identity code or call order changed |
| `codex-spark-reasoning-summary-compat` | downstream patch | preserved | Spark no-injection and reasoning-summary behavior remain covered |

## Validation

- [x] `go test -count=1 ./internal/runtime/executor -run 'TestEnsureImageGenerationTool|TestCodexExecutorExecuteResponsesLite|TestCodexExecutorCompact'` before retirement commit
- [x] `go test -count=1 ./internal/runtime/executor`
- [x] `scripts/check-lts-contract.sh`
- [x] `go run ./scripts/ltsregistry --root . --base-ref origin/main`
- [x] `go build -o test-output ./cmd/server && rm -f test-output`
- [x] `go test -count=1 ./...`
- [x] `git diff --check origin/main...HEAD`
- [ ] Hugging Face runtime smoke — skipped; no release or deployment is in scope

## Review focus

- The code diff should match upstream's `isImageGenerationFunctionTool` implementation exactly after removal of the downstream delegate.
- `retired_in` must remain reachable through a merge commit.
- No unrelated image-generation fallback or config behavior should be removed.
