### PR TITLE
sync: protected upstream stage 2 through 93d74a89

### DIFF
--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -4,7 +4,7 @@ patches:
   - id: codex-model-fallback
     reason: Codex usage-limit and model-capacity failures need an opt-in ordered model fallback after same-model credentials are exhausted, while cross-model retries must not replay model-private reasoning signatures or replay a stream after client-visible delivery.
     introduced_in: 0bd5a46fd34dff4711fe5618afe66c93f316897b
-    affected_upstream_range: through 81d70f5d9f3fdb39a6290ed9c917ff0c6f27ca30 (v7.2.78-27-g81d70f5d); upstream adds agent-scoped Claude replay turns, Responses Lite parallel-tool normalization, input-ID shortening, and selected-auth trace metadata, but it still does not provide typed configurable cross-model fallback, conservative source/target reasoning-continuity gates, target-model auth reselection, pre-delivery stream safety, or migration that preserves legacy flat replay entries.
+    affected_upstream_range: through 93d74a890a44802f656d7f39a573916b2611896e (v7.2.78-37-g93d74a89); upstream adds agent-scoped Claude replay turns, Responses Lite parallel-tool normalization, input-ID shortening, and selected-auth trace metadata, but it still does not provide typed configurable cross-model fallback, conservative source/target reasoning-continuity gates, target-model auth reselection, pre-delivery stream safety, or migration that preserves legacy flat replay entries.
     files:
       - config.example.yaml
       - docs/lts/codex-429-resilience.md
@@ -72,7 +72,7 @@ patches:
   - id: codex-rate-limit-continuity
     reason: A fresh Codex session can receive usage_limit_reached while previously successful sessions on the same auth/model are still allowed to finish, so Core needs a bounded observation state instead of immediately suspending the auth/model for every session.
     introduced_in: 6ee281422e460ac7d5db8d69ef3fe6b49560e96a
-    affected_upstream_range: through 81d70f5d9f3fdb39a6290ed9c917ff0c6f27ca30 (v7.2.78-27-g81d70f5d); upstream now publishes stable selected-auth indexes for CPA trace, but still immediately writes model quota cooldown for every 429 and has no Healthy/FreshBlocked/ConfirmedCooldown phases, established lease plus incumbent evidence, single-canary confirmation, lifecycle invalidation, or continuity generation guard. LTS therefore keeps delayed final-auth publication so fallback and hedge losers cannot become the selected trace or session pin.
+    affected_upstream_range: through 93d74a890a44802f656d7f39a573916b2611896e (v7.2.78-37-g93d74a89); upstream now publishes stable selected-auth indexes for CPA trace, but still immediately writes model quota cooldown for every 429 and has no Healthy/FreshBlocked/ConfirmedCooldown phases, established lease plus incumbent evidence, single-canary confirmation, lifecycle invalidation, or continuity generation guard. LTS therefore keeps delayed final-auth publication so fallback and hedge losers cannot become the selected trace or session pin.
     files:
       - config.example.yaml
       - docs/lts/codex-429-resilience.md
@@ -131,7 +131,7 @@ patches:
   - id: codex-interactions-service-tier-response
     reason: Codex Interactions requests can send priority service, but the shared response translator hardcodes streaming completion metadata to standard and omits the non-streaming tier instead of reporting the effective outbound or upstream tier.
     introduced_in: be649f04a4a66b952d5210c7cdf74e1d90a12b76
-    affected_upstream_range: through 81d70f5d9f3fdb39a6290ed9c917ff0c6f27ca30 (v7.2.78-27-g81d70f5d); da087d7f maps Claude Code speed fast to priority requests, but the separate Codex Interactions response translator still does not report the effective service_tier for streaming, non-streaming, and DONE-fallback responses, so router-for-me/CLIProxyAPI#4189 remains only partially relevant.
+    affected_upstream_range: through 93d74a890a44802f656d7f39a573916b2611896e (v7.2.78-37-g93d74a89); da087d7f maps Claude Code speed fast to priority requests, but the separate Codex Interactions response translator still does not report the effective service_tier for streaming, non-streaming, and DONE-fallback responses, so router-for-me/CLIProxyAPI#4189 remains only partially relevant.
     files:
       - internal/translator/codex/interactions/interactions_codex_response.go
       - internal/translator/codex/interactions/interactions_codex_test.go
@@ -162,7 +162,7 @@ patches:
   - id: plugin-configured-enable-default
     reason: A configured plugin without an explicit enabled field must inherit the enabled plugin subsystem default instead of being silently disabled during YAML parsing or runtime config synthesis.
     introduced_in: f3ff2f889026c6a28dc2d14f602c4fef108a0347
-    affected_upstream_range: through 81d70f5d9f3fdb39a6290ed9c917ff0c6f27ca30 (v7.2.78-27-g81d70f5d); the new Home plugin synchronization and sync-revision plumbing do not replace the configured-plugin enable default through YAML parsing and runtime host synthesis; an omitted per-plugin enabled field must still inherit true while the subsystem-level switch remains authoritative.
+    affected_upstream_range: through 93d74a890a44802f656d7f39a573916b2611896e (v7.2.78-37-g93d74a89); the new Home plugin synchronization and auth-revision plumbing do not replace the configured-plugin enable default through YAML parsing and runtime host synthesis; an omitted per-plugin enabled field must still inherit true while the subsystem-level switch remains authoritative.
     files:
       - internal/config/config.go
       - internal/config/plugin_config_test.go
@@ -179,7 +179,7 @@ patches:
   - id: codex-gpt56-ultra-level
     reason: Upstream now publishes and remotely refreshes Codex client metadata with logical Sol/Terra Ultra and Luna max-only, but it still does not provide the CPA-Core-LTS server-side capability overlay, custom-model policy, payload-override-safe wire canonicalization, usage/retry alignment, or HTTP/WebSocket enforcement. CPA-Core-LTS therefore validates the refreshed client catalog as an LTS prerequisite while retaining the downstream runtime patch.
     introduced_in: 6e12fb1dd6d522ca80a02644d286d765d7a649bd
-    affected_upstream_range: through 81d70f5d9f3fdb39a6290ed9c917ff0c6f27ca30 (v7.2.78-27-g81d70f5d); upstream PR #4276 provides the revisioned Codex client catalog, while the newer replay, input-ID, Responses Lite, trace, and WebSocket changes do not replace the downstream provider lookup/tier overlay, model-aware custom-model behavior, payload-override-safe final reasoning.effort, usage/retry alignment, or HTTP/WebSocket enforcement.
+    affected_upstream_range: through 93d74a890a44802f656d7f39a573916b2611896e (v7.2.78-37-g93d74a89); upstream PR #4276 provides the revisioned Codex client catalog, while the newer replay, input-ID, Responses Lite, trace, and WebSocket changes do not replace the downstream provider lookup/tier overlay, model-aware custom-model behavior, payload-override-safe final reasoning.effort, usage/retry alignment, or HTTP/WebSocket enforcement.
     files:
       - .github/scripts/refresh-model-catalogs.sh
       - .github/workflows/docker-image.yml
@@ -249,7 +249,7 @@ patches:
   - id: codex-model-header-provider-snapshot
     reason: Codex model override headers must be resolved from the Codex provider and captured once so the real handshake and connection key cannot disagree or be shadowed by another provider registration.
     introduced_in: 0877a26d333a3be918f5e48aadf0e4d71709ab2f
-    affected_upstream_range: through 81d70f5d9f3fdb39a6290ed9c917ff0c6f27ca30 (v7.2.78-27-g81d70f5d); upstream adds raw connection target tracking, but still does not resolve a provider-owned immutable model-header snapshot or include its digest and resolved model in reusable WebSocket connection identity.
+    affected_upstream_range: through 93d74a890a44802f656d7f39a573916b2611896e (v7.2.78-37-g93d74a89); upstream adds raw connection target tracking, but still does not resolve a provider-owned immutable model-header snapshot or include its digest and resolved model in reusable WebSocket connection identity.
     files:
       - internal/runtime/executor/codex_executor.go
       - internal/runtime/executor/codex_openai_images.go
@@ -269,7 +269,7 @@ patches:
   - id: codex-oauth-client-identity-finalization
     reason: Codex OAuth requests must finalize the official Originator, User-Agent, optional Version floor, and macOS Session_id after model-specific header overrides; otherwise the backend can reject a valid model route with a misleading 404 Model not found response.
     introduced_in: ded0314d23dc38656e2fb02220504bd98373813c
-    affected_upstream_range: through 81d70f5d9f3fdb39a6290ed9c917ff0c6f27ca30 (v7.2.78-27-g81d70f5d); input-ID shortening, Responses Lite normalization, replay isolation, and WebSocket target tracking still do not add an equivalent final OAuth client-identity pass shared by HTTP, compact, streaming, WebSocket, and image paths.
+    affected_upstream_range: through 93d74a890a44802f656d7f39a573916b2611896e (v7.2.78-37-g93d74a89); input-ID shortening, Responses Lite normalization, replay isolation, and WebSocket target tracking still do not add an equivalent final OAuth client-identity pass shared by HTTP, compact, streaming, WebSocket, and image paths.
     files:
       - config.example.yaml
       - internal/runtime/executor/codex_client_identity.go
@@ -289,7 +289,7 @@ patches:
   - id: codex-model-not-found-request-scope
     reason: An OpenAI-style 404 with error.type invalid_request_error and error.param model is a request/model routing failure, not evidence of unhealthy Codex credentials; retrying every auth or applying the generic 12-hour model cooldown can suspend the entire model pool.
     introduced_in: ded0314d23dc38656e2fb02220504bd98373813c
-    affected_upstream_range: through 81d70f5d9f3fdb39a6290ed9c917ff0c6f27ca30 (v7.2.78-27-g81d70f5d); upstream retains the generic RequestScopedError contract and new trace metadata, but still does not recognize the OpenAI-style invalid_request_error model 404, so the downstream classifier and cooldown guard remain required.
+    affected_upstream_range: through 93d74a890a44802f656d7f39a573916b2611896e (v7.2.78-37-g93d74a89); upstream retains the generic RequestScopedError contract and new trace metadata, but still does not recognize the OpenAI-style invalid_request_error model 404, so the downstream classifier and cooldown guard remain required.
     files:
       - sdk/cliproxy/auth/conductor.go
       - sdk/cliproxy/auth/conductor_overrides_test.go
@@ -305,7 +305,7 @@ patches:
   - id: codex-websocket-reader-generation
     reason: Reusable Codex WebSocket sessions need generation ownership so a stale reader or shutdown race cannot deliver to, clear, close, or deadlock a newer request.
     introduced_in: 0877a26d333a3be918f5e48aadf0e4d71709ab2f
-    affected_upstream_range: through 81d70f5d9f3fdb39a6290ed9c917ff0c6f27ca30 (v7.2.78-27-g81d70f5d); fbe11607 tracks an active raw connection and target changes, but still lacks executor-side connection generations, atomic reader/request ownership, request-owned cancellation signals, and stale-reader protection across retry, session close, and model-header profile changes.
+    affected_upstream_range: through 93d74a890a44802f656d7f39a573916b2611896e (v7.2.78-37-g93d74a89); fbe11607 tracks an active raw connection and target changes, but still lacks executor-side connection generations, atomic reader/request ownership, request-owned cancellation signals, and stale-reader protection across retry, session close, and model-header profile changes.
     files:
       - internal/runtime/executor/codex_websockets_executor.go
       - internal/runtime/executor/codex_websockets_executor_test.go
