### PR TITLE
sync(lts): 引入 Codex 客户端模型目录刷新与 LTS 兼容保护

### DIFF
--- a/.github/scripts/refresh-model-catalogs.sh
+++ b/.github/scripts/refresh-model-catalogs.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+models_repository="${MODELS_REPOSITORY_URL:-https://github.com/router-for-me/models.git}"
+models_ref="${MODELS_REPOSITORY_REF:-main}"
+catalog_dir="${MODEL_CATALOG_DIR:-internal/registry/models}"
+codex_catalog="$catalog_dir/codex_client_models.json"
+codex_candidate="$(mktemp)"
+trap 'rm -f "$codex_candidate"' EXIT
+
+git fetch --depth 1 "$models_repository" "$models_ref"
+git show FETCH_HEAD:models.json > "$catalog_dir/models.json"
+
+if git show FETCH_HEAD:codex_client_models.json > "$codex_candidate" &&
+  go run ./cmd/validate_codex_models --file "$codex_candidate"; then
+	mv "$codex_candidate" "$codex_catalog"
+	printf 'Refreshed validated Codex client model catalog.\n'
+else
+	printf '::warning::Remote Codex client model catalog is missing or invalid; using embedded fallback.\n'
+fi
+
+go run ./cmd/validate_codex_models --file "$codex_catalog"

--- a/.github/scripts/refresh-model-catalogs.sh
+++ b/.github/scripts/refresh-model-catalogs.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+models_repository="${MODELS_REPOSITORY_URL:-https://github.com/router-for-me/models.git}"
+models_ref="${MODELS_REPOSITORY_REF:-main}"
+catalog_dir="${MODEL_CATALOG_DIR:-internal/registry/models}"
+codex_catalog="$catalog_dir/codex_client_models.json"
+codex_candidate="$(mktemp)"
+trap 'rm -f "$codex_candidate"' EXIT
+
+git fetch --depth 1 "$models_repository" "$models_ref"
+git show FETCH_HEAD:models.json > "$catalog_dir/models.json"
+
+if git show FETCH_HEAD:codex_client_models.json > "$codex_candidate" &&
+  go run ./cmd/validate_codex_models --file "$codex_candidate"; then
+	mv "$codex_candidate" "$codex_catalog"
+	printf 'Refreshed validated Codex client model catalog.\n'
+else
+  printf '::warning::Remote Codex client model catalog is missing, invalid, or LTS-incompatible; using embedded fallback.\n'
+fi
+
+go run ./cmd/validate_codex_models --file "$codex_catalog"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,10 +15,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
       - name: Refresh models catalog
-        run: |
-          git fetch --depth 1 https://github.com/router-for-me/models.git main
-          git show FETCH_HEAD:models.json > internal/registry/models/models.json
+        run: bash .github/scripts/refresh-model-catalogs.sh
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
@@ -50,10 +53,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
       - name: Refresh models catalog
-        run: |
-          git fetch --depth 1 https://github.com/router-for-me/models.git main
-          git show FETCH_HEAD:models.json > internal/registry/models/models.json
+        run: bash .github/scripts/refresh-model-catalogs.sh
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,10 +19,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
       - name: Refresh models catalog
-        run: |
-          git fetch --depth 1 https://github.com/router-for-me/models.git main
-          git show FETCH_HEAD:models.json > internal/registry/models/models.json
+        run: bash .github/scripts/refresh-model-catalogs.sh
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GHCR
@@ -57,10 +60,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
       - name: Refresh models catalog
-        run: |
-          git fetch --depth 1 https://github.com/router-for-me/models.git main
-          git show FETCH_HEAD:models.json > internal/registry/models/models.json
+        run: bash .github/scripts/refresh-model-catalogs.sh
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GHCR

--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -12,15 +12,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Refresh models catalog
-        run: |
-          git fetch --depth 1 https://github.com/router-for-me/models.git main
-          git show FETCH_HEAD:models.json > internal/registry/models/models.json
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           cache: true
+      - name: Refresh models catalog
+        run: bash .github/scripts/refresh-model-catalogs.sh
       - name: Build
         run: |
           go build -o test-output ./cmd/server

--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -12,15 +12,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Refresh models catalog
-        run: |
-          git fetch --depth 1 https://github.com/router-for-me/models.git main
-          git show FETCH_HEAD:models.json > internal/registry/models/models.json
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           cache: true
+      - name: Refresh models catalog
+        run: bash .github/scripts/refresh-model-catalogs.sh
       - name: Validate GPT-5.6 Ultra compatibility
         run: |
           go test ./internal/registry ./internal/thinking \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -127,19 +127,16 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Refresh models catalog
-        shell: bash
-        run: |
-          set -euo pipefail
-          git fetch --depth 1 https://github.com/router-for-me/models.git main
-          git show FETCH_HEAD:models.json > internal/registry/models/models.json
-      - name: Fetch tags
-        shell: bash
-        run: git fetch --force --tags
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
+      - name: Refresh models catalog
+        shell: bash
+        run: bash .github/scripts/refresh-model-catalogs.sh
+      - name: Fetch tags
+        shell: bash
+        run: git fetch --force --tags
       - uses: actions/cache@v4
         with:
           path: |
@@ -257,12 +254,13 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
       - name: Refresh models catalog
         shell: bash
-        run: |
-          set -euo pipefail
-          git fetch --depth 1 https://github.com/router-for-me/models.git main
-          git show FETCH_HEAD:models.json > internal/registry/models/models.json
+        run: bash .github/scripts/refresh-model-catalogs.sh
       - name: Fetch tags
         shell: bash
         run: git fetch --force --tags
@@ -388,19 +386,16 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Refresh models catalog
-        shell: bash
-        run: |
-          set -euo pipefail
-          git fetch --depth 1 https://github.com/router-for-me/models.git main
-          git show FETCH_HEAD:models.json > internal/registry/models/models.json
-      - name: Fetch tags
-        shell: bash
-        run: git fetch --force --tags
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
+      - name: Refresh models catalog
+        shell: bash
+        run: bash .github/scripts/refresh-model-catalogs.sh
+      - name: Fetch tags
+        shell: bash
+        run: git fetch --force --tags
       - uses: actions/cache@v4
         with:
           path: |
@@ -519,16 +514,14 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Refresh models catalog
-        run: |
-          git fetch --depth 1 https://github.com/router-for-me/models.git main
-          git show FETCH_HEAD:models.json > internal/registry/models/models.json
-      - name: Fetch tags
-        run: git fetch --force --tags
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
+      - name: Refresh models catalog
+        run: bash .github/scripts/refresh-model-catalogs.sh
+      - name: Fetch tags
+        run: git fetch --force --tags
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,15 +27,12 @@ jobs:
         with:
           ref: ${{ github.event.inputs.release_tag || github.ref }}
           fetch-depth: 0
-      - name: Refresh models catalog
-        run: |
-          set -euo pipefail
-          git fetch --depth 1 https://github.com/router-for-me/models.git main
-          git show FETCH_HEAD:models.json > internal/registry/models/models.json
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
+      - name: Refresh models catalog
+        run: bash .github/scripts/refresh-model-catalogs.sh
       - name: Validate GPT-5.6 Ultra compatibility
         run: |
           go test ./internal/registry ./internal/thinking \
@@ -45,7 +42,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: validated-models-catalog
-          path: internal/registry/models/models.json
+          path: |
+            internal/registry/models/models.json
+            internal/registry/models/codex_client_models.json
           if-no-files-found: error
           retention-days: 1
 
@@ -180,13 +179,13 @@ jobs:
         with:
           name: validated-models-catalog
           path: internal/registry/models
-      - name: Fetch tags
-        shell: bash
-        run: git fetch --force --tags
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
+      - name: Fetch tags
+        shell: bash
+        run: git fetch --force --tags
       - uses: actions/cache@v4
         with:
           path: |
@@ -459,13 +458,13 @@ jobs:
         with:
           name: validated-models-catalog
           path: internal/registry/models
-      - name: Fetch tags
-        shell: bash
-        run: git fetch --force --tags
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
+      - name: Fetch tags
+        shell: bash
+        run: git fetch --force --tags
       - uses: actions/cache@v4
         with:
           path: |
@@ -605,12 +604,12 @@ jobs:
         with:
           name: validated-models-catalog
           path: internal/registry/models
-      - name: Fetch tags
-        run: git fetch --force --tags
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
+      - name: Fetch tags
+        run: git fetch --force --tags
       - uses: actions/cache@v4
         with:
           path: |

--- a/cmd/fetch_codex_models/main.go
+++ b/cmd/fetch_codex_models/main.go
@@ -10,8 +10,8 @@
 //
 //	--auths-dir       <path>  Directory containing auth JSON files (default: config auth-dir)
 //	--config          <path>  Config file path                 (default: "config.yaml")
-//	--output          <path>  Output JSON file path             (default: "codex_models.json")
-//	--client-version <ver>   Codex client_version query value  (default: "0.133.0")
+//	--output          <path>  Output JSON file path             (default: "codex_client_models.json")
+//	--client-version <ver>   Codex client_version query value  (default: "0.144.1")
 //	--pretty                 Pretty-print the output JSON      (default: true)
 package main
 
