### PR TITLE
feat(codex): 引入不中断已建立会话的 429 连续性状态机

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -222,7 +222,8 @@ codex:
     observation-window-seconds: 30
     # Established-session successes can open the canary gate earlier.
     established-success-threshold: 2
-    # Successful session leases are process-local and expire after this interval.
+    # Successful session leases are process-local and expire after this interval;
+    # normally keep it aligned with routing.session-affinity-ttl.
     established-session-ttl-seconds: 3600
   # CPA-Core-LTS extra feature. When explicitly enabled, discard and retry
   # matching Codex OAuth responses whose completed usage reports suspicious

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -213,6 +213,17 @@ codex:
     #     to:
     #       - "gpt-5.6-terra"
     #       - "gpt-5.5"
+  # CPA-Core-LTS extra feature. Keep established Codex sessions on an auth/model
+  # while a fresh-session usage-limit 429 is observed. Requires
+  # routing.session-affinity and a stable session identifier. Disabled by default.
+  rate-limit-continuity:
+    enabled: false
+    # After this many seconds, one fresh session may act as the canary.
+    observation-window-seconds: 30
+    # Established-session successes can open the canary gate earlier.
+    established-success-threshold: 2
+    # Successful session leases are process-local and expire after this interval.
+    established-session-ttl-seconds: 3600
   # CPA-Core-LTS extra feature. When explicitly enabled, discard and retry
   # matching Codex OAuth responses whose completed usage reports suspicious
   # reasoning token counts. Disabled by default.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -222,8 +222,8 @@ codex:
     observation-window-seconds: 30
     # Established-session successes can open the canary gate earlier.
     established-success-threshold: 2
-    # Successful session leases are process-local and expire after this interval;
-    # normally keep it aligned with routing.session-affinity-ttl.
+    # Successful session leases are process-local. The effective TTL is capped by
+    # routing.session-affinity-ttl and the active selector cache TTL.
     established-session-ttl-seconds: 3600
   # CPA-Core-LTS extra feature. When explicitly enabled, discard and retry
   # matching Codex OAuth responses whose completed usage reports suspicious

--- a/docs/lts/codex-429-resilience.md
+++ b/docs/lts/codex-429-resilience.md
@@ -68,7 +68,8 @@ codex:
 The state is scoped by Codex auth ID and the auth-selection model. Successful
 sessions receive process-local leases. A selector cache binding alone does not
 make a session established: the request must complete successfully on that
-auth/model first.
+auth/model first. Operators should normally align
+`established-session-ttl-seconds` with `routing.session-affinity-ttl`.
 
 When a fresh session receives the first typed usage-limit 429:
 

--- a/docs/lts/codex-429-resilience.md
+++ b/docs/lts/codex-429-resilience.md
@@ -46,6 +46,66 @@ while the upstream failure is still in the bootstrap/pre-delivery phase; once a
 stream has been returned and client-visible payload can be emitted, Core does
 not replace it with a different model.
 
+## Rate-limit continuity for established sessions
+
+`codex.rate-limit-continuity` is a separate, default-off observation state
+machine for Codex `usage_limit_reached`. It is effective only when
+`routing.session-affinity` is enabled and Core can extract a stable session ID.
+Message-content hashes, generic user IDs, and per-request client request IDs do
+not qualify for this exemption.
+
+```yaml
+routing:
+  session-affinity: true
+codex:
+  rate-limit-continuity:
+    enabled: true
+    observation-window-seconds: 30
+    established-success-threshold: 2
+    established-session-ttl-seconds: 3600
+```
+
+The state is scoped by Codex auth ID and the auth-selection model. Successful
+sessions receive process-local leases. A selector cache binding alone does not
+make a session established: the request must complete successfully on that
+auth/model first.
+
+When a fresh session receives the first typed usage-limit 429:
+
+1. Core records the failure for request/error accounting but does not write the
+   normal `ModelState` quota cooldown or suspend the registry model.
+2. The auth/model enters `suspect`. Other fresh sessions exclude that candidate
+   and can continue through another auth or the configured model fallback.
+3. Previously successful sessions remain eligible for the same auth/model and
+   act as passive observations. Their streams are not cancelled.
+4. One fresh-session canary becomes eligible after
+   `observation-window-seconds`, or earlier after
+   `established-success-threshold` successful established-session completions.
+5. A successful canary returns the auth/model to healthy. A typed usage-limit
+   failure from an established session or the reserved canary confirms the
+   quota and enters the existing persisted cooldown path exactly once.
+
+Canary reservation uses an in-memory token that is released on terminal result,
+local abandonment, or stream cancellation, so concurrent fresh requests cannot
+dispatch a canary stampede. Non-quota canary errors are inconclusive: another
+canary waits for a new observation window, and the ordinary error policy still
+applies to that failure. A state generation prevents results from requests that
+started before confirmation from clearing the newly confirmed cooldown or
+incrementing its backoff again.
+
+This feature intentionally does not persist session leases or suspect/canary
+state to the cooldown store. Process restart starts from normal routing state.
+Requests without a stable session ID retain the existing immediate cooldown
+behavior. Transient `rate_limit_error`, model capacity, and bare HTTP 429 do not
+activate the continuity state machine. Home runtime-auth dispatch is excluded;
+the feature applies to normal Core-managed Codex auth files.
+
+Session affinity and continuity are related but have distinct responsibilities:
+the selector supplies a stable session-to-auth routing preference, while the
+continuity state machine records which bindings actually completed and decides
+whether a typed usage-limit failure is fresh-session ambiguity or confirmed
+auth/model exhaustion.
+
 ## Reasoning signature boundary
 
 Model fallback does **not** repair or migrate

--- a/docs/lts/codex-429-resilience.md
+++ b/docs/lts/codex-429-resilience.md
@@ -68,33 +68,78 @@ codex:
 The state is scoped by Codex auth ID and the auth-selection model. Successful
 sessions receive process-local leases. A selector cache binding alone does not
 make a session established: the request must complete successfully on that
-auth/model first. Operators should normally align
-`established-session-ttl-seconds` with `routing.session-affinity-ttl`.
+auth/model first. The effective lease TTL is the minimum of
+`established-session-ttl-seconds`, the configured
+`routing.session-affinity-ttl`, and the actual `SessionAffinitySelector` cache
+TTL. Replacing the selector invalidates old absolute lease deadlines.
 
-When a fresh session receives the first typed usage-limit 429:
+The process-local phase is explicit:
 
-1. Core records the failure for request/error accounting but does not write the
-   normal `ModelState` quota cooldown or suspend the registry model.
-2. The auth/model enters `suspect`. Other fresh sessions exclude that candidate
-   and can continue through another auth or the configured model fallback.
-3. Previously successful sessions remain eligible for the same auth/model and
-   act as passive observations. Their streams are not cancelled.
-4. One fresh-session canary becomes eligible after
-   `observation-window-seconds`, or earlier after
-   `established-success-threshold` successful established-session completions.
-5. A successful canary returns the auth/model to healthy. A typed usage-limit
-   failure from an established session or the reserved canary confirms the
-   quota and enters the existing persisted cooldown path exactly once.
+- `Healthy`
+- `FreshBlocked`
+- `ConfirmedCooldown`
 
-Canary reservation uses an in-memory token that is released on terminal result,
-local abandonment, or stream cancellation, so concurrent fresh requests cannot
-dispatch a canary stampede. Non-quota canary errors are inconclusive: another
-canary waits for a new observation window, and the ordinary error policy still
-applies to that failure. A state generation prevents results from requests that
-started before confirmation from clearing the newly confirmed cooldown or
-incrementing its backoff again.
+While `Healthy`, an admitted execution attempt is registered as incumbent
+in-flight before executor dispatch. If another request reports a typed
+`usage_limit_reached` before that attempt completes, its later result is still
+classified as incumbent rather than as a new canary.
 
-This feature intentionally does not persist session leases or suspect/canary
+The first typed usage-limit from a fresh session always moves the auth/model to
+`FreshBlocked`, even when no established or in-flight incumbent currently
+exists. Core records normal request/error accounting but does not write the
+formal `ModelState` quota cooldown or suspend the registry model. Other fresh
+sessions exclude that candidate and can continue through another auth or the
+configured model fallback. Established leases and incumbent in-flight sessions
+remain eligible for the same auth/model; their streams are not cancelled.
+
+`FreshBlocked` transitions are:
+
+- An established or incumbent success renews or creates its lease and keeps the
+  phase `FreshBlocked`. A success from an attempt that began before the first
+  fresh 429 does not silently restore `Healthy`.
+- One fresh-session canary becomes eligible after
+  `observation-window-seconds`, or earlier after
+  `established-success-threshold` successful established/incumbent
+  completions.
+- A successful canary returns the auth/model to `Healthy`.
+- A canary typed usage-limit while any established lease or incumbent request
+  remains preserves those leases, stays `FreshBlocked`, and starts a new
+  observation window. Repeated fresh canary failures alone cannot globally
+  interrupt established work.
+- A canary typed usage-limit with no remaining incumbent evidence moves to
+  `ConfirmedCooldown`.
+- A typed usage-limit from an established or incumbent request confirms the
+  shared auth/model limit immediately and moves to `ConfirmedCooldown`.
+
+`ConfirmedCooldown` rejects admission in `begin()` as well as at the final
+pre-dispatch recheck. The existing persisted cooldown remains the source of the
+recovery deadline. When that cooldown expires, a generation-checked transition
+returns to canary-eligible `FreshBlocked`; it does not open the auth/model to a
+fresh-session stampede.
+
+Canary reservation and every live attempt use bounded in-memory tokens that are
+released on terminal result, local abandonment, cancellation, lifecycle reset,
+or confirmation. Continuity observation and `ModelState` mutation run in one
+`Manager.MarkResult` critical section with a fixed manager-to-continuity lock
+order. Stale success and stale typed usage-limit results are record-only, so
+they cannot clear or double-increment a newer cooldown. Stale non-quota results
+such as `401`, `403`, `invalid_grant`, and model-not-supported still update the
+normal auth/model availability state.
+
+Non-quota canary errors are inconclusive: another canary waits for a new
+observation window, and the ordinary error policy still applies to that
+failure. Post-bootstrap stream failures copy the provider `RetryAfter` into the
+formal cooldown. Config changes affecting the observation window, success
+threshold, lease TTL, Home mode, affinity enablement/TTL, or selector clear
+process-local continuity state. `Load` and selector replacement are global
+snapshot boundaries. A single `CloseExecutionSession` or auth removal is scoped
+to that execution session or auth, so unrelated sessions/auths and requests for
+which continuity is inactive remain dispatchable. A context-reset fallback
+closes the source execution session while preserving the already-admitted
+target auth/model attempt; later ordered targets therefore remain eligible if
+the first dispatched target returns another typed fallback error.
+
+This feature intentionally does not persist session leases or FreshBlocked/canary
 state to the cooldown store. Process restart starts from normal routing state.
 Requests without a stable session ID retain the existing immediate cooldown
 behavior. Transient `rate_limit_error`, model capacity, and bare HTTP 429 do not

--- a/docs/lts/core-feature-contracts.yaml
+++ b/docs/lts/core-feature-contracts.yaml
@@ -303,15 +303,17 @@ features:
     support: maintained
     owner: cpa-core-lts
     upstream_relation: downstream-only
-    reason: CPA-Core-LTS preserves successful Codex sessions while a fresh-session usage-limit 429 is observed, then confirms auth/model exhaustion through an established-session failure or a single reserved canary.
+    reason: CPA-Core-LTS preserves established and incumbent Codex work while fresh-session usage-limit 429s are observed, only confirms shared auth/model exhaustion through an established/incumbent failure or a reserved canary failure with no incumbent evidence, and scopes auth/session lifecycle invalidation without interrupting unrelated work.
     config_keys:
       - codex.rate-limit-continuity.enabled
       - codex.rate-limit-continuity.observation-window-seconds
       - codex.rate-limit-continuity.established-success-threshold
       - codex.rate-limit-continuity.established-session-ttl-seconds
       - routing.session-affinity
+      - routing.session-affinity-ttl
     core_files:
       - internal/config/config.go
+      - sdk/cliproxy/auth/codex_model_fallback.go
       - sdk/cliproxy/auth/codex_rate_limit_continuity.go
       - sdk/cliproxy/auth/conductor.go
       - sdk/cliproxy/auth/selector.go
@@ -322,11 +324,17 @@ features:
       - observation-window-seconds
       - established-success-threshold
       - codexRateLimitContinuityStore
+      - codexRateLimitContinuityFreshBlocked
+      - codexRateLimitContinuityConfirmedCooldown
+      - nextLeaseExpiry
+      - codexRateLimitContinuityLifecycleContextKey
+      - removeSessionPreservingKey
       - codexRateLimitObservationPendingError
       - ExecutionSessionMetadataKey
     validation:
       - go test ./internal/config ./internal/watcher/diff
       - go test ./sdk/cliproxy/auth -run 'CodexRateLimitContinuity|SessionAffinitySelector_ExplicitExecutionSessionMetadata'
+      - go test ./sdk/cliproxy/auth -run 'OpenAICompatAliasPoolPublishesSelectedAuth'
       - go test -race ./sdk/cliproxy/auth -run 'CodexRateLimitContinuity'
 
   - id: redis-compatible-usage-queue

--- a/docs/lts/core-feature-contracts.yaml
+++ b/docs/lts/core-feature-contracts.yaml
@@ -287,6 +287,37 @@ features:
       - go test ./internal/runtime/executor -run 'Codex.*ModelFallback|Codex.*Retry|Codex.*Signature'
       - go test ./sdk/cliproxy/auth -run 'CodexModelFallback'
 
+  - id: codex-rate-limit-continuity
+    kind: lts-feature
+    support: maintained
+    owner: cpa-core-lts
+    upstream_relation: downstream-only
+    reason: CPA-Core-LTS preserves successful Codex sessions while a fresh-session usage-limit 429 is observed, then confirms auth/model exhaustion through an established-session failure or a single reserved canary.
+    config_keys:
+      - codex.rate-limit-continuity.enabled
+      - codex.rate-limit-continuity.observation-window-seconds
+      - codex.rate-limit-continuity.established-success-threshold
+      - codex.rate-limit-continuity.established-session-ttl-seconds
+      - routing.session-affinity
+    core_files:
+      - internal/config/config.go
+      - sdk/cliproxy/auth/codex_rate_limit_continuity.go
+      - sdk/cliproxy/auth/conductor.go
+      - sdk/cliproxy/auth/selector.go
+      - config.example.yaml
+      - docs/lts/codex-429-resilience.md
+    required_markers:
+      - rate-limit-continuity
+      - observation-window-seconds
+      - established-success-threshold
+      - codexRateLimitContinuityStore
+      - codexRateLimitObservationPendingError
+      - ExecutionSessionMetadataKey
+    validation:
+      - go test ./internal/config ./internal/watcher/diff
+      - go test ./sdk/cliproxy/auth -run 'CodexRateLimitContinuity|SessionAffinitySelector_ExplicitExecutionSessionMetadata'
+      - go test -race ./sdk/cliproxy/auth -run 'CodexRateLimitContinuity'
+
   - id: redis-compatible-usage-queue
     kind: lts-feature
     support: maintained

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -39,6 +39,41 @@ patches:
     state: required
     retire_when: Upstream provides typed usage-limit and capacity-only model fallback after same-model auth exhaustion, reselects credentials for each target model, blocks or explicitly resets cross-model reasoning state without copying encrypted_content, preserves pre-delivery stream replay safety, and all listed regressions pass after removing the downstream implementation.
 
+  - id: codex-rate-limit-continuity
+    reason: A fresh Codex session can receive usage_limit_reached while previously successful sessions on the same auth/model are still allowed to finish, so Core needs a bounded observation state instead of immediately suspending the auth/model for every session.
+    introduced_in: 6ee281422e460ac7d5db8d69ef3fe6b49560e96a
+    affected_upstream_range: through e99a2056baa981345f4a93600039725363ffca46 (v7.2.66); the synced upstream baseline immediately writes model quota cooldown for every 429 and has no success-established session lease, fresh-session quarantine, single-canary reservation, or generation guard integrated with session affinity.
+    files:
+      - config.example.yaml
+      - docs/lts/codex-429-resilience.md
+      - docs/lts/core-feature-contracts.yaml
+      - docs/lts/protected-deltas.yaml
+      - internal/config/config.go
+      - internal/config/codex_rate_limit_continuity_test.go
+      - internal/watcher/diff/config_diff.go
+      - internal/watcher/diff/config_diff_test.go
+      - scripts/check-lts-contract.sh
+      - sdk/cliproxy/auth/codex_rate_limit_continuity.go
+      - sdk/cliproxy/auth/codex_rate_limit_continuity_test.go
+      - sdk/cliproxy/auth/conductor.go
+      - sdk/cliproxy/auth/selector.go
+      - sdk/cliproxy/auth/selector_test.go
+    regression_tests:
+      - TestLoadConfigOptionalCodexRateLimitContinuity
+      - TestSessionAffinitySelector_ExplicitExecutionSessionMetadata
+      - TestCodexRateLimitContinuityFirstFreshUsageLimitBecomesSuspect
+      - TestCodexRateLimitContinuityOnlyOneConcurrentCanary
+      - TestCodexRateLimitContinuityConfirmedGenerationRejectsStaleResult
+      - TestManagerCodexRateLimitContinuityKeepsEstablishedSessionAndExcludesFresh
+      - TestManagerCodexRateLimitContinuityEstablishedFailureConfirmsCooldown
+      - TestManagerCodexRateLimitContinuityConcurrentCanaryCallsSelectorCallbackOnce
+      - TestManagerCodexRateLimitContinuityLongStreamIsNotCancelledByFresh429
+      - TestManagerCodexRateLimitContinuityPendingFreshSessionUsesModelFallback
+      - TestManagerCodexRateLimitContinuityConfirmedCooldownUsesModelFallback
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: Upstream distinguishes successful established sessions from fresh sessions for typed Codex usage limits; preserves established streams during observation; reserves only one fresh canary; prevents stale results from clearing or double-advancing confirmed cooldown; composes with session affinity and model fallback; and all listed regressions pass after removing the downstream implementation.
+
   - id: codex-interactions-service-tier-response
     reason: Codex Interactions requests can send priority service, but the shared response translator hardcodes streaming completion metadata to standard and omits the non-streaming tier instead of reporting the effective outbound or upstream tier.
     introduced_in: be649f04a4a66b952d5210c7cdf74e1d90a12b76

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -65,7 +65,7 @@ patches:
   - id: codex-rate-limit-continuity
     reason: A fresh Codex session can receive usage_limit_reached while previously successful sessions on the same auth/model are still allowed to finish, so Core needs a bounded observation state instead of immediately suspending the auth/model for every session.
     introduced_in: 6ee281422e460ac7d5db8d69ef3fe6b49560e96a
-    affected_upstream_range: through e99a2056baa981345f4a93600039725363ffca46 (v7.2.66); the synced upstream baseline immediately writes model quota cooldown for every 429 and has no success-established session lease, fresh-session quarantine, single-canary reservation, or generation guard integrated with session affinity.
+    affected_upstream_range: through e99a2056baa981345f4a93600039725363ffca46 (v7.2.66); the synced upstream baseline immediately writes model quota cooldown for every 429 and has no explicit Healthy/FreshBlocked/ConfirmedCooldown phases, established lease plus incumbent in-flight evidence, single-canary confirmation, lifecycle invalidation, or generation guard integrated with session affinity.
     files:
       - config.example.yaml
       - docs/lts/codex-429-resilience.md
@@ -76,26 +76,49 @@ patches:
       - internal/watcher/diff/config_diff.go
       - internal/watcher/diff/config_diff_test.go
       - scripts/check-lts-contract.sh
+      - sdk/cliproxy/auth/codex_model_fallback.go
+      - sdk/cliproxy/auth/codex_model_fallback_test.go
       - sdk/cliproxy/auth/codex_rate_limit_continuity.go
       - sdk/cliproxy/auth/codex_rate_limit_continuity_test.go
       - sdk/cliproxy/auth/conductor.go
+      - sdk/cliproxy/auth/openai_compat_pool_test.go
       - sdk/cliproxy/auth/selector.go
       - sdk/cliproxy/auth/selector_test.go
     regression_tests:
       - TestLoadConfigOptionalCodexRateLimitContinuity
       - TestSessionAffinitySelector_ExplicitExecutionSessionMetadata
-      - TestCodexRateLimitContinuityFirstFreshUsageLimitBecomesSuspect
+      - TestCodexRateLimitContinuityFirstFreshUsageLimitEntersFreshBlocked
+      - TestCodexRateLimitContinuityCanaryFailureWithoutIncumbentConfirms
+      - TestCodexRateLimitContinuityPreBlockSuccessKeepsFreshBlocked
+      - TestCodexRateLimitContinuityPreBlockUsageLimitConfirmsCooldown
       - TestCodexRateLimitContinuityOnlyOneConcurrentCanary
-      - TestCodexRateLimitContinuityConfirmedGenerationRejectsStaleResult
+      - TestCodexRateLimitContinuityCanaryFailureWithIncumbentKeepsGeneration
+      - TestCodexRateLimitContinuityActiveAttemptsDrainAfterChurn
+      - TestCodexRateLimitContinuitySettingsChangedCoversLeaseContract
+      - TestManagerCodexRateLimitContinuityLifecycleResetAfterAdmissionBlocksDispatch
+      - TestManagerCodexRateLimitContinuityInactiveScopesBypassLifecycleAndCanonicalGuards
+      - TestManagerCodexRateLimitContinuityHomeCodexDispatchBypassesContinuity
+      - TestManagerCodexRateLimitContinuityUnrelatedSessionCloseDoesNotBlockDispatch
+      - TestManagerCodexRateLimitContinuityUnrelatedAuthRemovalDoesNotBlockDispatch
+      - TestManagerCodexRateLimitContinuityShorterSelectorReplacementClearsOldLease
+      - TestCodexRateLimitContinuityStaleSuccessAndUsageLimitAreRecordOnly
+      - TestCodexRateLimitContinuityStaleInvalidGrantStillMutatesAvailability
+      - TestManagerCodexRateLimitContinuityStaleUsageLimitDoesNotIncreaseBackoff
       - TestManagerCodexRateLimitContinuityKeepsEstablishedSessionAndExcludesFresh
+      - TestManagerCodexRateLimitContinuityRepeatedCanaryFailuresPreserveEstablishedSession
       - TestManagerCodexRateLimitContinuityEstablishedFailureConfirmsCooldown
       - TestManagerCodexRateLimitContinuityConcurrentCanaryCallsSelectorCallbackOnce
       - TestManagerCodexRateLimitContinuityLongStreamIsNotCancelledByFresh429
+      - TestManagerCodexRateLimitContinuityEstablishedStreamTerminalUsageLimitPreservesRetryAfter
       - TestManagerCodexRateLimitContinuityPendingFreshSessionUsesModelFallback
       - TestManagerCodexRateLimitContinuityConfirmedCooldownUsesModelFallback
+      - TestManagerExecuteCodexModelFallbackContextResetContinuesOrderedTargetsWithContinuity
+      - TestManagerExecute_OpenAICompatAliasPoolPublishesSelectedAuthOnceAcrossModels
+      - TestManagerExecuteStream_OpenAICompatAliasPoolPublishesSelectedAuthOnceAcrossModels
+      - TestManagerExecuteCount_OpenAICompatAliasPoolPublishesSelectedAuthOnce
     upstream_issue_or_pr: not-filed
     state: required
-    retire_when: Upstream distinguishes successful established sessions from fresh sessions for typed Codex usage limits; preserves established streams during observation; reserves only one fresh canary; prevents stale results from clearing or double-advancing confirmed cooldown; composes with session affinity and model fallback; and all listed regressions pass after removing the downstream implementation.
+    retire_when: Upstream distinguishes successful established and incumbent sessions from fresh sessions for typed Codex usage limits; preserves established streams across repeated fresh canary failures; reserves only one recovery canary; atomically invalidates global config/load/selector snapshots while scoping session close and auth removal to affected work; prevents stale results from clearing or double-advancing confirmed cooldown; composes with ordered context-reset model fallback; and all listed regressions pass after removing the downstream implementation.
 
   - id: codex-interactions-service-tier-response
     reason: Codex Interactions requests can send priority service, but the shared response translator hardcodes streaming completion metadata to standard and omits the non-streaming tier instead of reporting the effective outbound or upstream tier.

--- a/docs/lts/protected-deltas.yaml
+++ b/docs/lts/protected-deltas.yaml
@@ -96,6 +96,10 @@ lts_owned_features:
     markers:
       - rate-limit-continuity
       - codexRateLimitContinuityStore
+      - codexRateLimitContinuityFreshBlocked
+      - codexRateLimitContinuityConfirmedCooldown
+      - nextLeaseExpiry
+      - removeSessionPreservingKey
       - established-success-threshold
     validation:
       - codex-rate-limit-continuity-regression-tests

--- a/docs/lts/protected-deltas.yaml
+++ b/docs/lts/protected-deltas.yaml
@@ -90,6 +90,18 @@ lts_owned_features:
       - codex-model-fallback-race-tests
     conflict_policy: adapt_lts_feature_to_upstream_auth_and_codex_runtime
 
+  - id: codex-rate-limit-continuity
+    registry_feature: codex-rate-limit-continuity
+    maintenance_policy: long-term-maintained
+    markers:
+      - rate-limit-continuity
+      - codexRateLimitContinuityStore
+      - established-success-threshold
+    validation:
+      - codex-rate-limit-continuity-regression-tests
+      - codex-rate-limit-continuity-race-tests
+    conflict_policy: adapt_lts_feature_to_upstream_auth_selection_and_session_affinity
+
   - id: codex-abnormal-reasoning-retry
     registry_feature: codex-abnormal-reasoning-retry
     maintenance_policy: long-term-maintained

