### PR TITLE
feat(usage): 记录可审计的 effective service tier

### DIFF
--- a/docs/lts/core-feature-contracts.yaml
+++ b/docs/lts/core-feature-contracts.yaml
@@ -42,6 +42,7 @@ features:
       - service_tier
       - request_service_tier
       - response_service_tier
+      - effective_service_tier
       - generate
       - success_count
       - failure_count
@@ -86,6 +87,7 @@ features:
       - service_tier
       - request_service_tier
       - response_service_tier
+      - effective_service_tier
       - generate
     validation:
       - go test ./internal/api/handlers/management -run 'Usage|usage'
@@ -370,6 +372,7 @@ features:
       - latency_ms
       - auth_index
       - uncached_input_tokens
+      - effective_service_tier
       - generate
     validation:
       - go test ./internal/redisqueue ./internal/api -run 'Redis|redis|Usage|usage'

--- a/internal/api/handlers/management/usage_contract_test.go
+++ b/internal/api/handlers/management/usage_contract_test.go
@@ -55,6 +55,9 @@ func TestUsageManagementResponseShapeAndImportExportRoundTrip(t *testing.T) {
 	if !bytes.Contains(exportedJSON, []byte(`"response_service_tier":"standard"`)) {
 		t.Fatalf("exported usage missing response_service_tier: %s", exportedJSON)
 	}
+	if !bytes.Contains(exportedJSON, []byte(`"effective_service_tier":"standard"`)) {
+		t.Fatalf("exported usage missing effective_service_tier: %s", exportedJSON)
+	}
 	if !bytes.Contains(exportedJSON, []byte(`"generate":false`)) {
 		t.Fatalf("exported usage missing explicit generate=false: %s", exportedJSON)
 	}
@@ -227,8 +230,8 @@ func TestUsageManagementImportLegacyExportKeepsServiceTierUnknown(t *testing.T) 
 	if details[0].ServiceTier != "" {
 		t.Fatalf("legacy detail.service_tier = %q, want empty/unknown", details[0].ServiceTier)
 	}
-	if details[0].RequestServiceTier != "" || details[0].ResponseServiceTier != "" {
-		t.Fatalf("legacy detail service tiers = request:%q response:%q, want empty/unknown", details[0].RequestServiceTier, details[0].ResponseServiceTier)
+	if details[0].RequestServiceTier != "" || details[0].ResponseServiceTier != "" || details[0].EffectiveServiceTier != "" {
+		t.Fatalf("legacy detail service tiers = request:%q response:%q effective:%q, want empty/unknown", details[0].RequestServiceTier, details[0].ResponseServiceTier, details[0].EffectiveServiceTier)
 	}
 	if details[0].Tokens.UncachedInputTokens != nil {
 		t.Fatalf("legacy detail uncached_input_tokens = %v, want nil/unknown", details[0].Tokens.UncachedInputTokens)
@@ -257,7 +260,7 @@ func TestUsageManagementImportLegacyExportKeepsServiceTierUnknown(t *testing.T) 
 	if !bytes.Contains(reexportedJSON, []byte(`"generate":true`)) {
 		t.Fatalf("legacy re-export missing normalized generate=true: %s", reexportedJSON)
 	}
-	if bytes.Contains(reexportedJSON, []byte(`"request_service_tier"`)) || bytes.Contains(reexportedJSON, []byte(`"response_service_tier"`)) {
+	if bytes.Contains(reexportedJSON, []byte(`"request_service_tier"`)) || bytes.Contains(reexportedJSON, []byte(`"response_service_tier"`)) || bytes.Contains(reexportedJSON, []byte(`"effective_service_tier"`)) {
 		t.Fatalf("legacy re-export fabricated explicit service-tier fields: %s", reexportedJSON)
 	}
 	if bytes.Contains(reexportedJSON, []byte(`"uncached_input_tokens"`)) {
@@ -401,19 +404,20 @@ func usageCacheCreationSnapshot(timestamp time.Time, tokens usage.TokenStats) us
 
 func recordPanelContractUsage(stats *usage.RequestStatistics) {
 	stats.Record(context.Background(), coreusage.Record{
-		APIKey:              "panel-client-key",
-		Provider:            "openai",
-		Model:               "gpt-5.4",
-		Alias:               "panel-visible-model",
-		Source:              "auths/openai.json",
-		AuthIndex:           "1",
-		ReasoningEffort:     "medium",
-		ServiceTier:         "priority",
-		RequestServiceTier:  "priority",
-		ResponseServiceTier: "standard",
-		Generate:            coreusage.GenerateFlag(false),
-		RequestedAt:         time.Date(2026, 6, 10, 11, 30, 0, 0, time.UTC),
-		Latency:             2 * time.Second,
+		APIKey:               "panel-client-key",
+		Provider:             "openai",
+		Model:                "gpt-5.4",
+		Alias:                "panel-visible-model",
+		Source:               "auths/openai.json",
+		AuthIndex:            "1",
+		ReasoningEffort:      "medium",
+		ServiceTier:          "priority",
+		RequestServiceTier:   "priority",
+		ResponseServiceTier:  "standard",
+		EffectiveServiceTier: "standard",
+		Generate:             coreusage.GenerateFlag(false),
+		RequestedAt:          time.Date(2026, 6, 10, 11, 30, 0, 0, time.UTC),
+		Latency:              2 * time.Second,
 		Detail: coreusage.Detail{
 			InputTokens:              5,
 			UncachedInputTokens:      0,
@@ -569,6 +573,9 @@ func requirePanelUsageShape(t *testing.T, snapshot usage.StatisticsSnapshot) {
 	}
 	if detail.ResponseServiceTier != "standard" {
 		t.Fatalf("detail.response_service_tier = %q, want standard", detail.ResponseServiceTier)
+	}
+	if detail.EffectiveServiceTier != "standard" {
+		t.Fatalf("detail.effective_service_tier = %q, want standard", detail.EffectiveServiceTier)
 	}
 	if detail.Generate {
 		t.Fatalf("detail.generate = true, want false")

--- a/internal/redisqueue/plugin.go
+++ b/internal/redisqueue/plugin.go
@@ -69,6 +69,7 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 		requestServiceTier = serviceTier
 	}
 	responseServiceTier := strings.TrimSpace(record.ResponseServiceTier)
+	effectiveServiceTier := coreusage.CanonicalEffectiveServiceTier(record.EffectiveServiceTier)
 
 	tokens := tokenStats{
 		InputTokens:            record.Detail.InputTokens,
@@ -113,19 +114,20 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 	}
 
 	payload, err := json.Marshal(queuedUsageDetail{
-		requestDetail:       detail,
-		Provider:            provider,
-		ExecutorType:        executorType,
-		Model:               modelName,
-		Alias:               aliasName,
-		Endpoint:            resolveEndpoint(ctx),
-		AuthType:            authType,
-		APIKey:              apiKey,
-		RequestID:           requestID,
-		ReasoningEffort:     reasoningEffort,
-		ServiceTier:         serviceTier,
-		RequestServiceTier:  requestServiceTier,
-		ResponseServiceTier: responseServiceTier,
+		requestDetail:        detail,
+		Provider:             provider,
+		ExecutorType:         executorType,
+		Model:                modelName,
+		Alias:                aliasName,
+		Endpoint:             resolveEndpoint(ctx),
+		AuthType:             authType,
+		APIKey:               apiKey,
+		RequestID:            requestID,
+		ReasoningEffort:      reasoningEffort,
+		ServiceTier:          serviceTier,
+		RequestServiceTier:   requestServiceTier,
+		ResponseServiceTier:  responseServiceTier,
+		EffectiveServiceTier: effectiveServiceTier,
 	})
 	if err != nil {
 		return
@@ -135,18 +137,19 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 
 type queuedUsageDetail struct {
 	requestDetail
-	Provider            string `json:"provider"`
-	ExecutorType        string `json:"executor_type"`
-	Model               string `json:"model"`
-	Alias               string `json:"alias"`
-	Endpoint            string `json:"endpoint"`
-	AuthType            string `json:"auth_type"`
-	APIKey              string `json:"api_key"`
-	RequestID           string `json:"request_id"`
-	ReasoningEffort     string `json:"reasoning_effort"`
-	ServiceTier         string `json:"service_tier"`
-	RequestServiceTier  string `json:"request_service_tier"`
-	ResponseServiceTier string `json:"response_service_tier,omitempty"`
+	Provider             string `json:"provider"`
+	ExecutorType         string `json:"executor_type"`
+	Model                string `json:"model"`
+	Alias                string `json:"alias"`
+	Endpoint             string `json:"endpoint"`
+	AuthType             string `json:"auth_type"`
+	APIKey               string `json:"api_key"`
+	RequestID            string `json:"request_id"`
+	ReasoningEffort      string `json:"reasoning_effort"`
+	ServiceTier          string `json:"service_tier"`
+	RequestServiceTier   string `json:"request_service_tier"`
+	ResponseServiceTier  string `json:"response_service_tier,omitempty"`
+	EffectiveServiceTier string `json:"effective_service_tier,omitempty"`
 }
 
 type requestDetail struct {

--- a/internal/redisqueue/plugin_test.go
+++ b/internal/redisqueue/plugin_test.go
@@ -25,20 +25,21 @@ func TestUsageQueuePluginPayloadIncludesStableFieldsAndSuccess(t *testing.T) {
 
 		plugin := &usageQueuePlugin{}
 		plugin.HandleUsage(ctx, coreusage.Record{
-			Provider:            "openai",
-			ExecutorType:        "KimiExecutor",
-			Model:               "gpt-5.4",
-			Alias:               "client-gpt",
-			APIKey:              "test-key",
-			AuthIndex:           "0",
-			AuthType:            "apikey",
-			Source:              "user@example.com",
-			ReasoningEffort:     "medium",
-			ServiceTier:         "auto",
-			ResponseServiceTier: "default",
-			Generate:            coreusage.GenerateFlag(true),
-			RequestedAt:         time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC),
-			Latency:             1500 * time.Millisecond,
+			Provider:             "openai",
+			ExecutorType:         "KimiExecutor",
+			Model:                "gpt-5.4",
+			Alias:                "client-gpt",
+			APIKey:               "test-key",
+			AuthIndex:            "0",
+			AuthType:             "apikey",
+			Source:               "user@example.com",
+			ReasoningEffort:      "medium",
+			ServiceTier:          "auto",
+			ResponseServiceTier:  "default",
+			EffectiveServiceTier: "standard",
+			Generate:             coreusage.GenerateFlag(true),
+			RequestedAt:          time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC),
+			Latency:              1500 * time.Millisecond,
 			Detail: coreusage.Detail{
 				InputTokens:  10,
 				OutputTokens: 20,
@@ -61,6 +62,7 @@ func TestUsageQueuePluginPayloadIncludesStableFieldsAndSuccess(t *testing.T) {
 		requireStringField(t, payload, "service_tier", "auto")
 		requireStringField(t, payload, "request_service_tier", "auto")
 		requireStringField(t, payload, "response_service_tier", "default")
+		requireStringField(t, payload, "effective_service_tier", "standard")
 		requireTokensBoolField(t, payload, "cache_read_tokens_present", true)
 		requireHeaderField(t, payload, "response_headers", "X-Upstream-Request-Id", []string{"upstream-req-1"})
 		requireHeaderField(t, payload, "response_headers", "Retry-After", []string{"30"})

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -1212,6 +1212,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	if err != nil {
 		return resp, err
 	}
+	reporter.SetOutboundServiceTier(upstreamBody)
 	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
 	applyFinalCodexClientHeaders(httpReq.Header, modelHeaderProfile, auth)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
@@ -1410,6 +1411,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	if err != nil {
 		return resp, err
 	}
+	reporter.SetOutboundServiceTier(upstreamBody)
 	applyCodexHeaders(httpReq, auth, apiKey, false, e.cfg)
 	applyFinalCodexClientHeaders(httpReq.Header, modelHeaderProfile, auth)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
@@ -1546,6 +1548,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	if err != nil {
 		return nil, err
 	}
+	reporter.SetOutboundServiceTier(upstreamBody)
 	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
 	applyFinalCodexClientHeaders(httpReq.Header, modelHeaderProfile, auth)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)

--- a/internal/runtime/executor/codex_openai_images.go
+++ b/internal/runtime/executor/codex_openai_images.go
@@ -113,6 +113,7 @@ func (e *CodexExecutor) executeOpenAIImage(ctx context.Context, auth *cliproxyau
 	if errCache != nil {
 		return resp, errCache
 	}
+	reporter.SetOutboundServiceTier(body)
 	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
 	applyFinalCodexClientHeaders(httpReq.Header, modelHeaderProfile, auth)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
@@ -211,6 +212,7 @@ func (e *CodexExecutor) executeOpenAIImageStream(ctx context.Context, auth *clip
 	if errCache != nil {
 		return nil, errCache
 	}
+	reporter.SetOutboundServiceTier(body)
 	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
 	applyFinalCodexClientHeaders(httpReq.Header, modelHeaderProfile, auth)
 	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
@@ -339,6 +341,7 @@ func (e *CodexExecutor) executeDirectOpenAIImage(ctx context.Context, auth *clip
 	if errCache != nil {
 		return resp, errCache
 	}
+	reporter.SetOutboundServiceTier(body)
 	applyCodexDirectImageHeaders(httpReq, auth, apiKey, false, e.cfg)
 	applyFinalCodexClientHeaders(httpReq.Header, modelHeaderProfile, auth)
 	if contentType != "" {
@@ -401,6 +404,7 @@ func (e *CodexExecutor) executeDirectOpenAIImageStream(ctx context.Context, auth
 	if errCache != nil {
 		return nil, errCache
 	}
+	reporter.SetOutboundServiceTier(body)
 	applyCodexDirectImageHeaders(httpReq, auth, apiKey, true, e.cfg)
 	applyFinalCodexClientHeaders(httpReq.Header, modelHeaderProfile, auth)
 	if contentType != "" {

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -473,6 +473,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	var identityState codexIdentityConfuseState
 	upstreamBody, identityState := applyCodexIdentityConfuseBody(e.cfg, auth, originalPayloadSource, body)
 	reporter.SetTranslatedReasoningEffort(clientBody, to.String())
+	reporter.SetOutboundServiceTier(upstreamBody)
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
 	applyFinalCodexClientHeaders(wsHeaders, modelHeaderProfile, auth)
 	applyCodexIdentityConfuseHeaders(wsHeaders, &identityState)
@@ -744,6 +745,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	var identityState codexIdentityConfuseState
 	upstreamBody, identityState := applyCodexIdentityConfuseBody(e.cfg, auth, originalPayloadSource, body)
 	reporter.SetTranslatedReasoningEffort(clientBody, to.String())
+	reporter.SetOutboundServiceTier(upstreamBody)
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
 	applyFinalCodexClientHeaders(wsHeaders, modelHeaderProfile, auth)
 	applyCodexIdentityConfuseHeaders(wsHeaders, &identityState)

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -34,6 +34,7 @@ type UsageReporter struct {
 	source       string
 	reasoning    string
 	serviceTier  string
+	outboundTier string
 	generate     bool
 	requestedAt  time.Time
 	ttftMu       sync.RWMutex
@@ -110,6 +111,16 @@ func (r *UsageReporter) SetTranslatedReasoningEffort(payload []byte, format stri
 		return
 	}
 	r.reasoning = thinking.ExtractTranslatedReasoningEffort(payload, format)
+}
+
+// SetOutboundServiceTier records the only request-side fallback allowed for
+// effective usage tier: an explicit recognized value in the final outbound
+// payload. The payload itself is not retained with usage metadata.
+func (r *UsageReporter) SetOutboundServiceTier(payload []byte) {
+	if r == nil {
+		return
+	}
+	r.outboundTier = explicitOutboundServiceTier(payload)
 }
 
 func (r *UsageReporter) ReasoningEffort() string {
@@ -286,14 +297,29 @@ func (r *UsageReporter) buildRecordForModel(model string, detail usage.Detail, f
 		ServiceTier:         r.serviceTier,
 		RequestServiceTier:  r.serviceTier,
 		ResponseServiceTier: strings.TrimSpace(detail.ResponseServiceTier),
-		Generate:            usage.GenerateFlag(r.generate),
-		RequestedAt:         r.requestedAt,
-		Latency:             r.latency(),
-		TTFT:                r.ttftDuration(),
-		Failed:              failed,
-		Fail:                fail,
-		Detail:              detail,
+		EffectiveServiceTier: usage.ResolveEffectiveServiceTier(
+			detail.ResponseServiceTier,
+			r.outboundTier,
+		),
+		Generate:    usage.GenerateFlag(r.generate),
+		RequestedAt: r.requestedAt,
+		Latency:     r.latency(),
+		TTFT:        r.ttftDuration(),
+		Failed:      failed,
+		Fail:        fail,
+		Detail:      detail,
 	}
+}
+
+func explicitOutboundServiceTier(payload []byte) string {
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return ""
+	}
+	tier := gjson.GetBytes(payload, "service_tier")
+	if !tier.Exists() || tier.Type != gjson.String {
+		return ""
+	}
+	return usage.CanonicalEffectiveServiceTier(tier.String())
 }
 
 func failFromErrors(errs ...error) usage.Failure {

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -680,6 +680,36 @@ func TestUsageReporterBuildRecordIncludesServiceTier(t *testing.T) {
 	if record.ResponseServiceTier != "default" {
 		t.Fatalf("response service tier = %q, want default", record.ResponseServiceTier)
 	}
+	if record.EffectiveServiceTier != "standard" {
+		t.Fatalf("effective service tier = %q, want standard", record.EffectiveServiceTier)
+	}
+}
+
+func TestUsageReporterResolvesEffectiveServiceTierFromFinalOutboundPayload(t *testing.T) {
+	tests := []struct {
+		name     string
+		outbound string
+		response string
+		want     string
+	}{
+		{name: "non stream response wins", outbound: `{"service_tier":"priority"}`, response: "standard", want: "standard"},
+		{name: "stream response wins", outbound: `{"service_tier":"standard"}`, response: "fast", want: "priority"},
+		{name: "missing response uses priority outbound", outbound: `{"service_tier":"fast"}`, want: "priority"},
+		{name: "missing response uses standard outbound", outbound: `{"service_tier":"default"}`, want: "standard"},
+		{name: "unknown response cannot fall back", outbound: `{"service_tier":"priority"}`, response: "flex", want: ""},
+		{name: "outbound omits tier", outbound: `{"model":"gpt-5.6"}`, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reporter := NewUsageReporter(context.Background(), "codex", "gpt-5.6", nil)
+			reporter.SetOutboundServiceTier([]byte(tt.outbound))
+			record := reporter.buildRecord(usage.Detail{TotalTokens: 1, ResponseServiceTier: tt.response}, false)
+			if record.EffectiveServiceTier != tt.want {
+				t.Fatalf("effective service tier = %q, want %q", record.EffectiveServiceTier, tt.want)
+			}
+		})
+	}
 }
 
 func TestUsageReporterBuildRecordDefaultsGenerateTrue(t *testing.T) {

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -90,20 +90,21 @@ type modelStats struct {
 
 // RequestDetail stores request-level metadata and token usage for a single request.
 type RequestDetail struct {
-	Timestamp           time.Time  `json:"timestamp"`
-	LatencyMs           int64      `json:"latency_ms"`
-	Source              string     `json:"source"`
-	AuthIndex           string     `json:"auth_index"`
-	Alias               string     `json:"alias,omitempty"`
-	ReasoningEffort     string     `json:"reasoning_effort,omitempty"`
-	ServiceTier         string     `json:"service_tier,omitempty"`
-	RequestServiceTier  string     `json:"request_service_tier,omitempty"`
-	ResponseServiceTier string     `json:"response_service_tier,omitempty"`
-	Tokens              TokenStats `json:"tokens"`
-	Failed              bool       `json:"failed"`
-	Generate            bool       `json:"generate"`
-	FailureReason       string     `json:"failure_reason,omitempty"`
-	FailureStatus       int        `json:"failure_status,omitempty"`
+	Timestamp            time.Time  `json:"timestamp"`
+	LatencyMs            int64      `json:"latency_ms"`
+	Source               string     `json:"source"`
+	AuthIndex            string     `json:"auth_index"`
+	Alias                string     `json:"alias,omitempty"`
+	ReasoningEffort      string     `json:"reasoning_effort,omitempty"`
+	ServiceTier          string     `json:"service_tier,omitempty"`
+	RequestServiceTier   string     `json:"request_service_tier,omitempty"`
+	ResponseServiceTier  string     `json:"response_service_tier,omitempty"`
+	EffectiveServiceTier string     `json:"effective_service_tier,omitempty"`
+	Tokens               TokenStats `json:"tokens"`
+	Failed               bool       `json:"failed"`
+	Generate             bool       `json:"generate"`
+	FailureReason        string     `json:"failure_reason,omitempty"`
+	FailureStatus        int        `json:"failure_status,omitempty"`
 }
 
 // UnmarshalJSON keeps legacy usage exports compatible with the generate field.
@@ -224,6 +225,7 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 	if responseServiceTier == "" {
 		responseServiceTier = strings.TrimSpace(record.Detail.ResponseServiceTier)
 	}
+	effectiveServiceTier := coreusage.CanonicalEffectiveServiceTier(record.EffectiveServiceTier)
 	dayKey := timestamp.Format("2006-01-02")
 	hourKey := timestamp.Hour()
 
@@ -244,20 +246,21 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 		s.apis[statsKey] = stats
 	}
 	s.updateAPIStats(stats, modelName, RequestDetail{
-		Timestamp:           timestamp,
-		LatencyMs:           normaliseLatency(record.Latency),
-		Source:              record.Source,
-		AuthIndex:           record.AuthIndex,
-		Alias:               strings.TrimSpace(record.Alias),
-		ReasoningEffort:     strings.TrimSpace(record.ReasoningEffort),
-		ServiceTier:         requestServiceTier,
-		RequestServiceTier:  requestServiceTier,
-		ResponseServiceTier: responseServiceTier,
-		Tokens:              detail,
-		Failed:              failed,
-		Generate:            coreusage.GenerateEnabled(record.Generate),
-		FailureReason:       failureReason,
-		FailureStatus:       failureStatus,
+		Timestamp:            timestamp,
+		LatencyMs:            normaliseLatency(record.Latency),
+		Source:               record.Source,
+		AuthIndex:            record.AuthIndex,
+		Alias:                strings.TrimSpace(record.Alias),
+		ReasoningEffort:      strings.TrimSpace(record.ReasoningEffort),
+		ServiceTier:          requestServiceTier,
+		RequestServiceTier:   requestServiceTier,
+		ResponseServiceTier:  responseServiceTier,
+		EffectiveServiceTier: effectiveServiceTier,
+		Tokens:               detail,
+		Failed:               failed,
+		Generate:             coreusage.GenerateEnabled(record.Generate),
+		FailureReason:        failureReason,
+		FailureStatus:        failureStatus,
 	})
 
 	s.requestsByDay[dayKey]++
@@ -419,6 +422,7 @@ func normaliseServiceTierAliases(detail RequestDetail) RequestDetail {
 	if strings.TrimSpace(detail.ServiceTier) == "" && strings.TrimSpace(detail.RequestServiceTier) != "" {
 		detail.ServiceTier = detail.RequestServiceTier
 	}
+	detail.EffectiveServiceTier = coreusage.CanonicalEffectiveServiceTier(detail.EffectiveServiceTier)
 	return detail
 }
 

--- a/internal/usage/logger_plugin_test.go
+++ b/internal/usage/logger_plugin_test.go
@@ -35,15 +35,16 @@ func TestRequestStatisticsRecordIncludesLatency(t *testing.T) {
 func TestRequestStatisticsRecordIncludesUsageMetadata(t *testing.T) {
 	stats := NewRequestStatistics()
 	stats.Record(context.Background(), coreusage.Record{
-		APIKey:              "test-key",
-		Model:               "gpt-5.4",
-		Alias:               "client-gpt",
-		ReasoningEffort:     "medium",
-		ServiceTier:         "legacy-default",
-		RequestServiceTier:  " priority ",
-		ResponseServiceTier: " standard ",
-		Generate:            coreusage.GenerateFlag(false),
-		RequestedAt:         time.Date(2026, 3, 20, 12, 0, 0, 0, time.UTC),
+		APIKey:               "test-key",
+		Model:                "gpt-5.4",
+		Alias:                "client-gpt",
+		ReasoningEffort:      "medium",
+		ServiceTier:          "legacy-default",
+		RequestServiceTier:   " priority ",
+		ResponseServiceTier:  " standard ",
+		EffectiveServiceTier: " fast ",
+		Generate:             coreusage.GenerateFlag(false),
+		RequestedAt:          time.Date(2026, 3, 20, 12, 0, 0, 0, time.UTC),
 		Detail: coreusage.Detail{
 			InputTokens:              10,
 			OutputTokens:             20,
@@ -75,6 +76,9 @@ func TestRequestStatisticsRecordIncludesUsageMetadata(t *testing.T) {
 	}
 	if detail.ResponseServiceTier != "standard" {
 		t.Fatalf("response_service_tier = %q, want %q", detail.ResponseServiceTier, "standard")
+	}
+	if detail.EffectiveServiceTier != "priority" {
+		t.Fatalf("effective_service_tier = %q, want priority", detail.EffectiveServiceTier)
 	}
 	if detail.Generate {
 		t.Fatalf("generate = true, want false")
@@ -388,13 +392,14 @@ func TestRequestStatisticsMergeSnapshotDedupIgnoresLatencyAndServiceTiers(t *tes
 				Models: map[string]ModelSnapshot{
 					"gpt-5.4": {
 						Details: []RequestDetail{{
-							Timestamp:           timestamp,
-							LatencyMs:           2500,
-							Source:              "user@example.com",
-							AuthIndex:           "0",
-							ServiceTier:         "priority",
-							RequestServiceTier:  "priority",
-							ResponseServiceTier: "standard",
+							Timestamp:            timestamp,
+							LatencyMs:            2500,
+							Source:               "user@example.com",
+							AuthIndex:            "0",
+							ServiceTier:          "priority",
+							RequestServiceTier:   "priority",
+							ResponseServiceTier:  "standard",
+							EffectiveServiceTier: "priority",
 							Tokens: TokenStats{
 								InputTokens:  10,
 								OutputTokens: 20,
@@ -425,8 +430,8 @@ func TestRequestStatisticsMergeSnapshotDedupIgnoresLatencyAndServiceTiers(t *tes
 	if details[0].ServiceTier != "" {
 		t.Fatalf("service_tier = %q, want legacy unknown to remain empty", details[0].ServiceTier)
 	}
-	if details[0].RequestServiceTier != "" || details[0].ResponseServiceTier != "" {
-		t.Fatalf("service tier metadata = request:%q response:%q, want legacy unknown to remain empty", details[0].RequestServiceTier, details[0].ResponseServiceTier)
+	if details[0].RequestServiceTier != "" || details[0].ResponseServiceTier != "" || details[0].EffectiveServiceTier != "" {
+		t.Fatalf("service tier metadata = request:%q response:%q effective:%q, want legacy unknown to remain empty", details[0].RequestServiceTier, details[0].ResponseServiceTier, details[0].EffectiveServiceTier)
 	}
 }
 
@@ -439,15 +444,17 @@ func TestRequestStatisticsMergeSnapshotNormalisesServiceTierAliases(t *testing.T
 		{
 			name: "legacy alias populates request tier",
 			detail: RequestDetail{
-				ServiceTier:         " priority ",
-				ResponseServiceTier: " standard ",
+				ServiceTier:          " priority ",
+				ResponseServiceTier:  " standard ",
+				EffectiveServiceTier: " fast ",
 			},
 		},
 		{
 			name: "request tier populates legacy alias",
 			detail: RequestDetail{
-				RequestServiceTier:  " priority ",
-				ResponseServiceTier: " standard ",
+				RequestServiceTier:   " priority ",
+				ResponseServiceTier:  " standard ",
+				EffectiveServiceTier: " fast ",
 			},
 		},
 	}
@@ -472,6 +479,9 @@ func TestRequestStatisticsMergeSnapshotNormalisesServiceTierAliases(t *testing.T
 			}
 			if got.ResponseServiceTier != " standard " {
 				t.Fatalf("response_service_tier = %q, want preserved raw import value", got.ResponseServiceTier)
+			}
+			if got.EffectiveServiceTier != "priority" {
+				t.Fatalf("effective_service_tier = %q, want canonical priority", got.EffectiveServiceTier)
 			}
 		})
 	}

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -160,6 +160,7 @@ require_grep 'json:"reasoning_effort,omitempty"' internal/usage
 require_grep 'json:"service_tier,omitempty"' internal/usage
 require_grep 'json:"request_service_tier,omitempty"' internal/usage
 require_grep 'json:"response_service_tier,omitempty"' internal/usage
+require_grep 'json:"effective_service_tier,omitempty"' internal/usage internal/redisqueue
 require_grep 'json:"generate"' internal/usage internal/redisqueue
 require_grep "GenerateEnabled" internal/usage internal/redisqueue sdk/cliproxy/usage
 if git grep -n 'json:"thinking' -- internal/usage; then
@@ -170,6 +171,7 @@ require_grep "reasoning_effort" internal/api/handlers/management/usage_contract_
 require_grep '"thinking"' internal/api/handlers/management/usage_contract_test.go
 require_grep "request_service_tier" internal/api/handlers/management/usage_contract_test.go
 require_grep "response_service_tier" internal/api/handlers/management/usage_contract_test.go
+require_grep "effective_service_tier" internal/api/handlers/management/usage_contract_test.go
 require_grep '"generate"' internal/api/handlers/management/usage_contract_test.go
 
 go test ./scripts/ltsregistry -count=1

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -39,6 +39,11 @@ type Record struct {
 	RequestServiceTier string
 	// ResponseServiceTier stores the final tier reported by the upstream response.
 	ResponseServiceTier string
+	// EffectiveServiceTier stores the canonical tier actually selected for the
+	// request. It is empty when the upstream response does not report a
+	// recognized tier and the final outbound payload did not explicitly request
+	// one.
+	EffectiveServiceTier string
 	// Generate reports whether the client requested actual generation.
 	// nil or true means generation is enabled; only an explicit false disables generation.
 	// Use GenerateFlag to set the value and GenerateEnabled to read it with the default.
@@ -71,6 +76,30 @@ type Detail struct {
 	UncachedInputTokensKnown bool
 	TotalTokens              int64
 	ResponseServiceTier      string
+}
+
+// CanonicalEffectiveServiceTier returns the stable usage representation for a
+// recognized service tier. It deliberately does not infer a value for unknown
+// or omitted tiers.
+func CanonicalEffectiveServiceTier(tier string) string {
+	switch strings.ToLower(strings.TrimSpace(tier)) {
+	case "priority", "fast":
+		return "priority"
+	case "standard", "default":
+		return "standard"
+	default:
+		return ""
+	}
+}
+
+// ResolveEffectiveServiceTier resolves the canonical tier used by a request.
+// A non-empty response value is authoritative: if it is unrecognized, the
+// result remains unknown rather than falling back to the request value.
+func ResolveEffectiveServiceTier(responseServiceTier, outboundServiceTier string) string {
+	if strings.TrimSpace(responseServiceTier) != "" {
+		return CanonicalEffectiveServiceTier(responseServiceTier)
+	}
+	return CanonicalEffectiveServiceTier(outboundServiceTier)
 }
 
 // NormalizeUncachedInputTokens clears uncached input data that is unknown or

--- a/sdk/cliproxy/usage/manager_test.go
+++ b/sdk/cliproxy/usage/manager_test.go
@@ -127,6 +127,31 @@ func TestRecordOmittedGenerateIsEnabled(t *testing.T) {
 	}
 }
 
+func TestResolveEffectiveServiceTier(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+		outbound string
+		want     string
+	}{
+		{name: "recognized response wins", response: " fast ", outbound: "standard", want: "priority"},
+		{name: "recognized standard response wins", response: "default", outbound: "priority", want: "standard"},
+		{name: "unknown response blocks fallback", response: "flex", outbound: "priority", want: ""},
+		{name: "missing response uses explicit outbound priority", outbound: "fast", want: "priority"},
+		{name: "missing response uses explicit outbound standard", outbound: "default", want: "standard"},
+		{name: "missing values stay unknown", want: ""},
+		{name: "unknown outbound stays unknown", outbound: "auto", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ResolveEffectiveServiceTier(tt.response, tt.outbound); got != tt.want {
+				t.Fatalf("ResolveEffectiveServiceTier(%q, %q) = %q, want %q", tt.response, tt.outbound, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestManagerDequeueClearsConsumedContextAndBackingArray(t *testing.T) {
 	m := NewManager(2)
 	ctx := context.WithValue(context.Background(), struct{}{}, bytesMarker(1))


### PR DESCRIPTION
## 结果与边界

新增 optional `effective_service_tier`，统一记录最终可审计的服务档位：可识别的 upstream response tier 优先；response 缺失时只使用 final outbound payload 中显式且可识别的 tier；非空未知 response 不回退到 request/outbound。该字段不会覆盖现有 request/response tier，不参与 usage 去重，也不会为旧 v1 import 虚构历史值。

本 PR 不执行 release、tag 或 deploy。

## Type

- [ ] Protected upstream full-sync
- [ ] Staged upstream full-sync
- [ ] LTS protected-delta patch
- [x] LTS feature / downstream patch maintenance
- [ ] Maintenance docs / CI
- [ ] Emergency hotfix

## Upstream sync info

- Upstream repo: N/A — 非 upstream sync
- Upstream branch: N/A
- Upstream from SHA: N/A
- Upstream to SHA: N/A
- Sync branch: `codex/effective-service-tier`

## Protected delta checklist

- [x] `usage-statistics-enabled` still exists
- [x] `internal/usage/` still exists
- [x] `/v0/management/usage` still exists
- [x] `/v0/management/usage/export` still exists
- [x] `/v0/management/usage/import` still exists
- [x] `docs/lts/core-feature-contracts.yaml` reviewed for touched protected or protected-adjacent features
- [x] `docs/lts/downstream-patches.yaml` reviewed for active patch retirement or reapplication
- [x] Usage record creation/schema reviewed or tested: API key, auth source, model, token breakdown, latency, success/failure
- [x] Management usage response shape reviewed or tested: `usage`, `failed_requests`, `apis`, `models`, `details`
- [x] Export/import roundtrip reviewed or tested when usage data shape is touched
- [x] CPA-Panel-LTS response shape reviewed
- [x] Local auth/config/panel/release/source customizations reviewed

## LTS classification review

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| `full-usage-statistics-core` | retained capability | adapted | `RequestDetail` 与 SDK `Record` 增加 optional additive field；既有统计字段和 dedup identity 保持不变 |
| `management-usage-api` | retained capability | adapted | `/usage` 与 v1 export/import round-trip 保留该字段；旧 v1 数据不自动回填 |
| `redis-compatible-usage-queue` | LTS feature | adapted | queue payload 同步携带 optional `effective_service_tier`，避免异步 sink 丢失 |
| `provider-runtime-usage-seams` | review seam | adapted | normal、stream、WebSocket 和 image 路径在 final outbound payload 形成后写入统一 reporter |
| `codex-interactions-service-tier-response` | downstream patch | preserved | translator patch 未修改；response tier 仍具有最高权威，非空未知值阻止 fallback |

- [x] 本 PR 不创建或删除 `introduced_in` / `retired_in` ledger commit，因此没有额外 merge-method 约束。

## 关键行为

- `fast` / `priority` canonicalize 为 `priority`。
- `default` / `standard` canonicalize 为 `standard`。
- response 可识别时覆盖 final outbound 推断。
- response 非空但未知时保持缺失，不回退到 request Fast。
- response 缺失且 final outbound 未显式提供可识别 tier 时保持缺失。
- stream、non-stream、Responses、Interactions、WebSocket 和 image execution 共用同一 resolver/reporting 语义。

## Conflict resolution notes

无 upstream merge 或文本冲突。本改动以 additive field 扩展 LTS usage contract；未修改 `internal/translator/**`，不需要 translator path-guard label。

## Validation

- [x] `scripts/check-lts-contract.sh`
- [x] `go run ./scripts/ltsregistry --root .`
- [x] `go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'`
- [x] `go build -o test-output ./cmd/server && rm -f test-output`
- [x] `go test ./...`
- [x] `git diff --check`

附加验证：CPA-Panel-LTS stacked head 已对本分支运行 authenticated local Core smoke，覆盖 response override、outbound fallback、未知 response、v1 import/export 和 Panel Fast/Std 展示。

## Optional real runtime smoke

- [x] Hugging Face Space smoke explicitly skipped：本 PR 未部署，且用户要求不执行 release/deploy。
- Space: N/A
- Runtime SHA: N/A
- CPA-Core-LTS branch/SHA deployed: 未部署；待审 branch head `c1f73ccd3d6b38541a880f92e249169fc06ed4b2`
- `/healthz` status: N/A
- `/management.html` status: N/A
- `/v0/management/usage*` status: 本地跨仓 smoke 通过；未做外部 runtime smoke

## Review focus

1. response 非空未知值是否应继续阻止 outbound fallback。
2. final outbound 仅显式可识别 tier 才生成 effective 值的边界。
3. v1 import/export、Redis queue 和 dedup identity 的兼容性。