@@ -62,7 +62,7 @@ func main() {
 
 	flag.StringVar(&authsDir, "auths-dir", "", "Directory containing auth JSON files (overrides config auth-dir)")
 	flag.StringVar(&configPath, "config", "", "Configure File Path")
-	flag.StringVar(&outputPath, "output", "codex_models.json", "Output JSON file path")
+	flag.StringVar(&outputPath, "output", "codex_client_models.json", "Output JSON file path")
 	flag.StringVar(&clientVersion, "client-version", defaultClientVersion, "Codex client_version query value")
 	flag.BoolVar(&pretty, "pretty", true, "Pretty-print the output JSON")
 	flag.Parse()
@@ -296,11 +296,14 @@ func codexModelsURL(clientVersion string) (string, error) {
 
 func countModels(raw []byte) (int, error) {
 	var payload struct {
-		Models []map[string]any `json:"models"`
+		Models []json.RawMessage `json:"models"`
 	}
 	if err := json.Unmarshal(raw, &payload); err != nil {
 		return 0, fmt.Errorf("failed to parse response JSON: %w", err)
 	}
+	// Keep this check intentionally loose: fetch_codex_models dumps the upstream
+	// Codex API payload. Strict CPA catalog validation belongs in
+	// cmd/validate_codex_models and registry.ValidateCodexClientModelsJSON.
 	if payload.Models == nil {
 		return 0, fmt.Errorf("response JSON does not contain models array")
 	}

--- a/cmd/fetch_codex_models/main_test.go
+++ b/cmd/fetch_codex_models/main_test.go
@@ -1,0 +1,48 @@
+package main
+
+import "testing"
+
+func TestCodexModelsURL(t *testing.T) {
+	got, err := codexModelsURL(" 0.144.1 ")
+	if err != nil {
+		t.Fatalf("codexModelsURL: %v", err)
+	}
+	want := "https://chatgpt.com/backend-api/codex/models?client_version=0.144.1"
+	if got != want {
+		t.Fatalf("codexModelsURL = %q, want %q", got, want)
+	}
+}
+
+func TestCountModels(t *testing.T) {
+	count, err := countModels([]byte(`{"models":[{"slug":"a"},{"slug":"b"}]}`))
+	if err != nil {
+		t.Fatalf("countModels(valid): %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("countModels(valid) = %d, want 2", count)
+	}
+
+	// Upstream dumps may omit CPA catalog-required fields; counting must still work.
+	count, err = countModels([]byte(`{"models":[{"slug":"gpt-5.6-sol"}]}`))
+	if err != nil {
+		t.Fatalf("countModels(incomplete upstream model): %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("countModels(incomplete upstream model) = %d, want 1", count)
+	}
+
+	count, err = countModels([]byte(`{"models":[]}`))
+	if err != nil {
+		t.Fatalf("countModels(empty): %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("countModels(empty) = %d, want 0", count)
+	}
+
+	if _, err := countModels([]byte(`{"models":`)); err == nil {
+		t.Fatal("countModels(malformed) error = nil, want error")
+	}
+	if _, err := countModels([]byte(`{}`)); err == nil {
+		t.Fatal("countModels(missing models) error = nil, want error")
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -107,7 +107,7 @@ func main() {
 	flag.BoolVar(&homeDisableClusterDiscovery, "home-disable-cluster-discovery", false, "Disable Home CLUSTER NODES discovery and keep using the configured -home-jwt address")
 	flag.BoolVar(&tuiMode, "tui", false, "Start with terminal management UI")
 	flag.BoolVar(&standalone, "standalone", false, "In TUI mode, start an embedded local server")
-	flag.BoolVar(&localModel, "local-model", false, "Use embedded model catalog only, skip remote model fetching")
+	flag.BoolVar(&localModel, "local-model", false, "Use embedded models.json and codex_client_models.json only, skip remote model catalog fetching")
 
 	flag.CommandLine.Usage = func() {
 		out := flag.CommandLine.Output()
@@ -621,18 +621,14 @@ func main() {
 			return
 		}
 		if localModel && (!tuiMode || standalone) {
-			log.Info("Local model mode: using embedded model catalog, remote model updates disabled")
+			log.Info("Local model mode: using embedded model catalogs, remote model updates disabled")
 		}
 		if tuiMode {
 			if standalone {
 				// Standalone mode: start an embedded local server and connect TUI client to it.
 				managementasset.StartAutoUpdater(context.Background(), configFilePath)
 				misc.StartAntigravityVersionUpdater(context.Background())
-				if !localModel && !cfg.Home.Enabled {
-					registry.StartModelsUpdater(context.Background())
-				} else if cfg.Home.Enabled {
-					log.Info("Home mode: remote model updates disabled")
-				}
+				startModelCatalogUpdaters(localModel, cfg.Home.Enabled)
 				hook := tui.NewLogHook(2000)
 				hook.SetFormatter(&logging.LogFormatter{})
 				log.AddHook(hook)
@@ -706,13 +702,31 @@ func main() {
 			// Start the main proxy service
 			managementasset.StartAutoUpdater(context.Background(), configFilePath)
 			misc.StartAntigravityVersionUpdater(context.Background())
-			if !localModel && !cfg.Home.Enabled {
-				registry.StartModelsUpdater(context.Background())
-			} else if cfg.Home.Enabled {
-				log.Info("Home mode: remote model updates disabled")
-			}
+			startModelCatalogUpdaters(localModel, cfg.Home.Enabled)
 			cmd.StartServiceWithPluginHost(cfg, configFilePath, password, pluginHost, serverOptions...)
 		}
+	}
+}
+
+// modelCatalogUpdaterPlan decides which remote model catalogs should refresh.
+// Codex client templates still refresh under Home mode because the model list
+// comes from Home IDs while template metadata stays edge-local.
+func modelCatalogUpdaterPlan(localModel, homeEnabled bool) (startModels, startCodexClient bool) {
+	if localModel {
+		return false, false
+	}
+	return !homeEnabled, true
+}
+
+func startModelCatalogUpdaters(localModel, homeEnabled bool) {
+	startModels, startCodexClient := modelCatalogUpdaterPlan(localModel, homeEnabled)
+	if startCodexClient {
+		registry.StartCodexClientModelsUpdater(context.Background())
+	}
+	if startModels {
+		registry.StartModelsUpdater(context.Background())
+	} else if homeEnabled {
+		log.Info("Home mode: remote models.json updates disabled; Codex client model list follows Home model IDs")
 	}
 }
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -110,7 +110,7 @@ func main() {
 	flag.BoolVar(&homeDisableClusterDiscovery, "home-disable-cluster-discovery", false, "Disable Home CLUSTER NODES discovery and keep using the configured -home-jwt address")
 	flag.BoolVar(&tuiMode, "tui", false, "Start with terminal management UI")
 	flag.BoolVar(&standalone, "standalone", false, "In TUI mode, start an embedded local server")
-	flag.BoolVar(&localModel, "local-model", false, "Use embedded model catalog only, skip remote model fetching")
+	flag.BoolVar(&localModel, "local-model", false, "Use embedded models.json and codex_client_models.json only, skip remote model catalog fetching")
 
 	flag.CommandLine.Usage = func() {
 		out := flag.CommandLine.Output()
@@ -625,18 +625,14 @@ func main() {
 			return
 		}
 		if localModel && (!tuiMode || standalone) {
-			log.Info("Local model mode: using embedded model catalog, remote model updates disabled")
+			log.Info("Local model mode: using embedded model catalogs, remote model updates disabled")
 		}
 		if tuiMode {
 			if standalone {
 				// Standalone mode: start an embedded local server and connect TUI client to it.
 				managementasset.StartAutoUpdater(context.Background(), configFilePath)
 				misc.StartAntigravityVersionUpdater(context.Background())
-				if !localModel && !cfg.Home.Enabled {
-					registry.StartModelsUpdater(context.Background())
-				} else if cfg.Home.Enabled {
-					log.Info("Home mode: remote model updates disabled")
-				}
+				startModelCatalogUpdaters(localModel, cfg.Home.Enabled)
 				hook := tui.NewLogHook(2000)
 				hook.SetFormatter(&logging.LogFormatter{})
 				log.AddHook(hook)
@@ -710,13 +706,31 @@ func main() {
 			// Start the main proxy service
 			managementasset.StartAutoUpdater(context.Background(), configFilePath)
 			misc.StartAntigravityVersionUpdater(context.Background())
-			if !localModel && !cfg.Home.Enabled {
-				registry.StartModelsUpdater(context.Background())
-			} else if cfg.Home.Enabled {
-				log.Info("Home mode: remote model updates disabled")
-			}
+			startModelCatalogUpdaters(localModel, cfg.Home.Enabled)
 			cmd.StartServiceWithPluginHost(cfg, configFilePath, password, pluginHost, serverOptions...)
 		}
+	}
+}
+
+// modelCatalogUpdaterPlan decides which remote model catalogs should refresh.
+// Codex client templates still refresh under Home mode because the model list
+// comes from Home IDs while template metadata stays edge-local.
+func modelCatalogUpdaterPlan(localModel, homeEnabled bool) (startModels, startCodexClient bool) {
+	if localModel {
+		return false, false
+	}
+	return !homeEnabled, true
+}
+
+func startModelCatalogUpdaters(localModel, homeEnabled bool) {
+	startModels, startCodexClient := modelCatalogUpdaterPlan(localModel, homeEnabled)
+	if startCodexClient {
+		registry.StartCodexClientModelsUpdater(context.Background())
+	}
+	if startModels {
+		registry.StartModelsUpdater(context.Background())
+	} else if homeEnabled {
+		log.Info("Home mode: remote models.json updates disabled; Codex client model list follows Home model IDs")
 	}
 }
 

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -87,3 +87,51 @@ func TestShouldEnableExampleAPIKeySafeMode(t *testing.T) {
 		})
 	}
 }
+
+func TestModelCatalogUpdaterPlan(t *testing.T) {
+	tests := []struct {
+		name            string
+		localModel      bool
+		homeEnabled     bool
+		wantModels      bool
+		wantCodexClient bool
+	}{
+		{
+			name:            "normal CPA refreshes both catalogs",
+			localModel:      false,
+			homeEnabled:     false,
+			wantModels:      true,
+			wantCodexClient: true,
+		},
+		{
+			name:            "home mode keeps models.json local and refreshes codex templates",
+			localModel:      false,
+			homeEnabled:     true,
+			wantModels:      false,
+			wantCodexClient: true,
+		},
+		{
+			name:            "local-model disables both remote catalogs",
+			localModel:      true,
+			homeEnabled:     false,
+			wantModels:      false,
+			wantCodexClient: false,
+		},
+		{
+			name:            "local-model disables both remote catalogs even under home",
+			localModel:      true,
+			homeEnabled:     true,
+			wantModels:      false,
+			wantCodexClient: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotModels, gotCodex := modelCatalogUpdaterPlan(tt.localModel, tt.homeEnabled)
+			if gotModels != tt.wantModels || gotCodex != tt.wantCodexClient {
+				t.Fatalf("modelCatalogUpdaterPlan(%v, %v) = (%v, %v), want (%v, %v)",
+					tt.localModel, tt.homeEnabled, gotModels, gotCodex, tt.wantModels, tt.wantCodexClient)
+			}
+		})
+	}
+}

--- a/cmd/validate_codex_models/main.go
+++ b/cmd/validate_codex_models/main.go
@@ -1,0 +1,32 @@
+// Command validate_codex_models validates a Codex client model catalog file.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+func main() {
+	var inputPath string
+	flag.StringVar(&inputPath, "file", "", "Codex client model catalog JSON file")
+	flag.Parse()
+
+	if strings.TrimSpace(inputPath) == "" {
+		fmt.Fprintln(os.Stderr, "error: --file is required")
+		os.Exit(2)
+	}
+	data, err := os.ReadFile(inputPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: read %s: %v\n", inputPath, err)
+		os.Exit(1)
+	}
+	if err = registry.ValidateCodexClientModelsJSON(data); err != nil {
+		fmt.Fprintf(os.Stderr, "error: invalid Codex client model catalog %s: %v\n", inputPath, err)
+		os.Exit(1)
+	}
+	fmt.Printf("Validated Codex client model catalog: %s\n", inputPath)
+}

--- a/cmd/validate_codex_models/main.go
+++ b/cmd/validate_codex_models/main.go
@@ -1,0 +1,36 @@
+// Command validate_codex_models validates a Codex client model catalog file.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+func main() {
+	var inputPath string
+	flag.StringVar(&inputPath, "file", "", "Codex client model catalog JSON file")
+	flag.Parse()
+
+	if strings.TrimSpace(inputPath) == "" {
+		fmt.Fprintln(os.Stderr, "error: --file is required")
+		os.Exit(2)
+	}
+	data, err := os.ReadFile(inputPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: read %s: %v\n", inputPath, err)
+		os.Exit(1)
+	}
+	if err = registry.ValidateCodexClientModelsJSON(data); err != nil {
+		fmt.Fprintf(os.Stderr, "error: invalid Codex client model catalog %s: %v\n", inputPath, err)
+		os.Exit(1)
+	}
+	if err = registry.ValidateCodexClientModelsLTSCompatibility(data); err != nil {
+		fmt.Fprintf(os.Stderr, "error: LTS-incompatible Codex client model catalog %s: %v\n", inputPath, err)
+		os.Exit(1)
+	}
+	fmt.Printf("Validated Codex client model catalog: %s\n", inputPath)
+}

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -169,14 +169,22 @@ patches:
     retire_when: Upstream preserves the configured plugin enable default through both YAML parsing and runtime host synthesis, and all listed tests pass without the downstream implementation.
 
   - id: codex-gpt56-ultra-level
-    reason: Temporary downstream compatibility patch after upstream added partial GPT-5.6 Ultra client metadata and then removed Ultra from models.json. The official models catalog refreshed by PR and release builds remains max-only, so CPA-Core-LTS applies a stable non-generated Codex capability overlay for logical Sol/Terra Ultra while keeping Luna max-only, then canonicalizes supported Ultra requests to reasoning.effort=max on the final HTTP/WebSocket wire.
+    reason: Upstream now publishes and remotely refreshes Codex client metadata with logical Sol/Terra Ultra and Luna max-only, but it still does not provide the CPA-Core-LTS server-side capability overlay, custom-model policy, payload-override-safe wire canonicalization, usage/retry alignment, or HTTP/WebSocket enforcement. CPA-Core-LTS therefore validates the refreshed client catalog as an LTS prerequisite while retaining the downstream runtime patch.
     introduced_in: 6e12fb1dd6d522ca80a02644d286d765d7a649bd
-    affected_upstream_range: LTS baseline through f4a8aee69500038289064bf5aba5ffc11cabd603 (v7.2.69); upstream added partial client metadata at 20e61f281f4b88e150c5cdfa81c3315d9fcfeabe and removed Ultra from models.json at f084eefae6a9aa67c273a697e4c3fdfc15102032, while router-for-me/models.git main at 9e658ffbc94b0d46392019c59d47d7dc7e5a2b96 still exposes Sol/Terra/Luna only through max; neither source provides the stable provider lookup/tier overlay, model-aware custom-model behavior, payload-override-safe final wire canonicalization, usage/retry alignment, or HTTP/WebSocket regression coverage
+    affected_upstream_range: Through 4fe2c60c5152f45e1180346a5186743cfac58363; upstream PR #4276 and router-for-me/models.git main at a837d9dba1c2d755eaa1ec4f535511c202cb3906 provide a revisioned, remotely refreshed Codex client catalog with Sol/Terra Ultra and Luna max-only. This is client-metadata equivalence only and does not replace the downstream provider lookup/tier overlay, model-aware custom-model behavior, payload-override-safe final reasoning.effort, usage/retry alignment, or HTTP/WebSocket regressions.
     files:
+      - .github/scripts/refresh-model-catalogs.sh
+      - .github/workflows/docker-image.yml
       - .github/workflows/pr-test-build.yml
       - .github/workflows/release.yaml
+      - cmd/server/main.go
+      - cmd/server/main_test.go
+      - cmd/validate_codex_models/main.go
       - config.example.yaml
       - docs/lts/codex-client-context-degradation-defense.md
+      - internal/registry/codex_client_models.go
+      - internal/registry/codex_client_models_test.go
+      - internal/registry/codex_client_models_updater.go
       - internal/registry/codex_compatibility.go
       - internal/registry/codex_gpt56_compatibility_test.go
       - internal/registry/model_definitions.go
@@ -222,9 +230,13 @@ patches:
       - TestCodexExecutorAbnormalReasoningRetry_PayloadOverrideUltraUsesFinalMaxUsage
       - TestCodexClientModelsResponse_GPT56UltraReasoningMetadata
       - TestCodexClientReasoningDescriptionUltra
-    upstream_issue_or_pr: router-for-me/CLIProxyAPI#4160 (partial client-metadata equivalent only)
+      - TestValidateCodexClientModelsLTSCompatibility
+      - TestFetchCodexClientModelsFallsBackToNextURL
+      - TestLoadCodexClientModelsRejectsInvalidWithoutReplacing
+      - TestModelCatalogUpdaterPlan
+    upstream_issue_or_pr: router-for-me/CLIProxyAPI#4160 and router-for-me/CLIProxyAPI#4276 (client-metadata equivalent only)
     state: required
-    retire_when: Upstream publishes a complete and authoritative Ultra server-side solution covering parser/suffix semantics, model-aware custom-model behavior, payload-override-safe final reasoning.effort, usage/retry alignment, and HTTP/WebSocket paths while preserving the client-side proactive multi-agent boundary; all listed Max/Ultra regressions must pass after removing this downstream implementation.
+    retire_when: Upstream publishes a complete and authoritative Ultra server-side solution covering parser/suffix semantics, model-aware custom-model behavior, payload-override-safe final reasoning.effort, usage/retry alignment, and HTTP/WebSocket paths while preserving the client-side proactive multi-agent boundary; the refreshed client catalog continues to satisfy the LTS compatibility validator and all listed regressions pass after removing the downstream runtime implementation.
 
   - id: codex-model-header-provider-snapshot
     reason: Codex model override headers must be resolved from the Codex provider and captured once so the real handshake and connection key cannot disagree or be shadowed by another provider registration.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1180,6 +1180,8 @@ func (s *Server) unifiedModelsHandler(openaiHandler *openai.OpenAIAPIHandler, cl
 	}
 }
 
+// handleHomeCodexClientModels builds the Codex client catalog from Home model IDs.
+// Template metadata still comes from the local/remote codex_client_models catalog.
 func (s *Server) handleHomeCodexClientModels(c *gin.Context) {
 	entries, ok := s.loadHomeModelEntries(c)
 	if !ok {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1364,6 +1364,8 @@ func (s *Server) unifiedModelsHandler(openaiHandler *openai.OpenAIAPIHandler, cl
 	}
 }
 
+// handleHomeCodexClientModels builds the Codex client catalog from Home model IDs.
+// Template metadata still comes from the local/remote codex_client_models catalog.
 func (s *Server) handleHomeCodexClientModels(c *gin.Context) {
 	entries, ok := s.loadHomeModelEntries(c)
 	if !ok {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -919,8 +919,9 @@ func TestModelsWithClientVersionReturnsCodexCatalog(t *testing.T) {
 	if got, _ := custom["display_name"].(string); got != "Custom Codex Model" {
 		t.Fatalf("custom display_name = %q, want Custom Codex Model", got)
 	}
-	if got := int(codexClientTestPriority(custom["priority"])); got != 129 {
-		t.Fatalf("custom priority = %v, want 129", custom["priority"])
+	wantCustomPriority := codexClientTestMaxTemplatePriority(t) + 100
+	if got := int(codexClientTestPriority(custom["priority"])); got != wantCustomPriority {
+		t.Fatalf("custom priority = %v, want %d", custom["priority"], wantCustomPriority)
 	}
 	if got, _ := custom["description"].(string); got != "Custom model from registry" {
 		t.Fatalf("custom description = %q, want Custom model from registry", got)
@@ -985,6 +986,23 @@ func codexClientTestPriority(raw any) int {
 	default:
 		return -1
 	}
+}
+
+func codexClientTestMaxTemplatePriority(t *testing.T) int {
+	t.Helper()
+	var payload struct {
+		Models []map[string]any `json:"models"`
+	}
+	if err := json.Unmarshal(registry.GetCodexClientModelsJSON(), &payload); err != nil {
+		t.Fatalf("parse Codex client model templates: %v", err)
+	}
+	maxPriority := 0
+	for _, model := range payload.Models {
+		if priority := codexClientTestPriority(model["priority"]); priority > maxPriority {
+			maxPriority = priority
+		}
+	}
+	return maxPriority
 }
 
 func assertCodexSupportedReasoningLevels(t *testing.T, model map[string]any, want []string) {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1571,7 +1571,6 @@ func codexClientTestPriority(raw any) int {
 
 func codexClientTestMaxTemplatePriority(t *testing.T) int {
 	t.Helper()
-
 	var catalog struct {
 		Models []map[string]any `json:"models"`
 	}

--- a/internal/registry/codex_client_models.go
+++ b/internal/registry/codex_client_models.go
@@ -1,11 +1,174 @@
 package registry
 
-import _ "embed"
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+)
 
 //go:embed models/codex_client_models.json
-var codexClientModelsJSON []byte
+var embeddedCodexClientModelsJSON []byte
 
-// GetCodexClientModelsJSON returns the embedded Codex client model catalog.
+type codexClientModelsPayload struct {
+	Models []map[string]any `json:"models"`
+}
+
+type codexClientModelsStore struct {
+	mu       sync.RWMutex
+	data     []byte
+	revision uint64
+}
+
+var codexClientCatalogStore = &codexClientModelsStore{}
+
+func init() {
+	if _, err := loadCodexClientModelsFromBytes(embeddedCodexClientModelsJSON, "embed"); err != nil {
+		log.Warnf("registry: failed to parse embedded codex_client_models.json (Codex client catalog will remain unavailable until a valid remote refresh): %v", err)
+	}
+}
+
+// GetCodexClientModelsJSON returns the current Codex client model catalog.
 func GetCodexClientModelsJSON() []byte {
-	return append([]byte(nil), codexClientModelsJSON...)
+	data, _ := GetCodexClientModelsSnapshot()
+	return data
+}
+
+// GetCodexClientModelsSnapshot returns a consistent catalog copy and revision.
+// The revision changes only when validated catalog content changes.
+func GetCodexClientModelsSnapshot() ([]byte, uint64) {
+	codexClientCatalogStore.mu.RLock()
+	defer codexClientCatalogStore.mu.RUnlock()
+	return append([]byte(nil), codexClientCatalogStore.data...), codexClientCatalogStore.revision
+}
+
+func loadCodexClientModelsFromBytes(data []byte, source string) (bool, error) {
+	if err := ValidateCodexClientModelsJSON(data); err != nil {
+		return false, fmt.Errorf("%s: %w", source, err)
+	}
+
+	cloned := append([]byte(nil), data...)
+	codexClientCatalogStore.mu.Lock()
+	defer codexClientCatalogStore.mu.Unlock()
+	if bytes.Equal(codexClientCatalogStore.data, cloned) {
+		return false, nil
+	}
+	codexClientCatalogStore.data = cloned
+	codexClientCatalogStore.revision++
+	return true, nil
+}
+
+// ValidateCodexClientModelsJSON validates the fields required to serve a
+// complete Codex client model catalog.
+func ValidateCodexClientModelsJSON(data []byte) error {
+	var payload codexClientModelsPayload
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return fmt.Errorf("decode Codex client model catalog: %w", err)
+	}
+	if len(payload.Models) == 0 {
+		return fmt.Errorf("Codex client model catalog has no models")
+	}
+
+	seen := make(map[string]struct{}, len(payload.Models))
+	for i, model := range payload.Models {
+		slug, err := requiredCodexClientModelString(model, "slug")
+		if err != nil {
+			return fmt.Errorf("Codex client model catalog models[%d]: %w", i, err)
+		}
+		if _, exists := seen[slug]; exists {
+			return fmt.Errorf("Codex client model catalog contains duplicate slug %q", slug)
+		}
+		seen[slug] = struct{}{}
+
+		if err = validateCodexClientModel(model); err != nil {
+			return fmt.Errorf("Codex client model catalog model %q: %w", slug, err)
+		}
+	}
+	if _, ok := seen["gpt-5.5"]; !ok {
+		return fmt.Errorf("Codex client model catalog is missing default template %q", "gpt-5.5")
+	}
+	return nil
+}
+
+func validateCodexClientModel(model map[string]any) error {
+	for _, field := range []string{
+		"display_name",
+		"description",
+		"base_instructions",
+		"minimal_client_version",
+		"visibility",
+		"default_reasoning_level",
+	} {
+		if _, err := requiredCodexClientModelString(model, field); err != nil {
+			return err
+		}
+	}
+
+	contextWindow, err := requiredCodexClientModelInteger(model, "context_window", true)
+	if err != nil {
+		return err
+	}
+	maxContextWindow, err := requiredCodexClientModelInteger(model, "max_context_window", true)
+	if err != nil {
+		return err
+	}
+	if contextWindow > maxContextWindow {
+		return fmt.Errorf("context_window %d exceeds max_context_window %d", contextWindow, maxContextWindow)
+	}
+	if _, err = requiredCodexClientModelInteger(model, "priority", false); err != nil {
+		return err
+	}
+
+	levels, ok := model["supported_reasoning_levels"].([]any)
+	if !ok || len(levels) == 0 {
+		return fmt.Errorf("field %q must be a non-empty array", "supported_reasoning_levels")
+	}
+	seenLevels := make(map[string]struct{}, len(levels))
+	for i, rawLevel := range levels {
+		level, ok := rawLevel.(map[string]any)
+		if !ok {
+			return fmt.Errorf("field %q entry %d must be an object", "supported_reasoning_levels", i)
+		}
+		effort, errEffort := requiredCodexClientModelString(level, "effort")
+		if errEffort != nil {
+			return fmt.Errorf("field %q entry %d: %w", "supported_reasoning_levels", i, errEffort)
+		}
+		if _, exists := seenLevels[effort]; exists {
+			return fmt.Errorf("field %q contains duplicate effort %q", "supported_reasoning_levels", effort)
+		}
+		seenLevels[effort] = struct{}{}
+	}
+	defaultLevel, _ := requiredCodexClientModelString(model, "default_reasoning_level")
+	if _, ok = seenLevels[defaultLevel]; !ok {
+		return fmt.Errorf("default_reasoning_level %q is not listed in supported_reasoning_levels", defaultLevel)
+	}
+	return nil
+}
+
+func requiredCodexClientModelString(model map[string]any, field string) (string, error) {
+	value, ok := model[field].(string)
+	value = strings.TrimSpace(value)
+	if !ok || value == "" {
+		return "", fmt.Errorf("field %q must be a non-empty string", field)
+	}
+	return value, nil
+}
+
+func requiredCodexClientModelInteger(model map[string]any, field string, positive bool) (int64, error) {
+	value, ok := model[field].(float64)
+	if !ok || math.IsNaN(value) || math.IsInf(value, 0) || math.Trunc(value) != value || value > math.MaxInt64 {
+		return 0, fmt.Errorf("field %q must be an integer", field)
+	}
+	if positive && value <= 0 {
+		return 0, fmt.Errorf("field %q must be positive", field)
+	}
+	if !positive && value < 0 {
+		return 0, fmt.Errorf("field %q must not be negative", field)
+	}
+	return int64(value), nil
 }

--- a/internal/registry/codex_client_models.go
+++ b/internal/registry/codex_client_models.go
@@ -1,11 +1,246 @@
 package registry
 
-import _ "embed"
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+)
 
 //go:embed models/codex_client_models.json
-var codexClientModelsJSON []byte
+var embeddedCodexClientModelsJSON []byte
 
-// GetCodexClientModelsJSON returns the embedded Codex client model catalog.
+type codexClientModelsPayload struct {
+	Models []map[string]any `json:"models"`
+}
+
+type codexClientModelsStore struct {
+	mu       sync.RWMutex
+	data     []byte
+	revision uint64
+}
+
+var codexClientCatalogStore = &codexClientModelsStore{}
+
+func init() {
+	if _, err := loadCodexClientModelsFromBytes(embeddedCodexClientModelsJSON, "embed"); err != nil {
+		log.Warnf("registry: failed to parse embedded codex_client_models.json (Codex client catalog will remain unavailable until a valid remote refresh): %v", err)
+	}
+}
+
+// GetCodexClientModelsJSON returns the current Codex client model catalog.
 func GetCodexClientModelsJSON() []byte {
-	return append([]byte(nil), codexClientModelsJSON...)
+	data, _ := GetCodexClientModelsSnapshot()
+	return data
+}
+
+// GetCodexClientModelsSnapshot returns a consistent catalog copy and revision.
+// The revision changes only when validated catalog content changes.
+func GetCodexClientModelsSnapshot() ([]byte, uint64) {
+	codexClientCatalogStore.mu.RLock()
+	defer codexClientCatalogStore.mu.RUnlock()
+	return append([]byte(nil), codexClientCatalogStore.data...), codexClientCatalogStore.revision
+}
+
+func loadCodexClientModelsFromBytes(data []byte, source string) (bool, error) {
+	if err := validateCodexClientModelsForLTS(data); err != nil {
+		return false, fmt.Errorf("%s: %w", source, err)
+	}
+
+	cloned := append([]byte(nil), data...)
+	codexClientCatalogStore.mu.Lock()
+	defer codexClientCatalogStore.mu.Unlock()
+	if bytes.Equal(codexClientCatalogStore.data, cloned) {
+		return false, nil
+	}
+	codexClientCatalogStore.data = cloned
+	codexClientCatalogStore.revision++
+	return true, nil
+}
+
+func validateCodexClientModelsForLTS(data []byte) error {
+	if err := ValidateCodexClientModelsJSON(data); err != nil {
+		return err
+	}
+	if err := ValidateCodexClientModelsLTSCompatibility(data); err != nil {
+		return fmt.Errorf("LTS compatibility: %w", err)
+	}
+	return nil
+}
+
+// ValidateCodexClientModelsJSON validates the fields required to serve a
+// complete Codex client model catalog.
+func ValidateCodexClientModelsJSON(data []byte) error {
+	var payload codexClientModelsPayload
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return fmt.Errorf("decode Codex client model catalog: %w", err)
+	}
+	if len(payload.Models) == 0 {
+		return fmt.Errorf("Codex client model catalog has no models")
+	}
+
+	seen := make(map[string]struct{}, len(payload.Models))
+	for i, model := range payload.Models {
+		slug, err := requiredCodexClientModelString(model, "slug")
+		if err != nil {
+			return fmt.Errorf("Codex client model catalog models[%d]: %w", i, err)
+		}
+		if _, exists := seen[slug]; exists {
+			return fmt.Errorf("Codex client model catalog contains duplicate slug %q", slug)
+		}
+		seen[slug] = struct{}{}
+
+		if err = validateCodexClientModel(model); err != nil {
+			return fmt.Errorf("Codex client model catalog model %q: %w", slug, err)
+		}
+	}
+	if _, ok := seen["gpt-5.5"]; !ok {
+		return fmt.Errorf("Codex client model catalog is missing default template %q", "gpt-5.5")
+	}
+	return nil
+}
+
+// ValidateCodexClientModelsLTSCompatibility enforces the Codex client model
+// capabilities required by CPA-Core-LTS without mixing downstream policy into
+// the upstream-compatible catalog schema validator.
+func ValidateCodexClientModelsLTSCompatibility(data []byte) error {
+	var payload codexClientModelsPayload
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return fmt.Errorf("decode Codex client model catalog: %w", err)
+	}
+
+	models := make(map[string]map[string]any, len(payload.Models))
+	for _, model := range payload.Models {
+		slug, _ := model["slug"].(string)
+		slug = strings.TrimSpace(slug)
+		if slug != "" {
+			models[slug] = model
+		}
+	}
+
+	requirements := []struct {
+		slug      string
+		required  []string
+		forbidden []string
+	}{
+		{slug: "gpt-5.6-sol", required: []string{"max", "ultra"}},
+		{slug: "gpt-5.6-terra", required: []string{"max", "ultra"}},
+		{slug: "gpt-5.6-luna", required: []string{"max"}, forbidden: []string{"ultra"}},
+	}
+	for _, requirement := range requirements {
+		model, ok := models[requirement.slug]
+		if !ok {
+			return fmt.Errorf("Codex client model catalog is missing LTS model %q", requirement.slug)
+		}
+		levels, ok := model["supported_reasoning_levels"].([]any)
+		if !ok {
+			return fmt.Errorf("Codex client model %q has invalid supported_reasoning_levels", requirement.slug)
+		}
+		seen := make(map[string]struct{}, len(levels))
+		for _, rawLevel := range levels {
+			level, okLevel := rawLevel.(map[string]any)
+			if !okLevel {
+				continue
+			}
+			effort, _ := level["effort"].(string)
+			effort = strings.TrimSpace(effort)
+			if effort != "" {
+				seen[effort] = struct{}{}
+			}
+		}
+		for _, effort := range requirement.required {
+			if _, ok = seen[effort]; !ok {
+				return fmt.Errorf("Codex client model %q is missing required reasoning effort %q", requirement.slug, effort)
+			}
+		}
+		for _, effort := range requirement.forbidden {
+			if _, ok = seen[effort]; ok {
+				return fmt.Errorf("Codex client model %q must not expose reasoning effort %q", requirement.slug, effort)
+			}
+		}
+	}
+	return nil
+}
+
+func validateCodexClientModel(model map[string]any) error {
+	for _, field := range []string{
+		"display_name",
+		"description",
+		"base_instructions",
+		"minimal_client_version",
+		"visibility",
+		"default_reasoning_level",
+	} {
+		if _, err := requiredCodexClientModelString(model, field); err != nil {
+			return err
+		}
+	}
+
+	contextWindow, err := requiredCodexClientModelInteger(model, "context_window", true)
+	if err != nil {
+		return err
+	}
+	maxContextWindow, err := requiredCodexClientModelInteger(model, "max_context_window", true)
+	if err != nil {
+		return err
+	}
+	if contextWindow > maxContextWindow {
+		return fmt.Errorf("context_window %d exceeds max_context_window %d", contextWindow, maxContextWindow)
+	}
+	if _, err = requiredCodexClientModelInteger(model, "priority", false); err != nil {
+		return err
+	}
+
+	levels, ok := model["supported_reasoning_levels"].([]any)
+	if !ok || len(levels) == 0 {
+		return fmt.Errorf("field %q must be a non-empty array", "supported_reasoning_levels")
+	}
+	seenLevels := make(map[string]struct{}, len(levels))
+	for i, rawLevel := range levels {
+		level, ok := rawLevel.(map[string]any)
+		if !ok {
+			return fmt.Errorf("field %q entry %d must be an object", "supported_reasoning_levels", i)
+		}
+		effort, errEffort := requiredCodexClientModelString(level, "effort")
+		if errEffort != nil {
+			return fmt.Errorf("field %q entry %d: %w", "supported_reasoning_levels", i, errEffort)
+		}
+		if _, exists := seenLevels[effort]; exists {
+			return fmt.Errorf("field %q contains duplicate effort %q", "supported_reasoning_levels", effort)
+		}
+		seenLevels[effort] = struct{}{}
+	}
+	defaultLevel, _ := requiredCodexClientModelString(model, "default_reasoning_level")
+	if _, ok = seenLevels[defaultLevel]; !ok {
+		return fmt.Errorf("default_reasoning_level %q is not listed in supported_reasoning_levels", defaultLevel)
+	}
+	return nil
+}
+
+func requiredCodexClientModelString(model map[string]any, field string) (string, error) {
+	value, ok := model[field].(string)
+	value = strings.TrimSpace(value)
+	if !ok || value == "" {
+		return "", fmt.Errorf("field %q must be a non-empty string", field)
+	}
+	return value, nil
+}
+
+func requiredCodexClientModelInteger(model map[string]any, field string, positive bool) (int64, error) {
+	value, ok := model[field].(float64)
+	if !ok || math.IsNaN(value) || math.IsInf(value, 0) || math.Trunc(value) != value || value > math.MaxInt64 {
+		return 0, fmt.Errorf("field %q must be an integer", field)
+	}
+	if positive && value <= 0 {
+		return 0, fmt.Errorf("field %q must be positive", field)
+	}
+	if !positive && value < 0 {
+		return 0, fmt.Errorf("field %q must not be negative", field)
+	}
+	return int64(value), nil
 }

--- a/internal/registry/codex_client_models_test.go
+++ b/internal/registry/codex_client_models_test.go
@@ -1,0 +1,208 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestEmbeddedCodexClientModelsCatalogIsValid(t *testing.T) {
+	data, revision := GetCodexClientModelsSnapshot()
+	if revision == 0 {
+		t.Fatal("embedded Codex client model catalog revision = 0, want non-zero")
+	}
+	if err := ValidateCodexClientModelsJSON(data); err != nil {
+		t.Fatalf("embedded Codex client model catalog is invalid: %v", err)
+	}
+
+	data[0] ^= 0xff
+	second, secondRevision := GetCodexClientModelsSnapshot()
+	if secondRevision != revision {
+		t.Fatalf("snapshot revision = %d, want %d", secondRevision, revision)
+	}
+	if err := ValidateCodexClientModelsJSON(second); err != nil {
+		t.Fatalf("mutating returned snapshot changed stored catalog: %v", err)
+	}
+}
+
+func TestValidateCodexClientModelsJSON(t *testing.T) {
+	validDefault := testCodexClientModel("gpt-5.5", 1)
+	validOther := testCodexClientModel("gpt-5.6-sol", 2)
+	emptySlug := testCodexClientModel("gpt-5.5", 1)
+	emptySlug["slug"] = ""
+	missingField := testCodexClientModel("gpt-5.5", 1)
+	delete(missingField, "base_instructions")
+	wrongFieldType := testCodexClientModel("gpt-5.5", 1)
+	wrongFieldType["context_window"] = "372000"
+	unsupportedDefault := testCodexClientModel("gpt-5.5", 1)
+	unsupportedDefault["default_reasoning_level"] = "high"
+
+	tests := []struct {
+		name string
+		raw  []byte
+	}{
+		{name: "malformed", raw: []byte(`{"models":`)},
+		{name: "empty", raw: []byte(`{"models":[]}`)},
+		{name: "empty slug", raw: testCodexClientCatalog(t, emptySlug)},
+		{name: "duplicate slug", raw: testCodexClientCatalog(t, validDefault, validDefault)},
+		{name: "missing default", raw: testCodexClientCatalog(t, validOther)},
+		{name: "missing required field", raw: testCodexClientCatalog(t, missingField)},
+		{name: "wrong required field type", raw: testCodexClientCatalog(t, wrongFieldType)},
+		{name: "default reasoning level not supported", raw: testCodexClientCatalog(t, unsupportedDefault)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateCodexClientModelsJSON(tt.raw); err == nil {
+				t.Fatal("ValidateCodexClientModelsJSON() error = nil, want error")
+			}
+		})
+	}
+
+	valid := testCodexClientCatalog(t, validDefault, validOther)
+	if err := ValidateCodexClientModelsJSON(valid); err != nil {
+		t.Fatalf("valid catalog rejected: %v", err)
+	}
+}
+
+func TestLoadCodexClientModelsRejectsInvalidWithoutReplacing(t *testing.T) {
+	original, _ := GetCodexClientModelsSnapshot()
+	t.Cleanup(func() {
+		if _, err := loadCodexClientModelsFromBytes(original, "test cleanup"); err != nil {
+			t.Fatalf("restore original catalog: %v", err)
+		}
+	})
+
+	valid := testCodexClientCatalog(t, testCodexClientModel("gpt-5.5", 1))
+	changed, err := loadCodexClientModelsFromBytes(valid, "test")
+	if err != nil {
+		t.Fatalf("load valid catalog: %v", err)
+	}
+	if !changed {
+		t.Fatal("load valid catalog changed = false, want true")
+	}
+	beforeInvalid, revision := GetCodexClientModelsSnapshot()
+
+	if _, err = loadCodexClientModelsFromBytes([]byte(`{"models":[]}`), "test invalid"); err == nil {
+		t.Fatal("load invalid catalog error = nil, want error")
+	}
+	afterInvalid, afterRevision := GetCodexClientModelsSnapshot()
+	if string(afterInvalid) != string(beforeInvalid) {
+		t.Fatal("invalid catalog replaced current snapshot")
+	}
+	if afterRevision != revision {
+		t.Fatalf("revision after invalid catalog = %d, want %d", afterRevision, revision)
+	}
+}
+
+func TestFetchCodexClientModelsFallsBackToNextURL(t *testing.T) {
+	invalidServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"models":[{"slug":"gpt-5.6-sol"}]}`))
+	}))
+	defer invalidServer.Close()
+
+	validCatalog := testCodexClientCatalog(t, testCodexClientModel("gpt-5.5", 1))
+	validServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(validCatalog)
+	}))
+	defer validServer.Close()
+
+	previousURLs := codexClientModelsURLs
+	codexClientModelsURLs = []string{invalidServer.URL, validServer.URL}
+	t.Cleanup(func() { codexClientModelsURLs = previousURLs })
+
+	data, sourceURL := fetchCodexClientModelsFromRemote(context.Background())
+	if sourceURL != validServer.URL {
+		t.Fatalf("source URL = %q, want %q", sourceURL, validServer.URL)
+	}
+	if string(data) != string(validCatalog) {
+		t.Fatalf("catalog = %s, want %s", data, validCatalog)
+	}
+}
+
+func TestRefreshCodexClientModelsKeepsLastValidSnapshot(t *testing.T) {
+	original, _ := GetCodexClientModelsSnapshot()
+	previousURLs := codexClientModelsURLs
+	t.Cleanup(func() {
+		codexClientModelsURLs = previousURLs
+		if _, err := loadCodexClientModelsFromBytes(original, "test cleanup"); err != nil {
+			t.Fatalf("restore original catalog: %v", err)
+		}
+	})
+
+	lastValid := testCodexClientCatalog(t, testCodexClientModel("gpt-5.5", 1))
+	if _, err := loadCodexClientModelsFromBytes(lastValid, "test last valid"); err != nil {
+		t.Fatalf("load last valid catalog: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+	}{
+		{name: "remote files missing", statusCode: http.StatusNotFound},
+		{name: "remote JSON malformed", statusCode: http.StatusOK, body: `{"models":`},
+		{name: "remote JSON incomplete", statusCode: http.StatusOK, body: `{"models":[{"slug":"gpt-5.5"}]}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			servers := make([]*httptest.Server, 0, 2)
+			urls := make([]string, 0, 2)
+			for range 2 {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(tt.statusCode)
+					_, _ = w.Write([]byte(tt.body))
+				}))
+				servers = append(servers, server)
+				urls = append(urls, server.URL)
+			}
+			defer func() {
+				for _, server := range servers {
+					server.Close()
+				}
+			}()
+
+			before, revision := GetCodexClientModelsSnapshot()
+			codexClientModelsURLs = urls
+			tryRefreshCodexClientModels(context.Background(), "test refresh")
+			after, afterRevision := GetCodexClientModelsSnapshot()
+			if string(after) != string(before) {
+				t.Fatal("failed remote refresh replaced last valid catalog")
+			}
+			if afterRevision != revision {
+				t.Fatalf("revision after failed refresh = %d, want %d", afterRevision, revision)
+			}
+		})
+	}
+}
+
+func testCodexClientModel(slug string, priority int) map[string]any {
+	return map[string]any{
+		"slug":                       slug,
+		"display_name":               "Test " + slug,
+		"description":                "Test model",
+		"base_instructions":          "Test instructions",
+		"minimal_client_version":     "0.144.0",
+		"visibility":                 "list",
+		"context_window":             372000,
+		"max_context_window":         372000,
+		"priority":                   priority,
+		"default_reasoning_level":    "medium",
+		"supported_reasoning_levels": []map[string]any{{"effort": "medium", "description": "Balanced"}},
+	}
+}
+
+func testCodexClientCatalog(t *testing.T, models ...map[string]any) []byte {
+	t.Helper()
+	data, err := json.Marshal(map[string]any{"models": models})
+	if err != nil {
+		t.Fatalf("marshal test Codex client catalog: %v", err)
+	}
+	return data
+}

--- a/internal/registry/codex_client_models_test.go
+++ b/internal/registry/codex_client_models_test.go
@@ -1,0 +1,345 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestEmbeddedCodexClientModelsCatalogIsValid(t *testing.T) {
+	data, revision := GetCodexClientModelsSnapshot()
+	if revision == 0 {
+		t.Fatal("embedded Codex client model catalog revision = 0, want non-zero")
+	}
+	if err := ValidateCodexClientModelsJSON(data); err != nil {
+		t.Fatalf("embedded Codex client model catalog is invalid: %v", err)
+	}
+	if err := ValidateCodexClientModelsLTSCompatibility(data); err != nil {
+		t.Fatalf("embedded Codex client model catalog is LTS-incompatible: %v", err)
+	}
+
+	data[0] ^= 0xff
+	second, secondRevision := GetCodexClientModelsSnapshot()
+	if secondRevision != revision {
+		t.Fatalf("snapshot revision = %d, want %d", secondRevision, revision)
+	}
+	if err := ValidateCodexClientModelsJSON(second); err != nil {
+		t.Fatalf("mutating returned snapshot changed stored catalog: %v", err)
+	}
+}
+
+func TestValidateCodexClientModelsJSON(t *testing.T) {
+	validDefault := testCodexClientModel("gpt-5.5", 1)
+	validOther := testCodexClientModel("gpt-5.6-sol", 2)
+	emptySlug := testCodexClientModel("gpt-5.5", 1)
+	emptySlug["slug"] = ""
+	missingField := testCodexClientModel("gpt-5.5", 1)
+	delete(missingField, "base_instructions")
+	wrongFieldType := testCodexClientModel("gpt-5.5", 1)
+	wrongFieldType["context_window"] = "372000"
+	unsupportedDefault := testCodexClientModel("gpt-5.5", 1)
+	unsupportedDefault["default_reasoning_level"] = "high"
+
+	tests := []struct {
+		name string
+		raw  []byte
+	}{
+		{name: "malformed", raw: []byte(`{"models":`)},
+		{name: "empty", raw: []byte(`{"models":[]}`)},
+		{name: "empty slug", raw: testCodexClientCatalog(t, emptySlug)},
+		{name: "duplicate slug", raw: testCodexClientCatalog(t, validDefault, validDefault)},
+		{name: "missing default", raw: testCodexClientCatalog(t, validOther)},
+		{name: "missing required field", raw: testCodexClientCatalog(t, missingField)},
+		{name: "wrong required field type", raw: testCodexClientCatalog(t, wrongFieldType)},
+		{name: "default reasoning level not supported", raw: testCodexClientCatalog(t, unsupportedDefault)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateCodexClientModelsJSON(tt.raw); err == nil {
+				t.Fatal("ValidateCodexClientModelsJSON() error = nil, want error")
+			}
+		})
+	}
+
+	valid := testCodexClientCatalog(t, validDefault, validOther)
+	if err := ValidateCodexClientModelsJSON(valid); err != nil {
+		t.Fatalf("valid catalog rejected: %v", err)
+	}
+}
+
+func TestValidateCodexClientModelsLTSCompatibility(t *testing.T) {
+	tests := []struct {
+		name   string
+		models []map[string]any
+		want   string
+	}{
+		{
+			name:   "missing sol",
+			models: testLTSCodexClientModelsWithout("gpt-5.6-sol"),
+			want:   "gpt-5.6-sol",
+		},
+		{
+			name: "sol missing max",
+			models: []map[string]any{
+				testCodexClientModel("gpt-5.5", 1),
+				testCodexClientModelWithEfforts("gpt-5.6-sol", 2, "medium", "ultra"),
+				testCodexClientModelWithEfforts("gpt-5.6-terra", 3, "medium", "max", "ultra"),
+				testCodexClientModelWithEfforts("gpt-5.6-luna", 4, "medium", "max"),
+			},
+			want: "max",
+		},
+		{
+			name: "terra missing ultra",
+			models: []map[string]any{
+				testCodexClientModel("gpt-5.5", 1),
+				testCodexClientModelWithEfforts("gpt-5.6-sol", 2, "medium", "max", "ultra"),
+				testCodexClientModelWithEfforts("gpt-5.6-terra", 3, "medium", "max"),
+				testCodexClientModelWithEfforts("gpt-5.6-luna", 4, "medium", "max"),
+			},
+			want: "ultra",
+		},
+		{
+			name: "luna missing max",
+			models: []map[string]any{
+				testCodexClientModel("gpt-5.5", 1),
+				testCodexClientModelWithEfforts("gpt-5.6-sol", 2, "medium", "max", "ultra"),
+				testCodexClientModelWithEfforts("gpt-5.6-terra", 3, "medium", "max", "ultra"),
+				testCodexClientModelWithEfforts("gpt-5.6-luna", 4, "medium"),
+			},
+			want: "max",
+		},
+		{
+			name: "luna exposes ultra",
+			models: []map[string]any{
+				testCodexClientModel("gpt-5.5", 1),
+				testCodexClientModelWithEfforts("gpt-5.6-sol", 2, "medium", "max", "ultra"),
+				testCodexClientModelWithEfforts("gpt-5.6-terra", 3, "medium", "max", "ultra"),
+				testCodexClientModelWithEfforts("gpt-5.6-luna", 4, "medium", "max", "ultra"),
+			},
+			want: "must not expose",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCodexClientModelsLTSCompatibility(testCodexClientCatalog(t, tt.models...))
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("ValidateCodexClientModelsLTSCompatibility() error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+
+	if err := ValidateCodexClientModelsLTSCompatibility(testLTSCompatibleCodexClientCatalog(t)); err != nil {
+		t.Fatalf("LTS-compatible catalog rejected: %v", err)
+	}
+}
+
+func TestLoadCodexClientModelsRejectsInvalidWithoutReplacing(t *testing.T) {
+	original, _ := GetCodexClientModelsSnapshot()
+	t.Cleanup(func() {
+		if _, err := loadCodexClientModelsFromBytes(original, "test cleanup"); err != nil {
+			t.Fatalf("restore original catalog: %v", err)
+		}
+	})
+
+	valid := testLTSCompatibleCodexClientCatalog(t)
+	changed, err := loadCodexClientModelsFromBytes(valid, "test")
+	if err != nil {
+		t.Fatalf("load valid catalog: %v", err)
+	}
+	if !changed {
+		t.Fatal("load valid catalog changed = false, want true")
+	}
+	beforeInvalid, revision := GetCodexClientModelsSnapshot()
+
+	if _, err = loadCodexClientModelsFromBytes([]byte(`{"models":[]}`), "test invalid"); err == nil {
+		t.Fatal("load invalid catalog error = nil, want error")
+	}
+	afterInvalid, afterRevision := GetCodexClientModelsSnapshot()
+	if string(afterInvalid) != string(beforeInvalid) {
+		t.Fatal("invalid catalog replaced current snapshot")
+	}
+	if afterRevision != revision {
+		t.Fatalf("revision after invalid catalog = %d, want %d", afterRevision, revision)
+	}
+
+	if _, err = loadCodexClientModelsFromBytes(testCodexClientCatalog(t, testCodexClientModel("gpt-5.5", 1)), "test incompatible"); err == nil {
+		t.Fatal("load LTS-incompatible catalog error = nil, want error")
+	}
+	afterIncompatible, incompatibleRevision := GetCodexClientModelsSnapshot()
+	if string(afterIncompatible) != string(beforeInvalid) || incompatibleRevision != revision {
+		t.Fatal("LTS-incompatible catalog replaced current snapshot or changed revision")
+	}
+}
+
+func TestLoadCodexClientModelsUnchangedDoesNotIncrementRevision(t *testing.T) {
+	original, _ := GetCodexClientModelsSnapshot()
+	t.Cleanup(func() {
+		if _, err := loadCodexClientModelsFromBytes(original, "test cleanup"); err != nil {
+			t.Fatalf("restore original catalog: %v", err)
+		}
+	})
+
+	valid := testLTSCompatibleCodexClientCatalog(t)
+	if _, err := loadCodexClientModelsFromBytes(valid, "test initial"); err != nil {
+		t.Fatalf("load initial catalog: %v", err)
+	}
+	_, revision := GetCodexClientModelsSnapshot()
+	changed, err := loadCodexClientModelsFromBytes(valid, "test unchanged")
+	if err != nil {
+		t.Fatalf("load unchanged catalog: %v", err)
+	}
+	if changed {
+		t.Fatal("load unchanged catalog changed = true, want false")
+	}
+	_, afterRevision := GetCodexClientModelsSnapshot()
+	if afterRevision != revision {
+		t.Fatalf("revision after unchanged catalog = %d, want %d", afterRevision, revision)
+	}
+}
+
+func TestFetchCodexClientModelsFallsBackToNextURL(t *testing.T) {
+	incompatibleCatalog := testCodexClientCatalog(t, testCodexClientModel("gpt-5.5", 1))
+	incompatibleServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(incompatibleCatalog)
+	}))
+	defer incompatibleServer.Close()
+
+	validCatalog := testLTSCompatibleCodexClientCatalog(t)
+	validServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(validCatalog)
+	}))
+	defer validServer.Close()
+
+	previousURLs := codexClientModelsURLs
+	codexClientModelsURLs = []string{incompatibleServer.URL, validServer.URL}
+	t.Cleanup(func() { codexClientModelsURLs = previousURLs })
+
+	data, sourceURL := fetchCodexClientModelsFromRemote(context.Background())
+	if sourceURL != validServer.URL {
+		t.Fatalf("source URL = %q, want %q", sourceURL, validServer.URL)
+	}
+	if string(data) != string(validCatalog) {
+		t.Fatalf("catalog = %s, want %s", data, validCatalog)
+	}
+}
+
+func TestRefreshCodexClientModelsKeepsLastValidSnapshot(t *testing.T) {
+	original, _ := GetCodexClientModelsSnapshot()
+	previousURLs := codexClientModelsURLs
+	t.Cleanup(func() {
+		codexClientModelsURLs = previousURLs
+		if _, err := loadCodexClientModelsFromBytes(original, "test cleanup"); err != nil {
+			t.Fatalf("restore original catalog: %v", err)
+		}
+	})
+
+	lastValid := testLTSCompatibleCodexClientCatalog(t)
+	if _, err := loadCodexClientModelsFromBytes(lastValid, "test last valid"); err != nil {
+		t.Fatalf("load last valid catalog: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+	}{
+		{name: "remote files missing", statusCode: http.StatusNotFound},
+		{name: "remote JSON malformed", statusCode: http.StatusOK, body: `{"models":`},
+		{name: "remote JSON incomplete", statusCode: http.StatusOK, body: `{"models":[{"slug":"gpt-5.5"}]}`},
+		{name: "remote LTS incompatible", statusCode: http.StatusOK, body: string(testCodexClientCatalog(t, testCodexClientModel("gpt-5.5", 1)))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			servers := make([]*httptest.Server, 0, 2)
+			urls := make([]string, 0, 2)
+			for range 2 {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(tt.statusCode)
+					_, _ = w.Write([]byte(tt.body))
+				}))
+				servers = append(servers, server)
+				urls = append(urls, server.URL)
+			}
+			defer func() {
+				for _, server := range servers {
+					server.Close()
+				}
+			}()
+
+			before, revision := GetCodexClientModelsSnapshot()
+			codexClientModelsURLs = urls
+			tryRefreshCodexClientModels(context.Background(), "test refresh")
+			after, afterRevision := GetCodexClientModelsSnapshot()
+			if string(after) != string(before) {
+				t.Fatal("failed remote refresh replaced last valid catalog")
+			}
+			if afterRevision != revision {
+				t.Fatalf("revision after failed refresh = %d, want %d", afterRevision, revision)
+			}
+		})
+	}
+}
+
+func testCodexClientModel(slug string, priority int) map[string]any {
+	return testCodexClientModelWithEfforts(slug, priority, "medium")
+}
+
+func testCodexClientModelWithEfforts(slug string, priority int, efforts ...string) map[string]any {
+	levels := make([]map[string]any, 0, len(efforts))
+	for _, effort := range efforts {
+		levels = append(levels, map[string]any{"effort": effort, "description": "Test " + effort})
+	}
+	return map[string]any{
+		"slug":                       slug,
+		"display_name":               "Test " + slug,
+		"description":                "Test model",
+		"base_instructions":          "Test instructions",
+		"minimal_client_version":     "0.144.0",
+		"visibility":                 "list",
+		"context_window":             372000,
+		"max_context_window":         372000,
+		"priority":                   priority,
+		"default_reasoning_level":    "medium",
+		"supported_reasoning_levels": levels,
+	}
+}
+
+func testLTSCompatibleCodexClientCatalog(t *testing.T) []byte {
+	return testCodexClientCatalog(t, testLTSCodexClientModelsWithout("")...)
+}
+
+func testLTSCodexClientModelsWithout(excluded string) []map[string]any {
+	models := []map[string]any{
+		testCodexClientModel("gpt-5.5", 1),
+		testCodexClientModelWithEfforts("gpt-5.6-sol", 2, "medium", "max", "ultra"),
+		testCodexClientModelWithEfforts("gpt-5.6-terra", 3, "medium", "max", "ultra"),
+		testCodexClientModelWithEfforts("gpt-5.6-luna", 4, "medium", "max"),
+	}
+	if excluded == "" {
+		return models
+	}
+	filtered := make([]map[string]any, 0, len(models)-1)
+	for _, model := range models {
+		if model["slug"] != excluded {
+			filtered = append(filtered, model)
+		}
+	}
+	return filtered
+}
+
+func testCodexClientCatalog(t *testing.T, models ...map[string]any) []byte {
+	t.Helper()
+	data, err := json.Marshal(map[string]any{"models": models})
+	if err != nil {
+		t.Fatalf("marshal test Codex client catalog: %v", err)
+	}
+	return data
+}

