### PR TITLE
feat(codex): 引入签名安全且预算共享的 429 模型回退

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -190,6 +190,29 @@ codex:
   # Some superstitious users believe request tracking identifiers can be used
   # as evidence for TOS enforcement bans; this option only satisfies those odd concerns.
   identity-confuse: false
+  # CPA-Core-LTS extra feature. After all same-model credentials fail with a
+  # precisely classified Codex usage-limit or model-capacity response, try the
+  # configured target models in order. Disabled by default.
+  model-fallback:
+    enabled: false
+    # Supported triggers: "usage-limit" and "capacity". Empty means both.
+    triggers:
+      - "usage-limit"
+      - "capacity"
+    # "same-model-only" (default) blocks cross-model fallback when the request
+    # or source-session cache contains model-private reasoning continuity.
+    # "context-reset" explicitly drops reasoning items before the fallback and
+    # keeps replayable tool-call pairs when available. This is a lossy fallback,
+    # not a repair or migration of reasoning.encrypted_content.
+    reasoning-continuity: "same-model-only"
+    # Exact, case-insensitive source model mappings. Targets are tried in order.
+    mappings: []
+    # Example:
+    # mappings:
+    #   - from: "gpt-5.6-sol"
+    #     to:
+    #       - "gpt-5.6-terra"
+    #       - "gpt-5.5"
   # CPA-Core-LTS extra feature. When explicitly enabled, discard and retry
   # matching Codex OAuth responses whose completed usage reports suspicious
   # reasoning token counts. Disabled by default.

--- a/docs/lts/codex-429-resilience.md
+++ b/docs/lts/codex-429-resilience.md
@@ -54,16 +54,35 @@ a GPT reasoning signature, but it cannot prove that a different model can
 decrypt or accept it.
 
 The default `reasoning-continuity: same-model-only` policy therefore blocks a
-cross-model fallback when either of these is present:
+cross-model fallback before target auth selection when any source-scoped state
+is present:
 
 - the translated request already contains a reasoning item; or
 - the source model/session has cached Codex reasoning replay state.
+- `previous_response_id` or an incremental WebSocket request;
+- a pinned auth or an execution session.
 
 This still permits normal same-model auth failover, whose replay cache is scoped
 by model and session rather than auth ID.
 
-`reasoning-continuity: context-reset` is an explicit lossy mode. Before the
-fallback request is sent, Core removes all reasoning items. If source replay
+`reasoning-continuity: context-reset` is an explicit lossy mode. It is allowed
+for stateful Responses WebSocket turns only when the CPA handler has constructed
+a complete transcript, verified all function/custom-tool call and output pairs,
+and added its internal replay marker before any payload from that turn is sent
+to the client. End-to-end WebSocket passthrough, bare incremental input, an
+unpaired tool transcript, any request retaining `previous_response_id`, and an
+already-delivered stream are blocked rather than guessed.
+
+The source replay-cache preflight uses the same resolver as the Codex executor.
+The executor attaches the final source model/session scope after request
+interception, translation, payload shaping, and header resolution to the typed
+source error. Fallback checks that exact scope before target auth selection, so
+lowercase/Gin-only headers or an after-auth payload rewrite cannot bypass the
+continuity gate.
+
+For an approved reset Core removes all reasoning items and
+`previous_response_id`, releases the source auth pin, closes the source
+execution session, and reselects auth using the target model. If source replay
 state contains function/custom-tool calls needed by tool outputs in the current
 request, those replayable call items may be retained so the tool pair remains
 valid. No reasoning signature is copied to the target model, and normal target
@@ -76,13 +95,28 @@ reasoning continuity.
 ## Retry, usage, and auth state
 
 - Same-model auth selection and ordinary retry run before model fallback.
-- Model fallback is not a `RetryWithoutPenalty` lane and does not consume or
-  extend the abnormal-reasoning hedge budget.
+- Source and fallback targets share one request-level abnormal-reasoning retry
+  counter, hedge state, and `UsageAccumulator`; fallback cannot reset or extend
+  the configured retry/hedge budget. A target gets one auth-selection wave,
+  while that wave still follows `max-retry-credentials`.
+- With `client-usage-aggregation: sum`, all dispatched source and target
+  attempts participate in the client-visible aggregate. The default
+  delivered-only policy continues to expose only the delivered result.
 - Each dispatched attempt keeps normal attempt-level usage/failure attribution
   to its actual auth and model.
 - A fallback blocked locally by the reasoning gate is a zero-dispatch outcome:
   it does not cool down the target model and does not create a synthetic upstream
   failure usage record.
+- `auth_not_found`, target model cooldown, and continuity-observation-pending
+  are zero-dispatch target outcomes and continue ordered target selection. A
+  typed target usage-limit/capacity also continues to the next target. A local
+  continuity block returns the original source error; a real dispatched
+  request-invalid, auth, transient, or other non-fallback target error stops
+  selection and is returned unchanged. If every target is zero-dispatch, Core
+  returns the original source typed 429.
+- Selected-auth callbacks are withheld for skipped and locally blocked targets;
+  only an auth that reaches the executor dispatch boundary and becomes the final
+  outcome is published to the external WebSocket pinning path.
 - A failed source model and a successful target model retain independent model
   availability state.
 

--- a/docs/lts/codex-429-resilience.md
+++ b/docs/lts/codex-429-resilience.md
@@ -1,0 +1,94 @@
+# Codex 429 resilience
+
+This document defines the CPA-Core-LTS contract for Codex quota/capacity
+fallback. It is intentionally separate from `codex.abnormal-reasoning-retry`:
+the abnormal-reasoning guard handles suspicious successful responses, while
+this feature handles a precisely classified upstream failure before a response
+is delivered.
+
+## Model fallback
+
+`codex.model-fallback` is disabled by default. When enabled, Core first exhausts
+the normal same-model credential selection and retry path. Only then may it try
+the configured target models in order.
+
+Supported triggers are:
+
+- `usage-limit`: Codex `error.type=usage_limit_reached`, including its reset
+  timing when present.
+- `capacity`: the Codex model-capacity response that asks the client to try a
+  different model.
+
+Transient `rate_limit_error` / `rate_limit_exceeded` responses are not model
+fallback signals. A bare HTTP 429 without one of the typed Codex classifications
+does not activate this feature.
+
+Example:
+
+```yaml
+codex:
+  model-fallback:
+    enabled: true
+    triggers: [usage-limit, capacity]
+    reasoning-continuity: same-model-only
+    mappings:
+      - from: gpt-5.6-sol
+        to: [gpt-5.6-terra, gpt-5.5]
+```
+
+The source mapping is exact and case-insensitive after trimming. Target order is
+significant. Duplicate and source-equivalent targets are removed in memory.
+Existing config files are not rewritten to add defaults.
+
+The fallback path is limited to standard Codex response execution. It does not
+apply to compact, image, or video requests. Streaming fallback is only possible
+while the upstream failure is still in the bootstrap/pre-delivery phase; once a
+stream has been returned and client-visible payload can be emitted, Core does
+not replace it with a different model.
+
+## Reasoning signature boundary
+
+Model fallback does **not** repair or migrate
+`reasoning.encrypted_content`. CPA-Core-LTS can validate the transport shape of
+a GPT reasoning signature, but it cannot prove that a different model can
+decrypt or accept it.
+
+The default `reasoning-continuity: same-model-only` policy therefore blocks a
+cross-model fallback when either of these is present:
+
+- the translated request already contains a reasoning item; or
+- the source model/session has cached Codex reasoning replay state.
+
+This still permits normal same-model auth failover, whose replay cache is scoped
+by model and session rather than auth ID.
+
+`reasoning-continuity: context-reset` is an explicit lossy mode. Before the
+fallback request is sent, Core removes all reasoning items. If source replay
+state contains function/custom-tool calls needed by tool outputs in the current
+request, those replayable call items may be retained so the tool pair remains
+valid. No reasoning signature is copied to the target model, and normal target
+model replay injection is skipped for that fallback attempt.
+
+This mode means "continue without model-private reasoning history". It must not
+be described as signature repair, signature translation, or equivalent
+reasoning continuity.
+
+## Retry, usage, and auth state
+
+- Same-model auth selection and ordinary retry run before model fallback.
+- Model fallback is not a `RetryWithoutPenalty` lane and does not consume or
+  extend the abnormal-reasoning hedge budget.
+- Each dispatched attempt keeps normal attempt-level usage/failure attribution
+  to its actual auth and model.
+- A fallback blocked locally by the reasoning gate is a zero-dispatch outcome:
+  it does not cool down the target model and does not create a synthetic upstream
+  failure usage record.
+- A failed source model and a successful target model retain independent model
+  availability state.
+
+## Downstream surface
+
+The config is available through Core's normal config serialization and hot
+reload path. `CPA-Panel-LTS` needs a separate UI/schema follow-up before the
+visual editor can be treated as supporting these fields; this Core change does
+not modify the Panel repository.

--- a/docs/lts/core-feature-contracts.yaml
+++ b/docs/lts/core-feature-contracts.yaml
@@ -252,6 +252,41 @@ features:
       - go test ./internal/watcher/diff
       - go test ./sdk/cliproxy/auth
 
+  - id: codex-model-fallback
+    kind: lts-feature
+    support: maintained
+    owner: cpa-core-lts
+    upstream_relation: downstream-only
+    reason: CPA-Core-LTS provides opt-in, typed Codex quota/capacity model fallback without replaying model-private reasoning signatures across models.
+    config_keys:
+      - codex.model-fallback.enabled
+      - codex.model-fallback.triggers
+      - codex.model-fallback.reasoning-continuity
+      - codex.model-fallback.mappings
+    core_files:
+      - internal/config/config.go
+      - internal/runtime/executor/codex_model_fallback.go
+      - internal/runtime/executor/codex_executor.go
+      - internal/runtime/executor/codex_websockets_executor.go
+      - sdk/cliproxy/auth/codex_model_fallback.go
+      - sdk/cliproxy/auth/conductor.go
+      - sdk/cliproxy/executor/types.go
+      - config.example.yaml
+      - docs/lts/codex-429-resilience.md
+    required_markers:
+      - model-fallback
+      - reasoning-continuity
+      - same-model-only
+      - context-reset
+      - ModelFallbackReason
+      - ModelFallbackBlocked
+      - CodexModelFallbackSourceModelMetadataKey
+      - CodexModelFallbackReasoningContinuityMetadataKey
+    validation:
+      - go test ./internal/config ./internal/watcher/diff
+      - go test ./internal/runtime/executor -run 'Codex.*ModelFallback|Codex.*Retry|Codex.*Signature'
+      - go test ./sdk/cliproxy/auth -run 'CodexModelFallback'
+
   - id: redis-compatible-usage-queue
     kind: lts-feature
     support: maintained

--- a/docs/lts/core-feature-contracts.yaml
+++ b/docs/lts/core-feature-contracts.yaml
@@ -265,9 +265,14 @@ features:
       - codex.model-fallback.mappings
     core_files:
       - internal/config/config.go
+      - internal/cache/codex_reasoning_replay_scope.go
       - internal/runtime/executor/codex_model_fallback.go
       - internal/runtime/executor/codex_executor.go
       - internal/runtime/executor/codex_websockets_executor.go
+      - internal/runtime/executor/helps/claude_code_session.go
+      - sdk/api/handlers/handlers.go
+      - sdk/api/handlers/handlers_metadata_test.go
+      - sdk/api/handlers/openai/openai_responses_websocket.go
       - sdk/cliproxy/auth/codex_model_fallback.go
       - sdk/cliproxy/auth/conductor.go
       - sdk/cliproxy/executor/types.go
@@ -282,6 +287,12 @@ features:
       - ModelFallbackBlocked
       - CodexModelFallbackSourceModelMetadataKey
       - CodexModelFallbackReasoningContinuityMetadataKey
+      - CodexModelFallbackContextResetReplayMetadataKey
+      - ResolveCodexReasoningReplaySessionKey
+      - responsesWebsocketCanAttestContextReset
+      - ModelFallbackZeroDispatch
+      - CodexModelFallbackContextResetReplayMetadataKey
+      - ModelFallbackZeroDispatch
     validation:
       - go test ./internal/config ./internal/watcher/diff
       - go test ./internal/runtime/executor -run 'Codex.*ModelFallback|Codex.*Retry|Codex.*Signature'

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -1,6 +1,44 @@
 version: 1
 
 patches:
+  - id: codex-model-fallback
+    reason: Codex usage-limit and model-capacity failures need an opt-in ordered model fallback after same-model credentials are exhausted, while cross-model retries must not replay model-private reasoning signatures or replay a stream after client-visible delivery.
+    introduced_in: 0bd5a46fd34dff4711fe5618afe66c93f316897b
+    affected_upstream_range: through e99a2056baa981345f4a93600039725363ffca46 (v7.2.66); the synced upstream baseline has no typed, configurable cross-model fallback with a conservative reasoning-continuity gate, target-model auth reselection, and pre-delivery streaming boundary.
+    files:
+      - config.example.yaml
+      - docs/lts/codex-429-resilience.md
+      - docs/lts/core-feature-contracts.yaml
+      - docs/lts/protected-deltas.yaml
+      - internal/config/config.go
+      - internal/config/codex_model_fallback_test.go
+      - internal/runtime/executor/codex_executor.go
+      - internal/runtime/executor/codex_executor_retry_test.go
+      - internal/runtime/executor/codex_model_fallback.go
+      - internal/runtime/executor/codex_model_fallback_test.go
+      - internal/runtime/executor/codex_websockets_executor.go
+      - internal/runtime/executor/openai_compat_executor.go
+      - internal/watcher/diff/config_diff.go
+      - internal/watcher/diff/config_diff_test.go
+      - scripts/check-lts-contract.sh
+      - sdk/cliproxy/auth/codex_model_fallback.go
+      - sdk/cliproxy/auth/codex_model_fallback_test.go
+      - sdk/cliproxy/auth/conductor.go
+      - sdk/cliproxy/executor/types.go
+    regression_tests:
+      - TestLoadConfigOptionalCodexModelFallback
+      - TestCodexModelFallbackEffectiveDefaultsAndNormalizesMappings
+      - TestNewCodexStatusErrDoesNotClassifyTransientRateLimitForModelFallback
+      - TestCodexExecutorModelFallbackSameModelOnlyBlocksClientReasoning
+      - TestCodexExecutorModelFallbackSameModelOnlyBlocksSourceReplayCache
+      - TestCodexExecutorModelFallbackContextResetDropsReasoningAndKeepsToolPair
+      - TestManagerExecuteCodexModelFallbackSelectsCredentialForTargetModel
+      - TestManagerExecuteStreamCodexModelFallbackBeforeFirstPayload
+      - TestManagerExecuteStreamCodexModelFallbackDoesNotReplayAfterPayload
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: Upstream provides typed usage-limit and capacity-only model fallback after same-model auth exhaustion, reselects credentials for each target model, blocks or explicitly resets cross-model reasoning state without copying encrypted_content, preserves pre-delivery stream replay safety, and all listed regressions pass after removing the downstream implementation.
+
   - id: codex-interactions-service-tier-response
     reason: Codex Interactions requests can send priority service, but the shared response translator hardcodes streaming completion metadata to standard and omits the non-streaming tier instead of reporting the effective outbound or upstream tier.
     introduced_in: be649f04a4a66b952d5210c7cdf74e1d90a12b76

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -9,22 +9,31 @@ patches:
       - config.example.yaml
       - docs/lts/codex-429-resilience.md
       - docs/lts/core-feature-contracts.yaml
+      - docs/lts/downstream-patches.yaml
       - docs/lts/protected-deltas.yaml
+      - internal/cache/codex_reasoning_replay_scope.go
       - internal/config/config.go
       - internal/config/codex_model_fallback_test.go
+      - internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
       - internal/runtime/executor/codex_executor.go
       - internal/runtime/executor/codex_executor_retry_test.go
       - internal/runtime/executor/codex_model_fallback.go
       - internal/runtime/executor/codex_model_fallback_test.go
       - internal/runtime/executor/codex_websockets_executor.go
+      - internal/runtime/executor/codex_websockets_executor_test.go
+      - internal/runtime/executor/helps/claude_code_session.go
       - internal/runtime/executor/openai_compat_executor.go
       - internal/watcher/diff/config_diff.go
       - internal/watcher/diff/config_diff_test.go
       - scripts/check-lts-contract.sh
+      - sdk/api/handlers/handlers.go
+      - sdk/api/handlers/handlers_metadata_test.go
       - sdk/cliproxy/auth/codex_model_fallback.go
       - sdk/cliproxy/auth/codex_model_fallback_test.go
       - sdk/cliproxy/auth/conductor.go
       - sdk/cliproxy/executor/types.go
+      - sdk/api/handlers/openai/openai_responses_websocket.go
+      - sdk/api/handlers/openai/openai_responses_websocket_test.go
     regression_tests:
       - TestLoadConfigOptionalCodexModelFallback
       - TestCodexModelFallbackEffectiveDefaultsAndNormalizesMappings
@@ -35,6 +44,20 @@ patches:
       - TestManagerExecuteCodexModelFallbackSelectsCredentialForTargetModel
       - TestManagerExecuteStreamCodexModelFallbackBeforeFirstPayload
       - TestManagerExecuteStreamCodexModelFallbackDoesNotReplayAfterPayload
+      - TestManagerExecuteCodexModelFallbackBlocksCachedClaudeReplayBeforeTargetSelection
+      - TestManagerExecuteCodexModelFallbackReplayPreflightUsesExecutorKeyPriority
+      - TestManagerExecuteCodexModelFallbackReplayPreflightUsesSharedHeaderResolver
+      - TestCodexExecutorModelFallbackPreflightUsesAfterAuthRewrittenReplayScope
+      - TestCodexExecutorModelFallbackPreservesSourceAbnormalPolicyAndUsageAggregation
+      - TestCodexModelFallbackTargetSharesRequestRetryHedgeAndUsageBudget
+      - TestManagerExecuteCodexModelFallbackSharesRemainingAbnormalBudgetAndHedgeWinner
+      - TestManagerExecuteStreamCodexModelFallbackSharesRemainingAbnormalBudgetAndHedgeWinner
+      - TestManagerExecuteCodexModelFallbackContinuesPastRealTargetCooldown
+      - TestManagerCodexModelFallbackTargetExhaustionPreservesBehavior
+      - TestCodexWebsocketHandshakeStatusClassifiesFallbackAndPreservesHeaders
+      - TestCodexWebsocketReconnectHandshakePreservesTypedQuotaError
+      - TestResponsesWebsocketFirstIncrementalCreateCannotAttestContextReset
+      - TestResponsesWebsocketRepairCannotRetroactivelyAttestIncompleteTranscript
     upstream_issue_or_pr: not-filed
     state: required
     retire_when: Upstream provides typed usage-limit and capacity-only model fallback after same-model auth exhaustion, reselects credentials for each target model, blocks or explicitly resets cross-model reasoning state without copying encrypted_content, preserves pre-delivery stream replay safety, and all listed regressions pass after removing the downstream implementation.

--- a/docs/lts/protected-deltas.yaml
+++ b/docs/lts/protected-deltas.yaml
@@ -78,6 +78,18 @@ retained_capabilities:
     conflict_policy: preserve_config_compatibility
 
 lts_owned_features:
+  - id: codex-model-fallback
+    registry_feature: codex-model-fallback
+    maintenance_policy: long-term-maintained
+    markers:
+      - model-fallback
+      - ModelFallbackReason
+      - reasoning-continuity
+    validation:
+      - codex-model-fallback-regression-tests
+      - codex-model-fallback-race-tests
+    conflict_policy: adapt_lts_feature_to_upstream_auth_and_codex_runtime
+
   - id: codex-abnormal-reasoning-retry
     registry_feature: codex-abnormal-reasoning-retry
     maintenance_policy: long-term-maintained