--- a/internal/config/codex_rate_limit_continuity_test.go
+++ b/internal/config/codex_rate_limit_continuity_test.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCodexRateLimitContinuityEffectiveDefaults(t *testing.T) {
+	effective := (CodexRateLimitContinuityConfig{}).Effective()
+	if effective.Enabled {
+		t.Fatal("Enabled = true, want false")
+	}
+	if effective.ObservationWindowSeconds != CodexRateLimitContinuityDefaultObservationWindowSeconds {
+		t.Fatalf("ObservationWindowSeconds = %d", effective.ObservationWindowSeconds)
+	}
+	if effective.EstablishedSuccessThreshold != CodexRateLimitContinuityDefaultEstablishedSuccessThreshold {
+		t.Fatalf("EstablishedSuccessThreshold = %d", effective.EstablishedSuccessThreshold)
+	}
+	if effective.EstablishedSessionTTLSeconds != CodexRateLimitContinuityDefaultEstablishedSessionTTLSeconds {
+		t.Fatalf("EstablishedSessionTTLSeconds = %d", effective.EstablishedSessionTTLSeconds)
+	}
+}
+
+func TestLoadConfigOptionalCodexRateLimitContinuity(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	configYAML := []byte(`
+routing:
+  session-affinity: true
+codex:
+  rate-limit-continuity:
+    enabled: true
+    observation-window-seconds: 12
+    established-success-threshold: 3
+    established-session-ttl-seconds: 900
+`)
+	if err := os.WriteFile(configPath, configYAML, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cfg, err := LoadConfigOptional(configPath, false)
+	if err != nil {
+		t.Fatalf("LoadConfigOptional() error = %v", err)
+	}
+	if !cfg.Routing.SessionAffinity {
+		t.Fatal("Routing.SessionAffinity = false, want true")
+	}
+	effective := cfg.Codex.RateLimitContinuity.Effective()
+	if !effective.Enabled {
+		t.Fatal("Enabled = false, want true")
+	}
+	if effective.ObservationWindowSeconds != 12 || effective.EstablishedSuccessThreshold != 3 || effective.EstablishedSessionTTLSeconds != 900 {
+		t.Fatalf("Effective() = %+v", effective)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -330,6 +330,7 @@ type CodexHeaderDefaults struct {
 type CodexConfig struct {
 	IdentityConfuse        bool                              `yaml:"identity-confuse" json:"identity-confuse"`
 	ModelFallback          CodexModelFallbackConfig          `yaml:"model-fallback" json:"model-fallback"`
+	RateLimitContinuity    CodexRateLimitContinuityConfig    `yaml:"rate-limit-continuity" json:"rate-limit-continuity"`
 	AbnormalReasoningRetry CodexAbnormalReasoningRetryConfig `yaml:"abnormal-reasoning-retry" json:"abnormal-reasoning-retry"`
 }
 
@@ -338,6 +339,9 @@ const (
 	CodexModelFallbackTriggerCapacity                                      = "capacity"
 	CodexModelFallbackReasoningContinuitySameModelOnly                     = "same-model-only"
 	CodexModelFallbackReasoningContinuityContextReset                      = "context-reset"
+	CodexRateLimitContinuityDefaultObservationWindowSeconds                = 30
+	CodexRateLimitContinuityDefaultEstablishedSuccessThreshold             = 2
+	CodexRateLimitContinuityDefaultEstablishedSessionTTLSeconds            = 3600
 	CodexAbnormalReasoningRetryActionRetry                                 = "retry"
 	CodexAbnormalReasoningRetryActionObserveOnly                           = "observe-only"
 	CodexAbnormalReasoningRetryActionDisabled                              = "disabled"
@@ -458,6 +462,47 @@ func (c EffectiveCodexModelFallbackConfig) TargetsFor(model, trigger string) []s
 		}
 	}
 	return nil
+}
+
+// CodexRateLimitContinuityConfig controls the in-memory observation window
+// used to distinguish a fresh-session usage limit from an auth/model-wide
+// quota failure. It is effective only while routing.session-affinity is enabled.
+type CodexRateLimitContinuityConfig struct {
+	Enabled                      bool `yaml:"enabled" json:"enabled"`
+	ObservationWindowSeconds     int  `yaml:"observation-window-seconds" json:"observation-window-seconds"`
+	EstablishedSuccessThreshold  int  `yaml:"established-success-threshold" json:"established-success-threshold"`
+	EstablishedSessionTTLSeconds int  `yaml:"established-session-ttl-seconds" json:"established-session-ttl-seconds"`
+}
+
+// EffectiveCodexRateLimitContinuityConfig is the sanitized runtime view of
+// CodexRateLimitContinuityConfig.
+type EffectiveCodexRateLimitContinuityConfig struct {
+	Enabled                      bool
+	ObservationWindowSeconds     int
+	EstablishedSuccessThreshold  int
+	EstablishedSessionTTLSeconds int
+}
+
+// Effective returns a normalized rate-limit continuity policy.
+func (c CodexRateLimitContinuityConfig) Effective() EffectiveCodexRateLimitContinuityConfig {
+	observationWindowSeconds := c.ObservationWindowSeconds
+	if observationWindowSeconds <= 0 {
+		observationWindowSeconds = CodexRateLimitContinuityDefaultObservationWindowSeconds
+	}
+	establishedSuccessThreshold := c.EstablishedSuccessThreshold
+	if establishedSuccessThreshold <= 0 {
+		establishedSuccessThreshold = CodexRateLimitContinuityDefaultEstablishedSuccessThreshold
+	}
+	establishedSessionTTLSeconds := c.EstablishedSessionTTLSeconds
+	if establishedSessionTTLSeconds <= 0 {
+		establishedSessionTTLSeconds = CodexRateLimitContinuityDefaultEstablishedSessionTTLSeconds
+	}
+	return EffectiveCodexRateLimitContinuityConfig{
+		Enabled:                      c.Enabled,
+		ObservationWindowSeconds:     observationWindowSeconds,
+		EstablishedSuccessThreshold:  establishedSuccessThreshold,
+		EstablishedSessionTTLSeconds: establishedSessionTTLSeconds,
+	}
 }
 
 // CodexAbnormalReasoningRetryConfig controls the CPA-Core-LTS retry guard for
@@ -761,9 +806,9 @@ type RoutingConfig struct {
 
 	// SessionAffinity enables universal session-sticky routing for all clients.
 	// Session IDs are extracted from multiple sources:
-	// metadata.user_id (Claude Code session format), X-Session-ID, Session_id (Codex),
-	// X-Amp-Thread-Id (Amp CLI thread), X-Client-Request-Id (PI), metadata.user_id,
-	// conversation_id, or message hash.
+	// explicit execution_session_id metadata, metadata.user_id (Claude Code session
+	// format), X-Session-ID, Session_id (Codex), X-Amp-Thread-Id (Amp CLI thread),
+	// X-Client-Request-Id (PI), metadata.user_id, conversation_id, or message hash.
 	// Automatic failover is always enabled when bound auth becomes unavailable.
 	SessionAffinity bool `yaml:"session-affinity,omitempty" json:"session-affinity,omitempty"`
 

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -106,6 +106,7 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 		changes = append(changes, fmt.Sprintf("codex.identity-confuse: %t -> %t", oldCfg.Codex.IdentityConfuse, newCfg.Codex.IdentityConfuse))
 	}
 	changes = appendCodexModelFallbackChanges(changes, oldCfg.Codex.ModelFallback.Effective(), newCfg.Codex.ModelFallback.Effective())
+	changes = appendCodexRateLimitContinuityChanges(changes, oldCfg.Codex.RateLimitContinuity.Effective(), newCfg.Codex.RateLimitContinuity.Effective())
 	changes = appendCodexAbnormalReasoningRetryChanges(changes, oldCfg.Codex.AbnormalReasoningRetry.Effective(), newCfg.Codex.AbnormalReasoningRetry.Effective())
 
 	if oldCfg.Routing.Strategy != newCfg.Routing.Strategy {
@@ -494,6 +495,25 @@ func appendCodexModelFallbackChanges(changes []string, oldCfg, newCfg config.Eff
 	}
 	if !reflect.DeepEqual(oldCfg.Mappings, newCfg.Mappings) {
 		changes = append(changes, fmt.Sprintf("codex.model-fallback.mappings: updated (%d -> %d entries)", len(oldCfg.Mappings), len(newCfg.Mappings)))
+	}
+	return changes
+}
+
+func appendCodexRateLimitContinuityChanges(changes []string, oldCfg, newCfg config.EffectiveCodexRateLimitContinuityConfig) []string {
+	if oldCfg == newCfg {
+		return changes
+	}
+	if oldCfg.Enabled != newCfg.Enabled {
+		changes = append(changes, fmt.Sprintf("codex.rate-limit-continuity.enabled: %t -> %t", oldCfg.Enabled, newCfg.Enabled))
+	}
+	if oldCfg.ObservationWindowSeconds != newCfg.ObservationWindowSeconds {
+		changes = append(changes, fmt.Sprintf("codex.rate-limit-continuity.observation-window-seconds: %d -> %d", oldCfg.ObservationWindowSeconds, newCfg.ObservationWindowSeconds))
+	}
+	if oldCfg.EstablishedSuccessThreshold != newCfg.EstablishedSuccessThreshold {
+		changes = append(changes, fmt.Sprintf("codex.rate-limit-continuity.established-success-threshold: %d -> %d", oldCfg.EstablishedSuccessThreshold, newCfg.EstablishedSuccessThreshold))
+	}
+	if oldCfg.EstablishedSessionTTLSeconds != newCfg.EstablishedSessionTTLSeconds {
+		changes = append(changes, fmt.Sprintf("codex.rate-limit-continuity.established-session-ttl-seconds: %d -> %d", oldCfg.EstablishedSessionTTLSeconds, newCfg.EstablishedSessionTTLSeconds))
 	}
 	return changes
 }

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -261,6 +261,26 @@ func TestBuildConfigChangeDetails_CodexModelFallback(t *testing.T) {
 	expectContains(t, details, "codex.model-fallback.mappings: updated (0 -> 1 entries)")
 }
 
+func TestBuildConfigChangeDetails_CodexRateLimitContinuity(t *testing.T) {
+	oldCfg := &config.Config{}
+	newCfg := &config.Config{
+		Codex: config.CodexConfig{
+			RateLimitContinuity: config.CodexRateLimitContinuityConfig{
+				Enabled:                      true,
+				ObservationWindowSeconds:     12,
+				EstablishedSuccessThreshold:  3,
+				EstablishedSessionTTLSeconds: 900,
+			},
+		},
+	}
+
+	details := BuildConfigChangeDetails(oldCfg, newCfg)
+	expectContains(t, details, "codex.rate-limit-continuity.enabled: false -> true")
+	expectContains(t, details, "codex.rate-limit-continuity.observation-window-seconds: 30 -> 12")
+	expectContains(t, details, "codex.rate-limit-continuity.established-success-threshold: 2 -> 3")
+	expectContains(t, details, "codex.rate-limit-continuity.established-session-ttl-seconds: 3600 -> 900")
+}
+
 func TestBuildConfigChangeDetails_NoChanges(t *testing.T) {
 	cfg := &config.Config{
 		Port: 8080,

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -132,6 +132,8 @@ require_grep "BlueSkyXN/CPA-Panel-LTS" internal/managementasset/updater.go inter
 require_grep "UsageReporter" internal/runtime/executor/helps/usage_helpers.go
 require_grep "codex.model-fallback" docs/lts/core-feature-contracts.yaml docs/lts/codex-429-resilience.md
 require_grep "CodexModelFallbackSourceModelMetadataKey" sdk/cliproxy/executor/types.go sdk/cliproxy/auth/codex_model_fallback.go
+require_grep "codex.rate-limit-continuity" docs/lts/core-feature-contracts.yaml docs/lts/codex-429-resilience.md
+require_grep "codexRateLimitContinuityStore" sdk/cliproxy/auth/codex_rate_limit_continuity.go docs/lts/core-feature-contracts.yaml
 require_grep "auth_index" internal/usage internal/api/handlers/management internal/runtime/executor/helps internal/redisqueue
 require_grep "latency_ms" internal/usage internal/redisqueue internal/tui
 require_grep 'json:"service_tier,omitempty"' internal/usage

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -134,6 +134,12 @@ require_grep "codex.model-fallback" docs/lts/core-feature-contracts.yaml docs/lt
 require_grep "CodexModelFallbackSourceModelMetadataKey" sdk/cliproxy/executor/types.go sdk/cliproxy/auth/codex_model_fallback.go
 require_grep "codex.rate-limit-continuity" docs/lts/core-feature-contracts.yaml docs/lts/codex-429-resilience.md
 require_grep "codexRateLimitContinuityStore" sdk/cliproxy/auth/codex_rate_limit_continuity.go docs/lts/core-feature-contracts.yaml
+require_grep "codexRateLimitContinuityFreshBlocked" sdk/cliproxy/auth/codex_rate_limit_continuity.go
+require_grep "codexRateLimitContinuityFreshBlocked" docs/lts/core-feature-contracts.yaml docs/lts/protected-deltas.yaml
+require_grep "codexRateLimitContinuityConfirmedCooldown" sdk/cliproxy/auth/codex_rate_limit_continuity.go
+require_grep "nextLeaseExpiry" sdk/cliproxy/auth/codex_rate_limit_continuity.go docs/lts/core-feature-contracts.yaml
+require_grep "codexRateLimitContinuityLifecycleContextKey" sdk/cliproxy/auth/codex_rate_limit_continuity.go docs/lts/core-feature-contracts.yaml
+require_grep "removeSessionPreservingKey" sdk/cliproxy/auth/codex_rate_limit_continuity.go sdk/cliproxy/auth/conductor.go docs/lts/core-feature-contracts.yaml
 require_grep "CodexModelFallbackContextResetReplayMetadataKey" sdk/cliproxy/executor/types.go sdk/api/handlers/openai/openai_responses_websocket.go
 require_grep "ResolveCodexReasoningReplaySessionKey" internal/cache/codex_reasoning_replay_scope.go internal/runtime/executor/codex_executor.go sdk/cliproxy/auth/codex_model_fallback.go
 require_grep "responsesWebsocketCanAttestContextReset" sdk/api/handlers/openai/openai_responses_websocket.go sdk/api/handlers/openai/openai_responses_websocket_test.go

--- a/sdk/cliproxy/auth/codex_model_fallback.go
+++ b/sdk/cliproxy/auth/codex_model_fallback.go
@@ -301,7 +301,7 @@ func isCodexModelFallbackZeroDispatchError(err error) bool {
 	return false
 }
 
-func codexModelFallbackSelectedAuthCollector(opts cliproxyexecutor.Options, onDispatch func()) (cliproxyexecutor.Options, func()) {
+func codexModelFallbackSelectedAuthCollector(opts cliproxyexecutor.Options, onDispatch func(string)) (cliproxyexecutor.Options, func()) {
 	if len(opts.Metadata) == 0 {
 		return opts, func() {}
 	}
@@ -323,7 +323,7 @@ func codexModelFallbackSelectedAuthCollector(opts cliproxyexecutor.Options, onDi
 		}
 		dispatchOnce.Do(func() {
 			if onDispatch != nil {
-				onDispatch()
+				onDispatch(authID)
 			}
 		})
 		mu.Lock()
@@ -377,11 +377,11 @@ func (m *Manager) executeCodexModelFallback(ctx context.Context, providers []str
 		fallbackReq := req
 		fallbackReq.Model = target
 		fallbackOpts := withCodexModelFallbackMetadata(opts, sourceModel, target, effective.ReasoningContinuity)
-		fallbackOpts, publishSelected := codexModelFallbackSelectedAuthCollector(fallbackOpts, func() {
+		fallbackOpts, publishSelected := codexModelFallbackSelectedAuthCollector(fallbackOpts, func(targetAuthID string) {
 			closeSourceOnce.Do(func() {
 				if effective.ReasoningContinuity == internalconfig.CodexModelFallbackReasoningContinuityContextReset && codexModelFallbackContextResetAllowed(fallbackOpts.Metadata) {
 					if sessionID := codexModelFallbackMetadataString(opts.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey); sessionID != "" {
-						m.CloseExecutionSession(sessionID)
+						m.closeExecutionSession(sessionID, targetAuthID, target)
 					}
 				}
 			})
@@ -445,11 +445,11 @@ func (m *Manager) executeStreamCodexModelFallback(ctx context.Context, providers
 		fallbackReq := req
 		fallbackReq.Model = target
 		fallbackOpts := withCodexModelFallbackMetadata(opts, sourceModel, target, effective.ReasoningContinuity)
-		fallbackOpts, publishSelected := codexModelFallbackSelectedAuthCollector(fallbackOpts, func() {
+		fallbackOpts, publishSelected := codexModelFallbackSelectedAuthCollector(fallbackOpts, func(targetAuthID string) {
 			closeSourceOnce.Do(func() {
 				if effective.ReasoningContinuity == internalconfig.CodexModelFallbackReasoningContinuityContextReset && codexModelFallbackContextResetAllowed(fallbackOpts.Metadata) {
 					if sessionID := codexModelFallbackMetadataString(opts.Metadata, cliproxyexecutor.ExecutionSessionMetadataKey); sessionID != "" {
-						m.CloseExecutionSession(sessionID)
+						m.closeExecutionSession(sessionID, targetAuthID, target)
 					}
 				}
 			})

--- a/sdk/cliproxy/auth/codex_model_fallback_test.go
+++ b/sdk/cliproxy/auth/codex_model_fallback_test.go
@@ -651,6 +651,99 @@ func TestManagerExecuteCodexModelFallbackContextResetDropsSourcePinAndPublishesT
 	}
 }
 
+func TestManagerExecuteCodexModelFallbackContextResetContinuesOrderedTargetsWithContinuity(t *testing.T) {
+	initial := &codexFallbackTestError{message: "source usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit}
+	targetLimit := &codexFallbackTestError{message: "target usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit}
+	executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{
+		"gpt-source":   initial,
+		"gpt-target-a": targetLimit,
+	}}
+	selector := NewSessionAffinitySelector(&FillFirstSelector{})
+	manager := NewManager(nil, selector, nil)
+	t.Cleanup(selector.Stop)
+	manager.SetRetryConfig(0, 0, 0)
+	manager.SetConfig(&internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{SessionAffinity: true},
+		Codex: internalconfig.CodexConfig{
+			RateLimitContinuity: internalconfig.CodexRateLimitContinuityConfig{
+				Enabled:                      true,
+				ObservationWindowSeconds:     10,
+				EstablishedSuccessThreshold:  2,
+				EstablishedSessionTTLSeconds: 3600,
+			},
+			ModelFallback: internalconfig.CodexModelFallbackConfig{
+				Enabled:             true,
+				ReasoningContinuity: internalconfig.CodexModelFallbackReasoningContinuityContextReset,
+				Mappings: []internalconfig.CodexModelFallbackMapping{{
+					From: "gpt-source",
+					To:   []string{"gpt-target-a", "gpt-target-b"},
+				}},
+			},
+		},
+	})
+	manager.RegisterExecutor(executor)
+
+	reg := registry.GetGlobalRegistry()
+	authModels := map[string]string{
+		"fallback-source":   "gpt-source",
+		"fallback-target-a": "gpt-target-a",
+		"fallback-target-b": "gpt-target-b",
+	}
+	for authID, model := range authModels {
+		reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+		if _, err := manager.Register(context.Background(), &Auth{ID: authID, Provider: "codex", Status: StatusActive}); err != nil {
+			t.Fatalf("Register(%s) error = %v", authID, err)
+		}
+	}
+	t.Cleanup(func() {
+		for authID := range authModels {
+			reg.UnregisterClient(authID)
+		}
+	})
+
+	var callbacks []string
+	sessionID := "ordered-context-reset"
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.PinnedAuthMetadataKey:                           "fallback-source",
+		cliproxyexecutor.ExecutionSessionMetadataKey:                     sessionID,
+		cliproxyexecutor.CodexModelFallbackContextResetReplayMetadataKey: true,
+		cliproxyexecutor.SelectedAuthCallbackMetadataKey: func(authID string) {
+			callbacks = append(callbacks, authID)
+		},
+	}})
+	if err != nil || string(resp.Payload) != "gpt-target-b" {
+		t.Fatalf("Execute() response/error = %q/%v, want target B success", resp.Payload, err)
+	}
+	calls, _ := executor.snapshot()
+	if len(calls) != 3 || calls[0] != "gpt-source" || calls[1] != "gpt-target-a" || calls[2] != "gpt-target-b" {
+		t.Fatalf("calls = %#v, want source, target A, target B", calls)
+	}
+	if authCalls := executor.authSnapshot(); len(authCalls) != 3 || authCalls[0] != "fallback-source" || authCalls[1] != "fallback-target-a" || authCalls[2] != "fallback-target-b" {
+		t.Fatalf("auth calls = %#v", authCalls)
+	}
+	if len(callbacks) != 2 || callbacks[0] != "fallback-source" || callbacks[1] != "fallback-target-b" {
+		t.Fatalf("selected callbacks = %#v, want source and final target B", callbacks)
+	}
+	if closed := executor.closedSnapshot(); len(closed) != 1 || closed[0] != sessionID {
+		t.Fatalf("closed source sessions = %#v, want one close", closed)
+	}
+
+	manager.codexRateLimitContinuity.mu.Lock()
+	stateA := manager.codexRateLimitContinuity.states[codexRateLimitContinuityKey{authID: "fallback-target-a", model: "gpt-target-a"}]
+	stateB := manager.codexRateLimitContinuity.states[codexRateLimitContinuityKey{authID: "fallback-target-b", model: "gpt-target-b"}]
+	leaseB := time.Time{}
+	if stateB != nil {
+		leaseB = stateB.establishedSessions["execution:"+sessionID]
+	}
+	manager.codexRateLimitContinuity.mu.Unlock()
+	if stateA == nil || stateA.phase != codexRateLimitContinuityFreshBlocked {
+		t.Fatalf("target A continuity state = %+v, want FreshBlocked", stateA)
+	}
+	if stateB == nil || stateB.phase != codexRateLimitContinuityHealthy || leaseB.IsZero() {
+		t.Fatalf("target B continuity state = %+v lease=%v, want Healthy established", stateB, leaseB)
+	}
+}
+
 func TestManagerExecuteCodexModelFallbackContinuesAfterTargetAuthNotFound(t *testing.T) {
 	initial := &codexFallbackTestError{message: "usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit}
 	executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{"gpt-source": initial}}

--- a/sdk/cliproxy/auth/codex_rate_limit_continuity.go
+++ b/sdk/cliproxy/auth/codex_rate_limit_continuity.go
@@ -1,0 +1,498 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type codexRateLimitContinuityKey struct {
+	authID string
+	model  string
+}
+
+type codexRateLimitContinuityState struct {
+	suspect              bool
+	confirmed            bool
+	generation           uint64
+	observeUntil         time.Time
+	establishedSuccesses int
+	establishedSessions  map[string]time.Time
+	canaryToken          uint64
+}
+
+type codexRateLimitContinuityStore struct {
+	mu        sync.Mutex
+	states    map[codexRateLimitContinuityKey]*codexRateLimitContinuityState
+	nextToken uint64
+	now       func() time.Time
+}
+
+type codexRateLimitContinuityAttempt struct {
+	key         codexRateLimitContinuityKey
+	sessionID   string
+	generation  uint64
+	established bool
+	canaryToken uint64
+}
+
+type codexRateLimitContinuityAttemptContextKey struct{}
+
+type codexRateLimitContinuityDisposition uint8
+
+const (
+	codexRateLimitContinuityNormal codexRateLimitContinuityDisposition = iota
+	codexRateLimitContinuityObserveOnly
+	codexRateLimitContinuityRecordOnly
+)
+
+type codexRateLimitObservationPendingError struct {
+	confirmed bool
+}
+
+func (e codexRateLimitObservationPendingError) Error() string {
+	if e.confirmed {
+		return "codex auth/model has a confirmed usage-limit cooldown"
+	}
+	return "codex auth/model is under fresh-session rate-limit observation"
+}
+
+func (codexRateLimitObservationPendingError) StatusCode() int { return http.StatusTooManyRequests }
+
+func (codexRateLimitObservationPendingError) ModelFallbackReason() string {
+	return internalconfig.CodexModelFallbackTriggerUsageLimit
+}
+
+func newCodexRateLimitContinuityStore() *codexRateLimitContinuityStore {
+	return &codexRateLimitContinuityStore{
+		states: make(map[codexRateLimitContinuityKey]*codexRateLimitContinuityState),
+		now:    time.Now,
+	}
+}
+
+func (s *codexRateLimitContinuityStore) currentTime() time.Time {
+	if s == nil || s.now == nil {
+		return time.Now()
+	}
+	return s.now()
+}
+
+func (s *codexRateLimitContinuityStore) clear() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.states = make(map[codexRateLimitContinuityKey]*codexRateLimitContinuityState)
+	s.mu.Unlock()
+}
+
+func (s *codexRateLimitContinuityStore) removeAuth(authID string) {
+	if s == nil || strings.TrimSpace(authID) == "" {
+		return
+	}
+	s.mu.Lock()
+	for key := range s.states {
+		if key.authID == authID {
+			delete(s.states, key)
+		}
+	}
+	s.mu.Unlock()
+}
+
+func codexRateLimitObservationWindow(cfg internalconfig.EffectiveCodexRateLimitContinuityConfig) time.Duration {
+	return time.Duration(cfg.ObservationWindowSeconds) * time.Second
+}
+
+func codexRateLimitEstablishedSessionTTL(cfg internalconfig.EffectiveCodexRateLimitContinuityConfig) time.Duration {
+	return time.Duration(cfg.EstablishedSessionTTLSeconds) * time.Second
+}
+
+func pruneCodexRateLimitContinuityState(state *codexRateLimitContinuityState, now time.Time) {
+	if state == nil {
+		return
+	}
+	for sessionID, expiresAt := range state.establishedSessions {
+		if !expiresAt.After(now) {
+			delete(state.establishedSessions, sessionID)
+		}
+	}
+}
+
+func codexRateLimitCanaryEligible(state *codexRateLimitContinuityState, cfg internalconfig.EffectiveCodexRateLimitContinuityConfig, now time.Time) bool {
+	if state == nil || !state.suspect || state.canaryToken != 0 {
+		return false
+	}
+	return !state.observeUntil.After(now) || state.establishedSuccesses >= cfg.EstablishedSuccessThreshold
+}
+
+func advanceCodexRateLimitContinuityGeneration(state *codexRateLimitContinuityState) {
+	if state == nil {
+		return
+	}
+	state.generation++
+	if state.generation == 0 {
+		state.generation = 1
+	}
+}
+
+func (s *codexRateLimitContinuityStore) candidateDisposition(key codexRateLimitContinuityKey, sessionID string, cfg internalconfig.EffectiveCodexRateLimitContinuityConfig) (allowed, establishedSuspect, confirmed bool) {
+	if s == nil {
+		return true, false, false
+	}
+	now := s.currentTime()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.states[key]
+	if state == nil {
+		return true, false, false
+	}
+	pruneCodexRateLimitContinuityState(state, now)
+	if state.confirmed {
+		return true, false, true
+	}
+	if !state.suspect {
+		return true, false, false
+	}
+	if expiresAt := state.establishedSessions[sessionID]; expiresAt.After(now) {
+		return true, true, false
+	}
+	return codexRateLimitCanaryEligible(state, cfg, now), false, false
+}
+
+func (s *codexRateLimitContinuityStore) candidateAllowed(key codexRateLimitContinuityKey, sessionID string, cfg internalconfig.EffectiveCodexRateLimitContinuityConfig) bool {
+	allowed, _, _ := s.candidateDisposition(key, sessionID, cfg)
+	return allowed
+}
+
+func (s *codexRateLimitContinuityStore) begin(key codexRateLimitContinuityKey, sessionID string, cfg internalconfig.EffectiveCodexRateLimitContinuityConfig) (codexRateLimitContinuityAttempt, bool) {
+	attempt := codexRateLimitContinuityAttempt{key: key, sessionID: sessionID}
+	if s == nil {
+		return attempt, true
+	}
+	now := s.currentTime()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.states[key]
+	if state == nil {
+		state = &codexRateLimitContinuityState{
+			generation:          1,
+			establishedSessions: make(map[string]time.Time),
+		}
+		s.states[key] = state
+	}
+	if state.generation == 0 {
+		state.generation = 1
+	}
+	pruneCodexRateLimitContinuityState(state, now)
+	if state.confirmed {
+		state.confirmed = false
+		state.suspect = false
+		state.observeUntil = time.Time{}
+		state.establishedSuccesses = 0
+		state.canaryToken = 0
+		state.establishedSessions = make(map[string]time.Time)
+	}
+	attempt.generation = state.generation
+	if expiresAt := state.establishedSessions[sessionID]; expiresAt.After(now) {
+		attempt.established = true
+		return attempt, true
+	}
+	if !state.suspect {
+		return attempt, true
+	}
+	if !codexRateLimitCanaryEligible(state, cfg, now) {
+		return attempt, false
+	}
+	s.nextToken++
+	if s.nextToken == 0 {
+		s.nextToken++
+	}
+	state.canaryToken = s.nextToken
+	attempt.canaryToken = state.canaryToken
+	return attempt, true
+}
+
+func (s *codexRateLimitContinuityStore) observe(attempt codexRateLimitContinuityAttempt, success bool, fallbackReason string, cfg internalconfig.EffectiveCodexRateLimitContinuityConfig) codexRateLimitContinuityDisposition {
+	if s == nil || attempt.key.authID == "" || attempt.key.model == "" || attempt.sessionID == "" {
+		return codexRateLimitContinuityNormal
+	}
+	now := s.currentTime()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.states[attempt.key]
+	usageLimit := strings.EqualFold(strings.TrimSpace(fallbackReason), internalconfig.CodexModelFallbackTriggerUsageLimit)
+	if state == nil && !success && !usageLimit {
+		return codexRateLimitContinuityNormal
+	}
+	if state == nil {
+		generation := attempt.generation
+		if generation == 0 {
+			generation = 1
+		}
+		state = &codexRateLimitContinuityState{
+			generation:          generation,
+			establishedSessions: make(map[string]time.Time),
+		}
+		s.states[attempt.key] = state
+	}
+	if state.generation == 0 {
+		state.generation = 1
+	}
+	if state.establishedSessions == nil {
+		state.establishedSessions = make(map[string]time.Time)
+	}
+	pruneCodexRateLimitContinuityState(state, now)
+	if attempt.generation != 0 && attempt.generation != state.generation {
+		return codexRateLimitContinuityRecordOnly
+	}
+	matchingCanary := attempt.canaryToken != 0 && attempt.canaryToken == state.canaryToken
+
+	if success {
+		state.establishedSessions[attempt.sessionID] = now.Add(codexRateLimitEstablishedSessionTTL(cfg))
+		switch {
+		case matchingCanary:
+			advanceCodexRateLimitContinuityGeneration(state)
+			state.confirmed = false
+			state.suspect = false
+			state.observeUntil = time.Time{}
+			state.establishedSuccesses = 0
+			state.canaryToken = 0
+		case state.suspect && attempt.established:
+			if state.establishedSuccesses < cfg.EstablishedSuccessThreshold {
+				state.establishedSuccesses++
+			}
+		case state.suspect && !attempt.established && attempt.canaryToken == 0:
+			// A fresh request that was already in flight when suspicion began is
+			// equivalent evidence that fresh sessions can still execute.
+			advanceCodexRateLimitContinuityGeneration(state)
+			state.confirmed = false
+			state.suspect = false
+			state.observeUntil = time.Time{}
+			state.establishedSuccesses = 0
+			state.canaryToken = 0
+		}
+		return codexRateLimitContinuityNormal
+	}
+
+	if usageLimit {
+		if attempt.established || matchingCanary {
+			advanceCodexRateLimitContinuityGeneration(state)
+			state.confirmed = true
+			state.suspect = false
+			state.observeUntil = time.Time{}
+			state.establishedSuccesses = 0
+			state.canaryToken = 0
+			state.establishedSessions = make(map[string]time.Time)
+			return codexRateLimitContinuityNormal
+		}
+		if !state.suspect {
+			state.suspect = true
+			state.observeUntil = now.Add(codexRateLimitObservationWindow(cfg))
+			state.establishedSuccesses = 0
+			state.canaryToken = 0
+		}
+		return codexRateLimitContinuityObserveOnly
+	}
+
+	if matchingCanary {
+		state.canaryToken = 0
+		state.observeUntil = now.Add(codexRateLimitObservationWindow(cfg))
+		state.establishedSuccesses = 0
+	}
+	return codexRateLimitContinuityNormal
+}
+
+func (s *codexRateLimitContinuityStore) abandon(attempt codexRateLimitContinuityAttempt, cfg internalconfig.EffectiveCodexRateLimitContinuityConfig) {
+	if s == nil || attempt.canaryToken == 0 {
+		return
+	}
+	now := s.currentTime()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.states[attempt.key]
+	if state == nil || state.canaryToken != attempt.canaryToken || (attempt.generation != 0 && attempt.generation != state.generation) {
+		return
+	}
+	state.canaryToken = 0
+	state.observeUntil = now.Add(codexRateLimitObservationWindow(cfg))
+	state.establishedSuccesses = 0
+}
+
+func codexRateLimitStableSessionID(opts cliproxyexecutor.Options) string {
+	sessionID := strings.TrimSpace(ExtractSessionID(opts.Headers, opts.OriginalRequest, opts.Metadata))
+	for _, prefix := range []string{"execution:", "claude:", "header:", "codex:", "amp:", "conv:"} {
+		if strings.HasPrefix(sessionID, prefix) && len(sessionID) > len(prefix) {
+			return sessionID
+		}
+	}
+	return ""
+}
+
+func (m *Manager) codexRateLimitContinuityPolicy() (internalconfig.EffectiveCodexRateLimitContinuityConfig, bool) {
+	if m == nil {
+		return internalconfig.EffectiveCodexRateLimitContinuityConfig{}, false
+	}
+	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	if cfg == nil || cfg.Home.Enabled || !cfg.Routing.SessionAffinity {
+		return internalconfig.EffectiveCodexRateLimitContinuityConfig{}, false
+	}
+	effective := cfg.Codex.RateLimitContinuity.Effective()
+	if !effective.Enabled {
+		return effective, false
+	}
+	m.mu.RLock()
+	_, selectorOK := m.selector.(*SessionAffinitySelector)
+	m.mu.RUnlock()
+	return effective, selectorOK
+}
+
+func (m *Manager) codexRateLimitContinuityRequest(opts cliproxyexecutor.Options) (internalconfig.EffectiveCodexRateLimitContinuityConfig, string, bool) {
+	effective, ok := m.codexRateLimitContinuityPolicy()
+	if !ok {
+		return effective, "", false
+	}
+	sessionID := codexRateLimitStableSessionID(opts)
+	return effective, sessionID, sessionID != ""
+}
+
+func (m *Manager) filterCodexRateLimitContinuityCandidates(candidates []*Auth, routeModel string, opts cliproxyexecutor.Options) ([]*Auth, error) {
+	effective, sessionID, ok := m.codexRateLimitContinuityRequest(opts)
+	if !ok || m.codexRateLimitContinuity == nil {
+		return candidates, nil
+	}
+	filtered := make([]*Auth, 0, len(candidates))
+	establishedSuspect := make([]*Auth, 0, 1)
+	removedCodex := false
+	removedConfirmed := false
+	now := time.Now()
+	for _, auth := range candidates {
+		if auth == nil || executorKeyFromAuth(auth) != "codex" {
+			filtered = append(filtered, auth)
+			continue
+		}
+		modelKey := m.selectionModelKeyForAuth(auth, routeModel)
+		key := codexRateLimitContinuityKey{authID: auth.ID, model: modelKey}
+		allowed, established, confirmed := m.codexRateLimitContinuity.candidateDisposition(key, sessionID, effective)
+		if confirmed {
+			checkModel := m.selectionModelForAuth(auth, routeModel)
+			if blocked, _, _ := isAuthBlockedForModel(auth, checkModel, now); blocked {
+				removedCodex = true
+				removedConfirmed = true
+				continue
+			}
+		}
+		if modelKey == "" || allowed {
+			filtered = append(filtered, auth)
+			if established {
+				checkModel := m.selectionModelForAuth(auth, routeModel)
+				if blocked, _, _ := isAuthBlockedForModel(auth, checkModel, now); !blocked {
+					establishedSuspect = append(establishedSuspect, auth)
+				}
+			}
+			continue
+		}
+		removedCodex = true
+	}
+	if len(filtered) == 0 && removedCodex {
+		return nil, codexRateLimitObservationPendingError{confirmed: removedConfirmed}
+	}
+	if len(establishedSuspect) > 0 {
+		return establishedSuspect, nil
+	}
+	return filtered, nil
+}
+
+func (m *Manager) beginCodexRateLimitContinuityAttempt(ctx context.Context, auth *Auth, provider, routeModel string, opts cliproxyexecutor.Options) (context.Context, bool) {
+	if auth == nil || strings.ToLower(strings.TrimSpace(provider)) != "codex" || m.codexRateLimitContinuity == nil {
+		return ctx, true
+	}
+	effective, sessionID, ok := m.codexRateLimitContinuityRequest(opts)
+	if !ok {
+		return ctx, true
+	}
+	modelKey := m.selectionModelKeyForAuth(auth, routeModel)
+	if modelKey == "" {
+		return ctx, true
+	}
+	attempt, allowed := m.codexRateLimitContinuity.begin(codexRateLimitContinuityKey{authID: auth.ID, model: modelKey}, sessionID, effective)
+	if !allowed {
+		return ctx, false
+	}
+	if attempt.canaryToken != 0 {
+		logEntryWithRequestID(ctx).
+			WithField("auth_id", auth.ID).
+			WithField("model", modelKey).
+			WithField("session", truncateSessionID(sessionID)).
+			Info("codex rate-limit continuity: reserved fresh-session canary")
+	}
+	return context.WithValue(ctx, codexRateLimitContinuityAttemptContextKey{}, attempt), true
+}
+
+func codexRateLimitContinuityAttemptFromContext(ctx context.Context) (codexRateLimitContinuityAttempt, bool) {
+	if ctx == nil {
+		return codexRateLimitContinuityAttempt{}, false
+	}
+	attempt, ok := ctx.Value(codexRateLimitContinuityAttemptContextKey{}).(codexRateLimitContinuityAttempt)
+	return attempt, ok && attempt.key.authID != "" && attempt.key.model != "" && attempt.sessionID != ""
+}
+
+func (m *Manager) observeCodexRateLimitContinuityResult(ctx context.Context, result Result) codexRateLimitContinuityDisposition {
+	if m == nil || m.codexRateLimitContinuity == nil || strings.ToLower(strings.TrimSpace(result.Provider)) != "codex" {
+		return codexRateLimitContinuityNormal
+	}
+	effective, ok := m.codexRateLimitContinuityPolicy()
+	if !ok {
+		return codexRateLimitContinuityNormal
+	}
+	attempt, ok := codexRateLimitContinuityAttemptFromContext(ctx)
+	if !ok || attempt.key.authID != result.AuthID {
+		return codexRateLimitContinuityNormal
+	}
+	disposition := m.codexRateLimitContinuity.observe(attempt, result.Success, result.ModelFallbackReason, effective)
+	entry := logEntryWithRequestID(ctx).
+		WithField("auth_id", result.AuthID).
+		WithField("model", attempt.key.model).
+		WithField("session", truncateSessionID(attempt.sessionID))
+	switch {
+	case disposition == codexRateLimitContinuityObserveOnly:
+		entry.Info("codex rate-limit continuity: observing fresh-session usage limit")
+	case disposition == codexRateLimitContinuityRecordOnly:
+		entry.Debug("codex rate-limit continuity: ignored stale result after state generation advanced")
+	case result.Success && attempt.canaryToken != 0:
+		entry.Info("codex rate-limit continuity: fresh-session canary recovered auth/model")
+	case !result.Success && strings.EqualFold(strings.TrimSpace(result.ModelFallbackReason), internalconfig.CodexModelFallbackTriggerUsageLimit) && (attempt.established || attempt.canaryToken != 0):
+		entry.Info("codex rate-limit continuity: confirmed auth/model usage limit")
+	case !result.Success && attempt.canaryToken != 0:
+		entry.Info("codex rate-limit continuity: canary result was inconclusive")
+	}
+	return disposition
+}
+
+func (m *Manager) abandonCodexRateLimitContinuityAttempt(ctx context.Context) {
+	if m == nil || m.codexRateLimitContinuity == nil {
+		return
+	}
+	effective, ok := m.codexRateLimitContinuityPolicy()
+	if !ok {
+		return
+	}
+	attempt, ok := codexRateLimitContinuityAttemptFromContext(ctx)
+	if !ok {
+		return
+	}
+	m.codexRateLimitContinuity.abandon(attempt, effective)
+}
+
+func (m *Manager) clearCodexRateLimitContinuityIfDisabled(cfg *internalconfig.Config) {
+	if m == nil || m.codexRateLimitContinuity == nil {
+		return
+	}
+	if cfg == nil || cfg.Home.Enabled || !cfg.Routing.SessionAffinity || !cfg.Codex.RateLimitContinuity.Effective().Enabled {
+		m.codexRateLimitContinuity.clear()
+	}
+}

--- a/sdk/cliproxy/auth/codex_rate_limit_continuity.go
+++ b/sdk/cliproxy/auth/codex_rate_limit_continuity.go
@@ -9,6 +9,7 @@ import (
 
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/tidwall/gjson"
 )
 
 type codexRateLimitContinuityKey struct {
@@ -17,31 +18,51 @@ type codexRateLimitContinuityKey struct {
 }
 
 type codexRateLimitContinuityState struct {
+	// phase is the authoritative admission state. suspect/confirmed are kept in
+	// sync for compatibility with the initial implementation and its tests.
+	phase                codexRateLimitContinuityPhase
 	suspect              bool
 	confirmed            bool
 	generation           uint64
 	observeUntil         time.Time
 	establishedSuccesses int
 	establishedSessions  map[string]time.Time
+	inFlight             map[string]int
+	nextLeaseExpiry      time.Time
+	leasePruneScans      uint64
 	canaryToken          uint64
 }
 
+type codexRateLimitContinuityPhase uint8
+
+const (
+	codexRateLimitContinuityHealthy codexRateLimitContinuityPhase = iota
+	codexRateLimitContinuityFreshBlocked
+	codexRateLimitContinuityConfirmedCooldown
+)
+
 type codexRateLimitContinuityStore struct {
-	mu        sync.Mutex
-	states    map[codexRateLimitContinuityKey]*codexRateLimitContinuityState
-	nextToken uint64
-	now       func() time.Time
+	mu             sync.Mutex
+	states         map[codexRateLimitContinuityKey]*codexRateLimitContinuityState
+	nextToken      uint64
+	nextAttempt    uint64
+	activeAttempts map[uint64]codexRateLimitContinuityAttempt
+	now            func() time.Time
 }
 
 type codexRateLimitContinuityAttempt struct {
-	key         codexRateLimitContinuityKey
-	sessionID   string
-	generation  uint64
-	established bool
-	canaryToken uint64
+	key          codexRateLimitContinuityKey
+	sessionID    string
+	generation   uint64
+	established  bool
+	incumbent    bool
+	canaryToken  uint64
+	attemptToken uint64
+	leaseTTL     time.Duration
 }
 
 type codexRateLimitContinuityAttemptContextKey struct{}
+type codexRateLimitContinuityLifecycleContextKey struct{}
 
 type codexRateLimitContinuityDisposition uint8
 
@@ -68,11 +89,57 @@ func (codexRateLimitObservationPendingError) ModelFallbackReason() string {
 	return internalconfig.CodexModelFallbackTriggerUsageLimit
 }
 
+// ModelFallbackZeroDispatch lets fallback orchestration distinguish local
+// continuity admission from an upstream attempt. It must not consume usage,
+// cooldown, selected-auth callback, or ordered-target budget.
+func (codexRateLimitObservationPendingError) ModelFallbackZeroDispatch() bool { return true }
+
 func newCodexRateLimitContinuityStore() *codexRateLimitContinuityStore {
 	return &codexRateLimitContinuityStore{
-		states: make(map[codexRateLimitContinuityKey]*codexRateLimitContinuityState),
-		now:    time.Now,
+		states:         make(map[codexRateLimitContinuityKey]*codexRateLimitContinuityState),
+		activeAttempts: make(map[uint64]codexRateLimitContinuityAttempt),
+		now:            time.Now,
 	}
+}
+
+func (m *Manager) advanceCodexRateLimitContinuityLifecycleLocked() {
+	if m == nil {
+		return
+	}
+	m.codexRateLimitContinuityLifecycle++
+	if m.codexRateLimitContinuityLifecycle == 0 {
+		m.codexRateLimitContinuityLifecycle++
+	}
+}
+
+func (m *Manager) withCodexRateLimitContinuityLifecycle(ctx context.Context) context.Context {
+	if m == nil {
+		return ctx
+	}
+	m.mu.RLock()
+	generation := m.codexRateLimitContinuityLifecycle
+	m.mu.RUnlock()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, codexRateLimitContinuityLifecycleContextKey{}, generation)
+}
+
+func codexRateLimitContinuityLifecycleFromContext(ctx context.Context) (uint64, bool) {
+	if ctx == nil {
+		return 0, false
+	}
+	switch value := ctx.Value(codexRateLimitContinuityLifecycleContextKey{}).(type) {
+	case uint64:
+		return value, true
+	case uint:
+		return uint64(value), true
+	case int:
+		if value >= 0 {
+			return uint64(value), true
+		}
+	}
+	return 0, false
 }
 
 func (s *codexRateLimitContinuityStore) currentTime() time.Time {
@@ -88,6 +155,7 @@ func (s *codexRateLimitContinuityStore) clear() {
 	}
 	s.mu.Lock()
 	s.states = make(map[codexRateLimitContinuityKey]*codexRateLimitContinuityState)
+	s.activeAttempts = make(map[uint64]codexRateLimitContinuityAttempt)
 	s.mu.Unlock()
 }
 
@@ -101,6 +169,11 @@ func (s *codexRateLimitContinuityStore) removeAuth(authID string) {
 			delete(s.states, key)
 		}
 	}
+	for token, attempt := range s.activeAttempts {
+		if attempt.key.authID == authID {
+			delete(s.activeAttempts, token)
+		}
+	}
 	s.mu.Unlock()
 }
 
@@ -112,19 +185,64 @@ func codexRateLimitEstablishedSessionTTL(cfg internalconfig.EffectiveCodexRateLi
 	return time.Duration(cfg.EstablishedSessionTTLSeconds) * time.Second
 }
 
-func pruneCodexRateLimitContinuityState(state *codexRateLimitContinuityState, now time.Time) {
+func codexRateLimitEstablishedSessionTTLWithAffinity(cfg internalconfig.EffectiveCodexRateLimitContinuityConfig, affinityTTL string) time.Duration {
+	ttl := codexRateLimitEstablishedSessionTTL(cfg)
+	parsed, err := time.ParseDuration(strings.TrimSpace(affinityTTL))
+	if err != nil || parsed <= 0 {
+		parsed = time.Hour
+	}
+	if parsed < ttl {
+		return parsed
+	}
+	return ttl
+}
+
+func setCodexRateLimitContinuityPhase(state *codexRateLimitContinuityState, phase codexRateLimitContinuityPhase) {
 	if state == nil {
 		return
 	}
+	state.phase = phase
+	state.suspect = phase == codexRateLimitContinuityFreshBlocked
+	state.confirmed = phase == codexRateLimitContinuityConfirmedCooldown
+}
+
+func ensureCodexRateLimitContinuityState(state *codexRateLimitContinuityState) {
+	if state == nil {
+		return
+	}
+	if state.establishedSessions == nil {
+		state.establishedSessions = make(map[string]time.Time)
+	}
+	if state.inFlight == nil {
+		state.inFlight = make(map[string]int)
+	}
+	// Old in-memory states were represented by these booleans.
+	if state.confirmed {
+		setCodexRateLimitContinuityPhase(state, codexRateLimitContinuityConfirmedCooldown)
+	} else if state.suspect {
+		setCodexRateLimitContinuityPhase(state, codexRateLimitContinuityFreshBlocked)
+	}
+}
+
+func pruneCodexRateLimitContinuityState(state *codexRateLimitContinuityState, now time.Time) {
+	if state == nil || (state.nextLeaseExpiry.After(now) && !state.nextLeaseExpiry.IsZero()) {
+		return
+	}
+	state.leasePruneScans++
+	state.nextLeaseExpiry = time.Time{}
 	for sessionID, expiresAt := range state.establishedSessions {
 		if !expiresAt.After(now) {
 			delete(state.establishedSessions, sessionID)
+			continue
+		}
+		if state.nextLeaseExpiry.IsZero() || expiresAt.Before(state.nextLeaseExpiry) {
+			state.nextLeaseExpiry = expiresAt
 		}
 	}
 }
 
 func codexRateLimitCanaryEligible(state *codexRateLimitContinuityState, cfg internalconfig.EffectiveCodexRateLimitContinuityConfig, now time.Time) bool {
-	if state == nil || !state.suspect || state.canaryToken != 0 {
+	if state == nil || state.phase != codexRateLimitContinuityFreshBlocked || state.canaryToken != 0 {
 		return false
 	}
 	return !state.observeUntil.After(now) || state.establishedSuccesses >= cfg.EstablishedSuccessThreshold
@@ -151,14 +269,15 @@ func (s *codexRateLimitContinuityStore) candidateDisposition(key codexRateLimitC
 	if state == nil {
 		return true, false, false
 	}
+	ensureCodexRateLimitContinuityState(state)
 	pruneCodexRateLimitContinuityState(state, now)
-	if state.confirmed {
+	if state.phase == codexRateLimitContinuityConfirmedCooldown {
 		return true, false, true
 	}
-	if !state.suspect {
+	if state.phase == codexRateLimitContinuityHealthy {
 		return true, false, false
 	}
-	if expiresAt := state.establishedSessions[sessionID]; expiresAt.After(now) {
+	if expiresAt := state.establishedSessions[sessionID]; expiresAt.After(now) || state.inFlight[sessionID] > 0 {
 		return true, true, false
 	}
 	return codexRateLimitCanaryEligible(state, cfg, now), false, false
@@ -170,7 +289,11 @@ func (s *codexRateLimitContinuityStore) candidateAllowed(key codexRateLimitConti
 }
 
 func (s *codexRateLimitContinuityStore) begin(key codexRateLimitContinuityKey, sessionID string, cfg internalconfig.EffectiveCodexRateLimitContinuityConfig) (codexRateLimitContinuityAttempt, bool) {
-	attempt := codexRateLimitContinuityAttempt{key: key, sessionID: sessionID}
+	return s.beginWithLeaseTTL(key, sessionID, cfg, codexRateLimitEstablishedSessionTTL(cfg))
+}
+
+func (s *codexRateLimitContinuityStore) beginWithLeaseTTL(key codexRateLimitContinuityKey, sessionID string, cfg internalconfig.EffectiveCodexRateLimitContinuityConfig, leaseTTL time.Duration) (codexRateLimitContinuityAttempt, bool) {
+	attempt := codexRateLimitContinuityAttempt{key: key, sessionID: sessionID, leaseTTL: leaseTTL}
 	if s == nil {
 		return attempt, true
 	}
@@ -182,30 +305,45 @@ func (s *codexRateLimitContinuityStore) begin(key codexRateLimitContinuityKey, s
 		state = &codexRateLimitContinuityState{
 			generation:          1,
 			establishedSessions: make(map[string]time.Time),
+			inFlight:            make(map[string]int),
 		}
 		s.states[key] = state
 	}
+	ensureCodexRateLimitContinuityState(state)
 	if state.generation == 0 {
 		state.generation = 1
 	}
 	pruneCodexRateLimitContinuityState(state, now)
-	if state.confirmed {
-		state.confirmed = false
-		state.suspect = false
-		state.observeUntil = time.Time{}
-		state.establishedSuccesses = 0
-		state.canaryToken = 0
-		state.establishedSessions = make(map[string]time.Time)
+	if state.phase == codexRateLimitContinuityConfirmedCooldown {
+		return attempt, false
 	}
 	attempt.generation = state.generation
+	s.nextAttempt++
+	if s.nextAttempt == 0 {
+		s.nextAttempt++
+	}
+	attempt.attemptToken = s.nextAttempt
+	s.activeAttempts[attempt.attemptToken] = attempt
 	if expiresAt := state.establishedSessions[sessionID]; expiresAt.After(now) {
 		attempt.established = true
+		state.inFlight[sessionID]++
 		return attempt, true
 	}
-	if !state.suspect {
+	if state.inFlight[sessionID] > 0 {
+		// A second request on a session that was already dispatched before the
+		// fresh-session observation is an incumbent continuation, not a canary.
+		attempt.incumbent = true
+		state.inFlight[sessionID]++
+		return attempt, true
+	}
+	if state.phase == codexRateLimitContinuityHealthy {
+		attempt.incumbent = true
+		state.inFlight[sessionID]++
 		return attempt, true
 	}
 	if !codexRateLimitCanaryEligible(state, cfg, now) {
+		delete(s.activeAttempts, attempt.attemptToken)
+		attempt.attemptToken = 0
 		return attempt, false
 	}
 	s.nextToken++
@@ -214,7 +352,34 @@ func (s *codexRateLimitContinuityStore) begin(key codexRateLimitContinuityKey, s
 	}
 	state.canaryToken = s.nextToken
 	attempt.canaryToken = state.canaryToken
+	state.inFlight[sessionID]++
 	return attempt, true
+}
+
+func (s *codexRateLimitContinuityStore) attemptCurrentLocked(attempt codexRateLimitContinuityAttempt) bool {
+	// token zero is reserved for direct synthetic state-machine tests. Every
+	// real dispatch is live only while its bounded active token remains present.
+	if attempt.attemptToken == 0 {
+		return true
+	}
+	active, ok := s.activeAttempts[attempt.attemptToken]
+	return ok && active.key == attempt.key && active.sessionID == attempt.sessionID
+}
+
+func (s *codexRateLimitContinuityStore) releaseAttemptLocked(state *codexRateLimitContinuityState, attempt codexRateLimitContinuityAttempt) bool {
+	if attempt.attemptToken == 0 {
+		return false
+	}
+	if activeAttempt, active := s.activeAttempts[attempt.attemptToken]; !active || activeAttempt.key != attempt.key || activeAttempt.sessionID != attempt.sessionID {
+		return false
+	}
+	delete(s.activeAttempts, attempt.attemptToken)
+	if state.inFlight[attempt.sessionID] > 1 {
+		state.inFlight[attempt.sessionID]--
+	} else {
+		delete(state.inFlight, attempt.sessionID)
+	}
+	return true
 }
 
 func (s *codexRateLimitContinuityStore) observe(attempt codexRateLimitContinuityAttempt, success bool, fallbackReason string, cfg internalconfig.EffectiveCodexRateLimitContinuityConfig) codexRateLimitContinuityDisposition {
@@ -226,6 +391,12 @@ func (s *codexRateLimitContinuityStore) observe(attempt codexRateLimitContinuity
 	defer s.mu.Unlock()
 	state := s.states[attempt.key]
 	usageLimit := strings.EqualFold(strings.TrimSpace(fallbackReason), internalconfig.CodexModelFallbackTriggerUsageLimit)
+	if !s.attemptCurrentLocked(attempt) {
+		if success || usageLimit {
+			return codexRateLimitContinuityRecordOnly
+		}
+		return codexRateLimitContinuityNormal
+	}
 	if state == nil && !success && !usageLimit {
 		return codexRateLimitContinuityNormal
 	}
@@ -243,55 +414,72 @@ func (s *codexRateLimitContinuityStore) observe(attempt codexRateLimitContinuity
 	if state.generation == 0 {
 		state.generation = 1
 	}
-	if state.establishedSessions == nil {
-		state.establishedSessions = make(map[string]time.Time)
-	}
+	ensureCodexRateLimitContinuityState(state)
 	pruneCodexRateLimitContinuityState(state, now)
+	s.releaseAttemptLocked(state, attempt)
 	if attempt.generation != 0 && attempt.generation != state.generation {
-		return codexRateLimitContinuityRecordOnly
+		if success || usageLimit {
+			return codexRateLimitContinuityRecordOnly
+		}
+		return codexRateLimitContinuityNormal
 	}
 	matchingCanary := attempt.canaryToken != 0 && attempt.canaryToken == state.canaryToken
 
 	if success {
-		state.establishedSessions[attempt.sessionID] = now.Add(codexRateLimitEstablishedSessionTTL(cfg))
+		leaseTTL := attempt.leaseTTL
+		if leaseTTL <= 0 {
+			leaseTTL = codexRateLimitEstablishedSessionTTL(cfg)
+		}
+		expiresAt := now.Add(leaseTTL)
+		state.establishedSessions[attempt.sessionID] = expiresAt
+		if state.nextLeaseExpiry.IsZero() || expiresAt.Before(state.nextLeaseExpiry) {
+			state.nextLeaseExpiry = expiresAt
+		}
 		switch {
 		case matchingCanary:
 			advanceCodexRateLimitContinuityGeneration(state)
-			state.confirmed = false
-			state.suspect = false
+			setCodexRateLimitContinuityPhase(state, codexRateLimitContinuityHealthy)
 			state.observeUntil = time.Time{}
 			state.establishedSuccesses = 0
 			state.canaryToken = 0
-		case state.suspect && attempt.established:
+		case state.phase == codexRateLimitContinuityFreshBlocked && (attempt.established || attempt.incumbent):
 			if state.establishedSuccesses < cfg.EstablishedSuccessThreshold {
 				state.establishedSuccesses++
 			}
-		case state.suspect && !attempt.established && attempt.canaryToken == 0:
-			// A fresh request that was already in flight when suspicion began is
-			// equivalent evidence that fresh sessions can still execute.
-			advanceCodexRateLimitContinuityGeneration(state)
-			state.confirmed = false
-			state.suspect = false
-			state.observeUntil = time.Time{}
-			state.establishedSuccesses = 0
-			state.canaryToken = 0
 		}
 		return codexRateLimitContinuityNormal
 	}
 
 	if usageLimit {
-		if attempt.established || matchingCanary {
+		// The request that first observes a healthy fresh-session 429 is not an
+		// incumbent. Only a request that started before another request moved the
+		// state into FreshBlocked may confirm the shared limit.
+		incumbentUsageLimit := attempt.established || (attempt.incumbent && state.phase == codexRateLimitContinuityFreshBlocked)
+		if incumbentUsageLimit || matchingCanary {
+			if matchingCanary && (len(state.establishedSessions) > 0 || len(state.inFlight) > 0) {
+				state.canaryToken = 0
+				state.observeUntil = now.Add(codexRateLimitObservationWindow(cfg))
+				state.establishedSuccesses = 0
+				return codexRateLimitContinuityObserveOnly
+			}
 			advanceCodexRateLimitContinuityGeneration(state)
-			state.confirmed = true
-			state.suspect = false
+			setCodexRateLimitContinuityPhase(state, codexRateLimitContinuityConfirmedCooldown)
 			state.observeUntil = time.Time{}
 			state.establishedSuccesses = 0
 			state.canaryToken = 0
+			// A confirmed shared limit invalidates all old continuity evidence.
 			state.establishedSessions = make(map[string]time.Time)
+			state.inFlight = make(map[string]int)
+			state.nextLeaseExpiry = time.Time{}
+			for token, activeAttempt := range s.activeAttempts {
+				if activeAttempt.key == attempt.key {
+					delete(s.activeAttempts, token)
+				}
+			}
 			return codexRateLimitContinuityNormal
 		}
-		if !state.suspect {
-			state.suspect = true
+		if state.phase != codexRateLimitContinuityFreshBlocked {
+			setCodexRateLimitContinuityPhase(state, codexRateLimitContinuityFreshBlocked)
 			state.observeUntil = now.Add(codexRateLimitObservationWindow(cfg))
 			state.establishedSuccesses = 0
 			state.canaryToken = 0
@@ -308,27 +496,61 @@ func (s *codexRateLimitContinuityStore) observe(attempt codexRateLimitContinuity
 }
 
 func (s *codexRateLimitContinuityStore) abandon(attempt codexRateLimitContinuityAttempt, cfg internalconfig.EffectiveCodexRateLimitContinuityConfig) {
-	if s == nil || attempt.canaryToken == 0 {
+	if s == nil {
 		return
 	}
 	now := s.currentTime()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	state := s.states[attempt.key]
-	if state == nil || state.canaryToken != attempt.canaryToken || (attempt.generation != 0 && attempt.generation != state.generation) {
+	if state == nil {
 		return
 	}
-	state.canaryToken = 0
-	state.observeUntil = now.Add(codexRateLimitObservationWindow(cfg))
-	state.establishedSuccesses = 0
+	if !s.attemptCurrentLocked(attempt) {
+		return
+	}
+	ensureCodexRateLimitContinuityState(state)
+	if !s.releaseAttemptLocked(state, attempt) {
+		return
+	}
+	if attempt.canaryToken != 0 && state.canaryToken == attempt.canaryToken && (attempt.generation == 0 || attempt.generation == state.generation) {
+		state.canaryToken = 0
+		state.observeUntil = now.Add(codexRateLimitObservationWindow(cfg))
+		state.establishedSuccesses = 0
+	}
 }
 
 func codexRateLimitStableSessionID(opts cliproxyexecutor.Options) string {
-	sessionID := strings.TrimSpace(ExtractSessionID(opts.Headers, opts.OriginalRequest, opts.Metadata))
-	for _, prefix := range []string{"execution:", "claude:", "header:", "codex:", "amp:", "conv:"} {
-		if strings.HasPrefix(sessionID, prefix) && len(sessionID) > len(prefix) {
-			return sessionID
+	// Do not call ExtractSessionID and reject its answer wholesale: it can select
+	// a request-id or generic user-id before a later conversation_id. Continuity
+	// only accepts durable conversation/session identities.
+	if raw := contextStringValue(opts.Metadata[cliproxyexecutor.ExecutionSessionMetadataKey]); raw != "" {
+		return "execution:" + raw
+	}
+	// Claude is the next selector priority. Parse only its explicit stable form;
+	// generic user/request IDs can never hide the permitted sources below.
+	if primary, _ := extractSessionIDs(nil, opts.OriginalRequest, opts.Metadata); strings.HasPrefix(primary, "claude:") && len(primary) > len("claude:") {
+		return primary
+	}
+	// Check each permitted header directly. In particular this must happen even
+	// when X-Client-Request-Id (which is intentionally not stable here) is also
+	// present.
+	if opts.Headers != nil {
+		if sessionID := strings.TrimSpace(opts.Headers.Get("X-Session-ID")); sessionID != "" {
+			return "header:" + sessionID
 		}
+		if sessionID := strings.TrimSpace(opts.Headers.Get("Session-Id")); sessionID != "" {
+			return "codex:" + sessionID
+		}
+		if sessionID := strings.TrimSpace(opts.Headers.Get("Session_id")); sessionID != "" {
+			return "codex:" + sessionID
+		}
+		if threadID := strings.TrimSpace(opts.Headers.Get("X-Amp-Thread-Id")); threadID != "" {
+			return "amp:" + threadID
+		}
+	}
+	if conversationID := strings.TrimSpace(gjson.GetBytes(opts.OriginalRequest, "conversation_id").String()); conversationID != "" {
+		return "conv:" + conversationID
 	}
 	return ""
 }
@@ -349,6 +571,121 @@ func (m *Manager) codexRateLimitContinuityPolicy() (internalconfig.EffectiveCode
 	_, selectorOK := m.selector.(*SessionAffinitySelector)
 	m.mu.RUnlock()
 	return effective, selectorOK
+}
+
+// codexRateLimitContinuityPolicyLocked is the MarkResult variant. The caller
+// owns manager.mu, preserving the lock order manager -> continuity store.
+func (m *Manager) codexRateLimitContinuityPolicyLocked() (internalconfig.EffectiveCodexRateLimitContinuityConfig, bool) {
+	if m == nil {
+		return internalconfig.EffectiveCodexRateLimitContinuityConfig{}, false
+	}
+	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	if cfg == nil || cfg.Home.Enabled || !cfg.Routing.SessionAffinity {
+		return internalconfig.EffectiveCodexRateLimitContinuityConfig{}, false
+	}
+	effective := cfg.Codex.RateLimitContinuity.Effective()
+	if !effective.Enabled {
+		return effective, false
+	}
+	_, selectorOK := m.selector.(*SessionAffinitySelector)
+	return effective, selectorOK
+}
+
+func codexRateLimitContinuitySettingsChanged(oldCfg, newCfg *internalconfig.Config) bool {
+	if oldCfg == nil {
+		oldCfg = &internalconfig.Config{}
+	}
+	if newCfg == nil {
+		newCfg = &internalconfig.Config{}
+	}
+	old := oldCfg.Codex.RateLimitContinuity.Effective()
+	new := newCfg.Codex.RateLimitContinuity.Effective()
+	return old.Enabled != new.Enabled ||
+		old.ObservationWindowSeconds != new.ObservationWindowSeconds ||
+		old.EstablishedSuccessThreshold != new.EstablishedSuccessThreshold ||
+		old.EstablishedSessionTTLSeconds != new.EstablishedSessionTTLSeconds ||
+		oldCfg.Home.Enabled != newCfg.Home.Enabled ||
+		oldCfg.Routing.SessionAffinity != newCfg.Routing.SessionAffinity ||
+		strings.TrimSpace(oldCfg.Routing.SessionAffinityTTL) != strings.TrimSpace(newCfg.Routing.SessionAffinityTTL)
+}
+
+func (s *codexRateLimitContinuityStore) removeSession(sessionID string) {
+	s.removeSessionPreservingKey(sessionID, nil)
+}
+
+func (s *codexRateLimitContinuityStore) removeSessionPreservingKey(sessionID string, preserve *codexRateLimitContinuityKey) {
+	if s == nil || sessionID == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for token, attempt := range s.activeAttempts {
+		if attempt.sessionID != sessionID || (preserve != nil && attempt.key == *preserve) {
+			continue
+		}
+		if state := s.states[attempt.key]; state != nil && attempt.canaryToken != 0 && state.canaryToken == attempt.canaryToken {
+			state.canaryToken = 0
+			state.establishedSuccesses = 0
+		}
+		delete(s.activeAttempts, token)
+	}
+	for key, state := range s.states {
+		if state == nil {
+			continue
+		}
+		ensureCodexRateLimitContinuityState(state)
+		delete(state.establishedSessions, sessionID)
+		if preserve == nil || key != *preserve {
+			delete(state.inFlight, sessionID)
+		}
+		state.nextLeaseExpiry = time.Time{}
+	}
+}
+
+// reopenConfirmed converts an expired persisted cooldown into FreshBlocked.
+// It is only called after the caller has verified the auth/model is available,
+// so a single canary, rather than a fresh-session stampede, performs recovery.
+func (s *codexRateLimitContinuityStore) reopenConfirmed(key codexRateLimitContinuityKey, expectedGeneration uint64) bool {
+	if s == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.states[key]
+	if state == nil {
+		return false
+	}
+	ensureCodexRateLimitContinuityState(state)
+	if state.phase != codexRateLimitContinuityConfirmedCooldown || (expectedGeneration != 0 && state.generation != expectedGeneration) {
+		return false
+	}
+	advanceCodexRateLimitContinuityGeneration(state)
+	setCodexRateLimitContinuityPhase(state, codexRateLimitContinuityFreshBlocked)
+	state.observeUntil = time.Time{}
+	state.canaryToken = 0
+	state.establishedSuccesses = 0
+	state.establishedSessions = make(map[string]time.Time)
+	state.inFlight = make(map[string]int)
+	state.nextLeaseExpiry = time.Time{}
+	return true
+}
+
+func (s *codexRateLimitContinuityStore) dispatchAllowed(attempt codexRateLimitContinuityAttempt) (allowed, confirmed bool) {
+	if s == nil || attempt.key.authID == "" {
+		return true, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state := s.states[attempt.key]
+	if state == nil {
+		return false, false
+	}
+	if !s.attemptCurrentLocked(attempt) {
+		return false, false
+	}
+	ensureCodexRateLimitContinuityState(state)
+	confirmed = state.phase == codexRateLimitContinuityConfirmedCooldown
+	return !confirmed && (attempt.generation == 0 || attempt.generation == state.generation), confirmed
 }
 
 func (m *Manager) codexRateLimitContinuityRequest(opts cliproxyexecutor.Options) (internalconfig.EffectiveCodexRateLimitContinuityConfig, string, bool) {
@@ -379,12 +716,33 @@ func (m *Manager) filterCodexRateLimitContinuityCandidates(candidates []*Auth, r
 		key := codexRateLimitContinuityKey{authID: auth.ID, model: modelKey}
 		allowed, established, confirmed := m.codexRateLimitContinuity.candidateDisposition(key, sessionID, effective)
 		if confirmed {
-			checkModel := m.selectionModelForAuth(auth, routeModel)
-			if blocked, _, _ := isAuthBlockedForModel(auth, checkModel, now); blocked {
+			// Reopen only while holding manager -> continuity locks and only from
+			// canonical auth state. A stale candidate clone must not revive a
+			// confirmed cooldown after Load/remove/another result changes auth.
+			m.mu.Lock()
+			canonical := m.auths[auth.ID]
+			checkModel := ""
+			blocked := true
+			if canonical != nil {
+				checkModel = m.selectionModelForAuth(canonical, routeModel)
+				blocked, _, _ = isAuthBlockedForModel(canonical, checkModel, now)
+			}
+			if !blocked {
+				stateGeneration := uint64(0)
+				m.codexRateLimitContinuity.mu.Lock()
+				if state := m.codexRateLimitContinuity.states[key]; state != nil {
+					stateGeneration = state.generation
+				}
+				m.codexRateLimitContinuity.mu.Unlock()
+				m.codexRateLimitContinuity.reopenConfirmed(key, stateGeneration)
+			}
+			m.mu.Unlock()
+			if blocked {
 				removedCodex = true
 				removedConfirmed = true
 				continue
 			}
+			allowed, established, _ = m.codexRateLimitContinuity.candidateDisposition(key, sessionID, effective)
 		}
 		if modelKey == "" || allowed {
 			filtered = append(filtered, auth)
@@ -411,15 +769,45 @@ func (m *Manager) beginCodexRateLimitContinuityAttempt(ctx context.Context, auth
 	if auth == nil || strings.ToLower(strings.TrimSpace(provider)) != "codex" || m.codexRateLimitContinuity == nil {
 		return ctx, true
 	}
-	effective, sessionID, ok := m.codexRateLimitContinuityRequest(opts)
-	if !ok {
+	sessionID := codexRateLimitStableSessionID(opts)
+	if sessionID == "" {
 		return ctx, true
 	}
-	modelKey := m.selectionModelKeyForAuth(auth, routeModel)
+	// Hold manager -> continuity locks through active-policy validation,
+	// canonical auth recheck, selector TTL, and admission. Home/default-off and
+	// requests without stable identity must bypass continuity before canonical
+	// Core auth checks because their auth may not live in m.auths at all.
+	m.mu.RLock()
+	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	selector, selectorOK := m.selector.(*SessionAffinitySelector)
+	if cfg == nil || cfg.Home.Enabled || !cfg.Routing.SessionAffinity || !selectorOK {
+		m.mu.RUnlock()
+		return ctx, true
+	}
+	effective := cfg.Codex.RateLimitContinuity.Effective()
+	if !effective.Enabled {
+		m.mu.RUnlock()
+		return ctx, true
+	}
+	requestLifecycle, hasLifecycle := codexRateLimitContinuityLifecycleFromContext(ctx)
+	canonical := m.auths[auth.ID]
+	if (hasLifecycle && requestLifecycle != m.codexRateLimitContinuityLifecycle) || canonical == nil {
+		m.mu.RUnlock()
+		return ctx, false
+	}
+	modelKey := m.selectionModelKeyForAuth(canonical, routeModel)
 	if modelKey == "" {
+		m.mu.RUnlock()
 		return ctx, true
 	}
-	attempt, allowed := m.codexRateLimitContinuity.begin(codexRateLimitContinuityKey{authID: auth.ID, model: modelKey}, sessionID, effective)
+	affinityTTL := ""
+	affinityTTL = cfg.Routing.SessionAffinityTTL
+	leaseTTL := codexRateLimitEstablishedSessionTTLWithAffinity(effective, affinityTTL)
+	if selector != nil && selector.cache != nil && selector.cache.ttl > 0 && selector.cache.ttl < leaseTTL {
+		leaseTTL = selector.cache.ttl
+	}
+	attempt, allowed := m.codexRateLimitContinuity.beginWithLeaseTTL(codexRateLimitContinuityKey{authID: auth.ID, model: modelKey}, sessionID, effective, leaseTTL)
+	m.mu.RUnlock()
 	if !allowed {
 		return ctx, false
 	}
@@ -431,6 +819,17 @@ func (m *Manager) beginCodexRateLimitContinuityAttempt(ctx context.Context, auth
 			Info("codex rate-limit continuity: reserved fresh-session canary")
 	}
 	return context.WithValue(ctx, codexRateLimitContinuityAttemptContextKey{}, attempt), true
+}
+
+func (m *Manager) codexRateLimitContinuityDispatchDisposition(ctx context.Context) (allowed, confirmed bool) {
+	if m == nil || m.codexRateLimitContinuity == nil {
+		return true, false
+	}
+	attempt, ok := codexRateLimitContinuityAttemptFromContext(ctx)
+	if !ok {
+		return true, false
+	}
+	return m.codexRateLimitContinuity.dispatchAllowed(attempt)
 }
 
 func codexRateLimitContinuityAttemptFromContext(ctx context.Context) (codexRateLimitContinuityAttempt, bool) {
@@ -445,7 +844,7 @@ func (m *Manager) observeCodexRateLimitContinuityResult(ctx context.Context, res
 	if m == nil || m.codexRateLimitContinuity == nil || strings.ToLower(strings.TrimSpace(result.Provider)) != "codex" {
 		return codexRateLimitContinuityNormal
 	}
-	effective, ok := m.codexRateLimitContinuityPolicy()
+	effective, ok := m.codexRateLimitContinuityPolicyLocked()
 	if !ok {
 		return codexRateLimitContinuityNormal
 	}
@@ -486,13 +885,4 @@ func (m *Manager) abandonCodexRateLimitContinuityAttempt(ctx context.Context) {
 		return
 	}
 	m.codexRateLimitContinuity.abandon(attempt, effective)
-}
-
-func (m *Manager) clearCodexRateLimitContinuityIfDisabled(cfg *internalconfig.Config) {
-	if m == nil || m.codexRateLimitContinuity == nil {
-		return
-	}
-	if cfg == nil || cfg.Home.Enabled || !cfg.Routing.SessionAffinity || !cfg.Codex.RateLimitContinuity.Effective().Enabled {
-		m.codexRateLimitContinuity.clear()
-	}
 }

--- a/sdk/cliproxy/auth/codex_rate_limit_continuity_test.go
+++ b/sdk/cliproxy/auth/codex_rate_limit_continuity_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -11,11 +12,45 @@ import (
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/tidwall/gjson"
 )
 
 type codexContinuityTestClock struct {
 	mu  sync.Mutex
 	now time.Time
+}
+
+type codexContinuityReloadStore struct {
+	auth *Auth
+}
+
+func (s *codexContinuityReloadStore) List(context.Context) ([]*Auth, error) {
+	if s == nil || s.auth == nil {
+		return nil, nil
+	}
+	return []*Auth{s.auth.Clone()}, nil
+}
+
+func (*codexContinuityReloadStore) Save(context.Context, *Auth) (string, error) { return "", nil }
+func (*codexContinuityReloadStore) Delete(context.Context, string) error        { return nil }
+
+type codexContinuityUsageLimitError struct {
+	retryAfter time.Duration
+}
+
+func (*codexContinuityUsageLimitError) Error() string { return "usage limit reached" }
+func (*codexContinuityUsageLimitError) StatusCode() int {
+	return http.StatusTooManyRequests
+}
+func (*codexContinuityUsageLimitError) ModelFallbackReason() string {
+	return internalconfig.CodexModelFallbackTriggerUsageLimit
+}
+func (e *codexContinuityUsageLimitError) RetryAfter() *time.Duration {
+	if e == nil {
+		return nil
+	}
+	retryAfter := e.retryAfter
+	return &retryAfter
 }
 
 func (c *codexContinuityTestClock) Now() time.Time {
@@ -48,7 +83,7 @@ func newCodexContinuityTestStore(clock *codexContinuityTestClock) *codexRateLimi
 	return store
 }
 
-func TestCodexRateLimitContinuityFirstFreshUsageLimitBecomesSuspect(t *testing.T) {
+func TestCodexRateLimitContinuityFirstFreshUsageLimitEntersFreshBlocked(t *testing.T) {
 	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
 	store := newCodexContinuityTestStore(clock)
 	cfg := codexContinuityTestPolicy(2)
@@ -66,8 +101,8 @@ func TestCodexRateLimitContinuityFirstFreshUsageLimitBecomesSuspect(t *testing.T
 	store.mu.Lock()
 	state := store.states[key]
 	store.mu.Unlock()
-	if state == nil || !state.suspect {
-		t.Fatalf("state = %+v, want suspect", state)
+	if state == nil || state.phase != codexRateLimitContinuityFreshBlocked {
+		t.Fatalf("state = %+v, want FreshBlocked", state)
 	}
 }
 
@@ -97,7 +132,7 @@ func TestCodexRateLimitContinuityEstablishedSessionObservesThenCanaryRecovers(t 
 	}
 }
 
-func TestCodexRateLimitContinuityEstablishedOrCanaryUsageLimitConfirmsCooldown(t *testing.T) {
+func TestCodexRateLimitContinuityEstablishedFailureConfirmsButCanaryWithIncumbentObserves(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		canary bool
@@ -125,20 +160,31 @@ func TestCodexRateLimitContinuityEstablishedOrCanaryUsageLimitConfirmsCooldown(t
 			} else {
 				probe, _ = store.begin(key, "execution:established", cfg)
 			}
-			if got := store.observe(probe, false, internalconfig.CodexModelFallbackTriggerUsageLimit, cfg); got != codexRateLimitContinuityNormal {
+			got := store.observe(probe, false, internalconfig.CodexModelFallbackTriggerUsageLimit, cfg)
+			if tc.canary {
+				// A failed fresh canary cannot globally cool an auth while the
+				// established lease is still healthy.
+				if got != codexRateLimitContinuityObserveOnly {
+					t.Fatalf("canary observe() = %v, want observe-only", got)
+				}
+			} else if got != codexRateLimitContinuityNormal {
 				t.Fatalf("observe() = %v, want normal cooldown", got)
 			}
 			store.mu.Lock()
 			state := store.states[key]
 			store.mu.Unlock()
-			if state == nil || !state.confirmed || state.generation <= probe.generation {
+			if tc.canary {
+				if state == nil || state.phase != codexRateLimitContinuityFreshBlocked || len(state.establishedSessions) == 0 {
+					t.Fatalf("fresh-blocked state = %+v", state)
+				}
+			} else if state == nil || !state.confirmed || state.generation <= probe.generation {
 				t.Fatalf("confirmed state = %+v, probe generation=%d", state, probe.generation)
 			}
 		})
 	}
 }
 
-func TestCodexRateLimitContinuityConfirmedGenerationRejectsStaleResult(t *testing.T) {
+func TestCodexRateLimitContinuityCanaryFailureWithIncumbentKeepsGeneration(t *testing.T) {
 	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
 	store := newCodexContinuityTestStore(clock)
 	cfg := codexContinuityTestPolicy(2)
@@ -151,8 +197,8 @@ func TestCodexRateLimitContinuityConfirmedGenerationRejectsStaleResult(t *testin
 	clock.Advance(11 * time.Second)
 	canary, _ := store.begin(key, "execution:canary", cfg)
 	store.observe(canary, false, internalconfig.CodexModelFallbackTriggerUsageLimit, cfg)
-	if got := store.observe(staleEstablished, true, "", cfg); got != codexRateLimitContinuityRecordOnly {
-		t.Fatalf("stale observe() = %v, want record-only", got)
+	if got := store.observe(staleEstablished, true, "", cfg); got != codexRateLimitContinuityNormal {
+		t.Fatalf("stale observe() = %v, want normal; canary failure with incumbent must not advance generation", got)
 	}
 }
 
@@ -232,6 +278,39 @@ func TestCodexRateLimitContinuityAbandonedCanaryRequiresNewObservationWindow(t *
 	}
 }
 
+func TestCodexRateLimitContinuityActiveAttemptsDrainAfterChurn(t *testing.T) {
+	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
+	store := newCodexContinuityTestStore(clock)
+	cfg := codexContinuityTestPolicy(2)
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+
+	for i := 0; i < 512; i++ {
+		sessionID := "execution:churn-" + time.Unix(int64(i), 0).Format(time.RFC3339Nano)
+		attempt, allowed := store.begin(key, sessionID, cfg)
+		if !allowed || attempt.attemptToken == 0 {
+			t.Fatalf("begin %d = %+v allowed=%t", i, attempt, allowed)
+		}
+		if i%2 == 0 {
+			store.observe(attempt, true, "", cfg)
+		} else {
+			store.abandon(attempt, cfg)
+		}
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if got := len(store.activeAttempts); got != 0 {
+		t.Fatalf("active attempts after churn = %d, want 0", got)
+	}
+	state := store.states[key]
+	if state == nil {
+		t.Fatal("continuity state missing after churn")
+	}
+	if got := len(state.inFlight); got != 0 {
+		t.Fatalf("in-flight sessions after churn = %d, want 0", got)
+	}
+}
+
 func TestCodexRateLimitContinuitySameSessionDifferentModelIsFresh(t *testing.T) {
 	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
 	store := newCodexContinuityTestStore(clock)
@@ -243,6 +322,918 @@ func TestCodexRateLimitContinuitySameSessionDifferentModelIsFresh(t *testing.T) 
 	attemptB, allowed := store.begin(modelB, "execution:same", cfg)
 	if !allowed || attemptB.established {
 		t.Fatalf("model B attempt = %+v allowed=%t, want fresh", attemptB, allowed)
+	}
+}
+
+func TestCodexRateLimitContinuityFirstFreshFailureOnlyStartsObservation(t *testing.T) {
+	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
+	store := newCodexContinuityTestStore(clock)
+	cfg := codexContinuityTestPolicy(2)
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	fresh, allowed := store.begin(key, "execution:fresh", cfg)
+	if !allowed || !fresh.incumbent {
+		t.Fatalf("healthy fresh begin = %+v allowed=%t", fresh, allowed)
+	}
+	if got := store.observe(fresh, false, internalconfig.CodexModelFallbackTriggerUsageLimit, cfg); got != codexRateLimitContinuityObserveOnly {
+		t.Fatalf("first fresh failure = %v, want observe-only", got)
+	}
+	store.mu.Lock()
+	state := store.states[key]
+	store.mu.Unlock()
+	if state == nil || state.phase != codexRateLimitContinuityFreshBlocked || state.confirmed {
+		t.Fatalf("state after first fresh failure = %+v, want FreshBlocked", state)
+	}
+}
+
+func TestCodexRateLimitContinuityCanaryFailureWithoutIncumbentConfirms(t *testing.T) {
+	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
+	store := newCodexContinuityTestStore(clock)
+	cfg := codexContinuityTestPolicy(2)
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	fresh, _ := store.begin(key, "execution:fresh", cfg)
+	store.observe(fresh, false, internalconfig.CodexModelFallbackTriggerUsageLimit, cfg)
+	clock.Advance(11 * time.Second)
+	canary, allowed := store.begin(key, "execution:canary", cfg)
+	if !allowed || canary.canaryToken == 0 {
+		t.Fatalf("canary = %+v allowed=%t", canary, allowed)
+	}
+	store.observe(canary, false, internalconfig.CodexModelFallbackTriggerUsageLimit, cfg)
+	store.mu.Lock()
+	state := store.states[key]
+	store.mu.Unlock()
+	if state == nil || state.phase != codexRateLimitContinuityConfirmedCooldown || !state.confirmed {
+		t.Fatalf("state after no-incumbent canary failure = %+v", state)
+	}
+	if _, allowed := store.begin(key, "execution:after-confirm", cfg); allowed {
+		t.Fatal("confirmed cooldown allowed a dispatch")
+	}
+}
+
+func TestCodexRateLimitContinuityPreBlockSuccessKeepsFreshBlocked(t *testing.T) {
+	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
+	store := newCodexContinuityTestStore(clock)
+	cfg := codexContinuityTestPolicy(2)
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	preBlock, _ := store.begin(key, "execution:pre-block", cfg)
+	fresh, _ := store.begin(key, "execution:fresh", cfg)
+	store.observe(fresh, false, internalconfig.CodexModelFallbackTriggerUsageLimit, cfg)
+	store.observe(preBlock, true, "", cfg)
+	store.mu.Lock()
+	state := store.states[key]
+	store.mu.Unlock()
+	if state == nil || state.phase != codexRateLimitContinuityFreshBlocked {
+		t.Fatalf("pre-block success recovered Healthy: %+v", state)
+	}
+	if expiresAt := state.establishedSessions["execution:pre-block"]; !expiresAt.After(clock.Now()) {
+		t.Fatalf("pre-block success did not create lease: %+v", state)
+	}
+}
+
+func TestCodexRateLimitContinuityPreBlockUsageLimitConfirmsCooldown(t *testing.T) {
+	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
+	store := newCodexContinuityTestStore(clock)
+	cfg := codexContinuityTestPolicy(2)
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	preBlock, _ := store.begin(key, "execution:pre-block", cfg)
+	fresh, _ := store.begin(key, "execution:fresh", cfg)
+	store.observe(fresh, false, internalconfig.CodexModelFallbackTriggerUsageLimit, cfg)
+	if got := store.observe(preBlock, false, internalconfig.CodexModelFallbackTriggerUsageLimit, cfg); got != codexRateLimitContinuityNormal {
+		t.Fatalf("pre-block usage-limit disposition = %v, want formal cooldown", got)
+	}
+	store.mu.Lock()
+	state := store.states[key]
+	store.mu.Unlock()
+	if state == nil || state.phase != codexRateLimitContinuityConfirmedCooldown {
+		t.Fatalf("pre-block usage-limit state = %+v, want ConfirmedCooldown", state)
+	}
+}
+
+func TestCodexRateLimitContinuityFreshBlockedAllowsSameSessionInFlightContinuation(t *testing.T) {
+	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
+	store := newCodexContinuityTestStore(clock)
+	cfg := codexContinuityTestPolicy(2)
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	store.states[key] = &codexRateLimitContinuityState{
+		phase: codexRateLimitContinuityFreshBlocked, suspect: true, generation: 1,
+		observeUntil: clock.Now().Add(time.Hour), establishedSessions: make(map[string]time.Time),
+		inFlight: map[string]int{"execution:incumbent": 1},
+	}
+	if allowed, established, _ := store.candidateDisposition(key, "execution:incumbent", cfg); !allowed || !established {
+		t.Fatalf("candidate disposition = allowed=%t incumbent=%t", allowed, established)
+	}
+	attempt, allowed := store.begin(key, "execution:incumbent", cfg)
+	if !allowed || !attempt.incumbent {
+		t.Fatalf("same-session begin = %+v allowed=%t", attempt, allowed)
+	}
+	store.mu.Lock()
+	count := store.states[key].inFlight["execution:incumbent"]
+	store.mu.Unlock()
+	if count != 2 {
+		t.Fatalf("in-flight count = %d, want 2", count)
+	}
+	store.abandon(attempt, cfg)
+}
+
+func TestCodexRateLimitStableSessionIDPrefersAllowedConversationOverRequestID(t *testing.T) {
+	opts := cliproxyexecutor.Options{
+		Headers:         http.Header{"X-Client-Request-Id": []string{"ephemeral"}},
+		OriginalRequest: []byte(`{"metadata":{"user_id":"generic"},"conversation_id":"conversation-1"}`),
+	}
+	if got := codexRateLimitStableSessionID(opts); got != "conv:conversation-1" {
+		t.Fatalf("stable session id = %q, want conversation ID", got)
+	}
+	opts.Headers.Set("Session-Id", "codex-session")
+	if got := codexRateLimitStableSessionID(opts); got != "codex:codex-session" {
+		t.Fatalf("stable session id = %q, want Codex session header", got)
+	}
+}
+
+func TestCodexRateLimitStableSessionIDMatchesSelectorClaudePriority(t *testing.T) {
+	opts := cliproxyexecutor.Options{
+		Headers: http.Header{
+			"X-Session-ID":        []string{"header-session"},
+			"X-Client-Request-Id": []string{"ephemeral"},
+		},
+		OriginalRequest: []byte(`{"metadata":{"user_id":"user_hash_account__session_123e4567-e89b-12d3-a456-426614174000"},"conversation_id":"conversation-1"}`),
+	}
+	if got := codexRateLimitStableSessionID(opts); got != "claude:123e4567-e89b-12d3-a456-426614174000" {
+		t.Fatalf("stable session id = %q, want Claude session before header", got)
+	}
+}
+
+func TestCodexRateLimitLeaseTTLClampsToEffectiveAffinityTTL(t *testing.T) {
+	cfg := codexContinuityTestPolicy(2)
+	cfg.EstablishedSessionTTLSeconds = 7200
+	for _, tc := range []struct {
+		name     string
+		affinity string
+		want     time.Duration
+	}{
+		{name: "empty uses selector default", want: time.Hour},
+		{name: "invalid uses selector default", affinity: "not-a-duration", want: time.Hour},
+		{name: "lower affinity", affinity: "30m", want: 30 * time.Minute},
+		{name: "sub-second preserved", affinity: "500ms", want: 500 * time.Millisecond},
+		{name: "larger affinity", affinity: "3h", want: 2 * time.Hour},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := codexRateLimitEstablishedSessionTTLWithAffinity(cfg, tc.affinity); got != tc.want {
+				t.Fatalf("lease TTL = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCodexRateLimitContinuitySettingsChangedCoversLeaseContract(t *testing.T) {
+	base := &internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{SessionAffinity: true, SessionAffinityTTL: "1h"},
+		Codex: internalconfig.CodexConfig{RateLimitContinuity: internalconfig.CodexRateLimitContinuityConfig{
+			Enabled:                      true,
+			ObservationWindowSeconds:     10,
+			EstablishedSuccessThreshold:  2,
+			EstablishedSessionTTLSeconds: 3600,
+		}},
+	}
+	if codexRateLimitContinuitySettingsChanged(base, base) {
+		t.Fatal("unchanged config reported a continuity contract change")
+	}
+	for _, tc := range []struct {
+		name   string
+		mutate func(*internalconfig.Config)
+	}{
+		{name: "enabled", mutate: func(cfg *internalconfig.Config) { cfg.Codex.RateLimitContinuity.Enabled = false }},
+		{name: "observation window", mutate: func(cfg *internalconfig.Config) { cfg.Codex.RateLimitContinuity.ObservationWindowSeconds++ }},
+		{name: "success threshold", mutate: func(cfg *internalconfig.Config) { cfg.Codex.RateLimitContinuity.EstablishedSuccessThreshold++ }},
+		{name: "lease TTL", mutate: func(cfg *internalconfig.Config) { cfg.Codex.RateLimitContinuity.EstablishedSessionTTLSeconds++ }},
+		{name: "home mode", mutate: func(cfg *internalconfig.Config) { cfg.Home.Enabled = true }},
+		{name: "affinity enabled", mutate: func(cfg *internalconfig.Config) { cfg.Routing.SessionAffinity = false }},
+		{name: "affinity TTL", mutate: func(cfg *internalconfig.Config) { cfg.Routing.SessionAffinityTTL = "30m" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			changed := *base
+			tc.mutate(&changed)
+			if !codexRateLimitContinuitySettingsChanged(base, &changed) {
+				t.Fatalf("%s change did not invalidate continuity state", tc.name)
+			}
+		})
+	}
+}
+
+func TestManagerCodexRateLimitContinuityPreservesSubSecondAffinityLeaseTTL(t *testing.T) {
+	executor := &codexContinuityTestExecutor{failures: make(map[string]error)}
+	manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-5"}, 2)
+	manager.SetConfig(&internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{SessionAffinity: true, SessionAffinityTTL: "500ms"},
+		Codex: internalconfig.CodexConfig{RateLimitContinuity: internalconfig.CodexRateLimitContinuityConfig{
+			Enabled: true, ObservationWindowSeconds: 10, EstablishedSuccessThreshold: 2, EstablishedSessionTTLSeconds: 3600,
+		}},
+	})
+	auth, _ := manager.GetByID("auth-a")
+	ctx, allowed := manager.beginCodexRateLimitContinuityAttempt(context.Background(), auth, "codex", "gpt-5", codexContinuityOptions("subsecond"))
+	if !allowed {
+		t.Fatal("begin rejected")
+	}
+	attempt, ok := codexRateLimitContinuityAttemptFromContext(ctx)
+	if !ok || attempt.leaseTTL != 500*time.Millisecond {
+		t.Fatalf("attempt lease TTL = %+v, want 500ms", attempt)
+	}
+	manager.abandonCodexRateLimitContinuityAttempt(ctx)
+}
+
+func TestManagerCodexRateLimitContinuityUsesActualSelectorTTL(t *testing.T) {
+	executor := &codexContinuityTestExecutor{failures: make(map[string]error)}
+	manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-5"}, 2)
+	previous, _ := manager.selector.(*SessionAffinitySelector)
+	manager.SetSelector(NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{Fallback: &FillFirstSelector{}, TTL: 125 * time.Millisecond}))
+	if previous != nil {
+		previous.Stop()
+	}
+	auth, _ := manager.GetByID("auth-a")
+	ctx, allowed := manager.beginCodexRateLimitContinuityAttempt(context.Background(), auth, "codex", "gpt-5", codexContinuityOptions("selector-ttl"))
+	if !allowed {
+		t.Fatal("begin rejected")
+	}
+	attempt, _ := codexRateLimitContinuityAttemptFromContext(ctx)
+	if attempt.leaseTTL != 125*time.Millisecond {
+		t.Fatalf("actual selector TTL = %v, want 125ms", attempt.leaseTTL)
+	}
+	manager.abandonCodexRateLimitContinuityAttempt(ctx)
+}
+
+func TestManagerCodexRateLimitContinuityShorterSelectorReplacementClearsOldLease(t *testing.T) {
+	executor := &codexContinuityTestExecutor{failures: make(map[string]error)}
+	manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-5"}, 2)
+	sessionID := "selector-replacement"
+	if _, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions(sessionID)); err != nil {
+		t.Fatalf("establish Execute() error = %v", err)
+	}
+
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	manager.codexRateLimitContinuity.mu.Lock()
+	leaseBefore := manager.codexRateLimitContinuity.states[key].establishedSessions["execution:"+sessionID]
+	manager.codexRateLimitContinuity.mu.Unlock()
+	if leaseBefore.IsZero() {
+		t.Fatal("expected established lease before selector replacement")
+	}
+
+	previous, _ := manager.selector.(*SessionAffinitySelector)
+	manager.SetSelector(NewSessionAffinitySelectorWithConfig(SessionAffinityConfig{
+		Fallback: &FillFirstSelector{},
+		TTL:      100 * time.Millisecond,
+	}))
+	if previous != nil {
+		previous.Stop()
+	}
+
+	manager.codexRateLimitContinuity.mu.Lock()
+	stateCount := len(manager.codexRateLimitContinuity.states)
+	activeCount := len(manager.codexRateLimitContinuity.activeAttempts)
+	manager.codexRateLimitContinuity.mu.Unlock()
+	if stateCount != 0 || activeCount != 0 {
+		t.Fatalf("selector replacement retained continuity state: states=%d active=%d", stateCount, activeCount)
+	}
+}
+
+func TestCodexRateLimitContinuityLifecycleClearDoesNotResurrectFromInFlightResult(t *testing.T) {
+	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
+	cfg := codexContinuityTestPolicy(2)
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	for _, tc := range []struct {
+		name  string
+		clear func(*codexRateLimitContinuityStore)
+	}{
+		{name: "global clear", clear: func(s *codexRateLimitContinuityStore) { s.clear() }},
+		{name: "auth removal", clear: func(s *codexRateLimitContinuityStore) { s.removeAuth("auth-a") }},
+		{name: "session close", clear: func(s *codexRateLimitContinuityStore) { s.removeSession("execution:in-flight") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newCodexContinuityTestStore(clock)
+			attempt, allowed := store.begin(key, "execution:in-flight", cfg)
+			if !allowed || attempt.attemptToken == 0 {
+				t.Fatalf("begin = %+v allowed=%t", attempt, allowed)
+			}
+			tc.clear(store)
+			if got := store.observe(attempt, true, "", cfg); got != codexRateLimitContinuityRecordOnly {
+				t.Fatalf("in-flight completion disposition = %v, want record-only", got)
+			}
+			store.mu.Lock()
+			state, exists := store.states[key]
+			leaseExists := false
+			if state != nil {
+				_, leaseExists = state.establishedSessions["execution:in-flight"]
+			}
+			store.mu.Unlock()
+			if tc.name == "session close" {
+				if leaseExists {
+					t.Fatal("session-close stale completion recreated continuity lease")
+				}
+			} else if exists {
+				t.Fatal("stale in-flight completion recreated continuity state")
+			}
+		})
+	}
+}
+
+func TestManagerCodexRateLimitContinuityLifecycleEntrypointsDoNotResurrectInFlightLease(t *testing.T) {
+	newAttempt := func(t *testing.T) (*Manager, context.Context, codexRateLimitContinuityKey) {
+		t.Helper()
+		executor := &codexContinuityTestExecutor{failures: make(map[string]error)}
+		manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-5"}, 2)
+		auth, _ := manager.GetByID("auth-a")
+		ctx, allowed := manager.beginCodexRateLimitContinuityAttempt(context.Background(), auth, "codex", "gpt-5", codexContinuityOptions("entrypoint"))
+		if !allowed {
+			t.Fatal("begin rejected")
+		}
+		return manager, ctx, codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	}
+	for _, tc := range []struct {
+		name  string
+		clear func(*Manager)
+	}{
+		{name: "session close", clear: func(m *Manager) { m.CloseExecutionSession("entrypoint") }},
+		{name: "hot reload", clear: func(m *Manager) {
+			m.SetConfig(&internalconfig.Config{Routing: internalconfig.RoutingConfig{SessionAffinity: true, SessionAffinityTTL: "10m"}, Codex: internalconfig.CodexConfig{RateLimitContinuity: internalconfig.CodexRateLimitContinuityConfig{Enabled: true, ObservationWindowSeconds: 11, EstablishedSuccessThreshold: 2, EstablishedSessionTTLSeconds: 3600}}})
+		}},
+		{name: "load", clear: func(m *Manager) {
+			m.SetStore(&countingStore{})
+			if err := m.Load(context.Background()); err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+		}},
+		{name: "auth removal", clear: func(m *Manager) { m.invalidateSessionAffinity("auth-a") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			manager, ctx, key := newAttempt(t)
+			tc.clear(manager)
+			manager.MarkResult(ctx, Result{AuthID: "auth-a", Provider: "codex", Model: "gpt-5", Success: true})
+			manager.codexRateLimitContinuity.mu.Lock()
+			state := manager.codexRateLimitContinuity.states[key]
+			lease := time.Time{}
+			if state != nil {
+				lease = state.establishedSessions["execution:entrypoint"]
+			}
+			manager.codexRateLimitContinuity.mu.Unlock()
+			if !lease.IsZero() {
+				t.Fatalf("%s stale completion recreated lease: %v", tc.name, lease)
+			}
+		})
+	}
+}
+
+func TestManagerCodexRateLimitContinuityLifecycleResetAfterAdmissionBlocksDispatch(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		reset func(*testing.T, *Manager, string)
+	}{
+		{
+			name: "load",
+			reset: func(t *testing.T, manager *Manager, _ string) {
+				t.Helper()
+				auth, ok := manager.GetByID("auth-a")
+				if !ok || auth == nil {
+					t.Fatal("auth-a missing before Load")
+				}
+				manager.SetStore(&codexContinuityReloadStore{auth: auth})
+				if err := manager.Load(context.Background()); err != nil {
+					t.Fatalf("Load() error = %v", err)
+				}
+			},
+		},
+		{
+			name: "remove",
+			reset: func(_ *testing.T, manager *Manager, _ string) {
+				manager.Remove(context.Background(), "auth-a")
+			},
+		},
+		{
+			name: "close execution session",
+			reset: func(_ *testing.T, manager *Manager, sessionID string) {
+				manager.CloseExecutionSession(sessionID)
+			},
+		},
+		{
+			name: "changed config",
+			reset: func(_ *testing.T, manager *Manager, _ string) {
+				manager.SetConfig(&internalconfig.Config{
+					Routing: internalconfig.RoutingConfig{SessionAffinity: true},
+					Codex: internalconfig.CodexConfig{RateLimitContinuity: internalconfig.CodexRateLimitContinuityConfig{
+						Enabled:                      true,
+						ObservationWindowSeconds:     11,
+						EstablishedSuccessThreshold:  2,
+						EstablishedSessionTTLSeconds: 3600,
+					}},
+				})
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			executor := &codexContinuityTestExecutor{failures: make(map[string]error)}
+			manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-5"}, 2)
+			sessionID := "lifecycle-race"
+			if _, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions(sessionID)); err != nil {
+				t.Fatalf("establish Execute() error = %v", err)
+			}
+
+			beforeCalls := len(executor.snapshot())
+			var callbackCalls atomic.Int32
+			opts := codexContinuityOptions(sessionID)
+			opts.Metadata[cliproxyexecutor.SelectedAuthCallbackMetadataKey] = func(string) {
+				callbackCalls.Add(1)
+			}
+			var once sync.Once
+			manager.continuityBeforeDispatchHook = func() {
+				once.Do(func() { tc.reset(t, manager, sessionID) })
+			}
+			_, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, opts)
+			manager.continuityBeforeDispatchHook = nil
+			if err == nil {
+				t.Fatal("Execute() error = nil after lifecycle reset")
+			}
+			if got := len(executor.snapshot()); got != beforeCalls {
+				t.Fatalf("executor calls after lifecycle reset = %d, want %d", got, beforeCalls)
+			}
+			if got := callbackCalls.Load(); got != 0 {
+				t.Fatalf("selected-auth callback calls = %d, want 0", got)
+			}
+			if _, published := opts.Metadata[cliproxyexecutor.SelectedAuthMetadataKey]; published {
+				t.Fatal("selected auth metadata was published for zero-dispatch request")
+			}
+
+			key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+			manager.codexRateLimitContinuity.mu.Lock()
+			state := manager.codexRateLimitContinuity.states[key]
+			lease := time.Time{}
+			inFlight := 0
+			if state != nil {
+				lease = state.establishedSessions["execution:"+sessionID]
+				inFlight = state.inFlight["execution:"+sessionID]
+			}
+			activeAttempts := len(manager.codexRateLimitContinuity.activeAttempts)
+			manager.codexRateLimitContinuity.mu.Unlock()
+			if !lease.IsZero() || inFlight != 0 || activeAttempts != 0 {
+				t.Fatalf("lifecycle reset resurrected continuity state: lease=%v in-flight=%d active=%d", lease, inFlight, activeAttempts)
+			}
+		})
+	}
+}
+
+func TestManagerCodexRateLimitContinuityInactiveScopesBypassLifecycleAndCanonicalGuards(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  *internalconfig.Config
+		opts cliproxyexecutor.Options
+		want bool
+	}{
+		{
+			name: "default off",
+			cfg:  &internalconfig.Config{Routing: internalconfig.RoutingConfig{SessionAffinity: true}},
+			opts: codexContinuityOptions("default-off"),
+			want: true,
+		},
+		{
+			name: "home runtime auth",
+			cfg: &internalconfig.Config{
+				Home:    internalconfig.HomeConfig{Enabled: true},
+				Routing: internalconfig.RoutingConfig{SessionAffinity: true},
+				Codex: internalconfig.CodexConfig{RateLimitContinuity: internalconfig.CodexRateLimitContinuityConfig{
+					Enabled: true,
+				}},
+			},
+			opts: codexContinuityOptions("home"),
+			want: true,
+		},
+		{
+			name: "no stable session",
+			cfg: &internalconfig.Config{
+				Routing: internalconfig.RoutingConfig{SessionAffinity: true},
+				Codex: internalconfig.CodexConfig{RateLimitContinuity: internalconfig.CodexRateLimitContinuityConfig{
+					Enabled: true,
+				}},
+			},
+			opts: cliproxyexecutor.Options{},
+			want: true,
+		},
+		{
+			name: "active continuity requires canonical auth",
+			cfg: &internalconfig.Config{
+				Routing: internalconfig.RoutingConfig{SessionAffinity: true},
+				Codex: internalconfig.CodexConfig{RateLimitContinuity: internalconfig.CodexRateLimitContinuityConfig{
+					Enabled: true,
+				}},
+			},
+			opts: codexContinuityOptions("active"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			selector := NewSessionAffinitySelector(&FillFirstSelector{})
+			manager := NewManager(nil, selector, nil)
+			t.Cleanup(selector.Stop)
+			manager.SetConfig(tc.cfg)
+			ctx := manager.withCodexRateLimitContinuityLifecycle(context.Background())
+			manager.mu.Lock()
+			manager.advanceCodexRateLimitContinuityLifecycleLocked()
+			manager.mu.Unlock()
+			_, allowed := manager.beginCodexRateLimitContinuityAttempt(ctx, &Auth{ID: "runtime-only", Provider: "codex"}, "codex", "gpt-5", tc.opts)
+			if allowed != tc.want {
+				t.Fatalf("begin allowed = %t, want %t", allowed, tc.want)
+			}
+		})
+	}
+}
+
+func TestManagerCodexRateLimitContinuityHomeCodexDispatchBypassesContinuity(t *testing.T) {
+	executor := &codexContinuityTestExecutor{failures: make(map[string]error)}
+	manager := NewManager(nil, NewSessionAffinitySelector(&FillFirstSelector{}), nil)
+	t.Cleanup(func() {
+		if selector, ok := manager.selector.(*SessionAffinitySelector); ok {
+			selector.Stop()
+		}
+	})
+	manager.SetRetryConfig(0, 0, 0)
+	manager.SetConfig(&internalconfig.Config{
+		Home:    internalconfig.HomeConfig{Enabled: true},
+		Routing: internalconfig.RoutingConfig{SessionAffinity: true},
+		Codex: internalconfig.CodexConfig{RateLimitContinuity: internalconfig.CodexRateLimitContinuityConfig{
+			Enabled: true,
+		}},
+	})
+	manager.RegisterExecutor(executor)
+	sessionID := "home-codex"
+	homeAuth := &Auth{
+		ID:       "home-codex-auth",
+		Provider: "codex",
+		Status:   StatusActive,
+		Attributes: map[string]string{
+			"websockets":                  "true",
+			homeUpstreamModelAttributeKey: "gpt-5",
+		},
+	}
+	homeAuth.EnsureIndex()
+	manager.rememberHomeRuntimeAuth(sessionID, homeAuth)
+
+	opts := codexContinuityOptions(sessionID)
+	opts.Metadata[cliproxyexecutor.PinnedAuthMetadataKey] = homeAuth.ID
+	resp, err := manager.Execute(cliproxyexecutor.WithDownstreamWebsocket(context.Background()), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, opts)
+	if err != nil || string(resp.Payload) != "home-codex-auth|gpt-5|home-codex" {
+		t.Fatalf("Execute() response/error = %q/%v", resp.Payload, err)
+	}
+	if calls := executor.snapshot(); len(calls) != 1 || calls[0] != "home-codex-auth|gpt-5|home-codex" {
+		t.Fatalf("executor calls = %#v, want one Home Codex dispatch", calls)
+	}
+}
+
+func TestManagerCodexRateLimitContinuityUnrelatedSessionCloseDoesNotBlockDispatch(t *testing.T) {
+	executor := &codexContinuityTestExecutor{failures: make(map[string]error)}
+	manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-5"}, 2)
+	var once sync.Once
+	manager.continuityBeforeDispatchHook = func() {
+		once.Do(func() { manager.CloseExecutionSession("unrelated") })
+	}
+	defer func() { manager.continuityBeforeDispatchHook = nil }()
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions("session-b"))
+	if err != nil || string(resp.Payload) != "auth-a|gpt-5|session-b" {
+		t.Fatalf("Execute() response/error = %q/%v", resp.Payload, err)
+	}
+	if calls := executor.snapshot(); len(calls) != 1 {
+		t.Fatalf("executor calls = %#v, want one dispatch", calls)
+	}
+}
+
+func TestManagerCodexRateLimitContinuityUnrelatedAuthRemovalDoesNotBlockDispatch(t *testing.T) {
+	executor := &codexContinuityTestExecutor{failures: make(map[string]error)}
+	manager := newCodexContinuityManager(t, executor, []string{"auth-a", "auth-b"}, []string{"gpt-5"}, 2)
+	var once sync.Once
+	manager.continuityBeforeDispatchHook = func() {
+		once.Do(func() { manager.Remove(context.Background(), "auth-a") })
+	}
+	defer func() { manager.continuityBeforeDispatchHook = nil }()
+	opts := codexContinuityOptions("session-b")
+	opts.Metadata[cliproxyexecutor.PinnedAuthMetadataKey] = "auth-b"
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, opts)
+	if err != nil || string(resp.Payload) != "auth-b|gpt-5|session-b" {
+		t.Fatalf("Execute() response/error = %q/%v", resp.Payload, err)
+	}
+	if calls := executor.snapshot(); len(calls) != 1 || calls[0] != "auth-b|gpt-5|session-b" {
+		t.Fatalf("executor calls = %#v, want auth-b only", calls)
+	}
+}
+
+func TestCodexRateLimitContinuitySessionCloseRemovesLease(t *testing.T) {
+	store := newCodexRateLimitContinuityStore()
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	store.states[key] = &codexRateLimitContinuityState{
+		phase:               codexRateLimitContinuityFreshBlocked,
+		generation:          1,
+		establishedSessions: map[string]time.Time{"execution:one": time.Now().Add(time.Hour)},
+		inFlight:            map[string]int{"execution:one": 1},
+		canaryToken:         7,
+	}
+	store.activeAttempts[9] = codexRateLimitContinuityAttempt{
+		key: key, sessionID: "execution:one", generation: 1, canaryToken: 7, attemptToken: 9,
+	}
+	store.removeSession("execution:one")
+	store.mu.Lock()
+	state := store.states[key]
+	_, exists := state.establishedSessions["execution:one"]
+	inFlight := state.inFlight["execution:one"]
+	canaryToken := state.canaryToken
+	activeAttempts := len(store.activeAttempts)
+	store.mu.Unlock()
+	if exists || inFlight != 0 || canaryToken != 0 || activeAttempts != 0 {
+		t.Fatalf("CloseExecutionSession retained state: lease=%t in-flight=%d canary=%d active=%d", exists, inFlight, canaryToken, activeAttempts)
+	}
+}
+
+func TestCodexRateLimitContinuityStaleSuccessAndUsageLimitAreRecordOnly(t *testing.T) {
+	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
+	store := newCodexContinuityTestStore(clock)
+	cfg := codexContinuityTestPolicy(2)
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	store.states[key] = &codexRateLimitContinuityState{
+		phase:               codexRateLimitContinuityConfirmedCooldown,
+		confirmed:           true,
+		generation:          2,
+		establishedSessions: make(map[string]time.Time),
+	}
+	for _, result := range []struct {
+		name    string
+		success bool
+		reason  string
+	}{
+		{name: "success", success: true},
+		{name: "usage-limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit},
+	} {
+		t.Run(result.name, func(t *testing.T) {
+			attempt := codexRateLimitContinuityAttempt{key: key, sessionID: "execution:stale-" + result.name, generation: 1}
+			if got := store.observe(attempt, result.success, result.reason, cfg); got != codexRateLimitContinuityRecordOnly {
+				t.Fatalf("stale %s = %v, want record-only", result.name, got)
+			}
+		})
+	}
+}
+
+func TestCodexRateLimitContinuityStaleNonQuotaFailureStillMutatesAvailability(t *testing.T) {
+	executor := &codexContinuityTestExecutor{failures: make(map[string]error)}
+	manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-5"}, 2)
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	manager.codexRateLimitContinuity.states[key] = &codexRateLimitContinuityState{
+		phase:               codexRateLimitContinuityConfirmedCooldown,
+		confirmed:           true,
+		generation:          2,
+		establishedSessions: make(map[string]time.Time),
+	}
+	ctx := context.WithValue(context.Background(), codexRateLimitContinuityAttemptContextKey{}, codexRateLimitContinuityAttempt{
+		key: key, sessionID: "execution:stale-401", generation: 1,
+	})
+	manager.MarkResult(ctx, Result{AuthID: "auth-a", Provider: "codex", Model: "gpt-5", Success: false, Error: &Error{HTTPStatus: http.StatusUnauthorized, Message: "expired"}})
+	auth, _ := manager.GetByID("auth-a")
+	state := auth.ModelStates["gpt-5"]
+	if state == nil || state.NextRetryAfter.IsZero() || !state.Unavailable {
+		t.Fatalf("stale 401 did not mutate availability: %+v", state)
+	}
+}
+
+func TestCodexRateLimitContinuityStaleInvalidGrantStillMutatesAvailability(t *testing.T) {
+	executor := &codexContinuityTestExecutor{failures: make(map[string]error)}
+	manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-5"}, 2)
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	manager.codexRateLimitContinuity.states[key] = &codexRateLimitContinuityState{
+		phase:               codexRateLimitContinuityConfirmedCooldown,
+		confirmed:           true,
+		generation:          2,
+		establishedSessions: make(map[string]time.Time),
+	}
+	ctx := context.WithValue(context.Background(), codexRateLimitContinuityAttemptContextKey{}, codexRateLimitContinuityAttempt{
+		key: key, sessionID: "execution:stale-invalid-grant", generation: 1,
+	})
+	manager.MarkResult(ctx, Result{
+		AuthID: "auth-a", Provider: "codex", Model: "gpt-5", Success: false,
+		Error: &Error{HTTPStatus: http.StatusBadRequest, Code: "invalid_grant", Message: "invalid_grant"},
+	})
+	auth, _ := manager.GetByID("auth-a")
+	state := auth.ModelStates["gpt-5"]
+	if state == nil || state.NextRetryAfter.IsZero() || !state.Unavailable || !strings.Contains(strings.ToLower(state.StatusMessage), "invalid_grant") {
+		t.Fatalf("stale invalid_grant did not mutate availability: %+v", state)
+	}
+}
+
+func TestCodexRateLimitContinuityConfirmedRecoveryReopensAsSingleCanary(t *testing.T) {
+	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
+	store := newCodexContinuityTestStore(clock)
+	cfg := codexContinuityTestPolicy(2)
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	store.states[key] = &codexRateLimitContinuityState{
+		phase:      codexRateLimitContinuityConfirmedCooldown,
+		confirmed:  true,
+		generation: 4,
+		establishedSessions: map[string]time.Time{
+			"execution:old-one": clock.Now().Add(time.Hour),
+			"execution:old-two": clock.Now().Add(time.Hour),
+		},
+		inFlight: map[string]int{"execution:old-three": 1},
+	}
+	store.reopenConfirmed(key, 4)
+	store.mu.Lock()
+	state := store.states[key]
+	oldLeases := len(state.establishedSessions)
+	oldInflight := len(state.inFlight)
+	store.mu.Unlock()
+	if oldLeases != 0 || oldInflight != 0 {
+		t.Fatalf("confirmed recovery retained stale continuity evidence: leases=%d in-flight=%d", oldLeases, oldInflight)
+	}
+	first, allowed := store.begin(key, "execution:recover-1", cfg)
+	if !allowed || first.canaryToken == 0 {
+		t.Fatalf("recovery attempt = %+v allowed=%t, want one canary", first, allowed)
+	}
+	if _, allowed := store.begin(key, "execution:recover-2", cfg); allowed {
+		t.Fatal("confirmed recovery admitted a second fresh request")
+	}
+}
+
+func TestCodexRateLimitContinuityDispatchRecheckRejectsConfirmedBarrier(t *testing.T) {
+	store := newCodexRateLimitContinuityStore()
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	attempt := codexRateLimitContinuityAttempt{key: key, sessionID: "execution:barrier", generation: 1}
+	store.states[key] = &codexRateLimitContinuityState{
+		phase:               codexRateLimitContinuityConfirmedCooldown,
+		confirmed:           true,
+		generation:          2,
+		establishedSessions: make(map[string]time.Time),
+	}
+	if allowed, _ := store.dispatchAllowed(attempt); allowed {
+		t.Fatal("dispatch recheck admitted request after confirmation")
+	}
+}
+
+func TestCodexRateLimitContinuityDispatchRecheckReleasesInFlightAttempt(t *testing.T) {
+	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
+	store := newCodexContinuityTestStore(clock)
+	cfg := codexContinuityTestPolicy(2)
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	attempt, allowed := store.begin(key, "execution:recheck", cfg)
+	if !allowed {
+		t.Fatal("healthy begin rejected")
+	}
+	store.mu.Lock()
+	state := store.states[key]
+	setCodexRateLimitContinuityPhase(state, codexRateLimitContinuityConfirmedCooldown)
+	state.generation++
+	store.mu.Unlock()
+	if allowed, confirmed := store.dispatchAllowed(attempt); allowed || !confirmed {
+		t.Fatalf("dispatch disposition = allowed=%t confirmed=%t, want rejected confirmed", allowed, confirmed)
+	}
+	store.abandon(attempt, cfg)
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if got := store.states[key].inFlight["execution:recheck"]; got != 0 {
+		t.Fatalf("in-flight after rejected dispatch = %d, want 0", got)
+	}
+	if got := len(store.activeAttempts); got != 0 {
+		t.Fatalf("active attempts after rejected dispatch = %d, want 0", got)
+	}
+}
+
+func TestManagerCodexRateLimitContinuityConfirmationBarrierBlocksDispatchAndStaleSuccess(t *testing.T) {
+	executor := &codexContinuityTestExecutor{failures: make(map[string]error)}
+	manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-5"}, 2)
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	manager.codexRateLimitContinuity.states[key] = &codexRateLimitContinuityState{
+		phase: codexRateLimitContinuityFreshBlocked, suspect: true, generation: 1,
+		establishedSessions: map[string]time.Time{"execution:established": time.Now().Add(time.Hour)},
+	}
+	confirmCtx := context.WithValue(context.Background(), codexRateLimitContinuityAttemptContextKey{}, codexRateLimitContinuityAttempt{
+		key: key, sessionID: "execution:established", generation: 1, established: true,
+	})
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	manager.continuityTransitionHook = func() {
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
+		<-release
+	}
+	marked := make(chan struct{})
+	go func() {
+		defer close(marked)
+		manager.MarkResult(confirmCtx, Result{
+			AuthID: "auth-a", Provider: "codex", Model: "gpt-5", Success: false,
+			Error:               &Error{HTTPStatus: http.StatusTooManyRequests, Message: "limit"},
+			ModelFallbackReason: internalconfig.CodexModelFallbackTriggerUsageLimit,
+		})
+	}()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("confirmation did not reach manager-lock barrier")
+	}
+	competingDone := make(chan error, 1)
+	go func() {
+		_, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions("racing-fresh"))
+		competingDone <- err
+	}()
+	select {
+	case err := <-competingDone:
+		t.Fatalf("competing Execute returned before confirmation barrier release: %v", err)
+	case <-time.After(100 * time.Millisecond):
+		if got := len(executor.snapshot()); got != 0 {
+			t.Fatalf("competing request dispatched during confirmation barrier: %#v", executor.snapshot())
+		}
+	}
+	close(release)
+	<-marked
+	if err := <-competingDone; err == nil {
+		t.Fatal("competing Execute unexpectedly succeeded after confirmed cooldown")
+	}
+	if got := len(executor.snapshot()); got != 0 {
+		t.Fatalf("competing request dispatched after confirmed cooldown: %#v", executor.snapshot())
+	}
+	manager.continuityTransitionHook = nil
+	manager.MarkResult(confirmCtx, Result{AuthID: "auth-a", Provider: "codex", Model: "gpt-5", Success: true})
+	auth, _ := manager.GetByID("auth-a")
+	state := auth.ModelStates["gpt-5"]
+	if state == nil || !state.Quota.Exceeded || state.NextRetryAfter.IsZero() {
+		t.Fatalf("stale success cleared confirmed cooldown: %+v", state)
+	}
+}
+
+func TestCodexRateLimitContinuityPrunesOnlyAtNextLeaseExpiry(t *testing.T) {
+	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
+	store := newCodexContinuityTestStore(clock)
+	cfg := codexContinuityTestPolicy(2)
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	firstExpiry := clock.Now().Add(time.Hour)
+	sessions := make(map[string]time.Time, 2048)
+	for i := 0; i < 2048; i++ {
+		sessions["execution:lease-"+time.Unix(int64(i), 0).Format(time.RFC3339Nano)] = firstExpiry.Add(time.Duration(i) * time.Second)
+	}
+	store.states[key] = &codexRateLimitContinuityState{
+		establishedSessions: sessions,
+		nextLeaseExpiry:     firstExpiry,
+	}
+	for i := 0; i < 32; i++ {
+		store.candidateAllowed(key, "execution:fresh", cfg)
+	}
+	store.mu.Lock()
+	scans := store.states[key].leasePruneScans
+	store.mu.Unlock()
+	if scans != 0 {
+		t.Fatalf("lease pruning scanned before next expiry %d times", scans)
+	}
+	clock.Advance(time.Hour + 500*time.Millisecond)
+	store.candidateAllowed(key, "execution:fresh", cfg)
+	store.mu.Lock()
+	state := store.states[key]
+	scans = state.leasePruneScans
+	remaining := len(state.establishedSessions)
+	nextExpiry := state.nextLeaseExpiry
+	store.mu.Unlock()
+	if scans != 1 {
+		t.Fatalf("lease pruning scans after expiry = %d, want 1", scans)
+	}
+	if remaining != 2047 || !nextExpiry.Equal(firstExpiry.Add(time.Second)) {
+		t.Fatalf("lease pruning result: remaining=%d next=%v", remaining, nextExpiry)
+	}
+}
+
+func TestManagerCodexRateLimitContinuityCloseLoadAndAuthRemovalClearState(t *testing.T) {
+	store := &countingStore{}
+	manager := NewManager(store, NewSessionAffinitySelector(&FillFirstSelector{}), nil)
+	t.Cleanup(func() {
+		if selector, ok := manager.selector.(*SessionAffinitySelector); ok {
+			selector.Stop()
+		}
+	})
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	putState := func() {
+		manager.codexRateLimitContinuity.mu.Lock()
+		manager.codexRateLimitContinuity.states[key] = &codexRateLimitContinuityState{establishedSessions: map[string]time.Time{"execution:close": time.Now().Add(time.Hour)}}
+		manager.codexRateLimitContinuity.mu.Unlock()
+	}
+	putState()
+	manager.CloseExecutionSession("close")
+	manager.codexRateLimitContinuity.mu.Lock()
+	_, leased := manager.codexRateLimitContinuity.states[key].establishedSessions["execution:close"]
+	manager.codexRateLimitContinuity.mu.Unlock()
+	if leased {
+		t.Fatal("CloseExecutionSession did not clear continuity lease")
+	}
+	putState()
+	if err := manager.Load(context.Background()); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	manager.codexRateLimitContinuity.mu.Lock()
+	count := len(manager.codexRateLimitContinuity.states)
+	manager.codexRateLimitContinuity.mu.Unlock()
+	if count != 0 {
+		t.Fatalf("Load retained %d continuity states", count)
+	}
+	putState()
+	manager.invalidateSessionAffinity("auth-a")
+	manager.codexRateLimitContinuity.mu.Lock()
+	count = len(manager.codexRateLimitContinuity.states)
+	manager.codexRateLimitContinuity.mu.Unlock()
+	if count != 0 {
+		t.Fatalf("auth removal retained %d continuity states", count)
 	}
 }
 
@@ -261,7 +1252,10 @@ type codexContinuityTestExecutor struct {
 func (e *codexContinuityTestExecutor) Identifier() string { return "codex" }
 
 func codexContinuitySession(opts cliproxyexecutor.Options) string {
-	return contextStringValue(opts.Metadata[cliproxyexecutor.ExecutionSessionMetadataKey])
+	if sessionID := contextStringValue(opts.Metadata[cliproxyexecutor.ExecutionSessionMetadataKey]); sessionID != "" {
+		return sessionID
+	}
+	return strings.TrimSpace(gjson.GetBytes(opts.OriginalRequest, "conversation_id").String())
 }
 
 func (e *codexContinuityTestExecutor) callKey(auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) string {
@@ -402,6 +1396,10 @@ func codexContinuityOptions(sessionID string) cliproxyexecutor.Options {
 	return cliproxyexecutor.Options{Metadata: metadata}
 }
 
+func codexContinuityConversationOptions(conversationID string) cliproxyexecutor.Options {
+	return cliproxyexecutor.Options{OriginalRequest: []byte(`{"conversation_id":"` + conversationID + `"}`)}
+}
+
 func TestManagerCodexRateLimitContinuityKeepsEstablishedSessionAndExcludesFresh(t *testing.T) {
 	usageLimit := &codexFallbackTestError{message: "usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit}
 	executor := &codexContinuityTestExecutor{failures: map[string]error{
@@ -438,6 +1436,56 @@ func TestManagerCodexRateLimitContinuityKeepsEstablishedSessionAndExcludesFresh(
 	calls = executor.snapshot()[before:]
 	if len(calls) != 1 || calls[0] != "auth-a|gpt-5|established-a" {
 		t.Fatalf("established calls = %#v, want sticky auth-a", calls)
+	}
+}
+
+func TestManagerCodexRateLimitContinuityRepeatedCanaryFailuresPreserveEstablishedSession(t *testing.T) {
+	usageLimit := &codexContinuityUsageLimitError{}
+	executor := &codexContinuityTestExecutor{failures: map[string]error{
+		"auth-a|gpt-5|fresh-initial": usageLimit,
+		"auth-a|gpt-5|canary-0":      usageLimit,
+		"auth-a|gpt-5|canary-1":      usageLimit,
+		"auth-a|gpt-5|canary-2":      usageLimit,
+	}}
+	manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-5"}, 2)
+	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
+	manager.codexRateLimitContinuity.now = clock.Now
+
+	if _, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions("established")); err != nil {
+		t.Fatalf("establish Execute() error = %v", err)
+	}
+	if _, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions("fresh-initial")); err == nil {
+		t.Fatal("initial fresh usage-limit error = nil")
+	}
+
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	for i := 0; i < 3; i++ {
+		clock.Advance(11 * time.Second)
+		canarySession := "canary-" + string(rune('0'+i))
+		if _, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions(canarySession)); err == nil {
+			t.Fatalf("canary %d usage-limit error = nil", i)
+		}
+
+		auth, _ := manager.GetByID("auth-a")
+		if modelState := auth.ModelStates["gpt-5"]; modelState != nil && (modelState.Quota.Exceeded || !modelState.NextRetryAfter.IsZero()) {
+			t.Fatalf("canary %d wrote formal cooldown: %+v", i, modelState)
+		}
+		manager.codexRateLimitContinuity.mu.Lock()
+		state := manager.codexRateLimitContinuity.states[key]
+		phase := codexRateLimitContinuityHealthy
+		lease := time.Time{}
+		if state != nil {
+			phase = state.phase
+			lease = state.establishedSessions["execution:established"]
+		}
+		manager.codexRateLimitContinuity.mu.Unlock()
+		if state == nil || phase != codexRateLimitContinuityFreshBlocked || lease.IsZero() {
+			t.Fatalf("canary %d state = %+v lease=%v, want FreshBlocked with incumbent lease", i, state, lease)
+		}
+
+		if _, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions("established")); err != nil {
+			t.Fatalf("established Execute() after canary %d error = %v", i, err)
+		}
 	}
 }
 
@@ -523,6 +1571,52 @@ func TestManagerCodexRateLimitContinuityStaleSuccessDoesNotClearConfirmedCooldow
 	state := updated.ModelStates["gpt-5"]
 	if state == nil || !state.Quota.Exceeded || !state.Unavailable {
 		t.Fatalf("stale success cleared cooldown: %+v", state)
+	}
+}
+
+func TestManagerCodexRateLimitContinuityStaleUsageLimitDoesNotIncreaseBackoff(t *testing.T) {
+	executor := &codexContinuityTestExecutor{failures: make(map[string]error)}
+	manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-5"}, 2)
+	now := time.Now()
+	deadline := now.Add(time.Minute)
+	manager.mu.Lock()
+	authA := manager.auths["auth-a"]
+	authA.ModelStates = map[string]*ModelState{
+		"gpt-5": {
+			Status:         StatusError,
+			Unavailable:    true,
+			NextRetryAfter: deadline,
+			StatusMessage:  "quota",
+			Quota:          QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: deadline, BackoffLevel: 1},
+		},
+	}
+	updateAggregatedAvailability(authA, now)
+	manager.mu.Unlock()
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	manager.codexRateLimitContinuity.states[key] = &codexRateLimitContinuityState{
+		phase:               codexRateLimitContinuityConfirmedCooldown,
+		confirmed:           true,
+		generation:          2,
+		establishedSessions: make(map[string]time.Time),
+	}
+	staleAttempt := codexRateLimitContinuityAttempt{
+		key:         key,
+		sessionID:   "execution:established",
+		generation:  1,
+		established: true,
+	}
+	ctx := context.WithValue(context.Background(), codexRateLimitContinuityAttemptContextKey{}, staleAttempt)
+	retryAfter := 10 * time.Minute
+	manager.MarkResult(ctx, Result{
+		AuthID: "auth-a", Provider: "codex", Model: "gpt-5", Success: false,
+		Error:               &Error{HTTPStatus: http.StatusTooManyRequests, Message: "stale usage limit"},
+		RetryAfter:          &retryAfter,
+		ModelFallbackReason: internalconfig.CodexModelFallbackTriggerUsageLimit,
+	})
+	updated, _ := manager.GetByID("auth-a")
+	state := updated.ModelStates["gpt-5"]
+	if state == nil || state.Quota.BackoffLevel != 1 || !state.NextRetryAfter.Equal(deadline) || !state.Quota.NextRecoverAt.Equal(deadline) {
+		t.Fatalf("stale usage-limit changed cooldown: %+v", state)
 	}
 }
 
@@ -620,7 +1714,7 @@ func TestManagerCodexRateLimitContinuityPendingFreshSessionUsesModelFallback(t *
 		observeUntil:        time.Now().Add(time.Minute),
 		establishedSessions: make(map[string]time.Time),
 	}
-	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, codexContinuityOptions("fresh"))
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, codexContinuityConversationOptions("fresh"))
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -664,7 +1758,7 @@ func TestManagerCodexRateLimitContinuityConfirmedCooldownUsesModelFallback(t *te
 		generation:          2,
 		establishedSessions: make(map[string]time.Time),
 	}
-	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, codexContinuityOptions("fresh"))
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, codexContinuityConversationOptions("fresh"))
 	if err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
@@ -798,5 +1892,59 @@ func TestManagerCodexRateLimitContinuityLongStreamIsNotCancelledByFresh429(t *te
 	second, ok := <-stream.Chunks
 	if !ok || second.Err != nil || string(second.Payload) != "second" {
 		t.Fatalf("second chunk = %+v ok=%t", second, ok)
+	}
+}
+
+func TestManagerCodexRateLimitContinuityEstablishedStreamTerminalUsageLimitPreservesRetryAfter(t *testing.T) {
+	retryAfter := 90 * time.Second
+	usageLimit := &codexContinuityUsageLimitError{retryAfter: retryAfter}
+	executor := &codexContinuityTestExecutor{
+		failures: map[string]error{"auth-a|gpt-5|fresh": usageLimit},
+		streamPayloads: map[string][]cliproxyexecutor.StreamChunk{
+			"auth-a|gpt-5|established": {
+				{Payload: []byte("partial")},
+				{Err: usageLimit},
+			},
+		},
+	}
+	manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-5"}, 2)
+	if _, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions("established")); err != nil {
+		t.Fatalf("establish Execute() error = %v", err)
+	}
+	if _, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions("fresh")); err == nil {
+		t.Fatal("fresh usage-limit error = nil")
+	}
+
+	startedAt := time.Now()
+	stream, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions("established"))
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	first, ok := <-stream.Chunks
+	if !ok || first.Err != nil || string(first.Payload) != "partial" {
+		t.Fatalf("first chunk = %+v ok=%t", first, ok)
+	}
+	terminal, ok := <-stream.Chunks
+	if !ok || terminal.Err == nil {
+		t.Fatalf("terminal chunk = %+v ok=%t", terminal, ok)
+	}
+	if got := retryAfterFromError(terminal.Err); got == nil || *got != retryAfter {
+		t.Fatalf("terminal RetryAfter = %v, want %v", got, retryAfter)
+	}
+	if _, ok := <-stream.Chunks; ok {
+		t.Fatal("stream remained open after terminal error")
+	}
+
+	auth, _ := manager.GetByID("auth-a")
+	state := auth.ModelStates["gpt-5"]
+	if state == nil || !state.Quota.Exceeded || state.NextRetryAfter.IsZero() || state.Quota.NextRecoverAt.IsZero() {
+		t.Fatalf("formal cooldown state = %+v", state)
+	}
+	if !state.NextRetryAfter.Equal(state.Quota.NextRecoverAt) {
+		t.Fatalf("retry time mismatch: model=%v quota=%v", state.NextRetryAfter, state.Quota.NextRecoverAt)
+	}
+	remaining := state.NextRetryAfter.Sub(startedAt)
+	if remaining < retryAfter-2*time.Second || remaining > retryAfter+2*time.Second {
+		t.Fatalf("formal cooldown remaining = %v, want about %v", remaining, retryAfter)
 	}
 }

--- a/sdk/cliproxy/auth/codex_rate_limit_continuity_test.go
+++ b/sdk/cliproxy/auth/codex_rate_limit_continuity_test.go
@@ -1,0 +1,802 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type codexContinuityTestClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *codexContinuityTestClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *codexContinuityTestClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(d)
+	c.mu.Unlock()
+}
+
+func codexContinuityTestPolicy(threshold int) internalconfig.EffectiveCodexRateLimitContinuityConfig {
+	if threshold <= 0 {
+		threshold = 2
+	}
+	return internalconfig.EffectiveCodexRateLimitContinuityConfig{
+		Enabled:                      true,
+		ObservationWindowSeconds:     10,
+		EstablishedSuccessThreshold:  threshold,
+		EstablishedSessionTTLSeconds: 3600,
+	}
+}
+
+func newCodexContinuityTestStore(clock *codexContinuityTestClock) *codexRateLimitContinuityStore {
+	store := newCodexRateLimitContinuityStore()
+	store.now = clock.Now
+	return store
+}
+
+func TestCodexRateLimitContinuityFirstFreshUsageLimitBecomesSuspect(t *testing.T) {
+	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
+	store := newCodexContinuityTestStore(clock)
+	cfg := codexContinuityTestPolicy(2)
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	attempt, allowed := store.begin(key, "execution:fresh", cfg)
+	if !allowed {
+		t.Fatal("begin() denied healthy auth")
+	}
+	if got := store.observe(attempt, false, internalconfig.CodexModelFallbackTriggerUsageLimit, cfg); got != codexRateLimitContinuityObserveOnly {
+		t.Fatalf("observe() = %v, want observe-only", got)
+	}
+	if store.candidateAllowed(key, "execution:another-fresh", cfg) {
+		t.Fatal("fresh session was allowed before observation window")
+	}
+	store.mu.Lock()
+	state := store.states[key]
+	store.mu.Unlock()
+	if state == nil || !state.suspect {
+		t.Fatalf("state = %+v, want suspect", state)
+	}
+}
+
+func TestCodexRateLimitContinuityEstablishedSessionObservesThenCanaryRecovers(t *testing.T) {
+	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
+	store := newCodexContinuityTestStore(clock)
+	cfg := codexContinuityTestPolicy(1)
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+
+	established, _ := store.begin(key, "execution:established", cfg)
+	store.observe(established, true, "", cfg)
+	fresh, _ := store.begin(key, "execution:fresh", cfg)
+	store.observe(fresh, false, internalconfig.CodexModelFallbackTriggerUsageLimit, cfg)
+
+	established, allowed := store.begin(key, "execution:established", cfg)
+	if !allowed || !established.established {
+		t.Fatalf("established begin = %+v allowed=%t", established, allowed)
+	}
+	store.observe(established, true, "", cfg)
+	canary, allowed := store.begin(key, "execution:canary", cfg)
+	if !allowed || canary.canaryToken == 0 {
+		t.Fatalf("canary begin = %+v allowed=%t", canary, allowed)
+	}
+	store.observe(canary, true, "", cfg)
+	if !store.candidateAllowed(key, "execution:new", cfg) {
+		t.Fatal("healthy state did not allow a new session after canary success")
+	}
+}
+
+func TestCodexRateLimitContinuityEstablishedOrCanaryUsageLimitConfirmsCooldown(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		canary bool
+	}{
+		{name: "established"},
+		{name: "canary", canary: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
+			store := newCodexContinuityTestStore(clock)
+			cfg := codexContinuityTestPolicy(2)
+			key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+			established, _ := store.begin(key, "execution:established", cfg)
+			store.observe(established, true, "", cfg)
+			fresh, _ := store.begin(key, "execution:fresh", cfg)
+			store.observe(fresh, false, internalconfig.CodexModelFallbackTriggerUsageLimit, cfg)
+
+			var probe codexRateLimitContinuityAttempt
+			if tc.canary {
+				clock.Advance(11 * time.Second)
+				probe, _ = store.begin(key, "execution:canary", cfg)
+				if probe.canaryToken == 0 {
+					t.Fatal("canary token = 0")
+				}
+			} else {
+				probe, _ = store.begin(key, "execution:established", cfg)
+			}
+			if got := store.observe(probe, false, internalconfig.CodexModelFallbackTriggerUsageLimit, cfg); got != codexRateLimitContinuityNormal {
+				t.Fatalf("observe() = %v, want normal cooldown", got)
+			}
+			store.mu.Lock()
+			state := store.states[key]
+			store.mu.Unlock()
+			if state == nil || !state.confirmed || state.generation <= probe.generation {
+				t.Fatalf("confirmed state = %+v, probe generation=%d", state, probe.generation)
+			}
+		})
+	}
+}
+
+func TestCodexRateLimitContinuityConfirmedGenerationRejectsStaleResult(t *testing.T) {
+	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
+	store := newCodexContinuityTestStore(clock)
+	cfg := codexContinuityTestPolicy(2)
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	established, _ := store.begin(key, "execution:established", cfg)
+	store.observe(established, true, "", cfg)
+	fresh, _ := store.begin(key, "execution:fresh", cfg)
+	store.observe(fresh, false, internalconfig.CodexModelFallbackTriggerUsageLimit, cfg)
+	staleEstablished, _ := store.begin(key, "execution:established", cfg)
+	clock.Advance(11 * time.Second)
+	canary, _ := store.begin(key, "execution:canary", cfg)
+	store.observe(canary, false, internalconfig.CodexModelFallbackTriggerUsageLimit, cfg)
+	if got := store.observe(staleEstablished, true, "", cfg); got != codexRateLimitContinuityRecordOnly {
+		t.Fatalf("stale observe() = %v, want record-only", got)
+	}
+}
+
+func TestCodexRateLimitContinuityRecoveredGenerationRejectsStaleFailure(t *testing.T) {
+	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
+	store := newCodexContinuityTestStore(clock)
+	cfg := codexContinuityTestPolicy(2)
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	staleFresh, _ := store.begin(key, "execution:stale", cfg)
+	failingFresh, _ := store.begin(key, "execution:failing", cfg)
+	store.observe(failingFresh, false, internalconfig.CodexModelFallbackTriggerUsageLimit, cfg)
+	clock.Advance(11 * time.Second)
+	canary, _ := store.begin(key, "execution:canary", cfg)
+	store.observe(canary, true, "", cfg)
+	if got := store.observe(staleFresh, false, internalconfig.CodexModelFallbackTriggerUsageLimit, cfg); got != codexRateLimitContinuityRecordOnly {
+		t.Fatalf("stale failure observe() = %v, want record-only", got)
+	}
+	store.mu.Lock()
+	state := store.states[key]
+	store.mu.Unlock()
+	if state == nil || state.suspect || state.confirmed {
+		t.Fatalf("recovered state = %+v", state)
+	}
+}
+
+func TestCodexRateLimitContinuityOnlyOneConcurrentCanary(t *testing.T) {
+	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
+	store := newCodexContinuityTestStore(clock)
+	cfg := codexContinuityTestPolicy(2)
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	store.states[key] = &codexRateLimitContinuityState{
+		suspect:             true,
+		observeUntil:        clock.Now().Add(-time.Second),
+		establishedSessions: make(map[string]time.Time),
+	}
+
+	var allowed atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			attempt, ok := store.begin(key, "execution:canary-"+time.Unix(int64(index), 0).Format(time.RFC3339), cfg)
+			if ok && attempt.canaryToken != 0 {
+				allowed.Add(1)
+			}
+		}(i)
+	}
+	wg.Wait()
+	if got := allowed.Load(); got != 1 {
+		t.Fatalf("allowed canaries = %d, want 1", got)
+	}
+}
+
+func TestCodexRateLimitContinuityAbandonedCanaryRequiresNewObservationWindow(t *testing.T) {
+	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
+	store := newCodexContinuityTestStore(clock)
+	cfg := codexContinuityTestPolicy(2)
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	store.states[key] = &codexRateLimitContinuityState{
+		suspect:             true,
+		generation:          1,
+		observeUntil:        clock.Now().Add(-time.Second),
+		establishedSessions: make(map[string]time.Time),
+	}
+	canary, allowed := store.begin(key, "execution:canary", cfg)
+	if !allowed || canary.canaryToken == 0 {
+		t.Fatalf("canary = %+v allowed=%t", canary, allowed)
+	}
+	store.abandon(canary, cfg)
+	if store.candidateAllowed(key, "execution:next", cfg) {
+		t.Fatal("next canary was allowed immediately after abandonment")
+	}
+	clock.Advance(11 * time.Second)
+	if !store.candidateAllowed(key, "execution:next", cfg) {
+		t.Fatal("next canary was not allowed after the new observation window")
+	}
+}
+
+func TestCodexRateLimitContinuitySameSessionDifferentModelIsFresh(t *testing.T) {
+	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
+	store := newCodexContinuityTestStore(clock)
+	cfg := codexContinuityTestPolicy(2)
+	modelA := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-a"}
+	modelB := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-b"}
+	attemptA, _ := store.begin(modelA, "execution:same", cfg)
+	store.observe(attemptA, true, "", cfg)
+	attemptB, allowed := store.begin(modelB, "execution:same", cfg)
+	if !allowed || attemptB.established {
+		t.Fatalf("model B attempt = %+v allowed=%t, want fresh", attemptB, allowed)
+	}
+}
+
+type codexContinuityTestExecutor struct {
+	mu              sync.Mutex
+	calls           []string
+	failures        map[string]error
+	streamPayloads  map[string][]cliproxyexecutor.StreamChunk
+	streamStarted   chan struct{}
+	streamRelease   chan struct{}
+	blockExecuteKey string
+	executeStarted  chan struct{}
+	executeRelease  chan struct{}
+}
+
+func (e *codexContinuityTestExecutor) Identifier() string { return "codex" }
+
+func codexContinuitySession(opts cliproxyexecutor.Options) string {
+	return contextStringValue(opts.Metadata[cliproxyexecutor.ExecutionSessionMetadataKey])
+}
+
+func (e *codexContinuityTestExecutor) callKey(auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) string {
+	authID := ""
+	if auth != nil {
+		authID = auth.ID
+	}
+	return authID + "|" + req.Model + "|" + codexContinuitySession(opts)
+}
+
+func (e *codexContinuityTestExecutor) record(key string) {
+	e.mu.Lock()
+	e.calls = append(e.calls, key)
+	e.mu.Unlock()
+}
+
+func (e *codexContinuityTestExecutor) Execute(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	key := e.callKey(auth, req, opts)
+	e.record(key)
+	if key == e.blockExecuteKey && e.executeRelease != nil {
+		if e.executeStarted != nil {
+			select {
+			case e.executeStarted <- struct{}{}:
+			default:
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return cliproxyexecutor.Response{}, ctx.Err()
+		case <-e.executeRelease:
+		}
+	}
+	if err := e.failures[key]; err != nil {
+		return cliproxyexecutor.Response{}, err
+	}
+	return cliproxyexecutor.Response{Payload: []byte(key)}, nil
+}
+
+func (e *codexContinuityTestExecutor) ExecuteStream(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	key := e.callKey(auth, req, opts)
+	e.record(key)
+	if chunks, ok := e.streamPayloads[key]; ok {
+		out := make(chan cliproxyexecutor.StreamChunk)
+		go func() {
+			defer close(out)
+			if e.streamStarted != nil {
+				select {
+				case e.streamStarted <- struct{}{}:
+				default:
+				}
+			}
+			for index, chunk := range chunks {
+				if index == 1 && e.streamRelease != nil {
+					select {
+					case <-ctx.Done():
+						return
+					case <-e.streamRelease:
+					}
+				}
+				select {
+				case <-ctx.Done():
+					return
+				case out <- chunk:
+				}
+			}
+		}()
+		return &cliproxyexecutor.StreamResult{Chunks: out}, nil
+	}
+	ch := make(chan cliproxyexecutor.StreamChunk, 1)
+	if err := e.failures[key]; err != nil {
+		ch <- cliproxyexecutor.StreamChunk{Err: err}
+	} else {
+		ch <- cliproxyexecutor.StreamChunk{Payload: []byte(key)}
+	}
+	close(ch)
+	return &cliproxyexecutor.StreamResult{Chunks: ch}, nil
+}
+
+func (e *codexContinuityTestExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (e *codexContinuityTestExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+
+func (e *codexContinuityTestExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func (e *codexContinuityTestExecutor) snapshot() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]string(nil), e.calls...)
+}
+
+func newCodexContinuityManager(t *testing.T, executor *codexContinuityTestExecutor, authIDs, models []string, threshold int) *Manager {
+	t.Helper()
+	manager := NewManager(nil, NewSessionAffinitySelector(&FillFirstSelector{}), nil)
+	manager.SetRetryConfig(0, 0, 0)
+	manager.SetConfig(&internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{SessionAffinity: true},
+		Codex: internalconfig.CodexConfig{RateLimitContinuity: internalconfig.CodexRateLimitContinuityConfig{
+			Enabled:                      true,
+			ObservationWindowSeconds:     10,
+			EstablishedSuccessThreshold:  threshold,
+			EstablishedSessionTTLSeconds: 3600,
+		}},
+	})
+	manager.RegisterExecutor(executor)
+	reg := registry.GetGlobalRegistry()
+	for _, authID := range authIDs {
+		infos := make([]*registry.ModelInfo, 0, len(models))
+		for _, model := range models {
+			infos = append(infos, &registry.ModelInfo{ID: model})
+		}
+		reg.RegisterClient(authID, "codex", infos)
+		if _, err := manager.Register(context.Background(), &Auth{ID: authID, Provider: "codex", Status: StatusActive}); err != nil {
+			t.Fatalf("Register(%s) error = %v", authID, err)
+		}
+	}
+	t.Cleanup(func() {
+		for _, authID := range authIDs {
+			reg.UnregisterClient(authID)
+		}
+		if selector, ok := manager.selector.(*SessionAffinitySelector); ok {
+			selector.Stop()
+		}
+	})
+	return manager
+}
+
+func codexContinuityOptions(sessionID string) cliproxyexecutor.Options {
+	metadata := map[string]any{}
+	if sessionID != "" {
+		metadata[cliproxyexecutor.ExecutionSessionMetadataKey] = sessionID
+	}
+	return cliproxyexecutor.Options{Metadata: metadata}
+}
+
+func TestManagerCodexRateLimitContinuityKeepsEstablishedSessionAndExcludesFresh(t *testing.T) {
+	usageLimit := &codexFallbackTestError{message: "usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit}
+	executor := &codexContinuityTestExecutor{failures: map[string]error{
+		"auth-a|gpt-5|fresh-b": usageLimit,
+	}}
+	manager := newCodexContinuityManager(t, executor, []string{"auth-a", "auth-b"}, []string{"gpt-5"}, 2)
+
+	if _, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions("established-a")); err != nil {
+		t.Fatalf("establish Execute() error = %v", err)
+	}
+	if _, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions("fresh-b")); err != nil {
+		t.Fatalf("fresh-b Execute() error = %v", err)
+	}
+	authA, _ := manager.GetByID("auth-a")
+	if state := authA.ModelStates["gpt-5"]; state != nil && state.Quota.Exceeded {
+		t.Fatalf("auth-a entered formal cooldown: %+v", state)
+	}
+	manager.mu.Lock()
+	manager.auths["auth-a"].Attributes = map[string]string{"priority": "0"}
+	manager.auths["auth-b"].Attributes = map[string]string{"priority": "10"}
+	manager.mu.Unlock()
+	before := len(executor.snapshot())
+	if _, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions("fresh-c")); err != nil {
+		t.Fatalf("fresh-c Execute() error = %v", err)
+	}
+	calls := executor.snapshot()[before:]
+	if len(calls) != 1 || calls[0] != "auth-b|gpt-5|fresh-c" {
+		t.Fatalf("fresh-c calls = %#v, want auth-b only", calls)
+	}
+	before = len(executor.snapshot())
+	if _, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions("established-a")); err != nil {
+		t.Fatalf("established Execute() error = %v", err)
+	}
+	calls = executor.snapshot()[before:]
+	if len(calls) != 1 || calls[0] != "auth-a|gpt-5|established-a" {
+		t.Fatalf("established calls = %#v, want sticky auth-a", calls)
+	}
+}
+
+func TestManagerCodexRateLimitContinuityEstablishedFailureConfirmsCooldown(t *testing.T) {
+	usageLimit := &codexFallbackTestError{message: "usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit}
+	executor := &codexContinuityTestExecutor{failures: make(map[string]error)}
+	manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-5"}, 2)
+	if _, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions("established")); err != nil {
+		t.Fatalf("establish error = %v", err)
+	}
+	executor.failures["auth-a|gpt-5|fresh"] = usageLimit
+	_, _ = manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions("fresh"))
+	executor.failures["auth-a|gpt-5|established"] = usageLimit
+	_, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions("established"))
+	if err == nil {
+		t.Fatal("established failure error = nil")
+	}
+	authA, _ := manager.GetByID("auth-a")
+	state := authA.ModelStates["gpt-5"]
+	if state == nil || !state.Quota.Exceeded || state.Quota.BackoffLevel != 1 {
+		t.Fatalf("confirmed state = %+v", state)
+	}
+}
+
+func TestManagerCodexRateLimitContinuityCanaryFailureBacksOffOnce(t *testing.T) {
+	usageLimit := &codexFallbackTestError{message: "usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit}
+	executor := &codexContinuityTestExecutor{failures: map[string]error{"auth-a|gpt-5|canary": usageLimit}}
+	manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-5"}, 2)
+	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
+	manager.codexRateLimitContinuity.now = clock.Now
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	manager.codexRateLimitContinuity.states[key] = &codexRateLimitContinuityState{
+		suspect:             true,
+		observeUntil:        clock.Now().Add(-time.Second),
+		establishedSessions: make(map[string]time.Time),
+	}
+	_, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions("canary"))
+	if err == nil {
+		t.Fatal("canary error = nil")
+	}
+	authA, _ := manager.GetByID("auth-a")
+	state := authA.ModelStates["gpt-5"]
+	if state == nil || state.Quota.BackoffLevel != 1 {
+		t.Fatalf("canary state = %+v, want backoff level 1", state)
+	}
+	if got := len(executor.snapshot()); got != 1 {
+		t.Fatalf("executor calls = %d, want 1", got)
+	}
+}
+
+func TestManagerCodexRateLimitContinuityStaleSuccessDoesNotClearConfirmedCooldown(t *testing.T) {
+	executor := &codexContinuityTestExecutor{failures: make(map[string]error)}
+	manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-5"}, 2)
+	now := time.Now()
+	manager.mu.Lock()
+	authA := manager.auths["auth-a"]
+	authA.ModelStates = map[string]*ModelState{
+		"gpt-5": {
+			Status:         StatusError,
+			Unavailable:    true,
+			NextRetryAfter: now.Add(time.Minute),
+			StatusMessage:  "quota",
+			Quota:          QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: now.Add(time.Minute), BackoffLevel: 1},
+		},
+	}
+	updateAggregatedAvailability(authA, now)
+	manager.mu.Unlock()
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	manager.codexRateLimitContinuity.states[key] = &codexRateLimitContinuityState{
+		confirmed:           true,
+		generation:          2,
+		establishedSessions: make(map[string]time.Time),
+	}
+	staleAttempt := codexRateLimitContinuityAttempt{
+		key:         key,
+		sessionID:   "execution:established",
+		generation:  1,
+		established: true,
+	}
+	ctx := context.WithValue(context.Background(), codexRateLimitContinuityAttemptContextKey{}, staleAttempt)
+	manager.MarkResult(ctx, Result{AuthID: "auth-a", Provider: "codex", Model: "gpt-5", Success: true})
+	updated, _ := manager.GetByID("auth-a")
+	state := updated.ModelStates["gpt-5"]
+	if state == nil || !state.Quota.Exceeded || !state.Unavailable {
+		t.Fatalf("stale success cleared cooldown: %+v", state)
+	}
+}
+
+func TestManagerCodexRateLimitContinuityClearsProcessStateWhenDisabled(t *testing.T) {
+	executor := &codexContinuityTestExecutor{failures: make(map[string]error)}
+	manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-5"}, 2)
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	manager.codexRateLimitContinuity.states[key] = &codexRateLimitContinuityState{generation: 1, establishedSessions: make(map[string]time.Time)}
+	manager.SetConfig(&internalconfig.Config{})
+	manager.codexRateLimitContinuity.mu.Lock()
+	stateCount := len(manager.codexRateLimitContinuity.states)
+	manager.codexRateLimitContinuity.mu.Unlock()
+	if stateCount != 0 {
+		t.Fatalf("state count after config disable = %d", stateCount)
+	}
+
+	manager.codexRateLimitContinuity.states[key] = &codexRateLimitContinuityState{generation: 1, establishedSessions: make(map[string]time.Time)}
+	oldSelector, _ := manager.selector.(*SessionAffinitySelector)
+	manager.SetSelector(&RoundRobinSelector{})
+	if oldSelector != nil {
+		oldSelector.Stop()
+	}
+	manager.codexRateLimitContinuity.mu.Lock()
+	stateCount = len(manager.codexRateLimitContinuity.states)
+	manager.codexRateLimitContinuity.mu.Unlock()
+	if stateCount != 0 {
+		t.Fatalf("state count after selector disable = %d", stateCount)
+	}
+}
+
+func TestManagerCodexRateLimitContinuityWithoutStableSessionUsesNormalCooldown(t *testing.T) {
+	usageLimit := &codexFallbackTestError{message: "usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit}
+	executor := &codexContinuityTestExecutor{failures: map[string]error{"auth-a|gpt-5|": usageLimit}}
+	manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-5"}, 2)
+	opts := cliproxyexecutor.Options{OriginalRequest: []byte(`{"messages":[{"role":"user","content":"hash-only session"}]}`)}
+	_, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, opts)
+	if err == nil {
+		t.Fatal("Execute() error = nil")
+	}
+	authA, _ := manager.GetByID("auth-a")
+	state := authA.ModelStates["gpt-5"]
+	if state == nil || !state.Quota.Exceeded {
+		t.Fatalf("state = %+v, want normal cooldown", state)
+	}
+}
+
+func TestManagerCodexRateLimitContinuityIgnoresNonUsageLimit429(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		reason string
+	}{
+		{name: "transient"},
+		{name: "capacity", reason: internalconfig.CodexModelFallbackTriggerCapacity},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err429 := &codexFallbackTestError{message: tc.name, reason: tc.reason}
+			executor := &codexContinuityTestExecutor{failures: map[string]error{"auth-a|gpt-5|fresh": err429}}
+			manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-5"}, 2)
+			_, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions("fresh"))
+			if err == nil {
+				t.Fatal("Execute() error = nil")
+			}
+			authA, _ := manager.GetByID("auth-a")
+			state := authA.ModelStates["gpt-5"]
+			if state == nil || !state.Quota.Exceeded {
+				t.Fatalf("state = %+v, want normal cooldown", state)
+			}
+		})
+	}
+}
+
+func TestManagerCodexRateLimitContinuityPendingFreshSessionUsesModelFallback(t *testing.T) {
+	executor := &codexContinuityTestExecutor{failures: make(map[string]error)}
+	manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-source", "gpt-target"}, 2)
+	manager.SetConfig(&internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{SessionAffinity: true},
+		Codex: internalconfig.CodexConfig{
+			RateLimitContinuity: internalconfig.CodexRateLimitContinuityConfig{
+				Enabled:                      true,
+				ObservationWindowSeconds:     10,
+				EstablishedSuccessThreshold:  2,
+				EstablishedSessionTTLSeconds: 3600,
+			},
+			ModelFallback: internalconfig.CodexModelFallbackConfig{
+				Enabled: true,
+				Mappings: []internalconfig.CodexModelFallbackMapping{
+					{From: "gpt-source", To: []string{"gpt-target"}},
+				},
+			},
+		},
+	})
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-source"}
+	manager.codexRateLimitContinuity.states[key] = &codexRateLimitContinuityState{
+		suspect:             true,
+		observeUntil:        time.Now().Add(time.Minute),
+		establishedSessions: make(map[string]time.Time),
+	}
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, codexContinuityOptions("fresh"))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := string(resp.Payload); got != "auth-a|gpt-target|fresh" {
+		t.Fatalf("response payload = %q", got)
+	}
+	if calls := executor.snapshot(); len(calls) != 1 || calls[0] != "auth-a|gpt-target|fresh" {
+		t.Fatalf("calls = %#v, want target only", calls)
+	}
+}
+
+func TestManagerCodexRateLimitContinuityConfirmedCooldownUsesModelFallback(t *testing.T) {
+	executor := &codexContinuityTestExecutor{failures: make(map[string]error)}
+	manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-source", "gpt-target"}, 2)
+	manager.SetConfig(&internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{SessionAffinity: true},
+		Codex: internalconfig.CodexConfig{
+			RateLimitContinuity: internalconfig.CodexRateLimitContinuityConfig{Enabled: true},
+			ModelFallback: internalconfig.CodexModelFallbackConfig{
+				Enabled: true,
+				Mappings: []internalconfig.CodexModelFallbackMapping{
+					{From: "gpt-source", To: []string{"gpt-target"}},
+				},
+			},
+		},
+	})
+	now := time.Now()
+	manager.mu.Lock()
+	manager.auths["auth-a"].ModelStates = map[string]*ModelState{
+		"gpt-source": {
+			Status:         StatusError,
+			Unavailable:    true,
+			NextRetryAfter: now.Add(time.Minute),
+			Quota:          QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: now.Add(time.Minute), BackoffLevel: 1},
+		},
+	}
+	manager.mu.Unlock()
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-source"}
+	manager.codexRateLimitContinuity.states[key] = &codexRateLimitContinuityState{
+		confirmed:           true,
+		generation:          2,
+		establishedSessions: make(map[string]time.Time),
+	}
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, codexContinuityOptions("fresh"))
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := string(resp.Payload); got != "auth-a|gpt-target|fresh" {
+		t.Fatalf("response payload = %q", got)
+	}
+}
+
+func TestManagerCodexRateLimitContinuityConcurrentCanaryCallsSelectorCallbackOnce(t *testing.T) {
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	executor := &codexContinuityTestExecutor{
+		failures:        make(map[string]error),
+		blockExecuteKey: "auth-a|gpt-5|canary-0",
+		executeStarted:  started,
+		executeRelease:  release,
+	}
+	manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-5"}, 2)
+	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
+	manager.codexRateLimitContinuity.now = clock.Now
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	manager.codexRateLimitContinuity.states[key] = &codexRateLimitContinuityState{
+		suspect:             true,
+		observeUntil:        clock.Now().Add(-time.Second),
+		establishedSessions: make(map[string]time.Time),
+	}
+	var callbackCalls atomic.Int32
+	callback := func(string) { callbackCalls.Add(1) }
+	firstDone := make(chan error, 1)
+	go func() {
+		opts := codexContinuityOptions("canary-0")
+		opts.Metadata[cliproxyexecutor.SelectedAuthCallbackMetadataKey] = callback
+		_, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, opts)
+		firstDone <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("canary did not start")
+	}
+
+	var wg sync.WaitGroup
+	var pendingErrors atomic.Int32
+	for i := 1; i < 32; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			opts := codexContinuityOptions("canary-" + time.Unix(int64(index), 0).Format("150405"))
+			opts.Metadata[cliproxyexecutor.SelectedAuthCallbackMetadataKey] = callback
+			_, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, opts)
+			if modelFallbackReasonFromError(err) == internalconfig.CodexModelFallbackTriggerUsageLimit {
+				pendingErrors.Add(1)
+			}
+		}(i)
+	}
+	wg.Wait()
+	if got := pendingErrors.Load(); got != 31 {
+		t.Fatalf("pending errors = %d, want 31", got)
+	}
+	if got := callbackCalls.Load(); got != 1 {
+		t.Fatalf("callback calls before release = %d, want 1", got)
+	}
+	if got := len(executor.snapshot()); got != 1 {
+		t.Fatalf("executor calls before release = %d, want 1", got)
+	}
+	close(release)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("canary Execute() error = %v", err)
+	}
+}
+
+func TestManagerCodexRateLimitContinuityCancelledBeforeDispatchReleasesCanary(t *testing.T) {
+	executor := &codexContinuityTestExecutor{failures: make(map[string]error)}
+	manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-5"}, 2)
+	clock := &codexContinuityTestClock{now: time.Unix(1_700_000_000, 0)}
+	manager.codexRateLimitContinuity.now = clock.Now
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-5"}
+	manager.codexRateLimitContinuity.states[key] = &codexRateLimitContinuityState{
+		suspect:             true,
+		generation:          1,
+		observeUntil:        clock.Now().Add(-time.Second),
+		establishedSessions: make(map[string]time.Time),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := manager.Execute(ctx, []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions("cancelled-canary"))
+	if err == nil {
+		t.Fatal("Execute() error = nil")
+	}
+	manager.codexRateLimitContinuity.mu.Lock()
+	state := manager.codexRateLimitContinuity.states[key]
+	manager.codexRateLimitContinuity.mu.Unlock()
+	if state == nil || state.canaryToken != 0 {
+		t.Fatalf("state after cancellation = %+v", state)
+	}
+	if got := len(executor.snapshot()); got != 0 {
+		t.Fatalf("executor calls = %d, want 0", got)
+	}
+}
+
+func TestManagerCodexRateLimitContinuityLongStreamIsNotCancelledByFresh429(t *testing.T) {
+	usageLimit := &codexFallbackTestError{message: "usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit}
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	executor := &codexContinuityTestExecutor{
+		failures: map[string]error{"auth-a|gpt-5|fresh": usageLimit},
+		streamPayloads: map[string][]cliproxyexecutor.StreamChunk{
+			"auth-a|gpt-5|established": {{Payload: []byte("first")}, {Payload: []byte("second")}},
+		},
+		streamStarted: started,
+		streamRelease: release,
+	}
+	manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-5"}, 2)
+	if _, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions("established")); err != nil {
+		t.Fatalf("establish error = %v", err)
+	}
+	stream, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions("established"))
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	first := <-stream.Chunks
+	if string(first.Payload) != "first" {
+		t.Fatalf("first payload = %q", first.Payload)
+	}
+	select {
+	case <-started:
+	default:
+	}
+	_, _ = manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-5"}, codexContinuityOptions("fresh"))
+	close(release)
+	second, ok := <-stream.Chunks
+	if !ok || second.Err != nil || string(second.Payload) != "second" {
+		t.Fatalf("second chunk = %+v ok=%t", second, ok)
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -171,6 +171,9 @@ type Result struct {
 	RetryAfter *time.Duration
 	// Error describes the failure when Success is false.
 	Error *Error
+	// ModelFallbackReason carries a typed provider failure classification used
+	// by Codex model fallback and rate-limit continuity decisions.
+	ModelFallbackReason string
 }
 
 // Selector chooses an auth candidate for execution.
@@ -252,6 +255,10 @@ type Manager struct {
 	// It is initialized in NewManager; never Load() before first Store().
 	runtimeConfig atomic.Value
 
+	// codexRateLimitContinuity is an in-memory, process-local observation state.
+	// It is intentionally independent from persisted cooldown state.
+	codexRateLimitContinuity *codexRateLimitContinuityStore
+
 	// Optional HTTP RoundTripper provider injected by host.
 	rtProvider RoundTripperProvider
 
@@ -274,14 +281,15 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 		hook = NoopHook{}
 	}
 	manager := &Manager{
-		store:            store,
-		executors:        make(map[string]ProviderExecutor),
-		selector:         selector,
-		hook:             hook,
-		auths:            make(map[string]*Auth),
-		homeRuntimeAuths: make(map[string]map[string]*Auth),
-		providerOffsets:  make(map[string]int),
-		modelPoolOffsets: make(map[string]int),
+		store:                    store,
+		executors:                make(map[string]ProviderExecutor),
+		selector:                 selector,
+		hook:                     hook,
+		auths:                    make(map[string]*Auth),
+		homeRuntimeAuths:         make(map[string]map[string]*Auth),
+		providerOffsets:          make(map[string]int),
+		modelPoolOffsets:         make(map[string]int),
+		codexRateLimitContinuity: newCodexRateLimitContinuityStore(),
 	}
 	// atomic.Value requires non-nil initial value.
 	manager.runtimeConfig.Store(&internalconfig.Config{})
@@ -516,6 +524,9 @@ func (m *Manager) SetSelector(selector Selector) {
 	m.mu.Lock()
 	m.selector = selector
 	m.mu.Unlock()
+	if _, ok := selector.(*SessionAffinitySelector); !ok && m.codexRateLimitContinuity != nil {
+		m.codexRateLimitContinuity.clear()
+	}
 	if m.scheduler != nil {
 		m.scheduler.setSelector(selector)
 		m.syncScheduler()
@@ -556,6 +567,7 @@ func (m *Manager) SetConfig(cfg *internalconfig.Config) {
 		cfg = &internalconfig.Config{}
 	}
 	m.runtimeConfig.Store(cfg)
+	m.clearCodexRateLimitContinuityIfDisabled(cfg)
 	clearedCooldowns := m.clearDisabledCooldownStates(cfg)
 	if !cfg.Home.Enabled {
 		m.clearHomeRuntimeAuths()
@@ -1794,6 +1806,7 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 	out := make(chan cliproxyexecutor.StreamChunk)
 	go func() {
 		defer close(out)
+		defer m.abandonCodexRateLimitContinuityAttempt(ctx)
 		var failed bool
 		forward := true
 		var rewriter *StreamRewriter
@@ -1808,7 +1821,14 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 					if se, ok := errors.AsType[cliproxyexecutor.StatusError](chunk.Err); ok && se != nil {
 						rerr.HTTPStatus = se.StatusCode()
 					}
-					m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr})
+					m.MarkResult(ctx, Result{
+						AuthID:              auth.ID,
+						Provider:            provider,
+						Model:               resultModel,
+						Success:             false,
+						Error:               rerr,
+						ModelFallbackReason: modelFallbackReasonFromError(chunk.Err),
+					})
 				}
 			}
 			if !forward {
@@ -1923,6 +1943,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			}
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
 			result.RetryAfter = retryAfterFromError(errStream)
+			result.ModelFallbackReason = modelFallbackReasonFromError(errStream)
 			m.MarkResult(ctx, result)
 			if isRequestInvalidError(errStream) {
 				return nil, errStream
@@ -1970,6 +1991,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				}
 				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
+				result.ModelFallbackReason = modelFallbackReasonFromError(bootstrapErr)
 				m.MarkResult(ctx, result)
 				discardStreamChunks(streamResult.Chunks)
 				return nil, bootstrapErr
@@ -1981,6 +2003,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				}
 				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
+				result.ModelFallbackReason = modelFallbackReasonFromError(bootstrapErr)
 				m.MarkResult(ctx, result)
 				discardStreamChunks(streamResult.Chunks)
 				lastErr = bootstrapErr
@@ -1992,6 +2015,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			}
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
 			result.RetryAfter = retryAfterFromError(bootstrapErr)
+			result.ModelFallbackReason = modelFallbackReasonFromError(bootstrapErr)
 			m.MarkResult(ctx, result)
 			discardStreamChunks(streamResult.Chunks)
 			return nil, newStreamBootstrapError(bootstrapErr, streamResult.Headers)
@@ -2342,6 +2366,9 @@ func (m *Manager) Remove(ctx context.Context, id string) {
 func (m *Manager) invalidateSessionAffinity(authID string) {
 	if m == nil || authID == "" {
 		return
+	}
+	if m.codexRateLimitContinuity != nil {
+		m.codexRateLimitContinuity.removeAuth(authID)
 	}
 	if invalidator, ok := m.selector.(interface{ InvalidateAuth(string) }); ok && invalidator != nil {
 		invalidator.InvalidateAuth(authID)
@@ -2770,6 +2797,16 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			}
 			return cliproxyexecutor.Response{}, errPick
 		}
+		attemptCtx, allowed := m.beginCodexRateLimitContinuityAttempt(ctx, auth, provider, routeModel, opts)
+		if !allowed {
+			if tried == nil {
+				tried = make(map[string]struct{})
+			}
+			tried[auth.ID] = struct{}{}
+			lastErr = codexRateLimitObservationPendingError{}
+			continue
+		}
+		defer m.abandonCodexRateLimitContinuityAttempt(attemptCtx)
 
 		entry := logEntryWithRequestID(ctx)
 		debugLogAuthSelection(entry, auth, provider, routeModel)
@@ -2779,7 +2816,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 		}
 
 		tried[auth.ID] = struct{}{}
-		execCtx := ctx
+		execCtx := attemptCtx
 		if rt := m.roundTripperFor(auth); rt != nil {
 			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
@@ -2850,6 +2887,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				if ra := retryAfterFromError(errExec); ra != nil {
 					result.RetryAfter = ra
 				}
+				result.ModelFallbackReason = modelFallbackReasonFromError(errExec)
 				m.MarkResult(execCtx, result)
 				if isRequestInvalidError(errExec) {
 					return cliproxyexecutor.Response{}, errExec
@@ -3032,6 +3070,21 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			}
 			return nil, errPick
 		}
+		attemptCtx, allowed := m.beginCodexRateLimitContinuityAttempt(ctx, auth, provider, routeModel, opts)
+		if !allowed {
+			if tried == nil {
+				tried = make(map[string]struct{})
+			}
+			tried[auth.ID] = struct{}{}
+			lastErr = codexRateLimitObservationPendingError{}
+			continue
+		}
+		streamHandedOff := false
+		defer func(attemptCtx context.Context, handedOff *bool) {
+			if !*handedOff {
+				m.abandonCodexRateLimitContinuityAttempt(attemptCtx)
+			}
+		}(attemptCtx, &streamHandedOff)
 
 		entry := logEntryWithRequestID(ctx)
 		debugLogAuthSelection(entry, auth, provider, routeModel)
@@ -3041,7 +3094,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 		}
 
 		tried[auth.ID] = struct{}{}