--- a/internal/registry/codex_client_models_updater.go
+++ b/internal/registry/codex_client_models_updater.go
@@ -1,0 +1,114 @@
+package registry
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const maxCodexClientModelsSize = 8 << 20
+
+var codexClientModelsURLs = []string{
+	"https://raw.githubusercontent.com/router-for-me/models/refs/heads/main/codex_client_models.json",
+	"https://models.router-for.me/codex_client_models.json",
+}
+
+var codexClientModelsUpdaterOnce sync.Once
+
+// StartCodexClientModelsUpdater starts a background updater that fetches the
+// Codex client model catalog immediately and then refreshes it every 3 hours.
+// Safe to call multiple times; only one updater will run.
+func StartCodexClientModelsUpdater(ctx context.Context) {
+	codexClientModelsUpdaterOnce.Do(func() {
+		go runCodexClientModelsUpdater(ctx)
+	})
+}
+
+func runCodexClientModelsUpdater(ctx context.Context) {
+	tryRefreshCodexClientModels(ctx, "startup Codex client model refresh")
+
+	ticker := time.NewTicker(modelsRefreshInterval)
+	defer ticker.Stop()
+	log.Infof("periodic Codex client model refresh started (interval=%s)", modelsRefreshInterval)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tryRefreshCodexClientModels(ctx, "periodic Codex client model refresh")
+		}
+	}
+}
+
+func tryRefreshCodexClientModels(ctx context.Context, label string) {
+	data, sourceURL := fetchCodexClientModelsFromRemote(ctx)
+	if data == nil {
+		log.Warnf("%s: fetch failed from all URLs, keeping current data", label)
+		return
+	}
+
+	changed, err := loadCodexClientModelsFromBytes(data, sourceURL)
+	if err != nil {
+		log.Warnf("%s: fetched catalog rejected, keeping current data: %v", label, err)
+		return
+	}
+	if !changed {
+		log.Infof("%s completed from %s, no changes detected", label, sourceURL)
+		return
+	}
+	log.Infof("%s completed from %s, catalog updated", label, sourceURL)
+}
+
+func fetchCodexClientModelsFromRemote(ctx context.Context) ([]byte, string) {
+	client := &http.Client{Timeout: modelsFetchTimeout}
+	for _, sourceURL := range codexClientModelsURLs {
+		reqCtx, cancel := context.WithTimeout(ctx, modelsFetchTimeout)
+		req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, sourceURL, nil)
+		if err != nil {
+			cancel()
+			log.Debugf("Codex client models fetch request creation failed for %s: %v", sourceURL, err)
+			continue
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			cancel()
+			log.Debugf("Codex client models fetch failed from %s: %v", sourceURL, err)
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			if errClose := resp.Body.Close(); errClose != nil {
+				log.Debugf("Codex client models response close failed for %s: %v", sourceURL, errClose)
+			}
+			cancel()
+			log.Debugf("Codex client models fetch returned %d from %s", resp.StatusCode, sourceURL)
+			continue
+		}
+
+		data, errRead := io.ReadAll(io.LimitReader(resp.Body, maxCodexClientModelsSize+1))
+		errClose := resp.Body.Close()
+		cancel()
+		if errRead != nil {
+			log.Debugf("Codex client models fetch read error from %s: %v", sourceURL, errRead)
+			continue
+		}
+		if errClose != nil {
+			log.Debugf("Codex client models response close failed for %s: %v", sourceURL, errClose)
+			continue
+		}
+		if len(data) > maxCodexClientModelsSize {
+			log.Warnf("Codex client models fetch from %s exceeded %d bytes", sourceURL, maxCodexClientModelsSize)
+			continue
+		}
+		if err := ValidateCodexClientModelsJSON(data); err != nil {
+			log.Warnf("Codex client models validate failed from %s: %v", sourceURL, err)
+			continue
+		}
+		return data, sourceURL
+	}
+	return nil, ""
+}