--- a/internal/cache/codex_reasoning_replay_scope.go
+++ b/internal/cache/codex_reasoning_replay_scope.go
@@ -1,0 +1,159 @@
+package cache
+
+import (
+	"context"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+)
+
+const ClaudeCodeSessionHeader = "X-Claude-Code-Session-Id"
+
+var claudeCodeSessionSuffixPattern = regexp.MustCompile(`_session_([a-f0-9-]+)$`)
+
+// CodexReasoningReplaySessionInput contains the request identity surfaces used
+// by Codex reasoning replay. TranslatedPayload must be the final executor body
+// after request interception and payload shaping when it is available.
+type CodexReasoningReplaySessionInput struct {
+	Context                 context.Context
+	SourceFormat            string
+	TranslatedPayload       []byte
+	RequestPayload          []byte
+	Headers                 http.Header
+	OptionExecutionSession  string
+	RequestExecutionSession string
+}
+
+// ResolveCodexReasoningReplaySessionKey is the single priority resolver shared
+// by the Codex executor and the auth-layer model-fallback preflight.
+func ResolveCodexReasoningReplaySessionKey(input CodexReasoningReplaySessionInput) string {
+	if !strings.EqualFold(strings.TrimSpace(input.SourceFormat), "claude") {
+		return ""
+	}
+	if value := strings.TrimSpace(input.OptionExecutionSession); value != "" {
+		return "execution:" + value
+	}
+	if value := strings.TrimSpace(input.RequestExecutionSession); value != "" {
+		return "execution:" + value
+	}
+	if value := CodexReasoningReplaySessionKeyFromPayload(input.TranslatedPayload); value != "" {
+		return value
+	}
+	if value := CodexReasoningReplaySessionKeyFromPayload(input.RequestPayload); value != "" {
+		return value
+	}
+	if value := CodexReasoningReplaySessionKeyFromHeaders(input.Headers); value != "" {
+		return value
+	}
+	if ginHeaders := headersFromGinContext(input.Context); ginHeaders != nil {
+		if value := CodexReasoningReplaySessionKeyFromHeaders(ginHeaders); value != "" {
+			return value
+		}
+	}
+	if sessionID := ExtractClaudeCodeSessionID(input.Context, input.RequestPayload, input.Headers); sessionID != "" {
+		return "claude:" + sessionID
+	}
+	return ""
+}
+
+func CodexReasoningReplaySessionKeyFromPayload(payload []byte) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	if value := strings.TrimSpace(gjson.GetBytes(payload, "prompt_cache_key").String()); value != "" {
+		return "prompt-cache:" + value
+	}
+	if value := strings.TrimSpace(gjson.GetBytes(payload, "client_metadata.x-codex-window-id").String()); value != "" {
+		return "window:" + value
+	}
+	return CodexReasoningReplaySessionKeyFromTurnMetadata(gjson.GetBytes(payload, "client_metadata.x-codex-turn-metadata").String())
+}
+
+func CodexReasoningReplaySessionKeyFromHeaders(headers http.Header) string {
+	if headers == nil {
+		return ""
+	}
+	if value := CodexReasoningReplaySessionKeyFromTurnMetadata(headerValueCaseInsensitive(headers, "X-Codex-Turn-Metadata")); value != "" {
+		return value
+	}
+	if value := strings.TrimSpace(headerValueCaseInsensitive(headers, "X-Codex-Window-Id")); value != "" {
+		return "window:" + value
+	}
+	for _, name := range []string{"Session_id", "session_id", "Session-Id"} {
+		if value := strings.TrimSpace(headerValueCaseInsensitive(headers, name)); value != "" {
+			return "session-id:" + value
+		}
+	}
+	if value := strings.TrimSpace(headerValueCaseInsensitive(headers, "Conversation_id")); value != "" {
+		return "conversation_id:" + value
+	}
+	return ""
+}
+
+func CodexReasoningReplaySessionKeyFromTurnMetadata(raw string) string {
+	if value := strings.TrimSpace(gjson.Get(raw, "prompt_cache_key").String()); value != "" {
+		return "prompt-cache:" + value
+	}
+	if value := strings.TrimSpace(gjson.Get(raw, "window_id").String()); value != "" {
+		return "window:" + value
+	}
+	return ""
+}
+
+// ExtractClaudeCodeSessionID resolves both the legacy `_session_<uuid>` user
+// ID and the newer JSON metadata shape, preferring explicit request headers.
+func ExtractClaudeCodeSessionID(ctx context.Context, payload []byte, headers http.Header) string {
+	if sessionID := strings.TrimSpace(headerValueCaseInsensitive(headers, ClaudeCodeSessionHeader)); sessionID != "" {
+		return sessionID
+	}
+	if ginHeaders := headersFromGinContext(ctx); ginHeaders != nil {
+		if sessionID := strings.TrimSpace(headerValueCaseInsensitive(ginHeaders, ClaudeCodeSessionHeader)); sessionID != "" {
+			return sessionID
+		}
+	}
+	if len(payload) == 0 {
+		return ""
+	}
+	userID := strings.TrimSpace(gjson.GetBytes(payload, "metadata.user_id").String())
+	if userID == "" {
+		return ""
+	}
+	if matches := claudeCodeSessionSuffixPattern.FindStringSubmatch(userID); len(matches) >= 2 {
+		return strings.TrimSpace(matches[1])
+	}
+	if strings.HasPrefix(userID, "{") {
+		return strings.TrimSpace(gjson.Get(userID, "session_id").String())
+	}
+	return ""
+}
+
+func headersFromGinContext(ctx context.Context) http.Header {
+	if ctx == nil {
+		return nil
+	}
+	ginCtx, ok := ctx.Value("gin").(*gin.Context)
+	if !ok || ginCtx == nil || ginCtx.Request == nil {
+		return nil
+	}
+	return ginCtx.Request.Header
+}
+
+func headerValueCaseInsensitive(headers http.Header, name string) string {
+	if headers == nil {
+		return ""
+	}
+	for key, values := range headers {
+		if !strings.EqualFold(strings.TrimSpace(key), name) || len(values) == 0 {
+			continue
+		}
+		for _, value := range values {
+			if strings.TrimSpace(value) != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}

--- a/internal/config/codex_model_fallback_test.go
+++ b/internal/config/codex_model_fallback_test.go
@@ -1,0 +1,102 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestLoadConfigOptionalCodexModelFallback(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	configYAML := []byte(`
+codex:
+  model-fallback:
+    enabled: true
+    triggers: [capacity]
+    reasoning-continuity: context-reset
+    mappings:
+      - from: gpt-source
+        to: [gpt-target, gpt-backup]
+`)
+	if err := os.WriteFile(configPath, configYAML, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cfg, err := LoadConfigOptional(configPath, false)
+	if err != nil {
+		t.Fatalf("LoadConfigOptional() error = %v", err)
+	}
+	effective := cfg.Codex.ModelFallback.Effective()
+	if !effective.Enabled {
+		t.Fatal("Enabled = false, want true")
+	}
+	if effective.ReasoningContinuity != CodexModelFallbackReasoningContinuityContextReset {
+		t.Fatalf("ReasoningContinuity = %q, want context-reset", effective.ReasoningContinuity)
+	}
+	if got := effective.TargetsFor("gpt-source", CodexModelFallbackTriggerCapacity); !reflect.DeepEqual(got, []string{"gpt-target", "gpt-backup"}) {
+		t.Fatalf("TargetsFor() = %#v", got)
+	}
+}
+
+func TestCodexModelFallbackEffectiveDefaultsAndNormalizesMappings(t *testing.T) {
+	effective := (CodexModelFallbackConfig{
+		Enabled: true,
+		Mappings: []CodexModelFallbackMapping{
+			{From: " gpt-5.6-sol ", To: []string{" gpt-5.6-terra ", "GPT-5.6-TERRA", "gpt-5.6-sol", ""}},
+			{From: "", To: []string{"gpt-5.5"}},
+		},
+	}).Effective()
+
+	if !effective.Enabled {
+		t.Fatal("Enabled = false, want true")
+	}
+	if effective.ReasoningContinuity != CodexModelFallbackReasoningContinuitySameModelOnly {
+		t.Fatalf("ReasoningContinuity = %q, want %q", effective.ReasoningContinuity, CodexModelFallbackReasoningContinuitySameModelOnly)
+	}
+	if !reflect.DeepEqual(effective.Triggers, []string{CodexModelFallbackTriggerUsageLimit, CodexModelFallbackTriggerCapacity}) {
+		t.Fatalf("Triggers = %#v", effective.Triggers)
+	}
+	if len(effective.Mappings) != 1 {
+		t.Fatalf("Mappings = %#v, want one normalized mapping", effective.Mappings)
+	}
+	if got := effective.TargetsFor("gpt-5.6-sol", CodexModelFallbackTriggerUsageLimit); !reflect.DeepEqual(got, []string{"gpt-5.6-terra"}) {
+		t.Fatalf("TargetsFor() = %#v, want [gpt-5.6-terra]", got)
+	}
+	if got := effective.TargetsFor("gpt-5.6-sol", "rate-limit"); got != nil {
+		t.Fatalf("TargetsFor(transient) = %#v, want nil", got)
+	}
+}
+
+func TestCodexModelFallbackEffectiveSupportsExplicitContextResetAndTriggers(t *testing.T) {
+	effective := (CodexModelFallbackConfig{
+		Enabled:             true,
+		Triggers:            []string{"capacity", "unknown", "CAPACITY"},
+		ReasoningContinuity: "context-reset",
+		Mappings: []CodexModelFallbackMapping{
+			{From: "gpt-a", To: []string{"gpt-b", "gpt-c"}},
+		},
+	}).Effective()
+
+	if effective.ReasoningContinuity != CodexModelFallbackReasoningContinuityContextReset {
+		t.Fatalf("ReasoningContinuity = %q, want context-reset", effective.ReasoningContinuity)
+	}
+	if !reflect.DeepEqual(effective.Triggers, []string{CodexModelFallbackTriggerCapacity}) {
+		t.Fatalf("Triggers = %#v, want [capacity]", effective.Triggers)
+	}
+	if got := effective.TargetsFor("GPT-A", CodexModelFallbackTriggerCapacity); !reflect.DeepEqual(got, []string{"gpt-b", "gpt-c"}) {
+		t.Fatalf("TargetsFor(capacity) = %#v", got)
+	}
+	if got := effective.TargetsFor("gpt-a", CodexModelFallbackTriggerUsageLimit); got != nil {
+		t.Fatalf("TargetsFor(usage-limit) = %#v, want nil", got)
+	}
+}
+
+func TestCodexModelFallbackTargetsForDisabledPolicy(t *testing.T) {
+	effective := (CodexModelFallbackConfig{
+		Mappings: []CodexModelFallbackMapping{{From: "gpt-a", To: []string{"gpt-b"}}},
+	}).Effective()
+	if got := effective.TargetsFor("gpt-a", CodexModelFallbackTriggerUsageLimit); got != nil {
+		t.Fatalf("TargetsFor(disabled) = %#v, want nil", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -329,10 +329,15 @@ type CodexHeaderDefaults struct {
 // CodexConfig configures provider-wide Codex request behavior.
 type CodexConfig struct {
 	IdentityConfuse        bool                              `yaml:"identity-confuse" json:"identity-confuse"`
+	ModelFallback          CodexModelFallbackConfig          `yaml:"model-fallback" json:"model-fallback"`
 	AbnormalReasoningRetry CodexAbnormalReasoningRetryConfig `yaml:"abnormal-reasoning-retry" json:"abnormal-reasoning-retry"`
 }
 
 const (
+	CodexModelFallbackTriggerUsageLimit                                    = "usage-limit"
+	CodexModelFallbackTriggerCapacity                                      = "capacity"
+	CodexModelFallbackReasoningContinuitySameModelOnly                     = "same-model-only"
+	CodexModelFallbackReasoningContinuityContextReset                      = "context-reset"
 	CodexAbnormalReasoningRetryActionRetry                                 = "retry"
 	CodexAbnormalReasoningRetryActionObserveOnly                           = "observe-only"
 	CodexAbnormalReasoningRetryActionDisabled                              = "disabled"
@@ -351,6 +356,109 @@ const (
 	CodexAbnormalReasoningHedgedRetryModeSpeed                             = "speed"
 	CodexAbnormalReasoningHedgedRetryModeQuality                           = "quality"
 )
+
+// CodexModelFallbackConfig controls ordered, opt-in fallback between Codex
+// models after a precisely classified quota or capacity failure.
+type CodexModelFallbackConfig struct {
+	Enabled             bool                        `yaml:"enabled" json:"enabled"`
+	Triggers            []string                    `yaml:"triggers" json:"triggers"`
+	ReasoningContinuity string                      `yaml:"reasoning-continuity,omitempty" json:"reasoning-continuity,omitempty"`
+	Mappings            []CodexModelFallbackMapping `yaml:"mappings" json:"mappings"`
+}
+
+// CodexModelFallbackMapping defines ordered target models for one requested
+// Codex model. From is matched case-insensitively after trimming.
+type CodexModelFallbackMapping struct {
+	From string   `yaml:"from" json:"from"`
+	To   []string `yaml:"to" json:"to"`
+}
+
+// EffectiveCodexModelFallbackConfig is the sanitized runtime view of
+// CodexModelFallbackConfig. Defaults are derived in memory so existing config
+// files are not rewritten.
+type EffectiveCodexModelFallbackConfig struct {
+	Enabled             bool
+	Triggers            []string
+	ReasoningContinuity string
+	Mappings            []CodexModelFallbackMapping
+}
+
+// Effective returns a normalized model-fallback policy.
+func (c CodexModelFallbackConfig) Effective() EffectiveCodexModelFallbackConfig {
+	triggers := defaultedTrimmedStringList(c.Triggers, []string{
+		CodexModelFallbackTriggerUsageLimit,
+		CodexModelFallbackTriggerCapacity,
+	}, true)
+	filteredTriggers := make([]string, 0, len(triggers))
+	for _, trigger := range triggers {
+		switch trigger {
+		case CodexModelFallbackTriggerUsageLimit, CodexModelFallbackTriggerCapacity:
+			filteredTriggers = append(filteredTriggers, trigger)
+		}
+	}
+
+	reasoningContinuity := strings.ToLower(strings.TrimSpace(c.ReasoningContinuity))
+	if reasoningContinuity != CodexModelFallbackReasoningContinuityContextReset {
+		reasoningContinuity = CodexModelFallbackReasoningContinuitySameModelOnly
+	}
+
+	mappings := make([]CodexModelFallbackMapping, 0, len(c.Mappings))
+	for _, mapping := range c.Mappings {
+		from := strings.TrimSpace(mapping.From)
+		if from == "" {
+			continue
+		}
+		seen := make(map[string]struct{}, len(mapping.To))
+		to := make([]string, 0, len(mapping.To))
+		for _, target := range mapping.To {
+			target = strings.TrimSpace(target)
+			key := strings.ToLower(target)
+			if target == "" || strings.EqualFold(target, from) {
+				continue
+			}
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			to = append(to, target)
+		}
+		if len(to) == 0 {
+			continue
+		}
+		mappings = append(mappings, CodexModelFallbackMapping{From: from, To: to})
+	}
+
+	return EffectiveCodexModelFallbackConfig{
+		Enabled:             c.Enabled,
+		Triggers:            filteredTriggers,
+		ReasoningContinuity: reasoningContinuity,
+		Mappings:            mappings,
+	}
+}
+
+// TargetsFor returns the ordered fallback targets for model and trigger.
+func (c EffectiveCodexModelFallbackConfig) TargetsFor(model, trigger string) []string {
+	if !c.Enabled || strings.TrimSpace(model) == "" || strings.TrimSpace(trigger) == "" {
+		return nil
+	}
+	trigger = strings.ToLower(strings.TrimSpace(trigger))
+	allowed := false
+	for _, candidate := range c.Triggers {
+		if candidate == trigger {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		return nil
+	}
+	for _, mapping := range c.Mappings {
+		if strings.EqualFold(strings.TrimSpace(mapping.From), strings.TrimSpace(model)) {
+			return append([]string(nil), mapping.To...)
+		}
+	}
+	return nil
+}
 
 // CodexAbnormalReasoningRetryConfig controls the CPA-Core-LTS retry guard for
 // suspicious Codex successful responses.

--- a/internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
+++ b/internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -12,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
@@ -20,6 +22,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 func TestCodexExecutorAbnormalReasoningRetry_NonStreaming(t *testing.T) {
@@ -601,6 +604,144 @@ func TestCodexExecutorAbnormalReasoningRetry_ClientUsageAggregationSumSumsFields
 	}
 	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens_details.reasoning_tokens").Int(); got != 644 {
 		t.Fatalf("client response usage.reasoning_tokens = %d, want summed reasoning 644; payload=%s", got, resp.Payload)
+	}
+}
+
+func TestCodexExecutorModelFallbackPreservesSourceAbnormalPolicyAndUsageAggregation(t *testing.T) {
+	var sourceCalls, targetCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		model := strings.TrimSpace(gjson.GetBytes(body, "model").String())
+		switch model {
+		case "gpt-source":
+			sourceCalls++
+			if sourceCalls == 1 {
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = w.Write([]byte(codexCompletedSSEWithUsage("gpt-source", 516, 1, 2, 3)))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error":{"type":"usage_limit_reached","message":"source quota","resets_in_seconds":60}}`))
+		case "gpt-target":
+			targetCalls++
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write([]byte(codexCompletedSSEWithUsage("gpt-target", 128, 5, 7, 12)))
+		default:
+			t.Errorf("unexpected upstream model %q; body=%s", model, body)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	maxRetries := 1
+	cfg := codexAbnormalReasoningRetryTestConfigWithAggregation(config.CodexAbnormalReasoningRetryClientUsageAggregationSum)
+	cfg.Codex.AbnormalReasoningRetry.MaxRetries = &maxRetries
+	cfg.Codex.AbnormalReasoningRetry.ModelContains = []string{"gpt-source"}
+	cfg.Codex.ModelFallback = config.CodexModelFallbackConfig{
+		Enabled:  true,
+		Mappings: []config.CodexModelFallbackMapping{{From: "gpt-source", To: []string{"gpt-target"}}},
+	}
+
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	manager.SetConfig(cfg)
+	manager.RegisterExecutor(NewCodexExecutor(cfg))
+	manager.SetRetryConfig(0, 0, 0)
+
+	auth := codexAbnormalReasoningRetryTestAuth(server.URL)
+	auth.ID = "codex-oauth-model-fallback-shared-policy"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, "codex", []*registry.ModelInfo{{ID: "gpt-source"}, {ID: "gpt-target"}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	resp, errExecute := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{
+		Model:   "gpt-source",
+		Payload: []byte(`{"model":"gpt-source","input":"hello"}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse})
+	if errExecute != nil {
+		t.Fatalf("Execute error = %v, want target success", errExecute)
+	}
+	if sourceCalls != 2 || targetCalls != 1 {
+		t.Fatalf("upstream calls = source:%d target:%d, want source:2 target:1", sourceCalls, targetCalls)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.total_tokens").Int(); got != 15 {
+		t.Fatalf("client response usage.total_tokens = %d, want shared source+target total 15; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.input_tokens").Int(); got != 6 {
+		t.Fatalf("client response usage.input_tokens = %d, want shared input 6; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens").Int(); got != 9 {
+		t.Fatalf("client response usage.output_tokens = %d, want shared output 9; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "usage.output_tokens_details.reasoning_tokens").Int(); got != 644 {
+		t.Fatalf("client response usage.reasoning_tokens = %d, want shared reasoning 644; payload=%s", got, resp.Payload)
+	}
+}
+
+func TestCodexExecutorModelFallbackPreflightUsesAfterAuthRewrittenReplayScope(t *testing.T) {
+	internalcache.ClearCodexReasoningReplayCache()
+	t.Cleanup(internalcache.ClearCodexReasoningReplayCache)
+	if !internalcache.CacheCodexReasoningReplayItem("gpt-source", "prompt-cache:after-auth-rewritten", []byte(`{"type":"function_call","call_id":"call-after-auth","name":"tool","arguments":"{}"}`)) {
+		t.Fatal("failed to cache replay test item")
+	}
+	var upstreamCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamCalls++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"type":"usage_limit_reached","message":"source quota","resets_in_seconds":60}}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{Codex: config.CodexConfig{ModelFallback: config.CodexModelFallbackConfig{
+		Enabled:  true,
+		Mappings: []config.CodexModelFallbackMapping{{From: "gpt-source", To: []string{"gpt-target"}}},
+	}}}
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	manager.SetConfig(cfg)
+	manager.SetRetryConfig(0, 0, 0)
+	manager.RegisterExecutor(NewCodexExecutor(cfg))
+	auth := codexAbnormalReasoningRetryTestAuth(server.URL)
+	auth.ID = "codex-oauth-after-auth-replay"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, "codex", []*registry.ModelInfo{{ID: "gpt-source"}, {ID: "gpt-target"}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	var interceptedModels []string
+	_, errExecute := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{
+		Model:   "gpt-source",
+		Payload: []byte(`{"model":"gpt-source","messages":[{"role":"user","content":"continue"}],"max_tokens":32}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatClaude,
+		RequestAfterAuthInterceptor: func(_ context.Context, request cliproxyexecutor.RequestAfterAuthInterceptRequest) cliproxyexecutor.RequestAfterAuthInterceptResponse {
+			interceptedModels = append(interceptedModels, request.Model)
+			body := request.Body
+			if request.Model == "gpt-source" {
+				body, _ = sjson.SetBytes(body, "prompt_cache_key", "after-auth-rewritten")
+			}
+			return cliproxyexecutor.RequestAfterAuthInterceptResponse{Body: body}
+		},
+	})
+	var classified interface{ ModelFallbackReason() string }
+	if !errors.As(errExecute, &classified) || classified == nil || classified.ModelFallbackReason() != config.CodexModelFallbackTriggerUsageLimit {
+		t.Fatalf("Execute error = %v, want original typed usage-limit", errExecute)
+	}
+	if upstreamCalls != 1 {
+		t.Fatalf("upstream calls = %d, want source only", upstreamCalls)
+	}
+	if len(interceptedModels) != 1 || interceptedModels[0] != "gpt-source" {
+		t.Fatalf("after-auth interceptor models = %#v, want source only before fallback preflight", interceptedModels)
 	}
 }
 
@@ -1671,6 +1812,12 @@ func (r *codexAbnormalReasoningRetryUsageRecorder) HandleUsage(_ context.Context
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.records = append(r.records, record)
+}
+
+func (r *codexAbnormalReasoningRetryUsageRecorder) recordCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.records)
 }
 
 func (r *codexAbnormalReasoningRetryUsageRecorder) waitForRecord(t *testing.T, match func(usage.Record) bool) usage.Record {

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -841,7 +841,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
 	defer func() {
-		if !isRetryWithoutPenaltyError(err) {
+		if !isRetryWithoutPenaltyError(err) && !isCodexModelFallbackBlockedError(err) {
 			reporter.TrackFailure(ctx, &err)
 		}
 	}()
@@ -878,9 +878,16 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	}
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex executor", body)
 	body = normalizeCodexParallelToolCallsForTools(body)
-	body, replayScope, errReplay := applyCodexReasoningReplayCacheRequired(ctx, from, req, opts, body)
-	if errReplay != nil {
-		return resp, errReplay
+	body, replayScope, skipReplay, errFallback := prepareCodexModelFallbackBody(ctx, from, req, opts, body)
+	if errFallback != nil {
+		return resp, errFallback
+	}
+	if !skipReplay {
+		var errReplay error
+		body, replayScope, errReplay = applyCodexReasoningReplayCacheRequired(ctx, from, req, opts, body)
+		if errReplay != nil {
+			return resp, errReplay
+		}
 	}
 	body, err = thinking.NormalizeCodexReasoningEffortForWire(body, baseModel)
 	if err != nil {
@@ -1045,7 +1052,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
 	defer func() {
-		if !isRetryWithoutPenaltyError(err) {
+		if !isRetryWithoutPenaltyError(err) && !isCodexModelFallbackBlockedError(err) {
 			reporter.TrackFailure(ctx, &err)
 		}
 	}()
@@ -1196,9 +1203,16 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	}
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex executor", body)
 	body = normalizeCodexParallelToolCallsForTools(body)
-	body, replayScope, errReplay := applyCodexReasoningReplayCacheRequired(ctx, from, req, opts, body)
-	if errReplay != nil {
-		return nil, errReplay
+	body, replayScope, skipReplay, errFallback := prepareCodexModelFallbackBody(ctx, from, req, opts, body)
+	if errFallback != nil {
+		return nil, errFallback
+	}
+	if !skipReplay {
+		var errReplay error
+		body, replayScope, errReplay = applyCodexReasoningReplayCacheRequired(ctx, from, req, opts, body)
+		if errReplay != nil {
+			return nil, errReplay
+		}
 	}
 	body, err = thinking.NormalizeCodexReasoningEffortForWire(body, baseModel)
 	if err != nil {
@@ -1905,11 +1919,16 @@ func applyCodexHeadersFromSources(r *http.Request, auth *cliproxyauth.Auth, toke
 
 func newCodexStatusErr(statusCode int, body []byte) statusErr {
 	errCode := statusCode
-	if isCodexModelCapacityError(body) || isCodexUsageLimitError(body) {
+	fallbackReason := ""
+	if isCodexModelCapacityError(body) {
 		errCode = http.StatusTooManyRequests
+		fallbackReason = config.CodexModelFallbackTriggerCapacity
+	} else if isCodexUsageLimitError(body) {
+		errCode = http.StatusTooManyRequests
+		fallbackReason = config.CodexModelFallbackTriggerUsageLimit
 	}
 	body = classifyCodexStatusError(errCode, body)
-	err := statusErr{code: errCode, msg: string(body)}
+	err := statusErr{code: errCode, msg: string(body), modelFallbackReason: fallbackReason}
 	if retryAfter := parseCodexRetryAfter(errCode, body, time.Now()); retryAfter != nil {
 		err.retryAfter = retryAfter
 	}

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -378,47 +378,16 @@ func sourceFormatEqual(from, want sdktranslator.Format) bool {
 	return strings.EqualFold(strings.TrimSpace(from.String()), want.String())
 }
 
-func codexClaudeCodeReplaySessionKey(ctx context.Context, payload []byte, headers http.Header) string {
-	sessionID := helps.ExtractClaudeCodeSessionID(ctx, payload, headers)
-	if sessionID == "" {
-		return ""
-	}
-	return "claude:" + sessionID
-}
-
 func codexReasoningReplaySessionKey(ctx context.Context, from sdktranslator.Format, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, body []byte) string {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	if value := metadataString(opts.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey); value != "" {
-		return "execution:" + value
-	}
-	if value := metadataString(req.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey); value != "" {
-		return "execution:" + value
-	}
-	if value := codexReasoningReplaySessionKeyFromPayload(body); value != "" {
-		return value
-	}
-	if value := codexReasoningReplaySessionKeyFromPayload(req.Payload); value != "" {
-		return value
-	}
-	if value := codexReasoningReplaySessionKeyFromHeaders(opts.Headers); value != "" {
-		return value
-	}
-	if ginCtx, ok := ctx.Value("gin").(*gin.Context); ok && ginCtx != nil && ginCtx.Request != nil {
-		if value := codexReasoningReplaySessionKeyFromHeaders(ginCtx.Request.Header); value != "" {
-			return value
-		}
-	}
-	if sourceFormatEqual(from, sdktranslator.FormatClaude) {
-		return codexClaudeCodeReplaySessionKey(ctx, req.Payload, opts.Headers)
-	}
-	if sourceFormatEqual(from, sdktranslator.FormatOpenAI) {
-		if apiKey := strings.TrimSpace(helps.APIKeyFromContext(ctx)); apiKey != "" {
-			return "prompt-cache:" + uuid.NewSHA1(uuid.NameSpaceOID, []byte("cli-proxy-api:codex:prompt-cache:"+apiKey)).String()
-		}
-	}
-	return ""
+	return internalcache.ResolveCodexReasoningReplaySessionKey(internalcache.CodexReasoningReplaySessionInput{
+		Context:                 ctx,
+		SourceFormat:            from.String(),
+		TranslatedPayload:       body,
+		RequestPayload:          req.Payload,
+		Headers:                 opts.Headers,
+		OptionExecutionSession:  metadataString(opts.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey),
+		RequestExecutionSession: metadataString(req.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey),
+	})
 }
 
 func metadataString(metadata map[string]any, key string) string {
@@ -440,52 +409,15 @@ func metadataString(metadata map[string]any, key string) string {
 }
 
 func codexReasoningReplaySessionKeyFromPayload(payload []byte) string {
-	if len(payload) == 0 {
-		return ""
-	}
-	if promptCacheKey := strings.TrimSpace(gjson.GetBytes(payload, "prompt_cache_key").String()); promptCacheKey != "" {
-		return "prompt-cache:" + promptCacheKey
-	}
-	if windowID := strings.TrimSpace(gjson.GetBytes(payload, "client_metadata.x-codex-window-id").String()); windowID != "" {
-		return "window:" + windowID
-	}
-	if turnMetadata := strings.TrimSpace(gjson.GetBytes(payload, "client_metadata.x-codex-turn-metadata").String()); turnMetadata != "" {
-		return codexReasoningReplaySessionKeyFromTurnMetadata(turnMetadata)
-	}
-	return ""
+	return internalcache.CodexReasoningReplaySessionKeyFromPayload(payload)
 }
 
 func codexReasoningReplaySessionKeyFromHeaders(headers http.Header) string {
-	if headers == nil {
-		return ""
-	}
-	if turnMetadata := strings.TrimSpace(headers.Get("X-Codex-Turn-Metadata")); turnMetadata != "" {
-		if key := codexReasoningReplaySessionKeyFromTurnMetadata(turnMetadata); key != "" {
-			return key
-		}
-	}
-	if windowID := strings.TrimSpace(headerValueCaseInsensitive(headers, "X-Codex-Window-Id")); windowID != "" {
-		return "window:" + windowID
-	}
-	for _, headerName := range []string{"Session_id", "session_id", "Session-Id"} {
-		if value := strings.TrimSpace(headerValueCaseInsensitive(headers, headerName)); value != "" {
-			return "session-id:" + value
-		}
-	}
-	if conversationID := strings.TrimSpace(headerValueCaseInsensitive(headers, "Conversation_id")); conversationID != "" {
-		return "conversation_id:" + conversationID
-	}
-	return ""
+	return internalcache.CodexReasoningReplaySessionKeyFromHeaders(headers)
 }
 
 func codexReasoningReplaySessionKeyFromTurnMetadata(turnMetadata string) string {
-	if promptCacheKey := strings.TrimSpace(gjson.Get(turnMetadata, "prompt_cache_key").String()); promptCacheKey != "" {
-		return "prompt-cache:" + promptCacheKey
-	}
-	if windowID := strings.TrimSpace(gjson.Get(turnMetadata, "window_id").String()); windowID != "" {
-		return "window:" + windowID
-	}
-	return ""
+	return internalcache.CodexReasoningReplaySessionKeyFromTurnMetadata(turnMetadata)
 }
 
 func codexInputHasValidReasoningEncryptedContent(body []byte) bool {
@@ -840,11 +772,13 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	}
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
+	var replayScope codexReasoningReplayScope
 	defer func() {
 		if !isRetryWithoutPenaltyError(err) && !isCodexModelFallbackBlockedError(err) {
 			reporter.TrackFailure(ctx, &err)
 		}
 	}()
+	defer func() { err = withCodexReasoningReplayScope(err, replayScope) }()
 
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
@@ -878,9 +812,10 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	}
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex executor", body)
 	body = normalizeCodexParallelToolCallsForTools(body)
-	body, replayScope, skipReplay, errFallback := prepareCodexModelFallbackBody(ctx, from, req, opts, body)
-	if errFallback != nil {
-		return resp, errFallback
+	var skipReplay bool
+	body, replayScope, skipReplay, err = prepareCodexModelFallbackBody(ctx, from, req, opts, body)
+	if err != nil {
+		return resp, err
 	}
 	if !skipReplay {
 		var errReplay error
@@ -1166,11 +1101,13 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	}
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
+	var replayScope codexReasoningReplayScope
 	defer func() {
-		if !isRetryWithoutPenaltyError(err) {
+		if !isRetryWithoutPenaltyError(err) && !isCodexModelFallbackBlockedError(err) {
 			reporter.TrackFailure(ctx, &err)
 		}
 	}()
+	defer func() { err = withCodexReasoningReplayScope(err, replayScope) }()
 
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
@@ -1203,9 +1140,10 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	}
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex executor", body)
 	body = normalizeCodexParallelToolCallsForTools(body)
-	body, replayScope, skipReplay, errFallback := prepareCodexModelFallbackBody(ctx, from, req, opts, body)
-	if errFallback != nil {
-		return nil, errFallback
+	var skipReplay bool
+	body, replayScope, skipReplay, err = prepareCodexModelFallbackBody(ctx, from, req, opts, body)
+	if err != nil {
+		return nil, err
 	}
 	if !skipReplay {
 		var errReplay error
@@ -1345,7 +1283,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		}
 		emitError := func(err error) {
 			select {
-			case out <- cliproxyexecutor.StreamChunk{Err: err}:
+			case out <- cliproxyexecutor.StreamChunk{Err: withCodexReasoningReplayScope(err, replayScope)}:
 			case <-ctx.Done():
 			}
 		}

--- a/internal/runtime/executor/codex_executor_retry_test.go
+++ b/internal/runtime/executor/codex_executor_retry_test.go
@@ -72,6 +72,9 @@ func TestNewCodexStatusErrTreatsCapacityAsRetryableRateLimit(t *testing.T) {
 	if err.RetryAfter() != nil {
 		t.Fatalf("expected nil explicit retryAfter for capacity fallback, got %v", *err.RetryAfter())
 	}
+	if got := err.ModelFallbackReason(); got != "capacity" {
+		t.Fatalf("ModelFallbackReason() = %q, want capacity", got)
+	}
 }
 
 func TestNewCodexStatusErrTreatsUsageLimitAsRetryableRateLimit(t *testing.T) {
@@ -88,6 +91,16 @@ func TestNewCodexStatusErrTreatsUsageLimitAsRetryableRateLimit(t *testing.T) {
 	}
 	if *retryAfter != 120*time.Second {
 		t.Fatalf("retryAfter = %v, want %v", *retryAfter, 120*time.Second)
+	}
+	if got := err.ModelFallbackReason(); got != "usage-limit" {
+		t.Fatalf("ModelFallbackReason() = %q, want usage-limit", got)
+	}
+}
+
+func TestNewCodexStatusErrDoesNotClassifyTransientRateLimitForModelFallback(t *testing.T) {
+	err := newCodexStatusErr(http.StatusTooManyRequests, []byte(`{"error":{"type":"rate_limit_error","code":"rate_limit_exceeded"}}`))
+	if got := err.ModelFallbackReason(); got != "" {
+		t.Fatalf("ModelFallbackReason() = %q, want empty", got)
 	}
 }
 

--- a/internal/runtime/executor/codex_model_fallback.go
+++ b/internal/runtime/executor/codex_model_fallback.go
@@ -39,6 +39,45 @@ func (e *codexModelFallbackContinuityError) Unwrap() error {
 
 func (e *codexModelFallbackContinuityError) ModelFallbackBlocked() bool { return true }
 
+type codexReasoningReplayScopeError struct {
+	cause error
+	scope codexReasoningReplayScope
+}
+
+func (e *codexReasoningReplayScopeError) Error() string {
+	if e == nil || e.cause == nil {
+		return ""
+	}
+	return e.cause.Error()
+}
+
+func (e *codexReasoningReplayScopeError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+func (e *codexReasoningReplayScopeError) CodexReasoningReplayScope() (modelName, sessionKey string) {
+	if e == nil {
+		return "", ""
+	}
+	return e.scope.modelName, e.scope.sessionKey
+}
+
+func withCodexReasoningReplayScope(err error, scope codexReasoningReplayScope) error {
+	if err == nil || !scope.valid() {
+		return err
+	}
+	var existing interface {
+		CodexReasoningReplayScope() (modelName, sessionKey string)
+	}
+	if errors.As(err, &existing) && existing != nil {
+		return err
+	}
+	return &codexReasoningReplayScopeError{cause: err, scope: scope}
+}
+
 func isCodexModelFallbackBlockedError(err error) bool {
 	if err == nil {
 		return false
@@ -96,18 +135,38 @@ func prepareCodexModelFallbackBody(ctx context.Context, from sdktranslator.Forma
 	}
 
 	hasContinuity := codexInputHasReasoningItem(body) || len(sourceItems) > 0
-	if reasoningContinuity != config.CodexModelFallbackReasoningContinuityContextReset && hasContinuity {
+	hasPreviousResponse := strings.TrimSpace(gjson.GetBytes(req.Payload, "previous_response_id").String()) != ""
+	hasPinnedAuth := metadataString(opts.Metadata, cliproxyexecutor.PinnedAuthMetadataKey) != ""
+	hasExecutionSession := metadataString(opts.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey) != ""
+	hasStatefulContinuity := hasContinuity || hasPreviousResponse || hasPinnedAuth || hasExecutionSession
+	if reasoningContinuity != config.CodexModelFallbackReasoningContinuityContextReset && hasStatefulContinuity {
 		return body, codexReasoningReplayScope{}, true, &codexModelFallbackContinuityError{
 			sourceModel: sourceBase,
 			targetModel: targetBase,
-			reason:      "reasoning continuity is scoped to the source model",
+			reason:      "session and reasoning continuity are scoped to the source model",
 		}
 	}
 
 	updated := body
 	if reasoningContinuity == config.CodexModelFallbackReasoningContinuityContextReset {
+		// The handler marker is intentionally required only when there is state
+		// to reset. A stateless HTTP request remains a safe fallback candidate;
+		// a previous_response_id/pin/session without a complete transcript is
+		// not. In particular this rejects end-to-end websocket passthrough and
+		// incremental websocket turns before any target request is dispatched.
+		resetAllowed, _ := opts.Metadata[cliproxyexecutor.CodexModelFallbackContextResetReplayMetadataKey].(bool)
+		if hasStatefulContinuity && !resetAllowed {
+			return body, codexReasoningReplayScope{}, true, &codexModelFallbackContinuityError{
+				sourceModel: sourceBase,
+				targetModel: targetBase,
+				reason:      "context reset requires a complete handler-owned websocket transcript",
+			}
+		}
 		var errReset error
 		updated, errReset = dropCodexReasoningInputItems(updated)
+		if errReset == nil {
+			updated, errReset = sjson.DeleteBytes(updated, "previous_response_id")
+		}
 		if errReset != nil || codexInputHasReasoningItem(updated) {
 			return body, codexReasoningReplayScope{}, true, &codexModelFallbackContinuityError{
 				sourceModel: sourceBase,

--- a/internal/runtime/executor/codex_model_fallback.go
+++ b/internal/runtime/executor/codex_model_fallback.go
@@ -1,0 +1,186 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+type codexModelFallbackContinuityError struct {
+	sourceModel string
+	targetModel string
+	reason      string
+	cause       error
+}
+
+func (e *codexModelFallbackContinuityError) Error() string {
+	if e == nil {
+		return "codex model fallback blocked"
+	}
+	return fmt.Sprintf("codex model fallback from %s to %s blocked: %s", e.sourceModel, e.targetModel, e.reason)
+}
+
+func (e *codexModelFallbackContinuityError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+func (e *codexModelFallbackContinuityError) ModelFallbackBlocked() bool { return true }
+
+func isCodexModelFallbackBlockedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var blocked interface{ ModelFallbackBlocked() bool }
+	return errors.As(err, &blocked) && blocked != nil && blocked.ModelFallbackBlocked()
+}
+
+func codexModelFallbackMetadata(opts cliproxyexecutor.Options) (sourceModel, reasoningContinuity string, ok bool) {
+	sourceModel = metadataString(opts.Metadata, cliproxyexecutor.CodexModelFallbackSourceModelMetadataKey)
+	if sourceModel == "" {
+		return "", "", false
+	}
+	reasoningContinuity = strings.ToLower(metadataString(opts.Metadata, cliproxyexecutor.CodexModelFallbackReasoningContinuityMetadataKey))
+	if reasoningContinuity != config.CodexModelFallbackReasoningContinuityContextReset {
+		reasoningContinuity = config.CodexModelFallbackReasoningContinuitySameModelOnly
+	}
+	return sourceModel, reasoningContinuity, true
+}
+
+func prepareCodexModelFallbackBody(ctx context.Context, from sdktranslator.Format, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, body []byte) ([]byte, codexReasoningReplayScope, bool, error) {
+	sourceModel, reasoningContinuity, ok := codexModelFallbackMetadata(opts)
+	if !ok {
+		return body, codexReasoningReplayScope{}, false, nil
+	}
+	sourceBase := strings.TrimSpace(thinking.ParseSuffix(sourceModel).ModelName)
+	targetBase := strings.TrimSpace(thinking.ParseSuffix(req.Model).ModelName)
+	if sourceBase == "" {
+		sourceBase = strings.TrimSpace(sourceModel)
+	}
+	if targetBase == "" {
+		targetBase = strings.TrimSpace(req.Model)
+	}
+	if strings.EqualFold(sourceBase, targetBase) {
+		return body, codexReasoningReplayScope{}, false, nil
+	}
+
+	sourceReq := req
+	sourceReq.Model = sourceModel
+	sourceScope := codexReasoningReplayScopeFromRequest(ctx, from, sourceReq, opts, body)
+	var sourceItems [][]byte
+	if sourceScope.valid() {
+		items, found, errReplay := internalcache.GetCodexReasoningReplayItemsRequired(ctx, sourceScope.modelName, sourceScope.sessionKey)
+		if errReplay != nil {
+			return body, codexReasoningReplayScope{}, true, &codexModelFallbackContinuityError{
+				sourceModel: sourceBase,
+				targetModel: targetBase,
+				reason:      "source reasoning replay state is unavailable",
+				cause:       errReplay,
+			}
+		}
+		if found {
+			sourceItems = items
+		}
+	}
+
+	hasContinuity := codexInputHasReasoningItem(body) || len(sourceItems) > 0
+	if reasoningContinuity != config.CodexModelFallbackReasoningContinuityContextReset && hasContinuity {
+		return body, codexReasoningReplayScope{}, true, &codexModelFallbackContinuityError{
+			sourceModel: sourceBase,
+			targetModel: targetBase,
+			reason:      "reasoning continuity is scoped to the source model",
+		}
+	}
+
+	updated := body
+	if reasoningContinuity == config.CodexModelFallbackReasoningContinuityContextReset {
+		var errReset error
+		updated, errReset = dropCodexReasoningInputItems(updated)
+		if errReset != nil || codexInputHasReasoningItem(updated) {
+			return body, codexReasoningReplayScope{}, true, &codexModelFallbackContinuityError{
+				sourceModel: sourceBase,
+				targetModel: targetBase,
+				reason:      "reasoning context reset could not be applied safely",
+				cause:       errReset,
+			}
+		}
+		toolItems := codexModelFallbackToolReplayItems(sourceItems)
+		toolItems = filterCodexReasoningReplayItemsForInput(updated, toolItems)
+		if len(toolItems) > 0 {
+			if next, inserted := insertCodexReasoningReplayItems(updated, toolItems); inserted {
+				updated = next
+			}
+		}
+		helps.LogWithRequestID(ctx).WithFields(map[string]any{
+			"source_model": sourceBase,
+			"target_model": targetBase,
+		}).Info("codex model fallback: reset model-private reasoning continuity")
+	}
+
+	targetScope := codexReasoningReplayScopeFromRequest(ctx, from, req, opts, updated)
+	return updated, targetScope, true, nil
+}
+
+func codexInputHasReasoningItem(body []byte) bool {
+	input := gjson.GetBytes(body, "input")
+	if !input.IsArray() {
+		return false
+	}
+	for _, item := range input.Array() {
+		if strings.EqualFold(strings.TrimSpace(item.Get("type").String()), "reasoning") {
+			return true
+		}
+	}
+	return false
+}
+
+func dropCodexReasoningInputItems(body []byte) ([]byte, error) {
+	input := gjson.GetBytes(body, "input")
+	if !input.IsArray() {
+		return body, nil
+	}
+	items := input.Array()
+	kept := make([]string, 0, len(items))
+	changed := false
+	for _, item := range items {
+		if strings.EqualFold(strings.TrimSpace(item.Get("type").String()), "reasoning") {
+			changed = true
+			continue
+		}
+		kept = append(kept, item.Raw)
+	}
+	if !changed {
+		return body, nil
+	}
+	updated, err := sjson.SetRawBytes(body, "input", []byte("["+strings.Join(kept, ",")+"]"))
+	if err != nil {
+		return body, err
+	}
+	return updated, nil
+}
+
+func codexModelFallbackToolReplayItems(items [][]byte) [][]byte {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([][]byte, 0, len(items))
+	for _, item := range items {
+		switch strings.TrimSpace(gjson.GetBytes(item, "type").String()) {
+		case "function_call", "custom_tool_call":
+			out = append(out, append([]byte(nil), item...))
+		}
+	}
+	return out
+}

--- a/internal/runtime/executor/codex_model_fallback_test.go
+++ b/internal/runtime/executor/codex_model_fallback_test.go
@@ -1,0 +1,173 @@
+package executor
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func codexFallbackTestOptions(sourceModel, mode string) cliproxyexecutor.Options {
+	return cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+		Metadata: map[string]any{
+			cliproxyexecutor.CodexModelFallbackSourceModelMetadataKey:         sourceModel,
+			cliproxyexecutor.CodexModelFallbackReasoningContinuityMetadataKey: mode,
+		},
+	}
+}
+
+func newCodexFallbackExecutorTestServer(t *testing.T, bodies *[][]byte, calls *atomic.Int32) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("ReadAll() error = %v", errRead)
+		}
+		*bodies = append(*bodies, body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_fallback\",\"object\":\"response\",\"created_at\":0,\"status\":\"completed\",\"model\":\"gpt-target\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\n"))
+	}))
+}
+
+func TestCodexExecutorModelFallbackSameModelOnlyBlocksClientReasoning(t *testing.T) {
+	var calls atomic.Int32
+	var bodies [][]byte
+	server := newCodexFallbackExecutorTestServer(t, &bodies, &calls)
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	signature := validCodexReasoningEncryptedContentForTestSeed(31)
+	_, err := executor.Execute(context.Background(), &cliproxyauth.Auth{
+		ID: "auth-fallback-block-client",
+		Attributes: map[string]string{
+			"base_url": server.URL,
+			"api_key":  "test",
+		},
+	}, cliproxyexecutor.Request{
+		Model:   "gpt-target",
+		Payload: []byte(`{"model":"gpt-source","messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"private","signature":"` + signature + `"}]},{"role":"user","content":[{"type":"text","text":"continue"}]}]}`),
+	}, codexFallbackTestOptions("gpt-source", config.CodexModelFallbackReasoningContinuitySameModelOnly))
+	if err == nil || !isCodexModelFallbackBlockedError(err) {
+		t.Fatalf("Execute() error = %v, want model-fallback continuity block", err)
+	}
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("upstream calls = %d, want 0", got)
+	}
+}
+
+func TestCodexExecutorModelFallbackSameModelOnlyBlocksSourceReplayCache(t *testing.T) {
+	internalcache.ClearCodexReasoningReplayCache()
+	t.Cleanup(internalcache.ClearCodexReasoningReplayCache)
+	signature := validCodexReasoningEncryptedContentForTestSeed(32)
+	internalcache.CacheCodexReasoningReplayItem("gpt-source", "claude:session-fallback-source", []byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":"`+signature+`"}`))
+
+	var calls atomic.Int32
+	var bodies [][]byte
+	server := newCodexFallbackExecutorTestServer(t, &bodies, &calls)
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	_, err := executor.Execute(context.Background(), &cliproxyauth.Auth{
+		ID: "auth-fallback-block-cache",
+		Attributes: map[string]string{
+			"base_url": server.URL,
+			"api_key":  "test",
+		},
+	}, cliproxyexecutor.Request{
+		Model:   "gpt-target",
+		Payload: []byte(`{"model":"gpt-source","metadata":{"user_id":"{\"device_id\":\"device\",\"account_uuid\":\"\",\"session_id\":\"session-fallback-source\"}"},"messages":[{"role":"user","content":[{"type":"text","text":"continue"}]}]}`),
+	}, codexFallbackTestOptions("gpt-source", config.CodexModelFallbackReasoningContinuitySameModelOnly))
+	if err == nil || !isCodexModelFallbackBlockedError(err) {
+		t.Fatalf("Execute() error = %v, want cached continuity block", err)
+	}
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("upstream calls = %d, want 0", got)
+	}
+}
+
+func TestCodexExecutorModelFallbackContextResetDropsReasoningAndKeepsToolPair(t *testing.T) {
+	internalcache.ClearCodexReasoningReplayCache()
+	t.Cleanup(internalcache.ClearCodexReasoningReplayCache)
+	signature := validCodexReasoningEncryptedContentForTestSeed(33)
+	internalcache.CacheCodexReasoningReplayItems("gpt-source", "claude:session-fallback-reset", [][]byte{
+		[]byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":"` + signature + `"}`),
+		[]byte(`{"type":"function_call","call_id":"call_reset","name":"lookup","arguments":"{\"q\":\"x\"}"}`),
+	})
+
+	var calls atomic.Int32
+	var bodies [][]byte
+	server := newCodexFallbackExecutorTestServer(t, &bodies, &calls)
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	_, err := executor.Execute(context.Background(), &cliproxyauth.Auth{
+		ID: "auth-fallback-reset",
+		Attributes: map[string]string{
+			"base_url": server.URL,
+			"api_key":  "test",
+		},
+	}, cliproxyexecutor.Request{
+		Model:   "gpt-target",
+		Payload: []byte(`{"model":"gpt-source","metadata":{"user_id":"{\"device_id\":\"device\",\"account_uuid\":\"\",\"session_id\":\"session-fallback-reset\"}"},"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_reset","content":"ok"}]}]}`),
+	}, codexFallbackTestOptions("gpt-source", config.CodexModelFallbackReasoningContinuityContextReset))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := calls.Load(); got != 1 || len(bodies) != 1 {
+		t.Fatalf("upstream calls/bodies = %d/%d, want 1/1", got, len(bodies))
+	}
+	input := gjson.GetBytes(bodies[0], "input")
+	if !input.IsArray() {
+		t.Fatalf("input is not array: %s", bodies[0])
+	}
+	for _, item := range input.Array() {
+		if item.Get("type").String() == "reasoning" {
+			t.Fatalf("context-reset request retained reasoning item: %s", bodies[0])
+		}
+	}
+	if got := gjson.GetBytes(bodies[0], "input.0.type").String(); got != "function_call" {
+		t.Fatalf("input.0.type = %q, want function_call; body=%s", got, bodies[0])
+	}
+	if got := gjson.GetBytes(bodies[0], "input.1.type").String(); got != "function_call_output" {
+		t.Fatalf("input.1.type = %q, want function_call_output; body=%s", got, bodies[0])
+	}
+}
+
+func TestCodexExecutorModelFallbackWithoutReasoningReachesTarget(t *testing.T) {
+	var calls atomic.Int32
+	var bodies [][]byte
+	server := newCodexFallbackExecutorTestServer(t, &bodies, &calls)
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	_, err := executor.Execute(context.Background(), &cliproxyauth.Auth{
+		ID: "auth-fallback-stateless",
+		Attributes: map[string]string{
+			"base_url": server.URL,
+			"api_key":  "test",
+		},
+	}, cliproxyexecutor.Request{
+		Model:   "gpt-target",
+		Payload: []byte(`{"model":"gpt-source","messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`),
+	}, codexFallbackTestOptions("gpt-source", config.CodexModelFallbackReasoningContinuitySameModelOnly))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := calls.Load(); got != 1 || len(bodies) != 1 {
+		t.Fatalf("upstream calls/bodies = %d/%d, want 1/1", got, len(bodies))
+	}
+	if got := gjson.GetBytes(bodies[0], "model").String(); got != "gpt-target" {
+		t.Fatalf("upstream model = %q, want gpt-target; body=%s", got, bodies[0])
+	}
+}

--- a/internal/runtime/executor/codex_model_fallback_test.go
+++ b/internal/runtime/executor/codex_model_fallback_test.go
@@ -7,23 +7,29 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	"github.com/tidwall/gjson"
 )
 
 func codexFallbackTestOptions(sourceModel, mode string) cliproxyexecutor.Options {
-	return cliproxyexecutor.Options{
+	opts := cliproxyexecutor.Options{
 		SourceFormat: sdktranslator.FromString("claude"),
 		Metadata: map[string]any{
 			cliproxyexecutor.CodexModelFallbackSourceModelMetadataKey:         sourceModel,
 			cliproxyexecutor.CodexModelFallbackReasoningContinuityMetadataKey: mode,
 		},
 	}
+	if mode == config.CodexModelFallbackReasoningContinuityContextReset {
+		opts.Metadata[cliproxyexecutor.CodexModelFallbackContextResetReplayMetadataKey] = true
+	}
+	return opts
 }
 
 func newCodexFallbackExecutorTestServer(t *testing.T, bodies *[][]byte, calls *atomic.Int32) *httptest.Server {
@@ -63,6 +69,28 @@ func TestCodexExecutorModelFallbackSameModelOnlyBlocksClientReasoning(t *testing
 	}
 	if got := calls.Load(); got != 0 {
 		t.Fatalf("upstream calls = %d, want 0", got)
+	}
+}
+
+func TestCodexExecutorModelFallbackBlockedStreamDoesNotPublishFailureUsage(t *testing.T) {
+	recorder := &codexAbnormalReasoningRetryUsageRecorder{}
+	usage.RegisterNamedPlugin("codex-model-fallback-blocked-stream-usage", recorder)
+	t.Cleanup(func() { usage.RegisterNamedPlugin("codex-model-fallback-blocked-stream-usage", noopUsagePlugin{}) })
+
+	executor := NewCodexExecutor(&config.Config{})
+	signature := validCodexReasoningEncryptedContentForTestSeed(34)
+	_, err := executor.ExecuteStream(context.Background(), &cliproxyauth.Auth{ID: "auth-fallback-stream-block"}, cliproxyexecutor.Request{
+		Model:   "gpt-target",
+		Payload: []byte(`{"model":"gpt-source","messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"private","signature":"` + signature + `"}]}]}`),
+	}, codexFallbackTestOptions("gpt-source", config.CodexModelFallbackReasoningContinuitySameModelOnly))
+	if err == nil || !isCodexModelFallbackBlockedError(err) {
+		t.Fatalf("ExecuteStream() error = %v, want fallback continuity block", err)
+	}
+	// A blocked fallback has no upstream dispatch. Give the async default usage
+	// sink a scheduling opportunity, then prove no failed record was emitted.
+	time.Sleep(100 * time.Millisecond)
+	if got := recorder.recordCount(); got != 0 {
+		t.Fatalf("usage records = %d, want zero for blocked stream fallback", got)
 	}
 }
 
@@ -141,6 +169,31 @@ func TestCodexExecutorModelFallbackContextResetDropsReasoningAndKeepsToolPair(t 
 	}
 	if got := gjson.GetBytes(bodies[0], "input.1.type").String(); got != "function_call_output" {
 		t.Fatalf("input.1.type = %q, want function_call_output; body=%s", got, bodies[0])
+	}
+}
+
+func TestPrepareCodexModelFallbackContextResetDropsPreviousResponseID(t *testing.T) {
+	opts := codexFallbackTestOptions("gpt-source", config.CodexModelFallbackReasoningContinuityContextReset)
+	body := []byte(`{"model":"gpt-target","previous_response_id":"resp-source","input":[{"type":"message","role":"user","content":"replay the visible transcript"}]}`)
+	updated, _, skipReplay, err := prepareCodexModelFallbackBody(context.Background(), sdktranslator.FromString("openai"), cliproxyexecutor.Request{
+		Model:   "gpt-target",
+		Payload: body,
+	}, opts, body)
+	if err != nil || !skipReplay {
+		t.Fatalf("prepare error/skip = %v/%v, want safe reset", err, skipReplay)
+	}
+	if gjson.GetBytes(updated, "previous_response_id").Exists() {
+		t.Fatalf("context-reset retained previous_response_id: %s", updated)
+	}
+}
+
+func TestPrepareCodexModelFallbackContextResetRejectsUnattestedPreviousResponseID(t *testing.T) {
+	opts := codexFallbackTestOptions("gpt-source", config.CodexModelFallbackReasoningContinuityContextReset)
+	delete(opts.Metadata, cliproxyexecutor.CodexModelFallbackContextResetReplayMetadataKey)
+	body := []byte(`{"model":"gpt-target","previous_response_id":"resp-source","input":[{"type":"message","role":"user","content":"incremental"}]}`)
+	_, _, _, err := prepareCodexModelFallbackBody(context.Background(), sdktranslator.FromString("openai"), cliproxyexecutor.Request{Model: "gpt-target", Payload: body}, opts, body)
+	if err == nil || !isCodexModelFallbackBlockedError(err) {
+		t.Fatalf("prepare error = %v, want continuity block", err)
 	}
 }
 

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -333,7 +333,11 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	}
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
-	defer reporter.TrackFailure(ctx, &err)
+	defer func() {
+		if !isCodexModelFallbackBlockedError(err) {
+			reporter.TrackFailure(ctx, &err)
+		}
+	}()
 
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
@@ -363,6 +367,10 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		body = ensureImageGenerationTool(body, baseModel, auth, opts.Headers)
 	}
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex websockets executor", body)
+	body, _, _, err = prepareCodexModelFallbackBody(ctx, from, req, opts, body)
+	if err != nil {
+		return resp, err
+	}
 
 	httpURL := strings.TrimSuffix(baseURL, "/") + "/responses"
 	wsURL, err := buildCodexResponsesWebsocketURL(httpURL)
@@ -576,7 +584,11 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	}
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
-	defer reporter.TrackFailure(ctx, &err)
+	defer func() {
+		if !isCodexModelFallbackBlockedError(err) {
+			reporter.TrackFailure(ctx, &err)
+		}
+	}()
 
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
@@ -602,6 +614,10 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		body = ensureImageGenerationTool(body, baseModel, auth, opts.Headers)
 	}
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex websockets executor", body)
+	body, _, _, err = prepareCodexModelFallbackBody(ctx, from, req, opts, body)
+	if err != nil {
+		return nil, err
+	}
 
 	httpURL := strings.TrimSuffix(baseURL, "/") + "/responses"
 	wsURL, err := buildCodexResponsesWebsocketURL(httpURL)
@@ -1399,7 +1415,7 @@ func parseCodexWebsocketError(payload []byte) (error, bool) {
 
 	out := buildCodexWebsocketErrorPayload(payload, status)
 	headers := parseCodexWebsocketErrorHeaders(payload)
-	statusError := statusErr{code: status, msg: string(out)}
+	statusError := newCodexStatusErr(status, out)
 	if retryAfter := parseCodexRetryAfter(status, out, time.Now()); retryAfter != nil {
 		statusError.retryAfter = retryAfter
 	} else if isCodexWebsocketConnectionLimitError(payload) {

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -333,11 +333,13 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	}
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
+	var replayScope codexReasoningReplayScope
 	defer func() {
 		if !isCodexModelFallbackBlockedError(err) {
 			reporter.TrackFailure(ctx, &err)
 		}
 	}()
+	defer func() { err = withCodexReasoningReplayScope(err, replayScope) }()
 
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
@@ -382,6 +384,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	if errPromptCache != nil {
 		return resp, errPromptCache
 	}
+	replayScope = codexReasoningReplayScopeFromRequest(ctx, from, req, opts, body)
 	body, err = thinking.NormalizeCodexReasoningEffortForWire(body, baseModel)
 	if err != nil {
 		return resp, err
@@ -426,18 +429,11 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	connectionKey := newCodexWebsocketConnectionKey(authID, wsURL, baseModel, modelHeaderProfile.digest)
 	connection, respHS, errDial := e.ensureUpstreamConn(ctx, auth, sess, connectionKey, wsHeaders)
 	if errDial != nil {
-		bodyErr := websocketHandshakeBody(respHS)
-		if respHS != nil {
-			helps.RecordAPIWebsocketUpgradeRejection(ctx, e.cfg, websocketUpgradeRequestLog(wsReqLog), respHS.StatusCode, respHS.Header.Clone(), bodyErr)
-		}
-		if respHS != nil && respHS.StatusCode == http.StatusUpgradeRequired {
+		status, handshakeErr := codexWebsocketHandshakeFailure(ctx, e.cfg, wsReqLog, respHS, errDial, "dial")
+		if status == http.StatusUpgradeRequired {
 			return e.CodexExecutor.Execute(ctx, auth, req, opts)
 		}
-		if respHS != nil && respHS.StatusCode > 0 {
-			return resp, statusErr{code: respHS.StatusCode, msg: string(bodyErr)}
-		}
-		helps.RecordAPIWebsocketError(ctx, e.cfg, "dial", errDial)
-		return resp, errDial
+		return resp, handshakeErr
 	}
 	recordAPIWebsocketHandshake(ctx, e.cfg, respHS)
 	reporter.StartResponseTTFT()
@@ -504,9 +500,11 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 					return resp, errSendRetry
 				}
 			} else {
-				closeHTTPResponseBody(respHSRetry, "codex websockets executor: close handshake response body error")
-				helps.RecordAPIWebsocketError(ctx, e.cfg, "dial_retry", errDialRetry)
-				return resp, errDialRetry
+				status, handshakeErr := codexWebsocketHandshakeFailure(ctx, e.cfg, wsReqLog, respHSRetry, errDialRetry, "dial_retry")
+				if status == http.StatusUpgradeRequired {
+					return e.CodexExecutor.Execute(ctx, auth, req, opts)
+				}
+				return resp, handshakeErr
 			}
 		} else {
 			helps.RecordAPIWebsocketError(ctx, e.cfg, "send", errSend)
@@ -584,11 +582,13 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	}
 
 	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
+	var replayScope codexReasoningReplayScope
 	defer func() {
 		if !isCodexModelFallbackBlockedError(err) {
 			reporter.TrackFailure(ctx, &err)
 		}
 	}()
+	defer func() { err = withCodexReasoningReplayScope(err, replayScope) }()
 
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
@@ -629,6 +629,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	if errPromptCache != nil {
 		return nil, errPromptCache
 	}
+	replayScope = codexReasoningReplayScopeFromRequest(ctx, from, req, opts, body)
 	body, err = thinking.NormalizeCodexReasoningEffortForWire(body, baseModel)
 	if err != nil {
 		return nil, err
@@ -676,27 +677,14 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		upstreamHeaders = respHS.Header.Clone()
 	}
 	if errDial != nil {
-		bodyErr := websocketHandshakeBody(respHS)
-		if respHS != nil {
-			helps.RecordAPIWebsocketUpgradeRejection(ctx, e.cfg, websocketUpgradeRequestLog(wsReqLog), respHS.StatusCode, respHS.Header.Clone(), bodyErr)
-		}
-		if respHS != nil && respHS.StatusCode == http.StatusUpgradeRequired {
-			if sess != nil {
-				sess.reqMu.Unlock()
-			}
-			return e.CodexExecutor.ExecuteStream(ctx, auth, req, opts)
-		}
-		if respHS != nil && respHS.StatusCode > 0 {
-			if sess != nil {
-				sess.reqMu.Unlock()
-			}
-			return nil, statusErr{code: respHS.StatusCode, msg: string(bodyErr)}
-		}
-		helps.RecordAPIWebsocketError(ctx, e.cfg, "dial", errDial)
+		status, handshakeErr := codexWebsocketHandshakeFailure(ctx, e.cfg, wsReqLog, respHS, errDial, "dial")
 		if sess != nil {
 			sess.reqMu.Unlock()
 		}
-		return nil, errDial
+		if status == http.StatusUpgradeRequired {
+			return e.CodexExecutor.ExecuteStream(ctx, auth, req, opts)
+		}
+		return nil, handshakeErr
 	}
 	recordAPIWebsocketHandshake(ctx, e.cfg, respHS)
 	reporter.StartResponseTTFT()
@@ -725,11 +713,13 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			// Retry once with a new websocket connection for the same execution session.
 			connectionRetry, respHSRetry, errDialRetry := e.ensureUpstreamConn(ctx, auth, sess, connectionKey, wsHeaders)
 			if errDialRetry != nil || connectionRetry.conn == nil {
-				closeHTTPResponseBody(respHSRetry, "codex websockets executor: close handshake response body error")
-				helps.RecordAPIWebsocketError(ctx, e.cfg, "dial_retry", errDialRetry)
+				status, handshakeErr := codexWebsocketHandshakeFailure(ctx, e.cfg, wsReqLog, respHSRetry, errDialRetry, "dial_retry")
 				sess.clearActiveConnection(connection, readCh)
 				sess.reqMu.Unlock()
-				return nil, errDialRetry
+				if status == http.StatusUpgradeRequired {
+					return e.CodexExecutor.ExecuteStream(ctx, auth, req, opts)
+				}
+				return nil, handshakeErr
 			}
 			wsReqBodyRetry := buildCodexWebsocketRequestBody(upstreamBody)
 			helps.RecordAPIWebsocketRequest(ctx, e.cfg, helps.UpstreamRequestLog{
@@ -789,6 +779,9 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		}()
 
 		send := func(chunk cliproxyexecutor.StreamChunk) bool {
+			if chunk.Err != nil {
+				chunk.Err = withCodexReasoningReplayScope(chunk.Err, replayScope)
+			}
 			if ctx == nil {
 				out <- chunk
 				return true
@@ -1391,6 +1384,14 @@ type statusErrWithHeaders struct {
 	headers http.Header
 }
 
+// Websocket upgrade failures are still upstream Codex status responses. Keep
+// both the typed classification (usage_limit/capacity can therefore enter the
+// pre-payload fallback path) and retry headers for downstream error shaping.
+func newCodexWebsocketHandshakeStatusErr(status int, body []byte, headers http.Header) error {
+	classified := newCodexStatusErr(status, body)
+	return statusErrWithHeaders{statusErr: classified, headers: headers.Clone()}
+}
+
 func (e statusErrWithHeaders) Headers() http.Header {
 	if e.headers == nil {
 		return nil
@@ -1548,6 +1549,23 @@ func websocketHandshakeBody(resp *http.Response) []byte {
 		return nil
 	}
 	return body
+}
+
+// codexWebsocketHandshakeFailure keeps initial and reconnect upgrade failures
+// on the same classification path. In particular, a typed Codex quota or
+// capacity response before any payload remains eligible for model fallback,
+// while a 426 can still downgrade to the HTTP executor at the caller.
+func codexWebsocketHandshakeFailure(ctx context.Context, cfg *config.Config, requestLog helps.UpstreamRequestLog, resp *http.Response, dialErr error, stage string) (int, error) {
+	body := websocketHandshakeBody(resp)
+	if resp != nil && resp.StatusCode > 0 {
+		helps.RecordAPIWebsocketUpgradeRejection(ctx, cfg, websocketUpgradeRequestLog(requestLog), resp.StatusCode, resp.Header.Clone(), body)
+		return resp.StatusCode, newCodexWebsocketHandshakeStatusErr(resp.StatusCode, body, resp.Header)
+	}
+	if dialErr == nil {
+		dialErr = fmt.Errorf("codex websockets executor: websocket %s failed without a connection or handshake response", stage)
+	}
+	helps.RecordAPIWebsocketError(ctx, cfg, stage, dialErr)
+	return 0, dialErr
 }
 
 func closeHTTPResponseBody(resp *http.Response, logPrefix string) {

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -410,6 +411,126 @@ func TestCodexWebsocketHandshakeFailureReleasesExecutionSession(t *testing.T) {
 				t.Fatal("websocket handshake failure left the execution session locked")
 			}
 			exec.CloseExecutionSession(sessionID)
+		})
+	}
+}
+
+func TestCodexWebsocketReconnectHandshakePreservesTypedQuotaError(t *testing.T) {
+	tests := []struct {
+		name   string
+		stream bool
+	}{
+		{name: "non-stream"},
+		{name: "stream", stream: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var upgradeAttempts atomic.Int32
+			upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.URL.Path; got != "/responses" {
+					t.Errorf("request path = %q, want /responses", got)
+				}
+				if upgradeAttempts.Add(1) == 1 {
+					conn, err := upgrader.Upgrade(w, r, nil)
+					if err != nil {
+						t.Errorf("upgrade stale websocket: %v", err)
+						return
+					}
+					defer func() { _ = conn.Close() }()
+					for {
+						if _, _, errRead := conn.ReadMessage(); errRead != nil {
+							return
+						}
+					}
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Retry-After", "9")
+				w.Header().Set("X-Request-ID", "req-reconnect-quota")
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = w.Write([]byte(`{"error":{"type":"usage_limit_reached","message":"quota","resets_in_seconds":7}}`))
+			}))
+			defer server.Close()
+
+			wsURL, err := buildCodexResponsesWebsocketURL(strings.TrimSuffix(server.URL, "/") + "/responses")
+			if err != nil {
+				t.Fatalf("build websocket URL: %v", err)
+			}
+			staleConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+			if err != nil {
+				t.Fatalf("dial stale websocket: %v", err)
+			}
+			if errClose := staleConn.Close(); errClose != nil {
+				t.Fatalf("close stale websocket: %v", errClose)
+			}
+
+			exec := NewCodexWebsocketsExecutor(&config.Config{SDKConfig: config.SDKConfig{DisableImageGeneration: config.DisableImageGenerationAll}})
+			exec.store = &codexWebsocketSessionStore{sessions: make(map[string]*codexWebsocketSession)}
+			auth := &cliproxyauth.Auth{
+				ID:         "auth-reconnect-quota-" + tt.name,
+				Provider:   "codex",
+				Attributes: map[string]string{"api_key": "sk-test", "base_url": server.URL},
+			}
+			const model = "gpt-5.4"
+			sessionID := "session-reconnect-quota-" + tt.name
+			sess := exec.getOrCreateSession(sessionID)
+			connectionKey := newCodexWebsocketConnectionKey(auth.ID, wsURL, model, resolveCodexModelHeaderProfile(model).digest)
+			sess.connMu.Lock()
+			sess.conn = staleConn
+			sess.connGen = 1
+			sess.connKey = connectionKey
+			sess.wsURL = wsURL
+			sess.authID = auth.ID
+			sess.readerConn = staleConn
+			sess.readerGen = 1
+			sess.connMu.Unlock()
+			defer exec.CloseExecutionSession(sessionID)
+
+			req := cliproxyexecutor.Request{
+				Model:   model,
+				Payload: []byte(`{"model":"gpt-5.4","input":[{"type":"message","role":"user","content":"hello"}]}`),
+			}
+			opts := cliproxyexecutor.Options{
+				SourceFormat:   sdktranslator.FromString("openai-response"),
+				ResponseFormat: sdktranslator.FromString("openai-response"),
+				Metadata: map[string]any{
+					cliproxyexecutor.ExecutionSessionMetadataKey: sessionID,
+				},
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			var executeErr error
+			if tt.stream {
+				result, errStream := exec.ExecuteStream(ctx, auth, req, opts)
+				if result != nil {
+					t.Fatalf("ExecuteStream() result = %#v, want nil on reconnect handshake rejection", result)
+				}
+				executeErr = errStream
+			} else {
+				_, executeErr = exec.Execute(ctx, auth, req, opts)
+			}
+			if executeErr == nil {
+				t.Fatal("reconnect handshake error = nil, want typed usage-limit error")
+			}
+			classified, ok := executeErr.(interface{ ModelFallbackReason() string })
+			if !ok || classified.ModelFallbackReason() != config.CodexModelFallbackTriggerUsageLimit {
+				t.Fatalf("fallback reason = %T %v, want %q", executeErr, executeErr, config.CodexModelFallbackTriggerUsageLimit)
+			}
+			retryable, ok := executeErr.(interface{ RetryAfter() *time.Duration })
+			if !ok || retryable.RetryAfter() == nil || *retryable.RetryAfter() != 7*time.Second {
+				t.Fatalf("RetryAfter = %v, want 7s", retryable.RetryAfter())
+			}
+			withHeaders, ok := executeErr.(interface{ Headers() http.Header })
+			if !ok {
+				t.Fatalf("reconnect error type %T does not expose headers", executeErr)
+			}
+			if got := withHeaders.Headers().Get("X-Request-ID"); got != "req-reconnect-quota" {
+				t.Fatalf("X-Request-ID = %q, want req-reconnect-quota", got)
+			}
+			if got := upgradeAttempts.Load(); got != 2 {
+				t.Fatalf("upgrade attempts = %d, want stale connection plus one reconnect", got)
+			}
 		})
 	}
 }
@@ -1504,6 +1625,29 @@ func TestParseCodexWebsocketErrorUsesUsageLimitRetryMetadata(t *testing.T) {
 	}
 	if got := *retryable.RetryAfter(); got != 7*time.Second {
 		t.Fatalf("retryAfter = %v, want 7s", got)
+	}
+}
+
+func TestCodexWebsocketHandshakeStatusClassifiesFallbackAndPreservesHeaders(t *testing.T) {
+	headers := make(http.Header)
+	headers.Set("Retry-After", "9")
+	headers.Set("X-Request-ID", "req-handshake")
+	err := newCodexWebsocketHandshakeStatusErr(http.StatusTooManyRequests, []byte(`{"error":{"type":"usage_limit_reached","message":"quota","resets_in_seconds":7}}`), headers)
+	classified, ok := err.(interface{ ModelFallbackReason() string })
+	if !ok || classified.ModelFallbackReason() != config.CodexModelFallbackTriggerUsageLimit {
+		t.Fatalf("fallback reason = %#v, want usage-limit", err)
+	}
+	retryable, ok := err.(interface{ RetryAfter() *time.Duration })
+	if !ok || retryable.RetryAfter() == nil || *retryable.RetryAfter() != 7*time.Second {
+		t.Fatalf("RetryAfter = %#v, want resets_in_seconds", err)
+	}
+	withHeaders, ok := err.(interface{ Headers() http.Header })
+	if !ok || withHeaders.Headers().Get("X-Request-ID") != "req-handshake" {
+		t.Fatalf("headers = %#v, want preserved upgrade headers", err)
+	}
+	transient := newCodexWebsocketHandshakeStatusErr(http.StatusTooManyRequests, []byte(`{"error":{"type":"rate_limit_error","message":"transient"}}`), nil)
+	if got := transient.(interface{ ModelFallbackReason() string }).ModelFallbackReason(); got != "" {
+		t.Fatalf("bare/transient 429 fallback reason = %q, want empty", got)
 	}
 }
 

--- a/internal/runtime/executor/helps/claude_code_session.go
+++ b/internal/runtime/executor/helps/claude_code_session.go
@@ -3,51 +3,17 @@ package helps
 import (
 	"context"
 	"net/http"
-	"regexp"
-	"strings"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	"github.com/tidwall/gjson"
+	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
 )
 
-const ClaudeCodeSessionHeader = "X-Claude-Code-Session-Id"
-
-var claudeCodeSessionSuffixPattern = regexp.MustCompile(`_session_([a-f0-9-]+)$`)
+const ClaudeCodeSessionHeader = internalcache.ClaudeCodeSessionHeader
 
 // ExtractClaudeCodeSessionID resolves a Claude Code session ID, preferring X-Claude-Code-Session-Id over payload metadata.
 func ExtractClaudeCodeSessionID(ctx context.Context, payload []byte, headers http.Header) string {
-	if headers != nil {
-		if sessionID := strings.TrimSpace(headers.Get(ClaudeCodeSessionHeader)); sessionID != "" {
-			return sessionID
-		}
-	}
-	if ctx != nil {
-		if ginCtx, ok := ctx.Value("gin").(*gin.Context); ok && ginCtx != nil && ginCtx.Request != nil {
-			if sessionID := strings.TrimSpace(ginCtx.Request.Header.Get(ClaudeCodeSessionHeader)); sessionID != "" {
-				return sessionID
-			}
-		}
-	}
-	return extractClaudeCodeSessionIDFromPayload(payload)
-}
-
-func extractClaudeCodeSessionIDFromPayload(payload []byte) string {
-	if len(payload) == 0 {
-		return ""
-	}
-	userID := gjson.GetBytes(payload, "metadata.user_id").String()
-	if userID == "" {
-		return ""
-	}
-	if matches := claudeCodeSessionSuffixPattern.FindStringSubmatch(userID); len(matches) >= 2 {
-		return matches[1]
-	}
-	if len(userID) > 0 && userID[0] == '{' {
-		return strings.TrimSpace(gjson.Get(userID, "session_id").String())
-	}
-	return ""
+	return internalcache.ExtractClaudeCodeSessionID(ctx, payload, headers)
 }
 
 // ClaudeCodePromptCache maps a Claude Code session to a stable upstream prompt_cache_key.

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -783,9 +783,10 @@ func (e *OpenAICompatExecutor) overrideModel(payload []byte, model string) []byt
 }
 
 type statusErr struct {
-	code       int
-	msg        string
-	retryAfter *time.Duration
+	code                int
+	msg                 string
+	retryAfter          *time.Duration
+	modelFallbackReason string
 }
 
 func (e statusErr) Error() string {
@@ -794,5 +795,6 @@ func (e statusErr) Error() string {
 	}
 	return fmt.Sprintf("status %d", e.code)
 }
-func (e statusErr) StatusCode() int            { return e.code }
-func (e statusErr) RetryAfter() *time.Duration { return e.retryAfter }
+func (e statusErr) StatusCode() int             { return e.code }
+func (e statusErr) RetryAfter() *time.Duration  { return e.retryAfter }
+func (e statusErr) ModelFallbackReason() string { return e.modelFallbackReason }

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -105,6 +105,7 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.Codex.IdentityConfuse != newCfg.Codex.IdentityConfuse {
 		changes = append(changes, fmt.Sprintf("codex.identity-confuse: %t -> %t", oldCfg.Codex.IdentityConfuse, newCfg.Codex.IdentityConfuse))
 	}
+	changes = appendCodexModelFallbackChanges(changes, oldCfg.Codex.ModelFallback.Effective(), newCfg.Codex.ModelFallback.Effective())
 	changes = appendCodexAbnormalReasoningRetryChanges(changes, oldCfg.Codex.AbnormalReasoningRetry.Effective(), newCfg.Codex.AbnormalReasoningRetry.Effective())
 
 	if oldCfg.Routing.Strategy != newCfg.Routing.Strategy {
@@ -474,6 +475,25 @@ func appendCodexAbnormalReasoningRetryChanges(changes []string, oldCfg, newCfg c
 	}
 	if !reflect.DeepEqual(oldCfg.AuthIDs, newCfg.AuthIDs) {
 		changes = append(changes, fmt.Sprintf("codex.abnormal-reasoning-retry.auth-ids: updated (%d -> %d entries)", len(oldCfg.AuthIDs), len(newCfg.AuthIDs)))
+	}
+	return changes
+}
+
+func appendCodexModelFallbackChanges(changes []string, oldCfg, newCfg config.EffectiveCodexModelFallbackConfig) []string {
+	if reflect.DeepEqual(oldCfg, newCfg) {
+		return changes
+	}
+	if oldCfg.Enabled != newCfg.Enabled {
+		changes = append(changes, fmt.Sprintf("codex.model-fallback.enabled: %t -> %t", oldCfg.Enabled, newCfg.Enabled))
+	}
+	if oldCfg.ReasoningContinuity != newCfg.ReasoningContinuity {
+		changes = append(changes, fmt.Sprintf("codex.model-fallback.reasoning-continuity: %s -> %s", oldCfg.ReasoningContinuity, newCfg.ReasoningContinuity))
+	}
+	if !reflect.DeepEqual(oldCfg.Triggers, newCfg.Triggers) {
+		changes = append(changes, fmt.Sprintf("codex.model-fallback.triggers: updated (%d -> %d entries)", len(oldCfg.Triggers), len(newCfg.Triggers)))
+	}
+	if !reflect.DeepEqual(oldCfg.Mappings, newCfg.Mappings) {
+		changes = append(changes, fmt.Sprintf("codex.model-fallback.mappings: updated (%d -> %d entries)", len(oldCfg.Mappings), len(newCfg.Mappings)))
 	}
 	return changes
 }

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -239,6 +239,28 @@ func TestBuildConfigChangeDetails_CodexAbnormalReasoningRetry(t *testing.T) {
 	expectContains(t, details, "codex.abnormal-reasoning-retry.auth-ids: updated (0 -> 1 entries)")
 }
 
+func TestBuildConfigChangeDetails_CodexModelFallback(t *testing.T) {
+	oldCfg := &config.Config{}
+	newCfg := &config.Config{
+		Codex: config.CodexConfig{
+			ModelFallback: config.CodexModelFallbackConfig{
+				Enabled:             true,
+				Triggers:            []string{config.CodexModelFallbackTriggerCapacity},
+				ReasoningContinuity: config.CodexModelFallbackReasoningContinuityContextReset,
+				Mappings: []config.CodexModelFallbackMapping{
+					{From: "gpt-5.6-sol", To: []string{"gpt-5.6-terra", "gpt-5.5"}},
+				},
+			},
+		},
+	}
+
+	details := BuildConfigChangeDetails(oldCfg, newCfg)
+	expectContains(t, details, "codex.model-fallback.enabled: false -> true")
+	expectContains(t, details, "codex.model-fallback.reasoning-continuity: same-model-only -> context-reset")
+	expectContains(t, details, "codex.model-fallback.triggers: updated (2 -> 1 entries)")
+	expectContains(t, details, "codex.model-fallback.mappings: updated (0 -> 1 entries)")
+}
+
 func TestBuildConfigChangeDetails_NoChanges(t *testing.T) {
 	cfg := &config.Config{
 		Port: 8080,

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -116,6 +116,7 @@ require_path internal/managementasset/updater.go
 require_path internal/config/config.go
 require_path internal/redisqueue
 require_path config.example.yaml
+require_path docs/lts/codex-429-resilience.md
 
 require_grep "mgmt.GET(\"/usage\"" internal/api/server.go
 require_grep "mgmt.GET(\"/usage/export\"" internal/api/server.go
@@ -129,6 +130,8 @@ require_grep "managementAssetName" internal/managementasset/updater.go
 require_grep "serveManagementControlPanel" internal/api/server.go
 require_grep "BlueSkyXN/CPA-Panel-LTS" internal/managementasset/updater.go internal/managementasset/updater_test.go internal/config/config.go
 require_grep "UsageReporter" internal/runtime/executor/helps/usage_helpers.go
+require_grep "codex.model-fallback" docs/lts/core-feature-contracts.yaml docs/lts/codex-429-resilience.md
+require_grep "CodexModelFallbackSourceModelMetadataKey" sdk/cliproxy/executor/types.go sdk/cliproxy/auth/codex_model_fallback.go
 require_grep "auth_index" internal/usage internal/api/handlers/management internal/runtime/executor/helps internal/redisqueue
 require_grep "latency_ms" internal/usage internal/redisqueue internal/tui
 require_grep 'json:"service_tier,omitempty"' internal/usage

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -132,6 +132,10 @@ require_grep "BlueSkyXN/CPA-Panel-LTS" internal/managementasset/updater.go inter
 require_grep "UsageReporter" internal/runtime/executor/helps/usage_helpers.go
 require_grep "codex.model-fallback" docs/lts/core-feature-contracts.yaml docs/lts/codex-429-resilience.md
 require_grep "CodexModelFallbackSourceModelMetadataKey" sdk/cliproxy/executor/types.go sdk/cliproxy/auth/codex_model_fallback.go
+require_grep "CodexModelFallbackContextResetReplayMetadataKey" sdk/cliproxy/executor/types.go sdk/api/handlers/openai/openai_responses_websocket.go
+require_grep "ResolveCodexReasoningReplaySessionKey" internal/cache/codex_reasoning_replay_scope.go internal/runtime/executor/codex_executor.go sdk/cliproxy/auth/codex_model_fallback.go
+require_grep "responsesWebsocketCanAttestContextReset" sdk/api/handlers/openai/openai_responses_websocket.go sdk/api/handlers/openai/openai_responses_websocket_test.go
+require_grep "ModelFallbackZeroDispatch" sdk/cliproxy/auth/codex_model_fallback.go docs/lts/core-feature-contracts.yaml
 require_grep "auth_index" internal/usage internal/api/handlers/management internal/runtime/executor/helps internal/redisqueue
 require_grep "latency_ms" internal/usage internal/redisqueue internal/tui
 require_grep 'json:"service_tier,omitempty"' internal/usage

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -65,6 +65,7 @@ type pinnedAuthContextKey struct{}
 type selectedAuthCallbackContextKey struct{}
 type executionSessionContextKey struct{}
 type disallowFreeAuthContextKey struct{}
+type codexModelFallbackContextResetReplayContextKey struct{}
 
 // PluginInterceptorHost applies plugin interceptors around handler execution.
 type PluginInterceptorHost interface {
@@ -151,6 +152,17 @@ func WithExecutionSessionID(ctx context.Context, sessionID string) context.Conte
 		ctx = context.Background()
 	}
 	return context.WithValue(ctx, executionSessionContextKey{}, sessionID)
+}
+
+// WithCodexModelFallbackContextResetReplay marks a CPA-mediated Responses
+// websocket turn as a complete transcript that can be replayed with an
+// explicit context reset. The marker is deliberately internal-only: callers
+// cannot supply it through the wire protocol.
+func WithCodexModelFallbackContextResetReplay(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, codexModelFallbackContextResetReplayContextKey{}, true)
 }
 
 // WithDisallowFreeAuth returns a child context that requests skipping known free-tier credentials.
@@ -285,6 +297,9 @@ func requestExecutionMetadata(ctx context.Context) map[string]any {
 	}
 	if executionSessionID := executionSessionIDFromContext(ctx); executionSessionID != "" {
 		meta[coreexecutor.ExecutionSessionMetadataKey] = executionSessionID
+	}
+	if allowed, _ := ctx.Value(codexModelFallbackContextResetReplayContextKey{}).(bool); allowed {
+		meta[coreexecutor.CodexModelFallbackContextResetReplayMetadataKey] = true
 	}
 	if disallowFreeAuthFromContext(ctx) {
 		meta[coreexecutor.DisallowFreeAuthMetadataKey] = true

--- a/sdk/api/handlers/handlers_metadata_test.go
+++ b/sdk/api/handlers/handlers_metadata_test.go
@@ -19,6 +19,13 @@ func TestRequestExecutionMetadataIncludesExecutionSessionWithoutIdempotencyKey(t
 	}
 }
 
+func TestRequestExecutionMetadataIncludesInternalCodexContextResetReplayMarker(t *testing.T) {
+	meta := requestExecutionMetadata(WithCodexModelFallbackContextResetReplay(context.Background()))
+	if got, ok := meta[coreexecutor.CodexModelFallbackContextResetReplayMetadataKey].(bool); !ok || !got {
+		t.Fatalf("context reset replay marker = %#v, want true", meta[coreexecutor.CodexModelFallbackContextResetReplayMetadataKey])
+	}
+}
+
 func TestSetReasoningEffortMetadataUsesSuffixOverBody(t *testing.T) {
 	meta := make(map[string]any)
 

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -397,6 +397,7 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		previousLastResponseID := lastResponseID
 		previousLastResponsePendingToolCallIDs := append([]string(nil), lastResponsePendingToolCallIDs...)
 		forcedTranscriptReplay := forceTranscriptReplayNextRequest
+		preRepairContextResetSafe := !useUpstreamWebsocketPassthrough && responsesWebsocketCanAttestContextReset(requestJSON)
 		if useUpstreamWebsocketPassthrough {
 			if modelName := strings.TrimSpace(gjson.GetBytes(requestJSON, "model").String()); modelName != "" {
 				passthroughModelName = modelName
@@ -418,24 +419,33 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		cliCtx, cliCancel := h.GetContextWithCancel(h, c, context.Background())
 		cliCtx = cliproxyexecutor.WithDownstreamWebsocket(cliCtx)
 		cliCtx = handlers.WithExecutionSessionID(cliCtx, passthroughSessionID)
+		// Only CPA-mediated websocket turns have a reconstructed complete
+		// transcript. Passthrough and incremental turns deliberately cannot
+		// opt into cross-model context reset.
+		if !useUpstreamWebsocketPassthrough && preRepairContextResetSafe && responsesWebsocketCanAttestContextReset(requestJSON) {
+			cliCtx = handlers.WithCodexModelFallbackContextResetReplay(cliCtx)
+		}
 		if pinnedAuthID != "" {
 			cliCtx = handlers.WithPinnedAuthID(cliCtx, pinnedAuthID)
-		} else {
-			cliCtx = handlers.WithSelectedAuthIDCallback(cliCtx, func(authID string) {
-				authID = strings.TrimSpace(authID)
-				if authID == "" || h == nil || h.AuthManager == nil {
-					return
-				}
-				lastAttemptedAuthID = authID
-				selectedAuth, ok := sessionAuthByID(authID)
-				if !ok || selectedAuth == nil {
-					return
-				}
-				if websocketUpstreamSupportsIncrementalInput(selectedAuth.Attributes, selectedAuth.Metadata) {
-					pinnedAuthID = authID
-				}
-			})
 		}
+		// Keep the callback even when the current turn starts pinned. A safe
+		// model-fallback context reset intentionally drops that source pin; the
+		// delayed callback then installs the actually dispatched target auth for
+		// subsequent websocket turns.
+		cliCtx = handlers.WithSelectedAuthIDCallback(cliCtx, func(authID string) {
+			authID = strings.TrimSpace(authID)
+			if authID == "" || h == nil || h.AuthManager == nil {
+				return
+			}
+			lastAttemptedAuthID = authID
+			selectedAuth, ok := sessionAuthByID(authID)
+			if !ok || selectedAuth == nil {
+				return
+			}
+			if websocketUpstreamSupportsIncrementalInput(selectedAuth.Attributes, selectedAuth.Metadata) {
+				pinnedAuthID = authID
+			}
+		})
 		dataChan, _, errChan := h.ExecuteStreamWithAuthManager(cliCtx, h.HandlerType(), modelName, requestJSON, "")
 
 		completedOutput, completedResponseID, completedPendingToolCallIDs, forwardErrMsg, errForward := h.forwardResponsesWebsocket(c, conn, cliCancel, dataChan, errChan, wsTimelineLog, passthroughSessionID)
@@ -732,6 +742,52 @@ func inputSatisfiesPendingToolCalls(input gjson.Result, pendingCallIDs []string)
 		}
 	}
 	return true
+}
+
+// responsesWebsocketHasCompleteToolPairs is a final marker preflight. The
+// repair path normally removes/inserts orphaned items, but cross-model replay
+// must be stricter: an incomplete call/output pair cannot be safely recreated
+// after model-private reasoning and source execution state are discarded.
+func responsesWebsocketHasCompleteToolPairs(payload []byte) bool {
+	input := gjson.GetBytes(payload, "input")
+	if !input.IsArray() {
+		return false
+	}
+	calls := make(map[string]struct{})
+	outputs := make(map[string]struct{})
+	for _, item := range input.Array() {
+		callID := strings.TrimSpace(item.Get("call_id").String())
+		switch strings.TrimSpace(item.Get("type").String()) {
+		case "function_call", "custom_tool_call":
+			if callID == "" {
+				return false
+			}
+			calls[callID] = struct{}{}
+		case "function_call_output", "custom_tool_call_output":
+			if callID == "" {
+				return false
+			}
+			outputs[callID] = struct{}{}
+		}
+	}
+	for callID := range calls {
+		if _, ok := outputs[callID]; !ok {
+			return false
+		}
+	}
+	for callID := range outputs {
+		if _, ok := calls[callID]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func responsesWebsocketCanAttestContextReset(payload []byte) bool {
+	if strings.TrimSpace(gjson.GetBytes(payload, "previous_response_id").String()) != "" {
+		return false
+	}
+	return responsesWebsocketHasCompleteToolPairs(payload)
 }
 
 func normalizeResponseTranscriptReplacement(rawJSON []byte, lastRequest []byte) []byte {

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -3241,3 +3241,51 @@ func TestNormalizeSubsequentRequestAssistantInputTriggersTranscriptReplacement(t
 		t.Fatalf("input[0].id = %q, want %q", input[0].Get("id").String(), "msg-3")
 	}
 }
+
+func TestResponsesWebsocketContextResetMarkerRequiresCompleteToolPairs(t *testing.T) {
+	complete := []byte(`{"input":[{"type":"function_call","call_id":"call-1","name":"lookup","arguments":"{}"},{"type":"function_call_output","call_id":"call-1","output":"ok"}]}`)
+	if !responsesWebsocketCanAttestContextReset(complete) {
+		t.Fatal("paired transcript should be eligible for context-reset marker")
+	}
+	incomplete := []byte(`{"input":[{"type":"function_call","call_id":"call-1","name":"lookup","arguments":"{}"}]}`)
+	if responsesWebsocketHasCompleteToolPairs(incomplete) {
+		t.Fatal("unpaired tool call must not be eligible for context-reset marker")
+	}
+	orphan := []byte(`{"input":[{"type":"function_call_output","call_id":"call-1","output":"ok"}]}`)
+	if responsesWebsocketHasCompleteToolPairs(orphan) {
+		t.Fatal("orphan tool output must not be eligible for context-reset marker")
+	}
+}
+
+func TestResponsesWebsocketFirstIncrementalCreateCannotAttestContextReset(t *testing.T) {
+	raw := []byte(`{"type":"response.create","model":"gpt-source","previous_response_id":"resp-source","input":[{"type":"message","role":"user","content":"continue"}]}`)
+	normalized, _, errMsg := normalizeResponsesWebsocketRequestWithMode(raw, nil, nil, true, true)
+	if errMsg != nil {
+		t.Fatalf("normalize first response.create: %v", errMsg.Error)
+	}
+	if got := gjson.GetBytes(normalized, "previous_response_id").String(); got != "resp-source" {
+		t.Fatalf("previous_response_id = %q, want preserved incremental source id", got)
+	}
+	if responsesWebsocketCanAttestContextReset(normalized) {
+		t.Fatalf("incremental first frame received unsafe context-reset attestation: %s", normalized)
+	}
+}
+
+func TestResponsesWebsocketRepairCannotRetroactivelyAttestIncompleteTranscript(t *testing.T) {
+	// The repair cache can insert the missing call for a client tool output.
+	// That makes the forwarded transcript valid, but it must not turn an
+	// originally incomplete client transcript into a context-reset attestation.
+	preRepair := []byte(`{"input":[{"type":"function_call_output","call_id":"call-repair","output":"ok"}]}`)
+	if responsesWebsocketHasCompleteToolPairs(preRepair) {
+		t.Fatal("orphan pre-repair output unexpectedly attested")
+	}
+	callCache := newWebsocketToolOutputCache(0, 8)
+	callCache.record("marker-repair", "call-repair", []byte(`{"type":"function_call","call_id":"call-repair","name":"tool","arguments":"{}"}`))
+	repaired := repairResponsesWebsocketToolCallsWithCaches(newWebsocketToolOutputCache(0, 8), callCache, "marker-repair", preRepair)
+	if !responsesWebsocketHasCompleteToolPairs(repaired) {
+		t.Fatalf("repair should create a valid forwarded pair: %s", repaired)
+	}
+	if responsesWebsocketHasCompleteToolPairs(preRepair) {
+		t.Fatal("pre-repair safety must remain false after repair")
+	}
+}

--- a/sdk/cliproxy/auth/codex_model_fallback.go
+++ b/sdk/cliproxy/auth/codex_model_fallback.go
@@ -1,0 +1,215 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	log "github.com/sirupsen/logrus"
+)
+
+type modelFallbackReasonError interface {
+	ModelFallbackReason() string
+}
+
+type modelFallbackBlockedError interface {
+	ModelFallbackBlocked() bool
+}
+
+func modelFallbackReasonFromError(err error) string {
+	if err == nil {
+		return ""
+	}
+	var classified modelFallbackReasonError
+	if !errors.As(err, &classified) || classified == nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(classified.ModelFallbackReason()))
+}
+
+func isModelFallbackBlockedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var blocked modelFallbackBlockedError
+	return errors.As(err, &blocked) && blocked != nil && blocked.ModelFallbackBlocked()
+}
+
+func codexOnlyProviders(providers []string) bool {
+	found := false
+	for _, provider := range providers {
+		provider = strings.ToLower(strings.TrimSpace(provider))
+		if provider == "" {
+			continue
+		}
+		if provider != "codex" {
+			return false
+		}
+		found = true
+	}
+	return found
+}
+
+func codexModelFallbackRequestEligible(providers []string, opts cliproxyexecutor.Options) bool {
+	if !codexOnlyProviders(providers) || strings.TrimSpace(opts.Alt) != "" {
+		return false
+	}
+	if len(opts.Metadata) == 0 {
+		return true
+	}
+	raw, ok := opts.Metadata[cliproxyexecutor.RequestPathMetadataKey]
+	if !ok || raw == nil {
+		return true
+	}
+	path := ""
+	switch value := raw.(type) {
+	case string:
+		path = value
+	case []byte:
+		path = string(value)
+	}
+	path = strings.ToLower(strings.TrimSpace(path))
+	return !strings.Contains(path, "/images/") && !strings.Contains(path, "/videos/")
+}
+
+func (m *Manager) codexModelFallbackPlan(providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, err error) (internalconfig.EffectiveCodexModelFallbackConfig, string, []string, bool) {
+	if m == nil || !codexModelFallbackRequestEligible(providers, opts) {
+		return internalconfig.EffectiveCodexModelFallbackConfig{}, "", nil, false
+	}
+	reason := modelFallbackReasonFromError(err)
+	if reason == "" {
+		return internalconfig.EffectiveCodexModelFallbackConfig{}, "", nil, false
+	}
+	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	if cfg == nil {
+		return internalconfig.EffectiveCodexModelFallbackConfig{}, "", nil, false
+	}
+	effective := cfg.Codex.ModelFallback.Effective()
+	sourceModel := strings.TrimSpace(thinking.ParseSuffix(req.Model).ModelName)
+	if sourceModel == "" {
+		sourceModel = strings.TrimSpace(req.Model)
+	}
+	targets := effective.TargetsFor(sourceModel, reason)
+	if len(targets) == 0 {
+		return effective, reason, nil, false
+	}
+	seen := map[string]struct{}{strings.ToLower(sourceModel): {}}
+	filtered := make([]string, 0, len(targets))
+	for _, target := range targets {
+		target = strings.TrimSpace(target)
+		base := strings.TrimSpace(thinking.ParseSuffix(target).ModelName)
+		if base == "" {
+			base = target
+		}
+		key := strings.ToLower(base)
+		if target == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		filtered = append(filtered, target)
+	}
+	if len(filtered) == 0 {
+		return effective, reason, nil, false
+	}
+	return effective, reason, filtered, true
+}
+
+func withCodexModelFallbackMetadata(opts cliproxyexecutor.Options, sourceModel, targetModel, reasoningContinuity string) cliproxyexecutor.Options {
+	metadata := cloneSchedulerAnyMap(opts.Metadata)
+	if metadata == nil {
+		metadata = make(map[string]any, 3)
+	}
+	metadata[cliproxyexecutor.AuthSelectionModelMetadataKey] = strings.TrimSpace(targetModel)
+	metadata[cliproxyexecutor.CodexModelFallbackSourceModelMetadataKey] = strings.TrimSpace(sourceModel)
+	metadata[cliproxyexecutor.CodexModelFallbackReasoningContinuityMetadataKey] = strings.TrimSpace(reasoningContinuity)
+	opts.Metadata = metadata
+	return opts
+}
+
+func (m *Manager) executeCodexModelFallback(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, initialErr error) (cliproxyexecutor.Response, error) {
+	effective, reason, targets, ok := m.codexModelFallbackPlan(providers, req, opts, initialErr)
+	if !ok {
+		return cliproxyexecutor.Response{}, initialErr
+	}
+
+	sourceModel := req.Model
+	lastErr := initialErr
+	for _, target := range targets {
+		if errCtx := ctx.Err(); errCtx != nil {
+			return cliproxyexecutor.Response{}, errCtx
+		}
+		entry := logEntryWithRequestID(ctx)
+		entry.WithFields(log.Fields{
+			"source_model": sourceModel,
+			"target_model": target,
+			"reason":       reason,
+		}).Info("codex model fallback: attempting configured target")
+
+		fallbackReq := req
+		fallbackReq.Model = target
+		fallbackOpts := withCodexModelFallbackMetadata(opts, sourceModel, target, effective.ReasoningContinuity)
+		resp, errFallback := m.executeWithoutModelFallback(ctx, providers, fallbackReq, fallbackOpts)
+		if errFallback == nil {
+			return resp, nil
+		}
+		if isModelFallbackBlockedError(errFallback) {
+			entry.WithFields(log.Fields{
+				"source_model": sourceModel,
+				"target_model": target,
+			}).Info("codex model fallback: blocked by reasoning continuity policy")
+			return cliproxyexecutor.Response{}, initialErr
+		}
+		lastErr = errFallback
+		if modelFallbackReasonFromError(errFallback) == "" {
+			break
+		}
+	}
+	return cliproxyexecutor.Response{}, lastErr
+}
+
+func (m *Manager) executeStreamCodexModelFallback(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, initialErr error) (*cliproxyexecutor.StreamResult, error) {
+	effective, reason, targets, ok := m.codexModelFallbackPlan(providers, req, opts, initialErr)
+	if !ok {
+		return nil, initialErr
+	}
+
+	sourceModel := req.Model
+	lastErr := initialErr
+	for _, target := range targets {
+		if errCtx := ctx.Err(); errCtx != nil {
+			return nil, errCtx
+		}
+		entry := logEntryWithRequestID(ctx)
+		entry.WithFields(log.Fields{
+			"source_model": sourceModel,
+			"target_model": target,
+			"reason":       reason,
+		}).Info("codex model fallback: attempting configured streaming target")
+
+		fallbackReq := req
+		fallbackReq.Model = target
+		fallbackOpts := withCodexModelFallbackMetadata(opts, sourceModel, target, effective.ReasoningContinuity)
+		result, errFallback := m.executeStreamWithoutModelFallback(ctx, providers, fallbackReq, fallbackOpts)
+		if errFallback == nil {
+			return result, nil
+		}
+		if isModelFallbackBlockedError(errFallback) {
+			entry.WithFields(log.Fields{
+				"source_model": sourceModel,
+				"target_model": target,
+			}).Info("codex model fallback: blocked by reasoning continuity policy")
+			return nil, initialErr
+		}
+		lastErr = errFallback
+		if modelFallbackReasonFromError(errFallback) == "" {
+			break
+		}
+	}
+	return nil, lastErr
+}

--- a/sdk/cliproxy/auth/codex_model_fallback.go
+++ b/sdk/cliproxy/auth/codex_model_fallback.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 
+	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
 )
 
 type modelFallbackReasonError interface {
@@ -17,6 +20,17 @@ type modelFallbackReasonError interface {
 
 type modelFallbackBlockedError interface {
 	ModelFallbackBlocked() bool
+}
+
+type codexReasoningReplayScopeCarrier interface {
+	CodexReasoningReplayScope() (modelName, sessionKey string)
+}
+
+// modelFallbackZeroDispatchError marks a scheduler-local target rejection. It
+// is intentionally additive so continuity observation in the stacked PR can
+// participate without making its internal error type part of this package.
+type modelFallbackZeroDispatchError interface {
+	ModelFallbackZeroDispatch() bool
 }
 
 func modelFallbackReasonFromError(err error) string {
@@ -128,8 +142,209 @@ func withCodexModelFallbackMetadata(opts cliproxyexecutor.Options, sourceModel, 
 	metadata[cliproxyexecutor.AuthSelectionModelMetadataKey] = strings.TrimSpace(targetModel)
 	metadata[cliproxyexecutor.CodexModelFallbackSourceModelMetadataKey] = strings.TrimSpace(sourceModel)
 	metadata[cliproxyexecutor.CodexModelFallbackReasoningContinuityMetadataKey] = strings.TrimSpace(reasoningContinuity)
+	metadata[codexModelFallbackTargetWaveMetadataKey] = true
+	// A websocket auth pin belongs to the source upstream execution session.
+	// Carrying it into a different model silently makes target selection either
+	// impossible or, worse, sends a reset transcript to the source auth. It is
+	// safe to release only when the handler explicitly attested a complete
+	// mediated transcript for context-reset replay.
+	if reasoningContinuity == internalconfig.CodexModelFallbackReasoningContinuityContextReset && codexModelFallbackContextResetAllowed(metadata) {
+		delete(metadata, cliproxyexecutor.PinnedAuthMetadataKey)
+		delete(metadata, cliproxyexecutor.SelectedAuthMetadataKey)
+	}
 	opts.Metadata = metadata
 	return opts
+}
+
+func codexModelFallbackContextResetAllowed(metadata map[string]any) bool {
+	allowed, _ := metadata[cliproxyexecutor.CodexModelFallbackContextResetReplayMetadataKey].(bool)
+	return allowed
+}
+
+func codexModelFallbackMetadataString(metadata map[string]any, key string) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	value, ok := metadata[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case []byte:
+		return strings.TrimSpace(string(typed))
+	default:
+		return ""
+	}
+}
+
+func codexModelFallbackHasStatefulContinuity(req cliproxyexecutor.Request, opts cliproxyexecutor.Options) bool {
+	if strings.TrimSpace(gjson.GetBytes(req.Payload, "previous_response_id").String()) != "" {
+		return true
+	}
+	// Translators represent cross-provider thinking differently. Inspect only
+	// protocol fields, never raw user text: prompts are allowed to discuss
+	// "thinking" or contain JSON examples without becoming session state.
+	if codexPayloadHasStatefulReasoning(req.Payload) {
+		return true
+	}
+	if len(opts.Metadata) == 0 {
+		return false
+	}
+	return codexModelFallbackMetadataString(opts.Metadata, cliproxyexecutor.PinnedAuthMetadataKey) != "" ||
+		codexModelFallbackMetadataString(opts.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey) != ""
+}
+
+func codexPayloadHasStatefulReasoning(payload []byte) bool {
+	if len(payload) == 0 {
+		return false
+	}
+	if strings.TrimSpace(gjson.GetBytes(payload, "reasoning.encrypted_content").String()) != "" {
+		return true
+	}
+	input := gjson.GetBytes(payload, "input")
+	if input.IsArray() {
+		for _, item := range input.Array() {
+			if strings.EqualFold(strings.TrimSpace(item.Get("type").String()), "reasoning") {
+				return true
+			}
+		}
+	}
+	messages := gjson.GetBytes(payload, "messages")
+	if !messages.IsArray() {
+		return false
+	}
+	for _, message := range messages.Array() {
+		content := message.Get("content")
+		if !content.IsArray() {
+			continue
+		}
+		for _, block := range content.Array() {
+			if strings.EqualFold(strings.TrimSpace(block.Get("type").String()), "thinking") &&
+				(strings.TrimSpace(block.Get("signature").String()) != "" || strings.TrimSpace(block.Get("thinking").String()) != "") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func codexModelFallbackMayAttemptContextReset(req cliproxyexecutor.Request, opts cliproxyexecutor.Options, continuity string) bool {
+	if continuity != internalconfig.CodexModelFallbackReasoningContinuityContextReset {
+		return !codexModelFallbackHasStatefulContinuity(req, opts)
+	}
+	// Stateless requests do not need the websocket-only attestation. Any state
+	// that would require a reset does: it prevents a bare incremental request
+	// from being mistaken for a reconstructable transcript.
+	return !codexModelFallbackHasStatefulContinuity(req, opts) || codexModelFallbackContextResetAllowed(opts.Metadata)
+}
+
+// codexModelFallbackSourceReplayPreflight mirrors the source-key priority used
+// by the Codex executor. It runs before target auth selection so an existing
+// source replay entry (or an unavailable required lookup) cannot create an
+// observable target selection for an unsafe continuation.
+func codexModelFallbackSourceReplayPreflight(ctx context.Context, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, continuity string, sourceErr error) bool {
+	if continuity == internalconfig.CodexModelFallbackReasoningContinuityContextReset && codexModelFallbackContextResetAllowed(opts.Metadata) {
+		return true
+	}
+	sourceModel := strings.TrimSpace(thinking.ParseSuffix(req.Model).ModelName)
+	if sourceModel == "" {
+		sourceModel = strings.TrimSpace(req.Model)
+	}
+	if sourceModel == "" {
+		return true
+	}
+	key := ""
+	var scope codexReasoningReplayScopeCarrier
+	if errors.As(sourceErr, &scope) && scope != nil {
+		if scopedModel, scopedKey := scope.CodexReasoningReplayScope(); strings.TrimSpace(scopedKey) != "" {
+			key = strings.TrimSpace(scopedKey)
+			if strings.TrimSpace(scopedModel) != "" {
+				sourceModel = strings.TrimSpace(scopedModel)
+			}
+		}
+	}
+	if key == "" {
+		key = internalcache.ResolveCodexReasoningReplaySessionKey(internalcache.CodexReasoningReplaySessionInput{
+			Context:                 ctx,
+			SourceFormat:            opts.SourceFormat.String(),
+			RequestPayload:          req.Payload,
+			Headers:                 opts.Headers,
+			OptionExecutionSession:  codexModelFallbackMetadataString(opts.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey),
+			RequestExecutionSession: codexModelFallbackMetadataString(req.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey),
+		})
+	}
+	if key == "" {
+		return true
+	}
+	items, found, err := internalcache.GetCodexReasoningReplayItemsRequired(ctx, sourceModel, key)
+	return err == nil && !found && len(items) == 0
+}
+
+func isCodexModelFallbackZeroDispatchError(err error) bool {
+	var marked modelFallbackZeroDispatchError
+	if errors.As(err, &marked) && marked != nil && marked.ModelFallbackZeroDispatch() {
+		return true
+	}
+	var authErr *Error
+	if errors.As(err, &authErr) && authErr != nil {
+		switch strings.ToLower(strings.TrimSpace(authErr.Code)) {
+		case "auth_not_found", "model_not_supported", "model_cooldown", "continuity_observation_pending":
+			return true
+		}
+	}
+	var cooldownErr *modelCooldownError
+	if errors.As(err, &cooldownErr) && cooldownErr != nil {
+		return true
+	}
+	return false
+}
+
+func codexModelFallbackSelectedAuthCollector(opts cliproxyexecutor.Options, onDispatch func()) (cliproxyexecutor.Options, func()) {
+	if len(opts.Metadata) == 0 {
+		return opts, func() {}
+	}
+	var mu sync.Mutex
+	var selected string
+	dispatched := make(map[string]struct{})
+	var dispatchOnce sync.Once
+	metadata := opts.Metadata
+	externalCallback, _ := metadata[cliproxyexecutor.SelectedAuthCallbackMetadataKey].(func(string))
+	metadata[cliproxyexecutor.SelectedAuthCallbackMetadataKey] = func(authID string) {
+		mu.Lock()
+		defer mu.Unlock()
+		selected = strings.TrimSpace(authID)
+	}
+	metadata[codexModelFallbackDispatchMetadataKey] = func(authID string) {
+		authID = strings.TrimSpace(authID)
+		if authID == "" {
+			return
+		}
+		dispatchOnce.Do(func() {
+			if onDispatch != nil {
+				onDispatch()
+			}
+		})
+		mu.Lock()
+		defer mu.Unlock()
+		dispatched[authID] = struct{}{}
+	}
+	return opts, func() {
+		mu.Lock()
+		defer mu.Unlock()
+		metadata[cliproxyexecutor.SelectedAuthCallbackMetadataKey] = externalCallback
+		delete(metadata, codexModelFallbackDispatchMetadataKey)
+		// Hedge lanes publish their final winner through the selected-auth
+		// callback after all internal lane choices. Only expose that winner when
+		// the same auth reached the real executor dispatch boundary.
+		if _, ok := dispatched[selected]; ok && selected != "" {
+			metadata[cliproxyexecutor.SelectedAuthMetadataKey] = selected
+			if externalCallback != nil {
+				externalCallback(selected)
+			}
+		}
+	}
 }
 
 func (m *Manager) executeCodexModelFallback(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, initialErr error) (cliproxyexecutor.Response, error) {
@@ -139,7 +354,15 @@ func (m *Manager) executeCodexModelFallback(ctx context.Context, providers []str
 	}
 
 	sourceModel := req.Model
+	if !codexModelFallbackMayAttemptContextReset(req, opts, effective.ReasoningContinuity) {
+		return cliproxyexecutor.Response{}, initialErr
+	}
+	if !codexModelFallbackSourceReplayPreflight(ctx, req, opts, effective.ReasoningContinuity, initialErr) {
+		return cliproxyexecutor.Response{}, initialErr
+	}
 	lastErr := initialErr
+	var publishLastDispatched func()
+	var closeSourceOnce sync.Once
 	for _, target := range targets {
 		if errCtx := ctx.Err(); errCtx != nil {
 			return cliproxyexecutor.Response{}, errCtx
@@ -154,8 +377,18 @@ func (m *Manager) executeCodexModelFallback(ctx context.Context, providers []str
 		fallbackReq := req
 		fallbackReq.Model = target
 		fallbackOpts := withCodexModelFallbackMetadata(opts, sourceModel, target, effective.ReasoningContinuity)
+		fallbackOpts, publishSelected := codexModelFallbackSelectedAuthCollector(fallbackOpts, func() {
+			closeSourceOnce.Do(func() {
+				if effective.ReasoningContinuity == internalconfig.CodexModelFallbackReasoningContinuityContextReset && codexModelFallbackContextResetAllowed(fallbackOpts.Metadata) {
+					if sessionID := codexModelFallbackMetadataString(opts.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey); sessionID != "" {
+						m.CloseExecutionSession(sessionID)
+					}
+				}
+			})
+		})
 		resp, errFallback := m.executeWithoutModelFallback(ctx, providers, fallbackReq, fallbackOpts)
 		if errFallback == nil {
+			publishSelected()
 			return resp, nil
 		}
 		if isModelFallbackBlockedError(errFallback) {
@@ -165,10 +398,19 @@ func (m *Manager) executeCodexModelFallback(ctx context.Context, providers []str
 			}).Info("codex model fallback: blocked by reasoning continuity policy")
 			return cliproxyexecutor.Response{}, initialErr
 		}
+		if isCodexModelFallbackZeroDispatchError(errFallback) {
+			continue
+		}
+		publishLastDispatched = publishSelected
 		lastErr = errFallback
 		if modelFallbackReasonFromError(errFallback) == "" {
+			publishLastDispatched()
+			publishLastDispatched = nil
 			break
 		}
+	}
+	if publishLastDispatched != nil {
+		publishLastDispatched()
 	}
 	return cliproxyexecutor.Response{}, lastErr
 }
@@ -180,7 +422,15 @@ func (m *Manager) executeStreamCodexModelFallback(ctx context.Context, providers
 	}
 
 	sourceModel := req.Model
+	if !codexModelFallbackMayAttemptContextReset(req, opts, effective.ReasoningContinuity) {
+		return nil, initialErr
+	}
+	if !codexModelFallbackSourceReplayPreflight(ctx, req, opts, effective.ReasoningContinuity, initialErr) {
+		return nil, initialErr
+	}
 	lastErr := initialErr
+	var publishLastDispatched func()
+	var closeSourceOnce sync.Once
 	for _, target := range targets {
 		if errCtx := ctx.Err(); errCtx != nil {
 			return nil, errCtx
@@ -195,8 +445,18 @@ func (m *Manager) executeStreamCodexModelFallback(ctx context.Context, providers
 		fallbackReq := req
 		fallbackReq.Model = target
 		fallbackOpts := withCodexModelFallbackMetadata(opts, sourceModel, target, effective.ReasoningContinuity)
+		fallbackOpts, publishSelected := codexModelFallbackSelectedAuthCollector(fallbackOpts, func() {
+			closeSourceOnce.Do(func() {
+				if effective.ReasoningContinuity == internalconfig.CodexModelFallbackReasoningContinuityContextReset && codexModelFallbackContextResetAllowed(fallbackOpts.Metadata) {
+					if sessionID := codexModelFallbackMetadataString(opts.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey); sessionID != "" {
+						m.CloseExecutionSession(sessionID)
+					}
+				}
+			})
+		})
 		result, errFallback := m.executeStreamWithoutModelFallback(ctx, providers, fallbackReq, fallbackOpts)
 		if errFallback == nil {
+			publishSelected()
 			return result, nil
 		}
 		if isModelFallbackBlockedError(errFallback) {
@@ -206,10 +466,19 @@ func (m *Manager) executeStreamCodexModelFallback(ctx context.Context, providers
 			}).Info("codex model fallback: blocked by reasoning continuity policy")
 			return nil, initialErr
 		}
+		if isCodexModelFallbackZeroDispatchError(errFallback) {
+			continue
+		}
+		publishLastDispatched = publishSelected
 		lastErr = errFallback
 		if modelFallbackReasonFromError(errFallback) == "" {
+			publishLastDispatched()
+			publishLastDispatched = nil
 			break
 		}
+	}
+	if publishLastDispatched != nil {
+		publishLastDispatched()
 	}
 	return nil, lastErr
 }

--- a/sdk/cliproxy/auth/codex_model_fallback_test.go
+++ b/sdk/cliproxy/auth/codex_model_fallback_test.go
@@ -5,10 +5,15 @@ import (
 	"net/http"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/gin-gonic/gin"
+	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 )
 
 type codexFallbackTestError struct {
@@ -25,13 +30,239 @@ func (e *codexFallbackTestError) ModelFallbackReason() string { return e.reason 
 func (e *codexFallbackTestError) ModelFallbackBlocked() bool  { return e.blocked }
 
 type codexModelFallbackTestExecutor struct {
-	mu           sync.Mutex
-	calls        []string
-	authCalls    []string
-	executeErrs  map[string]error
-	streamErrs   map[string]error
-	streamChunks map[string][]cliproxyexecutor.StreamChunk
-	metadataSeen map[string]map[string]any
+	mu             sync.Mutex
+	calls          []string
+	authCalls      []string
+	executeErrs    map[string]error
+	streamErrs     map[string]error
+	streamChunks   map[string][]cliproxyexecutor.StreamChunk
+	metadataSeen   map[string]map[string]any
+	closedSessions []string
+}
+
+type codexModelFallbackRetryBehavior struct {
+	kind              string
+	payload           string
+	delay             time.Duration
+	maxRetries        int
+	hedgeEnabled      bool
+	hedgeMode         string
+	hedgeDelay        time.Duration
+	requireDistinct   bool
+	exhaustedBehavior string
+	deliveryPolicy    string
+	fallbackPolicy    string
+	usage             coreusage.Detail
+	finalize          bool
+}
+
+type codexModelFallbackRetryExecutor struct {
+	mu              sync.Mutex
+	calls           []string
+	behaviors       map[string][]codexModelFallbackRetryBehavior
+	streamBehaviors map[string][]codexModelFallbackRetryBehavior
+}
+
+func (e *codexModelFallbackRetryExecutor) Identifier() string { return "codex" }
+
+func codexModelFallbackRetryBehaviorKey(authID, model string) string {
+	return authID + "|" + model
+}
+
+func (e *codexModelFallbackRetryExecutor) next(authID, model string, stream bool) codexModelFallbackRetryBehavior {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	key := codexModelFallbackRetryBehaviorKey(authID, model)
+	e.calls = append(e.calls, key)
+	queues := e.behaviors
+	if stream {
+		queues = e.streamBehaviors
+	}
+	queue := queues[key]
+	if len(queue) == 0 {
+		return codexModelFallbackRetryBehavior{kind: "success", payload: "ok"}
+	}
+	behavior := queue[0]
+	queues[key] = queue[1:]
+	return behavior
+}
+
+func (e *codexModelFallbackRetryExecutor) wait(ctx context.Context, behavior codexModelFallbackRetryBehavior) error {
+	if behavior.kind == "wait_cancel" {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	if behavior.delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(behavior.delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func (e *codexModelFallbackRetryExecutor) retryError(authID string, behavior codexModelFallbackRetryBehavior, stream bool) error {
+	usage := behavior.usage
+	if !hasRetryWithoutPenaltyUsageDetail(usage) {
+		usage = coreusage.Detail{InputTokens: 1, OutputTokens: 2, ReasoningTokens: 516, TotalTokens: 3}
+	}
+	fallbackPayload := []byte(behavior.payload)
+	fallbackStream := []cliproxyexecutor.StreamChunk(nil)
+	if stream && behavior.payload != "" {
+		fallbackStream = []cliproxyexecutor.StreamChunk{{Payload: []byte(behavior.payload)}}
+	}
+	return hedgedRetryTestError{
+		maxRetries:         behavior.maxRetries,
+		hedgeEnabled:       behavior.hedgeEnabled,
+		hedgeMode:          behavior.hedgeMode,
+		hedgeDelay:         behavior.hedgeDelay,
+		requireDistinct:    behavior.requireDistinct,
+		authID:             authID,
+		usage:              usage,
+		exhaustedBehavior:  behavior.exhaustedBehavior,
+		deliveryPolicy:     behavior.deliveryPolicy,
+		fallbackPolicy:     behavior.fallbackPolicy,
+		fallbackPayload:    fallbackPayload,
+		fallbackStreamData: fallbackStream,
+	}
+}
+
+func (e *codexModelFallbackRetryExecutor) Execute(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	behavior := e.next(auth.ID, req.Model, false)
+	if err := e.wait(ctx, behavior); err != nil {
+		return cliproxyexecutor.Response{}, err
+	}
+	switch behavior.kind {
+	case "abnormal":
+		return cliproxyexecutor.Response{}, e.retryError(auth.ID, behavior, false)
+	case "usage_limit":
+		return cliproxyexecutor.Response{}, &codexFallbackTestError{message: "usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit}
+	case "usage":
+		return cliproxyexecutor.Response{Payload: []byte(hedgedRetryUsagePayload(opts))}, nil
+	default:
+		payload := behavior.payload
+		if payload == "" {
+			payload = "ok"
+		}
+		meta := hedgedRetryTestResponseMetadata(hedgedRetryBehavior{
+			usage:    behavior.usage,
+			finalize: behavior.finalize,
+			policy:   hedgedRetryTestCandidatePolicy(behavior.deliveryPolicy),
+		})
+		return cliproxyexecutor.Response{Payload: []byte(payload), Metadata: meta}, nil
+	}
+}
+
+func (e *codexModelFallbackRetryExecutor) ExecuteStream(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	behavior := e.next(auth.ID, req.Model, true)
+	if err := e.wait(ctx, behavior); err != nil {
+		return nil, err
+	}
+	if behavior.kind == "usage_limit" {
+		return nil, &codexFallbackTestError{message: "usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit}
+	}
+	ch := make(chan cliproxyexecutor.StreamChunk, 1)
+	if behavior.kind == "abnormal" {
+		ch <- cliproxyexecutor.StreamChunk{Err: e.retryError(auth.ID, behavior, true)}
+	} else {
+		payload := behavior.payload
+		if behavior.kind == "usage" {
+			payload = hedgedRetryUsagePayload(opts)
+		}
+		if payload == "" {
+			payload = "ok"
+		}
+		ch <- cliproxyexecutor.StreamChunk{Payload: []byte(payload)}
+	}
+	close(ch)
+	meta := hedgedRetryTestStreamMetadata(hedgedRetryBehavior{
+		usage:    behavior.usage,
+		finalize: behavior.finalize,
+		policy:   hedgedRetryTestCandidatePolicy(behavior.deliveryPolicy),
+	})
+	return &cliproxyexecutor.StreamResult{Chunks: ch, Metadata: meta}, nil
+}
+
+func (e *codexModelFallbackRetryExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (e *codexModelFallbackRetryExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *codexModelFallbackRetryExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func (e *codexModelFallbackRetryExecutor) callsSnapshot() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]string(nil), e.calls...)
+}
+
+type codexModelFallbackAuthSpec struct {
+	id     string
+	models []string
+}
+
+type codexModelFallbackSequenceSelector struct {
+	mu      sync.Mutex
+	byModel map[string][]string
+}
+
+func (s *codexModelFallbackSequenceSelector) Pick(_ context.Context, _ string, model string, _ cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	s.mu.Lock()
+	sequence := s.byModel[model]
+	authID := ""
+	if len(sequence) > 0 {
+		authID = sequence[0]
+		s.byModel[model] = sequence[1:]
+	}
+	s.mu.Unlock()
+	if authID != "" {
+		return pickHedgedRetryTestAuth(auths, authID)
+	}
+	if len(auths) == 0 {
+		return nil, &Error{Code: "auth_not_found", Message: "test auth unavailable"}
+	}
+	return auths[0], nil
+}
+
+func newCodexModelFallbackRetryManager(t *testing.T, executor *codexModelFallbackRetryExecutor, targets []string, auths ...codexModelFallbackAuthSpec) *Manager {
+	return newCodexModelFallbackRetryManagerWithSelector(t, executor, &FillFirstSelector{}, targets, auths...)
+}
+
+func newCodexModelFallbackRetryManagerWithSelector(t *testing.T, executor *codexModelFallbackRetryExecutor, selector Selector, targets []string, auths ...codexModelFallbackAuthSpec) *Manager {
+	t.Helper()
+	manager := NewManager(nil, selector, nil)
+	manager.SetRetryConfig(0, 0, 0)
+	manager.SetConfig(&internalconfig.Config{Codex: internalconfig.CodexConfig{ModelFallback: internalconfig.CodexModelFallbackConfig{
+		Enabled:  true,
+		Mappings: []internalconfig.CodexModelFallbackMapping{{From: "gpt-source", To: targets}},
+	}}})
+	manager.RegisterExecutor(executor)
+	reg := registry.GetGlobalRegistry()
+	for _, spec := range auths {
+		models := make([]*registry.ModelInfo, 0, len(spec.models))
+		for _, model := range spec.models {
+			models = append(models, &registry.ModelInfo{ID: model})
+		}
+		reg.RegisterClient(spec.id, "codex", models)
+		if _, err := manager.Register(context.Background(), &Auth{ID: spec.id, Provider: "codex", Status: StatusActive}); err != nil {
+			t.Fatalf("register auth %s: %v", spec.id, err)
+		}
+	}
+	t.Cleanup(func() {
+		for _, spec := range auths {
+			reg.UnregisterClient(spec.id)
+		}
+	})
+	return manager
 }
 
 func (e *codexModelFallbackTestExecutor) Identifier() string { return "codex" }
@@ -96,6 +327,18 @@ func (e *codexModelFallbackTestExecutor) authSnapshot() []string {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	return append([]string(nil), e.authCalls...)
+}
+
+func (e *codexModelFallbackTestExecutor) CloseExecutionSession(sessionID string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.closedSessions = append(e.closedSessions, sessionID)
+}
+
+func (e *codexModelFallbackTestExecutor) closedSnapshot() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]string(nil), e.closedSessions...)
 }
 
 func (e *codexModelFallbackTestExecutor) snapshot() ([]string, map[string]map[string]any) {
@@ -242,6 +485,549 @@ func TestManagerExecuteCodexModelFallbackBlockedReturnsOriginalAndDoesNotCooldow
 	}
 	if _, ok := auth.ModelStates["gpt-target"]; ok {
 		t.Fatalf("target model was penalized despite zero dispatch: %#v", auth.ModelStates["gpt-target"])
+	}
+}
+
+func TestManagerExecuteCodexModelFallbackSameModelOnlyBlocksPreviousResponseBeforeTargetSelection(t *testing.T) {
+	initial := &codexFallbackTestError{message: "usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit}
+	executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{"gpt-source": initial}}
+	manager, _ := newCodexModelFallbackTestManager(t, executor, internalconfig.CodexModelFallbackReasoningContinuitySameModelOnly)
+
+	_, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{
+		Model:   "gpt-source",
+		Payload: []byte(`{"previous_response_id":"resp-source","input":[{"type":"message","role":"user","content":"continue"}]}`),
+	}, cliproxyexecutor.Options{})
+	if err != initial {
+		t.Fatalf("Execute() error = %v, want original source error", err)
+	}
+	calls, _ := executor.snapshot()
+	if len(calls) != 1 || calls[0] != "gpt-source" {
+		t.Fatalf("calls = %#v, want source only", calls)
+	}
+}
+
+func TestManagerExecuteCodexModelFallbackBlocksCachedClaudeReplayBeforeTargetSelection(t *testing.T) {
+	internalcache.ClearCodexReasoningReplayCache()
+	t.Cleanup(internalcache.ClearCodexReasoningReplayCache)
+	const sessionID = "123e4567-e89b-12d3-a456-426614174000"
+	if !internalcache.CacheCodexReasoningReplayItem("gpt-source", "claude:"+sessionID, []byte(`{"type":"function_call","call_id":"call-preflight","name":"tool","arguments":"{}"}`)) {
+		t.Fatal("failed to cache replay test item")
+	}
+	initial := &codexFallbackTestError{message: "usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit}
+	executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{"gpt-source": initial}}
+	manager, _ := newCodexModelFallbackTestManager(t, executor, internalconfig.CodexModelFallbackReasoningContinuitySameModelOnly)
+	_, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{
+		Model:   "gpt-source",
+		Payload: []byte(`{"metadata":{"user_id":"user_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_account_123e4567-e89b-12d3-a456-426614174001_session_` + sessionID + `"},"messages":[{"role":"user","content":[{"type":"text","text":"continue"}]}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != initial {
+		t.Fatalf("Execute() error = %v, want source error", err)
+	}
+	calls, _ := executor.snapshot()
+	if len(calls) != 1 || calls[0] != "gpt-source" {
+		t.Fatalf("calls = %#v, want target zero-dispatch", calls)
+	}
+}
+
+func TestManagerExecuteCodexModelFallbackReplayPreflightUsesExecutorKeyPriority(t *testing.T) {
+	internalcache.ClearCodexReasoningReplayCache()
+	t.Cleanup(internalcache.ClearCodexReasoningReplayCache)
+	const sessionID = "123e4567-e89b-12d3-a456-426614174010"
+	if !internalcache.CacheCodexReasoningReplayItem("gpt-source", "claude:"+sessionID, []byte(`{"type":"function_call","call_id":"call-lower-priority","name":"tool","arguments":"{}"}`)) {
+		t.Fatal("failed to cache replay test item")
+	}
+	initial := &codexFallbackTestError{message: "usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit}
+	executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{"gpt-source": initial}}
+	manager, _ := newCodexModelFallbackTestManager(t, executor, internalconfig.CodexModelFallbackReasoningContinuitySameModelOnly)
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{
+		Model:   "gpt-source",
+		Payload: []byte(`{"prompt_cache_key":"higher-priority-key-without-replay","metadata":{"user_id":"{\"session_id\":\"` + sessionID + `\"}"},"messages":[{"role":"user","content":[{"type":"text","text":"continue"}]}]}`),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude})
+	if err != nil || string(resp.Payload) != "gpt-target" {
+		t.Fatalf("Execute() = payload %q, err %v; want target success", resp.Payload, err)
+	}
+	calls, _ := executor.snapshot()
+	if len(calls) != 2 || calls[0] != "gpt-source" || calls[1] != "gpt-target" {
+		t.Fatalf("calls = %#v, want source then target", calls)
+	}
+}
+
+func TestManagerExecuteCodexModelFallbackReplayPreflightUsesSharedHeaderResolver(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		cacheKey   string
+		optsHeader http.Header
+		ginHeader  http.Header
+	}{
+		{
+			name:       "lowercase options header",
+			cacheKey:   "window:window-lowercase",
+			optsHeader: http.Header{"x-codex-window-id": {"window-lowercase"}},
+		},
+		{
+			name:      "gin-only header",
+			cacheKey:  "conversation_id:conversation-gin",
+			ginHeader: http.Header{"conversation_id": {"conversation-gin"}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			internalcache.ClearCodexReasoningReplayCache()
+			t.Cleanup(internalcache.ClearCodexReasoningReplayCache)
+			if !internalcache.CacheCodexReasoningReplayItem("gpt-source", tc.cacheKey, []byte(`{"type":"function_call","call_id":"call-shared-resolver","name":"tool","arguments":"{}"}`)) {
+				t.Fatal("failed to cache replay test item")
+			}
+			initial := &codexFallbackTestError{message: "usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit}
+			executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{"gpt-source": initial}}
+			manager, _ := newCodexModelFallbackTestManager(t, executor, internalconfig.CodexModelFallbackReasoningContinuitySameModelOnly)
+			ctx := context.Background()
+			if tc.ginHeader != nil {
+				ctx = context.WithValue(ctx, "gin", &gin.Context{Request: &http.Request{Header: tc.ginHeader}})
+			}
+			_, err := manager.Execute(ctx, []string{"codex"}, cliproxyexecutor.Request{
+				Model:   "gpt-source",
+				Payload: []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"continue"}]}]}`),
+			}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude, Headers: tc.optsHeader})
+			if err != initial {
+				t.Fatalf("Execute() error = %v, want source error", err)
+			}
+			calls, _ := executor.snapshot()
+			if len(calls) != 1 || calls[0] != "gpt-source" {
+				t.Fatalf("calls = %#v, want target zero-dispatch", calls)
+			}
+		})
+	}
+}
+
+func TestCodexModelFallbackStatefulContinuityDoesNotTreatPromptWordsAsState(t *testing.T) {
+	req := cliproxyexecutor.Request{Payload: []byte(`{"input":[{"type":"message","role":"user","content":"Explain the word thinking and the JSON snippet {\\\"type\\\":\\\"reasoning\\\"}."}],"reasoning":{"effort":"high"}}`)}
+	if codexModelFallbackHasStatefulContinuity(req, cliproxyexecutor.Options{}) {
+		t.Fatalf("ordinary user text/config must not be classified as reasoning continuity")
+	}
+}
+
+func TestManagerExecuteCodexModelFallbackContextResetDropsSourcePinAndPublishesTarget(t *testing.T) {
+	initial := &codexFallbackTestError{message: "usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit}
+	executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{"gpt-source": initial}}
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.SetRetryConfig(0, 0, 0)
+	manager.SetConfig(&internalconfig.Config{Codex: internalconfig.CodexConfig{ModelFallback: internalconfig.CodexModelFallbackConfig{
+		Enabled:             true,
+		ReasoningContinuity: internalconfig.CodexModelFallbackReasoningContinuityContextReset,
+		Mappings:            []internalconfig.CodexModelFallbackMapping{{From: "gpt-source", To: []string{"gpt-target"}}},
+	}}})
+	manager.RegisterExecutor(executor)
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("fallback-source-pin", "codex", []*registry.ModelInfo{{ID: "gpt-source"}})
+	reg.RegisterClient("fallback-target-pin", "codex", []*registry.ModelInfo{{ID: "gpt-target"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient("fallback-source-pin")
+		reg.UnregisterClient("fallback-target-pin")
+	})
+	for _, authID := range []string{"fallback-source-pin", "fallback-target-pin"} {
+		if _, err := manager.Register(context.Background(), &Auth{ID: authID, Provider: "codex", Status: StatusActive}); err != nil {
+			t.Fatalf("Register(%s) error = %v", authID, err)
+		}
+	}
+	var selected []string
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.PinnedAuthMetadataKey:                           "fallback-source-pin",
+		cliproxyexecutor.ExecutionSessionMetadataKey:                     "fallback-reset-session",
+		cliproxyexecutor.CodexModelFallbackContextResetReplayMetadataKey: true,
+		cliproxyexecutor.SelectedAuthCallbackMetadataKey: func(authID string) {
+			selected = append(selected, authID)
+		},
+	}})
+	if err != nil || string(resp.Payload) != "gpt-target" {
+		t.Fatalf("Execute() response/error = %q/%v, want target success", resp.Payload, err)
+	}
+	if got := executor.authSnapshot(); len(got) != 2 || got[0] != "fallback-source-pin" || got[1] != "fallback-target-pin" {
+		t.Fatalf("auth calls = %#v, want source then distinct target", got)
+	}
+	if len(selected) != 2 || selected[1] != "fallback-target-pin" {
+		t.Fatalf("selected callbacks = %#v, want final target callback", selected)
+	}
+	if closed := executor.closedSnapshot(); len(closed) != 1 || closed[0] != "fallback-reset-session" {
+		t.Fatalf("closed source sessions = %#v, want fallback-reset-session", closed)
+	}
+}
+
+func TestManagerExecuteCodexModelFallbackContinuesAfterTargetAuthNotFound(t *testing.T) {
+	initial := &codexFallbackTestError{message: "usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit}
+	executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{"gpt-source": initial}}
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.SetRetryConfig(0, 0, 0)
+	manager.SetConfig(&internalconfig.Config{Codex: internalconfig.CodexConfig{ModelFallback: internalconfig.CodexModelFallbackConfig{
+		Enabled:  true,
+		Mappings: []internalconfig.CodexModelFallbackMapping{{From: "gpt-source", To: []string{"gpt-missing", "gpt-target"}}},
+	}}})
+	manager.RegisterExecutor(executor)
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("fallback-ordered", "codex", []*registry.ModelInfo{{ID: "gpt-source"}, {ID: "gpt-target"}})
+	t.Cleanup(func() { reg.UnregisterClient("fallback-ordered") })
+	if _, err := manager.Register(context.Background(), &Auth{ID: "fallback-ordered", Provider: "codex", Status: StatusActive}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{})
+	if err != nil || string(resp.Payload) != "gpt-target" {
+		t.Fatalf("Execute() response/error = %q/%v, want second target success", resp.Payload, err)
+	}
+	calls, _ := executor.snapshot()
+	if len(calls) != 2 || calls[0] != "gpt-source" || calls[1] != "gpt-target" {
+		t.Fatalf("calls = %#v, want source and second target", calls)
+	}
+}
+
+func TestManagerExecuteCodexModelFallbackContinuesAfterTypedTargetAndHidesIntermediateCallback(t *testing.T) {
+	initial := &codexFallbackTestError{message: "usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit}
+	executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{
+		"gpt-source":   initial,
+		"gpt-target-a": &codexFallbackTestError{message: "capacity", reason: internalconfig.CodexModelFallbackTriggerCapacity},
+	}}
+	manager, _ := newCodexModelFallbackTestManager(t, executor, internalconfig.CodexModelFallbackReasoningContinuitySameModelOnly)
+	manager.SetConfig(&internalconfig.Config{Codex: internalconfig.CodexConfig{ModelFallback: internalconfig.CodexModelFallbackConfig{
+		Enabled:  true,
+		Mappings: []internalconfig.CodexModelFallbackMapping{{From: "gpt-source", To: []string{"gpt-target-a", "gpt-target"}}},
+	}}})
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("codex-fallback-auth", "codex", []*registry.ModelInfo{{ID: "gpt-source"}, {ID: "gpt-target-a"}, {ID: "gpt-target"}})
+	var callbacks []string
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.SelectedAuthCallbackMetadataKey: func(authID string) { callbacks = append(callbacks, authID) },
+	}})
+	if err != nil || string(resp.Payload) != "gpt-target" {
+		t.Fatalf("Execute() response/error = %q/%v, want target B success", resp.Payload, err)
+	}
+	if len(callbacks) != 2 { // source + final B; target A is deliberately internal.
+		t.Fatalf("callbacks = %#v, want source and final target only", callbacks)
+	}
+}
+
+func TestManagerExecuteCodexModelFallbackAllZeroDispatchReturnsSourceError(t *testing.T) {
+	initial := &codexFallbackTestError{message: "usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit}
+	executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{"gpt-source": initial}}
+	manager, _ := newCodexModelFallbackTestManager(t, executor, internalconfig.CodexModelFallbackReasoningContinuitySameModelOnly)
+	manager.SetConfig(&internalconfig.Config{Codex: internalconfig.CodexConfig{ModelFallback: internalconfig.CodexModelFallbackConfig{
+		Enabled:  true,
+		Mappings: []internalconfig.CodexModelFallbackMapping{{From: "gpt-source", To: []string{"gpt-missing-a", "gpt-missing-b"}}},
+	}}})
+	_, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{})
+	if err != initial {
+		t.Fatalf("Execute() error = %v, want source error after all zero-dispatch targets", err)
+	}
+	calls, _ := executor.snapshot()
+	if len(calls) != 1 || calls[0] != "gpt-source" {
+		t.Fatalf("calls = %#v, want source only", calls)
+	}
+}
+
+func TestManagerExecuteCodexModelFallbackContextResetDoesNotCloseSourceForZeroDispatchTarget(t *testing.T) {
+	initial := &codexFallbackTestError{message: "usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit}
+	executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{"gpt-source": initial}}
+	manager, _ := newCodexModelFallbackTestManager(t, executor, internalconfig.CodexModelFallbackReasoningContinuityContextReset)
+	manager.SetConfig(&internalconfig.Config{Codex: internalconfig.CodexConfig{ModelFallback: internalconfig.CodexModelFallbackConfig{
+		Enabled:             true,
+		ReasoningContinuity: internalconfig.CodexModelFallbackReasoningContinuityContextReset,
+		Mappings:            []internalconfig.CodexModelFallbackMapping{{From: "gpt-source", To: []string{"gpt-missing"}}},
+	}}})
+	_, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.ExecutionSessionMetadataKey:                     "must-not-close",
+		cliproxyexecutor.CodexModelFallbackContextResetReplayMetadataKey: true,
+	}})
+	if err != initial {
+		t.Fatalf("Execute() error = %v, want source error", err)
+	}
+	if closed := executor.closedSnapshot(); len(closed) != 0 {
+		t.Fatalf("closed sessions = %#v, zero-dispatch target must not close source", closed)
+	}
+}
+
+func TestCodexModelFallbackTargetSharesRequestRetryHedgeAndUsageBudget(t *testing.T) {
+	source := withCodexModelFallbackRequestBudget(cliproxyexecutor.Options{}, false)
+	target := withCodexModelFallbackMetadata(source, "gpt-source", "gpt-target", internalconfig.CodexModelFallbackReasoningContinuitySameModelOnly)
+	sourceBudget := codexModelFallbackBudget(source, false)
+	targetBudget := codexModelFallbackBudget(target, false)
+	if sourceBudget != targetBudget {
+		t.Fatal("target received a fresh retry/hedge/usage budget")
+	}
+	sourceBudget.retryCounts["abnormal"] = 1
+	sourceBudget.usage.Add(coreusage.Detail{InputTokens: 2, OutputTokens: 3, TotalTokens: 5})
+	if targetBudget.retryCounts["abnormal"] != 1 {
+		t.Fatalf("target retry budget = %#v, want source-consumed counter", targetBudget.retryCounts)
+	}
+	if got := targetBudget.usage.RetryWithoutPenaltySnapshot().Detail.TotalTokens; got != 5 {
+		t.Fatalf("target usage snapshot total = %d, want source usage included", got)
+	}
+	if !codexModelFallbackTargetWave(target) {
+		t.Fatal("target must be limited to a single auth-selection wave")
+	}
+}
+
+func TestManagerExecuteCodexModelFallbackSharesRemainingAbnormalBudgetAndHedgeWinner(t *testing.T) {
+	executor := &codexModelFallbackRetryExecutor{behaviors: map[string][]codexModelFallbackRetryBehavior{
+		codexModelFallbackRetryBehaviorKey("auth-source", "gpt-source"): {
+			{kind: "abnormal", maxRetries: 3},
+			{kind: "usage_limit"},
+		},
+		codexModelFallbackRetryBehaviorKey("auth-target-a", "gpt-target"): {
+			{kind: "abnormal", maxRetries: 3, hedgeEnabled: true, hedgeMode: retryWithoutPenaltyHedgeModeQuality, requireDistinct: true},
+			{kind: "abnormal", maxRetries: 3, hedgeEnabled: true, hedgeMode: retryWithoutPenaltyHedgeModeQuality, requireDistinct: true},
+		},
+		codexModelFallbackRetryBehaviorKey("auth-target-b", "gpt-target"): {
+			{kind: "usage"},
+		},
+	}}
+	selector := &codexModelFallbackSequenceSelector{byModel: map[string][]string{
+		"gpt-source": {"auth-source", "auth-source"},
+		"gpt-target": {"auth-target-a", "auth-target-a", "auth-target-a", "auth-target-b"},
+	}}
+	manager := newCodexModelFallbackRetryManagerWithSelector(t, executor, selector, []string{"gpt-target"},
+		codexModelFallbackAuthSpec{id: "auth-source", models: []string{"gpt-source"}},
+		codexModelFallbackAuthSpec{id: "auth-target-a", models: []string{"gpt-target"}},
+		codexModelFallbackAuthSpec{id: "auth-target-b", models: []string{"gpt-target"}},
+	)
+
+	var callbackMu sync.Mutex
+	var callbacks []string
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.SelectedAuthCallbackMetadataKey: func(authID string) {
+			callbackMu.Lock()
+			defer callbackMu.Unlock()
+			callbacks = append(callbacks, authID)
+		},
+	}})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := string(resp.Payload); got != "usage:9" {
+		t.Fatalf("payload = %q, want target winner with source+target abnormal usage; calls=%#v", got, executor.callsSnapshot())
+	}
+	counts := make(map[string]int)
+	for _, call := range executor.callsSnapshot() {
+		counts[call]++
+	}
+	for call, want := range map[string]int{
+		codexModelFallbackRetryBehaviorKey("auth-source", "gpt-source"):   2,
+		codexModelFallbackRetryBehaviorKey("auth-target-a", "gpt-target"): 2,
+		codexModelFallbackRetryBehaviorKey("auth-target-b", "gpt-target"): 1,
+	} {
+		if got := counts[call]; got != want {
+			t.Fatalf("call count %s = %d, want %d; all=%#v", call, got, want, executor.callsSnapshot())
+		}
+	}
+	callbackMu.Lock()
+	gotCallbacks := append([]string(nil), callbacks...)
+	callbackMu.Unlock()
+	if len(gotCallbacks) != 3 || gotCallbacks[0] != "auth-source" || gotCallbacks[1] != "auth-source" || gotCallbacks[2] != "auth-target-b" {
+		t.Fatalf("selected callbacks = %#v, want source attempts plus final target hedge winner", gotCallbacks)
+	}
+}
+
+func TestManagerExecuteStreamCodexModelFallbackSharesRemainingAbnormalBudgetAndHedgeWinner(t *testing.T) {
+	executor := &codexModelFallbackRetryExecutor{streamBehaviors: map[string][]codexModelFallbackRetryBehavior{
+		codexModelFallbackRetryBehaviorKey("auth-source-stream", "gpt-source"): {
+			{kind: "abnormal", maxRetries: 3},
+			{kind: "usage_limit"},
+		},
+		codexModelFallbackRetryBehaviorKey("auth-target-stream-a", "gpt-target"): {
+			{kind: "abnormal", maxRetries: 3, hedgeEnabled: true, hedgeMode: retryWithoutPenaltyHedgeModeQuality, requireDistinct: true},
+			{kind: "abnormal", maxRetries: 3, hedgeEnabled: true, hedgeMode: retryWithoutPenaltyHedgeModeQuality, requireDistinct: true},
+		},
+		codexModelFallbackRetryBehaviorKey("auth-target-stream-b", "gpt-target"): {
+			{kind: "usage"},
+		},
+	}}
+	selector := &codexModelFallbackSequenceSelector{byModel: map[string][]string{
+		"gpt-source": {"auth-source-stream", "auth-source-stream"},
+		"gpt-target": {"auth-target-stream-a", "auth-target-stream-a", "auth-target-stream-a", "auth-target-stream-b"},
+	}}
+	manager := newCodexModelFallbackRetryManagerWithSelector(t, executor, selector, []string{"gpt-target"},
+		codexModelFallbackAuthSpec{id: "auth-source-stream", models: []string{"gpt-source"}},
+		codexModelFallbackAuthSpec{id: "auth-target-stream-a", models: []string{"gpt-target"}},
+		codexModelFallbackAuthSpec{id: "auth-target-stream-b", models: []string{"gpt-target"}},
+	)
+
+	var callbackMu sync.Mutex
+	var callbacks []string
+	result, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{
+		Stream: true,
+		Metadata: map[string]any{
+			cliproxyexecutor.SelectedAuthCallbackMetadataKey: func(authID string) {
+				callbackMu.Lock()
+				defer callbackMu.Unlock()
+				callbacks = append(callbacks, authID)
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	if got := string(collectHedgedRetryStreamPayload(t, result)); got != "usage:9" {
+		t.Fatalf("stream payload = %q, want target winner with source+target abnormal usage; calls=%#v", got, executor.callsSnapshot())
+	}
+	counts := make(map[string]int)
+	for _, call := range executor.callsSnapshot() {
+		counts[call]++
+	}
+	for call, want := range map[string]int{
+		codexModelFallbackRetryBehaviorKey("auth-source-stream", "gpt-source"):   2,
+		codexModelFallbackRetryBehaviorKey("auth-target-stream-a", "gpt-target"): 2,
+		codexModelFallbackRetryBehaviorKey("auth-target-stream-b", "gpt-target"): 1,
+	} {
+		if got := counts[call]; got != want {
+			t.Fatalf("stream call count %s = %d, want %d; all=%#v", call, got, want, executor.callsSnapshot())
+		}
+	}
+	callbackMu.Lock()
+	gotCallbacks := append([]string(nil), callbacks...)
+	callbackMu.Unlock()
+	if len(gotCallbacks) != 3 || gotCallbacks[0] != "auth-source-stream" || gotCallbacks[1] != "auth-source-stream" || gotCallbacks[2] != "auth-target-stream-b" {
+		t.Fatalf("stream selected callbacks = %#v, want source attempts plus final target hedge winner", gotCallbacks)
+	}
+}
+
+func TestManagerExecuteCodexModelFallbackDoesNotReuseSourceMaxOutputCandidate(t *testing.T) {
+	executor := &codexModelFallbackRetryExecutor{behaviors: map[string][]codexModelFallbackRetryBehavior{
+		codexModelFallbackRetryBehaviorKey("auth-source-max", "gpt-source"): {
+			{kind: "abnormal", payload: "source-abnormal-much-longer", maxRetries: 1, deliveryPolicy: retryWithoutPenaltyDeliveryPolicyMaxOutput},
+			{kind: "usage_limit"},
+		},
+		codexModelFallbackRetryBehaviorKey("auth-target-max", "gpt-target"): {
+			{kind: "usage"},
+		},
+	}}
+	manager := newCodexModelFallbackRetryManager(t, executor, []string{"gpt-target"},
+		codexModelFallbackAuthSpec{id: "auth-source-max", models: []string{"gpt-source"}},
+		codexModelFallbackAuthSpec{id: "auth-target-max", models: []string{"gpt-target"}},
+	)
+
+	var callbacks []string
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.SelectedAuthCallbackMetadataKey: func(authID string) { callbacks = append(callbacks, authID) },
+	}})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := string(resp.Payload); got != "usage:3" {
+		t.Fatalf("payload = %q, source max-output candidate leaked across models", got)
+	}
+	if len(callbacks) == 0 || callbacks[len(callbacks)-1] != "auth-target-max" {
+		t.Fatalf("callbacks = %#v, want actual target result auth", callbacks)
+	}
+}
+
+func TestManagerCodexModelFallbackTargetExhaustionPreservesBehavior(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		for _, exhaustedBehavior := range []string{retryWithoutPenaltyExhaustedBehaviorError, retryWithoutPenaltyExhaustedBehaviorPassThrough} {
+			name := exhaustedBehavior
+			if stream {
+				name = "stream-" + name
+			} else {
+				name = "non-stream-" + name
+			}
+			t.Run(name, func(t *testing.T) {
+				queues := map[string][]codexModelFallbackRetryBehavior{
+					codexModelFallbackRetryBehaviorKey("auth-source-exhausted", "gpt-source"): {{kind: "usage_limit"}},
+					codexModelFallbackRetryBehaviorKey("auth-target-exhausted", "gpt-target"): {{
+						kind: "abnormal", payload: "target-abnormal", maxRetries: 0, exhaustedBehavior: exhaustedBehavior,
+					}},
+				}
+				executor := &codexModelFallbackRetryExecutor{}
+				if stream {
+					executor.streamBehaviors = queues
+				} else {
+					executor.behaviors = queues
+				}
+				manager := newCodexModelFallbackRetryManager(t, executor, []string{"gpt-target"},
+					codexModelFallbackAuthSpec{id: "auth-source-exhausted", models: []string{"gpt-source"}},
+					codexModelFallbackAuthSpec{id: "auth-target-exhausted", models: []string{"gpt-target"}},
+				)
+
+				if stream {
+					result, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{Stream: true})
+					if exhaustedBehavior == retryWithoutPenaltyExhaustedBehaviorError {
+						assertRetryWithoutPenaltyExhausted(t, err, "codex_abnormal_reasoning_retry_exhausted")
+						return
+					}
+					if err != nil {
+						t.Fatalf("ExecuteStream() error = %v", err)
+					}
+					if got := string(collectHedgedRetryStreamPayload(t, result)); got != "target-abnormal" {
+						t.Fatalf("stream pass-through payload = %q, want target-abnormal", got)
+					}
+					return
+				}
+
+				resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{})
+				if exhaustedBehavior == retryWithoutPenaltyExhaustedBehaviorError {
+					assertRetryWithoutPenaltyExhausted(t, err, "codex_abnormal_reasoning_retry_exhausted")
+					return
+				}
+				if err != nil {
+					t.Fatalf("Execute() error = %v", err)
+				}
+				if got := string(resp.Payload); got != "target-abnormal" {
+					t.Fatalf("pass-through payload = %q, want target-abnormal", got)
+				}
+			})
+		}
+	}
+}
+
+func TestManagerExecuteCodexModelFallbackContinuesPastRealTargetCooldown(t *testing.T) {
+	for _, allCooldown := range []bool{false, true} {
+		name := "target-b-success"
+		if allCooldown {
+			name = "all-targets-cooldown"
+		}
+		t.Run(name, func(t *testing.T) {
+			initial := &codexFallbackTestError{message: "source usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit}
+			executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{"gpt-source": initial}}
+			manager := NewManager(nil, &FillFirstSelector{}, nil)
+			manager.SetRetryConfig(0, 0, 0)
+			manager.SetConfig(&internalconfig.Config{Codex: internalconfig.CodexConfig{ModelFallback: internalconfig.CodexModelFallbackConfig{
+				Enabled:  true,
+				Mappings: []internalconfig.CodexModelFallbackMapping{{From: "gpt-source", To: []string{"gpt-target-a", "gpt-target-b"}}},
+			}}})
+			manager.RegisterExecutor(executor)
+			next := time.Now().Add(time.Hour)
+			modelStates := map[string]*ModelState{
+				"gpt-target-a": {Status: StatusActive, Unavailable: true, NextRetryAfter: next, Quota: QuotaState{Exceeded: true, NextRecoverAt: next}},
+			}
+			if allCooldown {
+				modelStates["gpt-target-b"] = &ModelState{Status: StatusActive, Unavailable: true, NextRetryAfter: next, Quota: QuotaState{Exceeded: true, NextRecoverAt: next}}
+			}
+			authID := "auth-real-cooldown-" + name
+			reg := registry.GetGlobalRegistry()
+			reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: "gpt-source"}, {ID: "gpt-target-a"}, {ID: "gpt-target-b"}})
+			t.Cleanup(func() { reg.UnregisterClient(authID) })
+			if _, err := manager.Register(context.Background(), &Auth{ID: authID, Provider: "codex", Status: StatusActive, ModelStates: modelStates}); err != nil {
+				t.Fatalf("Register() error = %v", err)
+			}
+
+			resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{})
+			if allCooldown {
+				if err != initial {
+					t.Fatalf("Execute() error = %v, want original source error", err)
+				}
+			} else {
+				if err != nil || string(resp.Payload) != "gpt-target-b" {
+					t.Fatalf("Execute() response/error = %q/%v, want target B success", resp.Payload, err)
+				}
+			}
+			calls, _ := executor.snapshot()
+			wantCalls := []string{"gpt-source"}
+			if !allCooldown {
+				wantCalls = append(wantCalls, "gpt-target-b")
+			}
+			if len(calls) != len(wantCalls) {
+				t.Fatalf("calls = %#v, want %#v", calls, wantCalls)
+			}
+			for i := range wantCalls {
+				if calls[i] != wantCalls[i] {
+					t.Fatalf("calls = %#v, want %#v", calls, wantCalls)
+				}
+			}
+		})
 	}
 }
 

