### PR TITLE
docs(lts): correct upstream service-tier issue status

### DIFF
--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -4,7 +4,7 @@ patches:
   - id: codex-interactions-service-tier-response
     reason: Codex Interactions requests can send priority service, but the shared response translator hardcodes streaming completion metadata to standard and omits the non-streaming tier instead of reporting the effective outbound or upstream tier.
     introduced_in: be649f04a4a66b952d5210c7cdf74e1d90a12b76
-    affected_upstream_range: through e99a2056baa981345f4a93600039725363ffca46 (v7.2.66); router-for-me/CLIProxyAPI#4189 remains open, and upstream PR #4202 adds runtime usage-tier reporting but does not change the Interactions response translator, which still hardcodes streaming service_tier to standard and omits it from non-streaming interactions
+    affected_upstream_range: through e99a2056baa981345f4a93600039725363ffca46 (v7.2.66); router-for-me/CLIProxyAPI#4189 was closed as completed on 2026-07-10, but upstream PR #4202 only adds runtime usage-tier reporting and does not change the Interactions response translator, which still hardcodes streaming service_tier to standard and omits it from non-streaming interactions
     files:
       - internal/translator/codex/interactions/interactions_codex_response.go
       - internal/translator/codex/interactions/interactions_codex_test.go


### PR DESCRIPTION
## Outcome

Corrects the live upstream status recorded for `codex-interactions-service-tier-response`.

- `router-for-me/CLIProxyAPI#4189` is now `CLOSED` with reason `COMPLETED` as of 2026-07-10.
- Upstream `v7.2.66` still ignores the original/outbound request in the Codex Interactions response translator, hardcodes streaming `service_tier` to `standard`, and omits the non-streaming field.
- The LTS downstream patch therefore remains `required`; this change updates status wording only and does not retire or alter the implementation.

## LTS classification

- patch state: `required` (unchanged)
- upstream baseline: `e99a2056baa981345f4a93600039725363ffca46` / `v7.2.66` (unchanged)
- contract behavior: unchanged
- code/runtime/API/config/usage/Panel impact: none

## Validation

- `git diff --check`
- `scripts/check-lts-contract.sh`
- `go run ./scripts/ltsregistry --root . --base-ref origin/main`
- `go test -count=1 ./internal/translator/codex/interactions -run ServiceTier`

Use a merge commit to keep normal repository history; no release or deployment is included.