### PR TITLE
sync(lts): 吸收上游 v7.2.70 并加固 alpha search 认证状态边界

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -218,6 +218,7 @@ nonstream-keepalive-interval: 0
 #     models:
 #       - name: "gemini-2.5-flash" # upstream model name
 #         alias: "gemini-flash"    # client alias mapped to the upstream model
+#         display-name: "Gemini Flash" # optional catalog display name
 #     excluded-models:
 #       - "gemini-2.5-pro"     # exclude specific models from this provider (exact match)
 #       - "gemini-2.5-*"       # wildcard matching prefix (e.g. gemini-2.5-flash, gemini-2.5-pro)
@@ -256,6 +257,7 @@ nonstream-keepalive-interval: 0
 #     models:
 #       - name: "gpt-5-codex"   # upstream model name
 #         alias: "codex-latest" # client alias mapped to the upstream model
+#         display-name: "Codex Latest" # optional catalog display name
 #         force-mapping: true    # optional: rewrite response model fields back to the alias
 #     excluded-models:
 #       - "gpt-5.1"         # exclude specific models (exact match)
@@ -277,6 +279,7 @@ nonstream-keepalive-interval: 0
 #     models:
 #       - name: "claude-3-5-sonnet-20241022" # upstream model name
 #         alias: "claude-sonnet-latest"      # client alias mapped to the upstream model
+#         display-name: "Claude Sonnet"      # optional catalog display name
 #         force-mapping: true                 # optional: rewrite response model fields back to the alias
 #     excluded-models:
 #       - "claude-opus-4-5-20251101" # exclude specific models (exact match)
@@ -341,6 +344,7 @@ nonstream-keepalive-interval: 0
 #     models: # The models supported by the provider.
 #       - name: "moonshotai/kimi-k2:free" # The actual model name.
 #         alias: "kimi-k2"               # The alias used in the API.
+#         display-name: "Kimi K2"         # optional catalog display name
 #         image: false                   # optional: set true to allow this model on /v1/images/generations and /v1/images/edits (not chat/responses image input)
 #         input-modalities: [text, image] # optional: declare /v1/chat/completions and /v1/responses multimodal input for Codex clients
 #         output-modalities: [text]       # optional: declare output modalities when known
@@ -370,6 +374,7 @@ nonstream-keepalive-interval: 0
 #     models:                                     # optional: map aliases to upstream model names
 #       - name: "gemini-2.5-flash"                # upstream model name
 #         alias: "vertex-flash"                   # client-visible alias
+#         display-name: "Vertex Flash"            # optional catalog display name
 #       - name: "gemini-2.5-pro"
 #         alias: "vertex-pro"
 #     excluded-models:                            # optional: models to exclude from listing

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -319,6 +319,7 @@ nonstream-keepalive-interval: 0
 #     models:
 #       - name: "gemini-2.5-flash" # upstream model name
 #         alias: "gemini-flash"    # client alias mapped to the upstream model
+#         display-name: "Gemini Flash" # optional catalog display name
 #     excluded-models:
 #       - "gemini-2.5-pro"     # exclude specific models from this provider (exact match)
 #       - "gemini-2.5-*"       # wildcard matching prefix (e.g. gemini-2.5-flash, gemini-2.5-pro)
@@ -357,6 +358,7 @@ nonstream-keepalive-interval: 0
 #     models:
 #       - name: "gpt-5-codex"   # upstream model name
 #         alias: "codex-latest" # client alias mapped to the upstream model
+#         display-name: "Codex Latest" # optional catalog display name
 #         force-mapping: true    # optional: rewrite response model fields back to the alias
 #     excluded-models:
 #       - "gpt-5.1"         # exclude specific models (exact match)
@@ -378,6 +380,7 @@ nonstream-keepalive-interval: 0
 #     models:
 #       - name: "claude-3-5-sonnet-20241022" # upstream model name
 #         alias: "claude-sonnet-latest"      # client alias mapped to the upstream model
+#         display-name: "Claude Sonnet"      # optional catalog display name
 #         force-mapping: true                 # optional: rewrite response model fields back to the alias
 #     excluded-models:
 #       - "claude-opus-4-5-20251101" # exclude specific models (exact match)
@@ -445,6 +448,7 @@ nonstream-keepalive-interval: 0
 #     models: # The models supported by the provider.
 #       - name: "moonshotai/kimi-k2:free" # The actual model name.
 #         alias: "kimi-k2"               # The alias used in the API.
+#         display-name: "Kimi K2"         # optional catalog display name
 #         image: false                   # optional: set true to allow this model on /v1/images/generations and /v1/images/edits (not chat/responses image input)
 #         input-modalities: [text, image] # optional: declare /v1/chat/completions and /v1/responses multimodal input for Codex clients
 #         output-modalities: [text]       # optional: declare output modalities when known
@@ -474,6 +478,7 @@ nonstream-keepalive-interval: 0
 #     models:                                     # optional: map aliases to upstream model names
 #       - name: "gemini-2.5-flash"                # upstream model name
 #         alias: "vertex-flash"                   # client-visible alias
+#         display-name: "Vertex Flash"            # optional catalog display name
 #       - name: "gemini-2.5-pro"
 #         alias: "vertex-pro"
 #     excluded-models:                            # optional: models to exclude from listing

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginhost"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/redisqueue"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/safemode"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
@@ -44,6 +45,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers/openai"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/http2"
 	"gopkg.in/yaml.v3"
@@ -632,23 +634,35 @@ func (s *Server) codexAlphaSearch(c *gin.Context) {
 		return
 	}
 
-	var selected *auth.Auth
-	for _, candidate := range s.handlers.AuthManager.List() {
-		if candidate != nil && candidate.Provider == "codex" && !candidate.Disabled && !candidate.Unavailable {
-			selected = candidate
-			break
-		}
-	}
-	if selected == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "No available Codex OAuth credential"})
-		return
-	}
-
 	body, err := io.ReadAll(io.LimitReader(c.Request.Body, 16<<20))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Failed to read search request"})
 		return
 	}
+
+	var routing struct {
+		ID    string `json:"id"`
+		Model string `json:"model"`
+	}
+	_ = json.Unmarshal(body, &routing)
+
+	selectionHeaders := c.Request.Header.Clone()
+	if sessionID := strings.TrimSpace(routing.ID); sessionID != "" {
+		selectionHeaders.Set("X-Session-ID", sessionID)
+	}
+	selected, err := s.handlers.AuthManager.SelectAuth(c.Request.Context(), "codex", strings.TrimSpace(routing.Model), coreexecutor.Options{
+		Headers:         selectionHeaders,
+		OriginalRequest: body,
+	})
+	if err != nil {
+		status := http.StatusServiceUnavailable
+		if statusError, ok := err.(interface{ StatusCode() int }); ok && statusError.StatusCode() > 0 {
+			status = statusError.StatusCode()
+		}
+		c.JSON(status, gin.H{"error": err.Error()})
+		return
+	}
+
 	headers := make(http.Header)
 	headers.Set("Content-Type", "application/json")
 	headers.Set("Accept", "application/json")
@@ -662,25 +676,54 @@ func (s *Server) codexAlphaSearch(c *gin.Context) {
 		headers.Set("Chatgpt-Account-Id", accountID)
 	}
 
+	ctx := context.WithValue(c.Request.Context(), "gin", c)
+	const upstreamURL = "https://chatgpt.com/backend-api/codex/alpha/search"
 	req, err := s.handlers.AuthManager.NewHttpRequest(
-		c.Request.Context(), selected, http.MethodPost,
-		"https://chatgpt.com/backend-api/codex/alpha/search", body, headers,
+		ctx, selected, http.MethodPost, upstreamURL, body, headers,
 	)
 	if err != nil {
 		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
 		return
 	}
-	resp, err := s.handlers.AuthManager.HttpRequest(c.Request.Context(), selected, req)
+
+	var authID, authLabel, authType, authValue string
+	if selected != nil {
+		authID = selected.ID
+		authLabel = selected.Label
+		authType, authValue = selected.AccountInfo()
+	}
+	helpHeaders := req.Header.Clone()
+	helps.RecordAPIRequest(ctx, s.cfg, helps.UpstreamRequestLog{
+		URL:       upstreamURL,
+		Method:    http.MethodPost,
+		Headers:   helpHeaders,
+		Body:      body,
+		Provider:  "codex",
+		AuthID:    authID,
+		AuthLabel: authLabel,
+		AuthType:  authType,
+		AuthValue: authValue,
+	})
+
+	resp, err := s.handlers.AuthManager.HttpRequest(ctx, selected, req)
 	if err != nil {
+		helps.RecordAPIResponseError(ctx, s.cfg, err)
 		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
 		return
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Errorf("codex alpha search: close response body error: %v", errClose)
+		}
+	}()
+	helps.RecordAPIResponseMetadata(ctx, s.cfg, resp.StatusCode, resp.Header.Clone())
 	upstreamBody, err := io.ReadAll(io.LimitReader(resp.Body, 32<<20))
 	if err != nil {
+		helps.RecordAPIResponseError(ctx, s.cfg, err)
 		c.JSON(http.StatusBadGateway, gin.H{"error": "Failed to read Codex search response"})
 		return
 	}
+	helps.AppendAPIResponseChunk(ctx, s.cfg, upstreamBody)
 	if contentType := resp.Header.Get("Content-Type"); contentType != "" {
 		c.Header("Content-Type", contentType)
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -532,6 +533,7 @@ func (s *Server) setupRoutes() {
 		v1.GET("/responses", openaiResponsesHandlers.ResponsesWebsocket)
 		v1.POST("/responses", openaiResponsesHandlers.Responses)
 		v1.POST("/responses/compact", openaiResponsesHandlers.Compact)
+		v1.POST("/alpha/search", s.codexAlphaSearch)
 	}
 
 	openaiV1 := s.engine.Group("/openai/v1")
@@ -619,6 +621,71 @@ func (s *Server) setupRoutes() {
 	})
 
 	// Management routes are registered lazily by registerManagementRoutes when a secret is configured.
+}
+
+// codexAlphaSearch forwards the standalone search endpoint used by current
+// Codex clients. Unlike /responses, this payload is already in Codex search
+// format and must not pass through a protocol translator.
+func (s *Server) codexAlphaSearch(c *gin.Context) {
+	if s == nil || s.handlers == nil || s.handlers.AuthManager == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Codex auth manager unavailable"})
+		return
+	}
+
+	var selected *auth.Auth
+	for _, candidate := range s.handlers.AuthManager.List() {
+		if candidate != nil && candidate.Provider == "codex" && !candidate.Disabled && !candidate.Unavailable {
+			selected = candidate
+			break
+		}
+	}
+	if selected == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "No available Codex OAuth credential"})
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(c.Request.Body, 16<<20))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Failed to read search request"})
+		return
+	}
+	headers := make(http.Header)
+	headers.Set("Content-Type", "application/json")
+	headers.Set("Accept", "application/json")
+	headers.Set("Originator", "codex_cli_rs")
+	for _, name := range []string{"Version", "User-Agent", "Session_id", "X-Client-Request-Id"} {
+		if value := strings.TrimSpace(c.GetHeader(name)); value != "" {
+			headers.Set(name, value)
+		}
+	}
+	if accountID, ok := selected.Metadata["account_id"].(string); ok && strings.TrimSpace(accountID) != "" {
+		headers.Set("Chatgpt-Account-Id", accountID)
+	}
+
+	req, err := s.handlers.AuthManager.NewHttpRequest(
+		c.Request.Context(), selected, http.MethodPost,
+		"https://chatgpt.com/backend-api/codex/alpha/search", body, headers,
+	)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+		return
+	}
+	resp, err := s.handlers.AuthManager.HttpRequest(c.Request.Context(), selected, req)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+		return
+	}
+	defer resp.Body.Close()
+	upstreamBody, err := io.ReadAll(io.LimitReader(resp.Body, 32<<20))
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "Failed to read Codex search response"})
+		return
+	}
+	if contentType := resp.Header.Get("Content-Type"); contentType != "" {
+		c.Header("Content-Type", contentType)
+	}
+	c.Status(resp.StatusCode)
+	_, _ = c.Writer.Write(upstreamBody)
 }
 
 // AttachWebsocketRoute registers a websocket upgrade handler on the primary Gin engine.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -5,12 +5,14 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"crypto/subtle"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -37,6 +39,8 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginhost"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/redisqueue"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	runtimeexecutor "github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/safemode"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/usage"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
@@ -47,7 +51,9 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers/openai"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
 	"golang.org/x/net/http2"
 	"gopkg.in/yaml.v3"
 )
@@ -557,6 +563,7 @@ func (s *Server) setupRoutes() {
 		v1.GET("/responses", openaiResponsesHandlers.ResponsesWebsocket)
 		v1.POST("/responses", openaiResponsesHandlers.Responses)
 		v1.POST("/responses/compact", openaiResponsesHandlers.Compact)
+		v1.POST("/alpha/search", s.codexAlphaSearch)
 	}
 
 	openaiV1 := s.engine.Group("/openai/v1")
@@ -644,6 +651,241 @@ func (s *Server) setupRoutes() {
 	})
 
 	// Management routes are registered lazily by registerManagementRoutes when a secret is configured.