--- a/internal/registry/codex_client_models_updater.go
+++ b/internal/registry/codex_client_models_updater.go
@@ -1,0 +1,114 @@
+package registry
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const maxCodexClientModelsSize = 8 << 20
+
+var codexClientModelsURLs = []string{
+	"https://raw.githubusercontent.com/router-for-me/models/refs/heads/main/codex_client_models.json",
+	"https://models.router-for.me/codex_client_models.json",
+}
+
+var codexClientModelsUpdaterOnce sync.Once
+
+// StartCodexClientModelsUpdater starts a background updater that fetches the
+// Codex client model catalog immediately and then refreshes it every 3 hours.
+// Safe to call multiple times; only one updater will run.
+func StartCodexClientModelsUpdater(ctx context.Context) {
+	codexClientModelsUpdaterOnce.Do(func() {
+		go runCodexClientModelsUpdater(ctx)
+	})
+}
+
+func runCodexClientModelsUpdater(ctx context.Context) {
+	tryRefreshCodexClientModels(ctx, "startup Codex client model refresh")
+
+	ticker := time.NewTicker(modelsRefreshInterval)
+	defer ticker.Stop()
+	log.Infof("periodic Codex client model refresh started (interval=%s)", modelsRefreshInterval)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tryRefreshCodexClientModels(ctx, "periodic Codex client model refresh")
+		}
+	}
+}
+
+func tryRefreshCodexClientModels(ctx context.Context, label string) {
+	data, sourceURL := fetchCodexClientModelsFromRemote(ctx)
+	if data == nil {
+		log.Warnf("%s: fetch failed from all URLs, keeping current data", label)
+		return
+	}
+
+	changed, err := loadCodexClientModelsFromBytes(data, sourceURL)
+	if err != nil {
+		log.Warnf("%s: fetched catalog rejected, keeping current data: %v", label, err)
+		return
+	}
+	if !changed {
+		log.Infof("%s completed from %s, no changes detected", label, sourceURL)
+		return
+	}
+	log.Infof("%s completed from %s, catalog updated", label, sourceURL)
+}
+
+func fetchCodexClientModelsFromRemote(ctx context.Context) ([]byte, string) {
+	client := &http.Client{Timeout: modelsFetchTimeout}
+	for _, sourceURL := range codexClientModelsURLs {
+		reqCtx, cancel := context.WithTimeout(ctx, modelsFetchTimeout)
+		req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, sourceURL, nil)
+		if err != nil {
+			cancel()
+			log.Debugf("Codex client models fetch request creation failed for %s: %v", sourceURL, err)
+			continue
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			cancel()
+			log.Debugf("Codex client models fetch failed from %s: %v", sourceURL, err)
+			continue
+		}
+		if resp.StatusCode != http.StatusOK {
+			if errClose := resp.Body.Close(); errClose != nil {
+				log.Debugf("Codex client models response close failed for %s: %v", sourceURL, errClose)
+			}
+			cancel()
+			log.Debugf("Codex client models fetch returned %d from %s", resp.StatusCode, sourceURL)
+			continue
+		}
+
+		data, errRead := io.ReadAll(io.LimitReader(resp.Body, maxCodexClientModelsSize+1))
+		errClose := resp.Body.Close()
+		cancel()
+		if errRead != nil {
+			log.Debugf("Codex client models fetch read error from %s: %v", sourceURL, errRead)
+			continue
+		}
+		if errClose != nil {
+			log.Debugf("Codex client models response close failed for %s: %v", sourceURL, errClose)
+			continue
+		}
+		if len(data) > maxCodexClientModelsSize {
+			log.Warnf("Codex client models fetch from %s exceeded %d bytes", sourceURL, maxCodexClientModelsSize)
+			continue
+		}
+		if err := validateCodexClientModelsForLTS(data); err != nil {
+			log.Warnf("Codex client models validate failed from %s: %v", sourceURL, err)
+			continue
+		}
+		return data, sourceURL
+	}
+	return nil, ""
+}

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -114,11 +114,13 @@ grep -R "/v0/management/usage/import" -n \
 require_path internal/api/handlers/management/usage.go
 require_path internal/api/handlers/management/usage_contract_test.go
 require_path internal/runtime/executor/helps/usage_helpers.go