@@ -328,7 +328,7 @@ patches:
   - id: codex-spark-reasoning-summary-compat
     reason: GPT-5.3-Codex-Spark needs reasoning effort enabled but its upstream rejects reasoning.summary, so Core must remove only that unsupported field after final payload shaping across HTTP and WebSocket transports.
     introduced_in: 37e306f939e8ef363254a49cdc7f924a6ceceff5
-    affected_upstream_range: through 81d70f5d9f3fdb39a6290ed9c917ff0c6f27ca30 (v7.2.78-27-g81d70f5d); upstream adds Responses Lite parallel-tool normalization and replay/input-ID changes, but still forwards reasoning.summary for gpt-5.3-codex-spark and has no equivalent post-override HTTP/WebSocket sanitization.
+    affected_upstream_range: through 93d74a890a44802f656d7f39a573916b2611896e (v7.2.78-37-g93d74a89); upstream adds Responses Lite parallel-tool normalization and replay/input-ID changes, but still forwards reasoning.summary for gpt-5.3-codex-spark and has no equivalent post-override HTTP/WebSocket sanitization.
     files:
       - internal/runtime/executor/codex_executor.go
       - internal/runtime/executor/codex_websockets_executor.go
@@ -352,7 +352,7 @@ patches:
   - id: xai-explicit-tool-choice-none
     reason: xAI request preparation injects native x_search after removing tool_choice fields for an empty client tool list, so an explicit tool_choice none can be lost and the model may invoke search despite the client prohibition.
     introduced_in: ad7244752d324a5b179c3e30a628acf976fa995c
-    affected_upstream_range: through 81d70f5d9f3fdb39a6290ed9c917ff0c6f27ca30 (v7.2.78-27-g81d70f5d); the new xAI image-ref, compact-route, transcript, and WebSocket target changes do not fix the shared request-preparation ordering, which still normalizes tool_choice before injecting x_search.
+    affected_upstream_range: through 93d74a890a44802f656d7f39a573916b2611896e (v7.2.78-37-g93d74a89); the new xAI image-ref, compact-route, transcript, and WebSocket target changes do not fix the shared request-preparation ordering, which still normalizes tool_choice before injecting x_search.
     files:
       - internal/runtime/executor/xai_executor.go
       - internal/runtime/executor/xai_executor_test.go
@@ -362,10 +362,23 @@ patches:
     state: required
     retire_when: Upstream injects the native x_search tool before the no-tools tool_choice cleanup, preserves explicit tool_choice none and parallel_tool_calls false on the shared HTTP/WebSocket preparation path, and the listed regression passes without the downstream ordering patch.
 
+  - id: kimi-claude-delegated-auth-immutability
+    reason: Kimi delegates Claude-format requests to the Claude executor, but the selected Auth attributes are shared immutable credential configuration and must not be mutated per request to install the Kimi messages base URL.
+    introduced_in: 772915acb699d8c6b6f6d8f9c51c1b4f3a61cf34
+    affected_upstream_range: introduced by 70c4bd78b2bc347bf988f74f2d2d7da85de5aa13 and still required through 93d74a890a44802f656d7f39a573916b2611896e (v7.2.78-37-g93d74a89); upstream writes auth.Attributes["base_url"] directly in Execute, ExecuteStream, and CountTokens, which can panic for a nil map, race across concurrent requests, and persist a request-local route into shared auth state.
+    files:
+      - internal/runtime/executor/kimi_executor.go
+      - internal/runtime/executor/kimi_executor_test.go
+    regression_tests:
+      - TestKimiClaudeAuthUsesRequestLocalBaseURL
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: Upstream delegates Kimi Claude-format requests with a request-local credential view or an explicit base URL parameter, never mutates shared Auth attributes, handles nil auth/maps safely, and the listed regression passes without the downstream clone helper.
+
   - id: request-body-panic-tempfile-cleanup
     reason: This historical patch originally closed a panic-path temporary-file leak in error-only request logging. CPA-Core-LTS now removes that request-body tempfile spool entirely, keeps only bounded in-memory request/response/upstream previews, and still requires middleware-owned unwind cleanup so panic and http.ErrAbortHandler paths close the original body and release retained buffers.
     introduced_in: ad7244752d324a5b179c3e30a628acf976fa995c
-    affected_upstream_range: through 81d70f5d9f3fdb39a6290ed9c917ff0c6f27ca30 (v7.2.78-27-g81d70f5d); the plugin, replay, trace, translator, and provider changes do not alter request logging; upstream still spools large error-only bodies to temporary files, retains larger deferred upstream bodies, and performs cleanup only from the response finalizer.
+    affected_upstream_range: through 93d74a890a44802f656d7f39a573916b2611896e (v7.2.78-37-g93d74a89); the plugin, replay, trace, translator, and provider changes do not alter request logging; upstream still spools large error-only bodies to temporary files, retains larger deferred upstream bodies, and performs cleanup only from the response finalizer.
     files:
       - internal/api/middleware/request_logging.go
       - internal/api/middleware/request_logging_test.go
@@ -387,7 +400,7 @@ patches:
   - id: api-request-body-size-limit
     reason: Public Claude, Gemini, OpenAI, Responses, image, and video JSON handlers previously used unbounded body reads and unbounded zstd expansion, so a small number of concurrent oversized requests could consume container memory before provider routing or normal validation ran.
     introduced_in: b2b593fad3f18bfe700fe5f11d4e88e10bbc7f16
-    affected_upstream_range: through 81d70f5d9f3fdb39a6290ed9c917ff0c6f27ca30 (v7.2.78-27-g81d70f5d); upstream handlers still use unbounded GetRawData/io.ReadAll behavior and do not enforce the same limit on every decoded Content-Encoding layer; the new Claude handler and header-filter changes are unrelated to body-size enforcement.
+    affected_upstream_range: through 93d74a890a44802f656d7f39a573916b2611896e (v7.2.78-37-g93d74a89); upstream handlers still use unbounded GetRawData/io.ReadAll behavior and do not enforce the same limit on every decoded Content-Encoding layer; the new Claude handler and header-filter changes are unrelated to body-size enforcement.
     files:
       - sdk/api/handlers/request_body.go
       - sdk/api/handlers/request_body_test.go

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -182,8 +182,8 @@ type PluginsConfig struct {
 	StoreSources []string `yaml:"store-sources,omitempty" json:"store-sources,omitempty"`
 	// StoreAuth defines optional auth rules for plugin store registry, metadata, and artifact requests.
 	StoreAuth []sdkpluginstore.AuthConfig `yaml:"store-auth,omitempty" json:"store-auth,omitempty"`
-	// SyncRevision changes when Home-managed plugin credentials change.
-	SyncRevision int64 `yaml:"sync-revision,omitempty" json:"sync-revision,omitempty"`
+	// AuthRevision changes when Home-managed plugin credentials change.
+	AuthRevision int64 `yaml:"auth-revision,omitempty" json:"auth-revision,omitempty"`
 	// Configs stores per-plugin instance configuration by plugin ID.
 	Configs map[string]PluginInstanceConfig `yaml:"configs" json:"configs"`
 }

--- a/internal/config/plugin_config_test.go
+++ b/internal/config/plugin_config_test.go
@@ -117,13 +117,13 @@ plugins:
 	}
 }
 
-func TestParseConfigBytes_PluginSyncRevision(t *testing.T) {
-	cfg, errParse := ParseConfigBytes([]byte("plugins:\n  sync-revision: 42\n"))
+func TestParseConfigBytes_PluginAuthRevision(t *testing.T) {
+	cfg, errParse := ParseConfigBytes([]byte("plugins:\n  auth-revision: 42\n"))
 	if errParse != nil {
 		t.Fatalf("ParseConfigBytes() error = %v", errParse)
 	}
-	if cfg.Plugins.SyncRevision != 42 {
-		t.Fatalf("Plugins.SyncRevision = %d, want 42", cfg.Plugins.SyncRevision)
+	if cfg.Plugins.AuthRevision != 42 {
+		t.Fatalf("Plugins.AuthRevision = %d, want 42", cfg.Plugins.AuthRevision)
 	}
 }
 

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -2178,12 +2178,33 @@
       "owned_by": "moonshot",
       "type": "kimi",
       "display_name": "Kimi K3",
-      "description": "Kimi K3 - Moonshot AI's next-generation flagship model (~2.5T MoE) with multimodal input and 1M context",
+      "description": "Kimi K3 - Moonshot AI's next-generation flagship model (~2.8T MoE) with multimodal input",
+      "context_length": 262144,
+      "max_completion_tokens": 65536,
+      "thinking": {
+        "zero_allowed": false,
+        "levels": [
+          "low",
+          "high",
+          "max"
+        ]
+      }
+    },
+    {
+      "id": "kimi-k3[1M]",
+      "object": "model",
+      "created": 1784073600,
+      "owned_by": "moonshot",
+      "type": "kimi",
+      "display_name": "Kimi K3",
+      "description": "Kimi K3 - Moonshot AI's next-generation flagship model (~2.8T MoE) with multimodal input and 1M context",
       "context_length": 1048576,
       "max_completion_tokens": 65536,
       "thinking": {
         "zero_allowed": false,
         "levels": [
+          "low",
+          "high",
           "max"
         ]
       }

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -2189,25 +2189,6 @@
           "max"
         ]
       }