+}
+
+// codexAlphaSearch forwards the standalone search endpoint used by current
+// Codex clients. Unlike /responses, this payload is already in Codex search
+// format and must not pass through a protocol translator.
+func (s *Server) codexAlphaSearch(c *gin.Context) {
+	if s == nil || s.handlers == nil || s.handlers.AuthManager == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Codex auth manager unavailable"})
+		return
+	}
+
+	body, tooLarge, err := readCodexAlphaSearchBody(c.Request.Body, codexAlphaSearchRequestMaxBytes)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Failed to read search request"})
+		return
+	}
+	if tooLarge {
+		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "Codex search request exceeds 16 MiB"})
+		return
+	}
+
+	var routing struct {
+		ID    string `json:"id"`
+		Model string `json:"model"`
+	}
+	trimmedBody := bytes.TrimSpace(body)
+	if len(trimmedBody) == 0 || trimmedBody[0] != '{' {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid Codex search request JSON"})
+		return
+	}
+	if err = json.Unmarshal(trimmedBody, &routing); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid Codex search request JSON"})
+		return
+	}
+
+	selectionHeaders := c.Request.Header.Clone()
+	if sessionID := strings.TrimSpace(routing.ID); sessionID != "" {
+		selectionHeaders.Set("X-Session-ID", sessionID)
+	}
+	routeModel := strings.TrimSpace(routing.Model)
+	selectionCtx := context.WithValue(c.Request.Context(), "gin", c)
+	selected, resultCtx, err := s.handlers.AuthManager.SelectAuthForRequest(selectionCtx, "codex", routeModel, coreexecutor.Options{
+		Headers:         selectionHeaders,
+		OriginalRequest: body,
+	})
+	if err != nil {
+		status := http.StatusServiceUnavailable
+		if statusError, ok := err.(interface{ StatusCode() int }); ok && statusError.StatusCode() > 0 {
+			status = statusError.StatusCode()
+		}
+		c.JSON(status, gin.H{"error": err.Error()})
+		return
+	}
+	defer s.handlers.AuthManager.AbandonSelectedAuthRequest(resultCtx)
+
+	headers := make(http.Header)
+	headers.Set("Content-Type", "application/json")
+	headers.Set("Accept", "application/json")
+	headers.Set("Originator", "codex_cli_rs")
+	for _, name := range []string{"Version", "User-Agent", "Session_id", "X-Client-Request-Id"} {
+		if value := strings.TrimSpace(c.GetHeader(name)); value != "" {
+			headers.Set(name, value)
+		}
+	}
+	if accountID, ok := selected.Metadata["account_id"].(string); ok && strings.TrimSpace(accountID) != "" {
+		headers.Set("Chatgpt-Account-Id", accountID)
+	}
+
+	ctx := resultCtx
+	const upstreamURL = "https://chatgpt.com/backend-api/codex/alpha/search"
+	req, err := s.handlers.AuthManager.NewHttpRequest(
+		ctx, selected, http.MethodPost, upstreamURL, body, headers,
+	)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+		return
+	}
+	var authID, authLabel, authType, authValue string
+	if selected != nil {
+		authID = selected.ID
+		authLabel = selected.Label
+		authType, authValue = selected.AccountInfo()
+	}
+	if err = s.handlers.AuthManager.ConfirmSelectedAuthDispatch(resultCtx); err != nil {
+		status := http.StatusServiceUnavailable
+		if statusError, ok := err.(interface{ StatusCode() int }); ok && statusError.StatusCode() > 0 {
+			status = statusError.StatusCode()
+		}
+		c.JSON(status, gin.H{"error": err.Error()})
+		return
+	}
+	helpHeaders := req.Header.Clone()
+	helps.RecordAPIRequest(ctx, s.cfg, helps.UpstreamRequestLog{
+		URL:       upstreamURL,
+		Method:    http.MethodPost,
+		Headers:   helpHeaders,
+		Body:      nil,
+		Provider:  "codex",
+		AuthID:    authID,
+		AuthLabel: authLabel,
+		AuthType:  authType,
+		AuthValue: authValue,
+	})
+
+	resp, err := s.handlers.AuthManager.HttpRequest(ctx, selected, req)
+	if err != nil {
+		if codexAlphaSearchShouldMarkTransportFailure(ctx, err) {
+			markCodexAlphaSearchResult(s.handlers.AuthManager, resultCtx, selected, routeModel, http.StatusBadGateway, nil, nil, err)
+		}
+		helps.RecordAPIResponseError(ctx, s.cfg, err)
+		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+		return
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Errorf("codex alpha search: close response body error: %v", errClose)
+		}
+	}()
+	helps.RecordAPIResponseMetadata(ctx, s.cfg, resp.StatusCode, resp.Header.Clone())
+	upstreamBody, responseTooLarge, err := readCodexAlphaSearchBody(resp.Body, codexAlphaSearchResponseMaxBytes)
+	if err != nil {
+		helps.RecordAPIResponseError(ctx, s.cfg, err)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "Failed to read Codex search response"})
+		return
+	}
+	if responseTooLarge {
+		errResponseTooLarge := errors.New("Codex search response exceeds 32 MiB")
+		helps.RecordAPIResponseError(ctx, s.cfg, errResponseTooLarge)
+		c.JSON(http.StatusBadGateway, gin.H{"error": errResponseTooLarge.Error()})
+		return
+	}
+	responseStatus := markCodexAlphaSearchResult(s.handlers.AuthManager, resultCtx, selected, routeModel, resp.StatusCode, resp.Header, upstreamBody, nil)
+	if contentType := resp.Header.Get("Content-Type"); contentType != "" {
+		c.Header("Content-Type", contentType)
+	}
+	c.Status(responseStatus)
+	_, _ = c.Writer.Write(upstreamBody)
+}
+
+const (
+	codexAlphaSearchRequestMaxBytes  int64 = 16 << 20
+	codexAlphaSearchResponseMaxBytes int64 = 32 << 20
+)
+
+func readCodexAlphaSearchBody(reader io.Reader, maxBytes int64) ([]byte, bool, error) {
+	if reader == nil {
+		return nil, false, nil
+	}
+	body, err := io.ReadAll(io.LimitReader(reader, maxBytes+1))
+	if err != nil {
+		return nil, false, err
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, true, nil
+	}
+	return body, false, nil
+}
+
+func codexAlphaSearchShouldMarkTransportFailure(ctx context.Context, requestErr error) bool {
+	if requestErr == nil {
+		return false
+	}
+	if ctx != nil && ctx.Err() != nil {
+		return false
+	}
+	return !errors.Is(requestErr, context.Canceled) && !errors.Is(requestErr, context.DeadlineExceeded)
+}
+
+func markCodexAlphaSearchResult(manager *auth.Manager, ctx context.Context, selected *auth.Auth, model string, status int, headers http.Header, body []byte, requestErr error) int {
+	statusCode := status
+	if statusError, ok := requestErr.(interface{ StatusCode() int }); ok && statusError.StatusCode() > 0 {
+		statusCode = statusError.StatusCode()
+	}
+	classification := runtimeexecutor.ClassifyCodexUpstreamError(statusCode, body, time.Now())
+	statusCode = classification.HTTPStatus
+	if manager == nil || selected == nil {
+		return statusCode
+	}
+	result := auth.Result{
+		AuthID:   selected.ID,
+		Provider: "codex",
+		Model:    strings.TrimSpace(model),
+		Success:  requestErr == nil && statusCode >= http.StatusOK && statusCode < http.StatusBadRequest,
+	}
+	if !result.Success && (classification.RequestInvalid || (result.Model == "" && !classification.RecordWithoutModel)) {
+		return statusCode
+	}
+	if !result.Success {
+		message := strings.TrimSpace(gjson.GetBytes(body, "error.message").String())
+		if message == "" {
+			message = strings.TrimSpace(gjson.GetBytes(body, "message").String())
+		}
+		if message == "" {
+			message = http.StatusText(statusCode)
+		}
+		if message == "" {
+			message = "Codex search request failed"
+		}
+		if requestErr != nil {
+			message = requestErr.Error()
+		}
+		code := codexAlphaSearchErrorCode(body)
+		result.Error = &auth.Error{Code: code, Message: message, HTTPStatus: statusCode}
+		result.RetryAfter = codexAlphaSearchHeaderRetryAfter(headers, time.Now())
+		if result.RetryAfter == nil {
+			result.RetryAfter = classification.RetryAfter
+		}
+		result.ModelFallbackReason = classification.ModelFallbackReason
+	}
+	manager.MarkResult(ctx, result)
+	return statusCode
+}
+
+func codexAlphaSearchErrorCode(body []byte) string {
+	for _, path := range []string{"error.code", "error.type", "code", "type"} {
+		if value := strings.TrimSpace(gjson.GetBytes(body, path).String()); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func codexAlphaSearchHeaderRetryAfter(headers http.Header, now time.Time) *time.Duration {
+	if headers != nil {
+		raw := strings.TrimSpace(headers.Get("Retry-After"))
+		if seconds, err := strconv.ParseInt(raw, 10, 64); err == nil && seconds > 0 {
+			duration := time.Duration(seconds) * time.Second
+			return &duration
+		}
+		if retryAt, err := http.ParseTime(raw); err == nil && retryAt.After(now) {
+			duration := retryAt.Sub(now)
+			return &duration
+		}
+	}
+	return nil
 }
 
 // AttachWebsocketRoute registers a websocket upgrade handler on the primary Gin engine.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -28,6 +28,7 @@ import (
 type codexSearchCaptureExecutor struct {
 	request *http.Request
 	body    []byte
+	authIDs []string
 }
 
 func (e *codexSearchCaptureExecutor) Identifier() string { return "codex" }
@@ -54,8 +55,9 @@ func (e *codexSearchCaptureExecutor) PrepareRequest(req *http.Request, a *auth.A
 	return nil
 }
 
-func (e *codexSearchCaptureExecutor) HttpRequest(_ context.Context, _ *auth.Auth, req *http.Request) (*http.Response, error) {
+func (e *codexSearchCaptureExecutor) HttpRequest(_ context.Context, selected *auth.Auth, req *http.Request) (*http.Response, error) {
 	e.request = req.Clone(req.Context())
+	e.authIDs = append(e.authIDs, selected.ID)
 	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		return nil, err
@@ -183,6 +185,107 @@ func TestCodexAlphaSearchForwardsRequest(t *testing.T) {
 	}
 	if got := rr.Header().Get("Content-Type"); got != "application/json" {
 		t.Fatalf("response Content-Type = %q", got)
+	}
+}
+
+func TestCodexAlphaSearchUsesRequestIDForSessionAffinity(t *testing.T) {
+	server := newTestServer(t)
+	server.handlers.AuthManager.SetSelector(auth.NewSessionAffinitySelector(&auth.RoundRobinSelector{}))
+	executor := &codexSearchCaptureExecutor{}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	for _, id := range []string{"codex-auth-a", "codex-auth-b"} {
+		registry.GetGlobalRegistry().RegisterClient(id, "codex", []*registry.ModelInfo{{ID: "gpt-5.6-luna"}})
+		t.Cleanup(func() {
+			registry.GetGlobalRegistry().UnregisterClient(id)
+		})
+		credential := &auth.Auth{
+			ID:       id,
+			Provider: "codex",
+			Status:   auth.StatusActive,
+			Metadata: map[string]any{"access_token": id},
+		}
+		if _, errRegister := server.handlers.AuthManager.Register(context.Background(), credential); errRegister != nil {
+			t.Fatalf("register Codex auth: %v", errRegister)
+		}
+	}
+
+	for _, payload := range []string{
+		`{"id":"session-a","model":"gpt-5.6-luna"}`,
+		`{"id":"session-b","model":"gpt-5.6-luna"}`,
+		`{"id":"session-a","model":"gpt-5.6-luna"}`,
+	} {
+		req := httptest.NewRequest(http.MethodPost, "/v1/alpha/search", strings.NewReader(payload))
+		req.Header.Set("Authorization", "Bearer test-key")
+		rr := httptest.NewRecorder()
+		server.engine.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+		}
+	}
+
+	if got, want := len(executor.authIDs), 3; got != want {
+		t.Fatalf("selected auth count = %d, want %d", got, want)
+	}
+	if executor.authIDs[0] == executor.authIDs[1] {
+		t.Fatalf("different sessions selected the same auth %q", executor.authIDs[0])
+	}
+	if got, want := executor.authIDs[2], executor.authIDs[0]; got != want {
+		t.Fatalf("session-affinity auth = %q, want %q", got, want)
+	}
+}
+
+func TestCodexAlphaSearchRecordsRequestLog(t *testing.T) {
+	server := newTestServer(t)
+	server.cfg.RequestLog = true
+
+	executor := &codexSearchCaptureExecutor{}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	credential := &auth.Auth{
+		ID:       "codex-auth",
+		Provider: "codex",
+		Status:   auth.StatusActive,
+		Metadata: map[string]any{"access_token": "codex-token", "account_id": "account-123"},
+	}
+	if _, err := server.handlers.AuthManager.Register(context.Background(), credential); err != nil {
+		t.Fatalf("register Codex auth: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rr)
+	req := httptest.NewRequest(http.MethodPost, "/v1/alpha/search", strings.NewReader(`{"query":"GPT-5.6"}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	server.codexAlphaSearch(c)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	rawAPIRequest, okRequest := c.Get("API_REQUEST")
+	if !okRequest {
+		t.Fatal("API_REQUEST was not captured")
+	}
+	apiRequest, _ := rawAPIRequest.([]byte)
+	if !strings.Contains(string(apiRequest), "=== API REQUEST 1 ===") {
+		t.Fatalf("API_REQUEST missing request header section: %q", apiRequest)
+	}
+	if !strings.Contains(string(apiRequest), "https://chatgpt.com/backend-api/codex/alpha/search") {
+		t.Fatalf("API_REQUEST missing upstream URL: %q", apiRequest)
+	}
+	if !strings.Contains(string(apiRequest), `{"query":"GPT-5.6"}`) {
+		t.Fatalf("API_REQUEST missing body: %q", apiRequest)
+	}
+	rawAPIResponse, okResponse := c.Get("API_RESPONSE")
+	if !okResponse {
+		t.Fatal("API_RESPONSE was not captured")
+	}
+	apiResponse, _ := rawAPIResponse.([]byte)
+	if !strings.Contains(string(apiResponse), "=== API RESPONSE 1 ===") {
+		t.Fatalf("API_RESPONSE missing response header section: %q", apiResponse)
+	}
+	if !strings.Contains(string(apiResponse), `{"results":[{"url":"https://example.com"}]}`) {
+		t.Fatalf("API_RESPONSE missing body: %q", apiResponse)
 	}
 }
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -19,8 +21,52 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 )
+
+type codexSearchCaptureExecutor struct {
+	request *http.Request
+	body    []byte
+}
+
+func (e *codexSearchCaptureExecutor) Identifier() string { return "codex" }
+
+func (e *codexSearchCaptureExecutor) Execute(context.Context, *auth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, nil
+}
+
+func (e *codexSearchCaptureExecutor) ExecuteStream(context.Context, *auth.Auth, coreexecutor.Request, coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	return nil, nil
+}
+
+func (e *codexSearchCaptureExecutor) Refresh(_ context.Context, a *auth.Auth) (*auth.Auth, error) {
+	return a, nil
+}
+
+func (e *codexSearchCaptureExecutor) CountTokens(context.Context, *auth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, nil
+}
+
+func (e *codexSearchCaptureExecutor) PrepareRequest(req *http.Request, a *auth.Auth) error {
+	token, _ := a.Metadata["access_token"].(string)
+	req.Header.Set("Authorization", "Bearer "+token)
+	return nil
+}
+
+func (e *codexSearchCaptureExecutor) HttpRequest(_ context.Context, _ *auth.Auth, req *http.Request) (*http.Response, error) {
+	e.request = req.Clone(req.Context())
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	e.body = body
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"results":[{"url":"https://example.com"}]}`)),
+	}, nil
+}
 
 func newTestServer(t *testing.T) *Server {
 	t.Helper()
@@ -91,6 +137,53 @@ func TestHealthz(t *testing.T) {
 			t.Fatalf("expected empty body for HEAD request, got %q", rr.Body.String())
 		}
 	})
+}
+
+func TestCodexAlphaSearchForwardsRequest(t *testing.T) {
+	server := newTestServer(t)
+	executor := &codexSearchCaptureExecutor{}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	credential := &auth.Auth{
+		ID:       "codex-auth",
+		Provider: "codex",
+		Status:   auth.StatusActive,
+		Metadata: map[string]any{"access_token": "codex-token", "account_id": "account-123"},
+	}
+	if _, err := server.handlers.AuthManager.Register(context.Background(), credential); err != nil {
+		t.Fatalf("register Codex auth: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/alpha/search", strings.NewReader(`{"query":"GPT-5.6"}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Session_id", "session-123")
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if executor.request == nil {
+		t.Fatal("Codex executor did not receive a request")
+	}
+	if got, want := executor.request.URL.String(), "https://chatgpt.com/backend-api/codex/alpha/search"; got != want {
+		t.Fatalf("upstream URL = %q, want %q", got, want)
+	}
+	if got, want := string(executor.body), `{"query":"GPT-5.6"}`; got != want {
+		t.Fatalf("upstream body = %q, want %q", got, want)
+	}
+	if got := executor.request.Header.Get("Authorization"); got != "Bearer codex-token" {
+		t.Fatalf("Authorization = %q", got)
+	}
+	if got := executor.request.Header.Get("Chatgpt-Account-Id"); got != "account-123" {
+		t.Fatalf("Chatgpt-Account-Id = %q", got)
+	}
+	if got := executor.request.Header.Get("Session_id"); got != "session-123" {
+		t.Fatalf("Session_id = %q", got)
+	}
+	if got := rr.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("response Content-Type = %q", got)
+	}
 }
 
 func TestManagementResponseExposesPluginSupportHeaderForCORS(t *testing.T) {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,7 +1,10 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -19,8 +22,100 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	sdkaccess "github.com/router-for-me/CLIProxyAPI/v7/sdk/access"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 )
+
+type codexSearchCaptureExecutor struct {
+	request *http.Request
+	body    []byte
+	authIDs []string
+	prepare func(*http.Request, *auth.Auth) error
+	respond func(*auth.Auth) (*http.Response, error)
+}
+
+type fixedByteReader struct {
+	remaining int64
+}
+
+type codexSearchErrorReader struct {
+	err error
+}
+
+func (r *codexSearchErrorReader) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func (r *fixedByteReader) Read(p []byte) (int, error) {
+	if r == nil || r.remaining <= 0 {
+		return 0, io.EOF
+	}
+	if int64(len(p)) > r.remaining {
+		p = p[:r.remaining]
+	}
+	for i := range p {
+		p[i] = 'x'
+	}
+	r.remaining -= int64(len(p))
+	return len(p), nil
+}
+
+func (e *codexSearchCaptureExecutor) Identifier() string { return "codex" }
+
+func (e *codexSearchCaptureExecutor) Execute(context.Context, *auth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, nil
+}
+
+func (e *codexSearchCaptureExecutor) ExecuteStream(context.Context, *auth.Auth, coreexecutor.Request, coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	return nil, nil
+}
+
+func (e *codexSearchCaptureExecutor) Refresh(_ context.Context, a *auth.Auth) (*auth.Auth, error) {
+	return a, nil
+}
+
+func (e *codexSearchCaptureExecutor) CountTokens(context.Context, *auth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, nil
+}
+
+func (e *codexSearchCaptureExecutor) PrepareRequest(req *http.Request, a *auth.Auth) error {
+	token, _ := a.Metadata["access_token"].(string)
+	req.Header.Set("Authorization", "Bearer "+token)
+	if e.prepare != nil {
+		return e.prepare(req, a)
+	}
+	return nil
+}
+
+type codexSearchGinContextSelector struct {
+	ginContext *gin.Context
+}
+
+func (s *codexSearchGinContextSelector) Pick(ctx context.Context, _ string, _ string, _ coreexecutor.Options, auths []*auth.Auth) (*auth.Auth, error) {
+	s.ginContext, _ = ctx.Value("gin").(*gin.Context)
+	if len(auths) == 0 {
+		return nil, nil
+	}
+	return auths[0], nil
+}
+
+func (e *codexSearchCaptureExecutor) HttpRequest(_ context.Context, selected *auth.Auth, req *http.Request) (*http.Response, error) {
+	e.request = req.Clone(req.Context())
+	e.authIDs = append(e.authIDs, selected.ID)
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	e.body = body
+	if e.respond != nil {
+		return e.respond(selected)
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"results":[{"url":"https://example.com"}]}`)),
+	}, nil
+}
 
 func newTestServer(t *testing.T) *Server {
 	t.Helper()
@@ -54,6 +149,24 @@ func newTestServerWithOptions(t *testing.T, opts ...ServerOption) *Server {
 
 	configPath := filepath.Join(tmpDir, "config.yaml")
 	return NewServer(cfg, authManager, accessManager, configPath, opts...)
+}
+
+func registerCodexSearchCredential(t *testing.T, server *Server, authID, model string) *auth.Auth {
+	t.Helper()
+	credential := &auth.Auth{
+		ID:       authID,
+		Provider: "codex",
+		Status:   auth.StatusActive,
+		Metadata: map[string]any{"access_token": authID},
+	}
+	if model != "" {
+		registry.GetGlobalRegistry().RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+		t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(authID) })
+	}
+	if _, err := server.handlers.AuthManager.Register(context.Background(), credential); err != nil {
+		t.Fatalf("register Codex auth: %v", err)
+	}
+	return credential
 }
 
 func TestHealthz(t *testing.T) {
@@ -91,6 +204,707 @@ func TestHealthz(t *testing.T) {
 			t.Fatalf("expected empty body for HEAD request, got %q", rr.Body.String())
 		}
 	})