+require_path internal/registry/models/codex_client_models.json
 require_path internal/managementasset/updater.go
 require_path internal/config/config.go
 require_path internal/redisqueue
 require_path config.example.yaml
 require_path docs/lts/codex-429-resilience.md
+require_path .github/scripts/refresh-model-catalogs.sh
 
 require_grep "mgmt.GET(\"/usage\"" internal/api/server.go
 require_grep "mgmt.GET(\"/usage/export\"" internal/api/server.go
@@ -144,6 +146,9 @@ require_grep "codexRateLimitContinuityLifecycleContextKey" sdk/cliproxy/auth/cod
 require_grep "removeSessionPreservingKey" sdk/cliproxy/auth/codex_rate_limit_continuity.go sdk/cliproxy/auth/conductor.go docs/lts/core-feature-contracts.yaml
 require_grep "CodexModelFallbackContextResetReplayMetadataKey" sdk/cliproxy/executor/types.go sdk/api/handlers/openai/openai_responses_websocket.go
 require_grep "ResolveCodexReasoningReplaySessionKey" internal/cache/codex_reasoning_replay_scope.go internal/runtime/executor/codex_executor.go sdk/cliproxy/auth/codex_model_fallback.go
+require_grep "ValidateCodexClientModelsLTSCompatibility" internal/registry/codex_client_models.go internal/registry/codex_client_models_test.go cmd/validate_codex_models/main.go
+require_grep "refresh-model-catalogs.sh" .github/workflows/pr-test-build.yml .github/workflows/release.yaml .github/workflows/docker-image.yml
+require_grep "codex_client_models.json" .github/scripts/refresh-model-catalogs.sh
 require_grep "responsesWebsocketCanAttestContextReset" sdk/api/handlers/openai/openai_responses_websocket.go sdk/api/handlers/openai/openai_responses_websocket_test.go
 require_grep "ModelFallbackZeroDispatch" sdk/cliproxy/auth/codex_model_fallback.go docs/lts/core-feature-contracts.yaml
 require_grep "auth_index" internal/usage internal/api/handlers/management internal/runtime/executor/helps internal/redisqueue