--- a/sdk/cliproxy/auth/codex_model_fallback_test.go
+++ b/sdk/cliproxy/auth/codex_model_fallback_test.go
@@ -1,0 +1,328 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type codexFallbackTestError struct {
+	message string
+	reason  string
+	blocked bool
+}
+
+func (e *codexFallbackTestError) Error() string { return e.message }
+func (e *codexFallbackTestError) StatusCode() int {
+	return http.StatusTooManyRequests
+}
+func (e *codexFallbackTestError) ModelFallbackReason() string { return e.reason }
+func (e *codexFallbackTestError) ModelFallbackBlocked() bool  { return e.blocked }
+
+type codexModelFallbackTestExecutor struct {
+	mu           sync.Mutex
+	calls        []string
+	authCalls    []string
+	executeErrs  map[string]error
+	streamErrs   map[string]error
+	streamChunks map[string][]cliproxyexecutor.StreamChunk
+	metadataSeen map[string]map[string]any
+}
+
+func (e *codexModelFallbackTestExecutor) Identifier() string { return "codex" }
+
+func (e *codexModelFallbackTestExecutor) Execute(_ context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.record(auth, req.Model, opts.Metadata)
+	if err := e.executeErrs[req.Model]; err != nil {
+		return cliproxyexecutor.Response{}, err
+	}
+	return cliproxyexecutor.Response{Payload: []byte(req.Model)}, nil
+}
+
+func (e *codexModelFallbackTestExecutor) ExecuteStream(_ context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	e.record(auth, req.Model, opts.Metadata)
+	if chunks, ok := e.streamChunks[req.Model]; ok {
+		ch := make(chan cliproxyexecutor.StreamChunk, len(chunks))
+		for _, chunk := range chunks {
+			ch <- chunk
+		}
+		close(ch)
+		return &cliproxyexecutor.StreamResult{Chunks: ch}, nil
+	}
+	ch := make(chan cliproxyexecutor.StreamChunk, 1)
+	if err := e.streamErrs[req.Model]; err != nil {
+		ch <- cliproxyexecutor.StreamChunk{Err: err}
+		close(ch)
+		return &cliproxyexecutor.StreamResult{Chunks: ch}, nil
+	}
+	ch <- cliproxyexecutor.StreamChunk{Payload: []byte(req.Model)}
+	close(ch)
+	return &cliproxyexecutor.StreamResult{Chunks: ch}, nil
+}
+
+func (e *codexModelFallbackTestExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (e *codexModelFallbackTestExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *codexModelFallbackTestExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func (e *codexModelFallbackTestExecutor) record(auth *Auth, model string, metadata map[string]any) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.calls = append(e.calls, model)
+	if auth != nil {
+		e.authCalls = append(e.authCalls, auth.ID)
+	} else {
+		e.authCalls = append(e.authCalls, "")
+	}
+	if e.metadataSeen == nil {
+		e.metadataSeen = make(map[string]map[string]any)
+	}
+	e.metadataSeen[model] = cloneSchedulerAnyMap(metadata)
+}
+
+func (e *codexModelFallbackTestExecutor) authSnapshot() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]string(nil), e.authCalls...)
+}
+
+func (e *codexModelFallbackTestExecutor) snapshot() ([]string, map[string]map[string]any) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	calls := append([]string(nil), e.calls...)
+	metadata := make(map[string]map[string]any, len(e.metadataSeen))
+	for model, values := range e.metadataSeen {
+		metadata[model] = cloneSchedulerAnyMap(values)
+	}
+	return calls, metadata
+}
+
+func newCodexModelFallbackTestManager(t *testing.T, executor *codexModelFallbackTestExecutor, mode string) (*Manager, string) {
+	t.Helper()
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.SetRetryConfig(0, 0, 0)
+	manager.SetConfig(&internalconfig.Config{
+		Codex: internalconfig.CodexConfig{
+			ModelFallback: internalconfig.CodexModelFallbackConfig{
+				Enabled:             true,
+				ReasoningContinuity: mode,
+				Mappings: []internalconfig.CodexModelFallbackMapping{
+					{From: "gpt-source", To: []string{"gpt-target"}},
+				},
+			},
+		},
+	})
+	manager.RegisterExecutor(executor)
+	authID := "codex-fallback-auth"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: "gpt-source"}, {ID: "gpt-target"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(authID)
+	})
+	if _, err := manager.Register(context.Background(), &Auth{ID: authID, Provider: "codex", Status: StatusActive}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	return manager, authID
+}
+
+func TestManagerExecuteCodexModelFallbackOnUsageLimit(t *testing.T) {
+	executor := &codexModelFallbackTestExecutor{
+		executeErrs: map[string]error{
+			"gpt-source": &codexFallbackTestError{message: "usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit},
+		},
+	}
+	manager, _ := newCodexModelFallbackTestManager(t, executor, internalconfig.CodexModelFallbackReasoningContinuitySameModelOnly)
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{
+		Metadata: map[string]any{cliproxyexecutor.AuthSelectionModelMetadataKey: "gpt-source"},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := string(resp.Payload); got != "gpt-target" {
+		t.Fatalf("response payload = %q, want gpt-target", got)
+	}
+	calls, metadata := executor.snapshot()
+	if len(calls) != 2 || calls[0] != "gpt-source" || calls[1] != "gpt-target" {
+		t.Fatalf("calls = %#v, want [gpt-source gpt-target]", calls)
+	}
+	if got := metadata["gpt-target"][cliproxyexecutor.CodexModelFallbackSourceModelMetadataKey]; got != "gpt-source" {
+		t.Fatalf("fallback source metadata = %#v, want gpt-source", got)
+	}
+	if got := metadata["gpt-target"][cliproxyexecutor.AuthSelectionModelMetadataKey]; got != "gpt-target" {
+		t.Fatalf("fallback auth-selection model = %#v, want gpt-target", got)
+	}
+}
+
+func TestManagerExecuteCodexModelFallbackSelectsCredentialForTargetModel(t *testing.T) {
+	executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{
+		"gpt-source": &codexFallbackTestError{message: "usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit},
+	}}
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.SetRetryConfig(0, 0, 0)
+	manager.SetConfig(&internalconfig.Config{Codex: internalconfig.CodexConfig{
+		ModelFallback: internalconfig.CodexModelFallbackConfig{
+			Enabled: true,
+			Mappings: []internalconfig.CodexModelFallbackMapping{
+				{From: "gpt-source", To: []string{"gpt-target"}},
+			},
+		},
+	}})
+	manager.RegisterExecutor(executor)
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient("source-auth", "codex", []*registry.ModelInfo{{ID: "gpt-source"}})
+	reg.RegisterClient("target-auth", "codex", []*registry.ModelInfo{{ID: "gpt-target"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient("source-auth")
+		reg.UnregisterClient("target-auth")
+	})
+	for _, authID := range []string{"source-auth", "target-auth"} {
+		if _, err := manager.Register(context.Background(), &Auth{ID: authID, Provider: "codex", Status: StatusActive}); err != nil {
+			t.Fatalf("Register(%s) error = %v", authID, err)
+		}
+	}
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{
+		Metadata: map[string]any{cliproxyexecutor.AuthSelectionModelMetadataKey: "gpt-source"},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := string(resp.Payload); got != "gpt-target" {
+		t.Fatalf("response payload = %q, want gpt-target", got)
+	}
+	if got := executor.authSnapshot(); len(got) != 2 || got[0] != "source-auth" || got[1] != "target-auth" {
+		t.Fatalf("auth calls = %#v, want [source-auth target-auth]", got)
+	}
+}
+
+func TestManagerExecuteCodexModelFallbackIgnoresUnclassified429(t *testing.T) {
+	transient := &codexFallbackTestError{message: "rate limited"}
+	executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{"gpt-source": transient}}
+	manager, _ := newCodexModelFallbackTestManager(t, executor, internalconfig.CodexModelFallbackReasoningContinuitySameModelOnly)
+
+	_, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{})
+	if err != transient {
+		t.Fatalf("Execute() error = %v, want original transient error", err)
+	}
+	calls, _ := executor.snapshot()
+	if len(calls) != 1 || calls[0] != "gpt-source" {
+		t.Fatalf("calls = %#v, want source only", calls)
+	}
+}
+
+func TestManagerExecuteCodexModelFallbackBlockedReturnsOriginalAndDoesNotCooldownTarget(t *testing.T) {
+	initial := &codexFallbackTestError{message: "usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit}
+	executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{
+		"gpt-source": initial,
+		"gpt-target": &codexFallbackTestError{message: "continuity blocked", blocked: true},
+	}}
+	manager, authID := newCodexModelFallbackTestManager(t, executor, internalconfig.CodexModelFallbackReasoningContinuitySameModelOnly)
+
+	_, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{})
+	if err != initial {
+		t.Fatalf("Execute() error = %v, want original usage-limit error", err)
+	}
+	auth, ok := manager.GetByID(authID)
+	if !ok || auth == nil {
+		t.Fatal("GetByID() = nil")
+	}
+	if _, ok := auth.ModelStates["gpt-target"]; ok {
+		t.Fatalf("target model was penalized despite zero dispatch: %#v", auth.ModelStates["gpt-target"])
+	}
+}
+
+func TestManagerExecuteStreamCodexModelFallbackBeforeFirstPayload(t *testing.T) {
+	executor := &codexModelFallbackTestExecutor{streamErrs: map[string]error{
+		"gpt-source": &codexFallbackTestError{message: "capacity", reason: internalconfig.CodexModelFallbackTriggerCapacity},
+	}}
+	manager, _ := newCodexModelFallbackTestManager(t, executor, internalconfig.CodexModelFallbackReasoningContinuitySameModelOnly)
+
+	result, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	var payload []byte
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v", chunk.Err)
+		}
+		payload = append(payload, chunk.Payload...)
+	}
+	if got := string(payload); got != "gpt-target" {
+		t.Fatalf("stream payload = %q, want gpt-target", got)
+	}
+	calls, _ := executor.snapshot()
+	if len(calls) != 2 || calls[0] != "gpt-source" || calls[1] != "gpt-target" {
+		t.Fatalf("calls = %#v, want [gpt-source gpt-target]", calls)
+	}
+}
+
+func TestManagerExecuteStreamCodexModelFallbackPreservesUnclassifiedBootstrapError(t *testing.T) {
+	initial := &codexFallbackTestError{message: "transient rate limit"}
+	executor := &codexModelFallbackTestExecutor{streamErrs: map[string]error{"gpt-source": initial}}
+	manager, _ := newCodexModelFallbackTestManager(t, executor, internalconfig.CodexModelFallbackReasoningContinuitySameModelOnly)
+
+	result, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	chunks := make([]cliproxyexecutor.StreamChunk, 0, 1)
+	for chunk := range result.Chunks {
+		chunks = append(chunks, chunk)
+	}
+	if len(chunks) != 1 || chunks[0].Err != initial {
+		t.Fatalf("stream chunks = %#v, want original bootstrap error", chunks)
+	}
+	calls, _ := executor.snapshot()
+	if len(calls) != 1 || calls[0] != "gpt-source" {
+		t.Fatalf("calls = %#v, want source only", calls)
+	}
+}
+
+func TestManagerExecuteStreamCodexModelFallbackDoesNotReplayAfterPayload(t *testing.T) {
+	initial := &codexFallbackTestError{message: "capacity", reason: internalconfig.CodexModelFallbackTriggerCapacity}
+	executor := &codexModelFallbackTestExecutor{streamChunks: map[string][]cliproxyexecutor.StreamChunk{
+		"gpt-source": {
+			{Payload: []byte("partial")},
+			{Err: initial},
+		},
+	}}
+	manager, _ := newCodexModelFallbackTestManager(t, executor, internalconfig.CodexModelFallbackReasoningContinuitySameModelOnly)
+
+	result, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{Stream: true})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	var payload []byte
+	var streamErr error
+	for chunk := range result.Chunks {
+		payload = append(payload, chunk.Payload...)
+		if chunk.Err != nil {
+			streamErr = chunk.Err
+		}
+	}
+	if got := string(payload); got != "partial" {
+		t.Fatalf("stream payload = %q, want partial", got)
+	}
+	if streamErr != initial {
+		t.Fatalf("stream error = %v, want original capacity error", streamErr)
+	}
+	calls, _ := executor.snapshot()
+	if len(calls) != 1 || calls[0] != "gpt-source" {
+		t.Fatalf("calls = %#v, want source only after downstream delivery", calls)
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1893,6 +1893,9 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			if errCtx := ctx.Err(); errCtx != nil {
 				return nil, errCtx
 			}
+			if isModelFallbackBlockedError(errStream) {
+				return nil, errStream
+			}
 			if isRetryWithoutPenaltyError(errStream) {
 				return nil, errStream
 			}
@@ -1903,6 +1906,9 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				if errStream != nil {
 					if errCtx := ctx.Err(); errCtx != nil {
 						return nil, errCtx
+					}
+					if isModelFallbackBlockedError(errStream) {
+						return nil, errStream
 					}
 					if isRetryWithoutPenaltyError(errStream) {
 						return nil, errStream
@@ -2375,6 +2381,14 @@ func (m *Manager) Load(ctx context.Context) error {
 // Execute performs a non-streaming execution using the configured selector and executor.
 // It supports multiple providers for the same model and round-robins the starting provider per model.
 func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	resp, err := m.executeWithoutModelFallback(ctx, providers, req, opts)
+	if err == nil {
+		return resp, nil
+	}
+	return m.executeCodexModelFallback(ctx, providers, req, opts, err)
+}
+
+func (m *Manager) executeWithoutModelFallback(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
 	normalized := m.normalizeProviders(providers)
 	if len(normalized) == 0 {
 		return cliproxyexecutor.Response{}, &Error{Code: "provider_not_found", Message: "no provider supplied"}
@@ -2520,6 +2534,22 @@ func (m *Manager) ExecuteCount(ctx context.Context, providers []string, req clip
 // ExecuteStream performs a streaming execution using the configured selector and executor.
 // It supports multiple providers for the same model and round-robins the starting provider per model.
 func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	result, err := m.executeStreamWithoutModelFallback(ctx, providers, req, opts)
+	if err == nil {
+		return result, nil
+	}
+	result, err = m.executeStreamCodexModelFallback(ctx, providers, req, opts, err)
+	if err == nil {
+		return result, nil
+	}
+	var bootstrapErr *streamBootstrapError
+	if errors.As(err, &bootstrapErr) && bootstrapErr != nil {
+		return streamErrorResult(bootstrapErr.Headers(), bootstrapErr.cause), nil
+	}
+	return nil, err
+}
+
+func (m *Manager) executeStreamWithoutModelFallback(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
 	normalized := m.normalizeProviders(providers)
 	if len(normalized) == 0 {
 		return nil, &Error{Code: "provider_not_found", Message: "no provider supplied"}
@@ -2613,10 +2643,6 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 			} else if ok {
 				return result, nil
 			}
-		}
-		var bootstrapErr *streamBootstrapError
-		if errors.As(lastErr, &bootstrapErr) && bootstrapErr != nil {
-			return streamErrorResult(bootstrapErr.Headers(), bootstrapErr.cause), nil
 		}
 		return nil, lastErr
 	}
@@ -2792,6 +2818,9 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				if errCtx := execCtx.Err(); errCtx != nil {
 					return cliproxyexecutor.Response{}, errCtx
 				}
+				if isModelFallbackBlockedError(errExec) {
+					return cliproxyexecutor.Response{}, errExec
+				}
 				if isRetryWithoutPenaltyError(errExec) {
 					return cliproxyexecutor.Response{}, errExec
 				}
@@ -2802,6 +2831,9 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 					if errExec != nil {
 						if errCtx := execCtx.Err(); errCtx != nil {
 							return cliproxyexecutor.Response{}, errCtx
+						}
+						if isModelFallbackBlockedError(errExec) {
+							return cliproxyexecutor.Response{}, errExec
 						}
 						if isRetryWithoutPenaltyError(errExec) {
 							return cliproxyexecutor.Response{}, errExec

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -1888,6 +1888,11 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		}
 		execOpts := opts
 		execReq, execOpts = applyRequestAfterAuthInterceptor(ctx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+		publishSelectedAuthMetadata(execOpts.Metadata, auth.ID)
+		if errCtx := ctx.Err(); errCtx != nil {
+			return nil, errCtx
+		}
+		markCodexModelFallbackDispatch(execOpts, auth.ID)
 		streamResult, errStream := executor.ExecuteStream(ctx, auth, execReq, execOpts)
 		if errStream != nil {
 			if errCtx := ctx.Err(); errCtx != nil {
@@ -1902,6 +1907,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			if refreshed, okRefresh := m.tryRefreshAfterUnauthorized(ctx, auth, errStream, didRefreshOnUnauthorized); okRefresh {
 				auth = refreshed
 				didRefreshOnUnauthorized = true
+				markCodexModelFallbackDispatch(execOpts, auth.ID)
 				streamResult, errStream = executor.ExecuteStream(ctx, auth, execReq, execOpts)
 				if errStream != nil {
 					if errCtx := ctx.Err(); errCtx != nil {
@@ -1945,6 +1951,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				discardStreamChunks(streamResult.Chunks)
 				auth = refreshed
 				didRefreshOnUnauthorized = true
+				markCodexModelFallbackDispatch(execOpts, auth.ID)
 				retryStream, retryErr := executor.ExecuteStream(ctx, auth, execReq, execOpts)
 				if retryErr != nil {
 					if errCtx := ctx.Err(); errCtx != nil {
@@ -2381,11 +2388,75 @@ func (m *Manager) Load(ctx context.Context) error {
 // Execute performs a non-streaming execution using the configured selector and executor.
 // It supports multiple providers for the same model and round-robins the starting provider per model.
 func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	if m.codexModelFallbackEnabled(providers) {
+		opts = ensureRequestedModelMetadata(opts, req.Model)
+		opts = withCodexModelFallbackRequestBudget(opts, false)
+	}
 	resp, err := m.executeWithoutModelFallback(ctx, providers, req, opts)
 	if err == nil {
 		return resp, nil
 	}
 	return m.executeCodexModelFallback(ctx, providers, req, opts, err)
+}
+
+const (
+	codexModelFallbackBudgetMetadataKey     = "__cliproxy_codex_model_fallback_budget"
+	codexModelFallbackTargetWaveMetadataKey = "__cliproxy_codex_model_fallback_target_wave"
+	codexModelFallbackDispatchMetadataKey   = "__cliproxy_codex_model_fallback_dispatch"
+)
+
+// codexModelFallbackRequestBudget is request-local metadata shared by the
+// source and every target. Keeping it out of Config avoids a new public knob
+// while ensuring abnormal-reasoning counters, hedge state, and discarded usage
+// cannot be reset just because the model changes.
+type codexModelFallbackRequestBudget struct {
+	retryCounts map[string]int
+	usage       *cliproxyexecutor.UsageAccumulator
+	hedge       *retryWithoutPenaltyHedgeRequestState
+}
+
+func (m *Manager) codexModelFallbackEnabled(providers []string) bool {
+	if m == nil || !codexOnlyProviders(providers) {
+		return false
+	}
+	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	return cfg != nil && cfg.Codex.ModelFallback.Effective().Enabled
+}
+
+func withCodexModelFallbackRequestBudget(opts cliproxyexecutor.Options, stream bool) cliproxyexecutor.Options {
+	metadata := cloneSchedulerAnyMap(opts.Metadata)
+	if metadata == nil {
+		metadata = make(map[string]any, 1)
+	}
+	metadata[codexModelFallbackBudgetMetadataKey] = &codexModelFallbackRequestBudget{
+		retryCounts: make(map[string]int),
+		usage:       cliproxyexecutor.NewUsageAccumulator(coreusage.Detail{}),
+		hedge:       &retryWithoutPenaltyHedgeRequestState{},
+	}
+	opts.Metadata = metadata
+	return opts
+}
+
+func codexModelFallbackBudget(opts cliproxyexecutor.Options, stream bool) *codexModelFallbackRequestBudget {
+	if budget, ok := opts.Metadata[codexModelFallbackBudgetMetadataKey].(*codexModelFallbackRequestBudget); ok && budget != nil {
+		return budget
+	}
+	return &codexModelFallbackRequestBudget{
+		retryCounts: make(map[string]int),
+		usage:       cliproxyexecutor.NewUsageAccumulator(coreusage.Detail{}),
+		hedge:       &retryWithoutPenaltyHedgeRequestState{},
+	}
+}
+
+func codexModelFallbackTargetWave(opts cliproxyexecutor.Options) bool {
+	target, _ := opts.Metadata[codexModelFallbackTargetWaveMetadataKey].(bool)
+	return target
+}
+
+func markCodexModelFallbackDispatch(opts cliproxyexecutor.Options, authID string) {
+	if callback, ok := opts.Metadata[codexModelFallbackDispatchMetadataKey].(func(string)); ok && callback != nil {
+		callback(authID)
+	}
 }
 
 func (m *Manager) executeWithoutModelFallback(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
@@ -2398,9 +2469,10 @@ func (m *Manager) executeWithoutModelFallback(ctx context.Context, providers []s
 
 	var lastErr error
 	retryModel := authSelectionModelFromOptions(opts, req.Model)
-	retryWithoutPenaltyCounts := make(map[string]int)
-	retryWithoutPenaltyUsage := cliproxyexecutor.NewUsageAccumulator(coreusage.Detail{})
-	retryWithoutPenaltyHedgeState := &retryWithoutPenaltyHedgeRequestState{}
+	budget := codexModelFallbackBudget(opts, false)
+	retryWithoutPenaltyCounts := budget.retryCounts
+	retryWithoutPenaltyUsage := budget.usage
+	retryWithoutPenaltyHedgeState := budget.hedge
 	retryWithoutPenaltyFallback := newRetryWithoutPenaltyFallbackCandidate(false)
 	for attempt := 0; ; {
 		attemptOpts := withRetryWithoutPenaltyUsageMetadata(opts, retryWithoutPenaltyUsage)
@@ -2443,6 +2515,9 @@ func (m *Manager) executeWithoutModelFallback(ctx context.Context, providers []s
 						retryWithoutPenaltyUsage.Add(detail)
 					}
 				}
+				if codexModelFallbackTargetWave(opts) && !isRetryWithoutPenaltyError(outcome.err) {
+					break
+				}
 				wait, shouldRetry, terminalErr := m.shouldRetryAfterError(outcome.err, attempt, normalized, retryModel, maxWait, retryWithoutPenaltyCounts)
 				if terminalErr != nil {
 					if resp, ok := retryWithoutPenaltyCandidateFallbackResponse(retryWithoutPenaltyFallback.Err(outcome.err), retryWithoutPenaltyFallback, retryWithoutPenaltyUsage); ok {
@@ -2459,6 +2534,9 @@ func (m *Manager) executeWithoutModelFallback(ctx context.Context, providers []s
 				attempt++
 				continue
 			}
+		}
+		if codexModelFallbackTargetWave(opts) && !isRetryWithoutPenaltyError(errExec) {
+			break
 		}
 		wait, shouldRetry, terminalErr := m.shouldRetryAfterError(errExec, attempt, normalized, retryModel, maxWait, retryWithoutPenaltyCounts)
 		if terminalErr != nil {
@@ -2534,6 +2612,10 @@ func (m *Manager) ExecuteCount(ctx context.Context, providers []string, req clip
 // ExecuteStream performs a streaming execution using the configured selector and executor.
 // It supports multiple providers for the same model and round-robins the starting provider per model.
 func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	if m.codexModelFallbackEnabled(providers) {
+		opts = ensureRequestedModelMetadata(opts, req.Model)
+		opts = withCodexModelFallbackRequestBudget(opts, true)
+	}
 	result, err := m.executeStreamWithoutModelFallback(ctx, providers, req, opts)
 	if err == nil {
 		return result, nil
@@ -2559,9 +2641,10 @@ func (m *Manager) executeStreamWithoutModelFallback(ctx context.Context, provide
 
 	var lastErr error
 	retryModel := authSelectionModelFromOptions(opts, req.Model)
-	retryWithoutPenaltyCounts := make(map[string]int)
-	retryWithoutPenaltyUsage := cliproxyexecutor.NewUsageAccumulator(coreusage.Detail{})
-	retryWithoutPenaltyHedgeState := &retryWithoutPenaltyHedgeRequestState{}
+	budget := codexModelFallbackBudget(opts, true)
+	retryWithoutPenaltyCounts := budget.retryCounts
+	retryWithoutPenaltyUsage := budget.usage
+	retryWithoutPenaltyHedgeState := budget.hedge
 	retryWithoutPenaltyFallback := newRetryWithoutPenaltyFallbackCandidate(true)
 	for attempt := 0; ; {
 		attemptOpts := withRetryWithoutPenaltyUsageMetadata(opts, retryWithoutPenaltyUsage)
@@ -2604,6 +2687,9 @@ func (m *Manager) executeStreamWithoutModelFallback(ctx context.Context, provide
 						retryWithoutPenaltyUsage.Add(detail)
 					}
 				}
+				if codexModelFallbackTargetWave(opts) && !isRetryWithoutPenaltyError(outcome.err) {
+					break
+				}
 				wait, shouldRetry, terminalErr := m.shouldRetryAfterError(outcome.err, attempt, normalized, retryModel, maxWait, retryWithoutPenaltyCounts)
 				if terminalErr != nil {
 					if result, ok := retryWithoutPenaltyCandidateFallbackStreamResult(retryWithoutPenaltyFallback.Err(outcome.err), retryWithoutPenaltyFallback, retryWithoutPenaltyUsage); ok {
@@ -2620,6 +2706,9 @@ func (m *Manager) executeStreamWithoutModelFallback(ctx context.Context, provide
 				attempt++
 				continue
 			}
+		}
+		if codexModelFallbackTargetWave(opts) && !isRetryWithoutPenaltyError(errStream) {
+			break
 		}
 		wait, shouldRetry, terminalErr := m.shouldRetryAfterError(errStream, attempt, normalized, retryModel, maxWait, retryWithoutPenaltyCounts)
 		if terminalErr != nil {
@@ -2773,7 +2862,6 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 
 		entry := logEntryWithRequestID(ctx)
 		debugLogAuthSelection(entry, auth, provider, routeModel)
-		publishSelectedAuthMetadata(opts.Metadata, auth.ID)
 		if errCtx := ctx.Err(); errCtx != nil {
 			return cliproxyexecutor.Response{}, errCtx
 		}
@@ -2813,6 +2901,11 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			}
 			execOpts := opts
 			execReq, execOpts = applyRequestAfterAuthInterceptor(execCtx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+			publishSelectedAuthMetadata(execOpts.Metadata, auth.ID)
+			if errCtx := execCtx.Err(); errCtx != nil {
+				return cliproxyexecutor.Response{}, errCtx
+			}
+			markCodexModelFallbackDispatch(execOpts, auth.ID)
 			resp, errExec := executor.Execute(execCtx, auth, execReq, execOpts)
 			if errExec != nil {
 				if errCtx := execCtx.Err(); errCtx != nil {
@@ -2827,6 +2920,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				if refreshed, okRefresh := m.tryRefreshAfterUnauthorized(execCtx, auth, errExec, didRefreshOnUnauthorized); okRefresh {
 					auth = refreshed
 					didRefreshOnUnauthorized = true
+					markCodexModelFallbackDispatch(execOpts, auth.ID)
 					resp, errExec = executor.Execute(execCtx, auth, execReq, execOpts)
 					if errExec != nil {
 						if errCtx := execCtx.Err(); errCtx != nil {
@@ -3035,7 +3129,6 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 
 		entry := logEntryWithRequestID(ctx)
 		debugLogAuthSelection(entry, auth, provider, routeModel)
-		publishSelectedAuthMetadata(opts.Metadata, auth.ID)
 		if errCtx := ctx.Err(); errCtx != nil {
 			return nil, errCtx
 		}

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -58,6 +58,12 @@ const (
 	CodexModelFallbackSourceModelMetadataKey = "codex_model_fallback_source_model"
 	// CodexModelFallbackReasoningContinuityMetadataKey carries the configured reasoning-continuity policy for a Codex fallback attempt.
 	CodexModelFallbackReasoningContinuityMetadataKey = "codex_model_fallback_reasoning_continuity"
+	// CodexModelFallbackContextResetReplayMetadataKey is an internal, additive
+	// attestation from the Responses websocket handler. It means the request is
+	// a complete, CPA-mediated transcript which may be replayed after dropping
+	// model-private reasoning state. It must never be set for websocket
+	// passthrough or incremental previous_response_id requests.
+	CodexModelFallbackContextResetReplayMetadataKey = "codex_model_fallback_context_reset_replay"
 )
 
 const (

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -54,6 +54,10 @@ const (
 	SelectedAuthCallbackMetadataKey = "selected_auth_callback"
 	// ExecutionSessionMetadataKey identifies a long-lived downstream execution session.
 	ExecutionSessionMetadataKey = "execution_session_id"
+	// CodexModelFallbackSourceModelMetadataKey records the source model that exhausted before a configured Codex fallback attempt.
+	CodexModelFallbackSourceModelMetadataKey = "codex_model_fallback_source_model"
+	// CodexModelFallbackReasoningContinuityMetadataKey carries the configured reasoning-continuity policy for a Codex fallback attempt.
+	CodexModelFallbackReasoningContinuityMetadataKey = "codex_model_fallback_reasoning_continuity"
 )
 
 const (


### PR DESCRIPTION
## 结果与硬边界

本 PR 为 Codex 引入默认关闭、仅由精确 typed 429/capacity 触发的 ordered model fallback。Core 先保留完整的同模型 auth selection 与 `request-retry` 行为；只有 source 路径耗尽后，才按配置顺序为 target model 重新选择可用 auth。

这项能力**不能修复、重新签名或跨模型迁移 `reasoning.encrypted_content`**。跨模型继续只能是：无状态请求安全回退，或在 CPA 已证明拥有完整 transcript 时执行显式、有损的 `context-reset` replay。

当前仍未 merge、tag、release 或 deploy。PR #159 继续负责 fresh-session observation 与 established-session continuity，合并顺序必须为 #158 → #159。

## 主要变更

- 仅将 typed `usage_limit_reached` 与 model capacity 作为 fallback trigger；transient `rate_limit_error`、`rate_limit_exceeded` 和裸 HTTP 429 不触发跨模型切换。
- fallback target 使用真实 target model 完成 registry/model support 检查和 auth selection，不继承 source `PinnedAuthMetadataKey`；只有通过安全 replay preflight 的 `context-reset` 才能解除 source pin。
- ordered targets 区分 zero-dispatch 与真实 dispatch：`auth_not_found`、model cooldown 等零派发错误继续下一个 target；所有 target 均零派发不可用时返回 source 原始 typed 429；真实 dispatch 后的非 fallback 错误保持真实终态。
- source 与所有 targets 共享 abnormal-reasoning retry counter、hedge request state 和 `UsageAccumulator`；target 不会重新获得一套 `max-retries`，`client-usage-aggregation: sum` 可覆盖 source 与 target 的已派发 attempts。
- selected-auth callback 延迟到真实 executor dispatch，并只发布最终交付 auth/hedge winner；continuity block、auth-not-found 或 cooldown 等 zero-dispatch target 不改变 WebSocket pin。

## reasoning / WebSocket 安全边界

- `same-model-only` 对 reasoning item、source replay state、`previous_response_id`、pinned auth、execution session 等 stateful continuity 直接返回 source 原错误，不进行 target selection。
- `context-reset` 只接受 CPA-mediated、完整 transcript、tool call/output 配对在 repair 前后都有效、且尚未产生 client-visible payload 的 WebSocket turn。
- 任意保留 `previous_response_id` 的首帧或后续增量请求、WebSocket passthrough、无法证明完整 transcript 的输入、首 payload 后 terminal 429 均阻断跨模型 replay。
- 安全 replay 删除 reasoning items、`reasoning.encrypted_content`、`previous_response_id` 和 source pin；只保留当前 tool output 所必需且可验证配对的 function/custom-tool call。
- executor 与 auth preflight 共用单一 replay-session resolver；最终 source scope 在 request interceptor、translation、payload shaping 和 header resolution 后附着到原始错误，因此 lowercase header、Gin-only header 和 after-auth payload rewrite 都不能绕过 target-selection preflight。
- WebSocket initial handshake 与 reconnect handshake 统一保留 typed status、headers 和 `RetryAfter`；HTTP fallback 仍只发生在 426 upgrade downgrade 场景。

## 兼容性与非目标

- `codex.model-fallback.enabled` 默认仍为 `false`，现有请求路径和旧配置不变。
- 仅覆盖标准 Codex Responses 执行；compact、image、video 不参与 model fallback。
- internal replay marker 是 additive SDK metadata，不新增 wire 字段。
- 本 PR 不修改 Management API、数据库或 `CPA-Panel-LTS` visual config。
- `context-reset` 是 visible-transcript 的有损 replay，不是 reasoning signature repair。

## 复查与分支改进

- 已通过普通 merge 吸收最新 `origin/main`，保留 stacked PR #159 所需的 ancestry；未执行 rebase 或 force push。
- 当前 head：`daa6301ab8e792a5db96040796932354cb55e3d3`。
- 当前 merge-base 为最新 `main`：`d5e13183912b9790fdccf1f7c6980a6f0c807e37`。
- base-to-head diff 仍是原有 28 个目标文件，没有混入 Core #160 的 usage 契约改动。
- 完整代码复查未发现需要新增运行时代码修复的阻断问题；主要改进是分支更新、补充静态/压力验证和收紧交付元数据。

## 验证

以下命令均在当前 head 上通过：

```bash
go test -count=1 \
  ./internal/config \
  ./internal/watcher/diff \
  ./internal/cache \
  ./internal/runtime/executor \
  ./internal/runtime/executor/helps \
  ./sdk/cliproxy/auth \
  ./sdk/api/handlers/openai

go test -race -count=1 \
  ./internal/runtime/executor \
  ./sdk/cliproxy/auth \
  ./sdk/api/handlers/openai

go test -count=20 ./sdk/cliproxy/auth \
  -run 'CodexModelFallback|SelectedAuth|RetryWithoutPenalty'

go vet \
  ./internal/config \
  ./internal/watcher/diff \
  ./internal/cache \
  ./internal/runtime/executor \
  ./sdk/cliproxy/auth \
  ./sdk/api/handlers/openai

scripts/check-lts-contract.sh
go build -o test-output ./cmd/server && rm -f test-output
go list ./... | rg -v '/tmp$' | xargs go test -count=1
git diff --check origin/main...HEAD
```

真实 provider quota smoke 未执行：没有安全、可控、可重复地产生真实 Codex quota 的测试条件。验收证据采用 deterministic HTTP/WebSocket fixtures、真实 executor integration、race、stress、contract、build、repo-wide tests 与 GitHub CI。

## Review focus

- typed 429 分类是否保持保守，未扩大 transient/bare 429 的触发面；
- replay scope 是否在 HTTP、stream、WebSocket handshake/terminal 路径完整保留；
- `context-reset` attestation 是否严格排除 `previous_response_id`、passthrough、repair 后追溯认证和已交付 payload；
- source/targets 的 retry、hedge、usage budget 与 selected-auth callback 是否确实共享且不产生 zero-dispatch 副作用。

最终 head 的 `build`、`lts-contract`、`full-test-observation`、`guard-agents-md-changes` 和 `ensure-no-translator-changes` 必须全部成功后才进入合并门禁。