+}
+
+func TestCodexAlphaSearchForwardsRequest(t *testing.T) {
+	server := newTestServer(t)
+	executor := &codexSearchCaptureExecutor{}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	credential := &auth.Auth{
+		ID:       "codex-auth",
+		Provider: "codex",
+		Status:   auth.StatusActive,
+		Metadata: map[string]any{"access_token": "codex-token", "account_id": "account-123"},
+	}
+	if _, err := server.handlers.AuthManager.Register(context.Background(), credential); err != nil {
+		t.Fatalf("register Codex auth: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/alpha/search", strings.NewReader(`{"query":"GPT-5.6"}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Session_id", "session-123")
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if executor.request == nil {
+		t.Fatal("Codex executor did not receive a request")
+	}
+	if got, want := executor.request.URL.String(), "https://chatgpt.com/backend-api/codex/alpha/search"; got != want {
+		t.Fatalf("upstream URL = %q, want %q", got, want)
+	}
+	if got, want := string(executor.body), `{"query":"GPT-5.6"}`; got != want {
+		t.Fatalf("upstream body = %q, want %q", got, want)
+	}
+	if got := executor.request.Header.Get("Authorization"); got != "Bearer codex-token" {
+		t.Fatalf("Authorization = %q", got)
+	}
+	if got := executor.request.Header.Get("Chatgpt-Account-Id"); got != "account-123" {
+		t.Fatalf("Chatgpt-Account-Id = %q", got)
+	}
+	if got := executor.request.Header.Get("Session_id"); got != "session-123" {
+		t.Fatalf("Session_id = %q", got)
+	}
+	if got := rr.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("response Content-Type = %q", got)
+	}
+}
+
+func TestCodexAlphaSearchPassesGinContextToAuthSelection(t *testing.T) {
+	server := newTestServer(t)
+	selector := &codexSearchGinContextSelector{}
+	server.handlers.AuthManager.SetSelector(selector)
+	executor := &codexSearchCaptureExecutor{}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	registerCodexSearchCredential(t, server, "codex-auth", "")
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/alpha/search?key=home-query-key", strings.NewReader(`{"query":"GPT-5.6"}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if selector.ginContext == nil {
+		t.Fatal("auth selection did not receive the Gin context required by Home scheduling")
+	}
+	if got := selector.ginContext.Query("key"); got != "home-query-key" {
+		t.Fatalf("Gin query key = %q, want %q", got, "home-query-key")
+	}
+}
+
+func TestCodexAlphaSearchUsesRequestIDForSessionAffinity(t *testing.T) {
+	server := newTestServer(t)
+	server.handlers.AuthManager.SetSelector(auth.NewSessionAffinitySelector(&auth.RoundRobinSelector{}))
+	executor := &codexSearchCaptureExecutor{}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	for _, id := range []string{"codex-auth-a", "codex-auth-b"} {
+		registry.GetGlobalRegistry().RegisterClient(id, "codex", []*registry.ModelInfo{{ID: "gpt-5.6-luna"}})
+		t.Cleanup(func() {
+			registry.GetGlobalRegistry().UnregisterClient(id)
+		})
+		credential := &auth.Auth{
+			ID:       id,
+			Provider: "codex",
+			Status:   auth.StatusActive,
+			Metadata: map[string]any{"access_token": id},
+		}
+		if _, errRegister := server.handlers.AuthManager.Register(context.Background(), credential); errRegister != nil {
+			t.Fatalf("register Codex auth: %v", errRegister)
+		}
+	}
+
+	for _, payload := range []string{
+		`{"id":"session-a","model":"gpt-5.6-luna"}`,
+		`{"id":"session-b","model":"gpt-5.6-luna"}`,
+		`{"id":"session-a","model":"gpt-5.6-luna"}`,
+	} {
+		req := httptest.NewRequest(http.MethodPost, "/v1/alpha/search", strings.NewReader(payload))
+		req.Header.Set("Authorization", "Bearer test-key")
+		rr := httptest.NewRecorder()
+		server.engine.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+		}
+	}
+
+	if got, want := len(executor.authIDs), 3; got != want {
+		t.Fatalf("selected auth count = %d, want %d", got, want)
+	}
+	if executor.authIDs[0] == executor.authIDs[1] {
+		t.Fatalf("different sessions selected the same auth %q", executor.authIDs[0])
+	}
+	if got, want := executor.authIDs[2], executor.authIDs[0]; got != want {
+		t.Fatalf("session-affinity auth = %q, want %q", got, want)
+	}
+}
+
+func TestCodexAlphaSearchRecordsRequestLog(t *testing.T) {
+	server := newTestServer(t)
+	server.cfg.RequestLog = true
+
+	executor := &codexSearchCaptureExecutor{}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	credential := &auth.Auth{
+		ID:       "codex-auth",
+		Provider: "codex",
+		Status:   auth.StatusActive,
+		Metadata: map[string]any{"access_token": "codex-token", "account_id": "account-123"},
+	}
+	if _, err := server.handlers.AuthManager.Register(context.Background(), credential); err != nil {
+		t.Fatalf("register Codex auth: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rr)
+	req := httptest.NewRequest(http.MethodPost, "/v1/alpha/search", strings.NewReader(`{"query":"GPT-5.6"}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	server.codexAlphaSearch(c)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	rawAPIRequest, okRequest := c.Get("API_REQUEST")
+	if !okRequest {
+		t.Fatal("API_REQUEST was not captured")
+	}
+	apiRequest, _ := rawAPIRequest.([]byte)
+	if !strings.Contains(string(apiRequest), "=== API REQUEST 1 ===") {
+		t.Fatalf("API_REQUEST missing request header section: %q", apiRequest)
+	}
+	if !strings.Contains(string(apiRequest), "https://chatgpt.com/backend-api/codex/alpha/search") {
+		t.Fatalf("API_REQUEST missing upstream URL: %q", apiRequest)
+	}
+	if strings.Contains(string(apiRequest), `{"query":"GPT-5.6"}`) {
+		t.Fatalf("API_REQUEST exposed search query: %q", apiRequest)
+	}
+	rawAPIResponse, okResponse := c.Get("API_RESPONSE")
+	if !okResponse {
+		t.Fatal("API_RESPONSE was not captured")
+	}
+	apiResponse, _ := rawAPIResponse.([]byte)
+	if !strings.Contains(string(apiResponse), "=== API RESPONSE 1 ===") {
+		t.Fatalf("API_RESPONSE missing response header section: %q", apiResponse)
+	}
+	if strings.Contains(string(apiResponse), `{"results":[{"url":"https://example.com"}]}`) {
+		t.Fatalf("API_RESPONSE exposed search results: %q", apiResponse)
+	}
+}
+
+func TestCodexAlphaSearchMarksRateLimitResult(t *testing.T) {
+	server := newTestServer(t)
+	executor := &codexSearchCaptureExecutor{
+		respond: func(*auth.Auth) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+					"Retry-After":  []string{"90"},
+				},
+				Body: io.NopCloser(strings.NewReader(`{"error":{"type":"usage_limit_reached","resets_in_seconds":120}}`)),
+			}, nil
+		},
+	}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	credential := &auth.Auth{
+		ID:       "codex-auth",
+		Provider: "codex",
+		Status:   auth.StatusActive,
+		Metadata: map[string]any{"access_token": "codex-token"},
+	}
+	registry.GetGlobalRegistry().RegisterClient(credential.ID, "codex", []*registry.ModelInfo{{ID: "gpt-5.6-luna"}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(credential.ID) })
+	if _, err := server.handlers.AuthManager.Register(context.Background(), credential); err != nil {
+		t.Fatalf("register Codex auth: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/alpha/search", strings.NewReader(`{"id":"session-a","model":"gpt-5.6-luna"}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429; body=%s", rr.Code, rr.Body.String())
+	}
+
+	updated, ok := server.handlers.AuthManager.GetByID(credential.ID)
+	if !ok {
+		t.Fatal("updated auth missing")
+	}
+	state := updated.ModelStates["gpt-5.6-luna"]
+	if state == nil || !state.Quota.Exceeded || state.Quota.Reason != "quota" {
+		t.Fatalf("model state = %#v, want quota exceeded", state)
+	}
+	remaining := time.Until(state.Quota.NextRecoverAt)
+	if remaining < 88*time.Second || remaining > 92*time.Second {
+		t.Fatalf("quota retry remaining = %v, want about 90s", remaining)
+	}
+	if updated.Failed != 1 {
+		t.Fatalf("failed count = %d, want 1", updated.Failed)
+	}
+}
+
+func TestCodexAlphaSearchNormalizesCodexFallbackErrors(t *testing.T) {
+	tests := []struct {
+		name             string
+		body             string
+		wantRetryAtLeast time.Duration
+		wantRetryAtMost  time.Duration
+	}{
+		{
+			name:             "usage limit returned as 400",
+			body:             `{"error":{"type":"usage_limit_reached","message":"quota","resets_in_seconds":120}}`,
+			wantRetryAtLeast: 118 * time.Second,
+			wantRetryAtMost:  122 * time.Second,
+		},
+		{
+			name: "capacity returned as 400",
+			body: `{"error":{"message":"Selected model is at capacity. Please try a different model."}}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := newTestServer(t)
+			executor := &codexSearchCaptureExecutor{
+				respond: func(*auth.Auth) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusBadRequest,
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(tc.body)),
+					}, nil
+				},
+			}
+			server.handlers.AuthManager.RegisterExecutor(executor)
+			credential := registerCodexSearchCredential(t, server, "codex-auth", "gpt-5.6-luna")
+
+			req := httptest.NewRequest(http.MethodPost, "/v1/alpha/search", strings.NewReader(`{"id":"session-a","model":"gpt-5.6-luna"}`))
+			req.Header.Set("Authorization", "Bearer test-key")
+			rr := httptest.NewRecorder()
+			server.engine.ServeHTTP(rr, req)
+			if rr.Code != http.StatusTooManyRequests {
+				t.Fatalf("status = %d, want 429; body=%s", rr.Code, rr.Body.String())
+			}
+
+			updated, ok := server.handlers.AuthManager.GetByID(credential.ID)
+			if !ok {
+				t.Fatal("updated auth missing")
+			}
+			state := updated.ModelStates["gpt-5.6-luna"]
+			if state == nil || !state.Quota.Exceeded || state.Quota.Reason != "quota" {
+				t.Fatalf("model state = %#v, want normalized quota cooldown", state)
+			}
+			if tc.wantRetryAtLeast > 0 {
+				remaining := time.Until(state.Quota.NextRecoverAt)
+				if remaining < tc.wantRetryAtLeast || remaining > tc.wantRetryAtMost {
+					t.Fatalf("quota retry remaining = %v, want %v..%v", remaining, tc.wantRetryAtLeast, tc.wantRetryAtMost)
+				}
+			}
+		})
+	}
+}
+
+func TestCodexAlphaSearchRejectsMalformedJSONWithoutSelectingAuth(t *testing.T) {
+	server := newTestServer(t)
+	executor := &codexSearchCaptureExecutor{}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	credential := registerCodexSearchCredential(t, server, "codex-auth", "gpt-5.6-luna")
+
+	for _, payload := range []string{`{"query":`, `null`, `[]`} {
+		req := httptest.NewRequest(http.MethodPost, "/v1/alpha/search", strings.NewReader(payload))
+		req.Header.Set("Authorization", "Bearer test-key")
+		rr := httptest.NewRecorder()
+		server.engine.ServeHTTP(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("payload %q status = %d, want 400; body=%s", payload, rr.Code, rr.Body.String())
+		}
+	}
+	if executor.request != nil {
+		t.Fatal("malformed JSON reached Codex executor")
+	}
+	updated, ok := server.handlers.AuthManager.GetByID(credential.ID)
+	if !ok || updated.Failed != 0 || updated.Unavailable || updated.Status != auth.StatusActive {
+		t.Fatalf("malformed JSON changed auth state: %#v", updated)
+	}
+}
+
+func TestCodexAlphaSearchRequestErrorsDoNotPoisonAuth(t *testing.T) {
+	tests := []struct {
+		name       string
+		payload    string
+		statusCode int
+		body       string
+	}{
+		{
+			name:       "query only invalid request",
+			payload:    `{"query":"bad"}`,
+			statusCode: http.StatusBadRequest,
+			body:       `{"error":{"type":"invalid_request_error","code":"invalid_query","message":"invalid query"}}`,
+		},
+		{
+			name:       "model request rejected as 422",
+			payload:    `{"id":"session-a","model":"gpt-5.6-luna","query":{}}`,
+			statusCode: http.StatusUnprocessableEntity,
+			body:       `{"error":{"type":"invalid_request_error","message":"query must be a string"}}`,
+		},
+		{
+			name:       "request scoped model 404",
+			payload:    `{"id":"session-a","model":"gpt-5.6-luna","query":"bad"}`,
+			statusCode: http.StatusNotFound,
+			body:       `{"error":{"type":"invalid_request_error","param":"model","message":"Model not found gpt-5.6-luna"}}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := newTestServer(t)
+			executor := &codexSearchCaptureExecutor{
+				respond: func(*auth.Auth) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: tc.statusCode,
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(tc.body)),
+					}, nil
+				},
+			}
+			server.handlers.AuthManager.RegisterExecutor(executor)
+			credential := registerCodexSearchCredential(t, server, "codex-auth", "gpt-5.6-luna")
+
+			req := httptest.NewRequest(http.MethodPost, "/v1/alpha/search", strings.NewReader(tc.payload))
+			req.Header.Set("Authorization", "Bearer test-key")
+			rr := httptest.NewRecorder()
+			server.engine.ServeHTTP(rr, req)
+			if rr.Code != tc.statusCode {
+				t.Fatalf("status = %d, want %d; body=%s", rr.Code, tc.statusCode, rr.Body.String())
+			}
+			updated, ok := server.handlers.AuthManager.GetByID(credential.ID)
+			if !ok {
+				t.Fatal("updated auth missing")
+			}
+			if updated.Failed != 0 || updated.Unavailable || updated.LastError != nil || updated.Status != auth.StatusActive {
+				t.Fatalf("request error poisoned auth: %#v", updated)
+			}
+			if state := updated.ModelStates["gpt-5.6-luna"]; state != nil {
+				t.Fatalf("request error created model state: %#v", state)
+			}
+		})
+	}
+}
+
+func TestCodexAlphaSearchCredentialFailuresStillMarkAuth(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+	}{
+		{
+			name:       "unauthorized",
+			statusCode: http.StatusUnauthorized,
+			body:       `{"error":{"type":"authentication_error","code":"invalid_api_key","message":"invalid token"}}`,
+		},
+		{
+			name:       "invalid grant returned as 400",
+			statusCode: http.StatusBadRequest,
+			body:       `{"error":{"type":"invalid_grant","code":"invalid_grant","message":"invalid_grant"}}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := newTestServer(t)
+			executor := &codexSearchCaptureExecutor{
+				respond: func(*auth.Auth) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: tc.statusCode,
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(tc.body)),
+					}, nil
+				},
+			}
+			server.handlers.AuthManager.RegisterExecutor(executor)
+			credential := registerCodexSearchCredential(t, server, "codex-auth", "")
+
+			req := httptest.NewRequest(http.MethodPost, "/v1/alpha/search", strings.NewReader(`{"query":"auth-check"}`))
+			req.Header.Set("Authorization", "Bearer test-key")
+			rr := httptest.NewRecorder()
+			server.engine.ServeHTTP(rr, req)
+			if rr.Code != tc.statusCode {
+				t.Fatalf("status = %d, want %d; body=%s", rr.Code, tc.statusCode, rr.Body.String())
+			}
+			updated, ok := server.handlers.AuthManager.GetByID(credential.ID)
+			if !ok || updated.Failed != 1 || !updated.Unavailable || updated.Status != auth.StatusError {
+				t.Fatalf("credential failure state = %#v, want failed unavailable auth", updated)
+			}
+		})
+	}
+}
+
+func TestCodexAlphaSearchDispatchRecheckBlocksLifecycleReset(t *testing.T) {
+	server := newTestServer(t)
+	server.cfg.RequestLog = true
+	selector := auth.NewSessionAffinitySelector(&auth.FillFirstSelector{})
+	t.Cleanup(selector.Stop)
+	server.handlers.AuthManager.SetSelector(selector)
+	continuityConfig := &proxyconfig.Config{
+		Routing: proxyconfig.RoutingConfig{SessionAffinity: true},
+		Codex: proxyconfig.CodexConfig{RateLimitContinuity: proxyconfig.CodexRateLimitContinuityConfig{
+			Enabled:                      true,
+			ObservationWindowSeconds:     10,
+			EstablishedSuccessThreshold:  1,
+			EstablishedSessionTTLSeconds: 3600,
+		}},
+	}
+	server.handlers.AuthManager.SetConfig(continuityConfig)
+	registerCodexSearchCredential(t, server, "codex-auth", "gpt-5.6-luna")
+	executor := &codexSearchCaptureExecutor{}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	executor.prepare = func(*http.Request, *auth.Auth) error {
+		reloaded := *continuityConfig
+		reloaded.Codex.RateLimitContinuity.ObservationWindowSeconds++
+		server.handlers.AuthManager.SetConfig(&reloaded)
+		return nil
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/alpha/search", strings.NewReader(`{"id":"racing-fresh","model":"gpt-5.6-luna"}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	rr := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rr)
+	c.Request = req
+	server.codexAlphaSearch(c)
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429; body=%s", rr.Code, rr.Body.String())
+	}
+	if executor.request != nil {
+		t.Fatal("stale lifecycle credential was dispatched after final continuity recheck")
+	}
+	if _, logged := c.Get("API_REQUEST"); logged {
+		t.Fatal("request log recorded an upstream dispatch rejected by final continuity recheck")
+	}
+}
+
+func TestCodexAlphaSearchRateLimitMovesSessionToAnotherAuth(t *testing.T) {
+	server := newTestServer(t)
+	server.handlers.AuthManager.SetSelector(auth.NewSessionAffinitySelector(&auth.FillFirstSelector{}))
+	executor := &codexSearchCaptureExecutor{
+		respond: func(selected *auth.Auth) (*http.Response, error) {
+			status := http.StatusOK
+			body := `{"results":[]}`
+			if selected.ID == "codex-auth-a" {
+				status = http.StatusTooManyRequests
+				body = `{"error":{"type":"usage_limit_reached","resets_in_seconds":60}}`
+			}
+			return &http.Response{
+				StatusCode: status,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		},
+	}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	for _, id := range []string{"codex-auth-a", "codex-auth-b"} {
+		registry.GetGlobalRegistry().RegisterClient(id, "codex", []*registry.ModelInfo{{ID: "gpt-5.6-luna"}})
+		t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(id) })
+		if _, err := server.handlers.AuthManager.Register(context.Background(), &auth.Auth{
+			ID:       id,
+			Provider: "codex",
+			Status:   auth.StatusActive,
+			Metadata: map[string]any{"access_token": id},
+		}); err != nil {
+			t.Fatalf("register %s: %v", id, err)
+		}
+	}
+
+	for requestIndex, wantStatus := range []int{http.StatusTooManyRequests, http.StatusOK} {
+		req := httptest.NewRequest(http.MethodPost, "/v1/alpha/search", strings.NewReader(`{"id":"stable-session","model":"gpt-5.6-luna"}`))
+		req.Header.Set("Authorization", "Bearer test-key")
+		rr := httptest.NewRecorder()
+		server.engine.ServeHTTP(rr, req)
+		if rr.Code != wantStatus {
+			t.Fatalf("request %d status = %d, want %d; body=%s", requestIndex+1, rr.Code, wantStatus, rr.Body.String())
+		}
+	}
+	if got, want := executor.authIDs, []string{"codex-auth-a", "codex-auth-b"}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("selected auths = %v, want %v", got, want)
+	}
+}
+
+func TestCodexAlphaSearchSuccessClearsModelFailure(t *testing.T) {
+	server := newTestServer(t)
+	executor := &codexSearchCaptureExecutor{}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	credential := &auth.Auth{
+		ID:       "codex-auth",
+		Provider: "codex",
+		Status:   auth.StatusError,
+		Metadata: map[string]any{"access_token": "codex-token"},
+		ModelStates: map[string]*auth.ModelState{
+			"gpt-5.6-luna": {
+				Status:    auth.StatusError,
+				LastError: &auth.Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"},
+			},
+		},
+	}
+	registry.GetGlobalRegistry().RegisterClient(credential.ID, "codex", []*registry.ModelInfo{{ID: "gpt-5.6-luna"}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(credential.ID) })
+	if _, err := server.handlers.AuthManager.Register(context.Background(), credential); err != nil {
+		t.Fatalf("register Codex auth: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/alpha/search", strings.NewReader(`{"model":"gpt-5.6-luna"}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+
+	updated, ok := server.handlers.AuthManager.GetByID(credential.ID)
+	if !ok {
+		t.Fatal("updated auth missing")
+	}
+	state := updated.ModelStates["gpt-5.6-luna"]
+	if state == nil || state.Status != auth.StatusActive || state.Quota.Exceeded || !state.NextRetryAfter.IsZero() {
+		t.Fatalf("model state = %#v, want active reset state", state)
+	}
+	if updated.Success != 1 {
+		t.Fatalf("success count = %d, want 1", updated.Success)
+	}
+}
+
+func TestCodexAlphaSearchLocalFailuresDoNotPoisonAuth(t *testing.T) {
+	tests := []struct {
+		name    string
+		prepare func(*http.Request, *auth.Auth) error
+		respond func(*auth.Auth) (*http.Response, error)
+	}{
+		{
+			name: "request construction",
+			prepare: func(*http.Request, *auth.Auth) error {
+				return errors.New("local request construction failed")
+			},
+		},
+		{
+			name: "client cancellation",
+			respond: func(*auth.Auth) (*http.Response, error) {
+				return nil, context.Canceled
+			},
+		},
+		{
+			name: "response body read",
+			respond: func(*auth.Auth) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(&codexSearchErrorReader{err: errors.New("local response read failed")}),
+				}, nil
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := newTestServer(t)
+			executor := &codexSearchCaptureExecutor{prepare: tc.prepare, respond: tc.respond}
+			server.handlers.AuthManager.RegisterExecutor(executor)
+			credential := registerCodexSearchCredential(t, server, "codex-auth", "gpt-5.6-luna")
+
+			req := httptest.NewRequest(http.MethodPost, "/v1/alpha/search", strings.NewReader(`{"id":"session-a","model":"gpt-5.6-luna"}`))
+			req.Header.Set("Authorization", "Bearer test-key")
+			rr := httptest.NewRecorder()
+			server.engine.ServeHTTP(rr, req)
+			if rr.Code != http.StatusBadGateway {
+				t.Fatalf("status = %d, want 502; body=%s", rr.Code, rr.Body.String())
+			}
+
+			updated, ok := server.handlers.AuthManager.GetByID(credential.ID)
+			if !ok {
+				t.Fatal("updated auth missing")
+			}
+			if updated.Failed != 0 || updated.LastError != nil || updated.Status != auth.StatusActive {
+				t.Fatalf("auth was poisoned by local failure: failed=%d status=%q lastError=%#v", updated.Failed, updated.Status, updated.LastError)
+			}
+			if state := updated.ModelStates["gpt-5.6-luna"]; state != nil {
+				t.Fatalf("model state was created by local failure: %#v", state)
+			}
+		})
+	}
+}
+
+func TestCodexAlphaSearchTransportFailureMarksAuth(t *testing.T) {
+	server := newTestServer(t)
+	executor := &codexSearchCaptureExecutor{
+		respond: func(*auth.Auth) (*http.Response, error) {
+			return nil, errors.New("upstream dial failed")
+		},
+	}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	credential := registerCodexSearchCredential(t, server, "codex-auth", "gpt-5.6-luna")
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/alpha/search", strings.NewReader(`{"id":"session-a","model":"gpt-5.6-luna"}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body=%s", rr.Code, rr.Body.String())
+	}
+	updated, ok := server.handlers.AuthManager.GetByID(credential.ID)
+	if !ok || updated.Failed != 1 {
+		t.Fatalf("transport failure state = %#v, want one failed result", updated)
+	}
+}
+
+func TestReadCodexAlphaSearchBodyRejectsOversize(t *testing.T) {
+	body, tooLarge, err := readCodexAlphaSearchBody(strings.NewReader("12345"), 4)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if !tooLarge {
+		t.Fatalf("tooLarge = false, body=%q", body)
+	}
+}
+
+func TestCodexAlphaSearchRejectsOversizeRequest(t *testing.T) {
+	server := newTestServer(t)
+	executor := &codexSearchCaptureExecutor{}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	reader := &fixedByteReader{remaining: codexAlphaSearchRequestMaxBytes + 1}
+	req := httptest.NewRequest(http.MethodPost, "/v1/alpha/search", reader)
+	req.Header.Set("Authorization", "Bearer test-key")
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413; body=%s", rr.Code, rr.Body.String())
+	}
+	if executor.request != nil {
+		t.Fatal("oversize request reached Codex executor")
+	}
+}
+
+func TestCodexAlphaSearchRejectsOversizeResponse(t *testing.T) {
+	server := newTestServer(t)
+	executor := &codexSearchCaptureExecutor{
+		respond: func(*auth.Auth) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body: io.NopCloser(&fixedByteReader{
+					remaining: codexAlphaSearchResponseMaxBytes + 1,
+				}),
+			}, nil
+		},
+	}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	credential := &auth.Auth{
+		ID:       "codex-auth",
+		Provider: "codex",
+		Status:   auth.StatusActive,
+		Metadata: map[string]any{"access_token": "codex-token"},
+	}
+	if _, err := server.handlers.AuthManager.Register(context.Background(), credential); err != nil {
+		t.Fatalf("register Codex auth: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/alpha/search", strings.NewReader(`{"query":"bounded"}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "exceeds 32 MiB") || rr.Body.Len() > 1024 {
+		t.Fatalf("oversize response was not replaced by bounded gateway error: %q", rr.Body.String())
+	}
+	updated, ok := server.handlers.AuthManager.GetByID(credential.ID)
+	if !ok {
+		t.Fatal("updated auth missing")
+	}
+	if updated.Failed != 0 || updated.LastError != nil || updated.Status != auth.StatusActive {
+		t.Fatalf("oversize response poisoned auth: failed=%d status=%q lastError=%#v", updated.Failed, updated.Status, updated.LastError)
+	}
 }
 
 func TestManagementResponseExposesPluginSupportHeaderForCORS(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -490,13 +490,17 @@ type ClaudeModel struct {
 	// Alias is the client-facing model name that maps to Name.
 	Alias string `yaml:"alias" json:"alias"`
 
+	// DisplayName is the optional human-readable name shown in model catalogs.
+	DisplayName string `yaml:"display-name,omitempty" json:"display-name,omitempty"`
+
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
 }
 
-func (m ClaudeModel) GetName() string       { return m.Name }
-func (m ClaudeModel) GetAlias() string      { return m.Alias }
-func (m ClaudeModel) GetForceMapping() bool { return m.ForceMapping }
+func (m ClaudeModel) GetName() string        { return m.Name }
+func (m ClaudeModel) GetAlias() string       { return m.Alias }
+func (m ClaudeModel) GetDisplayName() string { return m.DisplayName }
+func (m ClaudeModel) GetForceMapping() bool  { return m.ForceMapping }
 
 // CodexKey represents the configuration for a Codex API key,
 // including the API key itself and an optional base URL for the API endpoint.
@@ -545,13 +549,17 @@ type CodexModel struct {
 	// Alias is the client-facing model name that maps to Name.
 	Alias string `yaml:"alias" json:"alias"`
 
+	// DisplayName is the optional human-readable name shown in model catalogs.
+	DisplayName string `yaml:"display-name,omitempty" json:"display-name,omitempty"`
+
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
 }
 
-func (m CodexModel) GetName() string       { return m.Name }
-func (m CodexModel) GetAlias() string      { return m.Alias }
-func (m CodexModel) GetForceMapping() bool { return m.ForceMapping }
+func (m CodexModel) GetName() string        { return m.Name }
+func (m CodexModel) GetAlias() string       { return m.Alias }
+func (m CodexModel) GetDisplayName() string { return m.DisplayName }
+func (m CodexModel) GetForceMapping() bool  { return m.ForceMapping }
 
 // GeminiKey represents the configuration for a Gemini API key,
 // including optional overrides for upstream base URL, proxy routing, and headers.
@@ -596,13 +604,17 @@ type GeminiModel struct {
 	// Alias is the client-facing model name that maps to Name.
 	Alias string `yaml:"alias" json:"alias"`
 
+	// DisplayName is the optional human-readable name shown in model catalogs.
+	DisplayName string `yaml:"display-name,omitempty" json:"display-name,omitempty"`
+
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
 }
 
-func (m GeminiModel) GetName() string       { return m.Name }
-func (m GeminiModel) GetAlias() string      { return m.Alias }
-func (m GeminiModel) GetForceMapping() bool { return m.ForceMapping }
+func (m GeminiModel) GetName() string        { return m.Name }
+func (m GeminiModel) GetAlias() string       { return m.Alias }
+func (m GeminiModel) GetDisplayName() string { return m.DisplayName }
+func (m GeminiModel) GetForceMapping() bool  { return m.ForceMapping }
 
 // OpenAICompatibility represents the configuration for OpenAI API compatibility
 // with external providers, allowing model aliases to be routed through OpenAI API format.
@@ -654,6 +666,9 @@ type OpenAICompatibilityModel struct {
 	// Alias is the model name alias that clients will use to reference this model.
 	Alias string `yaml:"alias" json:"alias"`
 
+	// DisplayName is the optional human-readable name shown in model catalogs.
+	DisplayName string `yaml:"display-name,omitempty" json:"display-name,omitempty"`
+
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
 
@@ -672,9 +687,10 @@ type OpenAICompatibilityModel struct {
 	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
 }
 
-func (m OpenAICompatibilityModel) GetName() string       { return m.Name }
-func (m OpenAICompatibilityModel) GetAlias() string      { return m.Alias }
-func (m OpenAICompatibilityModel) GetForceMapping() bool { return m.ForceMapping }
+func (m OpenAICompatibilityModel) GetName() string        { return m.Name }
+func (m OpenAICompatibilityModel) GetAlias() string       { return m.Alias }
+func (m OpenAICompatibilityModel) GetDisplayName() string { return m.DisplayName }
+func (m OpenAICompatibilityModel) GetForceMapping() bool  { return m.ForceMapping }
 
 // LoadConfig reads a YAML configuration file from the given path,
 // unmarshals it into a Config struct, applies environment variable overrides,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1017,13 +1017,17 @@ type ClaudeModel struct {
 	// Alias is the client-facing model name that maps to Name.
 	Alias string `yaml:"alias" json:"alias"`
 
+	// DisplayName is the optional human-readable name shown in model catalogs.
+	DisplayName string `yaml:"display-name,omitempty" json:"display-name,omitempty"`
+
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
 }
 
-func (m ClaudeModel) GetName() string       { return m.Name }
-func (m ClaudeModel) GetAlias() string      { return m.Alias }
-func (m ClaudeModel) GetForceMapping() bool { return m.ForceMapping }
+func (m ClaudeModel) GetName() string        { return m.Name }
+func (m ClaudeModel) GetAlias() string       { return m.Alias }
+func (m ClaudeModel) GetDisplayName() string { return m.DisplayName }
+func (m ClaudeModel) GetForceMapping() bool  { return m.ForceMapping }
 
 // CodexKey represents the configuration for a Codex API key,
 // including the API key itself and an optional base URL for the API endpoint.
@@ -1072,13 +1076,17 @@ type CodexModel struct {
 	// Alias is the client-facing model name that maps to Name.
 	Alias string `yaml:"alias" json:"alias"`
 
+	// DisplayName is the optional human-readable name shown in model catalogs.
+	DisplayName string `yaml:"display-name,omitempty" json:"display-name,omitempty"`
+
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
 }
 
-func (m CodexModel) GetName() string       { return m.Name }
-func (m CodexModel) GetAlias() string      { return m.Alias }
-func (m CodexModel) GetForceMapping() bool { return m.ForceMapping }
+func (m CodexModel) GetName() string        { return m.Name }
+func (m CodexModel) GetAlias() string       { return m.Alias }
+func (m CodexModel) GetDisplayName() string { return m.DisplayName }
+func (m CodexModel) GetForceMapping() bool  { return m.ForceMapping }
 
 // GeminiKey represents the configuration for a Gemini API key,
 // including optional overrides for upstream base URL, proxy routing, and headers.
@@ -1123,13 +1131,17 @@ type GeminiModel struct {
 	// Alias is the client-facing model name that maps to Name.
 	Alias string `yaml:"alias" json:"alias"`
 
+	// DisplayName is the optional human-readable name shown in model catalogs.
+	DisplayName string `yaml:"display-name,omitempty" json:"display-name,omitempty"`
+
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
 }
 
-func (m GeminiModel) GetName() string       { return m.Name }
-func (m GeminiModel) GetAlias() string      { return m.Alias }
-func (m GeminiModel) GetForceMapping() bool { return m.ForceMapping }
+func (m GeminiModel) GetName() string        { return m.Name }
+func (m GeminiModel) GetAlias() string       { return m.Alias }
+func (m GeminiModel) GetDisplayName() string { return m.DisplayName }
+func (m GeminiModel) GetForceMapping() bool  { return m.ForceMapping }
 
 // OpenAICompatibility represents the configuration for OpenAI API compatibility
 // with external providers, allowing model aliases to be routed through OpenAI API format.
@@ -1181,6 +1193,9 @@ type OpenAICompatibilityModel struct {
 	// Alias is the model name alias that clients will use to reference this model.
 	Alias string `yaml:"alias" json:"alias"`
 
+	// DisplayName is the optional human-readable name shown in model catalogs.
+	DisplayName string `yaml:"display-name,omitempty" json:"display-name,omitempty"`
+
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
 
@@ -1199,9 +1214,10 @@ type OpenAICompatibilityModel struct {
 	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
 }
 
-func (m OpenAICompatibilityModel) GetName() string       { return m.Name }
-func (m OpenAICompatibilityModel) GetAlias() string      { return m.Alias }
-func (m OpenAICompatibilityModel) GetForceMapping() bool { return m.ForceMapping }
+func (m OpenAICompatibilityModel) GetName() string        { return m.Name }
+func (m OpenAICompatibilityModel) GetAlias() string       { return m.Alias }
+func (m OpenAICompatibilityModel) GetDisplayName() string { return m.DisplayName }
+func (m OpenAICompatibilityModel) GetForceMapping() bool  { return m.ForceMapping }
 
 // LoadConfig reads a YAML configuration file from the given path,
 // unmarshals it into a Config struct, applies environment variable overrides,

--- a/internal/config/model_display_name_test.go
+++ b/internal/config/model_display_name_test.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestModelDisplayNameConfigDecoding(t *testing.T) {
+	const yamlConfig = `codex-api-key:
+  - models:
+      - name: codex-upstream
+        alias: codex-alias
+        display-name: Codex Name
+claude-api-key:
+  - models:
+      - name: claude-upstream
+        alias: claude-alias
+        display-name: Claude Name
+gemini-api-key:
+  - models:
+      - name: gemini-upstream
+        alias: gemini-alias
+        display-name: Gemini Name
+vertex-api-key:
+  - models:
+      - name: vertex-upstream
+        alias: vertex-alias
+        display-name: Vertex Name
+openai-compatibility:
+  - models:
+      - name: compat-upstream
+        alias: compat-alias
+        display-name: Compatibility Name
+`
+	const jsonConfig = `{"codex-api-key":[{"models":[{"name":"codex-upstream","alias":"codex-alias","display-name":"Codex Name"}]}],"claude-api-key":[{"models":[{"name":"claude-upstream","alias":"claude-alias","display-name":"Claude Name"}]}],"gemini-api-key":[{"models":[{"name":"gemini-upstream","alias":"gemini-alias","display-name":"Gemini Name"}]}],"vertex-api-key":[{"models":[{"name":"vertex-upstream","alias":"vertex-alias","display-name":"Vertex Name"}]}],"openai-compatibility":[{"models":[{"name":"compat-upstream","alias":"compat-alias","display-name":"Compatibility Name"}]}]}`
+
+	for _, tt := range []struct {
+		name   string
+		decode func(*Config) error
+	}{
+		{
+			name: "YAML",
+			decode: func(cfg *Config) error {
+				return yaml.Unmarshal([]byte(yamlConfig), cfg)
+			},
+		},
+		{
+			name: "JSON",
+			decode: func(cfg *Config) error {
+				return json.Unmarshal([]byte(jsonConfig), cfg)
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var cfg Config
+			if errDecode := tt.decode(&cfg); errDecode != nil {
+				t.Fatalf("decode config: %v", errDecode)
+			}
+			if got := cfg.CodexKey[0].Models[0].DisplayName; got != "Codex Name" {
+				t.Fatalf("Codex display name = %q", got)
+			}
+			if got := cfg.ClaudeKey[0].Models[0].DisplayName; got != "Claude Name" {
+				t.Fatalf("Claude display name = %q", got)
+			}
+			if got := cfg.GeminiKey[0].Models[0].DisplayName; got != "Gemini Name" {
+				t.Fatalf("Gemini display name = %q", got)
+			}
+			if got := cfg.VertexCompatAPIKey[0].Models[0].DisplayName; got != "Vertex Name" {
+				t.Fatalf("Vertex display name = %q", got)
+			}
+			if got := cfg.OpenAICompatibility[0].Models[0].DisplayName; got != "Compatibility Name" {
+				t.Fatalf("OpenAI compatibility display name = %q", got)
+			}
+		})
+	}
+}

--- a/internal/config/vertex_compat.go
+++ b/internal/config/vertex_compat.go
@@ -51,13 +51,17 @@ type VertexCompatModel struct {
 	// Alias is the model name alias that clients will use to reference this model.
 	Alias string `yaml:"alias" json:"alias"`
 
+	// DisplayName is the optional human-readable name shown in model catalogs.
+	DisplayName string `yaml:"display-name,omitempty" json:"display-name,omitempty"`
+
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
 }
 
-func (m VertexCompatModel) GetName() string       { return m.Name }
-func (m VertexCompatModel) GetAlias() string      { return m.Alias }
-func (m VertexCompatModel) GetForceMapping() bool { return m.ForceMapping }
+func (m VertexCompatModel) GetName() string        { return m.Name }
+func (m VertexCompatModel) GetAlias() string       { return m.Alias }
+func (m VertexCompatModel) GetDisplayName() string { return m.DisplayName }
+func (m VertexCompatModel) GetForceMapping() bool  { return m.ForceMapping }
 
 // SanitizeVertexCompatKeys deduplicates and normalizes Vertex-compatible API key credentials.
 func (cfg *Config) SanitizeVertexCompatKeys() {

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -1856,21 +1856,132 @@ func applyCodexHeadersFromSources(r *http.Request, auth *cliproxyauth.Auth, toke
 }
 
 func newCodexStatusErr(statusCode int, body []byte) statusErr {
-	errCode := statusCode
-	fallbackReason := ""
-	if isCodexModelCapacityError(body) {
-		errCode = http.StatusTooManyRequests
-		fallbackReason = config.CodexModelFallbackTriggerCapacity
-	} else if isCodexUsageLimitError(body) {
-		errCode = http.StatusTooManyRequests
-		fallbackReason = config.CodexModelFallbackTriggerUsageLimit
-	}
-	body = classifyCodexStatusError(errCode, body)
-	err := statusErr{code: errCode, msg: string(body), modelFallbackReason: fallbackReason}
-	if retryAfter := parseCodexRetryAfter(errCode, body, time.Now()); retryAfter != nil {
-		err.retryAfter = retryAfter
+	classification := ClassifyCodexUpstreamError(statusCode, body, time.Now())
+	body = classifyCodexStatusError(classification.HTTPStatus, body)
+	err := statusErr{
+		code:                classification.HTTPStatus,
+		msg:                 string(body),
+		modelFallbackReason: classification.ModelFallbackReason,
+		retryAfter:          classification.RetryAfter,
 	}
 	return err
+}
+
+// CodexUpstreamErrorClassification captures the shared Codex error semantics
+// used by translated responses and standalone Codex endpoints.
+type CodexUpstreamErrorClassification struct {
+	HTTPStatus          int
+	ModelFallbackReason string
+	RetryAfter          *time.Duration
+	RequestInvalid      bool
+	RecordWithoutModel  bool
+}
+
+// ClassifyCodexUpstreamError normalizes Codex quota and capacity responses.
+// Codex can report these conditions with HTTP 400 even though routing and
+// cooldown behavior must treat them as HTTP 429.
+func ClassifyCodexUpstreamError(statusCode int, body []byte, now time.Time) CodexUpstreamErrorClassification {
+	classification := CodexUpstreamErrorClassification{HTTPStatus: statusCode}
+	if isCodexModelCapacityError(body) {
+		classification.HTTPStatus = http.StatusTooManyRequests
+		classification.ModelFallbackReason = config.CodexModelFallbackTriggerCapacity
+	} else if isCodexUsageLimitError(body) {
+		classification.HTTPStatus = http.StatusTooManyRequests
+		classification.ModelFallbackReason = config.CodexModelFallbackTriggerUsageLimit
+	}
+	classification.RetryAfter = parseCodexRetryAfter(classification.HTTPStatus, body, now)
+	classification.RequestInvalid = isCodexRequestInvalidError(classification.HTTPStatus, body)
+	classification.RecordWithoutModel = codexErrorRecordableWithoutModel(classification, body)
+	return classification
+}
+
+func isCodexRequestInvalidError(statusCode int, body []byte) bool {
+	if isCodexModelCapacityError(body) || isCodexUsageLimitError(body) || isCodexCredentialError(body) || isCodexModelSupportError(body) {
+		return false
+	}
+	lower := strings.ToLower(strings.TrimSpace(string(body)))
+	switch statusCode {
+	case http.StatusBadRequest:
+		return true
+	case http.StatusNotFound:
+		return isCodexRequestScopedNotFound(body)
+	case http.StatusUnprocessableEntity:
+		return true
+	case http.StatusInternalServerError:
+		return strings.Contains(lower, `"status":"unknown"`) || strings.Contains(lower, `"status": "unknown"`)
+	default:
+		return false
+	}
+}
+
+func codexErrorRecordableWithoutModel(classification CodexUpstreamErrorClassification, body []byte) bool {
+	if classification.RequestInvalid {
+		return false
+	}
+	if classification.ModelFallbackReason != "" || isCodexCredentialError(body) {
+		return true
+	}
+	switch classification.HTTPStatus {
+	case http.StatusUnauthorized, http.StatusPaymentRequired, http.StatusForbidden, http.StatusTooManyRequests:
+		return true
+	default:
+		return classification.HTTPStatus >= http.StatusInternalServerError
+	}
+}
+
+func isCodexCredentialError(body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+	candidates := []string{
+		gjson.GetBytes(body, "error.type").String(),
+		gjson.GetBytes(body, "error.code").String(),
+		gjson.GetBytes(body, "type").String(),
+		gjson.GetBytes(body, "code").String(),
+	}
+	for _, candidate := range candidates {
+		switch strings.ToLower(strings.TrimSpace(candidate)) {
+		case "authentication_error", "invalid_api_key", "invalid_grant", "auth_unavailable":
+			return true
+		}
+	}
+	lower := strings.ToLower(string(body))
+	return strings.Contains(lower, "invalid_grant") || strings.Contains(lower, "invalid or expired token")
+}
+
+func isCodexModelSupportError(body []byte) bool {
+	lower := strings.ToLower(strings.TrimSpace(string(body)))
+	for _, pattern := range []string{
+		"model_not_supported",
+		"requested model is not supported",
+		"requested model is unsupported",
+		"requested model is unavailable",
+		"model is not supported",
+		"model not supported",
+		"unsupported model",
+		"model unavailable",
+		"not available for your plan",
+		"not available for your account",
+	} {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func isCodexRequestScopedNotFound(body []byte) bool {
+	lower := strings.ToLower(strings.TrimSpace(string(body)))
+	if strings.Contains(lower, "item with id") &&
+		strings.Contains(lower, "not found") &&
+		strings.Contains(lower, "items are not persisted when `store` is set to false") {
+		return true
+	}
+	if !strings.Contains(lower, "model not found") ||
+		!strings.EqualFold(strings.TrimSpace(gjson.GetBytes(body, "error.type").String()), "invalid_request_error") {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(gjson.GetBytes(body, "error.param").String()), "model")
 }
 
 func classifyCodexStatusError(statusCode int, body []byte) []byte {

--- a/internal/runtime/executor/codex_executor_retry_test.go
+++ b/internal/runtime/executor/codex_executor_retry_test.go
@@ -104,6 +104,71 @@ func TestNewCodexStatusErrDoesNotClassifyTransientRateLimitForModelFallback(t *t
 	}
 }
 
+func TestClassifyCodexUpstreamErrorRequestSemantics(t *testing.T) {
+	tests := []struct {
+		name                   string
+		statusCode             int
+		body                   []byte
+		wantRequestInvalid     bool
+		wantRecordWithoutModel bool
+	}{
+		{
+			name:                   "invalid request",
+			statusCode:             http.StatusBadRequest,
+			body:                   []byte(`{"error":{"type":"invalid_request_error","message":"invalid query"}}`),
+			wantRequestInvalid:     true,
+			wantRecordWithoutModel: false,
+		},
+		{
+			name:                   "unprocessable request",
+			statusCode:             http.StatusUnprocessableEntity,
+			body:                   []byte(`{"error":{"type":"invalid_request_error","message":"query must be a string"}}`),
+			wantRequestInvalid:     true,
+			wantRecordWithoutModel: false,
+		},
+		{
+			name:                   "request scoped model not found",
+			statusCode:             http.StatusNotFound,
+			body:                   []byte(`{"error":{"type":"invalid_request_error","param":"model","message":"Model not found gpt-5"}}`),
+			wantRequestInvalid:     true,
+			wantRecordWithoutModel: false,
+		},
+		{
+			name:                   "model support error needs model scope",
+			statusCode:             http.StatusBadRequest,
+			body:                   []byte(`{"error":{"type":"invalid_request_error","message":"The requested model is not supported."}}`),
+			wantRequestInvalid:     false,
+			wantRecordWithoutModel: false,
+		},
+		{
+			name:                   "invalid grant is credential attributable",
+			statusCode:             http.StatusBadRequest,
+			body:                   []byte(`{"error":{"type":"invalid_grant","code":"invalid_grant","message":"invalid_grant"}}`),
+			wantRequestInvalid:     false,
+			wantRecordWithoutModel: true,
+		},
+		{
+			name:                   "unauthorized is credential attributable",
+			statusCode:             http.StatusUnauthorized,
+			body:                   []byte(`{"error":{"type":"authentication_error","code":"invalid_api_key"}}`),
+			wantRequestInvalid:     false,
+			wantRecordWithoutModel: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			classification := ClassifyCodexUpstreamError(tc.statusCode, tc.body, time.Now())
+			if classification.RequestInvalid != tc.wantRequestInvalid {
+				t.Fatalf("RequestInvalid = %t, want %t", classification.RequestInvalid, tc.wantRequestInvalid)
+			}
+			if classification.RecordWithoutModel != tc.wantRecordWithoutModel {
+				t.Fatalf("RecordWithoutModel = %t, want %t", classification.RecordWithoutModel, tc.wantRecordWithoutModel)
+			}
+		})
+	}
+}
+
 func TestIsCodexUsageLimitError(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/watcher/diff/model_hash.go
+++ b/internal/watcher/diff/model_hash.go
@@ -21,7 +21,7 @@ func ComputeOpenAICompatModelsHash(models []config.OpenAICompatibilityModel) str
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + fmt.Sprintf("image=%t", model.Image))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("image=%t", model.Image))
 		}
 	})
 	return hashJoined(keys)
@@ -36,7 +36,7 @@ func ComputeVertexCompatModelsHash(models []config.VertexCompatModel) string {
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName))
 		}
 	})
 	return hashJoined(keys)
@@ -51,7 +51,7 @@ func ComputeClaudeModelsHash(models []config.ClaudeModel) string {
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName))
 		}
 	})
 	return hashJoined(keys)
@@ -66,7 +66,7 @@ func ComputeCodexModelsHash(models []config.CodexModel) string {
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName))
 		}
 	})
 	return hashJoined(keys)
@@ -81,7 +81,7 @@ func ComputeGeminiModelsHash(models []config.GeminiModel) string {
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName))
 		}
 	})
 	return hashJoined(keys)

--- a/internal/watcher/diff/model_hash_test.go
+++ b/internal/watcher/diff/model_hash_test.go
@@ -129,6 +129,48 @@ func TestComputeCodexModelsHash_IgnoresBlankAndDedup(t *testing.T) {
 	}
 }
 
+func TestComputeModelHashesIncludeDisplayName(t *testing.T) {
+	tests := []struct {
+		name    string
+		base    string
+		changed string
+	}{
+		{
+			name:    "openai compatibility",
+			base:    ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{Name: "m", Alias: "a", DisplayName: "One"}}),
+			changed: ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{Name: "m", Alias: "a", DisplayName: "Two"}}),
+		},
+		{
+			name:    "vertex",
+			base:    ComputeVertexCompatModelsHash([]config.VertexCompatModel{{Name: "m", Alias: "a", DisplayName: "One"}}),
+			changed: ComputeVertexCompatModelsHash([]config.VertexCompatModel{{Name: "m", Alias: "a", DisplayName: "Two"}}),
+		},
+		{
+			name:    "claude",
+			base:    ComputeClaudeModelsHash([]config.ClaudeModel{{Name: "m", Alias: "a", DisplayName: "One"}}),
+			changed: ComputeClaudeModelsHash([]config.ClaudeModel{{Name: "m", Alias: "a", DisplayName: "Two"}}),
+		},
+		{
+			name:    "codex",
+			base:    ComputeCodexModelsHash([]config.CodexModel{{Name: "m", Alias: "a", DisplayName: "One"}}),
+			changed: ComputeCodexModelsHash([]config.CodexModel{{Name: "m", Alias: "a", DisplayName: "Two"}}),
+		},
+		{
+			name:    "gemini",
+			base:    ComputeGeminiModelsHash([]config.GeminiModel{{Name: "m", Alias: "a", DisplayName: "One"}}),
+			changed: ComputeGeminiModelsHash([]config.GeminiModel{{Name: "m", Alias: "a", DisplayName: "Two"}}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.base == "" || tt.base == tt.changed {
+				t.Fatalf("display name must change model hash: %q / %q", tt.base, tt.changed)
+			}
+		})
+	}
+}
+
 func TestComputeExcludedModelsHash_Normalizes(t *testing.T) {
 	hash1 := ComputeExcludedModelsHash([]string{" A ", "b", "a"})
 	hash2 := ComputeExcludedModelsHash([]string{"a", " b", "A"})

--- a/internal/watcher/diff/model_hash_test.go
+++ b/internal/watcher/diff/model_hash_test.go
@@ -140,6 +140,48 @@ func TestComputeCodexModelsHash_IgnoresBlankAndDedup(t *testing.T) {
 	}
 }
 
+func TestComputeModelHashesIncludeDisplayName(t *testing.T) {
+	tests := []struct {
+		name    string
+		base    string
+		changed string
+	}{
+		{
+			name:    "openai compatibility",
+			base:    ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{Name: "m", Alias: "a", DisplayName: "One"}}),
+			changed: ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{Name: "m", Alias: "a", DisplayName: "Two"}}),
+		},
+		{
+			name:    "vertex",
+			base:    ComputeVertexCompatModelsHash([]config.VertexCompatModel{{Name: "m", Alias: "a", DisplayName: "One"}}),
+			changed: ComputeVertexCompatModelsHash([]config.VertexCompatModel{{Name: "m", Alias: "a", DisplayName: "Two"}}),
+		},
+		{
+			name:    "claude",
+			base:    ComputeClaudeModelsHash([]config.ClaudeModel{{Name: "m", Alias: "a", DisplayName: "One"}}),
+			changed: ComputeClaudeModelsHash([]config.ClaudeModel{{Name: "m", Alias: "a", DisplayName: "Two"}}),
+		},
+		{
+			name:    "codex",
+			base:    ComputeCodexModelsHash([]config.CodexModel{{Name: "m", Alias: "a", DisplayName: "One"}}),
+			changed: ComputeCodexModelsHash([]config.CodexModel{{Name: "m", Alias: "a", DisplayName: "Two"}}),
+		},
+		{
+			name:    "gemini",
+			base:    ComputeGeminiModelsHash([]config.GeminiModel{{Name: "m", Alias: "a", DisplayName: "One"}}),
+			changed: ComputeGeminiModelsHash([]config.GeminiModel{{Name: "m", Alias: "a", DisplayName: "Two"}}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.base == "" || tt.base == tt.changed {
+				t.Fatalf("display name must change model hash: %q / %q", tt.base, tt.changed)
+			}
+		})
+	}
+}
+
 func TestComputeExcludedModelsHash_Normalizes(t *testing.T) {
 	hash1 := ComputeExcludedModelsHash([]string{" A ", "b", "a"})
 	hash2 := ComputeExcludedModelsHash([]string{"a", " b", "A"})

--- a/internal/watcher/diff/models_summary.go
+++ b/internal/watcher/diff/models_summary.go
@@ -41,7 +41,7 @@ func SummarizeGeminiModels(models []config.GeminiModel) GeminiModelsSummary {
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName))
 		}
 	})
 	return GeminiModelsSummary{
@@ -62,7 +62,7 @@ func SummarizeClaudeModels(models []config.ClaudeModel) ClaudeModelsSummary {
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName))
 		}
 	})
 	return ClaudeModelsSummary{
@@ -83,7 +83,7 @@ func SummarizeCodexModels(models []config.CodexModel) CodexModelsSummary {
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName))
 		}
 	})
 	return CodexModelsSummary{
@@ -107,7 +107,7 @@ func SummarizeVertexModels(models []config.VertexCompatModel) VertexModelsSummar
 		if alias != "" {
 			name = alias
 		}
-		names = append(names, name)
+		names = append(names, name+"|"+strings.TrimSpace(model.DisplayName))
 	}
 	if len(names) == 0 {
 		return VertexModelsSummary{}

--- a/internal/watcher/diff/openai_compat.go
+++ b/internal/watcher/diff/openai_compat.go
@@ -153,7 +153,7 @@ func openAICompatSignature(entry config.OpenAICompatibility) string {
 		if name == "" && alias == "" {
 			continue
 		}
-		models = append(models, strings.ToLower(name)+"|"+strings.ToLower(alias)+"|"+fmt.Sprintf("image=%t", model.Image))
+		models = append(models, strings.ToLower(name)+"|"+strings.ToLower(alias)+"|"+strings.TrimSpace(model.DisplayName)+"|"+fmt.Sprintf("image=%t", model.Image))
 	}
 	if len(models) > 0 {
 		sort.Strings(models)

--- a/sdk/api/handlers/claude/code_handlers_model_test.go
+++ b/sdk/api/handlers/claude/code_handlers_model_test.go
@@ -1,8 +1,13 @@
 package claude
 
 import (
+	"encoding/json"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 	"github.com/tidwall/gjson"
 )
 
@@ -22,6 +27,41 @@ func TestSortClaudeModelsByDisplayName(t *testing.T) {
 			t.Fatalf("models[%d].id = %q, want %q", i, got, want)
 		}
 	}
+}
+
+func TestClaudeModelsResponseUsesConfiguredDisplayName(t *testing.T) {
+	const clientID = "claude-display-name-catalog-test"
+	const modelID = "claude-display-name-catalog-test"
+	registryRef := registry.GetGlobalRegistry()
+	registryRef.RegisterClient(clientID, "claude", []*registry.ModelInfo{{
+		ID: modelID, Object: "model", OwnedBy: "test", DisplayName: "Configured Claude Name",
+	}})
+	t.Cleanup(func() {
+		registryRef.UnregisterClient(clientID)
+	})
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	NewClaudeCodeAPIHandler(&handlers.BaseAPIHandler{}).ClaudeModels(ctx)
+
+	var response struct {
+		Data []struct {
+			ID          string `json:"id"`
+			DisplayName string `json:"display_name"`
+		} `json:"data"`
+	}
+	if errUnmarshal := json.Unmarshal(recorder.Body.Bytes(), &response); errUnmarshal != nil {
+		t.Fatalf("decode response: %v", errUnmarshal)
+	}
+	for _, model := range response.Data {
+		if model.ID == modelID {
+			if model.DisplayName != "Configured Claude Name" {
+				t.Fatalf("display_name = %q, want Configured Claude Name", model.DisplayName)
+			}
+			return
+		}
+	}
+	t.Fatalf("model %q not found in response", modelID)
 }
 
 func TestRewriteClaudeDDModelInBody(t *testing.T) {

--- a/sdk/api/handlers/gemini/gemini_models_display_name_test.go
+++ b/sdk/api/handlers/gemini/gemini_models_display_name_test.go
@@ -1,0 +1,46 @@
+package gemini
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+)
+
+func TestGeminiModelsResponseUsesConfiguredDisplayName(t *testing.T) {
+	const clientID = "gemini-display-name-catalog-test"
+	const modelID = "gemini-display-name-catalog-test"
+	registryRef := registry.GetGlobalRegistry()
+	registryRef.RegisterClient(clientID, "gemini", []*registry.ModelInfo{{
+		ID: modelID, Name: modelID, DisplayName: "Configured Gemini Name",
+	}})
+	t.Cleanup(func() {
+		registryRef.UnregisterClient(clientID)
+	})
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	NewGeminiAPIHandler(&handlers.BaseAPIHandler{}).GeminiModels(ctx)
+
+	var response struct {
+		Models []struct {
+			Name        string `json:"name"`
+			DisplayName string `json:"displayName"`
+		} `json:"models"`
+	}
+	if errUnmarshal := json.Unmarshal(recorder.Body.Bytes(), &response); errUnmarshal != nil {
+		t.Fatalf("decode response: %v", errUnmarshal)
+	}
+	for _, model := range response.Models {
+		if model.Name == "models/"+modelID {
+			if model.DisplayName != "Configured Gemini Name" {
+				t.Fatalf("displayName = %q, want Configured Gemini Name", model.DisplayName)
+			}
+			return
+		}
+	}
+	t.Fatalf("model %q not found in response", modelID)
+}

--- a/sdk/api/handlers/openai/codex_client_models.go
+++ b/sdk/api/handlers/openai/codex_client_models.go
@@ -55,6 +55,7 @@ func buildCodexClientModels(models []map[string]any) []map[string]any {
 
 		if template, ok := templates[id]; ok {
 			entry := cloneCodexClientModelMap(template)
+			applyCodexClientDisplayName(entry, model)
 			sanitizeCodexClientReasoningMetadata(entry)
 			applyCodexClientVisibilityOverride(entry, id)
 			result = append(result, entry)
@@ -153,6 +154,12 @@ func loadCodexClientModelTemplates() (map[string]map[string]any, map[string]any,
 	})
 
 	return codexClientModelTemplates, codexClientDefaultTemplate, codexClientModelTemplatesErr
+}
+
+func applyCodexClientDisplayName(entry map[string]any, model map[string]any) {
+	if displayName := stringModelValue(model, "display_name"); displayName != "" {
+		entry["display_name"] = displayName
+	}
 }
 
 func applyCodexClientModelMetadata(entry map[string]any, id string, model map[string]any) {

--- a/sdk/api/handlers/openai/codex_client_models_test.go
+++ b/sdk/api/handlers/openai/codex_client_models_test.go
@@ -129,6 +129,20 @@ func TestCodexClientModelsResponse_InputModalitiesFromRegistry(t *testing.T) {
 	}
 }
 
+func TestCodexClientModelsResponse_AppliesDisplayNameToTemplateModel(t *testing.T) {
+	resp := CodexClientModelsResponse([]map[string]any{{
+		"id":           "gpt-5.5",
+		"display_name": "Configured Codex Name",
+	}})
+	models, ok := resp["models"].([]map[string]any)
+	if !ok || len(models) != 1 {
+		t.Fatalf("models = %#v, want one model", resp["models"])
+	}
+	if got := stringModelValue(models[0], "display_name"); got != "Configured Codex Name" {
+		t.Fatalf("display_name = %q, want Configured Codex Name", got)
+	}
+}
+
 func TestCodexClientModelsResponse_PreservesUltraReasoningEffort(t *testing.T) {
 	resp := CodexClientModelsResponse([]map[string]any{{"id": "gpt-5.6-sol"}})
 	models, ok := resp["models"].([]map[string]any)

--- a/sdk/api/handlers/openai/codex_client_models_test.go
+++ b/sdk/api/handlers/openai/codex_client_models_test.go
@@ -129,9 +129,23 @@ func TestCodexClientModelsResponse_InputModalitiesFromRegistry(t *testing.T) {
 	}
 }
 
+func TestCodexClientModelsResponse_AppliesDisplayNameToTemplateModel(t *testing.T) {
+	resp := CodexClientModelsResponse([]map[string]any{{
+		"id":           "gpt-5.5",
+		"display_name": "Configured Codex Name",
+	}})
+	models, ok := resp["models"].([]map[string]any)
+	if !ok || len(models) != 1 {
+		t.Fatalf("models = %#v, want one model", resp["models"])
+	}
+	if got := stringModelValue(models[0], "display_name"); got != "Configured Codex Name" {
+		t.Fatalf("display_name = %q, want Configured Codex Name", got)
+	}
+}
+
 func TestCodexClientModelsResponse_GPT56UltraReasoningMetadata(t *testing.T) {
 	resp := CodexClientModelsResponse([]map[string]any{
-		{"id": "gpt-5.6-sol"},
+		{"id": "gpt-5.6-sol", "display_name": "Configured Sol"},
 		{"id": "gpt-5.6-terra"},
 		{"id": "gpt-5.6-luna"},
 	})
@@ -153,6 +167,9 @@ func TestCodexClientModelsResponse_GPT56UltraReasoningMetadata(t *testing.T) {
 		if got := codexClientReasoningLevelDescription(model, "ultra"); got != "Maximum reasoning with automatic task delegation" {
 			t.Fatalf("%s ultra description = %q, want automatic task delegation description", slug, got)
 		}
+	}
+	if got := stringModelValue(bySlug["gpt-5.6-sol"], "display_name"); got != "Configured Sol" {
+		t.Fatalf("gpt-5.6-sol display_name = %q, want Configured Sol", got)
 	}
 
 	luna := bySlug["gpt-5.6-luna"]

--- a/sdk/cliproxy/auth/codex_rate_limit_continuity_test.go
+++ b/sdk/cliproxy/auth/codex_rate_limit_continuity_test.go
@@ -1400,6 +1400,116 @@ func codexContinuityConversationOptions(conversationID string) cliproxyexecutor.
 	return cliproxyexecutor.Options{OriginalRequest: []byte(`{"conversation_id":"` + conversationID + `"}`)}
 }
 
+func TestManagerSelectAuthForRequestReturnsContinuityContext(t *testing.T) {
+	manager := newCodexContinuityManager(
+		t,
+		&codexContinuityTestExecutor{},
+		[]string{"auth-a"},
+		[]string{"gpt-5"},
+		1,
+	)
+	selected, resultCtx, err := manager.SelectAuthForRequest(
+		context.Background(),
+		"codex",
+		"gpt-5",
+		codexContinuityOptions("search-session"),
+	)
+	if err != nil {
+		t.Fatalf("SelectAuthForRequest() error = %v", err)
+	}
+	if selected == nil || selected.ID != "auth-a" {
+		t.Fatalf("selected = %#v, want auth-a", selected)
+	}
+	attempt, ok := codexRateLimitContinuityAttemptFromContext(resultCtx)
+	if !ok {
+		t.Fatal("SelectAuthForRequest() did not return a continuity attempt context")
+	}
+	lifecycle, hasLifecycle := codexRateLimitContinuityLifecycleFromContext(resultCtx)
+	if !hasLifecycle || lifecycle != manager.codexRateLimitContinuityLifecycle {
+		t.Fatalf("request lifecycle = %d present=%t, want current lifecycle %d", lifecycle, hasLifecycle, manager.codexRateLimitContinuityLifecycle)
+	}
+	if attempt.key.authID != selected.ID || attempt.key.model != "gpt-5" || attempt.sessionID != "execution:search-session" {
+		t.Fatalf("attempt = %#v, want auth/model/session binding", attempt)
+	}
+	manager.MarkResult(resultCtx, Result{
+		AuthID:   selected.ID,
+		Provider: "codex",
+		Model:    "gpt-5",
+		Success:  true,
+	})
+}
+
+func TestManagerConfirmSelectedAuthDispatchRejectsConfirmedBarrierAndAbandons(t *testing.T) {
+	manager := newCodexContinuityManager(
+		t,
+		&codexContinuityTestExecutor{},
+		[]string{"auth-a"},
+		[]string{"gpt-5"},
+		1,
+	)
+	_, resultCtx, err := manager.SelectAuthForRequest(
+		context.Background(),
+		"codex",
+		"gpt-5",
+		codexContinuityOptions("search-session"),
+	)
+	if err != nil {
+		t.Fatalf("SelectAuthForRequest() error = %v", err)
+	}
+	attempt, ok := codexRateLimitContinuityAttemptFromContext(resultCtx)
+	if !ok {
+		t.Fatal("SelectAuthForRequest() did not return a continuity attempt")
+	}
+	manager.codexRateLimitContinuity.mu.Lock()
+	state := manager.codexRateLimitContinuity.states[attempt.key]
+	setCodexRateLimitContinuityPhase(state, codexRateLimitContinuityConfirmedCooldown)
+	manager.codexRateLimitContinuity.mu.Unlock()
+
+	err = manager.ConfirmSelectedAuthDispatch(resultCtx)
+	if err == nil {
+		t.Fatal("ConfirmSelectedAuthDispatch() succeeded after confirmed cooldown")
+	}
+	statusError, ok := err.(interface{ StatusCode() int })
+	if !ok || statusError.StatusCode() != http.StatusTooManyRequests {
+		t.Fatalf("ConfirmSelectedAuthDispatch() error = %#v, want HTTP 429", err)
+	}
+	manager.codexRateLimitContinuity.mu.Lock()
+	defer manager.codexRateLimitContinuity.mu.Unlock()
+	if got := len(manager.codexRateLimitContinuity.activeAttempts); got != 0 {
+		t.Fatalf("active attempts after rejected dispatch = %d, want 0", got)
+	}
+	if got := state.inFlight[attempt.sessionID]; got != 0 {
+		t.Fatalf("in-flight after rejected dispatch = %d, want 0", got)
+	}
+}
+
+func TestManagerConfirmSelectedAuthDispatchRejectsLifecycleReset(t *testing.T) {
+	manager := newCodexContinuityManager(
+		t,
+		&codexContinuityTestExecutor{},
+		[]string{"auth-a"},
+		[]string{"gpt-5"},
+		1,
+	)
+	_, resultCtx, err := manager.SelectAuthForRequest(
+		context.Background(),
+		"codex",
+		"gpt-5",
+		codexContinuityOptions("search-session"),
+	)
+	if err != nil {
+		t.Fatalf("SelectAuthForRequest() error = %v", err)
+	}
+	manager.mu.Lock()
+	manager.advanceCodexRateLimitContinuityLifecycleLocked()
+	manager.codexRateLimitContinuity.clear()
+	manager.mu.Unlock()
+
+	if err = manager.ConfirmSelectedAuthDispatch(resultCtx); err == nil {
+		t.Fatal("ConfirmSelectedAuthDispatch() succeeded after lifecycle reset")
+	}
+}
+
 func TestManagerCodexRateLimitContinuityKeepsEstablishedSessionAndExcludesFresh(t *testing.T) {
 	usageLimit := &codexFallbackTestError{message: "usage limit", reason: internalconfig.CodexModelFallbackTriggerUsageLimit}
 	executor := &codexContinuityTestExecutor{failures: map[string]error{

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -4594,6 +4594,16 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 	return authCopy, executor, nil
 }
 
+// SelectAuth selects one credential through the configured scheduling strategy.
+// It does not execute or alter the selected credential's result state.
+func (m *Manager) SelectAuth(ctx context.Context, provider, model string, opts cliproxyexecutor.Options) (*Auth, error) {
+	selected, _, errPick := m.pickNext(ctx, provider, model, opts, nil)
+	if errPick != nil {
+		return nil, errPick
+	}
+	return selected, nil
+}
+
 func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, error) {
 	if m.HomeEnabled() {
 		auth, exec, _, err := m.pickNextViaHome(ctx, model, opts, tried)

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -5305,6 +5305,66 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 	return authCopy, executor, nil
 }
 
+// SelectAuth selects one credential through the configured scheduling strategy.
+// It does not execute or alter the selected credential's result state.
+func (m *Manager) SelectAuth(ctx context.Context, provider, model string, opts cliproxyexecutor.Options) (*Auth, error) {
+	selected, _, errPick := m.pickNext(ctx, provider, model, opts, nil)
+	if errPick != nil {
+		return nil, errPick
+	}
+	return selected, nil
+}
+
+// SelectAuthForRequest selects one credential and starts any request-scoped
+// continuity tracking required by the selected auth. Callers must pass the
+// returned context to ConfirmSelectedAuthDispatch immediately before the
+// upstream dispatch, then to MarkResult exactly once when an upstream outcome
+// exists. If no upstream outcome exists, callers must abandon the attempt; it
+// is safe to defer AbandonSelectedAuthRequest because MarkResult consumes an
+// observed attempt first.
+func (m *Manager) SelectAuthForRequest(ctx context.Context, provider, model string, opts cliproxyexecutor.Options) (*Auth, context.Context, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx = m.withCodexRateLimitContinuityLifecycle(ctx)
+	tried := make(map[string]struct{})
+	for {
+		selected, _, errPick := m.pickNext(ctx, provider, model, opts, tried)
+		if errPick != nil {
+			return nil, ctx, errPick
+		}
+		attemptCtx, allowed := m.beginCodexRateLimitContinuityAttempt(ctx, selected, provider, model, opts)
+		if allowed {
+			return selected, attemptCtx, nil
+		}
+		tried[selected.ID] = struct{}{}
+	}
+}
+
+// ConfirmSelectedAuthDispatch rechecks request-scoped continuity immediately
+// before an upstream dispatch. It rejects attempts invalidated by a confirmed
+// cooldown or lifecycle reset and releases their in-flight continuity state.
+func (m *Manager) ConfirmSelectedAuthDispatch(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		m.abandonCodexRateLimitContinuityAttempt(ctx)
+		return err
+	}
+	if allowed, confirmed := m.codexRateLimitContinuityDispatchDisposition(ctx); !allowed {
+		m.abandonCodexRateLimitContinuityAttempt(ctx)
+		return codexRateLimitObservationPendingError{confirmed: confirmed}
+	}
+	return nil
+}
+
+// AbandonSelectedAuthRequest releases request-scoped continuity state when a
+// selected credential never produces an upstream outcome for MarkResult.
+func (m *Manager) AbandonSelectedAuthRequest(ctx context.Context) {
+	m.abandonCodexRateLimitContinuityAttempt(ctx)
+}
+
 func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, error) {
 	if m.HomeEnabled() {
 		auth, exec, _, err := m.pickNextViaHome(ctx, model, opts, tried)

--- a/sdk/cliproxy/config_model_display_name_test.go
+++ b/sdk/cliproxy/config_model_display_name_test.go
@@ -1,0 +1,97 @@
+package cliproxy
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestBuildConfigModelsDisplayName(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+		got  func() *ModelInfo
+	}{
+		{
+			name: "claude",
+			want: "Claude Catalog Name",
+			got: func() *ModelInfo {
+				return buildClaudeConfigModels(&config.ClaudeKey{Models: []config.ClaudeModel{{
+					Name: "claude-upstream", Alias: "claude-catalog", DisplayName: "Claude Catalog Name",
+				}}})[0]
+			},
+		},
+		{
+			name: "gemini",
+			want: "Gemini Catalog Name",
+			got: func() *ModelInfo {
+				return buildGeminiConfigModels(&config.GeminiKey{Models: []config.GeminiModel{{
+					Name: "gemini-upstream", Alias: "gemini-catalog", DisplayName: "Gemini Catalog Name",
+				}}})[0]
+			},
+		},
+		{
+			name: "vertex",
+			want: "Vertex Catalog Name",
+			got: func() *ModelInfo {
+				return buildVertexCompatConfigModels(&config.VertexCompatKey{Models: []config.VertexCompatModel{{
+					Name: "vertex-upstream", Alias: "vertex-catalog", DisplayName: "Vertex Catalog Name",
+				}}})[0]
+			},
+		},
+		{
+			name: "codex",
+			want: "Codex Catalog Name",
+			got: func() *ModelInfo {
+				return buildCodexConfigModels(&config.CodexKey{Models: []config.CodexModel{{
+					Name: "gpt-5.5", Alias: "gpt-5.5", DisplayName: "Codex Catalog Name",
+				}}})[0]
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.got().DisplayName; got != tt.want {
+				t.Fatalf("DisplayName = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildCodexConfigModelsPreservesBuiltinDisplayNames(t *testing.T) {
+	models := buildCodexConfigModels(&config.CodexKey{Models: []config.CodexModel{
+		{Name: "gpt-image-1.5", DisplayName: "Configured Image 1.5"},
+		{Name: "gpt-image-2", DisplayName: "Configured Image 2"},
+	}})
+
+	wantDisplayNames := map[string]string{
+		"gpt-image-1.5": "Configured Image 1.5",
+		"gpt-image-2":   "Configured Image 2",
+	}
+	for _, model := range models {
+		wantDisplayName, ok := wantDisplayNames[model.ID]
+		if !ok {
+			continue
+		}
+		if model.DisplayName != wantDisplayName {
+			t.Errorf("%s DisplayName = %q, want %q", model.ID, model.DisplayName, wantDisplayName)
+		}
+		if model.Object != "model" || model.OwnedBy != "openai" || model.Type != "openai" || model.Created != 1704067200 || model.Version != model.ID || model.UserDefined {
+			t.Errorf("%s builtin metadata was not preserved: %#v", model.ID, model)
+		}
+		delete(wantDisplayNames, model.ID)
+	}
+	for modelID := range wantDisplayNames {
+		t.Errorf("missing builtin model %s", modelID)
+	}
+}
+
+func TestBuildConfigModelsDisplayNameFallback(t *testing.T) {
+	model := buildClaudeConfigModels(&config.ClaudeKey{Models: []config.ClaudeModel{{
+		Name: "claude-upstream", Alias: "claude-catalog",
+	}}})[0]
+	if model.DisplayName != "claude-upstream" {
+		t.Fatalf("DisplayName = %q, want upstream model name", model.DisplayName)
+	}
+}

--- a/sdk/cliproxy/openai_compat_config_models_test.go
+++ b/sdk/cliproxy/openai_compat_config_models_test.go
@@ -14,6 +14,7 @@ func TestBuildOpenAICompatibilityConfigModels_InputModalities(t *testing.T) {
 			{
 				Name:            "upstream-vision",
 				Alias:           "mimo-v2.5-pro",
+				DisplayName:     "Mimo Vision",
 				InputModalities: []string{"TEXT", "image", "image"},
 			},
 			{
@@ -45,11 +46,17 @@ func TestBuildOpenAICompatibilityConfigModels_InputModalities(t *testing.T) {
 	if vision == nil {
 		t.Fatal("expected vision model")
 	}
+	if vision.DisplayName != "Mimo Vision" {
+		t.Fatalf("DisplayName = %q, want Mimo Vision", vision.DisplayName)
+	}
 	if got := joinModalities(vision.SupportedInputModalities); got != "text,image" {
 		t.Fatalf("SupportedInputModalities = %q, want text,image", got)
 	}
 	if imageModel == nil {
 		t.Fatal("expected image model")
+	}
+	if imageModel.DisplayName != "compat-image" {
+		t.Fatalf("image DisplayName = %q, want compat-image", imageModel.DisplayName)
 	}
 	if imageModel.Type != registry.OpenAIImageModelType {
 		t.Fatalf("image model type = %q, want %q", imageModel.Type, registry.OpenAIImageModelType)

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -2472,6 +2472,34 @@ func matchWildcard(pattern, value string) bool {
 type modelEntry interface {
 	GetName() string
 	GetAlias() string
+	GetDisplayName() string
+}
+
+func buildConfiguredModelInfo(model modelEntry, ownedBy, modelType string, created int64, fallbackDisplayName string, userDefined bool) *ModelInfo {
+	name := strings.TrimSpace(model.GetName())
+	alias := strings.TrimSpace(model.GetAlias())
+	if alias == "" {
+		alias = name
+	}
+	if alias == "" {
+		return nil
+	}
+	displayName := strings.TrimSpace(model.GetDisplayName())
+	if displayName == "" {
+		displayName = fallbackDisplayName
+	}
+	if displayName == "" {
+		displayName = alias
+	}
+	return &ModelInfo{
+		ID:          alias,
+		Object:      "model",
+		Created:     created,
+		OwnedBy:     ownedBy,
+		Type:        modelType,
+		DisplayName: displayName,
+		UserDefined: userDefined,
+	}
 }
 
 func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []*ModelInfo {
@@ -2482,35 +2510,22 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 	models := make([]*ModelInfo, 0, len(compat.Models))
 	for i := range compat.Models {
 		model := compat.Models[i]
-		modelID := strings.TrimSpace(model.Alias)
-		if modelID == "" {
-			modelID = strings.TrimSpace(model.Name)
-		}
-		if modelID == "" {
-			continue
-		}
 		modelType := "openai-compatibility"
 		if model.Image {
 			modelType = registry.OpenAIImageModelType
+		}
+		info := buildConfiguredModelInfo(model, compat.Name, modelType, now, strings.TrimSpace(model.Alias), false)
+		if info == nil {
+			continue
 		}
 		thinking := model.Thinking
 		if thinking == nil && !model.Image {
 			thinking = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
 		}
-		inputModalities := normalizeCompatConfigModalities(model.InputModalities)
-		outputModalities := normalizeCompatConfigModalities(model.OutputModalities)
-		models = append(models, &ModelInfo{
-			ID:                        modelID,
-			Object:                    "model",
-			Created:                   now,
-			OwnedBy:                   compat.Name,
-			Type:                      modelType,
-			DisplayName:               modelID,
-			UserDefined:               false,
-			Thinking:                  thinking,
-			SupportedInputModalities:  inputModalities,
-			SupportedOutputModalities: outputModalities,
-		})
+		info.Thinking = thinking
+		info.SupportedInputModalities = normalizeCompatConfigModalities(model.InputModalities)
+		info.SupportedOutputModalities = normalizeCompatConfigModalities(model.OutputModalities)
+		models = append(models, info)
 	}
 	return models
 }
@@ -2548,31 +2563,16 @@ func buildConfigModels[T modelEntry](models []T, ownedBy, modelType string) []*M
 	for i := range models {
 		model := models[i]
 		name := strings.TrimSpace(model.GetName())
-		alias := strings.TrimSpace(model.GetAlias())
-		if alias == "" {
-			alias = name
-		}
-		if alias == "" {
+		info := buildConfiguredModelInfo(model, ownedBy, modelType, now, name, true)
+		if info == nil {
 			continue
 		}
+		alias := info.ID
 		key := strings.ToLower(alias)
 		if _, exists := seen[key]; exists {
 			continue
 		}
 		seen[key] = struct{}{}
-		display := name
-		if display == "" {
-			display = alias
-		}
-		info := &ModelInfo{
-			ID:          alias,
-			Object:      "model",
-			Created:     now,
-			OwnedBy:     ownedBy,
-			Type:        modelType,
-			DisplayName: display,
-			UserDefined: true,
-		}
 		if name != "" {
 			if upstream := registry.LookupStaticModelInfo(name); upstream != nil && upstream.Thinking != nil {
 				info.Thinking = upstream.Thinking
@@ -2608,7 +2608,39 @@ func buildCodexConfigModels(entry *config.CodexKey) []*ModelInfo {
 	if entry == nil {
 		return nil
 	}
-	return registry.WithCodexBuiltins(buildConfigModels(entry.Models, "openai", "openai"))
+
+	models := registry.WithCodexBuiltins(buildConfigModels(entry.Models, "openai", "openai"))
+	configuredDisplayNames := make(map[string]string, len(entry.Models))
+	seenConfiguredModels := make(map[string]struct{}, len(entry.Models))
+	for i := range entry.Models {
+		model := entry.Models[i]
+		alias := strings.TrimSpace(model.Alias)
+		if alias == "" {
+			alias = strings.TrimSpace(model.Name)
+		}
+		if alias == "" {
+			continue
+		}
+		key := strings.ToLower(alias)
+		if _, exists := seenConfiguredModels[key]; exists {
+			continue
+		}
+		seenConfiguredModels[key] = struct{}{}
+
+		displayName := strings.TrimSpace(model.DisplayName)
+		if displayName != "" {
+			configuredDisplayNames[key] = displayName
+		}
+	}
+	for _, model := range models {
+		if model == nil {
+			continue
+		}
+		if displayName, ok := configuredDisplayNames[strings.ToLower(model.ID)]; ok {
+			model.DisplayName = displayName
+		}
+	}
+	return models
 }
 
 func rewriteModelInfoName(name, oldID, newID string) string {


### PR DESCRIPTION
## 结果

这是一次 **Protected upstream full-sync**：将 CPA-Core-LTS 从已吸收的 upstream `v7.2.69` 推进到 `v7.2.70`，同时针对新增 `/v1/alpha/search` 做 LTS auth lifecycle、日志隐私、限长和错误归因加固。Core 的完整 usage statistics、Management API、GPT-5.6 模型元数据和 Panel 兼容边界保持不变。

合并要求：**必须使用 Create a merge commit，禁止 squash/rebase**，以保留 upstream merge parent 与同步历史。

## Type

- [x] Protected upstream full-sync
- [ ] Staged upstream full-sync
- [ ] LTS protected-delta patch
- [ ] LTS feature / downstream patch maintenance
- [ ] Maintenance docs / CI
- [ ] Emergency hotfix

## Upstream sync info

- Upstream repo: `router-for-me/CLIProxyAPI`
- Upstream branch: `main`
- Upstream from SHA: `f4a8aee69500038289064bf5aba5ffc11cabd603` (`v7.2.69`)
- Upstream to SHA: `9c3f7207106a59f5a0b87cf8d7f1e9ab648159c2` (`v7.2.70`)
- Sync branch: `codex/sync-upstream-v7.2.70-20260712`
- Merge commit: `adaccb5d1153a636346431ea5f85fb0e1e1d710f`

本阶段吸收的 upstream first-parent 变更：

- `3586d3e7`：各 API 的模型 mapping 支持 canonical `display-name`
- `dee653cd`：代理 GPT-5.6 standalone search
- `9c3f7207`：alpha search session affinity 与 request logging

同步期间 upstream 又出现未打 tag 的 `55f4d6ed`。本 PR 已前向适配其中与当前改动直接相关的 Gin context 选择链路，确保 Home scheduler 在 alpha search credential selection 阶段仍能读取 Gin query/context；同步基准仍固定在稳定 tag `v7.2.70`。

## 关键改动

- 为 Gemini、Codex、Claude、Vertex 和 OpenAI compatibility model mapping 保留 `name`/`alias` 路由语义，并新增 canonical `display-name` catalog label。
- watcher hash/diff、SDK config、model catalog 和 Management config roundtrip 均纳入 `display-name`。
- `/v1/alpha/search` 继续直通 Codex search wire shape，不经过协议 translator。
- auth selection 绑定当前 continuity lifecycle，并在真实 HTTP dispatch 前 final recheck；未出站路径显式 abandon attempt。
- 真实 upstream HTTP/transport outcome 才进入 `MarkResult`；malformed/non-object JSON、本地 request construction、client cancellation、response read/size policy，以及 400/422/request-scoped 404 request-shape 错误不会污染健康 credential。
- `400 + usage_limit_reached` 与 capacity body 复用标准 Codex classifier，统一正规化为 `429` 并保留 retry/fallback/cooldown 语义；401、`invalid_grant`、真实 transport failure 仍正常记账。
- request log 仅记录安全 metadata，不记录 search query/result body；final recheck 未通过时不伪造 upstream dispatch log。
- request/response 超限分别返回有界 `413`/`502`，不再静默截断 JSON。

## Protected delta checklist

- [x] `usage-statistics-enabled` still exists
- [x] `internal/usage/` still exists
- [x] `/v0/management/usage` still exists
- [x] `/v0/management/usage/export` still exists
- [x] `/v0/management/usage/import` still exists
- [x] `docs/lts/core-feature-contracts.yaml` reviewed for touched protected or protected-adjacent features
- [x] `docs/lts/downstream-patches.yaml` reviewed for active patch retirement or reapplication
- [x] Usage record creation/schema reviewed or tested: API key, auth source, model, token breakdown, latency, success/failure
- [x] Management usage response shape reviewed or tested: `usage`, `failed_requests`, `apis`, `models`, `details`
- [x] Export/import roundtrip reviewed or tested when usage data shape is touched
- [x] CPA-Panel-LTS response shape reviewed
- [x] Local auth/config/panel/release/source customizations reviewed

## LTS classification review

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| Full usage statistics / Management usage | retained capability | preserved | usage/management tests、contract guard 和全仓测试通过；wire shape 未修改 |
| GPT-5.6 Sol/Terra/Luna/Spark client model metadata | downstream patch | adapted | 唯一冲突测试同时保留 Sol/Terra Ultra、Luna 非 Ultra、Spark effort/summary 契约与 upstream display-name |
| Model mapping `display-name` | upstream feature | newly-added | config/watcher/SDK/API handler roundtrip tests 覆盖 |
| Codex alpha search auth lifecycle | review seam | adapted | continuity lifecycle、dispatch barrier、abandon、request-error/credential-error 对照和 race tests 覆盖 |
| Request logging privacy | retained capability | preserved | query/result 不进入 request log；被 continuity 拒绝的请求不记录为 upstream dispatch |
| `docs/lts/downstream-patches.yaml` active entries | downstream patch ledger | patch-still-required | 已审查；本阶段没有足够 upstream 等价证据可退休条目，因此不改 ledger |

- [x] 此同步 PR 将使用 **Create a merge commit**；禁止 squash/rebase。

## Conflict resolution notes

唯一文本冲突：`sdk/api/handlers/openai/codex_client_models_test.go`。

解决方式同时保留：

- upstream `display-name` 配置覆盖；
- LTS GPT-5.6 Sol/Terra Ultra metadata；
- Luna 不暴露 Ultra；
- Spark `reasoning.effort` 与 summary default-off；
- 新增交叉断言，防止自定义 `display_name` 覆盖时破坏 Sol Ultra metadata。

## Validation

- [x] `scripts/check-lts-contract.sh`
- [x] `go run ./scripts/ltsregistry --root .`
- [x] `go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'`
- [x] `go test ./internal/api ./internal/config ./internal/watcher/diff`
- [x] `go test ./sdk/api/handlers/openai ./sdk/api/handlers/claude ./sdk/api/handlers/gemini ./sdk/cliproxy ./sdk/cliproxy/auth`
- [x] `go test ./internal/runtime/executor ./internal/runtime/executor/helps`
- [x] `go test -race ./internal/api ./sdk/cliproxy/auth -run 'CodexAlphaSearch|SelectAuthForRequest|ConfirmSelectedAuthDispatch|CodexRateLimitContinuity'`
- [x] `go build -o test-output ./cmd/server && rm -f test-output`
- [x] `go test ./...`
- [x] `git diff --check`

上述命令均在 PR head `adaccb5d1153a636346431ea5f85fb0e1e1d710f` 上通过；本轮 `go test ./...` 未出现根目录 `tmp/` 污染。

## Companion Panel PR

Companion: [CPA-Panel-LTS#21](https://github.com/BlueSkyXN/CPA-Panel-LTS/pull/21)。Panel 合并顺序必须晚于本 PR，以确保默认 Core 已支持 `display-name` schema。

## 边界

- 本 PR 不创建 tag、release，不发布镜像，不部署运行环境。
- 不修改现有 Codex `ultra -> max` wire compatibility、Provider thinking translator 或 usage schema。
- upstream `v7.2.70` 之后的新未打 tag 变更不作为本同步阶段的 merge parent；仅前向适配了与 alpha search 直接相关且已经验证的 Gin context selection 行为。

## Optional real runtime smoke

- [ ] Hugging Face Space smoke was run, or explicitly skipped with reason
- Skipped: 本 PR 只做本地 contract/package/race/full-suite/build 验证；未发布、未部署，因此没有对应 runtime SHA 可回读。