--- a/sdk/api/handlers/openai/codex_client_models.go
+++ b/sdk/api/handlers/openai/codex_client_models.go
@@ -14,10 +14,12 @@ type codexClientModelsPayload struct {
 }
 
 var (
-	codexClientModelTemplatesOnce sync.Once
-	codexClientModelTemplates     map[string]map[string]any
-	codexClientDefaultTemplate    map[string]any
-	codexClientModelTemplatesErr  error
+	codexClientModelTemplatesMu       sync.Mutex
+	codexClientModelTemplatesLoaded   bool
+	codexClientModelTemplatesRevision uint64
+	codexClientModelTemplates         map[string]map[string]any
+	codexClientDefaultTemplate        map[string]any
+	codexClientModelTemplatesErr      error
 )
 
 var codexClientAllowedReasoningLevels = map[string]struct{}{
@@ -133,26 +135,40 @@ func applyCodexClientNonTemplatePriorities(result []map[string]any, templates ma
 }
 
 func loadCodexClientModelTemplates() (map[string]map[string]any, map[string]any, error) {
-	codexClientModelTemplatesOnce.Do(func() {
-		var payload codexClientModelsPayload
-		codexClientModelTemplatesErr = json.Unmarshal(registry.GetCodexClientModelsJSON(), &payload)
-		if codexClientModelTemplatesErr != nil {
-			return
-		}
+	raw, revision := registry.GetCodexClientModelsSnapshot()
+	return loadCodexClientModelTemplatesSnapshot(raw, revision)
+}
 
-		codexClientModelTemplates = make(map[string]map[string]any, len(payload.Models))
+func loadCodexClientModelTemplatesSnapshot(raw []byte, revision uint64) (map[string]map[string]any, map[string]any, error) {
+	codexClientModelTemplatesMu.Lock()
+	defer codexClientModelTemplatesMu.Unlock()
+	if codexClientModelTemplatesLoaded && codexClientModelTemplatesRevision == revision {
+		return codexClientModelTemplates, codexClientDefaultTemplate, codexClientModelTemplatesErr
+	}
+
+	var payload codexClientModelsPayload
+	err := json.Unmarshal(raw, &payload)
+	var templates map[string]map[string]any
+	var defaultTemplate map[string]any
+	if err == nil {
+		templates = make(map[string]map[string]any, len(payload.Models))
 		for _, model := range payload.Models {
 			slug := strings.TrimSpace(stringModelValue(model, "slug"))
 			if slug == "" {
 				continue
 			}
-			codexClientModelTemplates[slug] = cloneCodexClientModelMap(model)
+			templates[slug] = cloneCodexClientModelMap(model)
 			if slug == "gpt-5.5" {
-				codexClientDefaultTemplate = cloneCodexClientModelMap(model)
+				defaultTemplate = cloneCodexClientModelMap(model)
 			}
 		}
-	})
+	}
 
+	codexClientModelTemplatesLoaded = true
+	codexClientModelTemplatesRevision = revision
+	codexClientModelTemplates = templates
+	codexClientDefaultTemplate = defaultTemplate
+	codexClientModelTemplatesErr = err
 	return codexClientModelTemplates, codexClientDefaultTemplate, codexClientModelTemplatesErr
 }
 

--- a/sdk/api/handlers/openai/codex_client_models_test.go
+++ b/sdk/api/handlers/openai/codex_client_models_test.go
@@ -174,3 +174,55 @@ func TestCodexClientModelsResponse_PreservesUltraReasoningEffort(t *testing.T) {
 
 	t.Fatalf("supported_reasoning_levels = %#v, want ultra", levels)
 }
+
+func TestLoadCodexClientModelTemplatesRefreshesOnRevision(t *testing.T) {
+	codexClientModelTemplatesMu.Lock()
+	previousLoaded := codexClientModelTemplatesLoaded
+	previousRevision := codexClientModelTemplatesRevision
+	previousTemplates := codexClientModelTemplates
+	previousDefault := codexClientDefaultTemplate
+	previousErr := codexClientModelTemplatesErr
+	codexClientModelTemplatesLoaded = false
+	codexClientModelTemplatesMu.Unlock()
+	t.Cleanup(func() {
+		codexClientModelTemplatesMu.Lock()
+		codexClientModelTemplatesLoaded = previousLoaded
+		codexClientModelTemplatesRevision = previousRevision
+		codexClientModelTemplates = previousTemplates
+		codexClientDefaultTemplate = previousDefault
+		codexClientModelTemplatesErr = previousErr
+		codexClientModelTemplatesMu.Unlock()
+	})
+
+	first := []byte(`{"models":[{"slug":"gpt-5.5","display_name":"First"}]}`)
+	templates, defaultTemplate, err := loadCodexClientModelTemplatesSnapshot(first, 100)
+	if err != nil {
+		t.Fatalf("load first snapshot: %v", err)
+	}
+	if got := stringModelValue(templates["gpt-5.5"], "display_name"); got != "First" {
+		t.Fatalf("first display_name = %q, want First", got)
+	}
+	if got := stringModelValue(defaultTemplate, "display_name"); got != "First" {
+		t.Fatalf("first default display_name = %q, want First", got)
+	}
+
+	second := []byte(`{"models":[{"slug":"gpt-5.5","display_name":"Second"}]}`)
+	templates, defaultTemplate, err = loadCodexClientModelTemplatesSnapshot(second, 101)
+	if err != nil {
+		t.Fatalf("load second snapshot: %v", err)
+	}
+	if got := stringModelValue(templates["gpt-5.5"], "display_name"); got != "Second" {
+		t.Fatalf("second display_name = %q, want Second", got)
+	}
+	if got := stringModelValue(defaultTemplate, "display_name"); got != "Second" {
+		t.Fatalf("second default display_name = %q, want Second", got)
+	}
+
+	templates, _, err = loadCodexClientModelTemplatesSnapshot(first, 101)
+	if err != nil {
+		t.Fatalf("reload cached revision: %v", err)
+	}
+	if got := stringModelValue(templates["gpt-5.5"], "display_name"); got != "Second" {
+		t.Fatalf("cached display_name = %q, want Second", got)
+	}
+}

--- a/sdk/api/handlers/openai/codex_client_models_test.go
+++ b/sdk/api/handlers/openai/codex_client_models_test.go
@@ -247,3 +247,55 @@ func codexClientReasoningLevelDescription(model map[string]any, effort string) s
 	}
 	return ""
 }
