### PR TITLE
sync(lts): 同步 Core v7.2.71 并保留 LTS 运行时契约

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -650,7 +650,8 @@ func (s *Server) codexAlphaSearch(c *gin.Context) {
 	if sessionID := strings.TrimSpace(routing.ID); sessionID != "" {
 		selectionHeaders.Set("X-Session-ID", sessionID)
 	}
-	selected, err := s.handlers.AuthManager.SelectAuth(c.Request.Context(), "codex", strings.TrimSpace(routing.Model), coreexecutor.Options{
+	ctx := context.WithValue(c.Request.Context(), "gin", c)
+	selected, err := s.handlers.AuthManager.SelectAuth(ctx, "codex", strings.TrimSpace(routing.Model), coreexecutor.Options{
 		Headers:         selectionHeaders,
 		OriginalRequest: body,
 	})
@@ -676,7 +677,6 @@ func (s *Server) codexAlphaSearch(c *gin.Context) {
 		headers.Set("Chatgpt-Account-Id", accountID)
 	}
 
-	ctx := context.WithValue(c.Request.Context(), "gin", c)
 	const upstreamURL = "https://chatgpt.com/backend-api/codex/alpha/search"
 	req, err := s.handlers.AuthManager.NewHttpRequest(
 		ctx, selected, http.MethodPost, upstreamURL, body, headers,

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -55,6 +55,18 @@ func (e *codexSearchCaptureExecutor) PrepareRequest(req *http.Request, a *auth.A
 	return nil
 }
 
+type codexSearchGinContextSelector struct {
+	ginContext *gin.Context
+}
+
+func (s *codexSearchGinContextSelector) Pick(ctx context.Context, _ string, _ string, _ coreexecutor.Options, auths []*auth.Auth) (*auth.Auth, error) {
+	s.ginContext, _ = ctx.Value("gin").(*gin.Context)
+	if len(auths) == 0 {
+		return nil, nil
+	}
+	return auths[0], nil
+}
+
 func (e *codexSearchCaptureExecutor) HttpRequest(_ context.Context, selected *auth.Auth, req *http.Request) (*http.Response, error) {
 	e.request = req.Clone(req.Context())
 	e.authIDs = append(e.authIDs, selected.ID)
@@ -185,6 +197,38 @@ func TestCodexAlphaSearchForwardsRequest(t *testing.T) {
 	}
 	if got := rr.Header().Get("Content-Type"); got != "application/json" {
 		t.Fatalf("response Content-Type = %q", got)
+	}
+}
+
+func TestCodexAlphaSearchPassesGinContextToAuthSelection(t *testing.T) {
+	server := newTestServer(t)
+	selector := &codexSearchGinContextSelector{}
+	server.handlers.AuthManager.SetSelector(selector)
+	executor := &codexSearchCaptureExecutor{}
+	server.handlers.AuthManager.RegisterExecutor(executor)
+	credential := &auth.Auth{
+		ID:       "codex-auth",
+		Provider: "codex",
+		Status:   auth.StatusActive,
+		Metadata: map[string]any{"access_token": "codex-token"},
+	}
+	if _, errRegister := server.handlers.AuthManager.Register(context.Background(), credential); errRegister != nil {
+		t.Fatalf("register Codex auth: %v", errRegister)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/alpha/search?key=home-query-key", strings.NewReader(`{"query":"GPT-5.6"}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	rr := httptest.NewRecorder()
+	server.engine.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	if selector.ginContext == nil {
+		t.Fatal("auth selection did not receive the Gin context required by Home scheduling")
+	}
+	if got := selector.ginContext.Query("key"); got != "home-query-key" {
+		t.Fatalf("Gin query key = %q, want %q", got, "home-query-key")
 	}
 }
 

--- a/internal/cache/xai_reasoning_replay_cache.go
+++ b/internal/cache/xai_reasoning_replay_cache.go
@@ -243,17 +243,18 @@ func xaiReasoningReplayKVKey(modelName, sessionKey string) string {
 
 func normalizeXAIReasoningReplayItems(items [][]byte) ([][]byte, bool) {
 	normalized := make([][]byte, 0, len(items))
-	hasReasoning := false
+	hasReplayAnchor := false
 	for _, item := range items {
 		normalizedItem, ok := normalizeXAIReasoningReplayItem(item)
 		if ok {
 			normalized = append(normalized, normalizedItem)
-			if strings.TrimSpace(gjson.GetBytes(normalizedItem, "type").String()) == "reasoning" {
-				hasReasoning = true
+			switch strings.TrimSpace(gjson.GetBytes(normalizedItem, "type").String()) {
+			case "reasoning", "function_call", "custom_tool_call":
+				hasReplayAnchor = true
 			}
 		}
 	}
-	return normalized, hasReasoning
+	return normalized, hasReplayAnchor
 }
 
 func normalizeXAIReasoningReplayItem(item []byte) ([]byte, bool) {

--- a/internal/cache/xai_reasoning_replay_cache.go
+++ b/internal/cache/xai_reasoning_replay_cache.go
@@ -63,32 +63,58 @@ func CacheXAIReasoningReplayItems(modelName, sessionKey string, items [][]byte) 
 	return CacheXAIReasoningReplayItemsBestEffort(context.Background(), modelName, sessionKey, items)
 }
 
+// XAIReasoningReplayStoreStatus reports why a completed-turn cache write
+// succeeded or failed so callers can decide whether to keep prior entries.
+type XAIReasoningReplayStoreStatus int
+
+const (
+	// XAIReasoningReplayStoreInvalidArgs means model/session were empty.
+	XAIReasoningReplayStoreInvalidArgs XAIReasoningReplayStoreStatus = iota
+	// XAIReasoningReplayStored means a valid reasoning batch was written.
+	XAIReasoningReplayStored
+	// XAIReasoningReplayNoReplayableState means the completed output had no
+	// cacheable reasoning batch (for example reasoning disabled).
+	XAIReasoningReplayNoReplayableState
+	// XAIReasoningReplayStoreBackendError means normalize succeeded but the
+	// storage backend failed; previous entries should be retained.
+	XAIReasoningReplayStoreBackendError
+)
+
 // CacheXAIReasoningReplayItemsBestEffort stores replay items for completed response paths.
 func CacheXAIReasoningReplayItemsBestEffort(ctx context.Context, modelName, sessionKey string, items [][]byte) bool {
+	return StoreXAIReasoningReplayItems(ctx, modelName, sessionKey, items) == XAIReasoningReplayStored
+}
+
+// StoreXAIReasoningReplayItems stores replay items and distinguishes empty
+// completed state from backend failures.
+func StoreXAIReasoningReplayItems(ctx context.Context, modelName, sessionKey string, items [][]byte) XAIReasoningReplayStoreStatus {
 	key := xaiReasoningReplayCacheKey(modelName, sessionKey)
 	if key == "" {
-		return false
+		return XAIReasoningReplayStoreInvalidArgs
 	}
 	normalized, ok := normalizeXAIReasoningReplayItems(items)
 	if !ok {
-		return false
+		return XAIReasoningReplayNoReplayableState
 	}
 	if client, homeMode, errClient := currentXAIReasoningReplayKVClient(); homeMode {
 		if errClient != nil {
 			log.Errorf("home kv best-effort xai reasoning replay set failed prefix=cpa:xai:*: %v", errClient)
-			return false
+			return XAIReasoningReplayStoreBackendError
 		}
 		raw, errMarshal := json.Marshal(normalized)
 		if errMarshal != nil {
 			log.Errorf("home kv best-effort xai reasoning replay set failed prefix=cpa:xai:*: %v", errMarshal)
-			return false
+			return XAIReasoningReplayStoreBackendError
 		}
 		written, errSet := client.KVSet(ctx, xaiReasoningReplayKVKey(modelName, sessionKey), raw, homekv.KVSetOptions{EX: XAIReasoningReplayCacheTTL})
 		if errSet != nil {
 			log.Errorf("home kv best-effort xai reasoning replay set failed prefix=cpa:xai:*: %v", errSet)
-			return false
+			return XAIReasoningReplayStoreBackendError
 		}
-		return written
+		if !written {
+			return XAIReasoningReplayStoreBackendError
+		}
+		return XAIReasoningReplayStored
 	}
 
 	cacheCleanupOnce.Do(startCacheCleanup)
@@ -102,7 +128,7 @@ func CacheXAIReasoningReplayItemsBestEffort(ctx context.Context, modelName, sess
 	if len(xaiReasoningReplayEntries) > XAIReasoningReplayCacheMaxEntries {
 		evictOldestXAIReasoningReplayEntriesLocked(XAIReasoningReplayCacheEvictBatchSize)
 	}
-	return true
+	return XAIReasoningReplayStored
 }
 
 // GetXAIReasoningReplayItem retrieves a normalized reasoning replay item.
@@ -217,13 +243,17 @@ func xaiReasoningReplayKVKey(modelName, sessionKey string) string {
 
 func normalizeXAIReasoningReplayItems(items [][]byte) ([][]byte, bool) {
 	normalized := make([][]byte, 0, len(items))
+	hasReasoning := false
 	for _, item := range items {
 		normalizedItem, ok := normalizeXAIReasoningReplayItem(item)
 		if ok {
 			normalized = append(normalized, normalizedItem)
+			if strings.TrimSpace(gjson.GetBytes(normalizedItem, "type").String()) == "reasoning" {
+				hasReasoning = true
+			}
 		}
 	}
-	return normalized, len(normalized) > 0
+	return normalized, hasReasoning
 }
 
 func normalizeXAIReasoningReplayItem(item []byte) ([]byte, bool) {
@@ -231,6 +261,8 @@ func normalizeXAIReasoningReplayItem(item []byte) ([]byte, bool) {
 	switch strings.TrimSpace(itemResult.Get("type").String()) {
 	case "reasoning":
 		return normalizeXAIReasoningReplayReasoningItem(itemResult)
+	case "message":
+		return normalizeXAIReasoningReplayMessageItem(itemResult)
 	case "function_call":
 		return normalizeXAIReasoningReplayFunctionCallItem(itemResult)
 	case "custom_tool_call":
@@ -255,6 +287,50 @@ func normalizeXAIReasoningReplayReasoningItem(itemResult gjson.Result) ([]byte, 
 
 	normalized := []byte(`{"type":"reasoning","summary":[],"content":null}`)
 	normalized, _ = sjson.SetBytes(normalized, "encrypted_content", encryptedContent)
+	return normalized, true
+}
+
+func normalizeXAIReasoningReplayMessageItem(itemResult gjson.Result) ([]byte, bool) {
+	if !strings.EqualFold(strings.TrimSpace(itemResult.Get("role").String()), "assistant") {
+		return nil, false
+	}
+	content := itemResult.Get("content")
+	if !content.IsArray() || len(content.Array()) == 0 {
+		return nil, false
+	}
+
+	normalized := []byte(`{"type":"message","role":"assistant","content":[]}`)
+	for _, part := range content.Array() {
+		partType := strings.TrimSpace(part.Get("type").String())
+		var nextPart []byte
+		switch partType {
+		case "output_text":
+			textValue := part.Get("text")
+			if textValue.Type != gjson.String {
+				continue
+			}
+			nextPart = []byte(`{"type":"output_text","text":""}`)
+			nextPart, _ = sjson.SetBytes(nextPart, "text", textValue.String())
+		case "refusal":
+			// Responses API refusal parts use the "refusal" field, not "text".
+			refusalValue := part.Get("refusal")
+			if refusalValue.Type != gjson.String {
+				continue
+			}
+			nextPart = []byte(`{"type":"refusal","refusal":""}`)
+			nextPart, _ = sjson.SetBytes(nextPart, "refusal", refusalValue.String())
+		default:
+			continue
+		}
+		updated, errSet := sjson.SetRawBytes(normalized, "content.-1", nextPart)
+		if errSet != nil {
+			return nil, false
+		}
+		normalized = updated
+	}
+	if len(gjson.GetBytes(normalized, "content").Array()) == 0 {
+		return nil, false
+	}
 	return normalized, true
 }
 

--- a/internal/cache/xai_reasoning_replay_cache_test.go
+++ b/internal/cache/xai_reasoning_replay_cache_test.go
@@ -172,6 +172,56 @@ func TestXAIReasoningReplayCacheRejectsAssistantMessageWithoutReasoning(t *testi
 	}
 }
 
+func TestXAIReasoningReplayCacheStoresToolCallWithoutReasoning(t *testing.T) {
+	ClearXAIReasoningReplayCache()
+	t.Cleanup(ClearXAIReasoningReplayCache)
+
+	tests := []struct {
+		name        string
+		sessionKey  string
+		item        []byte
+		wantType    string
+		wantPayload string
+	}{
+		{
+			name:        "function call",
+			sessionKey:  "prompt-cache:function-call-only",
+			item:        []byte(`{"type":"function_call","call_id":"call_1","name":"lookup","arguments":"{\"q\":\"weather\"}"}`),
+			wantType:    "function_call",
+			wantPayload: `{"q":"weather"}`,
+		},
+		{
+			name:        "custom tool call",
+			sessionKey:  "prompt-cache:custom-tool-call-only",
+			item:        []byte(`{"type":"custom_tool_call","call_id":"call_2","name":"shell","input":"pwd"}`),
+			wantType:    "custom_tool_call",
+			wantPayload: "pwd",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !CacheXAIReasoningReplayItems("grok-4.3", tt.sessionKey, [][]byte{tt.item}) {
+				t.Fatal("tool-call-only replay batch must be cached")
+			}
+			items, ok := GetXAIReasoningReplayItems("grok-4.3", tt.sessionKey)
+			if !ok || len(items) != 1 {
+				t.Fatalf("cached items = %q, %v, want one item", items, ok)
+			}
+			if got := gjson.GetBytes(items[0], "type").String(); got != tt.wantType {
+				t.Fatalf("cached type = %q, want %q; item=%s", got, tt.wantType, items[0])
+			}
+			payloadPath := "arguments"
+			if tt.wantType == "custom_tool_call" {
+				payloadPath = "input"
+			}
+			if got := gjson.GetBytes(items[0], payloadPath).String(); got != tt.wantPayload {
+				t.Fatalf("cached %s = %q, want %q; item=%s", payloadPath, got, tt.wantPayload, items[0])
+			}
+		})
+	}
+}
+
 func TestXAIReasoningReplayRequiredHomeExpireFailureReturnsItems(t *testing.T) {
 	ClearXAIReasoningReplayCache()
 	t.Cleanup(ClearXAIReasoningReplayCache)

--- a/internal/cache/xai_reasoning_replay_cache_test.go
+++ b/internal/cache/xai_reasoning_replay_cache_test.go
@@ -129,6 +129,49 @@ func TestXAIReasoningReplayCacheStoresGrokEncryptedContent(t *testing.T) {
 	}
 }
 
+func TestXAIReasoningReplayCacheStoresAssistantMessageWithReasoning(t *testing.T) {
+	ClearXAIReasoningReplayCache()
+	t.Cleanup(ClearXAIReasoningReplayCache)
+	encryptedContent := validGrokEncryptedContentForReplayCacheTest()
+
+	items := [][]byte{
+		[]byte(`{"id":"rs_1","type":"reasoning","summary":[{"type":"summary_text","text":"visible"}],"encrypted_content":"` + encryptedContent + `"}`),
+		[]byte(`{"id":"msg_1","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"answer","annotations":[],"logprobs":[]}]}`),
+	}
+	if !CacheXAIReasoningReplayItems("grok-4.5", "prompt-cache:session", items) {
+		t.Fatal("expected reasoning replay items to be cached")
+	}
+
+	got, ok := GetXAIReasoningReplayItems("grok-4.5", "prompt-cache:session")
+	if !ok || len(got) != 2 {
+		t.Fatalf("cached items = %q, %v, want two items", got, ok)
+	}
+	if gjson.GetBytes(got[0], "encrypted_content").String() != encryptedContent {
+		t.Fatalf("reasoning encrypted_content not preserved: %s", got[0])
+	}
+	if gotText := gjson.GetBytes(got[1], "content.0.text").String(); gotText != "answer" {
+		t.Fatalf("assistant message text = %q, want answer; item=%s", gotText, got[1])
+	}
+	if gjson.GetBytes(got[1], "id").Exists() || gjson.GetBytes(got[1], "status").Exists() {
+		t.Fatalf("assistant message transport fields were not stripped: %s", got[1])
+	}
+}
+
+func TestXAIReasoningReplayCacheRejectsAssistantMessageWithoutReasoning(t *testing.T) {
+	ClearXAIReasoningReplayCache()
+	t.Cleanup(ClearXAIReasoningReplayCache)
+
+	items := [][]byte{
+		[]byte(`{"id":"msg_1","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"answer"}]}`),
+	}
+	if CacheXAIReasoningReplayItems("grok-4.5", "prompt-cache:message-only", items) {
+		t.Fatal("message-only replay batch must not be cached")
+	}
+	if _, ok := GetXAIReasoningReplayItems("grok-4.5", "prompt-cache:message-only"); ok {
+		t.Fatal("message-only replay batch unexpectedly exists in cache")
+	}
+}
+
 func TestXAIReasoningReplayRequiredHomeExpireFailureReturnsItems(t *testing.T) {
 	ClearXAIReasoningReplayCache()
 	t.Cleanup(ClearXAIReasoningReplayCache)
@@ -158,4 +201,31 @@ func validGrokEncryptedContentForReplayCacheTest() string {
 		buf = append(buf, sum[:]...)
 	}
 	return base64.RawStdEncoding.EncodeToString(buf[:256])
+}
+
+func TestXAIReasoningReplayCacheStoresRefusalMessagePart(t *testing.T) {
+	ClearXAIReasoningReplayCache()
+	t.Cleanup(ClearXAIReasoningReplayCache)
+	encryptedContent := validGrokEncryptedContentForReplayCacheTest()
+
+	items := [][]byte{
+		[]byte(`{"type":"reasoning","summary":[],"encrypted_content":"` + encryptedContent + `"}`),
+		[]byte(`{"type":"message","role":"assistant","content":[{"type":"refusal","refusal":"I cannot help with that"}]}`),
+	}
+	if !CacheXAIReasoningReplayItems("grok-4.5", "prompt-cache:refusal", items) {
+		t.Fatal("expected refusal message with reasoning to be cached")
+	}
+	got, ok := GetXAIReasoningReplayItems("grok-4.5", "prompt-cache:refusal")
+	if !ok || len(got) != 2 {
+		t.Fatalf("cached items = %q, %v, want reasoning + refusal message", got, ok)
+	}
+	if gjson.GetBytes(got[1], "content.0.type").String() != "refusal" {
+		t.Fatalf("message part type = %s, want refusal; item=%s", gjson.GetBytes(got[1], "content.0.type").String(), got[1])
+	}
+	if gjson.GetBytes(got[1], "content.0.refusal").String() != "I cannot help with that" {
+		t.Fatalf("refusal text missing; item=%s", got[1])
+	}
+	if gjson.GetBytes(got[1], "content.0.text").Exists() {
+		t.Fatalf("refusal part should not use text field; item=%s", got[1])
+	}
 }

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -542,7 +542,7 @@ func codexReasoningReplayInsertIndex(inputItems []gjson.Result, replayItems [][]
 	}
 	for index := len(inputItems) - 1; index >= 0; index-- {
 		inputItem := inputItems[index]
-		if strings.TrimSpace(inputItem.Get("type").String()) == "message" && strings.TrimSpace(inputItem.Get("role").String()) == "assistant" {
+		if role, ok := codexReplayMessageRole(inputItem); ok && role == "assistant" {
 			return index
 		}
 	}
@@ -611,15 +611,25 @@ func codexReplayOutputCallIDs(inputItems []gjson.Result) map[string]string {
 }
 
 func shouldInsertCodexReasoningReplayBefore(item gjson.Result) bool {
-	if strings.TrimSpace(item.Get("type").String()) != "message" {
+	role, ok := codexReplayMessageRole(item)
+	if !ok {
 		return true
 	}
-	switch strings.TrimSpace(item.Get("role").String()) {
+	switch role {
 	case "developer", "system":
 		return false
 	default:
 		return true
 	}
+}
+
+func codexReplayMessageRole(item gjson.Result) (string, bool) {
+	itemType := strings.TrimSpace(item.Get("type").String())
+	role := strings.ToLower(strings.TrimSpace(item.Get("role").String()))
+	if role == "" || (itemType != "" && itemType != "message") {
+		return "", false
+	}
+	return role, true
 }
 
 func codexReplayToolCallKeys(item gjson.Result) []string {

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -272,6 +272,7 @@ func (e *XAIExecutor) executeCompactRequest(ctx context.Context, auth *cliproxya
 
 	reporter.Publish(ctx, helps.ParseOpenAIUsage(data))
 	reporter.EnsurePublished(ctx)
+	clearXAIReasoningReplayAfterCompaction(ctx, prepared.replayScope)
 	return prepared, data, httpResp.Header.Clone(), nil
 }
 

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -1144,7 +1144,6 @@ func xaiMetadataString(meta map[string]any, key string) string {
 }
 
 func sanitizeXAIResponsesBody(body []byte, model string) []byte {
-	body = removeXAIEncryptedReasoningInclude(body)
 	if !xaiSupportsReasoningEffort(model) {
 		if gjson.GetBytes(body, "reasoning.effort").Exists() {
 			log.Debugf("xai: stripping reasoning.effort for model %s (no thinking levels in model registry)", model)
@@ -1481,23 +1480,6 @@ func appendXAIReasoningSummary(previous json.RawMessage, currentSummary []gjson.
 		updated = updatedItem
 	}
 	return updated, true
-}
-
-func removeXAIEncryptedReasoningInclude(body []byte) []byte {
-	include := gjson.GetBytes(body, "include")
-	if !include.Exists() || !include.IsArray() {
-		return body
-	}
-	kept := make([]string, 0, len(include.Array()))
-	for _, item := range include.Array() {
-		value := strings.TrimSpace(item.String())
-		if value == "" || value == "reasoning.encrypted_content" {
-			continue
-		}
-		kept = append(kept, value)
-	}
-	body, _ = sjson.SetBytes(body, "include", kept)
-	return body
 }
 
 // xaiSupportsReasoningEffort reports whether the model accepts Responses API

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -1579,7 +1579,7 @@ func TestFilterXAIReasoningReplayItemsSkipsMatchingCachedTurn(t *testing.T) {
 	}
 }
 
-func TestFilterXAIReasoningReplayItemsKeepsNewCachedTurnWhenInputHasOlderReasoning(t *testing.T) {
+func TestFilterXAIReasoningReplayItemsSkipsAmbiguousCachedTurnWhenInputHasOlderReasoning(t *testing.T) {
 	oldEncryptedContent := testValidGrokEncryptedContentForSeed(10)
 	newEncryptedContent := testValidGrokEncryptedContentForSeed(12)
 	body := []byte(`{"input":[{"type":"reasoning","summary":[],"encrypted_content":""},{"type":"message","role":"assistant","content":[{"type":"output_text","text":"older answer"}]},{"type":"message","role":"user","content":[{"type":"input_text","text":"next"}]}]}`)
@@ -1591,11 +1591,8 @@ func TestFilterXAIReasoningReplayItemsKeepsNewCachedTurnWhenInputHasOlderReasoni
 	items[0], _ = sjson.SetBytes(items[0], "encrypted_content", newEncryptedContent)
 
 	filtered := filterXAIReasoningReplayItemsForInput(body, items)
-	if len(filtered) != 1 || gjson.GetBytes(filtered[0], "type").String() != "reasoning" {
-		t.Fatalf("filtered replay items = %q, want new reasoning only (input already has last assistant)", filtered)
-	}
-	if got := gjson.GetBytes(filtered[0], "encrypted_content").String(); got != newEncryptedContent {
-		t.Fatalf("filtered reasoning encrypted_content = %q, want new cached blob", got)
+	if len(filtered) != 0 {
+		t.Fatalf("filtered replay items = %q, want none when cached assistant does not match history", filtered)
 	}
 }
 
@@ -1614,6 +1611,38 @@ func TestFilterXAIReasoningReplayItemsSkipsDuplicateAssistantMessage(t *testing.
 	}
 }
 
+func TestFilterXAIReasoningReplayItemsRecognizesRoleOnlyAssistantMessage(t *testing.T) {
+	encryptedContent := testValidGrokEncryptedContentForSeed(31)
+	body := []byte(`{"input":[{"role":"assistant","content":"first answer"},{"role":"user","content":"second"}]}`)
+	items := [][]byte{
+		[]byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":""}`),
+		[]byte(`{"type":"message","role":"assistant","content":[{"type":"output_text","text":"first answer"}]}`),
+	}
+	items[0], _ = sjson.SetBytes(items[0], "encrypted_content", encryptedContent)
+
+	filtered := filterXAIReasoningReplayItemsForInput(body, items)
+	if len(filtered) != 1 || gjson.GetBytes(filtered[0], "type").String() != "reasoning" {
+		t.Fatalf("filtered replay items = %q, want reasoning only", filtered)
+	}
+	updated, ok := insertCodexReasoningReplayItems(body, filtered)
+	if !ok {
+		t.Fatal("insertCodexReasoningReplayItems failed")
+	}
+	input := gjson.GetBytes(updated, "input").Array()
+	if len(input) != 3 || input[0].Get("type").String() != "reasoning" || input[1].Get("role").String() != "assistant" {
+		t.Fatalf("unexpected role-only replay order: %s", updated)
+	}
+	assistantCount := 0
+	for _, item := range input {
+		if strings.EqualFold(item.Get("role").String(), "assistant") {
+			assistantCount++
+		}
+	}
+	if assistantCount != 1 {
+		t.Fatalf("assistant messages after replay = %d, want 1; body=%s", assistantCount, updated)
+	}
+}
+
 func TestFilterXAIReasoningReplayItemsDoesNotMatchOlderAssistantMessage(t *testing.T) {
 	encryptedContent := testValidGrokEncryptedContentForSeed(13)
 	body := []byte(`{"input":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"OK"}]},{"type":"message","role":"user","content":[{"type":"input_text","text":"continue"}]},{"type":"message","role":"assistant","content":[{"type":"output_text","text":"different answer"}]},{"type":"message","role":"user","content":[{"type":"input_text","text":"next"}]}]}`)
@@ -1624,15 +1653,15 @@ func TestFilterXAIReasoningReplayItemsDoesNotMatchOlderAssistantMessage(t *testi
 	items[0], _ = sjson.SetBytes(items[0], "encrypted_content", encryptedContent)
 
 	filtered := filterXAIReasoningReplayItemsForInput(body, items)
-	if len(filtered) != 1 || gjson.GetBytes(filtered[0], "type").String() != "reasoning" {
-		t.Fatalf("filtered replay items = %q, want reasoning only when a later assistant already exists", filtered)
+	if len(filtered) != 0 {
+		t.Fatalf("filtered replay items = %q, want none when the last assistant differs from the cached turn", filtered)
 	}
 }
 
-// Scenario #3 (partial inject): client already has a last assistant whose text
-// drifts from the cached message. Injecting the cached message would produce
-// two assistants around the same turn. Expect reasoning-only inject.
-func TestFilterXAIReasoningReplayItemsSkipsMessageWhenLastAssistantTextDrifts(t *testing.T) {
+// Scenario #3: client already has a last assistant whose text drifts from the
+// cached message. The cache cannot safely determine whether this is a trimmed
+// older turn or a modified latest turn, so skip the entire cached batch.
+func TestFilterXAIReasoningReplayItemsSkipsAmbiguousTurnWhenLastAssistantTextDrifts(t *testing.T) {
 	encryptedContent := testValidGrokEncryptedContentForSeed(20)
 	body := []byte(`{"input":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"first answer."}]},{"type":"message","role":"user","content":[{"type":"input_text","text":"second"}]}]}`)
 	items := [][]byte{
@@ -1642,26 +1671,8 @@ func TestFilterXAIReasoningReplayItemsSkipsMessageWhenLastAssistantTextDrifts(t 
 	items[0], _ = sjson.SetBytes(items[0], "encrypted_content", encryptedContent)
 
 	filtered := filterXAIReasoningReplayItemsForInput(body, items)
-	if len(filtered) != 1 || gjson.GetBytes(filtered[0], "type").String() != "reasoning" {
-		t.Fatalf("filtered = %q, want reasoning only for drifted last assistant", filtered)
-	}
-
-	// Full insert path: must not create two assistant messages.
-	updated, ok := insertCodexReasoningReplayItems(body, filtered)
-	if !ok {
-		t.Fatal("insertCodexReasoningReplayItems failed")
-	}
-	assistantCount := 0
-	for _, item := range gjson.GetBytes(updated, "input").Array() {
-		if item.Get("type").String() == "message" && item.Get("role").String() == "assistant" {
-			assistantCount++
-		}
-	}
-	if assistantCount != 1 {
-		t.Fatalf("assistant messages after inject = %d, want 1; body=%s", assistantCount, updated)
-	}
-	if gjson.GetBytes(updated, "input.0.type").String() != "reasoning" {
-		t.Fatalf("expected reasoning inserted before last assistant; body=%s", updated)
+	if len(filtered) != 0 {
+		t.Fatalf("filtered = %q, want no replay for ambiguous drifted assistant", filtered)
 	}
 }
 

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -1434,8 +1434,9 @@ func TestXAIExecutorReasoningReplayCacheStoresFinalDoneAndInjectsNextClaudeReque
 		SourceFormat: sdktranslator.FormatClaude,
 		Stream:       false,
 	}
+	ctx := testContextWithAPIKey("xai-replay-caller")
 
-	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
 		Model:   "grok-4.3",
 		Payload: []byte(`{"model":"grok-4.3","metadata":{"user_id":"{\"device_id\":\"device-test\",\"account_uuid\":\"\",\"session_id\":\"xai-session-1\"}"},"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`),
 	}, opts)
@@ -1443,7 +1444,7 @@ func TestXAIExecutorReasoningReplayCacheStoresFinalDoneAndInjectsNextClaudeReque
 		t.Fatalf("first Execute error: %v", err)
 	}
 
-	_, err = executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+	_, err = executor.Execute(ctx, auth, cliproxyexecutor.Request{
 		Model:   "grok-4.3",
 		Payload: []byte(`{"model":"grok-4.3","metadata":{"user_id":"{\"device_id\":\"device-test\",\"account_uuid\":\"\",\"session_id\":\"xai-session-1\"}"},"messages":[{"role":"user","content":[{"type":"text","text":"next"}]}]}`),
 	}, opts)
@@ -1831,6 +1832,44 @@ func TestXAIReasoningReplayScopeIsolatesOpenAIResponsePromptCacheKeyByAPIKey(t *
 	}
 }
 
+func TestXAIReasoningReplayScopeDisablesClaudeWithoutAPIKey(t *testing.T) {
+	payload := []byte(`{"model":"grok-4.3","metadata":{"user_id":"{\"session_id\":\"shared-session\"}"},"messages":[{"role":"user","content":"hello"}]}`)
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude}
+	req := cliproxyexecutor.Request{Model: "grok-4.3", Payload: payload}
+
+	scopeNoKey := xaiReasoningReplayScopeFromRequest(context.Background(), sdktranslator.FormatClaude, req, opts, payload)
+	if scopeNoKey.valid() {
+		t.Fatalf("Claude without caller API key must disable replay: %+v", scopeNoKey)
+	}
+
+	scopeWithKey := xaiReasoningReplayScopeFromRequest(testContextWithAPIKey("api-key-a"), sdktranslator.FormatClaude, req, opts, payload)
+	if !scopeWithKey.valid() {
+		t.Fatal("Claude with caller API key must enable replay")
+	}
+	if !strings.HasPrefix(scopeWithKey.sessionKey, "caller:") || !strings.Contains(scopeWithKey.sessionKey, "claude:shared-session") {
+		t.Fatalf("session key = %q, want caller-isolated Claude session key", scopeWithKey.sessionKey)
+	}
+}
+
+func TestXAIReasoningReplayScopeAllowsTrustedExecutionSessionWithoutAPIKey(t *testing.T) {
+	payload := []byte(`{"model":"grok-4.3","messages":[{"role":"user","content":"hello"}]}`)
+	scope := xaiReasoningReplayScopeFromRequest(context.Background(), sdktranslator.FormatClaude, cliproxyexecutor.Request{
+		Model:   "grok-4.3",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatClaude,
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: "trusted-session",
+		},
+	}, payload)
+	if !scope.valid() {
+		t.Fatal("trusted execution session must remain replayable without caller API key")
+	}
+	if scope.sessionKey != "execution:trusted-session" {
+		t.Fatalf("session key = %q, want execution:trusted-session", scope.sessionKey)
+	}
+}
+
 func TestXAIReasoningReplayScopeSkipsIncrementalWebsocketPreviousResponse(t *testing.T) {
 	scope := xaiReasoningReplayScopeFromRequest(
 		cliproxyexecutor.WithDownstreamWebsocket(context.Background()),
@@ -1955,8 +1994,9 @@ func TestXAIExecutorReasoningReplayCacheReplaysFunctionCallForClaudeToolResult(t
 		SourceFormat: sdktranslator.FormatClaude,
 		Stream:       false,
 	}
+	ctx := testContextWithAPIKey("xai-tool-replay-caller")
 
-	_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
 		Model: "grok-4.3",
 		Payload: []byte(`{
 			"model":"grok-4.3",
@@ -1969,7 +2009,7 @@ func TestXAIExecutorReasoningReplayCacheReplaysFunctionCallForClaudeToolResult(t
 		t.Fatalf("first Execute error: %v", err)
 	}
 
-	_, err = executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+	_, err = executor.Execute(ctx, auth, cliproxyexecutor.Request{
 		Model: "grok-4.3",
 		Payload: []byte(`{
 			"model":"grok-4.3",

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -337,6 +337,110 @@ func TestXAIExecutorCompactUsesCompactEndpoint(t *testing.T) {
 	}
 }
 
+func TestXAIExecutorCompactClearsReplayBeforePostCompactTurn(t *testing.T) {
+	internalcache.ClearXAIReasoningReplayCache()
+	t.Cleanup(internalcache.ClearXAIReasoningReplayCache)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_compact","object":"response.compaction","output":[{"type":"compaction","encrypted_content":"opaque-out"}]}`))
+	}))
+	defer server.Close()
+
+	exec := NewXAIExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider: "xai",
+		Attributes: map[string]string{
+			"base_url": server.URL,
+			"api_key":  "xai-token",
+		},
+	}
+	ctx := testContextWithAPIKey("xai-compact-caller")
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Alt:          "responses/compact",
+		Stream:       false,
+	}
+	compactEncryptedContent := testValidGrokEncryptedContentForSeed(41)
+	compactPayload := []byte(`{"model":"grok-4.3","prompt_cache_key":"compact-session","input":[{"type":"compaction","encrypted_content":""},{"type":"message","role":"user","content":[{"type":"input_text","text":"compact"}]}]}`)
+	compactPayload, _ = sjson.SetBytes(compactPayload, "input.0.encrypted_content", compactEncryptedContent)
+	compactReq := cliproxyexecutor.Request{Model: "grok-4.3", Payload: compactPayload}
+	scope := xaiReasoningReplayScopeFromRequest(ctx, sdktranslator.FormatOpenAIResponse, compactReq, opts, compactPayload)
+	if !scope.valid() {
+		t.Fatal("compact replay scope must be valid")
+	}
+	reasoning := []byte(`{"type":"reasoning","summary":[],"encrypted_content":""}`)
+	reasoning, _ = sjson.SetBytes(reasoning, "encrypted_content", testValidGrokEncryptedContentForSeed(42))
+	if !internalcache.CacheXAIReasoningReplayItems(scope.modelName, scope.sessionKey, [][]byte{
+		reasoning,
+		[]byte(`{"type":"message","role":"assistant","content":[{"type":"output_text","text":"pre-compact answer"}]}`),
+	}) {
+		t.Fatal("failed to seed xAI replay cache")
+	}
+
+	if _, err := exec.Execute(ctx, auth, compactReq, opts); err != nil {
+		t.Fatalf("Execute compact error: %v", err)
+	}
+	if _, ok := internalcache.GetXAIReasoningReplayItems(scope.modelName, scope.sessionKey); ok {
+		t.Fatal("successful compact must clear the pre-compact replay batch")
+	}
+
+	postCompactPayload := []byte(`{"model":"grok-4.3","prompt_cache_key":"compact-session","input":[{"type":"compaction","encrypted_content":""},{"type":"message","role":"user","content":[{"type":"input_text","text":"after compact"}]}]}`)
+	postCompactPayload, _ = sjson.SetBytes(postCompactPayload, "input.0.encrypted_content", compactEncryptedContent)
+	prepared, errPrepare := exec.prepareResponsesRequest(ctx, cliproxyexecutor.Request{
+		Model:   "grok-4.3",
+		Payload: postCompactPayload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Stream:       false,
+	}, false)
+	if errPrepare != nil {
+		t.Fatalf("prepare post-compact request: %v", errPrepare)
+	}
+	input := gjson.GetBytes(prepared.body, "input").Array()
+	if len(input) != 2 || input[0].Get("type").String() != "compaction" || input[1].Get("role").String() != "user" {
+		t.Fatalf("post-compact input contains stale replay state: %s", prepared.body)
+	}
+}
+
+func TestXAIExecutorCompactFailureRetainsReplay(t *testing.T) {
+	internalcache.ClearXAIReasoningReplayCache()
+	t.Cleanup(internalcache.ClearXAIReasoningReplayCache)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"compact failed"}}`))
+	}))
+	defer server.Close()
+
+	exec := NewXAIExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider: "xai",
+		Attributes: map[string]string{
+			"base_url": server.URL,
+			"api_key":  "xai-token",
+		},
+	}
+	ctx := testContextWithAPIKey("xai-compact-failure-caller")
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse, Alt: "responses/compact"}
+	payload := []byte(`{"model":"grok-4.3","prompt_cache_key":"compact-failure-session","input":[{"type":"message","role":"user","content":"compact"}]}`)
+	req := cliproxyexecutor.Request{Model: "grok-4.3", Payload: payload}
+	scope := xaiReasoningReplayScopeFromRequest(ctx, sdktranslator.FormatOpenAIResponse, req, opts, payload)
+	reasoning := []byte(`{"type":"reasoning","summary":[],"encrypted_content":""}`)
+	reasoning, _ = sjson.SetBytes(reasoning, "encrypted_content", testValidGrokEncryptedContentForSeed(43))
+	if !internalcache.CacheXAIReasoningReplayItems(scope.modelName, scope.sessionKey, [][]byte{reasoning}) {
+		t.Fatal("failed to seed xAI replay cache")
+	}
+
+	if _, err := exec.Execute(ctx, auth, req, opts); err == nil {
+		t.Fatal("Execute compact error = nil, want upstream failure")
+	}
+	if _, ok := internalcache.GetXAIReasoningReplayItems(scope.modelName, scope.sessionKey); !ok {
+		t.Fatal("failed compact must retain the previous replay batch")
+	}
+}
+
 func TestXAIExecutorExecuteStreamCompactionTriggerUsesCompactEndpoint(t *testing.T) {
 	var gotPath string
 	var gotAccept string

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -1877,6 +1877,47 @@ func TestApplyXAIReasoningReplayCacheFallsBackWhenReadFails(t *testing.T) {
 	}
 }
 
+func TestXAIReasoningReplayCacheReplaysFunctionCallWithoutReasoning(t *testing.T) {
+	internalcache.ClearXAIReasoningReplayCache()
+	t.Cleanup(internalcache.ClearXAIReasoningReplayCache)
+
+	const executionSessionID = "xai-tool-call-only"
+	cacheXAIReasoningReplayFromCompleted(context.Background(), xaiReasoningReplayScope{
+		modelName:  "grok-4.3",
+		sessionKey: "execution:" + executionSessionID,
+	}, []byte(`{"response":{"output":[{"type":"function_call","call_id":"call_1","name":"lookup","arguments":"{\"q\":\"weather\"}"}]}}`))
+
+	body := []byte(`{"model":"grok-4.3","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"call lookup"}]},{"type":"function_call_output","call_id":"call_1","output":"sunny"}]}`)
+	updated, scope, errReplay := applyXAIReasoningReplayCacheRequired(context.Background(), sdktranslator.FormatClaude, cliproxyexecutor.Request{
+		Model:   "grok-4.3",
+		Payload: body,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatClaude,
+		Metadata: map[string]any{
+			cliproxyexecutor.ExecutionSessionMetadataKey: executionSessionID,
+		},
+	}, body)
+	if errReplay != nil {
+		t.Fatalf("applyXAIReasoningReplayCacheRequired() error = %v", errReplay)
+	}
+	if !scope.valid() {
+		t.Fatal("tool-call-only replay scope must remain valid")
+	}
+	input := gjson.GetBytes(updated, "input").Array()
+	if len(input) != 3 {
+		t.Fatalf("input length = %d, want 3; body=%s", len(input), updated)
+	}
+	wantTypes := []string{"message", "function_call", "function_call_output"}
+	for i, wantType := range wantTypes {
+		if got := input[i].Get("type").String(); got != wantType {
+			t.Fatalf("input.%d.type = %q, want %q; body=%s", i, got, wantType, updated)
+		}
+	}
+	if got := input[1].Get("call_id").String(); got != "call_1" {
+		t.Fatalf("replayed call_id = %q, want call_1; body=%s", got, updated)
+	}
+}
+
 func TestXAIExecutorReasoningReplayCacheReplaysFunctionCallForClaudeToolResult(t *testing.T) {
 	internalcache.ClearXAIReasoningReplayCache()
 	t.Cleanup(internalcache.ClearXAIReasoningReplayCache)

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	xaiauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/xai"
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
@@ -23,6 +24,14 @@ import (
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
+
+func testContextWithAPIKey(apiKey string) context.Context {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(rec)
+	ginCtx.Set("userApiKey", apiKey)
+	return context.WithValue(context.Background(), "gin", ginCtx)
+}
 
 func TestXAIExecutorExecuteShapesResponsesRequest(t *testing.T) {
 	var gotPath string
@@ -159,10 +168,15 @@ func TestXAIExecutorExecuteShapesResponsesRequest(t *testing.T) {
 	if !foundNamespaceCustom {
 		t.Fatalf("namespace custom tool was not moved to top-level tools; body=%s", string(gotBody))
 	}
+	foundEncryptedReasoningInclude := false
 	for _, include := range gjson.GetBytes(gotBody, "include").Array() {
 		if include.String() == "reasoning.encrypted_content" {
-			t.Fatalf("xai request must not ask for encrypted reasoning content: %s", string(gotBody))
+			foundEncryptedReasoningInclude = true
+			break
 		}
+	}
+	if !foundEncryptedReasoningInclude {
+		t.Fatalf("xai request must preserve reasoning.encrypted_content include: %s", string(gotBody))
 	}
 }
 
@@ -1449,6 +1463,376 @@ func TestXAIExecutorReasoningReplayCacheStoresFinalDoneAndInjectsNextClaudeReque
 	}
 	if got := gjson.GetBytes(secondBody, "input.1.role").String(); got != "user" {
 		t.Fatalf("input.1.role = %q, want user; body=%s", got, string(secondBody))
+	}
+}
+
+func TestXAIExecutorResponsesSSEReplaysEncryptedReasoningAndAssistantMessage(t *testing.T) {
+	internalcache.ClearXAIReasoningReplayCache()
+	t.Cleanup(internalcache.ClearXAIReasoningReplayCache)
+
+	encryptedContent := testValidGrokEncryptedContentForSeed(9)
+	var bodies [][]byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read body: %v", errRead)
+		}
+		bodies = append(bodies, body)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		if len(bodies) == 1 {
+			_, _ = w.Write([]byte(`data: {"type":"response.output_item.done","item":{"id":"rs_1","type":"reasoning","summary":[],"encrypted_content":"` + encryptedContent + `"},"output_index":0}` + "\n"))
+			_, _ = w.Write([]byte(`data: {"type":"response.output_item.done","item":{"id":"msg_1","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"first answer"}]},"output_index":1}` + "\n"))
+			_, _ = w.Write([]byte(`data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","model":"grok-4.5","output":[]}}` + "\n\n"))
+			return
+		}
+		_, _ = w.Write([]byte(`data: {"type":"response.completed","response":{"id":"resp_2","status":"completed","model":"grok-4.5","output":[]}}` + "\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewXAIExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		ID:       "xai-auth-responses-sse-replay",
+		Provider: "xai",
+		Attributes: map[string]string{
+			"base_url": server.URL,
+		},
+		Metadata: map[string]any{"access_token": "xai-token"},
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FormatOpenAIResponse,
+		ResponseFormat: sdktranslator.FormatOpenAIResponse,
+		Stream:         true,
+	}
+	firstPayload := []byte(`{"model":"grok-4.5","stream":true,"store":false,"prompt_cache_key":"codex-sse-session","include":["reasoning.encrypted_content"],"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"first"}]}]}`)
+	secondPayload := []byte(`{"model":"grok-4.5","stream":true,"store":false,"prompt_cache_key":"codex-sse-session","include":["reasoning.encrypted_content"],"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"second"}]}]}`)
+
+	streamedResponses := make([][]byte, 0, 2)
+	ctx := testContextWithAPIKey("codex-sse-api-key")
+	for _, payload := range [][]byte{firstPayload, secondPayload} {
+		result, err := executor.ExecuteStream(ctx, auth, cliproxyexecutor.Request{Model: "grok-4.5", Payload: payload}, opts)
+		if err != nil {
+			t.Fatalf("ExecuteStream error: %v", err)
+		}
+		var streamed bytes.Buffer
+		for chunk := range result.Chunks {
+			if chunk.Err != nil {
+				t.Fatalf("stream chunk error: %v", chunk.Err)
+			}
+			streamed.Write(chunk.Payload)
+		}
+		streamedResponses = append(streamedResponses, bytes.Clone(streamed.Bytes()))
+	}
+
+	if len(bodies) != 2 {
+		t.Fatalf("upstream request count = %d, want 2", len(bodies))
+	}
+	if includes := gjson.GetBytes(bodies[0], "include").Array(); len(includes) != 1 || includes[0].String() != "reasoning.encrypted_content" {
+		t.Fatalf("first request include was not preserved: %s", bodies[0])
+	}
+	var downstreamEncryptedContent string
+	for _, line := range bytes.Split(streamedResponses[0], []byte("\n")) {
+		if !bytes.HasPrefix(line, xaiDataTag) {
+			continue
+		}
+		eventData := bytes.TrimSpace(line[len(xaiDataTag):])
+		if gjson.GetBytes(eventData, "type").String() != "response.output_item.done" ||
+			gjson.GetBytes(eventData, "item.type").String() != "reasoning" {
+			continue
+		}
+		downstreamEncryptedContent = gjson.GetBytes(eventData, "item.encrypted_content").String()
+		break
+	}
+	if downstreamEncryptedContent != encryptedContent {
+		t.Fatalf("downstream encrypted_content = %q, want upstream Grok blob; stream=%s", downstreamEncryptedContent, streamedResponses[0])
+	}
+	if got := gjson.GetBytes(bodies[1], "input.0.type").String(); got != "reasoning" {
+		t.Fatalf("second input.0.type = %q, want reasoning; body=%s", got, bodies[1])
+	}
+	if got := gjson.GetBytes(bodies[1], "input.0.encrypted_content").String(); got != encryptedContent {
+		t.Fatalf("replayed encrypted_content = %q, want cached Grok blob; body=%s", got, bodies[1])
+	}
+	if got := gjson.GetBytes(bodies[1], "input.1.type").String(); got != "message" {
+		t.Fatalf("second input.1.type = %q, want assistant message; body=%s", got, bodies[1])
+	}
+	if got := gjson.GetBytes(bodies[1], "input.1.content.0.text").String(); got != "first answer" {
+		t.Fatalf("replayed assistant text = %q, want first answer; body=%s", got, bodies[1])
+	}
+	if got := gjson.GetBytes(bodies[1], "input.2.content.0.text").String(); got != "second" {
+		t.Fatalf("new user text = %q, want second; body=%s", got, bodies[1])
+	}
+}
+
+func TestFilterXAIReasoningReplayItemsSkipsMatchingCachedTurn(t *testing.T) {
+	encryptedContent := testValidGrokEncryptedContentForSeed(10)
+	body := []byte(`{"input":[{"type":"reasoning","summary":[],"encrypted_content":""},{"type":"message","role":"assistant","content":[{"type":"output_text","text":"first answer"}]},{"type":"message","role":"user","content":[{"type":"input_text","text":"second"}]}]}`)
+	body, _ = sjson.SetBytes(body, "input.0.encrypted_content", encryptedContent)
+	items := [][]byte{
+		[]byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":""}`),
+		[]byte(`{"type":"message","role":"assistant","content":[{"type":"output_text","text":"first answer"}]}`),
+	}
+	items[0], _ = sjson.SetBytes(items[0], "encrypted_content", encryptedContent)
+
+	filtered := filterXAIReasoningReplayItemsForInput(body, items)
+	if len(filtered) != 0 {
+		t.Fatalf("filtered replay items = %q, want none for client-provided history", filtered)
+	}
+}
+
+func TestFilterXAIReasoningReplayItemsKeepsNewCachedTurnWhenInputHasOlderReasoning(t *testing.T) {
+	oldEncryptedContent := testValidGrokEncryptedContentForSeed(10)
+	newEncryptedContent := testValidGrokEncryptedContentForSeed(12)
+	body := []byte(`{"input":[{"type":"reasoning","summary":[],"encrypted_content":""},{"type":"message","role":"assistant","content":[{"type":"output_text","text":"older answer"}]},{"type":"message","role":"user","content":[{"type":"input_text","text":"next"}]}]}`)
+	body, _ = sjson.SetBytes(body, "input.0.encrypted_content", oldEncryptedContent)
+	items := [][]byte{
+		[]byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":""}`),
+		[]byte(`{"type":"message","role":"assistant","content":[{"type":"output_text","text":"new answer"}]}`),
+	}
+	items[0], _ = sjson.SetBytes(items[0], "encrypted_content", newEncryptedContent)
+
+	filtered := filterXAIReasoningReplayItemsForInput(body, items)
+	if len(filtered) != 1 || gjson.GetBytes(filtered[0], "type").String() != "reasoning" {
+		t.Fatalf("filtered replay items = %q, want new reasoning only (input already has last assistant)", filtered)
+	}
+	if got := gjson.GetBytes(filtered[0], "encrypted_content").String(); got != newEncryptedContent {
+		t.Fatalf("filtered reasoning encrypted_content = %q, want new cached blob", got)
+	}
+}
+
+func TestFilterXAIReasoningReplayItemsSkipsDuplicateAssistantMessage(t *testing.T) {
+	encryptedContent := testValidGrokEncryptedContentForSeed(11)
+	body := []byte(`{"input":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"first answer"}]},{"type":"message","role":"user","content":[{"type":"input_text","text":"second"}]}]}`)
+	items := [][]byte{
+		[]byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":""}`),
+		[]byte(`{"type":"message","role":"assistant","content":[{"type":"output_text","text":"first answer"}]}`),
+	}
+	items[0], _ = sjson.SetBytes(items[0], "encrypted_content", encryptedContent)
+
+	filtered := filterXAIReasoningReplayItemsForInput(body, items)
+	if len(filtered) != 1 || gjson.GetBytes(filtered[0], "type").String() != "reasoning" {
+		t.Fatalf("filtered replay items = %q, want reasoning only", filtered)
+	}
+}
+
+func TestFilterXAIReasoningReplayItemsDoesNotMatchOlderAssistantMessage(t *testing.T) {
+	encryptedContent := testValidGrokEncryptedContentForSeed(13)
+	body := []byte(`{"input":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"OK"}]},{"type":"message","role":"user","content":[{"type":"input_text","text":"continue"}]},{"type":"message","role":"assistant","content":[{"type":"output_text","text":"different answer"}]},{"type":"message","role":"user","content":[{"type":"input_text","text":"next"}]}]}`)
+	items := [][]byte{
+		[]byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":""}`),
+		[]byte(`{"type":"message","role":"assistant","content":[{"type":"output_text","text":"OK"}]}`),
+	}
+	items[0], _ = sjson.SetBytes(items[0], "encrypted_content", encryptedContent)
+
+	filtered := filterXAIReasoningReplayItemsForInput(body, items)
+	if len(filtered) != 1 || gjson.GetBytes(filtered[0], "type").String() != "reasoning" {
+		t.Fatalf("filtered replay items = %q, want reasoning only when a later assistant already exists", filtered)
+	}
+}
+
+// Scenario #3 (partial inject): client already has a last assistant whose text
+// drifts from the cached message. Injecting the cached message would produce
+// two assistants around the same turn. Expect reasoning-only inject.
+func TestFilterXAIReasoningReplayItemsSkipsMessageWhenLastAssistantTextDrifts(t *testing.T) {
+	encryptedContent := testValidGrokEncryptedContentForSeed(20)
+	body := []byte(`{"input":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"first answer."}]},{"type":"message","role":"user","content":[{"type":"input_text","text":"second"}]}]}`)
+	items := [][]byte{
+		[]byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":""}`),
+		[]byte(`{"type":"message","role":"assistant","content":[{"type":"output_text","text":"first answer"}]}`),
+	}
+	items[0], _ = sjson.SetBytes(items[0], "encrypted_content", encryptedContent)
+
+	filtered := filterXAIReasoningReplayItemsForInput(body, items)
+	if len(filtered) != 1 || gjson.GetBytes(filtered[0], "type").String() != "reasoning" {
+		t.Fatalf("filtered = %q, want reasoning only for drifted last assistant", filtered)
+	}
+
+	// Full insert path: must not create two assistant messages.
+	updated, ok := insertCodexReasoningReplayItems(body, filtered)
+	if !ok {
+		t.Fatal("insertCodexReasoningReplayItems failed")
+	}
+	assistantCount := 0
+	for _, item := range gjson.GetBytes(updated, "input").Array() {
+		if item.Get("type").String() == "message" && item.Get("role").String() == "assistant" {
+			assistantCount++
+		}
+	}
+	if assistantCount != 1 {
+		t.Fatalf("assistant messages after inject = %d, want 1; body=%s", assistantCount, updated)
+	}
+	if gjson.GetBytes(updated, "input.0.type").String() != "reasoning" {
+		t.Fatalf("expected reasoning inserted before last assistant; body=%s", updated)
+	}
+}
+
+// Scenario #2: Claude multi-turn where the client resends older thinking signature
+// but drops the latest turn's signature. Cache holds the latest R(+M); upstream
+// must receive the latest encrypted blob, not only the older client-provided one.
+func TestXAIExecutorClaudeInjectsLatestCachedReasoningWhenHistoryHasOnlyOlderSignature(t *testing.T) {
+	internalcache.ClearXAIReasoningReplayCache()
+	t.Cleanup(internalcache.ClearXAIReasoningReplayCache)
+
+	oldEncrypted := testValidGrokEncryptedContentForSeed(21)
+	latestEncrypted := testValidGrokEncryptedContentForSeed(22)
+	var bodies [][]byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read body: %v", errRead)
+		}
+		bodies = append(bodies, body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		if len(bodies) == 1 {
+			_, _ = w.Write([]byte(`data: {"type":"response.output_item.done","item":{"id":"rs_latest","type":"reasoning","summary":[],"encrypted_content":"` + latestEncrypted + `"},"output_index":0}` + "\n"))
+			_, _ = w.Write([]byte(`data: {"type":"response.output_item.done","item":{"id":"msg_1","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"latest answer"}]},"output_index":1}` + "\n"))
+			_, _ = w.Write([]byte(`data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","model":"grok-4.5","output":[]}}` + "\n\n"))
+			return
+		}
+		_, _ = w.Write([]byte(`data: {"type":"response.completed","response":{"id":"resp_2","status":"completed","model":"grok-4.5","output":[]}}` + "\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewXAIExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		ID:         "xai-auth-claude-missing-latest-sig",
+		Provider:   "xai",
+		Attributes: map[string]string{"base_url": server.URL},
+		Metadata:   map[string]any{"access_token": "xai-token"},
+	}
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude, Stream: false}
+	ctx := testContextWithAPIKey("claude-missing-sig-key")
+
+	// Turn 1: user only -> cache latest R+M
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "grok-4.5",
+		Payload: []byte(`{"model":"grok-4.5","metadata":{"user_id":"{\"session_id\":\"claude-missing-latest\"}"},"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`),
+	}, opts)
+	if err != nil {
+		t.Fatalf("first Execute: %v", err)
+	}
+
+	// Turn 2 (actual failure shape): client keeps an OLDER thinking signature and the
+	// assistant text, but does not resend the latest encrypted/signature blob.
+	secondPayload := []byte(`{
+		"model":"grok-4.5",
+		"metadata":{"user_id":"{\"session_id\":\"claude-missing-latest\"}"},
+		"messages":[
+			{"role":"user","content":[{"type":"text","text":"hello"}]},
+			{"role":"assistant","content":[
+				{"type":"thinking","thinking":"older summary","signature":""},
+				{"type":"text","text":"latest answer"}
+			]},
+			{"role":"user","content":[{"type":"text","text":"next"}]}
+		]
+	}`)
+	secondPayload, _ = sjson.SetBytes(secondPayload, "messages.1.content.0.signature", oldEncrypted)
+
+	_, err = executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "grok-4.5",
+		Payload: secondPayload,
+	}, opts)
+	if err != nil {
+		t.Fatalf("second Execute: %v", err)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("upstream requests = %d, want 2", len(bodies))
+	}
+
+	// Upstream must include BOTH older client signature (as reasoning) and latest cached blob.
+	// At minimum the latest cached encrypted_content must be present for continuity.
+	second := bodies[1]
+	foundLatest := false
+	foundOld := false
+	assistantCount := 0
+	for _, item := range gjson.GetBytes(second, "input").Array() {
+		switch item.Get("type").String() {
+		case "reasoning":
+			enc := item.Get("encrypted_content").String()
+			if enc == latestEncrypted {
+				foundLatest = true
+			}
+			if enc == oldEncrypted {
+				foundOld = true
+			}
+		case "message":
+			if item.Get("role").String() == "assistant" {
+				assistantCount++
+			}
+		}
+	}
+	if !foundLatest {
+		t.Fatalf("latest cached encrypted_content missing from upstream body (broken Claude missing-signature scenario): %s", second)
+	}
+	if !foundOld {
+		t.Fatalf("older client signature/reasoning missing after translate: %s", second)
+	}
+	if assistantCount != 1 {
+		t.Fatalf("assistant messages = %d, want 1 (no partial double-message inject); body=%s", assistantCount, second)
+	}
+}
+
+func TestCacheXAIReasoningReplayFromCompletedClearsPreviousEntryWhenNoReplayableState(t *testing.T) {
+	internalcache.ClearXAIReasoningReplayCache()
+	t.Cleanup(internalcache.ClearXAIReasoningReplayCache)
+
+	modelName := "grok-4.5"
+	sessionKey := "prompt-cache:clear-previous"
+	encryptedContent := testValidGrokEncryptedContentForSeed(14)
+	previousItems := [][]byte{
+		[]byte(`{"type":"reasoning","summary":[],"content":null,"encrypted_content":""}`),
+		[]byte(`{"type":"message","role":"assistant","content":[{"type":"output_text","text":"previous answer"}]}`),
+	}
+	previousItems[0], _ = sjson.SetBytes(previousItems[0], "encrypted_content", encryptedContent)
+	if !internalcache.CacheXAIReasoningReplayItems(modelName, sessionKey, previousItems) {
+		t.Fatal("failed to seed xAI reasoning replay cache")
+	}
+
+	cacheXAIReasoningReplayFromCompleted(context.Background(), xaiReasoningReplayScope{
+		modelName:  modelName,
+		sessionKey: sessionKey,
+	}, []byte(`{"response":{"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"message without reasoning"}]}]}}`))
+
+	if _, ok := internalcache.GetXAIReasoningReplayItems(modelName, sessionKey); ok {
+		t.Fatal("expected previous replay entry to be cleared after non-replayable completed output")
+	}
+}
+
+func TestXAIReasoningReplayScopeIsolatesOpenAIResponsePromptCacheKeyByAPIKey(t *testing.T) {
+	payload := []byte(`{"model":"grok-4.5","prompt_cache_key":"shared-session","input":[]}`)
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse}
+	req := cliproxyexecutor.Request{Model: "grok-4.5", Payload: payload}
+
+	scopeA := xaiReasoningReplayScopeFromRequest(testContextWithAPIKey("api-key-a"), sdktranslator.FormatOpenAIResponse, req, opts, payload)
+	scopeB := xaiReasoningReplayScopeFromRequest(testContextWithAPIKey("api-key-b"), sdktranslator.FormatOpenAIResponse, req, opts, payload)
+	if !scopeA.valid() || !scopeB.valid() {
+		t.Fatalf("scopes must be valid with caller api keys: A=%+v B=%+v", scopeA, scopeB)
+	}
+	if scopeA.sessionKey == scopeB.sessionKey {
+		t.Fatalf("session keys must differ across callers, both %q", scopeA.sessionKey)
+	}
+	if !strings.HasPrefix(scopeA.sessionKey, "caller:") || !strings.Contains(scopeA.sessionKey, "prompt-cache:shared-session") {
+		t.Fatalf("session key A = %q, want caller-isolated prompt-cache key", scopeA.sessionKey)
+	}
+
+	scopeNoKey := xaiReasoningReplayScopeFromRequest(context.Background(), sdktranslator.FormatOpenAIResponse, req, opts, payload)
+	if scopeNoKey.valid() {
+		t.Fatalf("OpenAI Responses without caller API key must disable replay: %+v", scopeNoKey)
+	}
+}
+
+func TestXAIReasoningReplayScopeSkipsIncrementalWebsocketPreviousResponse(t *testing.T) {
+	scope := xaiReasoningReplayScopeFromRequest(
+		cliproxyexecutor.WithDownstreamWebsocket(context.Background()),
+		sdktranslator.FormatOpenAIResponse,
+		cliproxyexecutor.Request{
+			Model:   "grok-4.5",
+			Payload: []byte(`{"model":"grok-4.5","previous_response_id":"resp_1","prompt_cache_key":"codex-ws-session","input":[]}`),
+		},
+		cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse},
+		[]byte(`{"model":"grok-4.5","prompt_cache_key":"codex-ws-session","input":[]}`),
+	)
+	if scope.valid() {
+		t.Fatalf("incremental websocket request must not enable cache replay: %+v", scope)
 	}
 }
 

--- a/internal/runtime/executor/xai_reasoning_replay.go
+++ b/internal/runtime/executor/xai_reasoning_replay.go
@@ -122,7 +122,14 @@ func filterXAIReasoningReplayItemsForInput(body []byte, items [][]byte) [][]byte
 	}
 
 	inputItems := input.Array()
-	_, hasLastAssistantMessage := xaiInputLastAssistantMessage(inputItems)
+	lastAssistantMessage, hasLastAssistantMessage := xaiInputLastAssistantMessage(inputItems)
+	cachedAssistantMessage, hasCachedAssistantMessage := xaiReplayAssistantMessage(items)
+	assistantMessageMatches := hasLastAssistantMessage && hasCachedAssistantMessage &&
+		xaiAssistantMessageContentEqual(lastAssistantMessage.Get("content"), cachedAssistantMessage.Get("content"))
+	ambiguousAssistantHistory := hasLastAssistantMessage && hasCachedAssistantMessage && !assistantMessageMatches
+	if ambiguousAssistantHistory {
+		return nil
+	}
 	existingCalls := make(map[string]bool)
 	existingOutputs := make(map[string]bool)
 	for _, inputItem := range inputItems {
@@ -149,11 +156,7 @@ func filterXAIReasoningReplayItemsForInput(body []byte, items [][]byte) [][]byte
 				continue
 			}
 		case "message":
-			// If the client already has any trailing assistant message, never inject
-			// another one. Equal content is a true duplicate; unequal content would
-			// create two adjacent assistants (partial-history / drift), which breaks
-			// turn pairing. Inject reasoning alone in that case.
-			if hasLastAssistantMessage {
+			if assistantMessageMatches {
 				continue
 			}
 		case "function_call", "custom_tool_call":
@@ -188,13 +191,73 @@ func filterXAIReasoningReplayItemsForInput(body []byte, items [][]byte) [][]byte
 func xaiInputLastAssistantMessage(inputItems []gjson.Result) (gjson.Result, bool) {
 	for i := len(inputItems) - 1; i >= 0; i-- {
 		inputItem := inputItems[i]
-		if strings.TrimSpace(inputItem.Get("type").String()) != "message" ||
-			!strings.EqualFold(strings.TrimSpace(inputItem.Get("role").String()), "assistant") {
+		itemType := strings.TrimSpace(inputItem.Get("type").String())
+		if (itemType != "" && itemType != "message") || !strings.EqualFold(strings.TrimSpace(inputItem.Get("role").String()), "assistant") {
 			continue
 		}
 		return inputItem, true
 	}
 	return gjson.Result{}, false
+}
+
+func xaiReplayAssistantMessage(items [][]byte) (gjson.Result, bool) {
+	for _, item := range items {
+		itemResult := gjson.ParseBytes(item)
+		if strings.TrimSpace(itemResult.Get("type").String()) == "message" &&
+			strings.EqualFold(strings.TrimSpace(itemResult.Get("role").String()), "assistant") {
+			return itemResult, true
+		}
+	}
+	return gjson.Result{}, false
+}
+
+type xaiAssistantMessagePart struct {
+	partType string
+	value    string
+}
+
+func xaiAssistantMessageContentEqual(left, right gjson.Result) bool {
+	leftParts, leftOK := xaiAssistantMessageParts(left)
+	rightParts, rightOK := xaiAssistantMessageParts(right)
+	if !leftOK || !rightOK || len(leftParts) != len(rightParts) {
+		return false
+	}
+	for i := range leftParts {
+		if leftParts[i] != rightParts[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func xaiAssistantMessageParts(content gjson.Result) ([]xaiAssistantMessagePart, bool) {
+	if content.Type == gjson.String {
+		return []xaiAssistantMessagePart{{partType: "output_text", value: content.String()}}, true
+	}
+	if !content.IsArray() {
+		return nil, false
+	}
+	parts := make([]xaiAssistantMessagePart, 0, len(content.Array()))
+	for _, part := range content.Array() {
+		partType := strings.TrimSpace(part.Get("type").String())
+		switch partType {
+		case "output_text":
+			text := part.Get("text")
+			if text.Type != gjson.String {
+				return nil, false
+			}
+			parts = append(parts, xaiAssistantMessagePart{partType: partType, value: text.String()})
+		case "refusal":
+			refusal := part.Get("refusal")
+			if refusal.Type != gjson.String {
+				return nil, false
+			}
+			parts = append(parts, xaiAssistantMessagePart{partType: partType, value: refusal.String()})
+		default:
+			return nil, false
+		}
+	}
+	return parts, len(parts) > 0
 }
 
 func cacheXAIReasoningReplayFromCompleted(ctx context.Context, scope xaiReasoningReplayScope, completedData []byte) {

--- a/internal/runtime/executor/xai_reasoning_replay.go
+++ b/internal/runtime/executor/xai_reasoning_replay.go
@@ -2,10 +2,12 @@ package executor
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"strings"
 
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
-	"github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
@@ -52,30 +54,61 @@ func xaiReasoningReplayScopeFromRequest(ctx context.Context, from sdktranslator.
 	if !xaiReasoningReplayEnabledForSource(from) {
 		return xaiReasoningReplayScope{}
 	}
+	// End-to-end WebSocket requests use upstream previous_response_id state.
+	// Replaying encrypted reasoning as input as well would duplicate the turn.
+	if cliproxyexecutor.DownstreamWebsocket(ctx) && strings.TrimSpace(gjson.GetBytes(req.Payload, "previous_response_id").String()) != "" {
+		return xaiReasoningReplayScope{}
+	}
+	sessionKey := codexReasoningReplaySessionKey(ctx, from, req, opts, body)
+	sessionKey = xaiReasoningReplayIsolateSessionKey(ctx, from, sessionKey)
 	return xaiReasoningReplayScope{
 		modelName:  thinking.ParseSuffix(req.Model).ModelName,
-		sessionKey: codexReasoningReplaySessionKey(ctx, from, req, opts, body),
+		sessionKey: sessionKey,
 	}
+}
+
+// xaiReasoningReplayIsolateSessionKey namespaces client-controlled session keys
+// by the downstream CPA API key so two callers cannot share encrypted reasoning
+// or assistant text by reusing prompt_cache_key / window / session headers.
+// Trusted execution session keys keep their existing form. OpenAI Responses
+// without a caller API key is disabled rather than storing under a global key.
+func xaiReasoningReplayIsolateSessionKey(ctx context.Context, from sdktranslator.Format, sessionKey string) string {
+	sessionKey = strings.TrimSpace(sessionKey)
+	if sessionKey == "" {
+		return ""
+	}
+	if strings.HasPrefix(sessionKey, "execution:") {
+		return sessionKey
+	}
+	apiKey := strings.TrimSpace(helps.APIKeyFromContext(ctx))
+	if apiKey == "" {
+		if sourceFormatEqual(from, sdktranslator.FormatOpenAIResponse) {
+			return ""
+		}
+		return sessionKey
+	}
+	sum := sha256.Sum256([]byte(apiKey))
+	return "caller:" + hex.EncodeToString(sum[:8]) + ":" + sessionKey
 }
 
 func xaiReasoningReplayEnabledForSource(from sdktranslator.Format) bool {
-	return sourceFormatEqual(from, sdktranslator.FormatClaude)
+	return sourceFormatEqual(from, sdktranslator.FormatClaude) ||
+		sourceFormatEqual(from, sdktranslator.FormatOpenAIResponse)
 }
 
-func xaiInputHasValidReasoningEncryptedContent(body []byte) bool {
-	input := gjson.GetBytes(body, "input")
-	if !input.IsArray() {
+func xaiInputHasReasoningEncryptedContent(inputItems []gjson.Result, encryptedContent string) bool {
+	if encryptedContent == "" {
 		return false
 	}
-	for _, item := range input.Array() {
+	for _, item := range inputItems {
 		if strings.TrimSpace(item.Get("type").String()) != "reasoning" {
 			continue
 		}
-		encryptedContent := item.Get("encrypted_content")
-		if encryptedContent.Type != gjson.String {
+		inputEncryptedContent := item.Get("encrypted_content")
+		if inputEncryptedContent.Type != gjson.String {
 			continue
 		}
-		if _, err := signature.InspectGrokEncryptedContent(encryptedContent.String()); err == nil {
+		if inputEncryptedContent.String() == encryptedContent {
 			return true
 		}
 	}
@@ -88,10 +121,11 @@ func filterXAIReasoningReplayItemsForInput(body []byte, items [][]byte) [][]byte
 		return nil
 	}
 
-	hasInputReasoning := xaiInputHasValidReasoningEncryptedContent(body)
+	inputItems := input.Array()
+	_, hasLastAssistantMessage := xaiInputLastAssistantMessage(inputItems)
 	existingCalls := make(map[string]bool)
 	existingOutputs := make(map[string]bool)
-	for _, inputItem := range input.Array() {
+	for _, inputItem := range inputItems {
 		itemType := strings.TrimSpace(inputItem.Get("type").String())
 		if itemType == "function_call_output" || itemType == "custom_tool_call_output" {
 			callID := strings.TrimSpace(inputItem.Get("call_id").String())
@@ -111,7 +145,15 @@ func filterXAIReasoningReplayItemsForInput(body []byte, items [][]byte) [][]byte
 		itemResult := gjson.ParseBytes(item)
 		switch strings.TrimSpace(itemResult.Get("type").String()) {
 		case "reasoning":
-			if hasInputReasoning {
+			if xaiInputHasReasoningEncryptedContent(inputItems, itemResult.Get("encrypted_content").String()) {
+				continue
+			}
+		case "message":
+			// If the client already has any trailing assistant message, never inject
+			// another one. Equal content is a true duplicate; unequal content would
+			// create two adjacent assistants (partial-history / drift), which breaks
+			// turn pairing. Inject reasoning alone in that case.
+			if hasLastAssistantMessage {
 				continue
 			}
 		case "function_call", "custom_tool_call":
@@ -143,6 +185,48 @@ func filterXAIReasoningReplayItemsForInput(body []byte, items [][]byte) [][]byte
 	return filtered
 }
 
+func xaiInputLastAssistantMessage(inputItems []gjson.Result) (gjson.Result, bool) {
+	for i := len(inputItems) - 1; i >= 0; i-- {
+		inputItem := inputItems[i]
+		if strings.TrimSpace(inputItem.Get("type").String()) != "message" ||
+			!strings.EqualFold(strings.TrimSpace(inputItem.Get("role").String()), "assistant") {
+			continue
+		}
+		return inputItem, true
+	}
+	return gjson.Result{}, false
+}
+
+func xaiAssistantMessageContentEqual(left, right gjson.Result) bool {
+	if !left.IsArray() || !right.IsArray() {
+		return false
+	}
+	leftParts := left.Array()
+	rightParts := right.Array()
+	if len(leftParts) != len(rightParts) {
+		return false
+	}
+	for i := range leftParts {
+		if strings.TrimSpace(leftParts[i].Get("type").String()) != strings.TrimSpace(rightParts[i].Get("type").String()) ||
+			xaiAssistantMessagePartValue(leftParts[i]) != xaiAssistantMessagePartValue(rightParts[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func xaiAssistantMessagePartValue(part gjson.Result) string {
+	switch strings.TrimSpace(part.Get("type").String()) {
+	case "refusal":
+		if refusal := part.Get("refusal"); refusal.Type == gjson.String {
+			return refusal.String()
+		}
+		return part.Get("text").String()
+	default:
+		return part.Get("text").String()
+	}
+}
+
 func cacheXAIReasoningReplayFromCompleted(ctx context.Context, scope xaiReasoningReplayScope, completedData []byte) {
 	if !scope.valid() {
 		return
@@ -157,15 +241,24 @@ func cacheXAIReasoningReplayFromCompleted(ctx context.Context, scope xaiReasonin
 	items := make([][]byte, 0, len(output.Array()))
 	for _, item := range output.Array() {
 		switch strings.TrimSpace(item.Get("type").String()) {
-		case "reasoning", "function_call", "custom_tool_call":
+		case "reasoning", "message", "function_call", "custom_tool_call":
 			items = append(items, []byte(item.Raw))
 		default:
 			continue
 		}
 	}
-	if !internalcache.CacheXAIReasoningReplayItemsBestEffort(ctx, scope.modelName, scope.sessionKey, items) {
+	switch internalcache.StoreXAIReasoningReplayItems(ctx, scope.modelName, scope.sessionKey, items) {
+	case internalcache.XAIReasoningReplayStored:
+		return
+	case internalcache.XAIReasoningReplayNoReplayableState:
+		// Successful completed turn without cacheable reasoning must not leave
+		// a previous turn's encrypted state to be injected later.
 		if errDelete := internalcache.DeleteXAIReasoningReplayItemRequired(ctx, scope.modelName, scope.sessionKey); errDelete != nil {
-			log.Warnf("xai reasoning replay cache delete failed after completed cache store failed: %v", errDelete)
+			log.Warnf("xai reasoning replay cache delete failed after non-replayable completed output: %v", errDelete)
 		}
+	case internalcache.XAIReasoningReplayStoreBackendError:
+		log.Debug("xai reasoning replay cache store backend error; retaining previous entry")
+	default:
+		// Invalid args: nothing to store or clear.
 	}
 }

--- a/internal/runtime/executor/xai_reasoning_replay.go
+++ b/internal/runtime/executor/xai_reasoning_replay.go
@@ -292,3 +292,15 @@ func cacheXAIReasoningReplayFromCompleted(ctx context.Context, scope xaiReasonin
 		// Invalid args: nothing to store or clear.
 	}
 }
+
+func clearXAIReasoningReplayAfterCompaction(ctx context.Context, scope xaiReasoningReplayScope) {
+	if !scope.valid() {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if errDelete := internalcache.DeleteXAIReasoningReplayItemRequired(ctx, scope.modelName, scope.sessionKey); errDelete != nil {
+		log.Warnf("xai reasoning replay cache delete failed after successful compaction: %v", errDelete)
+	}
+}

--- a/internal/runtime/executor/xai_reasoning_replay.go
+++ b/internal/runtime/executor/xai_reasoning_replay.go
@@ -60,7 +60,7 @@ func xaiReasoningReplayScopeFromRequest(ctx context.Context, from sdktranslator.
 		return xaiReasoningReplayScope{}
 	}
 	sessionKey := codexReasoningReplaySessionKey(ctx, from, req, opts, body)
-	sessionKey = xaiReasoningReplayIsolateSessionKey(ctx, from, sessionKey)
+	sessionKey = xaiReasoningReplayIsolateSessionKey(ctx, sessionKey)
 	return xaiReasoningReplayScope{
 		modelName:  thinking.ParseSuffix(req.Model).ModelName,
 		sessionKey: sessionKey,
@@ -70,9 +70,9 @@ func xaiReasoningReplayScopeFromRequest(ctx context.Context, from sdktranslator.
 // xaiReasoningReplayIsolateSessionKey namespaces client-controlled session keys
 // by the downstream CPA API key so two callers cannot share encrypted reasoning
 // or assistant text by reusing prompt_cache_key / window / session headers.
-// Trusted execution session keys keep their existing form. OpenAI Responses
-// without a caller API key is disabled rather than storing under a global key.
-func xaiReasoningReplayIsolateSessionKey(ctx context.Context, from sdktranslator.Format, sessionKey string) string {
+// Trusted execution session keys keep their existing form. Client-controlled
+// sessions without a caller API key are disabled rather than shared globally.
+func xaiReasoningReplayIsolateSessionKey(ctx context.Context, sessionKey string) string {
 	sessionKey = strings.TrimSpace(sessionKey)
 	if sessionKey == "" {
 		return ""
@@ -82,10 +82,7 @@ func xaiReasoningReplayIsolateSessionKey(ctx context.Context, from sdktranslator
 	}
 	apiKey := strings.TrimSpace(helps.APIKeyFromContext(ctx))
 	if apiKey == "" {
-		if sourceFormatEqual(from, sdktranslator.FormatOpenAIResponse) {
-			return ""
-		}
-		return sessionKey
+		return ""
 	}
 	sum := sha256.Sum256([]byte(apiKey))
 	return "caller:" + hex.EncodeToString(sum[:8]) + ":" + sessionKey

--- a/internal/runtime/executor/xai_reasoning_replay.go
+++ b/internal/runtime/executor/xai_reasoning_replay.go
@@ -197,36 +197,6 @@ func xaiInputLastAssistantMessage(inputItems []gjson.Result) (gjson.Result, bool
 	return gjson.Result{}, false
 }
 
-func xaiAssistantMessageContentEqual(left, right gjson.Result) bool {
-	if !left.IsArray() || !right.IsArray() {
-		return false
-	}
-	leftParts := left.Array()
-	rightParts := right.Array()
-	if len(leftParts) != len(rightParts) {
-		return false
-	}
-	for i := range leftParts {
-		if strings.TrimSpace(leftParts[i].Get("type").String()) != strings.TrimSpace(rightParts[i].Get("type").String()) ||
-			xaiAssistantMessagePartValue(leftParts[i]) != xaiAssistantMessagePartValue(rightParts[i]) {
-			return false
-		}
-	}
-	return true
-}
-
-func xaiAssistantMessagePartValue(part gjson.Result) string {
-	switch strings.TrimSpace(part.Get("type").String()) {
-	case "refusal":
-		if refusal := part.Get("refusal"); refusal.Type == gjson.String {
-			return refusal.String()
-		}
-		return part.Get("text").String()
-	default:
-		return part.Get("text").String()
-	}
-}
-
 func cacheXAIReasoningReplayFromCompleted(ctx context.Context, scope xaiReasoningReplayScope, completedData []byte) {
 	if !scope.valid() {
 		return

--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -139,9 +139,16 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 					return
 				}
 
-				signature, ok := sigcompat.CompatibleSignatureForProvider(sigcompat.SignatureProviderGPT, part.Get("signature").String())
+				rawSignature := part.Get("signature").String()
+				signature, ok := sigcompat.CompatibleSignatureForProvider(sigcompat.SignatureProviderGPT, rawSignature)
 				if !ok {
-					return
+					if !codexClaudeTargetAcceptsGrokSignature(modelName) {
+						return
+					}
+					if _, err := sigcompat.InspectGrokEncryptedContent(rawSignature); err != nil {
+						return
+					}
+					signature = rawSignature
 				}
 
 				flushMessage()
@@ -341,6 +348,11 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 	template, _ = sjson.SetBytes(template, "include", []string{"reasoning.encrypted_content"})
 
 	return template
+}
+
+func codexClaudeTargetAcceptsGrokSignature(modelName string) bool {
+	baseModel := strings.ToLower(strings.TrimSpace(thinking.ParseSuffix(modelName).ModelName))
+	return strings.Contains(baseModel, "grok")
 }
 
 func normalizeCodexServiceTier(result gjson.Result) string {

--- a/internal/translator/codex/claude/codex_claude_request_test.go
+++ b/internal/translator/codex/claude/codex_claude_request_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 func TestConvertClaudeRequestToCodex_SystemMessageScenarios(t *testing.T) {
@@ -477,6 +478,36 @@ func TestConvertClaudeRequestToCodex_AssistantThinkingSignatureToReasoningItem(t
 	}
 	if strings.Contains(string(result), "visible summary must not be replayed") {
 		t.Fatalf("thinking text should not be replayed into Codex input. Output: %s", string(result))
+	}
+}
+
+func TestConvertClaudeRequestToCodex_AssistantGrokSignatureToReasoningItem(t *testing.T) {
+	signature := "HmlYdr2aCAqCYP/m9mr8PS6KOsdMs72FGDigmydR+Jsmuv8KX97yWPlbOwmXJgWn0CbHaCacdQD3+n5EvpgLfPNmafS3kdICBjRuDf4bzHy7uBiUhNVhqPtp/ee1y9q4imPE4LYgD1VZ4J+bp9mTeqA1+nC9Oue58CiNEMV9SVaGenCD+aBnVuSTzQhD32Y+68i6HLJW0Dx6ifaRfb8hxYtA/sPM+/FTvAMW11nRho5a2BBSkpnzfqqAz/e/vGJ77/bygpXM823QA9wL9i0X"
+	payload := []byte(`{"model":"grok-4.5","messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"summary","signature":""},{"type":"text","text":"answer"}]},{"role":"user","content":"next"}]}`)
+	payload, _ = sjson.SetBytes(payload, "messages.0.content.0.signature", signature)
+
+	out := ConvertClaudeRequestToCodex("grok-4.5", payload, false)
+	reasoning := gjson.GetBytes(out, "input.0")
+	if reasoning.Get("type").String() != "reasoning" {
+		t.Fatalf("input.0 type = %q, want reasoning; output=%s", reasoning.Get("type").String(), out)
+	}
+	if got := reasoning.Get("encrypted_content").String(); got != signature {
+		t.Fatalf("encrypted_content = %q, want Grok signature", got)
+	}
+}
+
+func TestConvertClaudeRequestToCodex_IgnoresGrokSignatureForNonGrokTargets(t *testing.T) {
+	signature := "HmlYdr2aCAqCYP/m9mr8PS6KOsdMs72FGDigmydR+Jsmuv8KX97yWPlbOwmXJgWn0CbHaCacdQD3+n5EvpgLfPNmafS3kdICBjRuDf4bzHy7uBiUhNVhqPtp/ee1y9q4imPE4LYgD1VZ4J+bp9mTeqA1+nC9Oue58CiNEMV9SVaGenCD+aBnVuSTzQhD32Y+68i6HLJW0Dx6ifaRfb8hxYtA/sPM+/FTvAMW11nRho5a2BBSkpnzfqqAz/e/vGJ77/bygpXM823QA9wL9i0X"
+	payload := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"summary","signature":""},{"type":"text","text":"answer"}]},{"role":"user","content":"next"}]}`)
+	payload, _ = sjson.SetBytes(payload, "messages.0.content.0.signature", signature)
+
+	for _, modelName := range []string{"gpt-5.4", "claude-sonnet-4-6"} {
+		t.Run(modelName, func(t *testing.T) {
+			out := ConvertClaudeRequestToCodex(modelName, payload, false)
+			if got := countRequestInputItemsByType(out, "reasoning"); got != 0 {
+				t.Fatalf("got %d reasoning items for non-Grok target, want 0; output=%s", got, out)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 结果与合并约束

同步 Core Upstream `v7.2.71`，吸收 xAI encrypted reasoning replay 的 tenant isolation、compaction/cache 清理、tool-call-only 和 assistant/refusal 边界，同时保留 CPA-Core-LTS 的 Alpha Search auth lifecycle 与全部 usage/Management 契约。

本 PR 是三段 Core 同步的 Stage 1，必须使用 **Create a merge commit**。不包含 tag、release、Docker publish 或 HF deployment。

## Type

- [ ] Protected upstream full-sync
- [x] Staged upstream full-sync
- [ ] LTS protected-delta patch
- [ ] LTS feature / downstream patch maintenance
- [ ] Maintenance docs / CI
- [ ] Emergency hotfix

## Upstream sync info

- Upstream repo: `router-for-me/CLIProxyAPI`
- Upstream branch: `main`
- Upstream from SHA: `9c3f7207106a59f5a0b87cf8d7f1e9ab648159c2` (`v7.2.70`)
- Upstream to SHA: `5b7f2361ee27d195f6514dde08656f6e4773a9a4` (`v7.2.71`)
- Sync branch: `codex/sync-upstream-v7.2.71-20260713`
- Local validated head: `fa6a8b31afa574794f7609ba47a9276eb5106985`

## Protected delta checklist

- [x] `usage-statistics-enabled` and `internal/usage/` remain present
- [x] `/v0/management/usage`, `/export`, `/import` remain present
- [x] `docs/lts/core-feature-contracts.yaml` reviewed
- [x] `docs/lts/downstream-patches.yaml` reviewed
- [x] Usage record/schema and Management response shape tests passed
- [x] Export/import and CPA-Panel-LTS response contracts reviewed; no shape change
- [x] Local auth/config/panel/release/source customizations reviewed

## LTS classification review

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| `full-usage-statistics-core` | retained capability | preserved | contract guard, usage tests, repo-wide tests |
| `management-usage-api` | retained capability | preserved | Management usage tests |
| `panel-release-asset` | retained capability | preserved | not touched; contract guard |
| `auth-identity-attribution` | retained capability | adapted | xAI replay isolated by downstream caller API key |
| `config-compatibility-and-hot-reload` | retained capability | preserved | not touched |
| `redis-compatible-usage-queue` | LTS feature | preserved | contract guard and repo-wide tests |
| `commercial-neutral-documentation` | LTS feature | preserved | README/assets not touched |
| `provider-runtime-usage-seams` | review seam | adapted | executor/translator targeted and race tests |
| `codex-model-fallback` | downstream patch | patch-still-required | common xAI resolver added without widening the Claude-only fallback gate |
| `codex-rate-limit-continuity` | downstream patch | patch-still-required | no equivalent continuity state machine |
| `codex-interactions-service-tier-response` | downstream patch | patch-still-required | response-tier behavior remains downstream |
| `plugin-configured-enable-default` | downstream patch | patch-still-required | no equivalent in this range |
| `codex-gpt56-ultra-level` | downstream patch | patch-still-required | server-side Ultra/wire/usage behavior remains downstream |
| `codex-model-header-provider-snapshot` | downstream patch | patch-still-required | no equivalent immutable provider snapshot |
| `codex-oauth-client-identity-finalization` | downstream patch | patch-still-required | no equivalent final identity pass |
| `codex-model-not-found-request-scope` | downstream patch | patch-still-required | typed request-scope 404 boundary remains downstream |
| `codex-websocket-reader-generation` | downstream patch | patch-still-required | no equivalent generation ownership |
| `codex-spark-reasoning-summary-compat` | downstream patch | patch-still-required | Spark sanitizer remains downstream |
| `hf-space-runtime-smoke` | validation profile | preserved | skipped because no deployment is in scope |

- [x] This sync PR will use **Create a merge commit**; squash/rebase is forbidden.

## Conflict resolution notes

Text conflicts were limited to `internal/api/server.go` and `internal/api/server_test.go`. Resolution retained Gin context propagation into `SelectAuthForRequest`, selected `resultCtx`, and dispatch/result accounting; it deliberately does not regress to plain `SelectAuth`.

The first targeted run exposed an LTS integration seam: the downstream Codex replay resolver intentionally accepts only Claude, while Upstream xAI replay also needs OpenAI Responses session keys. The resolution adds a common replay-key resolver for xAI while keeping `ResolveCodexReasoningReplaySessionKey` Claude-gated, so `codex-model-fallback` preflight is not widened.

## Validation

- [x] `scripts/check-lts-contract.sh`
- [x] `go run ./scripts/ltsregistry --root .`
- [x] `go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'`
- [x] `go build -o test-output ./cmd/server && rm -f test-output`
- [x] `go test -count=1 ./internal/cache ./internal/runtime/executor ./internal/translator/codex/claude ./internal/api`
- [x] `go test -race -count=1 ./internal/cache ./internal/runtime/executor ./internal/translator/codex/claude ./internal/api`
- [x] `go test ./...`
- [x] `go list ./... | rg -v '/tmp$' | xargs go test -count=1`
- [x] `git diff --check origin/main...HEAD`

## Optional real runtime smoke

- [x] Hugging Face Space smoke explicitly skipped
- Reason: no deployment, release or runtime update is in scope.
- Space/runtime SHA: not changed
- `/healthz`, `/management.html`, `/v0/management/usage*`: not run against live deployment