### PR TITLE
fix(lts): close v7.2.78 review regressions

### DIFF
--- a/docs/lts/core-feature-contracts.yaml
+++ b/docs/lts/core-feature-contracts.yaml
@@ -187,10 +187,14 @@ features:
       - codex.abnormal-reasoning-retry.hedged-retry.hedge-delay-ms
       - codex.abnormal-reasoning-retry.hedged-retry.require-distinct-auth
     core_files:
+      - internal/api/middleware/response_writer.go
       - internal/config/config.go
+      - internal/logging/request_logger.go
       - internal/runtime/executor/codex_abnormal_reasoning_retry.go
       - internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
       - internal/runtime/executor/codex_executor.go
+      - internal/runtime/executor/helps/logging_helpers.go
+      - internal/runtime/executor/helps/logging_helpers_test.go
       - internal/runtime/executor/helps/usage_helpers.go
       - internal/usage/logger_plugin.go
       - sdk/cliproxy/auth/conductor.go
@@ -229,6 +233,7 @@ features:
     validation:
       - go test ./internal/config
       - go test ./internal/runtime/executor -run 'Codex.*AbnormalReasoning'
+      - go test -race ./internal/runtime/executor/helps -run 'RecordAPIRequestConcurrentDeferredRequests'
       - go test ./sdk/cliproxy/auth -run 'HedgedRetry|RetryWithoutPenalty'
       - go test ./internal/watcher/diff
 

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -335,3 +335,29 @@ patches:
     upstream_issue_or_pr: not-filed
     state: required
     retire_when: Upstream removes reasoning.summary for gpt-5.3-codex-spark after all request overrides while preserving reasoning.effort and the listed regressions pass without the downstream implementation.
+
+  - id: xai-explicit-tool-choice-none
+    reason: xAI request preparation injects native x_search after removing tool_choice fields for an empty client tool list, so an explicit tool_choice none can be lost and the model may invoke search despite the client prohibition.
+    introduced_in: ad7244752d324a5b179c3e30a628acf976fa995c
+    affected_upstream_range: through 09da52ad509e2c18e7b9540db3b98c2214c280aa (v7.2.78-6-g09da52ad); b6ce0beecd31dff389d3190f7db6d7a1d4ce0e7e simplifies xAI tool schemas but still normalizes tool_choice before injecting x_search.
+    files:
+      - internal/runtime/executor/xai_executor.go
+      - internal/runtime/executor/xai_executor_test.go
+    regression_tests:
+      - TestXAIExecutorPreparePreservesExplicitToolChoiceNoneAfterXSearchInject
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: Upstream injects the native x_search tool before the no-tools tool_choice cleanup, preserves explicit tool_choice none and parallel_tool_calls false on the shared HTTP/WebSocket preparation path, and the listed regression passes without the downstream ordering patch.
+
+  - id: request-body-panic-tempfile-cleanup
+    reason: Error-only request logging spools large request bodies into temporary files, but a handler panic unwinds past RequestLoggingMiddleware before ResponseWriterWrapper.Finalize runs, leaving sensitive request content on disk after both recovered panics and http.ErrAbortHandler.
+    introduced_in: ad7244752d324a5b179c3e30a628acf976fa995c
+    affected_upstream_range: through 09da52ad509e2c18e7b9540db3b98c2214c280aa (v7.2.78-6-g09da52ad); the deferred body capture introduced at e5741673e29dd87552ad1c017025af22b20f2895 still performs cleanup only from the response finalizer.
+    files:
+      - internal/api/middleware/request_logging.go
+      - internal/api/middleware/request_logging_test.go
+    regression_tests:
+      - TestRequestLoggingMiddlewareCleansDeferredBodyCaptureOnPanic
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: Upstream gives the middleware-owned deferred capture an idempotent unwind cleanup that runs for normal completion, recovered panics, and http.ErrAbortHandler, and the listed regression passes after removing the downstream defer.

--- a/internal/api/middleware/request_logging.go
+++ b/internal/api/middleware/request_logging.go
@@ -65,7 +65,10 @@ func RequestLoggingMiddleware(logger logging.RequestLogger) gin.HandlerFunc {
 		}
 		c.Writer = wrapper
 		attachRequestLogSources(c, logger, loggerEnabled)
