### PR TITLE
feat(usage): 暴露并严格校验未缓存输入 Token 契约

### DIFF
--- a/docs/lts/core-feature-contracts.yaml
+++ b/docs/lts/core-feature-contracts.yaml
@@ -37,6 +37,7 @@ features:
       - RequestDetail
       - auth_index
       - latency_ms
+      - uncached_input_tokens
       - reasoning_effort
       - service_tier
       - request_service_tier
@@ -76,6 +77,7 @@ features:
       - success_count
       - failure_count
       - total_tokens
+      - uncached_input_tokens
       - apis
       - models
       - details
@@ -356,6 +358,7 @@ features:
       - redisqueue
       - latency_ms
       - auth_index
+      - uncached_input_tokens
     validation:
       - go test ./internal/redisqueue ./internal/api -run 'Redis|redis|Usage|usage'
 

--- a/internal/api/handlers/management/usage_contract_test.go
+++ b/internal/api/handlers/management/usage_contract_test.go
@@ -29,6 +29,7 @@ func TestUsageManagementResponseShapeAndImportExportRoundTrip(t *testing.T) {
 	getPayload, getJSON := readUsageStatisticsResponse(t, h)
 	requirePanelUsageShape(t, getPayload.Usage)
 	requireCanonicalReasoningEffortJSON(t, getJSON, "GET usage response")
+	requireKnownZeroUncachedInputTokensJSON(t, getJSON, "GET usage response")
 	if getPayload.FailedRequests != 0 {
 		t.Fatalf("failed_requests = %d, want 0", getPayload.FailedRequests)
 	}
@@ -55,6 +56,7 @@ func TestUsageManagementResponseShapeAndImportExportRoundTrip(t *testing.T) {
 		t.Fatalf("exported usage missing response_service_tier: %s", exportedJSON)
 	}
 	requireCanonicalReasoningEffortJSON(t, exportedJSON, "exported usage")
+	requireKnownZeroUncachedInputTokensJSON(t, exportedJSON, "exported usage")
 	var legacyDecoded struct {
 		Version int `json:"version"`
 		Usage   struct {
@@ -94,6 +96,7 @@ func TestUsageManagementResponseShapeAndImportExportRoundTrip(t *testing.T) {
 		t.Fatalf("marshal re-exported usage: %v", err)
 	}
 	requireCanonicalReasoningEffortJSON(t, reimportedJSON, "usage re-exported after import")
+	requireKnownZeroUncachedInputTokensJSON(t, reimportedJSON, "usage re-exported after import")
 }
 
 func TestUsageManagementFailedDetailIncludesFailureReason(t *testing.T) {
@@ -224,6 +227,9 @@ func TestUsageManagementImportLegacyExportKeepsServiceTierUnknown(t *testing.T) 
 	if details[0].RequestServiceTier != "" || details[0].ResponseServiceTier != "" {
 		t.Fatalf("legacy detail service tiers = request:%q response:%q, want empty/unknown", details[0].RequestServiceTier, details[0].ResponseServiceTier)
 	}
+	if details[0].Tokens.UncachedInputTokens != nil {
+		t.Fatalf("legacy detail uncached_input_tokens = %v, want nil/unknown", details[0].Tokens.UncachedInputTokens)
+	}
 	if snapshot.TotalRequests != 1 || snapshot.SuccessCount != 1 || snapshot.FailureCount != 0 || snapshot.TotalTokens != 9 {
 		t.Fatalf("legacy snapshot totals = %+v, want requests=1 success=1 failure=0 tokens=9", snapshot)
 	}
@@ -245,6 +251,54 @@ func TestUsageManagementImportLegacyExportKeepsServiceTierUnknown(t *testing.T) 
 	if bytes.Contains(reexportedJSON, []byte(`"request_service_tier"`)) || bytes.Contains(reexportedJSON, []byte(`"response_service_tier"`)) {
 		t.Fatalf("legacy re-export fabricated explicit service-tier fields: %s", reexportedJSON)
 	}
+	if bytes.Contains(reexportedJSON, []byte(`"uncached_input_tokens"`)) {
+		t.Fatalf("legacy re-export fabricated uncached_input_tokens: %s", reexportedJSON)
+	}
+}
+
+func TestUsageManagementImportOmitsInvalidUncachedInputTokens(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       int64
+		wantPresent bool
+	}{
+		{name: "negative", value: -1},
+		{name: "greater than input", value: 6},
+		{name: "known zero", value: 0, wantPresent: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uncachedInputTokens := tt.value
+			snapshot := usageCacheCreationSnapshot(time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC), usage.TokenStats{
+				InputTokens:         5,
+				UncachedInputTokens: &uncachedInputTokens,
+				OutputTokens:        2,
+				TotalTokens:         7,
+			})
+
+			stats := usage.NewRequestStatistics()
+			h := &Handler{}
+			h.SetUsageStatistics(stats)
+			result := importUsageStatistics(t, h, snapshot)
+			if result.Added != 1 || result.Skipped != 0 {
+				t.Fatalf("import result = %+v, want added=1 skipped=0", result)
+			}
+
+			exported := exportUsageStatistics(t, h)
+			detail := exported.Usage.APIs["cache-key"].Models["gpt-5.6-sol"].Details[0]
+			if gotPresent := detail.Tokens.UncachedInputTokens != nil; gotPresent != tt.wantPresent {
+				t.Fatalf("uncached_input_tokens present = %v, want %v; tokens=%+v", gotPresent, tt.wantPresent, detail.Tokens)
+			}
+			exportedJSON, err := json.Marshal(exported)
+			if err != nil {
+				t.Fatalf("marshal exported usage: %v", err)
+			}
+			if gotPresent := bytes.Contains(exportedJSON, []byte(`"uncached_input_tokens"`)); gotPresent != tt.wantPresent {
+				t.Fatalf("uncached_input_tokens JSON present = %v, want %v; payload=%s", gotPresent, tt.wantPresent, exportedJSON)
+			}
+		})
+	}
 }
 
 func TestUsageManagementImportDeduplicatesLegacyAndCanonicalCacheCreation(t *testing.T) {
@@ -257,8 +311,10 @@ func TestUsageManagementImportDeduplicatesLegacyAndCanonicalCacheCreation(t *tes
 		CacheCreationTokens: 1024,
 		TotalTokens:         1210,
 	})
+	uncachedInputTokens := int64(176)
 	canonical := usageCacheCreationSnapshot(timestamp, usage.TokenStats{
 		InputTokens:         1200,
+		UncachedInputTokens: &uncachedInputTokens,
 		OutputTokens:        10,
 		CacheCreationTokens: 1024,
 		TotalTokens:         2234,
@@ -349,11 +405,13 @@ func recordPanelContractUsage(stats *usage.RequestStatistics) {
 		RequestedAt:         time.Date(2026, 6, 10, 11, 30, 0, 0, time.UTC),
 		Latency:             2 * time.Second,
 		Detail: coreusage.Detail{
-			InputTokens:     5,
-			OutputTokens:    7,
-			ReasoningTokens: 3,
-			CachedTokens:    2,
-			TotalTokens:     17,
+			InputTokens:              5,
+			UncachedInputTokens:      0,
+			UncachedInputTokensKnown: true,
+			OutputTokens:             7,
+			ReasoningTokens:          3,
+			CachedTokens:             2,
+			TotalTokens:              17,
 		},
 	})
 }
@@ -515,6 +573,9 @@ func requirePanelUsageShape(t *testing.T, snapshot usage.StatisticsSnapshot) {
 		detail.Tokens.TotalTokens != 17 {
 		t.Fatalf("detail.tokens = %+v, want panel-compatible token breakdown", detail.Tokens)
 	}
+	if detail.Tokens.UncachedInputTokens == nil || *detail.Tokens.UncachedInputTokens != 0 {
+		t.Fatalf("detail.tokens.uncached_input_tokens = %v, want pointer to 0", detail.Tokens.UncachedInputTokens)
+	}
 }
 
 func requireCanonicalReasoningEffortJSON(t *testing.T, payload []byte, surface string) {
@@ -525,5 +586,12 @@ func requireCanonicalReasoningEffortJSON(t *testing.T, payload []byte, surface s
 	}
 	if bytes.Contains(payload, []byte(`"thinking"`)) {
 		t.Fatalf("%s contains non-canonical thinking field: %s", surface, payload)
+	}
+}
+
+func requireKnownZeroUncachedInputTokensJSON(t *testing.T, payload []byte, surface string) {
+	t.Helper()
+	if !bytes.Contains(payload, []byte(`"uncached_input_tokens":0`)) {
+		t.Fatalf("%s missing known-zero uncached_input_tokens: %s", surface, payload)
 	}
 }

--- a/internal/pluginhost/adapters.go
+++ b/internal/pluginhost/adapters.go
@@ -1841,6 +1841,7 @@ func (a *usageAdapter) HandleUsage(ctx context.Context, record coreusage.Record)
 			a.host.fusePlugin(a.pluginID, "UsagePlugin.HandleUsage", recovered)
 		}
 	}()
+	uncachedInputTokens, uncachedInputTokensKnown := normalizePluginUsageUncachedInputTokens(record.Detail)
 	plugin.HandleUsage(ctx, pluginapi.UsageRecord{
 		Provider:        record.Provider,
 		ExecutorType:    record.ExecutorType,
@@ -1862,16 +1863,25 @@ func (a *usageAdapter) HandleUsage(ctx context.Context, record coreusage.Record)
 			Body:       record.Fail.Body,
 		},
 		Detail: pluginapi.UsageDetail{
-			InputTokens:         record.Detail.InputTokens,
-			OutputTokens:        record.Detail.OutputTokens,
-			ReasoningTokens:     record.Detail.ReasoningTokens,
-			CachedTokens:        record.Detail.CachedTokens,
-			CacheReadTokens:     record.Detail.CacheReadTokens,
-			CacheCreationTokens: record.Detail.CacheCreationTokens,
-			TotalTokens:         record.Detail.TotalTokens,
+			InputTokens:              record.Detail.InputTokens,
+			UncachedInputTokens:      uncachedInputTokens,
+			UncachedInputTokensKnown: uncachedInputTokensKnown,
+			OutputTokens:             record.Detail.OutputTokens,
+			ReasoningTokens:          record.Detail.ReasoningTokens,
+			CachedTokens:             record.Detail.CachedTokens,
+			CacheReadTokens:          record.Detail.CacheReadTokens,
+			CacheCreationTokens:      record.Detail.CacheCreationTokens,
+			TotalTokens:              record.Detail.TotalTokens,
 		},
 		ResponseHeaders: cloneHeader(record.ResponseHeaders),
 	})
+}
+
+func normalizePluginUsageUncachedInputTokens(detail coreusage.Detail) (int64, bool) {
+	if !detail.UncachedInputTokensKnown || detail.InputTokens < 0 || detail.UncachedInputTokens < 0 || detail.UncachedInputTokens > detail.InputTokens {
+		return 0, false
+	}
+	return detail.UncachedInputTokens, true
 }
 
 func (a *thinkingAdapter) Apply(body []byte, config thinking.ThinkingConfig, modelInfo *registry.ModelInfo) (out []byte, err error) {

--- a/internal/pluginhost/adapters_test.go
+++ b/internal/pluginhost/adapters_test.go
@@ -2453,6 +2453,41 @@ func TestUsageAdapterUsesCurrentSnapshotCapability(t *testing.T) {
 	}
 }
 