-		execCtx := ctx
+		execCtx := attemptCtx
 		if rt := m.roundTripperFor(auth); rt != nil {
 			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
@@ -3084,6 +3137,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			}
 			continue
 		}
+		streamHandedOff = true
 		return streamResult, nil
 	}
 }
@@ -3976,6 +4030,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	if result.AuthID == "" {
 		return
 	}
+	continuityDisposition := m.observeCodexRateLimitContinuityResult(ctx, result)
 
 	shouldResumeModel := false
 	shouldSuspendModel := false
@@ -4000,7 +4055,9 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			auth.Failed++
 		}
 
-		if result.Success {
+		if continuityDisposition == codexRateLimitContinuityRecordOnly {
+			auth.UpdatedAt = now
+		} else if result.Success {
 			if result.Model != "" {
 				state := ensureModelState(auth, result.Model)
 				resetModelState(state, now)
@@ -4016,6 +4073,8 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 			} else {
 				clearAuthStateOnSuccess(auth, now)
 			}
+		} else if continuityDisposition == codexRateLimitContinuityObserveOnly {
+			auth.UpdatedAt = now
 		} else {
 			if result.Model != "" {
 				if !isRequestScopedNotFoundResultError(result.Error) {
@@ -5185,13 +5244,16 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 		m.mu.RUnlock()
 		return nil, nil, "", &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
-	available, errAvailable := m.availableAuthsForRouteModel(candidates, "mixed", model, time.Now())
+	candidates = cloneAuthSlice(candidates)
+	m.mu.RUnlock()
+	candidates, errAvailable := m.filterCodexRateLimitContinuityCandidates(candidates, model, opts)
 	if errAvailable != nil {
-		m.mu.RUnlock()
 		return nil, nil, "", errAvailable
 	}
-	available = cloneAuthSlice(available)
-	m.mu.RUnlock()
+	available, errAvailable := m.availableAuthsForRouteModel(candidates, "mixed", model, time.Now())
+	if errAvailable != nil {
+		return nil, nil, "", errAvailable
+	}
 
 	selected, handled, errPick := m.pickViaPluginScheduler(ctx, pluginScheduler, "mixed", providers, model, opts, tried, available)
 	if errPick != nil {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -258,6 +258,18 @@ type Manager struct {
 	// codexRateLimitContinuity is an in-memory, process-local observation state.
 	// It is intentionally independent from persisted cooldown state.
 	codexRateLimitContinuity *codexRateLimitContinuityStore
+	// codexRateLimitContinuityLifecycle invalidates requests that started before
+	// a global config/selector/auth snapshot reset. Auth and session removal are
+	// scoped through the continuity store instead of advancing this global value.
+	// It is protected by manager.mu and intentionally process-local.
+	codexRateLimitContinuityLifecycle uint64
+
+	// continuityTransitionHook is an internal test seam. It runs while MarkResult
+	// owns manager.mu after continuity observation and before ModelState mutation.
+	continuityTransitionHook func()
+	// continuityBeforeDispatchHook is an internal test seam invoked after
+	// continuity admission and before the final dispatch recheck.
+	continuityBeforeDispatchHook func()
 
 	// Optional HTTP RoundTripper provider injected by host.
 	rtProvider RoundTripperProvider
@@ -523,10 +535,13 @@ func (m *Manager) SetSelector(selector Selector) {
 	}
 	m.mu.Lock()
 	m.selector = selector
-	m.mu.Unlock()
-	if _, ok := selector.(*SessionAffinitySelector); !ok && m.codexRateLimitContinuity != nil {
+	if m.codexRateLimitContinuity != nil {
+		m.advanceCodexRateLimitContinuityLifecycleLocked()
+		// Selector identity and TTL are part of the lease contract. Replacing
+		// either invalidates all absolute process-local deadlines.
 		m.codexRateLimitContinuity.clear()
 	}
+	m.mu.Unlock()
 	if m.scheduler != nil {
 		m.scheduler.setSelector(selector)
 		m.syncScheduler()
@@ -566,8 +581,17 @@ func (m *Manager) SetConfig(cfg *internalconfig.Config) {
 	if cfg == nil {
 		cfg = &internalconfig.Config{}
 	}
+	// Publish policy and invalidate old absolute deadlines atomically with
+	// respect to begin/MarkResult, preserving manager -> continuity lock order.
+	m.mu.Lock()
+	previous, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	settingsChanged := codexRateLimitContinuitySettingsChanged(previous, cfg)
 	m.runtimeConfig.Store(cfg)
-	m.clearCodexRateLimitContinuityIfDisabled(cfg)
+	if settingsChanged && m.codexRateLimitContinuity != nil {
+		m.advanceCodexRateLimitContinuityLifecycleLocked()
+		m.codexRateLimitContinuity.clear()
+	}
+	m.mu.Unlock()
 	clearedCooldowns := m.clearDisabledCooldownStates(cfg)
 	if !cfg.Home.Enabled {
 		m.clearHomeRuntimeAuths()
@@ -1827,6 +1851,7 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 						Model:               resultModel,
 						Success:             false,
 						Error:               rerr,
+						RetryAfter:          retryAfterFromError(chunk.Err),
 						ModelFallbackReason: modelFallbackReasonFromError(chunk.Err),
 					})
 				}
@@ -1899,6 +1924,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 	ctx = contextWithRequestedModelAlias(ctx, opts, routeModel)
 	var lastErr error
 	didRefreshOnUnauthorized := false
+	selectedPublished := false
 	for idx, execModel := range execModels {
 		resultModel := m.stateModelForExecution(auth, routeModel, execModel, pooled)
 		execReq := req
@@ -1908,7 +1934,14 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		}
 		execOpts := opts
 		execReq, execOpts = applyRequestAfterAuthInterceptor(ctx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
-		publishSelectedAuthMetadata(execOpts.Metadata, auth.ID)
+		if allowed, confirmed := m.codexRateLimitContinuityDispatchDisposition(ctx); !allowed {
+			m.abandonCodexRateLimitContinuityAttempt(ctx)
+			return nil, codexRateLimitObservationPendingError{confirmed: confirmed}
+		}
+		if !selectedPublished {
+			publishSelectedAuthMetadata(execOpts.Metadata, auth.ID)
+			selectedPublished = true
+		}
 		if errCtx := ctx.Err(); errCtx != nil {
 			return nil, errCtx
 		}
@@ -2374,10 +2407,13 @@ func (m *Manager) invalidateSessionAffinity(authID string) {
 	if m == nil || authID == "" {
 		return
 	}
+	m.mu.Lock()
 	if m.codexRateLimitContinuity != nil {
 		m.codexRateLimitContinuity.removeAuth(authID)
 	}
-	if invalidator, ok := m.selector.(interface{ InvalidateAuth(string) }); ok && invalidator != nil {
+	selector := m.selector
+	m.mu.Unlock()
+	if invalidator, ok := selector.(interface{ InvalidateAuth(string) }); ok && invalidator != nil {
 		invalidator.InvalidateAuth(authID)
 	}
 }
@@ -2395,6 +2431,12 @@ func (m *Manager) Load(ctx context.Context) error {
 		return err
 	}
 	m.auths = make(map[string]*Auth, len(items))
+	if m.codexRateLimitContinuity != nil {
+		// Credentials are a new runtime snapshot; continuity leases cannot be
+		// safely carried over a Load boundary.
+		m.advanceCodexRateLimitContinuityLifecycleLocked()
+		m.codexRateLimitContinuity.clear()
+	}
 	for _, auth := range items {
 		if auth == nil || auth.ID == "" {
 			continue
@@ -2415,6 +2457,7 @@ func (m *Manager) Load(ctx context.Context) error {
 // Execute performs a non-streaming execution using the configured selector and executor.
 // It supports multiple providers for the same model and round-robins the starting provider per model.
 func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	ctx = m.withCodexRateLimitContinuityLifecycle(ctx)
 	if m.codexModelFallbackEnabled(providers) {
 		opts = ensureRequestedModelMetadata(opts, req.Model)
 		opts = withCodexModelFallbackRequestBudget(opts, false)
@@ -2639,6 +2682,7 @@ func (m *Manager) ExecuteCount(ctx context.Context, providers []string, req clip
 // ExecuteStream performs a streaming execution using the configured selector and executor.
 // It supports multiple providers for the same model and round-robins the starting provider per model.
 func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	ctx = m.withCodexRateLimitContinuityLifecycle(ctx)
 	if m.codexModelFallbackEnabled(providers) {
 		opts = ensureRequestedModelMetadata(opts, req.Model)
 		opts = withCodexModelFallbackRequestBudget(opts, true)
@@ -2895,6 +2939,9 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			lastErr = codexRateLimitObservationPendingError{}
 			continue
 		}
+		if m.continuityBeforeDispatchHook != nil {
+			m.continuityBeforeDispatchHook()
+		}
 		defer m.abandonCodexRateLimitContinuityAttempt(attemptCtx)
 
 		entry := logEntryWithRequestID(ctx)
@@ -2929,6 +2976,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 		}
 		var authErr error
 		didRefreshOnUnauthorized := false
+		selectedPublished := false
 		for _, upstreamModel := range models {
 			resultModel := m.stateModelForExecution(auth, routeModel, upstreamModel, pooled)
 			execReq := req
@@ -2938,7 +2986,14 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			}
 			execOpts := opts
 			execReq, execOpts = applyRequestAfterAuthInterceptor(execCtx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
-			publishSelectedAuthMetadata(execOpts.Metadata, auth.ID)
+			if allowed, confirmed := m.codexRateLimitContinuityDispatchDisposition(execCtx); !allowed {
+				m.abandonCodexRateLimitContinuityAttempt(execCtx)
+				return cliproxyexecutor.Response{}, codexRateLimitObservationPendingError{confirmed: confirmed}
+			}
+			if !selectedPublished {
+				publishSelectedAuthMetadata(execOpts.Metadata, auth.ID)
+				selectedPublished = true
+			}
 			if errCtx := execCtx.Err(); errCtx != nil {
 				return cliproxyexecutor.Response{}, errCtx
 			}
@@ -3039,7 +3094,6 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 
 		entry := logEntryWithRequestID(ctx)
 		debugLogAuthSelection(entry, auth, provider, routeModel)
-		publishSelectedAuthMetadata(opts.Metadata, auth.ID)
 		if errCtx := ctx.Err(); errCtx != nil {
 			return cliproxyexecutor.Response{}, errCtx
 		}
@@ -3070,6 +3124,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 		}
 		var authErr error
 		didRefreshOnUnauthorized := false
+		selectedPublished := false
 		for _, upstreamModel := range models {
 			resultModel := m.stateModelForExecution(auth, routeModel, upstreamModel, pooled)
 			execReq := req
@@ -3079,6 +3134,13 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			}
 			execOpts := opts
 			execReq, execOpts = applyRequestAfterAuthInterceptor(execCtx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
+			if !selectedPublished {
+				publishSelectedAuthMetadata(execOpts.Metadata, auth.ID)
+				selectedPublished = true
+			}
+			if errCtx := execCtx.Err(); errCtx != nil {
+				return cliproxyexecutor.Response{}, errCtx
+			}
 			resp, errExec := executor.CountTokens(execCtx, auth, execReq, execOpts)
 			if errExec != nil {
 				if errCtx := execCtx.Err(); errCtx != nil {
@@ -3172,6 +3234,9 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			tried[auth.ID] = struct{}{}
 			lastErr = codexRateLimitObservationPendingError{}
 			continue
+		}
+		if m.continuityBeforeDispatchHook != nil {
+			m.continuityBeforeDispatchHook()
 		}
 		streamHandedOff := false
 		defer func(attemptCtx context.Context, handedOff *bool) {
@@ -4123,7 +4188,6 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	if result.AuthID == "" {
 		return
 	}
-	continuityDisposition := m.observeCodexRateLimitContinuityResult(ctx, result)
 
 	shouldResumeModel := false
 	shouldSuspendModel := false
@@ -4134,6 +4198,14 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	cooldownStateChanged := false
 
 	m.mu.Lock()
+	// The continuity state transition and the ModelState/cooldown mutation must
+	// be one manager critical section. begin() rechecks the continuity state
+	// before dispatch, so an in-flight candidate cannot clear a newly confirmed
+	// cooldown between observation and the availability write.
+	continuityDisposition := m.observeCodexRateLimitContinuityResult(ctx, result)
+	if m.continuityTransitionHook != nil {
+		m.continuityTransitionHook()
+	}
 	if auth, ok := m.auths[result.AuthID]; ok && auth != nil {
 		now := time.Now()
 		var cooldownRecordsBefore []CooldownStateRecord
@@ -5075,6 +5147,13 @@ func (m *Manager) Executor(provider string) (ProviderExecutor, bool) {
 
 // CloseExecutionSession asks all registered executors to release the supplied execution session.
 func (m *Manager) CloseExecutionSession(sessionID string) {
+	m.closeExecutionSession(sessionID, "", "")
+}
+
+// closeExecutionSession releases an execution session while optionally
+// preserving the already-admitted target auth/model attempt that triggered a
+// context-reset fallback. The source session state is still cleared.
+func (m *Manager) closeExecutionSession(sessionID, preserveAuthID, preserveRouteModel string) {
 	sessionID = strings.TrimSpace(sessionID)
 	if m == nil || sessionID == "" {
 		return
@@ -5082,9 +5161,25 @@ func (m *Manager) CloseExecutionSession(sessionID string) {
 
 	m.mu.Lock()
 	if sessionID == CloseAllExecutionSessionsID {
+		if m.codexRateLimitContinuity != nil {
+			m.advanceCodexRateLimitContinuityLifecycleLocked()
+		}
 		m.clearHomeRuntimeAuthsLocked()
+		if m.codexRateLimitContinuity != nil {
+			m.codexRateLimitContinuity.clear()
+		}
 	} else {
 		m.clearHomeRuntimeAuthsForSessionLocked(sessionID)
+		if m.codexRateLimitContinuity != nil {
+			var preserve *codexRateLimitContinuityKey
+			if auth := m.auths[strings.TrimSpace(preserveAuthID)]; auth != nil {
+				if modelKey := m.selectionModelKeyForAuth(auth, preserveRouteModel); modelKey != "" {
+					key := codexRateLimitContinuityKey{authID: auth.ID, model: modelKey}
+					preserve = &key
+				}
+			}
+			m.codexRateLimitContinuity.removeSessionPreservingKey("execution:"+sessionID, preserve)
+		}
 	}
 	executors := make([]ProviderExecutor, 0, len(m.executors))
 	for _, exec := range m.executors {

--- a/sdk/cliproxy/auth/openai_compat_pool_test.go
+++ b/sdk/cliproxy/auth/openai_compat_pool_test.go
@@ -19,8 +19,11 @@ type openAICompatPoolExecutor struct {
 
 	mu                sync.Mutex
 	executeModels     []string
+	executeSelected   []string
 	countModels       []string
+	countSelected     []string
 	streamModels      []string
+	streamSelected    []string
 	executePayloads   map[string][]byte
 	executeErrors     map[string]error
 	countErrors       map[string]error
@@ -33,9 +36,10 @@ func (e *openAICompatPoolExecutor) Identifier() string { return e.id }
 func (e *openAICompatPoolExecutor) Execute(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
 	_ = ctx
 	_ = auth
-	_ = opts
 	e.mu.Lock()
 	e.executeModels = append(e.executeModels, req.Model)
+	selected, _ := opts.Metadata[cliproxyexecutor.SelectedAuthMetadataKey].(string)
+	e.executeSelected = append(e.executeSelected, selected)
 	payload := append([]byte(nil), e.executePayloads[req.Model]...)
 	err := e.executeErrors[req.Model]
 	e.mu.Unlock()
@@ -51,9 +55,10 @@ func (e *openAICompatPoolExecutor) Execute(ctx context.Context, auth *Auth, req 
 func (e *openAICompatPoolExecutor) ExecuteStream(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
 	_ = ctx
 	_ = auth
-	_ = opts
 	e.mu.Lock()
 	e.streamModels = append(e.streamModels, req.Model)
+	selected, _ := opts.Metadata[cliproxyexecutor.SelectedAuthMetadataKey].(string)
+	e.streamSelected = append(e.streamSelected, selected)
 	err := e.streamFirstErrors[req.Model]
 	payloadChunks, hasCustomChunks := e.streamPayloads[req.Model]
 	chunks := append([]cliproxyexecutor.StreamChunk(nil), payloadChunks...)
@@ -82,9 +87,10 @@ func (e *openAICompatPoolExecutor) Refresh(_ context.Context, auth *Auth) (*Auth
 func (e *openAICompatPoolExecutor) CountTokens(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
 	_ = ctx
 	_ = auth
-	_ = opts
 	e.mu.Lock()
 	e.countModels = append(e.countModels, req.Model)
+	selected, _ := opts.Metadata[cliproxyexecutor.SelectedAuthMetadataKey].(string)
+	e.countSelected = append(e.countSelected, selected)
 	err := e.countErrors[req.Model]
 	e.mu.Unlock()
 	if err != nil {
@@ -116,12 +122,30 @@ func (e *openAICompatPoolExecutor) CountModels() []string {
 	return out
 }
 
+func (e *openAICompatPoolExecutor) ExecuteSelectedAuths() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]string(nil), e.executeSelected...)
+}
+
+func (e *openAICompatPoolExecutor) CountSelectedAuths() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]string(nil), e.countSelected...)
+}
+
 func (e *openAICompatPoolExecutor) StreamModels() []string {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	out := make([]string, len(e.streamModels))
 	copy(out, e.streamModels)
 	return out
+}
+
+func (e *openAICompatPoolExecutor) StreamSelectedAuths() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]string(nil), e.streamSelected...)
 }
 
 type authScopedOpenAICompatPoolExecutor struct {
@@ -453,6 +477,51 @@ func TestManagerExecute_OpenAICompatAliasPoolFallsBackWithinSameAuth(t *testing.
 	}
 }
 
+func TestManagerExecute_OpenAICompatAliasPoolPublishesSelectedAuthOnceAcrossModels(t *testing.T) {
+	alias := "claude-opus-4.66"
+	modelSupportErr := &Error{
+		HTTPStatus: http.StatusBadRequest,
+		Message:    "invalid_request_error: The requested model is unsupported.",
+	}
+	executor := &openAICompatPoolExecutor{
+		id:            openAICompatPoolProviderKey,
+		executeErrors: map[string]error{"deepseek-v3.1": modelSupportErr},
+	}
+	m := newOpenAICompatPoolTestManager(t, alias, []internalconfig.OpenAICompatibilityModel{
+		{Name: "deepseek-v3.1", Alias: alias},
+		{Name: "glm-5", Alias: alias},
+	}, executor)
+
+	metadata := map[string]any{}
+	var callbacks []string
+	metadata[cliproxyexecutor.SelectedAuthCallbackMetadataKey] = func(authID string) {
+		callbacks = append(callbacks, authID)
+	}
+	resp, err := m.Execute(context.Background(), []string{openAICompatPoolProviderKey}, cliproxyexecutor.Request{Model: alias}, cliproxyexecutor.Options{Metadata: metadata})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if string(resp.Payload) != "glm-5" {
+		t.Fatalf("payload = %q, want glm-5", resp.Payload)
+	}
+	if len(callbacks) != 1 || callbacks[0] == "" {
+		t.Fatalf("selected-auth callbacks = %#v, want exactly one", callbacks)
+	}
+	got := executor.ExecuteModels()
+	want := []string{"deepseek-v3.1", "glm-5"}
+	if len(got) != len(want) {
+		t.Fatalf("execute calls = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("execute call %d model = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if selected := executor.ExecuteSelectedAuths(); len(selected) != 2 || selected[0] != callbacks[0] || selected[1] != callbacks[0] {
+		t.Fatalf("executor selected auth metadata = %#v, want callback auth on both model attempts", selected)
+	}
+}
+
 func TestManagerExecuteStream_OpenAICompatAliasPoolRetriesOnEmptyBootstrap(t *testing.T) {
 	alias := "claude-opus-4.66"
 	executor := &openAICompatPoolExecutor{
@@ -523,6 +592,51 @@ func TestManagerExecuteStream_OpenAICompatAliasPoolFallsBackBeforeFirstByte(t *t
 	}
 	if gotHeader := streamResult.Headers.Get("X-Model"); gotHeader != "glm-5" {
 		t.Fatalf("header X-Model = %q, want %q", gotHeader, "glm-5")
+	}
+}
+
+func TestManagerExecuteStream_OpenAICompatAliasPoolPublishesSelectedAuthOnceAcrossModels(t *testing.T) {
+	alias := "claude-opus-4.66"
+	modelSupportErr := &Error{
+		HTTPStatus: http.StatusBadRequest,
+		Message:    "invalid_request_error: The requested model is unsupported.",
+	}
+	executor := &openAICompatPoolExecutor{
+		id:                openAICompatPoolProviderKey,
+		streamFirstErrors: map[string]error{"deepseek-v3.1": modelSupportErr},
+	}
+	m := newOpenAICompatPoolTestManager(t, alias, []internalconfig.OpenAICompatibilityModel{
+		{Name: "deepseek-v3.1", Alias: alias},
+		{Name: "glm-5", Alias: alias},
+	}, executor)
+
+	metadata := map[string]any{}
+	var callbacks []string
+	metadata[cliproxyexecutor.SelectedAuthCallbackMetadataKey] = func(authID string) {
+		callbacks = append(callbacks, authID)
+	}
+	streamResult, err := m.ExecuteStream(context.Background(), []string{openAICompatPoolProviderKey}, cliproxyexecutor.Request{Model: alias}, cliproxyexecutor.Options{Metadata: metadata})
+	if err != nil {
+		t.Fatalf("execute stream: %v", err)
+	}
+	if payload := readOpenAICompatStreamPayload(t, streamResult); payload != "glm-5" {
+		t.Fatalf("payload = %q, want glm-5", payload)
+	}
+	if len(callbacks) != 1 || callbacks[0] == "" {
+		t.Fatalf("selected-auth callbacks = %#v, want exactly one", callbacks)
+	}
+	got := executor.StreamModels()
+	want := []string{"deepseek-v3.1", "glm-5"}
+	if len(got) != len(want) {
+		t.Fatalf("stream calls = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("stream call %d model = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if selected := executor.StreamSelectedAuths(); len(selected) != 2 || selected[0] != callbacks[0] || selected[1] != callbacks[0] {
+		t.Fatalf("stream selected auth metadata = %#v, want callback auth on both model attempts", selected)
 	}
 }
 
@@ -649,6 +763,51 @@ func TestManagerExecuteCount_OpenAICompatAliasPoolRotatesWithinAuth(t *testing.T
 		if got[i] != want[i] {
 			t.Fatalf("count call %d model = %q, want %q", i, got[i], want[i])
 		}
+	}
+}
+
+func TestManagerExecuteCount_OpenAICompatAliasPoolPublishesSelectedAuthOnce(t *testing.T) {
+	alias := "claude-opus-4.66"
+	modelSupportErr := &Error{
+		HTTPStatus: http.StatusBadRequest,
+		Message:    "invalid_request_error: The requested model is unsupported.",
+	}
+	executor := &openAICompatPoolExecutor{
+		id:          openAICompatPoolProviderKey,
+		countErrors: map[string]error{"deepseek-v3.1": modelSupportErr},
+	}
+	m := newOpenAICompatPoolTestManager(t, alias, []internalconfig.OpenAICompatibilityModel{
+		{Name: "deepseek-v3.1", Alias: alias},
+		{Name: "glm-5", Alias: alias},
+	}, executor)
+
+	metadata := map[string]any{}
+	var callbacks []string
+	metadata[cliproxyexecutor.SelectedAuthCallbackMetadataKey] = func(authID string) {
+		callbacks = append(callbacks, authID)
+	}
+	resp, err := m.ExecuteCount(context.Background(), []string{openAICompatPoolProviderKey}, cliproxyexecutor.Request{Model: alias}, cliproxyexecutor.Options{Metadata: metadata})
+	if err != nil {
+		t.Fatalf("execute count: %v", err)
+	}
+	if string(resp.Payload) != "glm-5" {
+		t.Fatalf("payload = %q, want glm-5", resp.Payload)
+	}
+	if len(callbacks) != 1 || callbacks[0] == "" {
+		t.Fatalf("selected-auth callbacks = %#v, want exactly one", callbacks)
+	}
+	got := executor.CountModels()
+	want := []string{"deepseek-v3.1", "glm-5"}
+	if len(got) != len(want) {
+		t.Fatalf("count calls = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("count call %d model = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if selected := executor.CountSelectedAuths(); len(selected) != 2 || selected[0] != callbacks[0] || selected[1] != callbacks[0] {
+		t.Fatalf("count selected auth metadata = %#v, want callback auth on both model attempts", selected)
 	}
 }
 

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -403,14 +403,15 @@ func NewSessionAffinitySelectorWithConfig(cfg SessionAffinityConfig) *SessionAff
 
 // Pick selects an auth with session affinity when possible.
 // Priority for session ID extraction:
-//  1. metadata.user_id (Claude Code format with _session_{uuid}) - highest priority
-//  2. X-Session-ID header
-//  3. Session_id header (Codex)
-//  4. X-Amp-Thread-Id header (Amp CLI thread ID)
-//  5. X-Client-Request-Id header (PI)
-//  6. metadata.user_id (non-Claude Code format)
-//  7. conversation_id field in request body
-//  8. Stable hash from first few messages content (fallback)
+//  1. explicit execution_session_id metadata
+//  2. metadata.user_id (Claude Code format with _session_{uuid})
+//  3. X-Session-ID header
+//  4. Session_id header (Codex)
+//  5. X-Amp-Thread-Id header (Amp CLI thread ID)
+//  6. X-Client-Request-Id header (PI)
+//  7. metadata.user_id (non-Claude Code format)
+//  8. conversation_id field in request body
+//  9. Stable hash from first few messages content (fallback)
 //
 // Note: The cache key includes provider, session ID, and model to handle cases where
 // a session uses multiple models (e.g., gemini-2.5-pro and gemini-3-flash-preview)
@@ -505,14 +506,15 @@ func (s *SessionAffinitySelector) InvalidateAuth(authID string) {
 
 // ExtractSessionID extracts session identifier from multiple sources.
 // Priority order:
-//  1. metadata.user_id (Claude Code format with _session_{uuid}) - highest priority for Claude Code clients
-//  2. X-Session-ID header
-//  3. Session_id header (Codex)
-//  4. X-Amp-Thread-Id header (Amp CLI thread ID)
-//  5. X-Client-Request-Id header (PI)
-//  6. metadata.user_id (non-Claude Code format)
-//  7. conversation_id field in request body
-//  8. Stable hash from first few messages content (fallback)
+//  1. explicit execution_session_id metadata
+//  2. metadata.user_id (Claude Code format with _session_{uuid})
+//  3. X-Session-ID header
+//  4. Session_id header (Codex)
+//  5. X-Amp-Thread-Id header (Amp CLI thread ID)
+//  6. X-Client-Request-Id header (PI)
+//  7. metadata.user_id (non-Claude Code format)
+//  8. conversation_id field in request body
+//  9. Stable hash from first few messages content (fallback)
 func ExtractSessionID(headers http.Header, payload []byte, metadata map[string]any) string {
 	primary, _ := extractSessionIDs(headers, payload, metadata)
 	return primary
@@ -522,7 +524,12 @@ func ExtractSessionID(headers http.Header, payload []byte, metadata map[string]a
 // primaryID: full hash including assistant response (stable after first turn)
 // fallbackID: short hash without assistant (used to inherit binding from first turn)
 func extractSessionIDs(headers http.Header, payload []byte, metadata map[string]any) (string, string) {
-	// 1. metadata.user_id with Claude Code session format (highest priority)
+	// 1. Explicit execution session metadata supplied by the host.
+	if sessionID := contextStringValue(metadata[cliproxyexecutor.ExecutionSessionMetadataKey]); sessionID != "" {
+		return "execution:" + sessionID, ""
+	}
+
+	// 2. metadata.user_id with Claude Code session format.
 	if len(payload) > 0 {
 		userID := gjson.GetBytes(payload, "metadata.user_id").String()
 		if userID != "" {
@@ -541,14 +548,14 @@ func extractSessionIDs(headers http.Header, payload []byte, metadata map[string]
 		}
 	}
 
-	// 2. X-Session-ID header
+	// 3. X-Session-ID header
 	if headers != nil {
 		if sid := headers.Get("X-Session-ID"); sid != "" {
 			return "header:" + sid, ""
 		}
 	}
 
-	// 3. Session_id header (Codex)
+	// 4. Session_id header (Codex)
 	if headers != nil {
 		if sid := headers.Get("Session-Id"); sid != "" {
 			return "codex:" + sid, ""
@@ -558,14 +565,14 @@ func extractSessionIDs(headers http.Header, payload []byte, metadata map[string]
 		}
 	}
 
-	// 4. X-Amp-Thread-Id header (Amp CLI thread ID)
+	// 5. X-Amp-Thread-Id header (Amp CLI thread ID)
 	if headers != nil {
 		if tid := headers.Get("X-Amp-Thread-Id"); tid != "" {
 			return "amp:" + tid, ""
 		}
 	}
 
-	// 5. X-Client-Request-Id header (PI)
+	// 6. X-Client-Request-Id header (PI)
 	if headers != nil {
 		if rid := headers.Get("X-Client-Request-Id"); rid != "" {
 			return "clientreq:" + rid, ""
@@ -576,18 +583,18 @@ func extractSessionIDs(headers http.Header, payload []byte, metadata map[string]
 		return "", ""
 	}
 
-	// 6. metadata.user_id (non-Claude Code format)
+	// 7. metadata.user_id (non-Claude Code format)
 	userID := gjson.GetBytes(payload, "metadata.user_id").String()
 	if userID != "" {
 		return "user:" + userID, ""
 	}
 
-	// 7. conversation_id field
+	// 8. conversation_id field
 	if convID := gjson.GetBytes(payload, "conversation_id").String(); convID != "" {
 		return "conv:" + convID, ""
 	}
 
-	// 8. Hash-based fallback from message content
+	// 9. Hash-based fallback from message content
 	return extractMessageHashIDs(payload)
 }
 

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -497,6 +497,30 @@ func TestSessionAffinitySelector_SameSessionSameAuth(t *testing.T) {
 	}
 }
 
+func TestSessionAffinitySelector_ExplicitExecutionSessionMetadata(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelector(&RoundRobinSelector{})
+	auths := []*Auth{{ID: "auth-a"}, {ID: "auth-b"}}
+	opts := cliproxyexecutor.Options{
+		Metadata: map[string]any{cliproxyexecutor.ExecutionSessionMetadataKey: "execution-session-1"},
+	}
+	if got := ExtractSessionID(opts.Headers, opts.OriginalRequest, opts.Metadata); got != "execution:execution-session-1" {
+		t.Fatalf("ExtractSessionID() = %q", got)
+	}
+	first, err := selector.Pick(context.Background(), "codex", "gpt-5", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() error = %v", err)
+	}
+	second, err := selector.Pick(context.Background(), "codex", "gpt-5", opts, auths)
+	if err != nil {
+		t.Fatalf("Pick() second error = %v", err)
+	}
+	if first.ID != second.ID {
+		t.Fatalf("auth IDs = %q/%q, want sticky", first.ID, second.ID)
+	}
+}
+
 func TestSessionAffinitySelector_NoSessionFallback(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## 结果与交付边界

本 PR 为 Codex `usage_limit_reached` 引入默认关闭的三阶段 continuity 状态机：fresh session 的首个 typed 429 不再立即把整个 auth/model 写入正式 cooldown，也不会取消或阻断已经建立、仍在执行的 session；只有 established/incumbent 也失败，或在没有任何 incumbent 证据时单 canary 再失败，才确认共享 quota 已耗尽。

前置 PR #158 已合并到 `main`。本 PR 已重新以 `main` 为 base，仅保留 continuity 增量；当前仍未 merge、tag、release 或 deploy。该机制只处理精确 typed `usage_limit_reached`；capacity、transient `rate_limit_error` 和裸 HTTP 429 保持既有独立策略。

## 三阶段状态机

状态按 `Codex auth ID + auth-selection model` 隔离：

- `Healthy`：已 admission 的执行立即登记为 incumbent in-flight；fresh session 首次 typed usage-limit 进入 `FreshBlocked`，但不写正式 `ModelState` quota cooldown。
- `FreshBlocked`：
  - established/incumbent success 续租或建立 lease，但保持 `FreshBlocked`，不会绕过 canary gate；
  - observation window 到期或达到 established success threshold 后，只允许一个 fresh canary；
  - canary success 恢复 `Healthy`；
  - canary typed usage-limit 且仍有 established lease 或 incumbent 时，保留 lease、重启观察窗口；
  - canary typed usage-limit 且没有 incumbent 证据时，进入 `ConfirmedCooldown`；
  - established/incumbent typed usage-limit 一次即可进入 `ConfirmedCooldown`。
- `ConfirmedCooldown`：candidate filter、`begin()` 和 dispatch 前 recheck 都拒绝旧请求继续派发；persisted cooldown 到期后通过 generation CAS 回到 canary-eligible `FreshBlocked`，不会直接开放 fresh-session stampede。

因此，即使 fresh canary 连续失败，只要既有会话仍成功或仍在执行，就不会清空 lease，也不会把整个 auth/model 提前全局 cooldown。

## 原子性、生命周期与 stale result

- continuity transition 与 `ModelState` mutation 在同一个 `Manager.MarkResult` 临界区完成，固定使用 manager lock → continuity store lock 顺序。
- config、selector、`Load` 和 close-all 是全局 snapshot boundary；它们推进 lifecycle generation 并清理 process-local continuity state。
- 单个 auth removal 与单个 `CloseExecutionSession` 只清理对应 auth/session，不会误杀无关 session、auth 或已 admission 的其他请求。
- Home runtime auth、continuity default-off、session-affinity disabled、非 `SessionAffinitySelector` 和无 stable session ID 的请求在 lifecycle/canonical guard 前直接 bypass。
- stale success 与 stale typed usage-limit 只保留计数记录，不能清除新 cooldown 或重复增加 backoff；stale `401`、`403`、`invalid_grant` 和 model-not-supported 仍正常更新 availability。
- live attempt/canary token 在 terminal result、cancel、abandon、confirmation、load/remove/close 和 config/selector reset 后有界回收。

## Session identity、lease 与 affinity

- session-affinity 新增显式 `execution_session_id` metadata 作为最高优先级身份来源。
- continuity 只接受 execution、Claude session、session header、Codex session、Amp thread 和 `conversation_id`。
- `X-Client-Request-Id`、generic user ID 和 message hash 不获得 continuity 豁免，也不会遮蔽更靠后的稳定 conversation/session ID。
- established lease 的有效 TTL 取 `established-session-ttl-seconds`、`routing.session-affinity-ttl` 和实际 selector cache TTL 的最小值。
- lease 清理由 `nextLeaseExpiry` 驱动，只有到达下一过期时间才扫描；selector replacement、相关 hot reload、session close、auth removal 和 `Load` 会清理不再有效的期限。

Session affinity 负责稳定的 session-to-auth 偏好；continuity 负责记录哪些 binding 真实成功，并判断 typed 429 是 fresh admission 歧义还是 auth/model 全局失效。二者相关，但不是同一个算法。

## 与已合并 #158 model fallback 的组合

- continuity observation pending 是 zero-dispatch fallback error：不生成 usage failure、auth failure、cooldown、error event，也不发布 selected-auth callback。
- pending/confirmed candidate 可以继续交给 #158 的 ordered model fallback；所有 target 均零派发不可用时仍保留 source 原始 typed 429。
- `context-reset` 关闭 source execution session 时，会保留当前已 admission 的 target auth/model attempt；target A 返回 typed 429 后，target B 仍可真实派发。
- `Execute`、`ExecuteStream` 和 `ExecuteCount` 的 selected-auth callback 在 multi-model pool 中每次 auth selection 最多发布一次。
- post-bootstrap stream terminal error 会把 provider `RetryAfter` 传入正式 cooldown。

本 PR 不改变 #158 的硬边界：`context-reset` 只是有损 visible-transcript replay，不能修复、迁移或重新签名 `reasoning.encrypted_content`。

## 配置与兼容性

新增配置保持默认关闭：

```yaml
routing:
  session-affinity: true
codex:
  rate-limit-continuity:
    enabled: true
    observation-window-seconds: 30
    established-success-threshold: 2
    established-session-ttl-seconds: 3600
```

- 不修改 Management API、数据库或 wire protocol。
- process-local lease、phase、canary、generation 和 active attempt 不写入 cooldown store；进程重启从普通路由状态开始。
- 已同步 config hot-reload diff、示例、LTS feature contract、protected delta、downstream patch ledger 和 contract guard。
- 已检查 `CPA-Panel-LTS` visual config 保存链：Panel 基于完整 YAML `Document` 仅修改 dirty paths，`codex.model-fallback` 与 `codex.rate-limit-continuity` 会作为未知 sibling 原样保留，不会因编辑 `codex.abnormal-reasoning-retry` 被删除。本 PR 不新增 Panel 可视化表单。

## 复查与分支改进

- 已合入包含 #158 的最新 `origin/main`，并将 PR base 从旧 stacked branch 改为 `main`。
- 当前 head：`162a0b351f8371c4d93636a426ada3463218f1cc`。
- 当前 merge-base：`9aef9ffa989998825351d5b512c23c57a2039b8e`，即 #158 merge commit。
- retarget 后 base-to-head diff 为 18 个 continuity 目标文件，未重复携带 #158 的 28 文件实现。
- 完整代码复查未发现需要新增运行时代码修复的阻断问题；改进集中在正确 retarget、最新 main 对齐、跨仓保存语义确认、补充静态与压力验证。

## 验证

以下命令均在当前 head 上通过：

```bash
go test -count=1 \
  ./internal/config \
  ./internal/watcher/diff \
  ./internal/runtime/executor \
  ./sdk/cliproxy/auth \
  ./sdk/api/handlers/openai

go test -race -count=1 \
  ./internal/runtime/executor \
  ./sdk/cliproxy/auth \
  ./sdk/api/handlers/openai

go test -count=20 ./sdk/cliproxy/auth \
  -run 'CodexRateLimitContinuity|CodexModelFallbackContextReset|OpenAICompatAliasPoolPublishesSelectedAuth'

go vet \
  ./internal/config \
  ./internal/watcher/diff \
  ./internal/runtime/executor \
  ./sdk/cliproxy/auth \
  ./sdk/api/handlers/openai

scripts/check-lts-contract.sh
go build -o test-output ./cmd/server && rm -f test-output
go list ./... | rg -v '/tmp$' | xargs go test -count=1
git diff --check origin/main...HEAD
```

回归覆盖并发单 canary、repeated canary failure 保留 established session、pre-block in-flight 成败、confirmation/dispatch barrier、stale quota 与非 quota mutation、terminal stream `RetryAfter`、stable ID 优先级、TTL clamp、`nextLeaseExpiry`、hot reload/load/remove/session close、Home/default-off bypass、ordered context-reset target 和 callback 次数。

真实 provider quota smoke 未执行：没有安全、可控、可重复地产生真实 Codex quota 状态的条件。验收证据采用 deterministic executor/integration、barrier concurrency、stress、race、contract、build、repo-wide tests 与 GitHub CI。

## Review focus

- fresh canary 失败且仍有 incumbent 时，是否始终保持 `FreshBlocked` 且不写正式 cooldown；
- manager/continuity lock order、generation 与 dispatch recheck 是否封闭 confirmation race；
- global snapshot reset 与 scoped auth/session invalidation 是否不会互相误伤；
- Home/default-off/no-stable bypass 是否保持现有 dispatch；
- ordered `context-reset` 中 source close 是否只清理 source，并保留当前 target 与后续 target；
- zero-dispatch、selected-auth callback、usage/error reporting 是否没有副作用。

最终 head 的 `build`、`lts-contract`、`full-test-observation`、`guard-agents-md-changes` 和 `ensure-no-translator-changes` 必须全部成功后才进入合并门禁。