+
+func TestLoadCodexClientModelTemplatesRefreshesOnRevision(t *testing.T) {
+	codexClientModelTemplatesMu.Lock()
+	previousLoaded := codexClientModelTemplatesLoaded
+	previousRevision := codexClientModelTemplatesRevision
+	previousTemplates := codexClientModelTemplates
+	previousDefault := codexClientDefaultTemplate
+	previousErr := codexClientModelTemplatesErr
+	codexClientModelTemplatesLoaded = false
+	codexClientModelTemplatesMu.Unlock()
+	t.Cleanup(func() {
+		codexClientModelTemplatesMu.Lock()
+		codexClientModelTemplatesLoaded = previousLoaded
+		codexClientModelTemplatesRevision = previousRevision
+		codexClientModelTemplates = previousTemplates
+		codexClientDefaultTemplate = previousDefault
+		codexClientModelTemplatesErr = previousErr
+		codexClientModelTemplatesMu.Unlock()
+	})
+
+	first := []byte(`{"models":[{"slug":"gpt-5.5","display_name":"First"}]}`)
+	templates, defaultTemplate, err := loadCodexClientModelTemplatesSnapshot(first, 100)
+	if err != nil {
+		t.Fatalf("load first snapshot: %v", err)
+	}
+	if got := stringModelValue(templates["gpt-5.5"], "display_name"); got != "First" {
+		t.Fatalf("first display_name = %q, want First", got)
+	}
+	if got := stringModelValue(defaultTemplate, "display_name"); got != "First" {
+		t.Fatalf("first default display_name = %q, want First", got)
+	}
+
+	second := []byte(`{"models":[{"slug":"gpt-5.5","display_name":"Second"}]}`)
+	templates, defaultTemplate, err = loadCodexClientModelTemplatesSnapshot(second, 101)
+	if err != nil {
+		t.Fatalf("load second snapshot: %v", err)
+	}
+	if got := stringModelValue(templates["gpt-5.5"], "display_name"); got != "Second" {
+		t.Fatalf("second display_name = %q, want Second", got)
+	}
+	if got := stringModelValue(defaultTemplate, "display_name"); got != "Second" {
+		t.Fatalf("second default display_name = %q, want Second", got)
+	}
+
+	templates, _, err = loadCodexClientModelTemplatesSnapshot(first, 101)
+	if err != nil {
+		t.Fatalf("reload cached revision: %v", err)
+	}
+	if got := stringModelValue(templates["gpt-5.5"], "display_name"); got != "Second" {
+		t.Fatalf("cached display_name = %q, want Second", got)
+	}
+}


