### PR TITLE
fix(usage): 完整记录请求与响应 service tier

### DIFF
--- a/docs/lts/core-feature-contracts.yaml
+++ b/docs/lts/core-feature-contracts.yaml
@@ -38,6 +38,8 @@ features:
       - auth_index
       - latency_ms
       - service_tier
+      - request_service_tier
+      - response_service_tier
       - success_count
       - failure_count
       - failed_requests
@@ -77,6 +79,8 @@ features:
       - models
       - details
       - service_tier
+      - request_service_tier
+      - response_service_tier
     validation:
       - go test ./internal/api/handlers/management -run 'Usage|usage'
       - go test ./test -run 'Usage|usage'

--- a/internal/api/handlers/management/usage_contract_test.go
+++ b/internal/api/handlers/management/usage_contract_test.go
@@ -47,6 +47,12 @@ func TestUsageManagementResponseShapeAndImportExportRoundTrip(t *testing.T) {
 	if !bytes.Contains(exportedJSON, []byte(`"service_tier":"priority"`)) {
 		t.Fatalf("exported usage missing service_tier: %s", exportedJSON)
 	}
+	if !bytes.Contains(exportedJSON, []byte(`"request_service_tier":"priority"`)) {
+		t.Fatalf("exported usage missing request_service_tier: %s", exportedJSON)
+	}
+	if !bytes.Contains(exportedJSON, []byte(`"response_service_tier":"standard"`)) {
+		t.Fatalf("exported usage missing response_service_tier: %s", exportedJSON)
+	}
 	var legacyDecoded struct {
 		Version int `json:"version"`
 		Usage   struct {
@@ -62,7 +68,7 @@ func TestUsageManagementResponseShapeAndImportExportRoundTrip(t *testing.T) {
 		} `json:"usage"`
 	}
 	if err := json.Unmarshal(exportedJSON, &legacyDecoded); err != nil {
-		t.Fatalf("legacy decoder rejected additive service_tier field: %v", err)
+		t.Fatalf("legacy decoder rejected additive service-tier fields: %v", err)
 	}
 	legacyDetails := legacyDecoded.Usage.APIs["panel-client-key"].Models["gpt-5.4"].Details
 	if legacyDecoded.Version != 1 || legacyDecoded.Usage.TotalRequests != 1 || len(legacyDetails) != 1 || legacyDetails[0].Source != "auths/openai.json" || legacyDetails[0].Tokens.TotalTokens != 17 {
@@ -207,6 +213,9 @@ func TestUsageManagementImportLegacyExportKeepsServiceTierUnknown(t *testing.T) 
 	if details[0].ServiceTier != "" {
 		t.Fatalf("legacy detail.service_tier = %q, want empty/unknown", details[0].ServiceTier)
 	}
+	if details[0].RequestServiceTier != "" || details[0].ResponseServiceTier != "" {
+		t.Fatalf("legacy detail service tiers = request:%q response:%q, want empty/unknown", details[0].RequestServiceTier, details[0].ResponseServiceTier)
+	}
 	if snapshot.TotalRequests != 1 || snapshot.SuccessCount != 1 || snapshot.FailureCount != 0 || snapshot.TotalTokens != 9 {
 		t.Fatalf("legacy snapshot totals = %+v, want requests=1 success=1 failure=0 tokens=9", snapshot)
 	}
@@ -224,6 +233,9 @@ func TestUsageManagementImportLegacyExportKeepsServiceTierUnknown(t *testing.T) 
 	}
 	if bytes.Contains(reexportedJSON, []byte(`"service_tier"`)) {
 		t.Fatalf("legacy re-export fabricated service_tier: %s", reexportedJSON)
+	}
+	if bytes.Contains(reexportedJSON, []byte(`"request_service_tier"`)) || bytes.Contains(reexportedJSON, []byte(`"response_service_tier"`)) {
+		t.Fatalf("legacy re-export fabricated explicit service-tier fields: %s", reexportedJSON)
 	}
 }
 
@@ -316,16 +328,18 @@ func usageCacheCreationSnapshot(timestamp time.Time, tokens usage.TokenStats) us
 
 func recordPanelContractUsage(stats *usage.RequestStatistics) {
 	stats.Record(context.Background(), coreusage.Record{
-		APIKey:          "panel-client-key",
-		Provider:        "openai",
-		Model:           "gpt-5.4",
-		Alias:           "panel-visible-model",
-		Source:          "auths/openai.json",
-		AuthIndex:       "1",
-		ReasoningEffort: "medium",
-		ServiceTier:     "priority",
-		RequestedAt:     time.Date(2026, 6, 10, 11, 30, 0, 0, time.UTC),
-		Latency:         2 * time.Second,
+		APIKey:              "panel-client-key",
+		Provider:            "openai",
+		Model:               "gpt-5.4",
+		Alias:               "panel-visible-model",
+		Source:              "auths/openai.json",
+		AuthIndex:           "1",
+		ReasoningEffort:     "medium",
+		ServiceTier:         "priority",
+		RequestServiceTier:  "priority",
+		ResponseServiceTier: "standard",
+		RequestedAt:         time.Date(2026, 6, 10, 11, 30, 0, 0, time.UTC),
+		Latency:             2 * time.Second,
 		Detail: coreusage.Detail{
 			InputTokens:     5,
 			OutputTokens:    7,
@@ -473,6 +487,12 @@ func requirePanelUsageShape(t *testing.T, snapshot usage.StatisticsSnapshot) {
 	}
 	if detail.ServiceTier != "priority" {
 		t.Fatalf("detail.service_tier = %q, want priority", detail.ServiceTier)
+	}
+	if detail.RequestServiceTier != "priority" {
+		t.Fatalf("detail.request_service_tier = %q, want priority", detail.RequestServiceTier)
+	}
+	if detail.ResponseServiceTier != "standard" {
+		t.Fatalf("detail.response_service_tier = %q, want standard", detail.ResponseServiceTier)
 	}
 	if detail.LatencyMs != 2000 {
 		t.Fatalf("detail.latency_ms = %d, want 2000", detail.LatencyMs)

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -89,17 +89,19 @@ type modelStats struct {
 
 // RequestDetail stores request-level metadata and token usage for a single request.
 type RequestDetail struct {
-	Timestamp       time.Time  `json:"timestamp"`
-	LatencyMs       int64      `json:"latency_ms"`
-	Source          string     `json:"source"`
-	AuthIndex       string     `json:"auth_index"`
-	Alias           string     `json:"alias,omitempty"`
-	ReasoningEffort string     `json:"reasoning_effort,omitempty"`
-	ServiceTier     string     `json:"service_tier,omitempty"`
-	Tokens          TokenStats `json:"tokens"`
-	Failed          bool       `json:"failed"`
-	FailureReason   string     `json:"failure_reason,omitempty"`
-	FailureStatus   int        `json:"failure_status,omitempty"`
+	Timestamp           time.Time  `json:"timestamp"`
+	LatencyMs           int64      `json:"latency_ms"`
+	Source              string     `json:"source"`
+	AuthIndex           string     `json:"auth_index"`
+	Alias               string     `json:"alias,omitempty"`
+	ReasoningEffort     string     `json:"reasoning_effort,omitempty"`
+	ServiceTier         string     `json:"service_tier,omitempty"`
+	RequestServiceTier  string     `json:"request_service_tier,omitempty"`
+	ResponseServiceTier string     `json:"response_service_tier,omitempty"`
+	Tokens              TokenStats `json:"tokens"`
+	Failed              bool       `json:"failed"`
+	FailureReason       string     `json:"failure_reason,omitempty"`
+	FailureStatus       int        `json:"failure_status,omitempty"`
 }
 
 // TokenStats captures the token usage breakdown for a request.
@@ -186,6 +188,14 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 	if modelName == "" {
 		modelName = "unknown"
 	}
+	requestServiceTier := strings.TrimSpace(record.RequestServiceTier)
+	if requestServiceTier == "" {
+		requestServiceTier = strings.TrimSpace(record.ServiceTier)
+	}
+	responseServiceTier := strings.TrimSpace(record.ResponseServiceTier)
+	if responseServiceTier == "" {
+		responseServiceTier = strings.TrimSpace(record.Detail.ResponseServiceTier)
+	}
 	dayKey := timestamp.Format("2006-01-02")
 	hourKey := timestamp.Hour()
 
@@ -206,17 +216,19 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 		s.apis[statsKey] = stats
 	}
 	s.updateAPIStats(stats, modelName, RequestDetail{
-		Timestamp:       timestamp,
-		LatencyMs:       normaliseLatency(record.Latency),
-		Source:          record.Source,
-		AuthIndex:       record.AuthIndex,
-		Alias:           strings.TrimSpace(record.Alias),
-		ReasoningEffort: strings.TrimSpace(record.ReasoningEffort),
-		ServiceTier:     strings.TrimSpace(record.ServiceTier),
-		Tokens:          detail,
-		Failed:          failed,
-		FailureReason:   failureReason,
-		FailureStatus:   failureStatus,
+		Timestamp:           timestamp,
+		LatencyMs:           normaliseLatency(record.Latency),
+		Source:              record.Source,
+		AuthIndex:           record.AuthIndex,
+		Alias:               strings.TrimSpace(record.Alias),
+		ReasoningEffort:     strings.TrimSpace(record.ReasoningEffort),
+		ServiceTier:         requestServiceTier,
+		RequestServiceTier:  requestServiceTier,
+		ResponseServiceTier: responseServiceTier,
+		Tokens:              detail,
+		Failed:              failed,
+		FailureReason:       failureReason,
+		FailureStatus:       failureStatus,
 	})
 
 	s.requestsByDay[dayKey]++
@@ -347,6 +359,7 @@ func (s *RequestStatistics) MergeSnapshot(snapshot StatisticsSnapshot) MergeResu
 			}
 			for _, detail := range modelSnapshot.Details {
 				detail.Tokens = normaliseTokenStats(detail.Tokens)
+				detail = normaliseServiceTierAliases(detail)
 				if detail.LatencyMs < 0 {
 					detail.LatencyMs = 0
 				}
@@ -366,6 +379,16 @@ func (s *RequestStatistics) MergeSnapshot(snapshot StatisticsSnapshot) MergeResu
 	}
 
 	return result
+}
+
+func normaliseServiceTierAliases(detail RequestDetail) RequestDetail {
+	if strings.TrimSpace(detail.RequestServiceTier) == "" && strings.TrimSpace(detail.ServiceTier) != "" {
+		detail.RequestServiceTier = detail.ServiceTier
+	}
+	if strings.TrimSpace(detail.ServiceTier) == "" && strings.TrimSpace(detail.RequestServiceTier) != "" {
+		detail.ServiceTier = detail.RequestServiceTier
+	}
+	return detail
 }
 
 func (s *RequestStatistics) recordImported(apiName, modelName string, stats *apiStats, detail RequestDetail) {

--- a/internal/usage/logger_plugin_test.go
+++ b/internal/usage/logger_plugin_test.go
@@ -35,12 +35,14 @@ func TestRequestStatisticsRecordIncludesLatency(t *testing.T) {
 func TestRequestStatisticsRecordIncludesUsageMetadata(t *testing.T) {
 	stats := NewRequestStatistics()
 	stats.Record(context.Background(), coreusage.Record{
-		APIKey:          "test-key",
-		Model:           "gpt-5.4",
-		Alias:           "client-gpt",
-		ReasoningEffort: "medium",
-		ServiceTier:     " priority ",
-		RequestedAt:     time.Date(2026, 3, 20, 12, 0, 0, 0, time.UTC),
+		APIKey:              "test-key",
+		Model:               "gpt-5.4",
+		Alias:               "client-gpt",
+		ReasoningEffort:     "medium",
+		ServiceTier:         "legacy-default",
+		RequestServiceTier:  " priority ",
+		ResponseServiceTier: " standard ",
+		RequestedAt:         time.Date(2026, 3, 20, 12, 0, 0, 0, time.UTC),
 		Detail: coreusage.Detail{
 			InputTokens:         10,
 			OutputTokens:        20,
@@ -65,6 +67,12 @@ func TestRequestStatisticsRecordIncludesUsageMetadata(t *testing.T) {
 	if detail.ServiceTier != "priority" {
 		t.Fatalf("service_tier = %q, want %q", detail.ServiceTier, "priority")
 	}
+	if detail.RequestServiceTier != "priority" {
+		t.Fatalf("request_service_tier = %q, want %q", detail.RequestServiceTier, "priority")
+	}
+	if detail.ResponseServiceTier != "standard" {
+		t.Fatalf("response_service_tier = %q, want %q", detail.ResponseServiceTier, "standard")
+	}
 	if detail.Tokens.CacheReadTokens != 7 {
 		t.Fatalf("cache_read_tokens = %d, want 7", detail.Tokens.CacheReadTokens)
 	}
@@ -73,6 +81,27 @@ func TestRequestStatisticsRecordIncludesUsageMetadata(t *testing.T) {
 	}
 	if detail.Tokens.CachedTokens != 7 {
 		t.Fatalf("cached_tokens = %d, want 7", detail.Tokens.CachedTokens)
+	}
+}
+
+func TestRequestStatisticsRecordFallsBackToLegacyAndDetailServiceTiers(t *testing.T) {
+	stats := NewRequestStatistics()
+	stats.Record(context.Background(), coreusage.Record{
+		APIKey:      "test-key",
+		Model:       "gpt-5.4",
+		ServiceTier: " priority ",
+		Detail: coreusage.Detail{
+			ResponseServiceTier: " default ",
+			TotalTokens:         1,
+		},
+	})
+
+	detail := stats.Snapshot().APIs["test-key"].Models["gpt-5.4"].Details[0]
+	if detail.ServiceTier != "priority" || detail.RequestServiceTier != "priority" {
+		t.Fatalf("request tiers = service:%q request:%q, want priority aliases", detail.ServiceTier, detail.RequestServiceTier)
+	}
+	if detail.ResponseServiceTier != "default" {
+		t.Fatalf("response_service_tier = %q, want default", detail.ResponseServiceTier)
 	}
 }
 
@@ -108,17 +137,19 @@ func TestRequestStatisticsRecordPreservesLTSUsageContractFields(t *testing.T) {
 
 	stats := NewRequestStatistics()
 	stats.Record(context.Background(), coreusage.Record{
-		APIKey:          "client-api-key",
-		Provider:        "anthropic",
-		Model:           "claude-sonnet-4.5",
-		Alias:           "panel-alias",
-		Source:          "auths/anthropic.json",
-		AuthIndex:       "2",
-		ReasoningEffort: "high",
-		ServiceTier:     coreusage.DefaultServiceTier,
-		RequestedAt:     time.Date(2026, 6, 10, 9, 15, 0, 0, time.UTC),
-		Latency:         1234 * time.Millisecond,
-		Failed:          true,
+		APIKey:              "client-api-key",
+		Provider:            "anthropic",
+		Model:               "claude-sonnet-4.5",
+		Alias:               "panel-alias",
+		Source:              "auths/anthropic.json",
+		AuthIndex:           "2",
+		ReasoningEffort:     "high",
+		ServiceTier:         coreusage.DefaultServiceTier,
+		RequestServiceTier:  coreusage.DefaultServiceTier,
+		ResponseServiceTier: "standard",
+		RequestedAt:         time.Date(2026, 6, 10, 9, 15, 0, 0, time.UTC),
+		Latency:             1234 * time.Millisecond,
+		Failed:              true,
 		Fail: coreusage.Failure{
 			Body: "codex_abnormal_reasoning_response: codex abnormal reasoning response discarded",
 		},
@@ -187,6 +218,12 @@ func TestRequestStatisticsRecordPreservesLTSUsageContractFields(t *testing.T) {
 	if detail.ServiceTier != coreusage.DefaultServiceTier {
 		t.Fatalf("service_tier = %q, want %q", detail.ServiceTier, coreusage.DefaultServiceTier)
 	}
+	if detail.RequestServiceTier != coreusage.DefaultServiceTier {
+		t.Fatalf("request_service_tier = %q, want %q", detail.RequestServiceTier, coreusage.DefaultServiceTier)
+	}
+	if detail.ResponseServiceTier != "standard" {
+		t.Fatalf("response_service_tier = %q, want standard", detail.ResponseServiceTier)
+	}
 	if detail.LatencyMs != 1234 {
 		t.Fatalf("latency_ms = %d, want 1234", detail.LatencyMs)
 	}
@@ -240,7 +277,7 @@ func TestRequestStatisticsEnabledToggleStopsNewRecordsButKeepsSnapshotReadable(t
 	}
 }
 
-func TestRequestStatisticsMergeSnapshotDedupIgnoresLatencyAndServiceTier(t *testing.T) {
+func TestRequestStatisticsMergeSnapshotDedupIgnoresLatencyAndServiceTiers(t *testing.T) {
 	stats := NewRequestStatistics()
 	timestamp := time.Date(2026, 3, 20, 12, 0, 0, 0, time.UTC)
 	first := StatisticsSnapshot{
@@ -270,11 +307,13 @@ func TestRequestStatisticsMergeSnapshotDedupIgnoresLatencyAndServiceTier(t *test
 				Models: map[string]ModelSnapshot{
 					"gpt-5.4": {
 						Details: []RequestDetail{{
-							Timestamp:   timestamp,
-							LatencyMs:   2500,
-							Source:      "user@example.com",
-							AuthIndex:   "0",
-							ServiceTier: "priority",
+							Timestamp:           timestamp,
+							LatencyMs:           2500,
+							Source:              "user@example.com",
+							AuthIndex:           "0",
+							ServiceTier:         "priority",
+							RequestServiceTier:  "priority",
+							ResponseServiceTier: "standard",
 							Tokens: TokenStats{
 								InputTokens:  10,
 								OutputTokens: 20,
@@ -304,6 +343,56 @@ func TestRequestStatisticsMergeSnapshotDedupIgnoresLatencyAndServiceTier(t *test
 	}
 	if details[0].ServiceTier != "" {
 		t.Fatalf("service_tier = %q, want legacy unknown to remain empty", details[0].ServiceTier)
+	}
+	if details[0].RequestServiceTier != "" || details[0].ResponseServiceTier != "" {
+		t.Fatalf("service tier metadata = request:%q response:%q, want legacy unknown to remain empty", details[0].RequestServiceTier, details[0].ResponseServiceTier)
+	}
+}
+
+func TestRequestStatisticsMergeSnapshotNormalisesServiceTierAliases(t *testing.T) {
+	timestamp := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name   string
+		detail RequestDetail
+	}{
+		{
+			name: "legacy alias populates request tier",
+			detail: RequestDetail{
+				ServiceTier:         " priority ",
+				ResponseServiceTier: " standard ",
+			},
+		},
+		{
+			name: "request tier populates legacy alias",
+			detail: RequestDetail{
+				RequestServiceTier:  " priority ",
+				ResponseServiceTier: " standard ",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.detail.Timestamp = timestamp
+			tt.detail.Tokens.TotalTokens = 1
+			snapshot := StatisticsSnapshot{APIs: map[string]APISnapshot{
+				"test-key": {Models: map[string]ModelSnapshot{
+					"gpt-5.4": {Details: []RequestDetail{tt.detail}},
+				}},
+			}}
+			stats := NewRequestStatistics()
+			result := stats.MergeSnapshot(snapshot)
+			if result.Added != 1 || result.Skipped != 0 {
+				t.Fatalf("merge result = %+v, want added=1 skipped=0", result)
+			}
+			got := stats.Snapshot().APIs["test-key"].Models["gpt-5.4"].Details[0]
+			if got.ServiceTier != " priority " || got.RequestServiceTier != " priority " {
+				t.Fatalf("request tiers = service:%q request:%q, want preserved aliases", got.ServiceTier, got.RequestServiceTier)
+			}
+			if got.ResponseServiceTier != " standard " {
+				t.Fatalf("response_service_tier = %q, want preserved raw import value", got.ResponseServiceTier)
+			}
+		})
 	}
 }
 

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -132,7 +132,10 @@ require_grep "UsageReporter" internal/runtime/executor/helps/usage_helpers.go
 require_grep "auth_index" internal/usage internal/api/handlers/management internal/runtime/executor/helps internal/redisqueue
 require_grep "latency_ms" internal/usage internal/redisqueue internal/tui
 require_grep 'json:"service_tier,omitempty"' internal/usage
-require_grep "service_tier" internal/api/handlers/management/usage_contract_test.go
+require_grep 'json:"request_service_tier,omitempty"' internal/usage
+require_grep 'json:"response_service_tier,omitempty"' internal/usage
+require_grep "request_service_tier" internal/api/handlers/management/usage_contract_test.go
+require_grep "response_service_tier" internal/api/handlers/management/usage_contract_test.go
 
 go test ./scripts/ltsregistry -count=1
 


### PR DESCRIPTION
## 结果

补齐 upstream `v7.2.66` service-tier reporting 与 CPA-Core-LTS 完整 usage statistics 之间的最后一个集成缺口：Management usage detail 现在同时保留请求 tier 和上游实际响应 tier，同时继续提供 legacy `service_tier` 请求别名。

本 PR 是 retained capability 的 additive schema 适配，不新增 downstream patch，也不改变 token totals、成功/失败统计、dedup identity、路由、配置或部署状态。

## 背景与根因

upstream PR `router-for-me/CLIProxyAPI#4202` 已把 runtime usage 拆分为 `RequestServiceTier` 和 `ResponseServiceTier`。PR #154 吸收后，executor 与 Redis queue 已完整保存双 tier，但 LTS `internal/usage` 仍只写入 legacy `record.ServiceTier`。

因此请求 `priority`、上游实际返回 `standard` 时，`/v0/management/usage` 和 export 只能看到请求值，无法保留真实响应 tier。

## 变更

- `details[].service_tier` 继续作为请求 tier 的向后兼容别名；
- 新增可选 `details[].request_service_tier`；
- 新增可选 `details[].response_service_tier`；
- live records 优先使用显式 `RequestServiceTier`，缺失时回退 legacy `ServiceTier`；
- response tier 优先使用 `Record.ResponseServiceTier`，缺失时回退 `Detail.ResponseServiceTier`；
- import 时在 `service_tier` 与 `request_service_tier` 之间补等价别名，但保留原始非空值，不改变真正 legacy unknown；
- dedup identity 继续忽略 latency/service-tier metadata，避免同一请求因字段丰富而重复导入；
- 将两个新字段加入 `full-usage-statistics-core`、`management-usage-api` contract markers 和 sentinel guard。

## 兼容性与边界

- export version 仍为 `1`；新增字段均为 additive + `omitempty`；
- 旧 Panel/decoder 继续读取 `service_tier` 并忽略新字段；
- 真正缺少 tier 的旧 export 导入后仍保持 empty/unknown，re-export 不会伪造 tier；
- 仅带旧 `service_tier` 的中间版本数据会获得等价 `request_service_tier`；仅带新 request field 的数据会补 legacy alias；
- token breakdown、total normalization、cache read/write、success/failure、auth attribution、Management routes 和 Redis queue shape 均不变；
- 不包含 CPA-Panel-LTS UI 改动、release、tag 或 runtime deployment。

## LTS 分类

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| `full-usage-statistics-core` | retained capability | adapted | request/response tier fields, logger tests, import compatibility |
| `management-usage-api` | retained capability | adapted | response/export/import contract roundtrip |
| `panel-release-asset` | retained capability | preserved | legacy `service_tier` remains unchanged; new fields are optional |
| `provider-runtime-usage-seams` | review seam | adapted | consumes upstream dual-tier `usage.Record` without changing runtime routing |
| `redis-compatible-usage-queue` | LTS feature | preserved | queue already exposes request/response tier; focused tests pass |

`docs/lts/downstream-patches.yaml` 已复查：本变更不是需要退休追踪的临时 downstream patch，因此不新增 ledger entry。

## 验证

- [x] `gofmt -w internal/usage/logger_plugin.go internal/usage/logger_plugin_test.go internal/api/handlers/management/usage_contract_test.go`
- [x] `scripts/check-lts-contract.sh`
- [x] `go run ./scripts/ltsregistry --root . --base-ref origin/main`
- [x] `go test -count=1 ./internal/usage`
- [x] `go test -count=1 ./internal/api/handlers/management -run 'Usage|usage'`
- [x] `go test -count=1 ./test -run 'Usage|usage'`
- [x] `go test -count=1 ./internal/runtime/executor/helps ./internal/redisqueue ./internal/translator/codex/interactions`
- [x] `go build -o /tmp/cpa-core-response-tier-build ./cmd/server`
- [x] `go test -count=1 ./...`
- [x] `git diff --check`
- [ ] HF runtime smoke：跳过；本 PR 不发布、不部署

## Review focus

- legacy/request alias 的优先级与 import 兼容行为；
- response tier 从 record/detail 两条已存在 runtime 路径的回退；
- Management export version 1 的 additive compatibility；
- contract marker 是否只保护稳定字段而未绑定局部实现。

建议使用 **Create a merge commit** 合入 `main`；本 PR 不包含 `introduced_in` / `retired_in` provenance 变更。