+func TestUsageAdapterPreservesKnownUncachedInputTokens(t *testing.T) {
+	var got pluginapi.UsageRecord
+	host := newHostWithRecords(capabilityRecord{
+		id: "usage-uncached-input",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			UsagePlugin: usagePluginFunc(func(ctx context.Context, record pluginapi.UsageRecord) {
+				got = record
+			}),
+		}},
+	})
+	adapter := &usageAdapter{host: host, pluginID: "usage-uncached-input"}
+
+	adapter.HandleUsage(context.Background(), coreusage.Record{Detail: coreusage.Detail{
+		InputTokens:              10,
+		CacheReadTokens:          10,
+		TotalTokens:              10,
+		UncachedInputTokens:      0,
+		UncachedInputTokensKnown: true,
+	}})
+
+	if !got.Detail.UncachedInputTokensKnown || got.Detail.UncachedInputTokens != 0 {
+		t.Fatalf("plugin usage detail = %+v, want known uncached input 0", got.Detail)
+	}
+
+	adapter.HandleUsage(context.Background(), coreusage.Record{Detail: coreusage.Detail{
+		InputTokens:              10,
+		TotalTokens:              10,
+		UncachedInputTokens:      11,
+		UncachedInputTokensKnown: true,
+	}})
+	if got.Detail.UncachedInputTokensKnown || got.Detail.UncachedInputTokens != 0 {
+		t.Fatalf("plugin usage detail = %+v, want invalid uncached input downgraded to unknown zero", got.Detail)
+	}
+}
+
 func TestRegisterUsagePluginsStaleAdapterSkipsRemovedCapability(t *testing.T) {
 	calls := 0
 	plugin := usagePluginFunc(func(ctx context.Context, record pluginapi.UsageRecord) {

--- a/internal/redisqueue/plugin.go
+++ b/internal/redisqueue/plugin.go
@@ -75,6 +75,10 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 		CacheCreationTokens: record.Detail.CacheCreationTokens,
 		TotalTokens:         record.Detail.TotalTokens,
 	}
+	if record.Detail.UncachedInputTokensKnown && validUncachedInputTokens(record.Detail.UncachedInputTokens, record.Detail.InputTokens) {
+		uncachedInputTokens := record.Detail.UncachedInputTokens
+		tokens.UncachedInputTokens = &uncachedInputTokens
+	}
 	if tokens.TotalTokens == 0 {
 		tokens.TotalTokens = tokens.InputTokens + tokens.OutputTokens + tokens.ReasoningTokens + tokens.CacheReadTokens + tokens.CacheCreationTokens
 	}
@@ -152,13 +156,18 @@ type requestDetail struct {
 }
 
 type tokenStats struct {
-	InputTokens         int64 `json:"input_tokens"`
-	OutputTokens        int64 `json:"output_tokens"`
-	ReasoningTokens     int64 `json:"reasoning_tokens"`
-	CachedTokens        int64 `json:"cached_tokens"`
-	CacheReadTokens     int64 `json:"cache_read_tokens"`
-	CacheCreationTokens int64 `json:"cache_creation_tokens"`
-	TotalTokens         int64 `json:"total_tokens"`
+	InputTokens         int64  `json:"input_tokens"`
+	UncachedInputTokens *int64 `json:"uncached_input_tokens,omitempty"`
+	OutputTokens        int64  `json:"output_tokens"`
+	ReasoningTokens     int64  `json:"reasoning_tokens"`
+	CachedTokens        int64  `json:"cached_tokens"`
+	CacheReadTokens     int64  `json:"cache_read_tokens"`
+	CacheCreationTokens int64  `json:"cache_creation_tokens"`
+	TotalTokens         int64  `json:"total_tokens"`
+}
+
+func validUncachedInputTokens(uncachedInputTokens, inputTokens int64) bool {
+	return inputTokens >= 0 && uncachedInputTokens >= 0 && uncachedInputTokens <= inputTokens
 }
 
 type failDetail struct {

--- a/internal/redisqueue/plugin_test.go
+++ b/internal/redisqueue/plugin_test.go
@@ -77,17 +77,20 @@ func TestUsageQueuePluginKeepsCacheCreationSeparateFromCachedTokens(t *testing.T
 			Provider: "codex",
 			Model:    "gpt-5.6-sol",
 			Detail: coreusage.Detail{
-				InputTokens:         1200,
-				OutputTokens:        10,
-				CacheCreationTokens: 1024,
+				InputTokens:              1200,
+				OutputTokens:             10,
+				CacheCreationTokens:      1024,
+				UncachedInputTokens:      0,
+				UncachedInputTokensKnown: true,
 			},
 		})
 
 		payload := popSinglePayload(t)
 		var tokens struct {
-			CachedTokens        int64 `json:"cached_tokens"`
-			CacheCreationTokens int64 `json:"cache_creation_tokens"`
-			TotalTokens         int64 `json:"total_tokens"`
+			CachedTokens        int64  `json:"cached_tokens"`
+			CacheCreationTokens int64  `json:"cache_creation_tokens"`
+			UncachedInputTokens *int64 `json:"uncached_input_tokens"`
+			TotalTokens         int64  `json:"total_tokens"`
 		}
 		if err := json.Unmarshal(payload["tokens"], &tokens); err != nil {
 			t.Fatalf("unmarshal tokens: %v", err)
@@ -98,10 +101,49 @@ func TestUsageQueuePluginKeepsCacheCreationSeparateFromCachedTokens(t *testing.T
 		if tokens.CacheCreationTokens != 1024 {
 			t.Fatalf("cache_creation_tokens = %d, want 1024", tokens.CacheCreationTokens)
 		}
+		if tokens.UncachedInputTokens == nil || *tokens.UncachedInputTokens != 0 {
+			t.Fatalf("uncached_input_tokens = %v, want pointer to 0", tokens.UncachedInputTokens)
+		}
 		if tokens.TotalTokens != 2234 {
 			t.Fatalf("total_tokens = %d, want 2234 with cache creation included", tokens.TotalTokens)
 		}
 	})
+}
+
+func TestUsageQueuePluginOmitsInvalidUncachedInputTokens(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		value int64
+	}{
+		{name: "negative", value: -1},
+		{name: "greater than input", value: 6},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			withEnabledQueue(t, func() {
+				ctx := internallogging.WithResponseStatusHolder(context.Background())
+				internallogging.SetResponseStatus(ctx, http.StatusOK)
+
+				plugin := &usageQueuePlugin{}
+				plugin.HandleUsage(ctx, coreusage.Record{Detail: coreusage.Detail{
+					InputTokens:              5,
+					TotalTokens:              5,
+					UncachedInputTokens:      tt.value,
+					UncachedInputTokensKnown: true,
+				}})
+
+				payload := popSinglePayload(t)
+				var tokens struct {
+					UncachedInputTokens *int64 `json:"uncached_input_tokens"`
+				}
+				if err := json.Unmarshal(payload["tokens"], &tokens); err != nil {
+					t.Fatalf("unmarshal tokens: %v", err)
+				}
+				if tokens.UncachedInputTokens != nil {
+					t.Fatalf("uncached_input_tokens = %v, want omitted", tokens.UncachedInputTokens)
+				}
+			})
+		})
+	}
 }
 
 func TestUsageQueuePluginAsyncUsesRecordResponseHeaders(t *testing.T) {

--- a/internal/runtime/executor/codex_abnormal_reasoning_retry.go
+++ b/internal/runtime/executor/codex_abnormal_reasoning_retry.go
@@ -579,16 +579,31 @@ func codexAbnormalReasoningRetryAggregateClientUsage(previous cliproxyexecutor.R
 }
 
 func addCodexUsageDetail(a, b usage.Detail) usage.Detail {
+	aHasUsage := hasCodexUsageDetail(a)
+	bHasUsage := hasCodexUsageDetail(b)
 	a = normalizeCodexUsageDetail(a)
 	b = normalizeCodexUsageDetail(b)
 	return usage.Detail{
-		InputTokens:         a.InputTokens + b.InputTokens,
-		OutputTokens:        a.OutputTokens + b.OutputTokens,
-		ReasoningTokens:     a.ReasoningTokens + b.ReasoningTokens,
-		CachedTokens:        a.CachedTokens + b.CachedTokens,
-		CacheReadTokens:     a.CacheReadTokens + b.CacheReadTokens,
-		CacheCreationTokens: a.CacheCreationTokens + b.CacheCreationTokens,
-		TotalTokens:         a.TotalTokens + b.TotalTokens,
+		InputTokens:              a.InputTokens + b.InputTokens,
+		OutputTokens:             a.OutputTokens + b.OutputTokens,
+		ReasoningTokens:          a.ReasoningTokens + b.ReasoningTokens,
+		CachedTokens:             a.CachedTokens + b.CachedTokens,
+		CacheReadTokens:          a.CacheReadTokens + b.CacheReadTokens,
+		CacheCreationTokens:      a.CacheCreationTokens + b.CacheCreationTokens,
+		UncachedInputTokens:      a.UncachedInputTokens + b.UncachedInputTokens,
+		UncachedInputTokensKnown: mergedCodexUncachedInputTokensKnown(a, b, aHasUsage, bHasUsage),
+		TotalTokens:              a.TotalTokens + b.TotalTokens,
+	}
+}
+
+func mergedCodexUncachedInputTokensKnown(a, b usage.Detail, aHasUsage, bHasUsage bool) bool {
+	switch {
+	case !aHasUsage:
+		return b.UncachedInputTokensKnown
+	case !bHasUsage:
+		return a.UncachedInputTokensKnown
+	default:
+		return a.UncachedInputTokensKnown && b.UncachedInputTokensKnown
 	}
 }
 

--- a/internal/runtime/executor/codex_abnormal_reasoning_retry.go
+++ b/internal/runtime/executor/codex_abnormal_reasoning_retry.go
@@ -579,11 +579,11 @@ func codexAbnormalReasoningRetryAggregateClientUsage(previous cliproxyexecutor.R
 }
 
 func addCodexUsageDetail(a, b usage.Detail) usage.Detail {
-	aHasUsage := hasCodexUsageDetail(a)
-	bHasUsage := hasCodexUsageDetail(b)
 	a = normalizeCodexUsageDetail(a)
 	b = normalizeCodexUsageDetail(b)
-	return usage.Detail{
+	aHasUsage := hasCodexUsageDetail(a)
+	bHasUsage := hasCodexUsageDetail(b)
+	return usage.NormalizeUncachedInputTokens(usage.Detail{
 		InputTokens:              a.InputTokens + b.InputTokens,
 		OutputTokens:             a.OutputTokens + b.OutputTokens,
 		ReasoningTokens:          a.ReasoningTokens + b.ReasoningTokens,
@@ -593,7 +593,7 @@ func addCodexUsageDetail(a, b usage.Detail) usage.Detail {
 		UncachedInputTokens:      a.UncachedInputTokens + b.UncachedInputTokens,
 		UncachedInputTokensKnown: mergedCodexUncachedInputTokensKnown(a, b, aHasUsage, bHasUsage),
 		TotalTokens:              a.TotalTokens + b.TotalTokens,
-	}
+	})
 }
 
 func mergedCodexUncachedInputTokensKnown(a, b usage.Detail, aHasUsage, bHasUsage bool) bool {
@@ -780,6 +780,7 @@ func patchCodexAbnormalReasoningStreamPayload(payload []byte, previous cliproxye
 }
 
 func normalizeCodexUsageDetail(detail usage.Detail) usage.Detail {
+	detail = usage.NormalizeUncachedInputTokens(detail)
 	if detail.TotalTokens == 0 {
 		total := detail.InputTokens + detail.OutputTokens
 		if total > 0 {

--- a/internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
+++ b/internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
@@ -765,6 +765,31 @@ func TestPatchCodexAbnormalReasoningClientUsageSumsCacheReadAndWrite(t *testing.
 	}
 }
 
+func TestAddCodexUsageDetailPreservesUncachedInputKnowledge(t *testing.T) {
+	first := usage.Detail{
+		InputTokens:              10,
+		TotalTokens:              10,
+		UncachedInputTokens:      0,
+		UncachedInputTokensKnown: true,
+	}
+	second := usage.Detail{
+		InputTokens:              5,
+		TotalTokens:              5,
+		UncachedInputTokens:      5,
+		UncachedInputTokensKnown: true,
+	}
+
+	total := addCodexUsageDetail(first, second)
+	if !total.UncachedInputTokensKnown || total.UncachedInputTokens != 5 {
+		t.Fatalf("added detail = %+v, want known uncached input 5", total)
+	}
+
+	mixed := addCodexUsageDetail(first, usage.Detail{InputTokens: 1, TotalTokens: 1})
+	if mixed.UncachedInputTokensKnown {
+		t.Fatalf("mixed detail = %+v, want uncached input unknown", mixed)
+	}
+}
+
 func TestCodexExecutorAbnormalReasoningRetry_ClientUsageAggregationSumUsesCodexFallbackWhenPreviousTotalMissing(t *testing.T) {
 	var calls int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
+++ b/internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
@@ -790,6 +790,26 @@ func TestAddCodexUsageDetailPreservesUncachedInputKnowledge(t *testing.T) {
 	}
 }
 
+func TestAddCodexUsageDetailRejectsInvalidKnownUncachedInputContribution(t *testing.T) {
+	invalid := usage.Detail{
+		InputTokens:              10,
+		TotalTokens:              10,
+		UncachedInputTokens:      11,
+		UncachedInputTokensKnown: true,
+	}
+	valid := usage.Detail{
+		InputTokens:              10,
+		TotalTokens:              10,
+		UncachedInputTokens:      9,
+		UncachedInputTokensKnown: true,
+	}
+
+	total := addCodexUsageDetail(invalid, valid)
+	if total.UncachedInputTokensKnown || total.UncachedInputTokens != 0 {
+		t.Fatalf("added detail = %+v, want cleared unknown uncached input", total)
+	}
+}
+
 func TestCodexExecutorAbnormalReasoningRetry_ClientUsageAggregationSumUsesCodexFallbackWhenPreviousTotalMissing(t *testing.T) {
 	var calls int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -603,8 +604,9 @@ func parseOpenAIStyleUsageNode(usageNode gjson.Result) usage.Detail {
 	if !outputNode.Exists() {
 		outputNode = usageNode.Get("output_tokens")
 	}
+	inputTokens, inputTokensValid := parseStrictUsageTokenCount(inputNode)
 	detail := usage.Detail{
-		InputTokens:  inputNode.Int(),
+		InputTokens:  inputTokens,
 		OutputTokens: outputNode.Int(),
 		TotalTokens:  usageNode.Get("total_tokens").Int(),
 	}
@@ -612,10 +614,9 @@ func parseOpenAIStyleUsageNode(usageNode gjson.Result) usage.Detail {
 	if !cached.Exists() {
 		cached = usageNode.Get("input_tokens_details.cached_tokens")
 	}
-	if cached.Exists() {
-		detail.CachedTokens = cached.Int()
-		detail.CacheReadTokens = cached.Int()
-	}
+	cachedTokens, cachedTokensValid := parseOptionalStrictUsageTokenCount(cached)
+	detail.CachedTokens = cachedTokens
+	detail.CacheReadTokens = cachedTokens
 	cacheCreation := firstExistingUsageNode(
 		usageNode,
 		"input_tokens_details.cache_creation_tokens",
@@ -623,9 +624,8 @@ func parseOpenAIStyleUsageNode(usageNode gjson.Result) usage.Detail {
 		"prompt_tokens_details.cache_creation_tokens",
 		"prompt_tokens_details.cache_write_tokens",
 	)
-	if cacheCreation.Exists() {
-		detail.CacheCreationTokens = cacheCreation.Int()
-	}
+	cacheCreationTokens, cacheCreationTokensValid := parseOptionalStrictUsageTokenCount(cacheCreation)
+	detail.CacheCreationTokens = cacheCreationTokens
 	reasoning := usageNode.Get("completion_tokens_details.reasoning_tokens")
 	if !reasoning.Exists() {
 		reasoning = usageNode.Get("output_tokens_details.reasoning_tokens")
@@ -633,7 +633,7 @@ func parseOpenAIStyleUsageNode(usageNode gjson.Result) usage.Detail {
 	if reasoning.Exists() {
 		detail.ReasoningTokens = reasoning.Int()
 	}
-	if inputNode.Exists() {
+	if inputTokensValid && cachedTokensValid && cacheCreationTokensValid {
 		setKnownUncachedInputTokens(&detail, detail.InputTokens-detail.CacheReadTokens-detail.CacheCreationTokens)
 	}
 	return detail
@@ -679,17 +679,18 @@ func ParseClaudeStreamUsage(line []byte) (usage.Detail, bool) {
 
 func parseClaudeUsageNode(usageNode gjson.Result) usage.Detail {
 	inputTokens := usageNode.Get("input_tokens")
-	cacheReadTokens := usageNode.Get("cache_read_input_tokens").Int()
-	cacheCreationTokens := usageNode.Get("cache_creation_input_tokens").Int()
+	inputTokenCount, inputTokensValid := parseStrictUsageTokenCount(inputTokens)
+	cacheReadTokens, cacheReadTokensValid := parseOptionalStrictUsageTokenCount(usageNode.Get("cache_read_input_tokens"))
+	cacheCreationTokens, cacheCreationTokensValid := parseOptionalStrictUsageTokenCount(usageNode.Get("cache_creation_input_tokens"))
 	detail := usage.Detail{
-		InputTokens:         inputTokens.Int(),
+		InputTokens:         inputTokenCount,
 		OutputTokens:        usageNode.Get("output_tokens").Int(),
 		CachedTokens:        cacheReadTokens,
 		CacheReadTokens:     cacheReadTokens,
 		CacheCreationTokens: cacheCreationTokens,
 	}
 	detail.TotalTokens = detail.InputTokens + detail.OutputTokens + detail.CacheReadTokens + detail.CacheCreationTokens
-	if inputTokens.Exists() {
+	if inputTokensValid && cacheReadTokensValid && cacheCreationTokensValid {
 		setKnownUncachedInputTokens(&detail, detail.InputTokens)
 	}
 	return detail
@@ -697,9 +698,10 @@ func parseClaudeUsageNode(usageNode gjson.Result) usage.Detail {
 
 func parseGeminiFamilyUsageDetail(node gjson.Result) usage.Detail {
 	inputTokens := node.Get("promptTokenCount")
-	cachedTokens := node.Get("cachedContentTokenCount").Int()
+	inputTokenCount, inputTokensValid := parseStrictUsageTokenCount(inputTokens)
+	cachedTokens, cachedTokensValid := parseOptionalStrictUsageTokenCount(node.Get("cachedContentTokenCount"))
 	detail := usage.Detail{
-		InputTokens:     inputTokens.Int(),
+		InputTokens:     inputTokenCount,
 		OutputTokens:    node.Get("candidatesTokenCount").Int(),
 		ReasoningTokens: node.Get("thoughtsTokenCount").Int(),
 		TotalTokens:     node.Get("totalTokenCount").Int(),
@@ -709,7 +711,7 @@ func parseGeminiFamilyUsageDetail(node gjson.Result) usage.Detail {
 	if detail.TotalTokens == 0 {
 		detail.TotalTokens = detail.InputTokens + detail.OutputTokens + detail.ReasoningTokens
 	}
-	if inputTokens.Exists() {
+	if inputTokensValid && cachedTokensValid {
 		setKnownUncachedInputTokens(&detail, detail.InputTokens-detail.CacheReadTokens)
 	}
 	return detail
@@ -719,14 +721,19 @@ func parseInteractionsUsageDetail(node gjson.Result) usage.Detail {
 	inputTokens := firstExistingUsageNode(node, "input_tokens", "prompt_tokens", "total_input_tokens")
 	cacheRead := firstExistingUsageNode(node, "cache_read_tokens", "cacheReadTokens")
 	cachedTokens := firstExistingUsageNode(node, "cached_tokens", "cachedContentTokenCount", "total_cached_tokens")
+	cacheCreation := firstExistingUsageNode(node, "cache_creation_tokens", "cacheCreationTokens", "cache_write_tokens", "cacheWriteTokens")
+	inputTokenCount, inputTokensValid := parseStrictUsageTokenCount(inputTokens)
+	cacheReadTokenCount, cacheReadTokensValid := parseOptionalStrictUsageTokenCount(cacheRead)
+	cachedTokenCount, cachedTokensValid := parseOptionalStrictUsageTokenCount(cachedTokens)
+	cacheCreationTokenCount, cacheCreationTokensValid := parseOptionalStrictUsageTokenCount(cacheCreation)
 	detail := usage.Detail{
-		InputTokens:         inputTokens.Int(),
+		InputTokens:         inputTokenCount,
 		OutputTokens:        firstExistingUsageNode(node, "output_tokens", "completion_tokens", "total_output_tokens").Int(),
 		ReasoningTokens:     firstExistingUsageNode(node, "reasoning_tokens", "thoughtsTokenCount", "total_thought_tokens").Int(),
 		TotalTokens:         firstExistingUsageNode(node, "total_tokens", "totalTokenCount").Int(),
-		CachedTokens:        cachedTokens.Int(),
-		CacheReadTokens:     cacheRead.Int(),
-		CacheCreationTokens: firstExistingUsageNode(node, "cache_creation_tokens", "cacheCreationTokens", "cache_write_tokens", "cacheWriteTokens").Int(),
+		CachedTokens:        cachedTokenCount,
+		CacheReadTokens:     cacheReadTokenCount,
+		CacheCreationTokens: cacheCreationTokenCount,
 	}
 	if !cacheRead.Exists() && detail.CachedTokens > 0 {
 		detail.CacheReadTokens = detail.CachedTokens
@@ -737,7 +744,7 @@ func parseInteractionsUsageDetail(node gjson.Result) usage.Detail {
 			detail.TotalTokens += detail.CacheReadTokens
 		}
 	}
-	if inputTokens.Exists() {
+	if inputTokensValid && cacheReadTokensValid && cachedTokensValid && cacheCreationTokensValid {
 		uncachedInputTokens := detail.InputTokens
 		if !cacheRead.Exists() && cachedTokens.Exists() {
 			uncachedInputTokens -= detail.CacheReadTokens
@@ -745,6 +752,24 @@ func parseInteractionsUsageDetail(node gjson.Result) usage.Detail {
 		setKnownUncachedInputTokens(&detail, uncachedInputTokens)
 	}
 	return detail
+}
+
+func parseStrictUsageTokenCount(node gjson.Result) (int64, bool) {
+	if !node.Exists() || node.Type != gjson.Number {
+		return 0, false
+	}
+	value, err := strconv.ParseInt(strings.TrimSpace(node.Raw), 10, 64)
+	if err != nil || value < 0 {
+		return 0, false
+	}
+	return value, true
+}
+
+func parseOptionalStrictUsageTokenCount(node gjson.Result) (int64, bool) {
+	if !node.Exists() {
+		return 0, true
+	}
+	return parseStrictUsageTokenCount(node)
 }
 
 func setKnownUncachedInputTokens(detail *usage.Detail, value int64) {

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -633,6 +633,9 @@ func parseOpenAIStyleUsageNode(usageNode gjson.Result) usage.Detail {
 	if reasoning.Exists() {
 		detail.ReasoningTokens = reasoning.Int()
 	}
+	if inputNode.Exists() {
+		setKnownUncachedInputTokens(&detail, detail.InputTokens-detail.CacheReadTokens-detail.CacheCreationTokens)
+	}
 	return detail
 }
 
@@ -675,23 +678,28 @@ func ParseClaudeStreamUsage(line []byte) (usage.Detail, bool) {
 }
 
 func parseClaudeUsageNode(usageNode gjson.Result) usage.Detail {
+	inputTokens := usageNode.Get("input_tokens")
 	cacheReadTokens := usageNode.Get("cache_read_input_tokens").Int()
 	cacheCreationTokens := usageNode.Get("cache_creation_input_tokens").Int()
 	detail := usage.Detail{
-		InputTokens:         usageNode.Get("input_tokens").Int(),
+		InputTokens:         inputTokens.Int(),
 		OutputTokens:        usageNode.Get("output_tokens").Int(),
 		CachedTokens:        cacheReadTokens,
 		CacheReadTokens:     cacheReadTokens,
 		CacheCreationTokens: cacheCreationTokens,
 	}
 	detail.TotalTokens = detail.InputTokens + detail.OutputTokens + detail.CacheReadTokens + detail.CacheCreationTokens
+	if inputTokens.Exists() {
+		setKnownUncachedInputTokens(&detail, detail.InputTokens)
+	}
 	return detail
 }
 
 func parseGeminiFamilyUsageDetail(node gjson.Result) usage.Detail {
+	inputTokens := node.Get("promptTokenCount")
 	cachedTokens := node.Get("cachedContentTokenCount").Int()
 	detail := usage.Detail{
-		InputTokens:     node.Get("promptTokenCount").Int(),
+		InputTokens:     inputTokens.Int(),
 		OutputTokens:    node.Get("candidatesTokenCount").Int(),
 		ReasoningTokens: node.Get("thoughtsTokenCount").Int(),
 		TotalTokens:     node.Get("totalTokenCount").Int(),
@@ -701,17 +709,22 @@ func parseGeminiFamilyUsageDetail(node gjson.Result) usage.Detail {
 	if detail.TotalTokens == 0 {
 		detail.TotalTokens = detail.InputTokens + detail.OutputTokens + detail.ReasoningTokens
 	}
+	if inputTokens.Exists() {
+		setKnownUncachedInputTokens(&detail, detail.InputTokens-detail.CacheReadTokens)
+	}
 	return detail
 }
 
 func parseInteractionsUsageDetail(node gjson.Result) usage.Detail {
+	inputTokens := firstExistingUsageNode(node, "input_tokens", "prompt_tokens", "total_input_tokens")
 	cacheRead := firstExistingUsageNode(node, "cache_read_tokens", "cacheReadTokens")
+	cachedTokens := firstExistingUsageNode(node, "cached_tokens", "cachedContentTokenCount", "total_cached_tokens")
 	detail := usage.Detail{
-		InputTokens:         firstExistingUsageNode(node, "input_tokens", "prompt_tokens", "total_input_tokens").Int(),
+		InputTokens:         inputTokens.Int(),
 		OutputTokens:        firstExistingUsageNode(node, "output_tokens", "completion_tokens", "total_output_tokens").Int(),
 		ReasoningTokens:     firstExistingUsageNode(node, "reasoning_tokens", "thoughtsTokenCount", "total_thought_tokens").Int(),
 		TotalTokens:         firstExistingUsageNode(node, "total_tokens", "totalTokenCount").Int(),
-		CachedTokens:        firstExistingUsageNode(node, "cached_tokens", "cachedContentTokenCount", "total_cached_tokens").Int(),
+		CachedTokens:        cachedTokens.Int(),
 		CacheReadTokens:     cacheRead.Int(),
 		CacheCreationTokens: firstExistingUsageNode(node, "cache_creation_tokens", "cacheCreationTokens", "cache_write_tokens", "cacheWriteTokens").Int(),
 	}
@@ -724,7 +737,27 @@ func parseInteractionsUsageDetail(node gjson.Result) usage.Detail {
 			detail.TotalTokens += detail.CacheReadTokens
 		}
 	}
+	if inputTokens.Exists() {
+		uncachedInputTokens := detail.InputTokens
+		if !cacheRead.Exists() && cachedTokens.Exists() {
+			uncachedInputTokens -= detail.CacheReadTokens
+		}
+		setKnownUncachedInputTokens(&detail, uncachedInputTokens)
+	}
 	return detail
+}
+
+func setKnownUncachedInputTokens(detail *usage.Detail, value int64) {
+	if detail == nil {
+		return
+	}
+	detail.UncachedInputTokens = 0
+	detail.UncachedInputTokensKnown = false
+	if detail.InputTokens < 0 || value < 0 || value > detail.InputTokens {
+		return
+	}
+	detail.UncachedInputTokens = value
+	detail.UncachedInputTokensKnown = true
 }
 
 func hasUsageDetail(detail usage.Detail) bool {

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -2,6 +2,7 @@ package helps
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -25,6 +26,149 @@ func requireUnknownUncachedInputTokens(t *testing.T, detail usage.Detail) {
 	t.Helper()
 	if detail.UncachedInputTokensKnown {
 		t.Fatalf("uncached input tokens = %d known=true, want unknown; detail=%+v", detail.UncachedInputTokens, detail)
+	}
+	if detail.UncachedInputTokens != 0 {
+		t.Fatalf("uncached input tokens = %d known=false, want cleared zero; detail=%+v", detail.UncachedInputTokens, detail)
+	}
+}
+
+func TestUsageParsersRejectInvalidUncachedInputTokenInputs(t *testing.T) {
+	invalidLiterals := []struct {
+		name    string
+		literal string
+	}{
+		{name: "null", literal: "null"},
+		{name: "boolean", literal: "true"},
+		{name: "string", literal: `"5"`},
+		{name: "fractional", literal: "1.5"},
+		{name: "negative", literal: "-1"},
+		{name: "int64 overflow", literal: "9223372036854775808"},
+	}
+
+	parseCodex := func(data []byte) usage.Detail {
+		detail, _ := ParseCodexUsage(data)
+		return detail
+	}
+	cases := []struct {
+		name    string
+		payload func(string) []byte
+		parse   func([]byte) usage.Detail
+	}{
+		{
+			name: "openai input_tokens",
+			payload: func(literal string) []byte {
+				return []byte(fmt.Sprintf(`{"usage":{"input_tokens":%s,"input_tokens_details":{"cached_tokens":0,"cache_write_tokens":0}}}`, literal))
+			},
+			parse: ParseOpenAIUsage,
+		},
+		{
+			name: "openai cached_tokens",
+			payload: func(literal string) []byte {
+				return []byte(fmt.Sprintf(`{"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":%s,"cache_write_tokens":0}}}`, literal))
+			},
+			parse: ParseOpenAIUsage,
+		},
+		{
+			name: "openai cache_write_tokens",
+			payload: func(literal string) []byte {
+				return []byte(fmt.Sprintf(`{"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":0,"cache_write_tokens":%s}}}`, literal))
+			},
+			parse: ParseOpenAIUsage,
+		},
+		{
+			name: "codex input_tokens",
+			payload: func(literal string) []byte {
+				return []byte(fmt.Sprintf(`{"response":{"usage":{"input_tokens":%s,"input_tokens_details":{"cached_tokens":0,"cache_write_tokens":0}}}}`, literal))
+			},
+			parse: parseCodex,
+		},
+		{
+			name: "codex cached_tokens",
+			payload: func(literal string) []byte {
+				return []byte(fmt.Sprintf(`{"response":{"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":%s,"cache_write_tokens":0}}}}`, literal))
+			},
+			parse: parseCodex,
+		},
+		{
+			name: "codex cache_write_tokens",
+			payload: func(literal string) []byte {
+				return []byte(fmt.Sprintf(`{"response":{"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":0,"cache_write_tokens":%s}}}}`, literal))
+			},
+			parse: parseCodex,
+		},
+		{
+			name: "claude input_tokens",
+			payload: func(literal string) []byte {
+				return []byte(fmt.Sprintf(`{"usage":{"input_tokens":%s,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}`, literal))
+			},
+			parse: ParseClaudeUsage,
+		},
+		{
+			name: "claude cache_read_input_tokens",
+			payload: func(literal string) []byte {
+				return []byte(fmt.Sprintf(`{"usage":{"input_tokens":10,"cache_read_input_tokens":%s,"cache_creation_input_tokens":0}}`, literal))
+			},
+			parse: ParseClaudeUsage,
+		},
+		{
+			name: "claude cache_creation_input_tokens",
+			payload: func(literal string) []byte {
+				return []byte(fmt.Sprintf(`{"usage":{"input_tokens":10,"cache_read_input_tokens":0,"cache_creation_input_tokens":%s}}`, literal))
+			},
+			parse: ParseClaudeUsage,
+		},
+		{
+			name: "gemini promptTokenCount",
+			payload: func(literal string) []byte {
+				return []byte(fmt.Sprintf(`{"usageMetadata":{"promptTokenCount":%s,"cachedContentTokenCount":0}}`, literal))
+			},
+			parse: ParseGeminiUsage,
+		},
+		{
+			name: "gemini cachedContentTokenCount",
+			payload: func(literal string) []byte {
+				return []byte(fmt.Sprintf(`{"usageMetadata":{"promptTokenCount":10,"cachedContentTokenCount":%s}}`, literal))
+			},
+			parse: ParseGeminiUsage,
+		},
+		{
+			name: "interactions input_tokens",
+			payload: func(literal string) []byte {
+				return []byte(fmt.Sprintf(`{"usage":{"input_tokens":%s,"cached_tokens":0,"cache_read_tokens":0,"cache_write_tokens":0}}`, literal))
+			},
+			parse: ParseInteractionsUsage,
+		},
+		{
+			name: "interactions cached_tokens",
+			payload: func(literal string) []byte {
+				return []byte(fmt.Sprintf(`{"usage":{"input_tokens":10,"cached_tokens":%s,"cache_write_tokens":0}}`, literal))
+			},
+			parse: ParseInteractionsUsage,
+		},
+		{
+			name: "interactions cache_read_tokens",
+			payload: func(literal string) []byte {
+				return []byte(fmt.Sprintf(`{"usage":{"input_tokens":10,"cached_tokens":0,"cache_read_tokens":%s,"cache_write_tokens":0}}`, literal))
+			},
+			parse: ParseInteractionsUsage,
+		},
+		{
+			name: "interactions cache_write_tokens",
+			payload: func(literal string) []byte {
+				return []byte(fmt.Sprintf(`{"usage":{"input_tokens":10,"cached_tokens":0,"cache_write_tokens":%s}}`, literal))
+			},
+			parse: ParseInteractionsUsage,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, invalid := range invalidLiterals {
+				t.Run(invalid.name, func(t *testing.T) {
+					requireUnknownUncachedInputTokens(t, tc.parse(tc.payload(invalid.literal)))
+				})
+			}
+		})
 	}
 }
 

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -11,6 +11,23 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 )
 
+func requireKnownUncachedInputTokens(t *testing.T, detail usage.Detail, want int64) {
+	t.Helper()
+	if !detail.UncachedInputTokensKnown {
+		t.Fatalf("uncached input tokens known = false, want true; detail=%+v", detail)
+	}
+	if detail.UncachedInputTokens != want {
+		t.Fatalf("uncached input tokens = %d, want %d", detail.UncachedInputTokens, want)
+	}
+}
+
+func requireUnknownUncachedInputTokens(t *testing.T, detail usage.Detail) {
+	t.Helper()
+	if detail.UncachedInputTokensKnown {
+		t.Fatalf("uncached input tokens = %d known=true, want unknown; detail=%+v", detail.UncachedInputTokens, detail)
+	}
+}
+
 func TestParseOpenAIUsageChatCompletions(t *testing.T) {
 	data := []byte(`{"usage":{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12,"prompt_tokens_details":{"cached_tokens":4,"cache_write_tokens":6},"completion_tokens_details":{"reasoning_tokens":5}}}`)
 	detail := ParseOpenAIUsage(data)
@@ -35,6 +52,7 @@ func TestParseOpenAIUsageChatCompletions(t *testing.T) {
 	if detail.ReasoningTokens != 5 {
 		t.Fatalf("reasoning tokens = %d, want %d", detail.ReasoningTokens, 5)
 	}
+	requireKnownUncachedInputTokens(t, detail, 0)
 }
 
 func TestParseOpenAIUsageResponses(t *testing.T) {
@@ -61,6 +79,7 @@ func TestParseOpenAIUsageResponses(t *testing.T) {
 	if detail.ResponseServiceTier != "default" {
 		t.Fatalf("response service tier = %q, want default", detail.ResponseServiceTier)
 	}
+	requireKnownUncachedInputTokens(t, detail, 3)
 }
 
 func TestParseCodexUsageIncludesCacheWriteTokens(t *testing.T) {
@@ -90,6 +109,7 @@ func TestParseCodexUsageIncludesCacheWriteTokens(t *testing.T) {
 	if detail.ResponseServiceTier != "priority" {
 		t.Fatalf("response service tier = %q, want priority", detail.ResponseServiceTier)
 	}
+	requireKnownUncachedInputTokens(t, detail, 30)
 }
 
 func TestParseOpenAIUsageNormalizesCacheCreationAlias(t *testing.T) {
@@ -98,6 +118,15 @@ func TestParseOpenAIUsageNormalizesCacheCreationAlias(t *testing.T) {
 	if detail.CacheCreationTokens != 4 {
 		t.Fatalf("cache creation tokens = %d, want 4", detail.CacheCreationTokens)
 	}
+	requireKnownUncachedInputTokens(t, detail, 6)
+}
+
+func TestParseOpenAIUsageKeepsInconsistentOrMissingInputBreakdownUnknown(t *testing.T) {
+	detail := ParseOpenAIUsage([]byte(`{"usage":{"input_tokens":5,"input_tokens_details":{"cached_tokens":4,"cache_write_tokens":6}}}`))
+	requireUnknownUncachedInputTokens(t, detail)
+
+	detail = ParseOpenAIUsage([]byte(`{"usage":{"input_tokens_details":{"cached_tokens":4}}}`))
+	requireUnknownUncachedInputTokens(t, detail)
 }
 
 func TestParseOpenAIUsageIgnoresNullUsage(t *testing.T) {
@@ -160,6 +189,7 @@ func TestParseOpenAIStreamUsageResponsesFields(t *testing.T) {
 	if detail.ResponseServiceTier != "flex" {
 		t.Fatalf("response service tier = %q, want flex", detail.ResponseServiceTier)
 	}
+	requireKnownUncachedInputTokens(t, detail, 5)
 }
 
 func TestStreamUsageBufferKeepsLastUsage(t *testing.T) {
@@ -286,6 +316,7 @@ func TestParseClaudeUsageIncludesCacheTokensInTotal(t *testing.T) {
 	if detail.TotalTokens != 22859 {
 		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 22859)
 	}
+	requireKnownUncachedInputTokens(t, detail, 3085)
 }
 
 func TestParseClaudeUsageKeepsCacheCreationSeparateFromCachedTokens(t *testing.T) {
@@ -300,6 +331,7 @@ func TestParseClaudeUsageKeepsCacheCreationSeparateFromCachedTokens(t *testing.T
 	if detail.TotalTokens != 22852 {
 		t.Fatalf("total tokens = %d, want %d", detail.TotalTokens, 22852)
 	}
+	requireKnownUncachedInputTokens(t, detail, 3085)
 }
 
 func TestParseGeminiUsageNormalizesCachedContent(t *testing.T) {
@@ -310,6 +342,17 @@ func TestParseGeminiUsageNormalizesCachedContent(t *testing.T) {
 	if detail.CacheReadTokens != 4 {
 		t.Fatalf("cache read tokens = %d, want 4", detail.CacheReadTokens)
 	}
+	requireKnownUncachedInputTokens(t, detail, 6)
+}
+
+func TestParseGeminiUsageKeepsCacheGreaterThanInputUnknown(t *testing.T) {
+	detail := ParseGeminiUsage([]byte(`{"usageMetadata":{"promptTokenCount":5,"cachedContentTokenCount":6,"totalTokenCount":5}}`))
+	requireUnknownUncachedInputTokens(t, detail)
+}
+
+func TestParseAntigravityUsageComputesUncachedInputTokens(t *testing.T) {
+	detail := ParseAntigravityUsage([]byte(`{"response":{"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":2,"cachedContentTokenCount":4,"totalTokenCount":12}}}`))
+	requireKnownUncachedInputTokens(t, detail, 6)
 }
 
 func TestParseInteractionsUsage(t *testing.T) {
@@ -332,6 +375,7 @@ func TestParseInteractionsUsage(t *testing.T) {
 	if detail.CacheReadTokens != 2 {
 		t.Fatalf("cache read tokens = %d, want 2", detail.CacheReadTokens)
 	}
+	requireKnownUncachedInputTokens(t, detail, 1)
 }
 
 func TestParseInteractionsUsageNormalizesCacheWriteAlias(t *testing.T) {
@@ -339,6 +383,20 @@ func TestParseInteractionsUsageNormalizesCacheWriteAlias(t *testing.T) {
 	if detail.CacheCreationTokens != 2 {
 		t.Fatalf("cache creation tokens = %d, want 2", detail.CacheCreationTokens)
 	}
+	requireKnownUncachedInputTokens(t, detail, 3)
+}
+
+func TestParseInteractionsUsageKeepsExplicitCacheReadSeparateFromInput(t *testing.T) {
+	detail := ParseInteractionsUsage([]byte(`{"usage":{"input_tokens":3,"cache_read_tokens":2}}`))
+	if detail.CacheReadTokens != 2 {
+		t.Fatalf("cache read tokens = %d, want 2", detail.CacheReadTokens)
+	}
+	requireKnownUncachedInputTokens(t, detail, 3)
+}
+
+func TestParseInteractionsUsageKeepsIncludedCacheGreaterThanInputUnknown(t *testing.T) {
+	detail := ParseInteractionsUsage([]byte(`{"usage":{"input_tokens":3,"cached_tokens":4}}`))
+	requireUnknownUncachedInputTokens(t, detail)
 }
 
 func TestParseInteractionsStreamUsage(t *testing.T) {
@@ -349,6 +407,7 @@ func TestParseInteractionsStreamUsage(t *testing.T) {
 	if detail.TotalTokens != 8 {
 		t.Fatalf("total tokens = %d, want 8", detail.TotalTokens)
 	}
+	requireKnownUncachedInputTokens(t, detail, 2)
 }
 
 func TestParseInteractionsStreamUsageOfficialMetadata(t *testing.T) {
@@ -374,6 +433,7 @@ func TestParseInteractionsStreamUsageOfficialMetadata(t *testing.T) {
 	if detail.TotalTokens != 11 {
 		t.Fatalf("total tokens = %d, want 11", detail.TotalTokens)
 	}
+	requireKnownUncachedInputTokens(t, detail, 1)
 }
 
 func TestUsageReporterBuildRecordIncludesLatency(t *testing.T) {

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -106,13 +106,14 @@ type RequestDetail struct {
 
 // TokenStats captures the token usage breakdown for a request.
 type TokenStats struct {
-	InputTokens         int64 `json:"input_tokens"`
-	OutputTokens        int64 `json:"output_tokens"`
-	ReasoningTokens     int64 `json:"reasoning_tokens"`
-	CachedTokens        int64 `json:"cached_tokens"`
-	CacheReadTokens     int64 `json:"cache_read_tokens,omitempty"`
-	CacheCreationTokens int64 `json:"cache_creation_tokens,omitempty"`
-	TotalTokens         int64 `json:"total_tokens"`
+	InputTokens         int64  `json:"input_tokens"`
+	UncachedInputTokens *int64 `json:"uncached_input_tokens,omitempty"`
+	OutputTokens        int64  `json:"output_tokens"`
+	ReasoningTokens     int64  `json:"reasoning_tokens"`
+	CachedTokens        int64  `json:"cached_tokens"`
+	CacheReadTokens     int64  `json:"cache_read_tokens,omitempty"`
+	CacheCreationTokens int64  `json:"cache_creation_tokens,omitempty"`
+	TotalTokens         int64  `json:"total_tokens"`
 }
 
 // StatisticsSnapshot represents an immutable view of the aggregated metrics.
@@ -274,7 +275,9 @@ func (s *RequestStatistics) Snapshot() StatisticsSnapshot {
 		}
 		for modelName, modelStatsValue := range stats.Models {
 			requestDetails := make([]RequestDetail, len(modelStatsValue.Details))
-			copy(requestDetails, modelStatsValue.Details)
+			for i := range modelStatsValue.Details {
+				requestDetails[i] = cloneRequestDetail(modelStatsValue.Details[i])
+			}
 			apiSnapshot.Models[modelName] = ModelSnapshot{
 				TotalRequests: modelStatsValue.TotalRequests,
 				TotalTokens:   modelStatsValue.TotalTokens,
@@ -535,6 +538,10 @@ func normaliseDetail(detail coreusage.Detail) TokenStats {
 		CacheCreationTokens: detail.CacheCreationTokens,
 		TotalTokens:         detail.TotalTokens,
 	}
+	if detail.UncachedInputTokensKnown && validUncachedInputTokens(detail.UncachedInputTokens, detail.InputTokens) {
+		uncachedInputTokens := detail.UncachedInputTokens
+		tokens.UncachedInputTokens = &uncachedInputTokens
+	}
 	if tokens.TotalTokens == 0 {
 		tokens.TotalTokens = detail.InputTokens + detail.OutputTokens + detail.ReasoningTokens + detail.CacheReadTokens + detail.CacheCreationTokens
 	}
@@ -547,6 +554,14 @@ func normaliseDetail(detail coreusage.Detail) TokenStats {
 }
 
 func normaliseTokenStats(tokens TokenStats) TokenStats {
+	if tokens.UncachedInputTokens != nil {
+		uncachedInputTokens := *tokens.UncachedInputTokens
+		if validUncachedInputTokens(uncachedInputTokens, tokens.InputTokens) {
+			tokens.UncachedInputTokens = &uncachedInputTokens
+		} else {
+			tokens.UncachedInputTokens = nil
+		}
+	}
 	if tokens.TotalTokens == 0 {
 		tokens.TotalTokens = tokens.InputTokens + tokens.OutputTokens + tokens.ReasoningTokens + tokens.CacheReadTokens + tokens.CacheCreationTokens
 	}
@@ -554,6 +569,23 @@ func normaliseTokenStats(tokens TokenStats) TokenStats {
 		if tokens.CacheReadTokens != 0 {
 			tokens.CachedTokens = tokens.CacheReadTokens
 		}
+	}
+	return tokens
+}
+
+func validUncachedInputTokens(uncachedInputTokens, inputTokens int64) bool {
+	return inputTokens >= 0 && uncachedInputTokens >= 0 && uncachedInputTokens <= inputTokens
+}
+
+func cloneRequestDetail(detail RequestDetail) RequestDetail {
+	detail.Tokens = cloneTokenStats(detail.Tokens)
+	return detail
+}
+
+func cloneTokenStats(tokens TokenStats) TokenStats {
+	if tokens.UncachedInputTokens != nil {
+		uncachedInputTokens := *tokens.UncachedInputTokens
+		tokens.UncachedInputTokens = &uncachedInputTokens
 	}
 	return tokens
 }

--- a/internal/usage/logger_plugin_test.go
+++ b/internal/usage/logger_plugin_test.go
@@ -44,11 +44,13 @@ func TestRequestStatisticsRecordIncludesUsageMetadata(t *testing.T) {
 		ResponseServiceTier: " standard ",
 		RequestedAt:         time.Date(2026, 3, 20, 12, 0, 0, 0, time.UTC),
 		Detail: coreusage.Detail{
-			InputTokens:         10,
-			OutputTokens:        20,
-			CacheReadTokens:     7,
-			CacheCreationTokens: 3,
-			TotalTokens:         30,
+			InputTokens:              10,
+			OutputTokens:             20,
+			CacheReadTokens:          7,
+			CacheCreationTokens:      3,
+			TotalTokens:              30,
+			UncachedInputTokens:      0,
+			UncachedInputTokensKnown: true,
 		},
 	})
 
@@ -81,6 +83,67 @@ func TestRequestStatisticsRecordIncludesUsageMetadata(t *testing.T) {
 	}
 	if detail.Tokens.CachedTokens != 7 {
 		t.Fatalf("cached_tokens = %d, want 7", detail.Tokens.CachedTokens)
+	}
+	if detail.Tokens.UncachedInputTokens == nil || *detail.Tokens.UncachedInputTokens != 0 {
+		t.Fatalf("uncached_input_tokens = %v, want pointer to 0", detail.Tokens.UncachedInputTokens)
+	}
+}
+
+func TestRequestStatisticsSnapshotDoesNotExposeMutableUncachedInputPointer(t *testing.T) {
+	stats := NewRequestStatistics()
+	stats.Record(context.Background(), coreusage.Record{
+		APIKey: "test-key",
+		Model:  "gpt-5.4",
+		Detail: coreusage.Detail{
+			InputTokens:              10,
+			TotalTokens:              10,
+			UncachedInputTokens:      0,
+			UncachedInputTokensKnown: true,
+		},
+	})
+
+	first := stats.Snapshot().APIs["test-key"].Models["gpt-5.4"].Details[0]
+	if first.Tokens.UncachedInputTokens == nil {
+		t.Fatal("first snapshot missing uncached_input_tokens")
+	}
+	*first.Tokens.UncachedInputTokens = 99
+
+	second := stats.Snapshot().APIs["test-key"].Models["gpt-5.4"].Details[0]
+	if second.Tokens.UncachedInputTokens == nil || *second.Tokens.UncachedInputTokens != 0 {
+		t.Fatalf("second snapshot uncached_input_tokens = %v, want pointer to 0", second.Tokens.UncachedInputTokens)
+	}
+}
+
+func TestRequestStatisticsRecordOmitsInvalidUncachedInputTokens(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       int64
+		wantPresent bool
+	}{
+		{name: "negative", value: -1},
+		{name: "greater than input", value: 11},
+		{name: "known zero", value: 0, wantPresent: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stats := NewRequestStatistics()
+			stats.Record(context.Background(), coreusage.Record{
+				APIKey: "test-key",
+				Model:  "gpt-5.4",
+				Detail: coreusage.Detail{
+					InputTokens:              10,
+					TotalTokens:              10,
+					UncachedInputTokens:      tt.value,
+					UncachedInputTokensKnown: true,
+				},
+			})
+
+			detail := stats.Snapshot().APIs["test-key"].Models["gpt-5.4"].Details[0]
+			if gotPresent := detail.Tokens.UncachedInputTokens != nil; gotPresent != tt.wantPresent {
+				t.Fatalf("uncached_input_tokens present = %v, want %v; tokens=%+v", gotPresent, tt.wantPresent, detail.Tokens)
+			}
+		})
 	}
 }
 
@@ -398,6 +461,7 @@ func TestRequestStatisticsMergeSnapshotNormalisesServiceTierAliases(t *testing.T
 
 func TestRequestStatisticsMergeSnapshotDeduplicatesLegacyAndCanonicalCacheCreation(t *testing.T) {
 	timestamp := time.Date(2026, 7, 11, 9, 30, 0, 0, time.UTC)
+	uncachedInputTokens := int64(176)
 	legacy := cacheCreationSnapshot(timestamp, TokenStats{
 		InputTokens:         1200,
 		OutputTokens:        10,
@@ -407,6 +471,7 @@ func TestRequestStatisticsMergeSnapshotDeduplicatesLegacyAndCanonicalCacheCreati
 	})
 	canonical := cacheCreationSnapshot(timestamp, TokenStats{
 		InputTokens:         1200,
+		UncachedInputTokens: &uncachedInputTokens,
 		OutputTokens:        10,
 		CacheCreationTokens: 1024,
 		TotalTokens:         2234,

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -148,6 +148,9 @@ require_grep "responsesWebsocketCanAttestContextReset" sdk/api/handlers/openai/o
 require_grep "ModelFallbackZeroDispatch" sdk/cliproxy/auth/codex_model_fallback.go docs/lts/core-feature-contracts.yaml
 require_grep "auth_index" internal/usage internal/api/handlers/management internal/runtime/executor/helps internal/redisqueue
 require_grep "latency_ms" internal/usage internal/redisqueue internal/tui
+require_grep 'json:"uncached_input_tokens,omitempty"' internal/usage internal/redisqueue
+require_grep "UncachedInputTokensKnown" sdk/cliproxy/usage internal/runtime/executor/helps internal/usage internal/redisqueue sdk/pluginapi internal/pluginhost
+require_grep "uncached_input_tokens" internal/api/handlers/management/usage_contract_test.go
 require_grep 'json:"reasoning_effort,omitempty"' internal/usage
 require_grep 'json:"service_tier,omitempty"' internal/usage
 require_grep 'json:"request_service_tier,omitempty"' internal/usage

--- a/sdk/cliproxy/auth/retry_without_penalty.go
+++ b/sdk/cliproxy/auth/retry_without_penalty.go
@@ -209,13 +209,15 @@ func subtractRetryWithoutPenaltyUsageDetail(total, selected coreusage.Detail) co
 	total = normalizeRetryWithoutPenaltyUsageDetail(total)
 	selected = normalizeRetryWithoutPenaltyUsageDetail(selected)
 	return coreusage.Detail{
-		InputTokens:         subtractRetryWithoutPenaltyInt64(total.InputTokens, selected.InputTokens),
-		OutputTokens:        subtractRetryWithoutPenaltyInt64(total.OutputTokens, selected.OutputTokens),
-		ReasoningTokens:     subtractRetryWithoutPenaltyInt64(total.ReasoningTokens, selected.ReasoningTokens),
-		CachedTokens:        subtractRetryWithoutPenaltyInt64(total.CachedTokens, selected.CachedTokens),
-		CacheReadTokens:     subtractRetryWithoutPenaltyInt64(total.CacheReadTokens, selected.CacheReadTokens),
-		CacheCreationTokens: subtractRetryWithoutPenaltyInt64(total.CacheCreationTokens, selected.CacheCreationTokens),
-		TotalTokens:         subtractRetryWithoutPenaltyInt64(total.TotalTokens, selected.TotalTokens),
+		InputTokens:              subtractRetryWithoutPenaltyInt64(total.InputTokens, selected.InputTokens),
+		OutputTokens:             subtractRetryWithoutPenaltyInt64(total.OutputTokens, selected.OutputTokens),
+		ReasoningTokens:          subtractRetryWithoutPenaltyInt64(total.ReasoningTokens, selected.ReasoningTokens),
+		CachedTokens:             subtractRetryWithoutPenaltyInt64(total.CachedTokens, selected.CachedTokens),
+		CacheReadTokens:          subtractRetryWithoutPenaltyInt64(total.CacheReadTokens, selected.CacheReadTokens),
+		CacheCreationTokens:      subtractRetryWithoutPenaltyInt64(total.CacheCreationTokens, selected.CacheCreationTokens),
+		UncachedInputTokens:      subtractRetryWithoutPenaltyInt64(total.UncachedInputTokens, selected.UncachedInputTokens),
+		UncachedInputTokensKnown: total.UncachedInputTokensKnown && selected.UncachedInputTokensKnown,
+		TotalTokens:              subtractRetryWithoutPenaltyInt64(total.TotalTokens, selected.TotalTokens),
 	}
 }
 
@@ -657,16 +659,31 @@ func cloneRetryWithoutPenaltyHeader(headers http.Header) http.Header {
 }
 
 func addRetryWithoutPenaltyUsageDetail(a, b coreusage.Detail) coreusage.Detail {
+	aHasUsage := hasRetryWithoutPenaltyUsageDetail(a)
+	bHasUsage := hasRetryWithoutPenaltyUsageDetail(b)
 	a = normalizeRetryWithoutPenaltyUsageDetail(a)
 	b = normalizeRetryWithoutPenaltyUsageDetail(b)
 	return coreusage.Detail{
-		InputTokens:         a.InputTokens + b.InputTokens,
-		OutputTokens:        a.OutputTokens + b.OutputTokens,
-		ReasoningTokens:     a.ReasoningTokens + b.ReasoningTokens,
-		CachedTokens:        a.CachedTokens + b.CachedTokens,
-		CacheReadTokens:     a.CacheReadTokens + b.CacheReadTokens,
-		CacheCreationTokens: a.CacheCreationTokens + b.CacheCreationTokens,
-		TotalTokens:         a.TotalTokens + b.TotalTokens,
+		InputTokens:              a.InputTokens + b.InputTokens,
+		OutputTokens:             a.OutputTokens + b.OutputTokens,
+		ReasoningTokens:          a.ReasoningTokens + b.ReasoningTokens,
+		CachedTokens:             a.CachedTokens + b.CachedTokens,
+		CacheReadTokens:          a.CacheReadTokens + b.CacheReadTokens,
+		CacheCreationTokens:      a.CacheCreationTokens + b.CacheCreationTokens,
+		UncachedInputTokens:      a.UncachedInputTokens + b.UncachedInputTokens,
+		UncachedInputTokensKnown: mergedRetryWithoutPenaltyUncachedInputTokensKnown(a, b, aHasUsage, bHasUsage),
+		TotalTokens:              a.TotalTokens + b.TotalTokens,
+	}
+}
+
+func mergedRetryWithoutPenaltyUncachedInputTokensKnown(a, b coreusage.Detail, aHasUsage, bHasUsage bool) bool {
+	switch {
+	case !aHasUsage:
+		return b.UncachedInputTokensKnown
+	case !bHasUsage:
+		return a.UncachedInputTokensKnown
+	default:
+		return a.UncachedInputTokensKnown && b.UncachedInputTokensKnown
 	}
 }
 

--- a/sdk/cliproxy/auth/retry_without_penalty.go
+++ b/sdk/cliproxy/auth/retry_without_penalty.go
@@ -208,7 +208,7 @@ func (c *retryWithoutPenaltyFallbackCandidate) PreviousUsageSnapshot(accumulator
 func subtractRetryWithoutPenaltyUsageDetail(total, selected coreusage.Detail) coreusage.Detail {
 	total = normalizeRetryWithoutPenaltyUsageDetail(total)
 	selected = normalizeRetryWithoutPenaltyUsageDetail(selected)
-	return coreusage.Detail{
+	return coreusage.NormalizeUncachedInputTokens(coreusage.Detail{
 		InputTokens:              subtractRetryWithoutPenaltyInt64(total.InputTokens, selected.InputTokens),
 		OutputTokens:             subtractRetryWithoutPenaltyInt64(total.OutputTokens, selected.OutputTokens),
 		ReasoningTokens:          subtractRetryWithoutPenaltyInt64(total.ReasoningTokens, selected.ReasoningTokens),
@@ -218,7 +218,7 @@ func subtractRetryWithoutPenaltyUsageDetail(total, selected coreusage.Detail) co
 		UncachedInputTokens:      subtractRetryWithoutPenaltyInt64(total.UncachedInputTokens, selected.UncachedInputTokens),
 		UncachedInputTokensKnown: total.UncachedInputTokensKnown && selected.UncachedInputTokensKnown,
 		TotalTokens:              subtractRetryWithoutPenaltyInt64(total.TotalTokens, selected.TotalTokens),
-	}
+	})
 }
 
 func subtractRetryWithoutPenaltyInt64(total, selected int64) int64 {
@@ -659,11 +659,11 @@ func cloneRetryWithoutPenaltyHeader(headers http.Header) http.Header {
 }
 
 func addRetryWithoutPenaltyUsageDetail(a, b coreusage.Detail) coreusage.Detail {
-	aHasUsage := hasRetryWithoutPenaltyUsageDetail(a)
-	bHasUsage := hasRetryWithoutPenaltyUsageDetail(b)
 	a = normalizeRetryWithoutPenaltyUsageDetail(a)
 	b = normalizeRetryWithoutPenaltyUsageDetail(b)
-	return coreusage.Detail{
+	aHasUsage := hasRetryWithoutPenaltyUsageDetail(a)
+	bHasUsage := hasRetryWithoutPenaltyUsageDetail(b)
+	return coreusage.NormalizeUncachedInputTokens(coreusage.Detail{
 		InputTokens:              a.InputTokens + b.InputTokens,
 		OutputTokens:             a.OutputTokens + b.OutputTokens,
 		ReasoningTokens:          a.ReasoningTokens + b.ReasoningTokens,
@@ -673,7 +673,7 @@ func addRetryWithoutPenaltyUsageDetail(a, b coreusage.Detail) coreusage.Detail {
 		UncachedInputTokens:      a.UncachedInputTokens + b.UncachedInputTokens,
 		UncachedInputTokensKnown: mergedRetryWithoutPenaltyUncachedInputTokensKnown(a, b, aHasUsage, bHasUsage),
 		TotalTokens:              a.TotalTokens + b.TotalTokens,
-	}
+	})
 }
 
 func mergedRetryWithoutPenaltyUncachedInputTokensKnown(a, b coreusage.Detail, aHasUsage, bHasUsage bool) bool {
@@ -688,6 +688,7 @@ func mergedRetryWithoutPenaltyUncachedInputTokensKnown(a, b coreusage.Detail, aH
 }
 
 func normalizeRetryWithoutPenaltyUsageDetail(detail coreusage.Detail) coreusage.Detail {
+	detail = coreusage.NormalizeUncachedInputTokens(detail)
 	if detail.TotalTokens == 0 {
 		total := detail.InputTokens + detail.OutputTokens + detail.ReasoningTokens
 		if total > 0 {

--- a/sdk/cliproxy/auth/retry_without_penalty_test.go
+++ b/sdk/cliproxy/auth/retry_without_penalty_test.go
@@ -11,9 +11,40 @@ import (
 	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 )
 
 type retryWithoutPenaltyTestError struct{}
+
+func TestRetryWithoutPenaltyUsageMathPreservesUncachedInputKnowledge(t *testing.T) {
+	first := coreusage.Detail{
+		InputTokens:              10,
+		TotalTokens:              10,
+		UncachedInputTokens:      0,
+		UncachedInputTokensKnown: true,
+	}
+	second := coreusage.Detail{
+		InputTokens:              5,
+		TotalTokens:              5,
+		UncachedInputTokens:      5,
+		UncachedInputTokensKnown: true,
+	}
+
+	total := addRetryWithoutPenaltyUsageDetail(first, second)
+	if !total.UncachedInputTokensKnown || total.UncachedInputTokens != 5 {
+		t.Fatalf("added detail = %+v, want known uncached input 5", total)
+	}
+
+	remainder := subtractRetryWithoutPenaltyUsageDetail(total, second)
+	if !remainder.UncachedInputTokensKnown || remainder.UncachedInputTokens != 0 {
+		t.Fatalf("subtracted detail = %+v, want known uncached input 0", remainder)
+	}
+
+	mixed := addRetryWithoutPenaltyUsageDetail(first, coreusage.Detail{InputTokens: 1, TotalTokens: 1})
+	if mixed.UncachedInputTokensKnown {
+		t.Fatalf("mixed detail = %+v, want uncached input unknown", mixed)
+	}
+}
 
 func (retryWithoutPenaltyTestError) Error() string {
 	return "retry without penalty"

--- a/sdk/cliproxy/auth/retry_without_penalty_test.go
+++ b/sdk/cliproxy/auth/retry_without_penalty_test.go
@@ -46,6 +46,36 @@ func TestRetryWithoutPenaltyUsageMathPreservesUncachedInputKnowledge(t *testing.
 	}
 }
 
+func TestRetryWithoutPenaltyUsageMathRejectsInvalidKnownUncachedInputContribution(t *testing.T) {
+	invalid := coreusage.Detail{
+		InputTokens:              10,
+		TotalTokens:              10,
+		UncachedInputTokens:      11,
+		UncachedInputTokensKnown: true,
+	}
+	valid := coreusage.Detail{
+		InputTokens:              10,
+		TotalTokens:              10,
+		UncachedInputTokens:      9,
+		UncachedInputTokensKnown: true,
+	}
+
+	total := addRetryWithoutPenaltyUsageDetail(invalid, valid)
+	if total.UncachedInputTokensKnown || total.UncachedInputTokens != 0 {
+		t.Fatalf("added detail = %+v, want cleared unknown uncached input", total)
+	}
+
+	remainder := subtractRetryWithoutPenaltyUsageDetail(coreusage.Detail{
+		InputTokens:              20,
+		TotalTokens:              20,
+		UncachedInputTokens:      20,
+		UncachedInputTokensKnown: true,
+	}, invalid)
+	if remainder.UncachedInputTokensKnown || remainder.UncachedInputTokens != 0 {
+		t.Fatalf("subtracted detail = %+v, want cleared unknown uncached input", remainder)
+	}
+}
+
 func (retryWithoutPenaltyTestError) Error() string {
 	return "retry without penalty"
 }

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -159,16 +159,31 @@ func (a *UsageAccumulator) RetryWithoutPenaltySnapshot() RetryWithoutPenaltyUsag
 }
 
 func addUsageAccumulatorDetail(a, b coreusage.Detail) coreusage.Detail {
+	aHasUsage := hasUsageAccumulatorDetail(a)
+	bHasUsage := hasUsageAccumulatorDetail(b)
 	a = normalizeUsageAccumulatorDetail(a)
 	b = normalizeUsageAccumulatorDetail(b)
 	return coreusage.Detail{
-		InputTokens:         a.InputTokens + b.InputTokens,
-		OutputTokens:        a.OutputTokens + b.OutputTokens,
-		ReasoningTokens:     a.ReasoningTokens + b.ReasoningTokens,
-		CachedTokens:        a.CachedTokens + b.CachedTokens,
-		CacheReadTokens:     a.CacheReadTokens + b.CacheReadTokens,
-		CacheCreationTokens: a.CacheCreationTokens + b.CacheCreationTokens,
-		TotalTokens:         a.TotalTokens + b.TotalTokens,
+		InputTokens:              a.InputTokens + b.InputTokens,
+		OutputTokens:             a.OutputTokens + b.OutputTokens,
+		ReasoningTokens:          a.ReasoningTokens + b.ReasoningTokens,
+		CachedTokens:             a.CachedTokens + b.CachedTokens,
+		CacheReadTokens:          a.CacheReadTokens + b.CacheReadTokens,
+		CacheCreationTokens:      a.CacheCreationTokens + b.CacheCreationTokens,
+		UncachedInputTokens:      a.UncachedInputTokens + b.UncachedInputTokens,
+		UncachedInputTokensKnown: mergedUncachedInputTokensKnown(a, b, aHasUsage, bHasUsage),
+		TotalTokens:              a.TotalTokens + b.TotalTokens,
+	}
+}
+
+func mergedUncachedInputTokensKnown(a, b coreusage.Detail, aHasUsage, bHasUsage bool) bool {
+	switch {
+	case !aHasUsage:
+		return b.UncachedInputTokensKnown
+	case !bHasUsage:
+		return a.UncachedInputTokensKnown
+	default:
+		return a.UncachedInputTokensKnown && b.UncachedInputTokensKnown
 	}
 }
 

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -123,10 +123,13 @@ func NewUsageAccumulator(initial coreusage.Detail) *UsageAccumulator {
 
 // Add merges detail into the accumulator.
 func (a *UsageAccumulator) Add(detail coreusage.Detail) {
-	if a == nil || !hasUsageAccumulatorDetail(detail) {
+	if a == nil {
 		return
 	}
 	detail = normalizeUsageAccumulatorDetail(detail)
+	if !hasUsageAccumulatorDetail(detail) {
+		return
+	}
 	foldedOutputTokens := foldedUsageAccumulatorOutputTokens(detail)
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -159,11 +162,11 @@ func (a *UsageAccumulator) RetryWithoutPenaltySnapshot() RetryWithoutPenaltyUsag
 }
 
 func addUsageAccumulatorDetail(a, b coreusage.Detail) coreusage.Detail {
-	aHasUsage := hasUsageAccumulatorDetail(a)
-	bHasUsage := hasUsageAccumulatorDetail(b)
 	a = normalizeUsageAccumulatorDetail(a)
 	b = normalizeUsageAccumulatorDetail(b)
-	return coreusage.Detail{
+	aHasUsage := hasUsageAccumulatorDetail(a)
+	bHasUsage := hasUsageAccumulatorDetail(b)
+	return coreusage.NormalizeUncachedInputTokens(coreusage.Detail{
 		InputTokens:              a.InputTokens + b.InputTokens,
 		OutputTokens:             a.OutputTokens + b.OutputTokens,
 		ReasoningTokens:          a.ReasoningTokens + b.ReasoningTokens,
@@ -173,7 +176,7 @@ func addUsageAccumulatorDetail(a, b coreusage.Detail) coreusage.Detail {
 		UncachedInputTokens:      a.UncachedInputTokens + b.UncachedInputTokens,
 		UncachedInputTokensKnown: mergedUncachedInputTokensKnown(a, b, aHasUsage, bHasUsage),
 		TotalTokens:              a.TotalTokens + b.TotalTokens,
-	}
+	})
 }
 
 func mergedUncachedInputTokensKnown(a, b coreusage.Detail, aHasUsage, bHasUsage bool) bool {
@@ -195,6 +198,7 @@ func foldedUsageAccumulatorOutputTokens(detail coreusage.Detail) int64 {
 }
 
 func normalizeUsageAccumulatorDetail(detail coreusage.Detail) coreusage.Detail {
+	detail = coreusage.NormalizeUncachedInputTokens(detail)
 	if detail.TotalTokens == 0 {
 		total := detail.InputTokens + detail.OutputTokens + detail.ReasoningTokens
 		if total > 0 {

--- a/sdk/cliproxy/executor/types_test.go
+++ b/sdk/cliproxy/executor/types_test.go
@@ -52,3 +52,23 @@ func TestUsageAccumulatorOnlyKeepsKnownUncachedInputWhenAllContributionsAreKnown
 		t.Fatalf("mixed-known accumulator snapshot = %+v, want uncached input unknown", snapshot)
 	}
 }
+
+func TestUsageAccumulatorRejectsInvalidKnownUncachedInputContribution(t *testing.T) {
+	accumulator := NewUsageAccumulator(coreusage.Detail{
+		InputTokens:              10,
+		TotalTokens:              10,
+		UncachedInputTokens:      11,
+		UncachedInputTokensKnown: true,
+	})
+	accumulator.Add(coreusage.Detail{
+		InputTokens:              10,
+		TotalTokens:              10,
+		UncachedInputTokens:      9,
+		UncachedInputTokensKnown: true,
+	})
+
+	snapshot := accumulator.Snapshot()
+	if snapshot.UncachedInputTokensKnown || snapshot.UncachedInputTokens != 0 {
+		t.Fatalf("accumulator snapshot = %+v, want cleared unknown uncached input", snapshot)
+	}
+}

--- a/sdk/cliproxy/executor/types_test.go
+++ b/sdk/cliproxy/executor/types_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"testing"
 
+	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 )
 
@@ -22,5 +23,32 @@ func TestResponseFormatOrSourceFallsBackToSourceFormat(t *testing.T) {
 
 	if got := ResponseFormatOrSource(opts); got != sdktranslator.FormatGemini {
 		t.Fatalf("ResponseFormatOrSource() = %q, want %q", got, sdktranslator.FormatGemini)
+	}
+}
+
+func TestUsageAccumulatorOnlyKeepsKnownUncachedInputWhenAllContributionsAreKnown(t *testing.T) {
+	accumulator := NewUsageAccumulator(coreusage.Detail{
+		InputTokens:              10,
+		CacheReadTokens:          10,
+		TotalTokens:              10,
+		UncachedInputTokens:      0,
+		UncachedInputTokensKnown: true,
+	})
+	accumulator.Add(coreusage.Detail{
+		InputTokens:              5,
+		TotalTokens:              5,
+		UncachedInputTokens:      5,
+		UncachedInputTokensKnown: true,
+	})
+
+	snapshot := accumulator.Snapshot()
+	if !snapshot.UncachedInputTokensKnown || snapshot.UncachedInputTokens != 5 {
+		t.Fatalf("known accumulator snapshot = %+v, want known uncached input 5", snapshot)
+	}
+
+	accumulator.Add(coreusage.Detail{InputTokens: 1, TotalTokens: 1})
+	snapshot = accumulator.Snapshot()
+	if snapshot.UncachedInputTokensKnown {
+		t.Fatalf("mixed-known accumulator snapshot = %+v, want uncached input unknown", snapshot)
 	}
 }

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -51,14 +51,16 @@ type Failure struct {
 
 // Detail holds the token usage breakdown.
 type Detail struct {
-	InputTokens         int64
-	OutputTokens        int64
-	ReasoningTokens     int64
-	CachedTokens        int64
-	CacheReadTokens     int64
-	CacheCreationTokens int64
-	TotalTokens         int64
-	ResponseServiceTier string
+	InputTokens              int64
+	OutputTokens             int64
+	ReasoningTokens          int64
+	CachedTokens             int64
+	CacheReadTokens          int64
+	CacheCreationTokens      int64
+	UncachedInputTokens      int64
+	UncachedInputTokensKnown bool
+	TotalTokens              int64
+	ResponseServiceTier      string
 }
 
 type requestedModelAliasContextKey struct{}

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -63,6 +63,19 @@ type Detail struct {
 	ResponseServiceTier      string
 }
 
+// NormalizeUncachedInputTokens clears uncached input data that is unknown or
+// inconsistent with the contribution's input token count.
+func NormalizeUncachedInputTokens(detail Detail) Detail {
+	if !detail.UncachedInputTokensKnown ||
+		detail.InputTokens < 0 ||
+		detail.UncachedInputTokens < 0 ||
+		detail.UncachedInputTokens > detail.InputTokens {
+		detail.UncachedInputTokens = 0
+		detail.UncachedInputTokensKnown = false
+	}
+	return detail
+}
+
 type requestedModelAliasContextKey struct{}
 type reasoningEffortContextKey struct{}
 type serviceTierContextKey struct{}

--- a/sdk/cliproxy/usage/manager_test.go
+++ b/sdk/cliproxy/usage/manager_test.go
@@ -1,0 +1,78 @@
+package usage
+
+import "testing"
+
+func TestNormalizeUncachedInputTokens(t *testing.T) {
+	tests := []struct {
+		name  string
+		input Detail
+		want  Detail
+	}{
+		{
+			name: "valid known",
+			input: Detail{
+				InputTokens:              10,
+				UncachedInputTokens:      4,
+				UncachedInputTokensKnown: true,
+			},
+			want: Detail{
+				InputTokens:              10,
+				UncachedInputTokens:      4,
+				UncachedInputTokensKnown: true,
+			},
+		},
+		{
+			name: "valid known zero",
+			input: Detail{
+				InputTokens:              10,
+				UncachedInputTokensKnown: true,
+			},
+			want: Detail{
+				InputTokens:              10,
+				UncachedInputTokensKnown: true,
+			},
+		},
+		{
+			name: "unknown value cleared",
+			input: Detail{
+				InputTokens:         10,
+				UncachedInputTokens: 4,
+			},
+			want: Detail{InputTokens: 10},
+		},
+		{
+			name: "known greater than input cleared",
+			input: Detail{
+				InputTokens:              10,
+				UncachedInputTokens:      11,
+				UncachedInputTokensKnown: true,
+			},
+			want: Detail{InputTokens: 10},
+		},
+		{
+			name: "known negative cleared",
+			input: Detail{
+				InputTokens:              10,
+				UncachedInputTokens:      -1,
+				UncachedInputTokensKnown: true,
+			},
+			want: Detail{InputTokens: 10},
+		},
+		{
+			name: "negative input cleared",
+			input: Detail{
+				InputTokens:              -1,
+				UncachedInputTokensKnown: true,
+			},
+			want: Detail{InputTokens: -1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeUncachedInputTokens(tt.input); got != tt.want {
+				t.Fatalf("NormalizeUncachedInputTokens() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -1329,6 +1329,10 @@ type UsageFailure struct {
 type UsageDetail struct {
 	// InputTokens is the prompt or input token count.
 	InputTokens int64
+	// UncachedInputTokens is the input token count billed at the regular prompt/input rate.
+	UncachedInputTokens int64
+	// UncachedInputTokensKnown reports whether UncachedInputTokens is authoritative, including when it is zero.
+	UncachedInputTokensKnown bool
 	// OutputTokens is the completion or output token count.
 	OutputTokens int64
 	// ReasoningTokens is the reasoning token count.


### PR DESCRIPTION
## 结论与依赖

本 PR 为完整 usage statistics 增加 optional `uncached_input_tokens` 契约，并在 provider parser、聚合、持久化和公开插件边界严格区分 unknown、known-zero 与有效正值。它解决 Panel 无法仅凭模型名称可靠判断普通输入、cache read 和 cache write 是否互为子集的问题。

- JSON 字段为 additive optional；旧 consumer 可继续忽略。
- 配套 Panel follow-up 将优先使用该字段，字段缺失时继续使用 legacy fallback。
- 本 PR 不包含历史数据回填、release、tag 或部署。

## Type

- [ ] Protected upstream full-sync
- [ ] Staged upstream full-sync
- [ ] LTS protected-delta patch
- [x] LTS feature / downstream patch maintenance
- [ ] Maintenance docs / CI
- [ ] Emergency hotfix

## Upstream sync info

不适用：本 PR 不是 upstream sync。

## Changes

- 在 Management usage detail、export/import、Redis usage queue 和 public plugin usage record 中传播 optional `uncached_input_tokens`。
- 针对 OpenAI/Codex、Claude、Gemini 和 Interactions 的实际 usage schema，在持有 provider 原始字段时计算未缓存输入。
- 使用 `UncachedInputTokensKnown` 区分 unknown 与合法 known-zero；非法值统一清零并降级为 unknown。
- strict parser 仅接受非负整数 JSON number，拒绝 `null`、boolean、string、fractional、negative 和 overflow。
- 在 accumulator、retry-without-penalty 和 Codex abnormal-reasoning retry 的每个 contribution 入口先规范化，避免非法单次值在聚合后被洗成 authoritative 值。

## Protected delta checklist

- [x] `usage-statistics-enabled` still exists
- [x] `internal/usage/` still exists
- [x] `/v0/management/usage` still exists
- [x] `/v0/management/usage/export` still exists
- [x] `/v0/management/usage/import` still exists
- [x] `docs/lts/core-feature-contracts.yaml` reviewed for touched protected or protected-adjacent features
- [x] `docs/lts/downstream-patches.yaml` reviewed; no active patch is retired or reapplied by this change
- [x] Usage record creation/schema reviewed and tested
- [x] Management usage response shape reviewed and tested
- [x] Export/import roundtrip reviewed and tested
- [x] CPA-Panel-LTS response shape reviewed and validated with real-Core smoke
- [x] Local auth/config/panel/release/source customizations reviewed

## LTS classification review

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| `full-usage-statistics-core` | retained capability | adapted | optional detail field, provider parsing and usage tests |
| `management-usage-api` | retained capability | adapted | GET/export/import known, unknown and known-zero contract tests |
| `codex-abnormal-reasoning-retry` | LTS feature | adapted | per-contribution normalization and retry aggregation tests |
| `redis-compatible-usage-queue` | LTS feature | adapted | optional queue field and invalid-value downgrade tests |
| `provider-runtime-usage-seams` | review seam | adapted | strict provider parser and accumulator coverage |

- [x] No `introduced_in` or `retired_in` ledger commit is created by this PR.

## Compatibility and risks

- `sdk/cliproxy/usage.Detail` 和 `sdk/pluginapi.UsageDetail` 增加 exported fields。Keyed literals 和 JSON consumers 保持兼容；外部 unkeyed composite literals 可能需要调整源码。
- Plugin RPC schema 版本未改变；新增 JSON 字段对忽略未知字段的旧 consumer 是向后兼容的。
- 历史 usage 明细不会自动补充 `uncached_input_tokens`；字段缺失时由 Panel 保留 legacy fallback。
- Panel 合并和发布顺序必须在 Core 之后。

## Conflict resolution notes

无 upstream merge 或文本冲突。实现保留完整 usage statistics、Management API、Redis queue、plugin 和 retry 既有行为，仅增加 optional 字段与严格校验。

## Validation

- [x] `scripts/check-lts-contract.sh`
- [x] `go run ./scripts/ltsregistry --root .`
- [x] `go test ./internal/usage ./internal/api/handlers/management ./test -run Usage|usage`
- [x] `go build -o test-output ./cmd/server && rm -f test-output`
- [x] `go test ./...`
- [x] affected package tests with `-count=1`
- [x] affected package race tests with `-race -count=1`
- [x] `git diff --check origin/main...HEAD`
- [x] CPA-Panel-LTS `npm run smoke:lts:core` against this Core checkout

## Optional real runtime smoke

- [ ] Hugging Face Space smoke was run
- Skipped reason: 本 PR 尚未 merge 或部署；没有可供 runtime SHA 回读的目标环境。

## Review focus

1. Provider-specific input/cache semantics 是否正确归一化。
2. unknown、known-zero 和 invalid contribution 在 Management、Redis、plugin 和 retry 链路是否保持一致。
3. Public Go struct additive change 的 source-compatibility 说明是否充分。