-		attachDeferredRequestBodyCapture(c.Request, logger, requestInfo, loggerEnabled, captureBody)
+		deferredBodyCapture := attachDeferredRequestBodyCapture(c.Request, logger, requestInfo, loggerEnabled, captureBody)
+		if deferredBodyCapture != nil {
+			defer deferredBodyCapture.Cleanup()
+		}
 
 		// Process the request
 		c.Next()

--- a/internal/api/middleware/request_logging_test.go
+++ b/internal/api/middleware/request_logging_test.go
@@ -261,6 +261,61 @@ func TestRequestLoggingMiddlewareCapturesLargeErrorRequestAndDeferredAPIRequest(
 	}
 }
 
+func TestRequestLoggingMiddlewareCleansDeferredBodyCaptureOnPanic(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name          string
+		panicValue    any
+		wantRecovered any
+	}{
+		{name: "regular panic", panicValue: "boom"},
+		{name: "abort handler panic", panicValue: http.ErrAbortHandler, wantRecovered: http.ErrAbortHandler},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logsDir := t.TempDir()
+			logger := logging.NewFileRequestLogger(false, logsDir, "", 10)
+			payload := bytes.Repeat([]byte("s"), int(maxErrorOnlyCapturedRequestBodyBytes)+1)
+
+			router := gin.New()
+			router.Use(logging.GinLogrusRecovery())
+			router.Use(RequestLoggingMiddleware(logger))
+			router.POST("/v1/responses", func(c *gin.Context) {
+				if _, errRead := io.ReadAll(c.Request.Body); errRead != nil {
+					t.Fatalf("read request body: %v", errRead)
+				}
+				panic(test.panicValue)
+			})
+
+			request := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(payload))
+			request.Header.Set("Content-Type", "application/json")
+			response := httptest.NewRecorder()
+			recovered := func() (recovered any) {
+				defer func() {
+					recovered = recover()
+				}()
+				router.ServeHTTP(response, request)
+				return nil
+			}()
+			if recovered != test.wantRecovered {
+				t.Fatalf("recovered panic = %v, want %v", recovered, test.wantRecovered)
+			}
+
+			entries, errReadDir := os.ReadDir(logsDir)
+			if errReadDir != nil {
+				t.Fatalf("read logs dir: %v", errReadDir)
+			}
+			for _, entry := range entries {
+				if strings.HasPrefix(entry.Name(), "request-log-parts-request-body-") {
+					t.Fatalf("deferred request body capture leaked after panic: %s", entry.Name())
+				}
+			}
+		})
+	}
+}
+
 func TestAttachRequestLogSourcesUsesLoggerLogsDir(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/api/middleware/response_writer.go
+++ b/internal/api/middleware/response_writer.go
@@ -405,8 +405,16 @@ func (w *ResponseWriterWrapper) extractDeferredAPIRequest(c *gin.Context) []byte
 	if !exists {
 		return nil
 	}
-	requests, ok := value.([]logging.DeferredAPIRequest)
-	if !ok || len(requests) == 0 {
+	var requests []logging.DeferredAPIRequest
+	switch source := value.(type) {
+	case logging.DeferredAPIRequestSource:
+		requests = source.SnapshotDeferredAPIRequests()
+	case []logging.DeferredAPIRequest:
+		requests = source
+	default:
+		return nil
+	}
+	if len(requests) == 0 {
 		return nil
 	}
 	var body bytes.Buffer

--- a/internal/logging/request_logger.go
+++ b/internal/logging/request_logger.go
@@ -45,6 +45,11 @@ const (
 // DeferredAPIRequest builds an upstream request log only when an error log needs it.
 type DeferredAPIRequest func() []byte
 
+// DeferredAPIRequestSource provides a concurrency-safe snapshot of deferred upstream requests.
+type DeferredAPIRequestSource interface {
+	SnapshotDeferredAPIRequests() []DeferredAPIRequest
+}
+
 type homeRequestLogClient interface {
 	HeartbeatOK() bool
 	RPushRequestLog(ctx context.Context, payload []byte) error

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -24,10 +25,11 @@ const (
 	apiRequestKey                  = "API_REQUEST"
 	apiResponseKey                 = "API_RESPONSE"
 	apiWebsocketTimelineKey        = "API_WEBSOCKET_TIMELINE"
-	deferredAPIRequestBytesKey     = "DEFERRED_API_REQUEST_BYTES"
 	creditsUsedKey                 = "__antigravity_credits_used__"
 	maxDeferredAPIRequestBodyBytes = 32 << 20 // 32 MiB
 )
+
+var deferredAPIRequestStateInitMu sync.Mutex
 
 // UpstreamRequestLog captures the outbound upstream request details for logging.
 type UpstreamRequestLog struct {
@@ -40,6 +42,43 @@ type UpstreamRequestLog struct {
 	AuthLabel string
 	AuthType  string
 	AuthValue string
+}
+
+type deferredAPIRequestState struct {
+	mu        sync.Mutex
+	requests  []logging.DeferredAPIRequest
+	bytesUsed int
+}
+
+func (s *deferredAPIRequestState) SnapshotDeferredAPIRequests() []logging.DeferredAPIRequest {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]logging.DeferredAPIRequest(nil), s.requests...)
+}
+
+func deferredAPIRequestStateFor(ginCtx *gin.Context) *deferredAPIRequestState {
+	if ginCtx == nil {
+		return nil
+	}
+	if value, exists := ginCtx.Get(logging.DeferredAPIRequestContextKey); exists {
+		if state, ok := value.(*deferredAPIRequestState); ok {
+			return state
+		}
+	}
+
+	deferredAPIRequestStateInitMu.Lock()
+	defer deferredAPIRequestStateInitMu.Unlock()
+	if value, exists := ginCtx.Get(logging.DeferredAPIRequestContextKey); exists {
+		if state, ok := value.(*deferredAPIRequestState); ok {
+			return state
+		}
+	}
+	state := &deferredAPIRequestState{}
+	ginCtx.Set(logging.DeferredAPIRequestContextKey, state)
+	return state
 }
 
 type upstreamAttempt struct {
@@ -128,16 +167,17 @@ func deferAPIRequest(ginCtx *gin.Context, info UpstreamRequestLog) {
 	if ginCtx == nil {
 		return
 	}
-	var requests []logging.DeferredAPIRequest
-	if value, exists := ginCtx.Get(logging.DeferredAPIRequestContextKey); exists {
-		requests, _ = value.([]logging.DeferredAPIRequest)
+	state := deferredAPIRequestStateFor(ginCtx)
+	if state == nil {
+		return
 	}
-	index := len(requests) + 1
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	index := len(state.requests) + 1
 	capturedInfo := info
 	capturedAt := time.Now()
-	capturedBytes, _ := ginCtx.Get(deferredAPIRequestBytesKey)
-	bytesUsed, _ := capturedBytes.(int)
-	remaining := maxDeferredAPIRequestBodyBytes - bytesUsed
+	remaining := maxDeferredAPIRequestBodyBytes - state.bytesUsed
 	if remaining < 0 {
 		remaining = 0
 	}
@@ -148,8 +188,8 @@ func deferAPIRequest(ginCtx *gin.Context, info UpstreamRequestLog) {
 	capturedInfo.Body = bytes.Clone(info.Body[:captureLength])
 	bodyEmpty := len(info.Body) == 0
 	bodyTruncated := captureLength < len(info.Body)
-	ginCtx.Set(deferredAPIRequestBytesKey, bytesUsed+captureLength)
-	requests = append(requests, func() []byte {
+	state.bytesUsed += captureLength
+	state.requests = append(state.requests, func() []byte {
 		builder := newAPIRequestLogBuilder(index, capturedInfo, capturedAt)
 		if bodyEmpty {
 			builder.WriteString("<empty>")
@@ -162,7 +202,6 @@ func deferAPIRequest(ginCtx *gin.Context, info UpstreamRequestLog) {
 		builder.WriteString("\n\n")
 		return []byte(builder.String())
 	})
-	ginCtx.Set(logging.DeferredAPIRequestContextKey, requests)
 }
 
 func newAPIRequestLogBuilder(index int, info UpstreamRequestLog, timestamp time.Time) *strings.Builder {

--- a/internal/runtime/executor/helps/logging_helpers_test.go
+++ b/internal/runtime/executor/helps/logging_helpers_test.go
@@ -1,16 +1,37 @@
 package helps
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 )
+
+type deferredAPIRequestSnapshotter interface {
+	SnapshotDeferredAPIRequests() []logging.DeferredAPIRequest
+}
+
+func snapshotDeferredAPIRequests(t *testing.T, value any) []logging.DeferredAPIRequest {
+	t.Helper()
+	switch source := value.(type) {
+	case []logging.DeferredAPIRequest:
+		return source
+	case deferredAPIRequestSnapshotter:
+		return source.SnapshotDeferredAPIRequests()
+	default:
+		t.Fatalf("deferred API request source type = %T", value)
+		return nil
+	}
+}
 
 func TestRecordAPIRequestClonesDeferredBodyWhenRequestLogDisabled(t *testing.T) {
 	gin.SetMode(gin.TestMode)
@@ -30,13 +51,78 @@ func TestRecordAPIRequestClonesDeferredBodyWhenRequestLogDisabled(t *testing.T) 
 	if !exists {
 		t.Fatal("deferred API request was not captured")
 	}
-	requests, ok := value.([]logging.DeferredAPIRequest)
-	if !ok || len(requests) != 1 {
+	requests := snapshotDeferredAPIRequests(t, value)
+	if len(requests) != 1 {
 		t.Fatalf("deferred API requests = %#v, want one request", value)
 	}
 	captured := string(requests[0]())
 	if !strings.Contains(captured, `{"model":"original"}`) {
 		t.Fatalf("captured API request = %q, want original body", captured)
+	}
+}
+
+func TestRecordAPIRequestConcurrentDeferredRequests(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+	ctx := context.WithValue(context.Background(), "gin", ginCtx)
+
+	const attempts = 200
+	bodySize := maxDeferredAPIRequestBodyBytes/attempts + 1024
+	body := bytes.Repeat([]byte("~"), bodySize)
+	previousProcs := runtime.GOMAXPROCS(8)
+	t.Cleanup(func() {
+		runtime.GOMAXPROCS(previousProcs)
+	})
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(attempts)
+	for i := 0; i < attempts; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			RecordAPIRequest(ctx, &config.Config{}, UpstreamRequestLog{
+				URL:    "https://api.example.com/v1/responses",
+				Method: http.MethodPost,
+				Body:   body,
+			})
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	value, exists := ginCtx.Get(logging.DeferredAPIRequestContextKey)
+	if !exists {
+		t.Fatal("deferred API requests were not captured")
+	}
+	requests := snapshotDeferredAPIRequests(t, value)
+	if len(requests) != attempts {
+		t.Fatalf("retained %d deferred requests, want %d", len(requests), attempts)
+	}
+
+	seen := make(map[int]struct{}, attempts)
+	capturedBodyBytes := 0
+	for _, buildRequest := range requests {
+		if buildRequest == nil {
+			t.Fatal("deferred API request builder is nil")
+		}
+		payload := buildRequest()
+		capturedBodyBytes += bytes.Count(payload, []byte("~"))
+		var index int
+		if _, errScan := fmt.Sscanf(string(payload), "=== API REQUEST %d ===", &index); errScan != nil {
+			t.Fatalf("parse deferred request index: %v; payload=%q", errScan, payload)
+		}
+		if _, duplicate := seen[index]; duplicate {
+			t.Fatalf("duplicate deferred request index %d", index)
+		}
+		seen[index] = struct{}{}
+	}
+	if len(seen) != attempts {
+		t.Fatalf("unique deferred request indexes = %d, want %d", len(seen), attempts)
+	}
+	if capturedBodyBytes != maxDeferredAPIRequestBodyBytes {
+		t.Fatalf("captured deferred request body bytes = %d, want cap %d", capturedBodyBytes, maxDeferredAPIRequestBodyBytes)
 	}
 }
 

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -914,8 +914,8 @@ func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliprox
 	// left pointing at a deleted tool once only x_search remains.
 	body = normalizeXAINamespaceToolChoice(body)
 	body = pruneXAIOrphanedToolChoice(body)
-	body = normalizeXAIToolChoiceForTools(body)
 	body = ensureXAINativeXSearchTool(body)
+	body = normalizeXAIToolChoiceForTools(body)
 	var replayScope xaiReasoningReplayScope
 	body, replayScope, err = applyXAIReasoningReplayCacheRequired(ctx, from, req, opts, body)
 	if err != nil {

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -709,6 +709,38 @@ func TestXAIExecutorPrepareAllowedToolsSyncsInjectedXSearch(t *testing.T) {
 	}
 }
 
+func TestXAIExecutorPreparePreservesExplicitToolChoiceNoneAfterXSearchInject(t *testing.T) {
+	t.Parallel()
+
+	exec := NewXAIExecutor(&config.Config{})
+	prepared, err := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+		Model: "grok-4.5",
+		Payload: []byte(`{
+			"model":"grok-4.5",
+			"input":"answer without tools",
+			"tool_choice":"none",
+			"parallel_tool_calls":false
+		}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatCodex,
+		Stream:       false,
+	}, false)
+	if err != nil {
+		t.Fatalf("prepareResponsesRequest() error = %v", err)
+	}
+
+	if got := gjson.GetBytes(prepared.body, "tools.0.type").String(); got != "x_search" {
+		t.Fatalf("tools.0.type = %q, want x_search; body=%s", got, prepared.body)
+	}
+	if got := gjson.GetBytes(prepared.body, "tool_choice").String(); got != "none" {
+		t.Fatalf("tool_choice = %q, want none; body=%s", got, prepared.body)
+	}
+	parallelToolCalls := gjson.GetBytes(prepared.body, "parallel_tool_calls")
+	if !parallelToolCalls.Exists() || parallelToolCalls.Bool() {
+		t.Fatalf("parallel_tool_calls = %s, want explicit false; body=%s", parallelToolCalls.Raw, prepared.body)
+	}
+}
+
 func TestXAIInternalXSearchResponseFilterRequiresNativeTool(t *testing.T) {
 	if xaiRequestHasNativeXSearch([]byte(`{"tools":[{"type":"web_search"}]}`)) {
 		t.Fatal("web_search must not enable internal X search filtering")


### PR DESCRIPTION
## 结论

收口 v7.2.78 / 09da52ad intake 后复查发现的两类真实回归：xAI 显式禁用工具被 native x_search 注入绕过，以及 error-only request logging 在 panic 路径可能遗留临时请求体文件。同时修复 deferred upstream request 记录的并发状态竞争。

## 问题与修复

- xAI：把 native `x_search` 注入放到 tool-choice normalization 之前，保留客户端显式 `tool_choice: none` 与 `parallel_tool_calls: false`。
- request logging：middleware 持有 deferred body capture 的 unwind cleanup，覆盖正常完成、普通 panic 与 `http.ErrAbortHandler`。
- deferred upstream request：用 mutex-protected snapshot source 替代并发读写同一 slice/context value，保留 32 MiB 总捕获上限与稳定 attempt index。
- LTS registry：登记 `xai-explicit-tool-choice-none` 与 `request-body-panic-tempfile-cleanup` downstream patches，并补充 protected review paths。

## Protected delta review

- retained capabilities: preserved
- LTS-owned features: two required regression patches added
- shared review seams: request lifecycle, logging metadata, executor tool semantics reviewed
- downstream patches: patch-still-required
- validation profiles: run locally
- upstream ordinary changes: unchanged; this PR only closes post-sync regressions

## 验证

- `go test -count=1 ./internal/api/middleware ./internal/logging ./internal/runtime/executor/helps ./internal/runtime/executor`
- `go test -race -count=1 ./internal/runtime/executor/helps -run "Deferred|RecordAPIRequest"`
- `scripts/check-lts-contract.sh`
- `go run ./scripts/ltsregistry --root .`
- `go build -o <temp> ./cmd/server`
- `go test ./...`
- `git diff --check`

以上本地均通过。该 PR 内的 patch ledger 引用实现 commit，因此合并必须使用 **Create a merge commit**，禁止 squash/rebase。