### PR TITLE
test(lts): 固化 usage 的 canonical reasoning_effort 契约

### DIFF
--- a/docs/lts/core-feature-contracts.yaml
+++ b/docs/lts/core-feature-contracts.yaml
@@ -37,6 +37,7 @@ features:
       - RequestDetail
       - auth_index
       - latency_ms
+      - reasoning_effort
       - service_tier
       - request_service_tier
       - response_service_tier
@@ -78,6 +79,7 @@ features:
       - apis
       - models
       - details
+      - reasoning_effort
       - service_tier
       - request_service_tier
       - response_service_tier

--- a/internal/api/handlers/management/usage_contract_test.go
+++ b/internal/api/handlers/management/usage_contract_test.go
@@ -26,8 +26,9 @@ func TestUsageManagementResponseShapeAndImportExportRoundTrip(t *testing.T) {
 	h := &Handler{}
 	h.SetUsageStatistics(stats)
 
-	getPayload := readUsageStatisticsResponse(t, h)
+	getPayload, getJSON := readUsageStatisticsResponse(t, h)
 	requirePanelUsageShape(t, getPayload.Usage)
+	requireCanonicalReasoningEffortJSON(t, getJSON, "GET usage response")
 	if getPayload.FailedRequests != 0 {
 		t.Fatalf("failed_requests = %d, want 0", getPayload.FailedRequests)
 	}
@@ -53,6 +54,7 @@ func TestUsageManagementResponseShapeAndImportExportRoundTrip(t *testing.T) {
 	if !bytes.Contains(exportedJSON, []byte(`"response_service_tier":"standard"`)) {
 		t.Fatalf("exported usage missing response_service_tier: %s", exportedJSON)
 	}
+	requireCanonicalReasoningEffortJSON(t, exportedJSON, "exported usage")
 	var legacyDecoded struct {
 		Version int `json:"version"`
 		Usage   struct {
@@ -85,7 +87,13 @@ func TestUsageManagementResponseShapeAndImportExportRoundTrip(t *testing.T) {
 	if importResult.TotalRequests != 1 || importResult.FailedRequests != 0 {
 		t.Fatalf("import totals = %+v, want total_requests=1 failed_requests=0", importResult)
 	}
-	requirePanelUsageShape(t, importStats.Snapshot())
+	reimported := exportUsageStatistics(t, importHandler)
+	requirePanelUsageShape(t, reimported.Usage)
+	reimportedJSON, err := json.Marshal(reimported)
+	if err != nil {
+		t.Fatalf("marshal re-exported usage: %v", err)
+	}
+	requireCanonicalReasoningEffortJSON(t, reimportedJSON, "usage re-exported after import")
 }
 
 func TestUsageManagementFailedDetailIncludesFailureReason(t *testing.T) {
@@ -117,7 +125,7 @@ func TestUsageManagementFailedDetailIncludesFailureReason(t *testing.T) {
 
 	h := &Handler{}
 	h.SetUsageStatistics(stats)
-	payload := readUsageStatisticsResponse(t, h)
+	payload, _ := readUsageStatisticsResponse(t, h)
 	if payload.FailedRequests != 1 {
 		t.Fatalf("failed_requests = %d, want 1", payload.FailedRequests)
 	}
@@ -350,10 +358,10 @@ func recordPanelContractUsage(stats *usage.RequestStatistics) {
 	})
 }
 
-func readUsageStatisticsResponse(t *testing.T, h *Handler) struct {
+func readUsageStatisticsResponse(t *testing.T, h *Handler) (struct {
 	Usage          usage.StatisticsSnapshot `json:"usage"`
 	FailedRequests int64                    `json:"failed_requests"`
-} {
+}, []byte) {
 	t.Helper()
 
 	rec := httptest.NewRecorder()
@@ -372,7 +380,7 @@ func readUsageStatisticsResponse(t *testing.T, h *Handler) struct {
 	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
 		t.Fatalf("unmarshal usage response: %v body=%s", err, rec.Body.String())
 	}
-	return payload
+	return payload, rec.Body.Bytes()
 }
 
 func exportUsageStatistics(t *testing.T, h *Handler) usageExportPayload {
@@ -506,5 +514,16 @@ func requirePanelUsageShape(t *testing.T, snapshot usage.StatisticsSnapshot) {
 		detail.Tokens.CachedTokens != 2 ||
 		detail.Tokens.TotalTokens != 17 {
 		t.Fatalf("detail.tokens = %+v, want panel-compatible token breakdown", detail.Tokens)
+	}
+}
+
+func requireCanonicalReasoningEffortJSON(t *testing.T, payload []byte, surface string) {
+	t.Helper()
+
+	if !bytes.Contains(payload, []byte(`"reasoning_effort":"medium"`)) {
+		t.Fatalf("%s missing canonical reasoning_effort: %s", surface, payload)
+	}
+	if bytes.Contains(payload, []byte(`"thinking"`)) {
+		t.Fatalf("%s contains non-canonical thinking field: %s", surface, payload)
 	}
 }

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -131,9 +131,16 @@ require_grep "BlueSkyXN/CPA-Panel-LTS" internal/managementasset/updater.go inter
 require_grep "UsageReporter" internal/runtime/executor/helps/usage_helpers.go
 require_grep "auth_index" internal/usage internal/api/handlers/management internal/runtime/executor/helps internal/redisqueue
 require_grep "latency_ms" internal/usage internal/redisqueue internal/tui
+require_grep 'json:"reasoning_effort,omitempty"' internal/usage
 require_grep 'json:"service_tier,omitempty"' internal/usage
 require_grep 'json:"request_service_tier,omitempty"' internal/usage
 require_grep 'json:"response_service_tier,omitempty"' internal/usage
+if git grep -n 'json:"thinking' -- internal/usage; then
+  echo "non-canonical usage JSON field thinking found; use reasoning_effort" >&2
+  exit 1
+fi
+require_grep "reasoning_effort" internal/api/handlers/management/usage_contract_test.go
+require_grep '"thinking"' internal/api/handlers/management/usage_contract_test.go
 require_grep "request_service_tier" internal/api/handlers/management/usage_contract_test.go
 require_grep "response_service_tier" internal/api/handlers/management/usage_contract_test.go
 


### PR DESCRIPTION
## 结果

固化 CPA-Core-LTS Management usage 的单一推理强度契约：请求明细只通过 `reasoning_effort` 暴露最终 translated upstream thinking level，不新增或接受同义的 usage `thinking` 字段。

本 PR 不改变运行时 schema 或请求转换行为；Codex 客户端的 `ultra → max` 输入兼容、model catalog compatibility 和 Provider thinking translator 均保持不变。

## Type

- [ ] Protected upstream full-sync
- [ ] Staged upstream full-sync
- [ ] LTS protected-delta patch
- [ ] LTS feature / downstream patch maintenance
- [x] Maintenance docs / CI
- [ ] Emergency hotfix

## Upstream sync info

不适用：本 PR 不是 upstream sync。

## 改动

- 扩展 Management usage GET、export/import roundtrip 契约测试，断言 JSON 包含 `reasoning_effort` 且不包含同义 `thinking` 字段。
- 将 `reasoning_effort` 登记为完整 usage statistics 与 Management usage API 的稳定 required marker。
- 扩展 LTS sentinel，保护 `json:"reasoning_effort,omitempty"`，并拒绝 `internal/usage` 引入 `json:"thinking..."`。

## Protected delta checklist

- [x] `usage-statistics-enabled` still exists
- [x] `internal/usage/` still exists
- [x] `/v0/management/usage` still exists
- [x] `/v0/management/usage/export` still exists
- [x] `/v0/management/usage/import` still exists
- [x] `docs/lts/core-feature-contracts.yaml` reviewed
- [x] `docs/lts/downstream-patches.yaml` reviewed; no ledger change required
- [x] Usage record/schema reviewed
- [x] Management usage response shape tested
- [x] Export/import roundtrip tested
- [x] CPA-Panel-LTS response shape reviewed
- [x] Local auth/config/panel/release/source customizations reviewed

## LTS classification review

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| `full-usage-statistics-core` | retained capability | preserved | registry marker、usage tests、全仓测试 |
| `management-usage-api` | retained capability | preserved | GET/export/import wire-shape assertions |
| Codex Ultra compatibility | review seam | preserved | 未修改 `LevelUltra`、catalog overlay 或 wire normalization |

## Conflict resolution notes

无 upstream 冲突。本 PR 仅将当前已存在的 wire shape 固化为可审计契约。

## Validation

- [x] `scripts/check-lts-contract.sh`
- [x] `go run ./scripts/ltsregistry --root .`
- [x] `go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage' -count=1`
- [x] `go test ./internal/thinking ./internal/runtime/executor/helps -count=1`
- [x] `go build -o test-output ./cmd/server && rm -f test-output`
- [x] `go test ./...`
- [x] `git diff --check`

## Optional real runtime smoke

- [x] Skipped：没有运行时逻辑或 wire-shape 变化，PR branch 未部署。
- 配套 Panel PR：BlueSkyXN/CPA-Panel-LTS#19；已使用 mock Core 和本地真实 Core 验证单一 `reasoning_effort` 展示与导出。

## Review focus

1. `reasoning_effort` 是否应作为 Management usage 唯一 canonical 推理强度字段。
2. 对 `internal/usage` 禁止新增 `json:"thinking..."` 是否符合长期契约边界。
3. GET、export/import roundtrip 的负向字段断言是否足够稳定。