### PR DESCRIPTION
## 结果、风险与合并约束

同步 Upstream PR #4276 的 `codex_client_models.json` runtime refresh，同时增加 CPA-Core-LTS compatibility guard：远端 catalog 只有在保留 `gpt-5.6-sol`/`terra`/`luna` 及正确 Max/Ultra 边界时才可激活；不兼容 candidate 会保留 embedded/last-known-good catalog。

本 PR 是三段 Core 同步的 Stage 3，依赖已合并的 PR #164/#165，必须使用 **Create a merge commit**。它修改 CI、Docker 和 release build 输入，但本 PR 不创建 tag、不执行 release、不发布 Docker image、不部署 HF。

## Type

- [ ] Protected upstream full-sync
- [x] Staged upstream full-sync
- [ ] LTS protected-delta patch
- [ ] LTS feature / downstream patch maintenance
- [ ] Maintenance docs / CI
- [ ] Emergency hotfix

## Upstream sync info

- Upstream repo: `router-for-me/CLIProxyAPI`
- Upstream branch: `main`
- Upstream from SHA: `e674f19129f187ddff65dacd5b1baed9bd9f413b`
- Upstream to SHA: `4fe2c60c5152f45e1180346a5186743cfac58363`
- Explicitly excluded: `6279bb8a4c2835ff6ed99c6b85083b2afbefa681` and later commits
- Sync branch: `codex/sync-upstream-codex-catalog-20260713`
- Local validated head: `4ff9aa027e7dd65df9464f29353bf50f75481c3e`

## Key behavior

- Start Codex client catalog refresh at server startup and every 3 hours.
- Reload handlers by catalog revision; unchanged content does not increment revision.
- `-local-model` disables both `models.json` and `codex_client_models.json` remote updates.
- Home mode keeps Home model IDs while allowing edge-local Codex template refresh.
- Runtime fetch validates schema and LTS policy before activation and continues to the fallback URL when a candidate is incompatible.
- No new Management API, config key, CLI flag or persisted-data migration.

`ValidateCodexClientModelsLTSCompatibility` requires:

- Sol and Terra: `max` and `ultra`.
- Luna: `max`, and no `ultra`.
- All three GPT-5.6 tier slugs must remain present.

## Protected delta checklist

- [x] Full usage and `/v0/management/usage*` contracts remain present
- [x] Feature registry and every active downstream patch reviewed
- [x] Model resolution, client catalog, runtime updater and handler revision behavior tested
- [x] Alpha Search `SelectAuthForRequest` lifecycle preserved
- [x] Panel release source and `management.html` contract unchanged
- [x] `v*-tls-*`, CPA-HFS parallel assets and checksum behavior preserved

## LTS classification review

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| `full-usage-statistics-core` | retained capability | preserved | contract guard, usage tests, repo-wide tests |
| `management-usage-api` | retained capability | preserved | Management usage tests |
| `panel-release-asset` | retained capability | preserved | release source not changed |
| `auth-identity-attribution` | retained capability | preserved | no auth identity change |
| `config-compatibility-and-hot-reload` | retained capability | preserved | no config/schema change |
| `redis-compatible-usage-queue` | LTS feature | preserved | contract guard |
| `commercial-neutral-documentation` | LTS feature | preserved | `6279bb8a` excluded; README/assets unchanged |
| `provider-runtime-usage-seams` | review seam | adapted | model catalog and handler revision paths reviewed |
| `codex-model-fallback` | downstream patch | patch-still-required | catalog refresh does not replace fallback/continuity semantics |
| `codex-rate-limit-continuity` | downstream patch | patch-still-required | no equivalent state machine |
| `codex-interactions-service-tier-response` | downstream patch | patch-still-required | no response-tier replacement |
| `plugin-configured-enable-default` | downstream patch | patch-still-required | not touched |
| `codex-gpt56-ultra-level` | downstream patch | adapted | client metadata is upstream-equivalent; server wire/custom-model/usage patch remains required and is now guarded |
| `codex-model-header-provider-snapshot` | downstream patch | patch-still-required | no equivalent immutable snapshot |
| `codex-oauth-client-identity-finalization` | downstream patch | patch-still-required | no equivalent final identity pass |
| `codex-model-not-found-request-scope` | downstream patch | patch-still-required | typed 404 boundary remains downstream |
| `codex-websocket-reader-generation` | downstream patch | patch-still-required | catalog revision is separate from connection ownership |
| `codex-spark-reasoning-summary-compat` | downstream patch | patch-still-required | Spark sanitizer remains downstream |
| `hf-space-runtime-smoke` | validation profile | preserved | skipped; no deployment |

- [x] This sync PR will use **Create a merge commit**; squash/rebase is forbidden.

## Conflict resolution notes

Conflicts were resolved in `.github/workflows/pr-test-build.yml`, `.github/workflows/release.yaml`, and `internal/api/server_test.go`.

- PR build now refreshes both catalogs, runs the existing GPT-5.6 Ultra guard, then builds.
- Release keeps the LTS `validate-release-catalog` job as the single source of truth. It refreshes and validates both JSON files once, uploads one short-lived artifact, and every platform build consumes the same validated pair.
- Release retains `v*-tls-*`, CPA-HFS parallel archives and checksums; per-matrix mutable refetching was intentionally not adopted.
- Docker tag/publish semantics remain unchanged; each architecture runs the shared validated refresh script before image build.
- Existing dynamic custom-model priority tests remain robust against catalog reordering.

## Validation

- [x] `scripts/check-lts-contract.sh`
- [x] `go run ./scripts/ltsregistry --root .`
- [x] `go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'`
- [x] `go build -o test-output ./cmd/server && rm -f test-output`
- [x] `go test -count=1 ./internal/registry ./internal/api ./cmd/server ./cmd/fetch_codex_models ./cmd/validate_codex_models ./sdk/api/handlers/openai`
- [x] `go test -race -count=1 ./internal/registry ./internal/api ./sdk/api/handlers/openai`
- [x] GPT-5.6 `GPT56|Ultra|CodexWire` regression set
- [x] `go test ./...`
- [x] `go list ./... | rg -v '/tmp$' | xargs go test -count=1`
- [x] `bash -n .github/scripts/refresh-model-catalogs.sh`
- [x] YAML parse of the three changed workflows
- [x] Live refresh script smoke against `router-for-me/models.git` main `a837d9dba1c2d755eaa1ec4f535511c202cb3906` in a temporary catalog directory
- [x] `git diff --check origin/main...HEAD`

## Optional real runtime smoke

- [x] Hugging Face Space smoke explicitly skipped
- Reason: no deployment, release, tag or runtime update is in scope.
- Release and Docker workflows were statically validated only; no publish trigger was executed.