-    },
-    {
-      "id": "kimi-k3[1m]",
-      "object": "model",
-      "created": 1784073600,
-      "owned_by": "moonshot",
-      "type": "kimi",
-      "display_name": "Kimi K3",
-      "description": "Kimi K3 - Moonshot AI's next-generation flagship model (~2.8T MoE) with multimodal input and 1M context",
-      "context_length": 1048576,
-      "max_completion_tokens": 65536,
-      "thinking": {
-        "zero_allowed": false,
-        "levels": [
-          "low",
-          "high",
-          "max"
-        ]
-      }
     }
   ],
   "antigravity": [

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -2191,7 +2191,7 @@
       }
     },
     {
-      "id": "kimi-k3[1M]",
+      "id": "kimi-k3[1m]",
       "object": "model",
       "created": 1784073600,
       "owned_by": "moonshot",

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -620,15 +620,15 @@
       }
     },
     {
-      "id": "gemini-3-pro-preview",
+      "id": "gemini-3-pro",
       "object": "model",
       "created": 1737158400,
       "owned_by": "google",
       "type": "gemini",
-      "display_name": "Gemini 3 Pro Preview",
-      "name": "models/gemini-3-pro-preview",
+      "display_name": "Gemini 3 Pro",
+      "name": "models/gemini-3-pro",
       "version": "3.0",
-      "description": "Gemini 3 Pro Preview",
+      "description": "Gemini 3 Pro",
       "inputTokenLimit": 1048576,
       "outputTokenLimit": 65536,
       "supportedGenerationMethods": [
@@ -648,13 +648,13 @@
       }
     },
     {
-      "id": "gemini-3-flash-preview",
+      "id": "gemini-3-flash",
       "object": "model",
       "created": 1765929600,
       "owned_by": "google",
       "type": "gemini",
-      "display_name": "Gemini 3 Flash Preview",
-      "name": "models/gemini-3-flash-preview",
+      "display_name": "Gemini 3 Flash",
+      "name": "models/gemini-3-flash",
       "version": "3.0",
       "description": "Our most intelligent model built for speed, combining frontier intelligence with superior search and grounding.",
       "inputTokenLimit": 1048576,
@@ -678,15 +678,15 @@
       }
     },
     {
-      "id": "gemini-3.1-pro-preview",
+      "id": "gemini-3.1-pro",
       "object": "model",
       "created": 1771459200,
       "owned_by": "google",
       "type": "gemini",
-      "display_name": "Gemini 3.1 Pro Preview",
-      "name": "models/gemini-3.1-pro-preview",
+      "display_name": "Gemini 3.1 Pro",
+      "name": "models/gemini-3.1-pro",
       "version": "3.1",
-      "description": "Gemini 3.1 Pro Preview",
+      "description": "Gemini 3.1 Pro",
       "inputTokenLimit": 1048576,
       "outputTokenLimit": 65536,
       "supportedGenerationMethods": [
@@ -707,15 +707,15 @@
       }
     },
     {
-      "id": "gemini-3.1-flash-image-preview",
+      "id": "gemini-3.1-flash-image",
       "object": "model",
       "created": 1771459200,
       "owned_by": "google",
       "type": "gemini",
-      "display_name": "Gemini 3.1 Flash Image Preview",
-      "name": "models/gemini-3.1-flash-image-preview",
+      "display_name": "Gemini 3.1 Flash Image",
+      "name": "models/gemini-3.1-flash-image",
       "version": "3.1",
-      "description": "Gemini 3.1 Flash Image Preview",
+      "description": "Gemini 3.1 Flash Image",
       "inputTokenLimit": 1048576,
       "outputTokenLimit": 65536,
       "supportedGenerationMethods": [
@@ -765,15 +765,15 @@
       }
     },
     {
-      "id": "gemini-3-pro-image-preview",
+      "id": "gemini-3-pro-image",
       "object": "model",
       "created": 1737158400,
       "owned_by": "google",
       "type": "gemini",
-      "display_name": "Gemini 3 Pro Image Preview",
-      "name": "models/gemini-3-pro-image-preview",
+      "display_name": "Gemini 3 Pro Image",
+      "name": "models/gemini-3-pro-image",
       "version": "3.0",
-      "description": "Gemini 3 Pro Image Preview",
+      "description": "Gemini 3 Pro Image",
       "inputTokenLimit": 1048576,
       "outputTokenLimit": 65536,
       "supportedGenerationMethods": [

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -38,7 +38,8 @@ import (
 // ClaudeExecutor is a stateless executor for Anthropic Claude over the messages API.
 // If api_key is unavailable on auth, it falls back to legacy via ClientAdapter.
 type ClaudeExecutor struct {
-	cfg *config.Config
+	cfg                *config.Config
+	requestLogProvider string
 }
 
 // claudeToolPrefix is empty to match real Claude Code behavior (no tool name prefix).
@@ -152,6 +153,13 @@ const defaultModelMaxTokens = 1024
 func NewClaudeExecutor(cfg *config.Config) *ClaudeExecutor { return &ClaudeExecutor{cfg: cfg} }
 
 func (e *ClaudeExecutor) Identifier() string { return "claude" }
+
+func (e *ClaudeExecutor) upstreamRequestLogProvider() string {
+	if provider := strings.TrimSpace(e.requestLogProvider); provider != "" {
+		return provider
+	}
+	return e.Identifier()
+}
 
 // PrepareRequest injects Claude credentials into the outgoing HTTP request.
 func (e *ClaudeExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Auth) error {
@@ -286,7 +294,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	if err != nil {
 		return resp, err
 	}
-	if errHeaders := applyClaudeHeaders(httpReq, auth, apiKey, false, extraBetas, e.cfg); errHeaders != nil {
+	if errHeaders := applyClaudeHeaders(httpReq, auth, apiKey, false, extraBetas, e.cfg, opts.Headers); errHeaders != nil {
 		return resp, errHeaders
 	}
 	var authID, authLabel, authType, authValue string
@@ -300,7 +308,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		Method:    http.MethodPost,
 		Headers:   httpReq.Header.Clone(),
 		Body:      bodyForUpstream,
-		Provider:  e.Identifier(),
+		Provider:  e.upstreamRequestLogProvider(),
 		AuthID:    authID,
 		AuthLabel: authLabel,
 		AuthType:  authType,
@@ -475,7 +483,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	if err != nil {
 		return nil, err
 	}
-	if errHeaders := applyClaudeHeaders(httpReq, auth, apiKey, true, extraBetas, e.cfg); errHeaders != nil {
+	if errHeaders := applyClaudeHeaders(httpReq, auth, apiKey, true, extraBetas, e.cfg, opts.Headers); errHeaders != nil {
 		return nil, errHeaders
 	}
 	var authID, authLabel, authType, authValue string
@@ -489,7 +497,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		Method:    http.MethodPost,
 		Headers:   httpReq.Header.Clone(),
 		Body:      bodyForUpstream,
-		Provider:  e.Identifier(),
+		Provider:  e.upstreamRequestLogProvider(),
 		AuthID:    authID,
 		AuthLabel: authLabel,
 		AuthType:  authType,
@@ -731,7 +739,7 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}
-	if errHeaders := applyClaudeHeaders(httpReq, auth, apiKey, false, extraBetas, e.cfg); errHeaders != nil {
+	if errHeaders := applyClaudeHeaders(httpReq, auth, apiKey, false, extraBetas, e.cfg, opts.Headers); errHeaders != nil {
 		return cliproxyexecutor.Response{}, errHeaders
 	}
 	var authID, authLabel, authType, authValue string
@@ -745,7 +753,7 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 		Method:    http.MethodPost,
 		Headers:   httpReq.Header.Clone(),
 		Body:      body,
-		Provider:  e.Identifier(),
+		Provider:  e.upstreamRequestLogProvider(),
 		AuthID:    authID,
 		AuthLabel: authLabel,
 		AuthType:  authType,
@@ -1048,7 +1056,7 @@ func decodeResponseBody(body io.ReadCloser, contentEncoding string) (io.ReadClos
 	return body, nil
 }
 
-func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string, stream bool, extraBetas []string, cfg *config.Config) error {
+func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string, stream bool, extraBetas []string, cfg *config.Config, incomingHeaders http.Header) error {
 	if r == nil {
 		return nil
 	}
@@ -1074,22 +1082,23 @@ func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string,
 	}
 	r.Header.Set("Content-Type", "application/json")
 
-	var ginHeaders http.Header
-	if ginCtx, ok := r.Context().Value("gin").(*gin.Context); ok && ginCtx != nil && ginCtx.Request != nil {
-		ginHeaders = ginCtx.Request.Header
+	if incomingHeaders == nil {
+		if ginCtx, ok := r.Context().Value("gin").(*gin.Context); ok && ginCtx != nil && ginCtx.Request != nil {
+			incomingHeaders = ginCtx.Request.Header
+		}
 	}
 	stabilizeDeviceProfile := helps.ClaudeDeviceProfileStabilizationEnabled(cfg)
 	var deviceProfile helps.ClaudeDeviceProfile
 	if stabilizeDeviceProfile {
 		var errDeviceProfile error
-		deviceProfile, errDeviceProfile = helps.ResolveClaudeDeviceProfileRequired(r.Context(), auth, apiKey, ginHeaders, cfg)
+		deviceProfile, errDeviceProfile = helps.ResolveClaudeDeviceProfileRequired(r.Context(), auth, apiKey, incomingHeaders, cfg)
 		if errDeviceProfile != nil {
 			return errDeviceProfile
 		}
 	}
 
 	baseBetas := "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,context-management-2025-06-27,prompt-caching-scope-2026-01-05,structured-outputs-2025-12-15,fast-mode-2026-02-01,redact-thinking-2026-02-12,token-efficient-tools-2026-03-28"
-	if val := strings.TrimSpace(ginHeaders.Get("Anthropic-Beta")); val != "" {
+	if val := strings.TrimSpace(strings.Join(incomingHeaders.Values("Anthropic-Beta"), ",")); val != "" {
 		baseBetas = val
 		if !strings.Contains(val, "oauth") {
 			baseBetas += ",oauth-2025-04-20"
@@ -1118,26 +1127,26 @@ func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string,
 	}
 	r.Header.Set("Anthropic-Beta", baseBetas)
 
-	misc.EnsureHeader(r.Header, ginHeaders, "Anthropic-Version", "2023-06-01")
+	misc.EnsureHeader(r.Header, incomingHeaders, "Anthropic-Version", "2023-06-01")
 	// Only set browser access header for API key mode; real Claude Code CLI does not send it.
 	if useAPIKey {
-		misc.EnsureHeader(r.Header, ginHeaders, "Anthropic-Dangerous-Direct-Browser-Access", "true")
+		misc.EnsureHeader(r.Header, incomingHeaders, "Anthropic-Dangerous-Direct-Browser-Access", "true")
 	}
-	misc.EnsureHeader(r.Header, ginHeaders, "X-App", "cli")
+	misc.EnsureHeader(r.Header, incomingHeaders, "X-App", "cli")
 	// Values below match Claude Code 2.1.63 / @anthropic-ai/sdk 0.74.0 (updated 2026-02-28).
-	misc.EnsureHeader(r.Header, ginHeaders, "X-Stainless-Retry-Count", "0")
-	misc.EnsureHeader(r.Header, ginHeaders, "X-Stainless-Runtime", "node")
-	misc.EnsureHeader(r.Header, ginHeaders, "X-Stainless-Lang", "js")
-	misc.EnsureHeader(r.Header, ginHeaders, "X-Stainless-Timeout", hdrDefault(hd.Timeout, "600"))
+	misc.EnsureHeader(r.Header, incomingHeaders, "X-Stainless-Retry-Count", "0")
+	misc.EnsureHeader(r.Header, incomingHeaders, "X-Stainless-Runtime", "node")
+	misc.EnsureHeader(r.Header, incomingHeaders, "X-Stainless-Lang", "js")
+	misc.EnsureHeader(r.Header, incomingHeaders, "X-Stainless-Timeout", hdrDefault(hd.Timeout, "600"))
 	// Session ID: stable per auth/apiKey, matches Claude Code's X-Claude-Code-Session-Id header.
 	sessionID, errSessionID := helps.CachedSessionIDRequired(r.Context(), apiKey)
 	if errSessionID != nil {
 		return errSessionID
 	}
-	misc.EnsureHeader(r.Header, ginHeaders, "X-Claude-Code-Session-Id", sessionID)
+	misc.EnsureHeader(r.Header, incomingHeaders, "X-Claude-Code-Session-Id", sessionID)
 	// Per-request UUID, matches Claude Code's x-client-request-id for first-party API.
 	if isAnthropicBase {
-		misc.EnsureHeader(r.Header, ginHeaders, "x-client-request-id", uuid.New().String())
+		misc.EnsureHeader(r.Header, incomingHeaders, "x-client-request-id", uuid.New().String())
 	}
 	r.Header.Set("Connection", "keep-alive")
 	if stream {
@@ -1156,7 +1165,7 @@ func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string,
 	if stabilizeDeviceProfile {
 		helps.ApplyClaudeDeviceProfileHeaders(r, deviceProfile)
 	} else {
-		helps.ApplyClaudeLegacyDeviceHeaders(r, ginHeaders, cfg)
+		helps.ApplyClaudeLegacyDeviceHeaders(r, incomingHeaders, cfg)
 	}
 	var attrs map[string]string
 	if auth != nil {

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -104,7 +104,7 @@ func TestApplyClaudeHeaders_UsesConfiguredBaselineFingerprint(t *testing.T) {
 	}
 
 	req := newClaudeHeaderTestRequest(t, incoming)
-	applyClaudeHeaders(req, auth, "key-baseline", false, nil, cfg)
+	applyClaudeHeaders(req, auth, "key-baseline", false, nil, cfg, nil)
 
 	assertClaudeFingerprint(t, req.Header, "evil-client/9.9", "9.9.9", "v24.5.0", "Linux", "x64")
 	if got := req.Header.Get("X-Stainless-Timeout"); got != "900" {
@@ -140,7 +140,7 @@ func TestApplyClaudeHeaders_TracksHighestClaudeCLIFingerprint(t *testing.T) {
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(firstReq, auth, "key-upgrade", false, nil, cfg)
+	applyClaudeHeaders(firstReq, auth, "key-upgrade", false, nil, cfg, nil)
 	assertClaudeFingerprint(t, firstReq.Header, "claude-cli/2.1.62 (external, cli)", "0.74.0", "v24.3.0", "MacOS", "arm64")
 
 	thirdPartyReq := newClaudeHeaderTestRequest(t, http.Header{
@@ -150,7 +150,7 @@ func TestApplyClaudeHeaders_TracksHighestClaudeCLIFingerprint(t *testing.T) {
 		"X-Stainless-Os":              []string{"Windows"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(thirdPartyReq, auth, "key-upgrade", false, nil, cfg)
+	applyClaudeHeaders(thirdPartyReq, auth, "key-upgrade", false, nil, cfg, nil)
 	assertClaudeFingerprint(t, thirdPartyReq.Header, "claude-cli/2.1.62 (external, cli)", "0.74.0", "v24.3.0", "MacOS", "arm64")
 
 	higherReq := newClaudeHeaderTestRequest(t, http.Header{
@@ -160,7 +160,7 @@ func TestApplyClaudeHeaders_TracksHighestClaudeCLIFingerprint(t *testing.T) {
 		"X-Stainless-Os":              []string{"MacOS"},
 		"X-Stainless-Arch":            []string{"arm64"},
 	})
-	applyClaudeHeaders(higherReq, auth, "key-upgrade", false, nil, cfg)
+	applyClaudeHeaders(higherReq, auth, "key-upgrade", false, nil, cfg, nil)
 	assertClaudeFingerprint(t, higherReq.Header, "claude-cli/2.1.63 (external, cli)", "0.75.0", "v24.4.0", "MacOS", "arm64")
 
 	lowerReq := newClaudeHeaderTestRequest(t, http.Header{
@@ -170,7 +170,7 @@ func TestApplyClaudeHeaders_TracksHighestClaudeCLIFingerprint(t *testing.T) {
 		"X-Stainless-Os":              []string{"Windows"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(lowerReq, auth, "key-upgrade", false, nil, cfg)
+	applyClaudeHeaders(lowerReq, auth, "key-upgrade", false, nil, cfg, nil)
 	assertClaudeFingerprint(t, lowerReq.Header, "claude-cli/2.1.63 (external, cli)", "0.75.0", "v24.4.0", "MacOS", "arm64")
 }
 
@@ -202,7 +202,7 @@ func TestApplyClaudeHeaders_DoesNotDowngradeConfiguredBaselineOnFirstClaudeClien
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(olderClaudeReq, auth, "key-baseline-floor", false, nil, cfg)
+	applyClaudeHeaders(olderClaudeReq, auth, "key-baseline-floor", false, nil, cfg, nil)
 	assertClaudeFingerprint(t, olderClaudeReq.Header, "claude-cli/2.1.70 (external, cli)", "0.80.0", "v24.5.0", "MacOS", "arm64")
 
 	newerClaudeReq := newClaudeHeaderTestRequest(t, http.Header{
@@ -212,7 +212,7 @@ func TestApplyClaudeHeaders_DoesNotDowngradeConfiguredBaselineOnFirstClaudeClien
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(newerClaudeReq, auth, "key-baseline-floor", false, nil, cfg)
+	applyClaudeHeaders(newerClaudeReq, auth, "key-baseline-floor", false, nil, cfg, nil)
 	assertClaudeFingerprint(t, newerClaudeReq.Header, "claude-cli/2.1.71 (external, cli)", "0.81.0", "v24.6.0", "MacOS", "arm64")
 }
 
@@ -254,7 +254,7 @@ func TestApplyClaudeHeaders_UpgradesCachedSoftwareFingerprintWhenBaselineAdvance
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(officialReq, auth, "key-baseline-reload", false, nil, oldCfg)
+	applyClaudeHeaders(officialReq, auth, "key-baseline-reload", false, nil, oldCfg, nil)
 	assertClaudeFingerprint(t, officialReq.Header, "claude-cli/2.1.71 (external, cli)", "0.81.0", "v24.6.0", "MacOS", "arm64")
 
 	thirdPartyReq := newClaudeHeaderTestRequest(t, http.Header{
@@ -264,7 +264,7 @@ func TestApplyClaudeHeaders_UpgradesCachedSoftwareFingerprintWhenBaselineAdvance
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(thirdPartyReq, auth, "key-baseline-reload", false, nil, newCfg)
+	applyClaudeHeaders(thirdPartyReq, auth, "key-baseline-reload", false, nil, newCfg, nil)
 	assertClaudeFingerprint(t, thirdPartyReq.Header, "claude-cli/2.1.77 (external, cli)", "0.87.0", "v24.8.0", "MacOS", "arm64")
 }
 
@@ -296,7 +296,7 @@ func TestApplyClaudeHeaders_LearnsOfficialFingerprintAfterCustomBaselineFallback
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(thirdPartyReq, auth, "key-custom-baseline-learning", false, nil, cfg)
+	applyClaudeHeaders(thirdPartyReq, auth, "key-custom-baseline-learning", false, nil, cfg, nil)
 	assertClaudeFingerprint(t, thirdPartyReq.Header, "my-gateway/1.0", "custom-pkg", "custom-runtime", "MacOS", "arm64")
 
 	officialReq := newClaudeHeaderTestRequest(t, http.Header{
@@ -306,7 +306,7 @@ func TestApplyClaudeHeaders_LearnsOfficialFingerprintAfterCustomBaselineFallback
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(officialReq, auth, "key-custom-baseline-learning", false, nil, cfg)
+	applyClaudeHeaders(officialReq, auth, "key-custom-baseline-learning", false, nil, cfg, nil)
 	assertClaudeFingerprint(t, officialReq.Header, "claude-cli/2.1.77 (external, cli)", "0.87.0", "v24.8.0", "MacOS", "arm64")
 
 	postLearningThirdPartyReq := newClaudeHeaderTestRequest(t, http.Header{
@@ -316,7 +316,7 @@ func TestApplyClaudeHeaders_LearnsOfficialFingerprintAfterCustomBaselineFallback
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(postLearningThirdPartyReq, auth, "key-custom-baseline-learning", false, nil, cfg)
+	applyClaudeHeaders(postLearningThirdPartyReq, auth, "key-custom-baseline-learning", false, nil, cfg, nil)
 	assertClaudeFingerprint(t, postLearningThirdPartyReq.Header, "claude-cli/2.1.77 (external, cli)", "0.87.0", "v24.8.0", "MacOS", "arm64")
 }
 
@@ -448,7 +448,7 @@ func TestApplyClaudeHeaders_ThirdPartyBaselineThenOfficialUpgradeKeepsPinnedPlat
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(thirdPartyReq, auth, "key-third-party-then-official", false, nil, cfg)
+	applyClaudeHeaders(thirdPartyReq, auth, "key-third-party-then-official", false, nil, cfg, nil)
 	assertClaudeFingerprint(t, thirdPartyReq.Header, "claude-cli/2.1.70 (external, cli)", "0.80.0", "v24.5.0", "MacOS", "arm64")
 
 	officialReq := newClaudeHeaderTestRequest(t, http.Header{
@@ -458,7 +458,7 @@ func TestApplyClaudeHeaders_ThirdPartyBaselineThenOfficialUpgradeKeepsPinnedPlat
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(officialReq, auth, "key-third-party-then-official", false, nil, cfg)
+	applyClaudeHeaders(officialReq, auth, "key-third-party-then-official", false, nil, cfg, nil)
 	assertClaudeFingerprint(t, officialReq.Header, "claude-cli/2.1.77 (external, cli)", "0.87.0", "v24.8.0", "MacOS", "arm64")
 }
 
@@ -490,7 +490,7 @@ func TestApplyClaudeHeaders_DisableDeviceProfileStabilization(t *testing.T) {
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(firstReq, auth, "key-disable-stability", false, nil, cfg)
+	applyClaudeHeaders(firstReq, auth, "key-disable-stability", false, nil, cfg, nil)
 	assertClaudeFingerprint(t, firstReq.Header, "claude-cli/2.1.62 (external, cli)", "0.74.0", "v24.3.0", "Linux", "x64")
 
 	thirdPartyReq := newClaudeHeaderTestRequest(t, http.Header{
@@ -500,7 +500,7 @@ func TestApplyClaudeHeaders_DisableDeviceProfileStabilization(t *testing.T) {
 		"X-Stainless-Os":              []string{"Windows"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(thirdPartyReq, auth, "key-disable-stability", false, nil, cfg)
+	applyClaudeHeaders(thirdPartyReq, auth, "key-disable-stability", false, nil, cfg, nil)
 	assertClaudeFingerprint(t, thirdPartyReq.Header, "claude-cli/2.1.60 (external, cli)", "0.10.0", "v18.0.0", "Windows", "x64")
 
 	lowerReq := newClaudeHeaderTestRequest(t, http.Header{
@@ -510,7 +510,7 @@ func TestApplyClaudeHeaders_DisableDeviceProfileStabilization(t *testing.T) {
 		"X-Stainless-Os":              []string{"Windows"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(lowerReq, auth, "key-disable-stability", false, nil, cfg)
+	applyClaudeHeaders(lowerReq, auth, "key-disable-stability", false, nil, cfg, nil)
 	assertClaudeFingerprint(t, lowerReq.Header, "claude-cli/2.1.61 (external, cli)", "0.73.0", "v24.2.0", "Windows", "x64")
 }
 
@@ -541,7 +541,7 @@ func TestApplyClaudeHeaders_LegacyModePreservesConfiguredUserAgentOverrideForCla
 		"X-Stainless-Os":              []string{"Linux"},
 		"X-Stainless-Arch":            []string{"x64"},
 	})
-	applyClaudeHeaders(req, auth, "key-legacy-ua-override", false, nil, cfg)
+	applyClaudeHeaders(req, auth, "key-legacy-ua-override", false, nil, cfg, nil)
 
 	assertClaudeFingerprint(t, req.Header, "config-ua/1.0", "0.74.0", "v24.3.0", "Linux", "x64")
 }
@@ -570,7 +570,7 @@ func TestApplyClaudeHeaders_LegacyModeFallsBackToRuntimeOSArchWhenMissing(t *tes
 	req := newClaudeHeaderTestRequest(t, http.Header{
 		"User-Agent": []string{"curl/8.7.1"},
 	})
-	applyClaudeHeaders(req, auth, "key-legacy-runtime-os-arch", false, nil, cfg)
+	applyClaudeHeaders(req, auth, "key-legacy-runtime-os-arch", false, nil, cfg, nil)
 
 	assertClaudeFingerprint(t, req.Header, "claude-cli/2.1.60 (external, cli)", "0.70.0", "v22.0.0", helps.MapStainlessOS(), helps.MapStainlessArch())
 }
@@ -597,7 +597,7 @@ func TestApplyClaudeHeaders_UnsetStabilizationAlsoUsesLegacyRuntimeOSArchFallbac
 	req := newClaudeHeaderTestRequest(t, http.Header{
 		"User-Agent": []string{"curl/8.7.1"},
 	})
-	applyClaudeHeaders(req, auth, "key-unset-runtime-os-arch", false, nil, cfg)
+	applyClaudeHeaders(req, auth, "key-unset-runtime-os-arch", false, nil, cfg, nil)
 
 	assertClaudeFingerprint(t, req.Header, "claude-cli/2.1.60 (external, cli)", "0.70.0", "v22.0.0", helps.MapStainlessOS(), helps.MapStainlessArch())
 }

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -34,7 +34,12 @@ type KimiExecutor struct {
 }
 
 // NewKimiExecutor creates a new Kimi executor.
-func NewKimiExecutor(cfg *config.Config) *KimiExecutor { return &KimiExecutor{cfg: cfg} }
+func NewKimiExecutor(cfg *config.Config) *KimiExecutor {
+	return &KimiExecutor{
+		ClaudeExecutor: ClaudeExecutor{cfg: cfg, requestLogProvider: "kimi"},
+		cfg:            cfg,
+	}
+}
 
 // Identifier returns the executor identifier.
 func (e *KimiExecutor) Identifier() string { return "kimi" }

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -80,10 +80,6 @@ func (e *KimiExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth,
 // Execute performs a non-streaming chat completion request to Kimi.
 func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
 	from := opts.SourceFormat
-	if from.String() == "claude" {
-		auth.Attributes["base_url"] = kimiauth.KimiAPIBaseURL
-		return e.ClaudeExecutor.Execute(ctx, auth, req, opts)
-	}
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
@@ -190,10 +186,6 @@ func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 // ExecuteStream performs a streaming chat completion request to Kimi.
 func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
 	from := opts.SourceFormat
-	if from.String() == "claude" {
-		auth.Attributes["base_url"] = kimiauth.KimiAPIBaseURL
-		return e.ClaudeExecutor.ExecuteStream(ctx, auth, req, opts)
-	}
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 
 	baseModel := thinking.ParseSuffix(req.Model).ModelName

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -77,6 +77,7 @@ func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 	from := opts.SourceFormat
 	if from.String() == "claude" {
 		auth.Attributes["base_url"] = kimiauth.KimiAPIBaseURL
+		req.Model = normalizeKimiUpstreamModel(req.Model)
 		return e.ClaudeExecutor.Execute(ctx, auth, req, opts)
 	}
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
@@ -97,8 +98,8 @@ func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, false)
 	body := sdktranslator.TranslateRequest(from, to, baseModel, bytes.Clone(req.Payload), false)
 
-	// Strip kimi- prefix for upstream API
-	upstreamModel := stripKimiPrefix(baseModel)
+	// Strip kimi- prefix and any [1m] suffix for upstream API
+	upstreamModel := normalizeKimiUpstreamModel(baseModel)
 	body, err = sjson.SetBytes(body, "model", upstreamModel)
 	if err != nil {
 		return resp, fmt.Errorf("kimi executor: failed to set model in payload: %w", err)
@@ -187,6 +188,7 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 	from := opts.SourceFormat
 	if from.String() == "claude" {
 		auth.Attributes["base_url"] = kimiauth.KimiAPIBaseURL
+		req.Model = normalizeKimiUpstreamModel(req.Model)
 		return e.ClaudeExecutor.ExecuteStream(ctx, auth, req, opts)
 	}
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
@@ -206,8 +208,8 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 	originalTranslated := sdktranslator.TranslateRequest(from, to, baseModel, originalPayload, true)
 	body := sdktranslator.TranslateRequest(from, to, baseModel, bytes.Clone(req.Payload), true)
 
-	// Strip kimi- prefix for upstream API
-	upstreamModel := stripKimiPrefix(baseModel)
+	// Strip kimi- prefix and any [1m] suffix for upstream API
+	upstreamModel := normalizeKimiUpstreamModel(baseModel)
 	body, err = sjson.SetBytes(body, "model", upstreamModel)
 	if err != nil {
 		return nil, fmt.Errorf("kimi executor: failed to set model in payload: %w", err)
@@ -327,6 +329,7 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 // CountTokens estimates token count for Kimi requests.
 func (e *KimiExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
 	auth.Attributes["base_url"] = kimiauth.KimiAPIBaseURL
+	req.Model = normalizeKimiUpstreamModel(req.Model)
 	return e.ClaudeExecutor.CountTokens(ctx, auth, req, opts)
 }
 
@@ -753,4 +756,22 @@ func stripKimiPrefix(model string) string {
 		return model[5:]
 	}
 	return model
+}
+
+// normalizeKimiUpstreamModel returns the canonical upstream model ID for Kimi.
+// It strips the CLIProxyAPI "kimi-" prefix and any Claude Code "[1m]" context
+// suffix while preserving a trailing thinking suffix (e.g. "(1024)"), so that
+// the upstream API receives IDs such as "k3(1024)" instead of "kimi-k3[1m](1024)".
+func normalizeKimiUpstreamModel(model string) string {
+	model = strings.TrimSpace(model)
+	parsed := thinking.ParseSuffix(model)
+	base := parsed.ModelName
+	if strings.HasSuffix(strings.ToLower(base), "[1m]") {
+		base = base[:len(base)-len("[1m]")]
+	}
+	normalized := strings.ToLower(stripKimiPrefix(strings.TrimSpace(base)))
+	if parsed.HasSuffix {
+		return normalized + "(" + parsed.RawSuffix + ")"
+	}
+	return normalized
 }

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -80,6 +80,10 @@ func (e *KimiExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth,
 // Execute performs a non-streaming chat completion request to Kimi.
 func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
 	from := opts.SourceFormat
+	if from.String() == "claude" {
+		auth.Attributes["base_url"] = kimiauth.KimiAPIBaseURL
+		return e.ClaudeExecutor.Execute(ctx, auth, req, opts)
+	}
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 
 	baseModel := thinking.ParseSuffix(req.Model).ModelName
@@ -186,6 +190,10 @@ func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 // ExecuteStream performs a streaming chat completion request to Kimi.
 func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
 	from := opts.SourceFormat
+	if from.String() == "claude" {
+		auth.Attributes["base_url"] = kimiauth.KimiAPIBaseURL
+		return e.ClaudeExecutor.ExecuteStream(ctx, auth, req, opts)
+	}
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 
 	baseModel := thinking.ParseSuffix(req.Model).ModelName

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -85,8 +85,7 @@ func (e *KimiExecutor) HttpRequest(ctx context.Context, auth *cliproxyauth.Auth,
 func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
 	from := opts.SourceFormat
 	if from.String() == "claude" {
-		auth.Attributes["base_url"] = kimiauth.KimiAPIBaseURL
-		return e.ClaudeExecutor.Execute(ctx, auth, req, opts)
+		return e.ClaudeExecutor.Execute(ctx, kimiClaudeAuth(auth), req, opts)
 	}
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 
@@ -195,8 +194,7 @@ func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
 	from := opts.SourceFormat
 	if from.String() == "claude" {
-		auth.Attributes["base_url"] = kimiauth.KimiAPIBaseURL
-		return e.ClaudeExecutor.ExecuteStream(ctx, auth, req, opts)
+		return e.ClaudeExecutor.ExecuteStream(ctx, kimiClaudeAuth(auth), req, opts)
 	}
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 
@@ -335,8 +333,19 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 
 // CountTokens estimates token count for Kimi requests.
 func (e *KimiExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
-	auth.Attributes["base_url"] = kimiauth.KimiAPIBaseURL
-	return e.ClaudeExecutor.CountTokens(ctx, auth, req, opts)
+	return e.ClaudeExecutor.CountTokens(ctx, kimiClaudeAuth(auth), req, opts)
+}
+
+func kimiClaudeAuth(auth *cliproxyauth.Auth) *cliproxyauth.Auth {
+	if auth == nil {
+		return nil
+	}
+	delegated := auth.Clone()
+	if delegated.Attributes == nil {
+		delegated.Attributes = make(map[string]string)
+	}
+	delegated.Attributes["base_url"] = kimiauth.KimiAPIBaseURL
+	return delegated
 }
 
 func normalizeKimiToolMessageLinks(body []byte) ([]byte, error) {

--- a/internal/runtime/executor/kimi_executor_test.go
+++ b/internal/runtime/executor/kimi_executor_test.go
@@ -270,3 +270,29 @@ func TestNormalizeKimiToolMessageLinks_PreservesAssistantWithToolLinkOrReasoning
 		t.Fatalf("messages.3.content.0.text = %q, want %q", got, " visible ")
 	}
 }
+
+func TestNormalizeKimiUpstreamModel(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"kimi-k3[1m]", "k3"},
+		{"kimi-k3", "k3"},
+		{"Kimi-K3[1M]", "k3"},
+		{"k3[1m]", "k3"},
+		{"k3", "k3"},
+		{"kimi-k2.6", "k2.6"},
+		{"kimi-k2.6[1m]", "k2.6"},
+		{"kimi-k3(1024)", "k3(1024)"},
+		{"kimi-k3[1m](1024)", "k3(1024)"},
+		{"kimi-k2.6(high)", "k2.6(high)"},
+		{"kimi-k2.6[1m](high)", "k2.6(high)"},
+	}
+
+	for _, c := range cases {
+		got := normalizeKimiUpstreamModel(c.in)
+		if got != c.want {
+			t.Errorf("normalizeKimiUpstreamModel(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/runtime/executor/kimi_executor_test.go
+++ b/internal/runtime/executor/kimi_executor_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-func TestNewKimiExecutorInitializesClaudeTokenCounterConfig(t *testing.T) {
+func TestNewKimiExecutorInitializesDelegatedClaudeConfig(t *testing.T) {
 	cfg := &config.Config{SDKConfig: config.SDKConfig{RequestLog: true}}
 	executor := NewKimiExecutor(cfg)
 
@@ -24,92 +24,29 @@ func TestNewKimiExecutorInitializesClaudeTokenCounterConfig(t *testing.T) {
 		t.Fatal("Kimi executor config was not initialized")
 	}
 	if executor.ClaudeExecutor.cfg != cfg {
-		t.Fatal("Claude token counter config was not initialized")
+		t.Fatal("delegated Claude executor config was not initialized")
 	}
 }
 
-func TestKimiExecutorClaudeRequestUsesChatCompletionsPath(t *testing.T) {
-	var upstreamRequest *http.Request
-	var upstreamBody []byte
-	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", kimiRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		upstreamRequest = req.Clone(req.Context())
-		upstreamRequest.Header = req.Header.Clone()
-		var errRead error
-		upstreamBody, errRead = io.ReadAll(req.Body)
-		if errRead != nil {
-			return nil, errRead
-		}
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Header:     http.Header{"Content-Type": []string{"application/json"}},
-			Body: io.NopCloser(strings.NewReader(
-				`{"id":"chatcmpl_test","object":"chat.completion","created":1,"model":"k2.5","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
-			)),
-		}, nil
-	}))
-
-	executor := NewKimiExecutor(&config.Config{})
-	auth := &cliproxyauth.Auth{
-		Attributes: map[string]string{},
-		Metadata:   map[string]any{"access_token": "test-token"},
-	}
-	payload := []byte(`{"model":"kimi-k2.5","max_tokens":32,"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`)
-	response, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
-		Model:   "kimi-k2.5",
-		Payload: payload,
-	}, cliproxyexecutor.Options{
-		SourceFormat:    sdktranslator.FormatClaude,
-		OriginalRequest: payload,
-	})
-	if err != nil {
-		t.Fatalf("Execute() error = %v", err)
-	}
-	if upstreamRequest == nil {
-		t.Fatal("upstream request was not captured")
-	}
-	if got := upstreamRequest.URL.String(); got != "https://api.kimi.com/coding/v1/chat/completions" {
-		t.Fatalf("upstream URL = %q, want Kimi chat completions endpoint", got)
-	}
-	if got := upstreamRequest.Header.Get("Authorization"); got != "Bearer test-token" {
-		t.Fatalf("Authorization = %q, want Kimi bearer token", got)
-	}
-	if got := gjson.GetBytes(upstreamBody, "model").String(); got != "k2.5" {
-		t.Fatalf("upstream model = %q, want stripped Kimi model", got)
-	}
-	if got := gjson.GetBytes(upstreamBody, "messages.0.content.0.text").String(); got != "hello" {
-		t.Fatalf("upstream message text = %q, want translated Claude request", got)
-	}
-	if got := gjson.GetBytes(response.Payload, "type").String(); got != "message" {
-		t.Fatalf("response type = %q, want Claude message", got)
-	}
-	if got := gjson.GetBytes(response.Payload, "content.0.text").String(); got != "hello" {
-		t.Fatalf("response text = %q, want translated Claude response", got)
-	}
-}
-
-func TestKimiExecutorClaudeStreamUsesChatCompletionsPath(t *testing.T) {
+func TestKimiExecutorClaudeStreamForwardsAnthropicBetaAndLogsUpstream(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
 	ginCtx, _ := gin.CreateTestContext(recorder)
 	ginCtx.Request = httptest.NewRequest(http.MethodPost, "/v1/messages?beta=true", nil)
 
 	var upstreamRequest *http.Request
-	var upstreamBody []byte
 	ctx := context.WithValue(context.Background(), "gin", ginCtx)
 	ctx = context.WithValue(ctx, "cliproxy.roundtripper", kimiRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		upstreamRequest = req.Clone(req.Context())
 		upstreamRequest.Header = req.Header.Clone()
-		var errRead error
-		upstreamBody, errRead = io.ReadAll(req.Body)
-		if errRead != nil {
-			return nil, errRead
-		}
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
 			Body: io.NopCloser(strings.NewReader(
-				`data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":1,"model":"k2.5","choices":[{"index":0,"delta":{"role":"assistant","content":"hello"},"finish_reason":null}]}` + "\n\n" +
-					`data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":1,"model":"k2.5","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}` + "\n\n",
+				"event: message_start\n" +
+					`data: {"type":"message_start","message":{"id":"msg_test","type":"message","role":"assistant","model":"kimi-k3","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}` + "\n\n" +
+					"event: message_stop\n" +
+					`data: {"type":"message_stop"}` + "\n\n",
 			)),
 		}, nil
 	}))
@@ -121,49 +58,36 @@ func TestKimiExecutorClaudeStreamUsesChatCompletionsPath(t *testing.T) {
 		Attributes: map[string]string{},
 		Metadata:   map[string]any{"access_token": "test-token"},
 	}
-	payload := []byte(`{"model":"kimi-k2.5","max_tokens":32,"stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`)
+	payload := []byte(`{"model":"kimi-k3","max_tokens":32,"messages":[{"role":"user","content":"hello"}]}`)
 	result, err := executor.ExecuteStream(ctx, auth, cliproxyexecutor.Request{
-		Model:   "kimi-k2.5",
+		Model:   "kimi-k3",
 		Payload: payload,
 	}, cliproxyexecutor.Options{
 		Stream:          true,
 		SourceFormat:    sdktranslator.FormatClaude,
 		OriginalRequest: payload,
 		Headers: http.Header{
-			"Anthropic-Beta": []string{"client-beta"},
+			"Anthropic-Beta": []string{"client-beta-one", "client-beta-two"},
 		},
 	})
 	if err != nil {
 		t.Fatalf("ExecuteStream() error = %v", err)
 	}
-	var output strings.Builder
 	for chunk := range result.Chunks {
 		if chunk.Err != nil {
 			t.Fatalf("stream chunk error = %v", chunk.Err)
 		}
-		output.Write(chunk.Payload)
 	}
 	if upstreamRequest == nil {
 		t.Fatal("upstream request was not captured")
 	}
-	if got := upstreamRequest.URL.String(); got != "https://api.kimi.com/coding/v1/chat/completions" {
-		t.Fatalf("upstream URL = %q, want Kimi chat completions endpoint", got)
+	if got := upstreamRequest.URL.String(); got != "https://api.kimi.com/coding/v1/messages?beta=true" {
+		t.Fatalf("upstream URL = %q, want Kimi messages endpoint", got)
 	}
-	if got := upstreamRequest.Header.Get("Anthropic-Beta"); got != "" {
-		t.Fatalf("Anthropic-Beta = %q, want header omitted from Kimi chat completions request", got)
-	}
-	if got := gjson.GetBytes(upstreamBody, "model").String(); got != "k2.5" {
-		t.Fatalf("upstream model = %q, want stripped Kimi model", got)
-	}
-	if !gjson.GetBytes(upstreamBody, "stream").Bool() {
-		t.Fatal("upstream stream = false, want true")
-	}
-	if !gjson.GetBytes(upstreamBody, "stream_options.include_usage").Bool() {
-		t.Fatal("upstream stream_options.include_usage = false, want true")
-	}
-	for _, want := range []string{`event: message_start`, `"type":"text_delta","text":"hello"`, `event: message_stop`} {
-		if !strings.Contains(output.String(), want) {
-			t.Fatalf("stream output = %q, want %q", output.String(), want)
+	upstreamBetas := upstreamRequest.Header.Get("Anthropic-Beta")
+	for _, beta := range []string{"client-beta-one", "client-beta-two", "oauth-2025-04-20", "interleaved-thinking-2025-05-14"} {
+		if !strings.Contains(upstreamBetas, beta) {
+			t.Fatalf("Anthropic-Beta = %q, want %q", upstreamBetas, beta)
 		}
 	}
 
@@ -175,13 +99,17 @@ func TestKimiExecutorClaudeStreamUsesChatCompletionsPath(t *testing.T) {
 	apiRequestText := string(apiRequest)
 	for _, want := range []string{
 		"=== API REQUEST 1 ===",
-		"Upstream URL: https://api.kimi.com/coding/v1/chat/completions",
+		"Upstream URL: https://api.kimi.com/coding/v1/messages?beta=true",
 		"Auth: provider=kimi",
-		`"model":"k2.5"`,
+		"Anthropic-Beta: " + upstreamBetas,
+		`"model":"kimi-k3"`,
 	} {
 		if !strings.Contains(apiRequestText, want) {
 			t.Fatalf("API_REQUEST = %q, want %q", apiRequestText, want)
 		}
+	}
+	if strings.Contains(apiRequestText, "<missing>") {
+		t.Fatalf("API_REQUEST = %q, want captured upstream request", apiRequestText)
 	}
 
 	rawAPIResponse, existsResponse := ginCtx.Get("API_RESPONSE")
@@ -190,7 +118,7 @@ func TestKimiExecutorClaudeStreamUsesChatCompletionsPath(t *testing.T) {
 		t.Fatalf("API_RESPONSE = %#v, want captured bytes", rawAPIResponse)
 	}
 	apiResponseText := string(apiResponse)
-	for _, want := range []string{"=== API RESPONSE 1 ===", "Status: 200", `"object":"chat.completion.chunk"`} {
+	for _, want := range []string{"=== API RESPONSE 1 ===", "Status: 200", `data: {"type":"message_stop"}`} {
 		if !strings.Contains(apiResponseText, want) {
 			t.Fatalf("API_RESPONSE = %q, want %q", apiResponseText, want)
 		}

--- a/internal/runtime/executor/kimi_executor_test.go
+++ b/internal/runtime/executor/kimi_executor_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-func TestNewKimiExecutorInitializesDelegatedClaudeConfig(t *testing.T) {
+func TestNewKimiExecutorInitializesClaudeTokenCounterConfig(t *testing.T) {
 	cfg := &config.Config{SDKConfig: config.SDKConfig{RequestLog: true}}
 	executor := NewKimiExecutor(cfg)
 
@@ -24,29 +24,92 @@ func TestNewKimiExecutorInitializesDelegatedClaudeConfig(t *testing.T) {
 		t.Fatal("Kimi executor config was not initialized")
 	}
 	if executor.ClaudeExecutor.cfg != cfg {
-		t.Fatal("delegated Claude executor config was not initialized")
+		t.Fatal("Claude token counter config was not initialized")
 	}
 }
 
-func TestKimiExecutorClaudeStreamForwardsAnthropicBetaAndLogsUpstream(t *testing.T) {
+func TestKimiExecutorClaudeRequestUsesChatCompletionsPath(t *testing.T) {
+	var upstreamRequest *http.Request
+	var upstreamBody []byte
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", kimiRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		upstreamRequest = req.Clone(req.Context())
+		upstreamRequest.Header = req.Header.Clone()
+		var errRead error
+		upstreamBody, errRead = io.ReadAll(req.Body)
+		if errRead != nil {
+			return nil, errRead
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(
+				`{"id":"chatcmpl_test","object":"chat.completion","created":1,"model":"k2.5","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+			)),
+		}, nil
+	}))
+
+	executor := NewKimiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{},
+		Metadata:   map[string]any{"access_token": "test-token"},
+	}
+	payload := []byte(`{"model":"kimi-k2.5","max_tokens":32,"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`)
+	response, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "kimi-k2.5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat:    sdktranslator.FormatClaude,
+		OriginalRequest: payload,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if upstreamRequest == nil {
+		t.Fatal("upstream request was not captured")
+	}
+	if got := upstreamRequest.URL.String(); got != "https://api.kimi.com/coding/v1/chat/completions" {
+		t.Fatalf("upstream URL = %q, want Kimi chat completions endpoint", got)
+	}
+	if got := upstreamRequest.Header.Get("Authorization"); got != "Bearer test-token" {
+		t.Fatalf("Authorization = %q, want Kimi bearer token", got)
+	}
+	if got := gjson.GetBytes(upstreamBody, "model").String(); got != "k2.5" {
+		t.Fatalf("upstream model = %q, want stripped Kimi model", got)
+	}
+	if got := gjson.GetBytes(upstreamBody, "messages.0.content.0.text").String(); got != "hello" {
+		t.Fatalf("upstream message text = %q, want translated Claude request", got)
+	}
+	if got := gjson.GetBytes(response.Payload, "type").String(); got != "message" {
+		t.Fatalf("response type = %q, want Claude message", got)
+	}
+	if got := gjson.GetBytes(response.Payload, "content.0.text").String(); got != "hello" {
+		t.Fatalf("response text = %q, want translated Claude response", got)
+	}
+}
+
+func TestKimiExecutorClaudeStreamUsesChatCompletionsPath(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
 	ginCtx, _ := gin.CreateTestContext(recorder)
 	ginCtx.Request = httptest.NewRequest(http.MethodPost, "/v1/messages?beta=true", nil)
 
 	var upstreamRequest *http.Request
+	var upstreamBody []byte
 	ctx := context.WithValue(context.Background(), "gin", ginCtx)
 	ctx = context.WithValue(ctx, "cliproxy.roundtripper", kimiRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		upstreamRequest = req.Clone(req.Context())
 		upstreamRequest.Header = req.Header.Clone()
+		var errRead error
+		upstreamBody, errRead = io.ReadAll(req.Body)
+		if errRead != nil {
+			return nil, errRead
+		}
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
 			Body: io.NopCloser(strings.NewReader(
-				"event: message_start\n" +
-					`data: {"type":"message_start","message":{"id":"msg_test","type":"message","role":"assistant","model":"kimi-k3","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}` + "\n\n" +
-					"event: message_stop\n" +
-					`data: {"type":"message_stop"}` + "\n\n",
+				`data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":1,"model":"k2.5","choices":[{"index":0,"delta":{"role":"assistant","content":"hello"},"finish_reason":null}]}` + "\n\n" +
+					`data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":1,"model":"k2.5","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}` + "\n\n",
 			)),
 		}, nil
 	}))
@@ -58,36 +121,49 @@ func TestKimiExecutorClaudeStreamForwardsAnthropicBetaAndLogsUpstream(t *testing
 		Attributes: map[string]string{},
 		Metadata:   map[string]any{"access_token": "test-token"},
 	}
-	payload := []byte(`{"model":"kimi-k3","max_tokens":32,"messages":[{"role":"user","content":"hello"}]}`)
+	payload := []byte(`{"model":"kimi-k2.5","max_tokens":32,"stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`)
 	result, err := executor.ExecuteStream(ctx, auth, cliproxyexecutor.Request{
-		Model:   "kimi-k3",
+		Model:   "kimi-k2.5",
 		Payload: payload,
 	}, cliproxyexecutor.Options{
 		Stream:          true,
 		SourceFormat:    sdktranslator.FormatClaude,
 		OriginalRequest: payload,
 		Headers: http.Header{
-			"Anthropic-Beta": []string{"client-beta-one", "client-beta-two"},
+			"Anthropic-Beta": []string{"client-beta"},
 		},
 	})
 	if err != nil {
 		t.Fatalf("ExecuteStream() error = %v", err)
 	}
+	var output strings.Builder
 	for chunk := range result.Chunks {
 		if chunk.Err != nil {
 			t.Fatalf("stream chunk error = %v", chunk.Err)
 		}
+		output.Write(chunk.Payload)
 	}
 	if upstreamRequest == nil {
 		t.Fatal("upstream request was not captured")
 	}
-	if got := upstreamRequest.URL.String(); got != "https://api.kimi.com/coding/v1/messages?beta=true" {
-		t.Fatalf("upstream URL = %q, want Kimi messages endpoint", got)
+	if got := upstreamRequest.URL.String(); got != "https://api.kimi.com/coding/v1/chat/completions" {
+		t.Fatalf("upstream URL = %q, want Kimi chat completions endpoint", got)
 	}
-	upstreamBetas := upstreamRequest.Header.Get("Anthropic-Beta")
-	for _, beta := range []string{"client-beta-one", "client-beta-two", "oauth-2025-04-20", "interleaved-thinking-2025-05-14"} {
-		if !strings.Contains(upstreamBetas, beta) {
-			t.Fatalf("Anthropic-Beta = %q, want %q", upstreamBetas, beta)
+	if got := upstreamRequest.Header.Get("Anthropic-Beta"); got != "" {
+		t.Fatalf("Anthropic-Beta = %q, want header omitted from Kimi chat completions request", got)
+	}
+	if got := gjson.GetBytes(upstreamBody, "model").String(); got != "k2.5" {
+		t.Fatalf("upstream model = %q, want stripped Kimi model", got)
+	}
+	if !gjson.GetBytes(upstreamBody, "stream").Bool() {
+		t.Fatal("upstream stream = false, want true")
+	}
+	if !gjson.GetBytes(upstreamBody, "stream_options.include_usage").Bool() {
+		t.Fatal("upstream stream_options.include_usage = false, want true")
+	}
+	for _, want := range []string{`event: message_start`, `"type":"text_delta","text":"hello"`, `event: message_stop`} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("stream output = %q, want %q", output.String(), want)
 		}
 	}
 
@@ -99,17 +175,13 @@ func TestKimiExecutorClaudeStreamForwardsAnthropicBetaAndLogsUpstream(t *testing
 	apiRequestText := string(apiRequest)
 	for _, want := range []string{
 		"=== API REQUEST 1 ===",
-		"Upstream URL: https://api.kimi.com/coding/v1/messages?beta=true",
+		"Upstream URL: https://api.kimi.com/coding/v1/chat/completions",
 		"Auth: provider=kimi",
-		"Anthropic-Beta: " + upstreamBetas,
-		`"model":"kimi-k3"`,
+		`"model":"k2.5"`,
 	} {
 		if !strings.Contains(apiRequestText, want) {
 			t.Fatalf("API_REQUEST = %q, want %q", apiRequestText, want)
 		}
-	}
-	if strings.Contains(apiRequestText, "<missing>") {
-		t.Fatalf("API_REQUEST = %q, want captured upstream request", apiRequestText)
 	}
 
 	rawAPIResponse, existsResponse := ginCtx.Get("API_RESPONSE")
@@ -118,7 +190,7 @@ func TestKimiExecutorClaudeStreamForwardsAnthropicBetaAndLogsUpstream(t *testing
 		t.Fatalf("API_RESPONSE = %#v, want captured bytes", rawAPIResponse)
 	}
 	apiResponseText := string(apiResponse)
-	for _, want := range []string{"=== API RESPONSE 1 ===", "Status: 200", `data: {"type":"message_stop"}`} {
+	for _, want := range []string{"=== API RESPONSE 1 ===", "Status: 200", `"object":"chat.completion.chunk"`} {
 		if !strings.Contains(apiResponseText, want) {
 			t.Fatalf("API_RESPONSE = %q, want %q", apiResponseText, want)
 		}

--- a/internal/runtime/executor/kimi_executor_test.go
+++ b/internal/runtime/executor/kimi_executor_test.go
@@ -1,10 +1,135 @@
 package executor
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	"github.com/tidwall/gjson"
 )
+
+func TestNewKimiExecutorInitializesDelegatedClaudeConfig(t *testing.T) {
+	cfg := &config.Config{SDKConfig: config.SDKConfig{RequestLog: true}}
+	executor := NewKimiExecutor(cfg)
+
+	if executor.cfg != cfg {
+		t.Fatal("Kimi executor config was not initialized")
+	}
+	if executor.ClaudeExecutor.cfg != cfg {
+		t.Fatal("delegated Claude executor config was not initialized")
+	}
+}
+
+func TestKimiExecutorClaudeStreamForwardsAnthropicBetaAndLogsUpstream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "/v1/messages?beta=true", nil)
+
+	var upstreamRequest *http.Request
+	ctx := context.WithValue(context.Background(), "gin", ginCtx)
+	ctx = context.WithValue(ctx, "cliproxy.roundtripper", kimiRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		upstreamRequest = req.Clone(req.Context())
+		upstreamRequest.Header = req.Header.Clone()
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body: io.NopCloser(strings.NewReader(
+				"event: message_start\n" +
+					`data: {"type":"message_start","message":{"id":"msg_test","type":"message","role":"assistant","model":"kimi-k3","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}` + "\n\n" +
+					"event: message_stop\n" +
+					`data: {"type":"message_stop"}` + "\n\n",
+			)),
+		}, nil
+	}))
+
+	cfg := &config.Config{SDKConfig: config.SDKConfig{RequestLog: true}}
+	executor := NewKimiExecutor(cfg)
+	auth := &cliproxyauth.Auth{
+		ID:         "kimi-test-auth",
+		Attributes: map[string]string{},
+		Metadata:   map[string]any{"access_token": "test-token"},
+	}
+	payload := []byte(`{"model":"kimi-k3","max_tokens":32,"messages":[{"role":"user","content":"hello"}]}`)
+	result, err := executor.ExecuteStream(ctx, auth, cliproxyexecutor.Request{
+		Model:   "kimi-k3",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		Stream:          true,
+		SourceFormat:    sdktranslator.FormatClaude,
+		OriginalRequest: payload,
+		Headers: http.Header{
+			"Anthropic-Beta": []string{"client-beta-one", "client-beta-two"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v", chunk.Err)
+		}
+	}
+	if upstreamRequest == nil {
+		t.Fatal("upstream request was not captured")
+	}
+	if got := upstreamRequest.URL.String(); got != "https://api.kimi.com/coding/v1/messages?beta=true" {
+		t.Fatalf("upstream URL = %q, want Kimi messages endpoint", got)
+	}
+	upstreamBetas := upstreamRequest.Header.Get("Anthropic-Beta")
+	for _, beta := range []string{"client-beta-one", "client-beta-two", "oauth-2025-04-20", "interleaved-thinking-2025-05-14"} {
+		if !strings.Contains(upstreamBetas, beta) {
+			t.Fatalf("Anthropic-Beta = %q, want %q", upstreamBetas, beta)
+		}
+	}
+
+	rawAPIRequest, existsRequest := ginCtx.Get("API_REQUEST")
+	apiRequest, okRequest := rawAPIRequest.([]byte)
+	if !existsRequest || !okRequest {
+		t.Fatalf("API_REQUEST = %#v, want captured bytes", rawAPIRequest)
+	}
+	apiRequestText := string(apiRequest)
+	for _, want := range []string{
+		"=== API REQUEST 1 ===",
+		"Upstream URL: https://api.kimi.com/coding/v1/messages?beta=true",
+		"Auth: provider=kimi",
+		"Anthropic-Beta: " + upstreamBetas,
+		`"model":"kimi-k3"`,
+	} {
+		if !strings.Contains(apiRequestText, want) {
+			t.Fatalf("API_REQUEST = %q, want %q", apiRequestText, want)
+		}
+	}
+	if strings.Contains(apiRequestText, "<missing>") {
+		t.Fatalf("API_REQUEST = %q, want captured upstream request", apiRequestText)
+	}
+
+	rawAPIResponse, existsResponse := ginCtx.Get("API_RESPONSE")
+	apiResponse, okResponse := rawAPIResponse.([]byte)
+	if !existsResponse || !okResponse {
+		t.Fatalf("API_RESPONSE = %#v, want captured bytes", rawAPIResponse)
+	}
+	apiResponseText := string(apiResponse)
+	for _, want := range []string{"=== API RESPONSE 1 ===", "Status: 200", `data: {"type":"message_stop"}`} {
+		if !strings.Contains(apiResponseText, want) {
+			t.Fatalf("API_RESPONSE = %q, want %q", apiResponseText, want)
+		}
+	}
+}
+
+type kimiRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f kimiRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestNormalizeKimiToolMessageLinks_UsesCallIDFallback(t *testing.T) {
 	body := []byte(`{

--- a/internal/runtime/executor/kimi_executor_test.go
+++ b/internal/runtime/executor/kimi_executor_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	kimiauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/kimi"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -70,6 +71,43 @@ func TestKimiExecutorClaudeRequestPreservesInternalModelSemantics(t *testing.T) 
 	}
 	if got := gjson.GetBytes(response.Payload, "model").String(); got != model {
 		t.Fatalf("response model = %q, want %q", got, model)
+	}
+}
+
+func TestKimiClaudeAuthUsesRequestLocalBaseURL(t *testing.T) {
+	original := &cliproxyauth.Auth{
+		ID:         "kimi-auth",
+		Attributes: map[string]string{"base_url": "https://example.invalid", "custom": "value"},
+		Metadata:   map[string]any{"access_token": "test-token"},
+	}
+
+	delegated := kimiClaudeAuth(original)
+	if delegated == nil || delegated == original {
+		t.Fatalf("kimiClaudeAuth() = %#v, want an independent clone", delegated)
+	}
+	if got := delegated.Attributes["base_url"]; got != kimiauth.KimiAPIBaseURL {
+		t.Fatalf("delegated base_url = %q, want %q", got, kimiauth.KimiAPIBaseURL)
+	}
+	if got := delegated.Attributes["custom"]; got != "value" {
+		t.Fatalf("delegated custom attribute = %q, want value", got)
+	}
+	if got := original.Attributes["base_url"]; got != "https://example.invalid" {
+		t.Fatalf("original base_url mutated to %q", got)
+	}
+	if got := delegated.Metadata["access_token"]; got != "test-token" {
+		t.Fatalf("delegated access token = %#v, want test-token", got)
+	}
+
+	withoutAttributes := &cliproxyauth.Auth{Metadata: map[string]any{"access_token": "test-token"}}
+	delegated = kimiClaudeAuth(withoutAttributes)
+	if delegated == nil || delegated.Attributes["base_url"] != kimiauth.KimiAPIBaseURL {
+		t.Fatalf("nil-attributes delegation = %#v, want Kimi base URL", delegated)
+	}
+	if withoutAttributes.Attributes != nil {
+		t.Fatalf("source nil attributes were mutated: %#v", withoutAttributes.Attributes)
+	}
+	if kimiClaudeAuth(nil) != nil {
+		t.Fatal("nil auth should remain nil")
 	}
 }
 

--- a/internal/thinking/kimi_max_clamp_repro_test.go
+++ b/internal/thinking/kimi_max_clamp_repro_test.go
@@ -7,11 +7,13 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/claude"
 	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/kimi"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	"github.com/tidwall/gjson"
 )
 
-// Reproduces Claude Code -> Kimi /v1/messages with effort=max.
-// KimiExecutor delegates to ClaudeExecutor, so ApplyThinking sees claude/claude.
+// Reproduces Claude Code -> Kimi /v1/messages with effort=max through
+// Kimi's OpenAI-compatible chat completions path.
 func TestKimiClaudeMessagesMaxClampsToHigh(t *testing.T) {
 	models := registry.GetKimiModels()
 	reg := registry.GetGlobalRegistry()
@@ -20,14 +22,18 @@ func TestKimiClaudeMessagesMaxClampsToHigh(t *testing.T) {
 	t.Cleanup(func() { reg.UnregisterClient(clientID) })
 
 	body := []byte(`{"model":"kimi-k2.5","messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"},"output_config":{"effort":"max"}}`)
-	out, err := thinking.ApplyThinking(body, "kimi-k2.5", "claude", "claude", "claude")
+	body = sdktranslator.TranslateRequest(sdktranslator.FormatClaude, sdktranslator.FormatOpenAI, "kimi-k2.5", body, false)
+	out, err := thinking.ApplyThinking(body, "kimi-k2.5", "claude", "kimi", "kimi")
 	if err != nil {
 		t.Fatalf("ApplyThinking returned error: %v", err)
 	}
-	if got := gjson.GetBytes(out, "thinking.type").String(); got != "adaptive" {
-		t.Fatalf("thinking.type = %q, want adaptive", got)
+	if got := gjson.GetBytes(out, "thinking.type").String(); got != "enabled" {
+		t.Fatalf("thinking.type = %q, want enabled", got)
 	}
-	if got := gjson.GetBytes(out, "output_config.effort").String(); got != "high" {
-		t.Fatalf("output_config.effort = %q, want high", got)
+	if got := gjson.GetBytes(out, "thinking.effort").String(); got != "high" {
+		t.Fatalf("thinking.effort = %q, want high", got)
+	}
+	if gjson.GetBytes(out, "reasoning_effort").Exists() {
+		t.Fatal("reasoning_effort should be removed from the Kimi payload")
 	}
 }

--- a/internal/thinking/kimi_max_clamp_repro_test.go
+++ b/internal/thinking/kimi_max_clamp_repro_test.go
@@ -7,13 +7,11 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/claude"
 	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/kimi"
-	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
-	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	"github.com/tidwall/gjson"
 )
 
-// Reproduces Claude Code -> Kimi /v1/messages with effort=max through
-// Kimi's OpenAI-compatible chat completions path.
+// Reproduces Claude Code -> Kimi /v1/messages with effort=max.
+// KimiExecutor delegates to ClaudeExecutor, so ApplyThinking sees claude/claude.
 func TestKimiClaudeMessagesMaxClampsToHigh(t *testing.T) {
 	models := registry.GetKimiModels()
 	reg := registry.GetGlobalRegistry()
@@ -22,18 +20,14 @@ func TestKimiClaudeMessagesMaxClampsToHigh(t *testing.T) {
 	t.Cleanup(func() { reg.UnregisterClient(clientID) })
 
 	body := []byte(`{"model":"kimi-k2.5","messages":[{"role":"user","content":"hi"}],"thinking":{"type":"adaptive"},"output_config":{"effort":"max"}}`)
-	body = sdktranslator.TranslateRequest(sdktranslator.FormatClaude, sdktranslator.FormatOpenAI, "kimi-k2.5", body, false)
-	out, err := thinking.ApplyThinking(body, "kimi-k2.5", "claude", "kimi", "kimi")
+	out, err := thinking.ApplyThinking(body, "kimi-k2.5", "claude", "claude", "claude")
 	if err != nil {
 		t.Fatalf("ApplyThinking returned error: %v", err)
 	}
-	if got := gjson.GetBytes(out, "thinking.type").String(); got != "enabled" {
-		t.Fatalf("thinking.type = %q, want enabled", got)
+	if got := gjson.GetBytes(out, "thinking.type").String(); got != "adaptive" {
+		t.Fatalf("thinking.type = %q, want adaptive", got)
 	}
-	if got := gjson.GetBytes(out, "thinking.effort").String(); got != "high" {
-		t.Fatalf("thinking.effort = %q, want high", got)
-	}
-	if gjson.GetBytes(out, "reasoning_effort").Exists() {
-		t.Fatal("reasoning_effort should be removed from the Kimi payload")
+	if got := gjson.GetBytes(out, "output_config.effort").String(); got != "high" {
+		t.Fatalf("output_config.effort = %q, want high", got)
 	}
 }

--- a/sdk/cliproxy/home_plugins.go
+++ b/sdk/cliproxy/home_plugins.go
@@ -145,7 +145,7 @@ func homePluginSyncKey(cfg *config.Config) string {
 		return ""
 	}
 	hash := sha256.New()
-	_, _ = fmt.Fprintf(hash, "enabled=%t\ndir=%s\nsync-revision=%d\n", cfg.Plugins.Enabled, strings.TrimSpace(cfg.Plugins.Dir), cfg.Plugins.SyncRevision)
+	_, _ = fmt.Fprintf(hash, "enabled=%t\ndir=%s\nauth-revision=%d\n", cfg.Plugins.Enabled, strings.TrimSpace(cfg.Plugins.Dir), cfg.Plugins.AuthRevision)
 	ids := make([]string, 0, len(cfg.Plugins.Configs))
 	for id := range cfg.Plugins.Configs {
 		ids = append(ids, id)

--- a/sdk/cliproxy/home_plugins_test.go
+++ b/sdk/cliproxy/home_plugins_test.go
@@ -215,7 +215,7 @@ func TestHomePluginSyncKeyIncludesCredentialRevision(t *testing.T) {
 	cfg.Plugins.Enabled = true
 	cfg.Plugins.Configs = map[string]config.PluginInstanceConfig{}
 	first := homePluginSyncKey(cfg)
-	cfg.Plugins.SyncRevision = 2
+	cfg.Plugins.AuthRevision = 2
 	second := homePluginSyncKey(cfg)
 	if first == second {
 		t.Fatalf("homePluginSyncKey() unchanged after sync revision update: %q", first)


### PR DESCRIPTION
## Upstream range

- From: `81d70f5d9f3fdb39a6290ed9c917ff0c6f27ca30` (`v7.2.78-27-g81d70f5d`)
- To: `93d74a890a44802f656d7f39a573916b2611896e` (`v7.2.78-37-g93d74a89`)
- Stage: 2 of 2 for the 2026-07-19 three-day upstream review
- Base: `origin/main` after merged PR #171 (`d1bc3e73a9bdfd3eefd64e513fafe70f7d6d154b`)
- Upstream merge commit: `595b2991a71a46d5541b55d2e612a42739f782fd`

## Included upstream work

- Kimi K3 catalog/model normalization, including canonical upstream `k3` routing for `[1m]` and thinking suffixes
- Claude-format Kimi requests delegated through the Claude messages executor with header forwarding, request logging, response-model restoration, and count-token support
- Gemini 3.x production model IDs/metadata
- Plugin Home credential revision rename from `sync-revision` to `auth-revision`

## Conflicts

No textual conflicts. The stage was still reviewed at the auth/config/model/runtime seams because it changes shared credential routing and provider execution.

## Protected delta review

- Usage statistics, Management usage APIs, usage queue, Panel source, auth attribution, and public usage response shapes are unchanged.
- The upstream Kimi Claude delegation wrote `auth.Attributes["base_url"]` directly. `Auth.Attributes` is shared immutable credential configuration, so that implementation could panic on a nil map, race across concurrent requests, and leak a request-local route into later work. Commit `772915ac` keeps the upstream behavior while applying the Kimi base URL to a request-local cloned auth.
- Canonical Kimi upstream model normalization is retained for Execute, ExecuteStream, CountTokens, response restoration, and thinking suffix semantics.
- The plugin revision rename is absorbed consistently across config parsing and Home sync keys; the LTS configured-plugin enabled default remains intact.
- Gemini production catalog changes are ordinary upstream model metadata and are accepted.
- All previously required downstream patches remain required through `93d74a89`; added ledger entry `kimi-claude-delegated-auth-immutability`. No patch retired.
- Covered old upstream-port PRs: none.

## Validation

- `go test ./internal/runtime/executor -run 'Kimi|ClaudeHeaders|ClaudeExecutor'`\n- `go test -race ./internal/runtime/executor -run 'Kimi|ClaudeExecutor|ClaudeHeaders'`\n- `go test ./internal/config ./sdk/cliproxy ./internal/registry ./internal/runtime/executor ./internal/thinking ./test`\n- `go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'`\n- `go run ./scripts/ltsregistry --root .`\n- `scripts/check-lts-contract.sh`\n- `go build -o <temp>/server ./cmd/server`\n- `go test ./...`\n- `go test -count=1 ./... -run 'Kimi|Claude|PluginAuthRevision|Gemini'`\n- `git diff --check`\n\nAll local checks passed. Merge this sync PR with **Create a merge commit**; do not squash or rebase.