### PR TITLE
feat(codex): 规范 client_metadata 并保护 workspace 隐私

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -187,9 +187,24 @@ routing:
 codex:
   # When true, and routing.strategy is fill-first or routing.session-affinity is true,
   # remap Codex prompt_cache_key and installation identity per selected auth.
-  # Some superstitious users believe request tracking identifiers can be used
-  # as evidence for TOS enforcement bans; this option only satisfies those odd concerns.
+  # Legacy behavior is skipped for requests that carry the canonical
+  # client_metadata.x-codex-turn-metadata object to avoid mixed identities.
+  # This legacy option is not a complete privacy boundary and does not hide
+  # account, network, or request-behavior signals from the upstream service.
   identity-confuse: false
+
+  # Canonical Codex client metadata handling. The body
+  # client_metadata.x-codex-turn-metadata value is the source of truth; flat body
+  # fields and direct compatibility headers are regenerated from it.
+  client-metadata:
+    # repair (default): repair conflicting flat/header projections.
+    # strict: reject conflicting projections. off: preserve canonical payloads unchanged.
+    mode: "repair"
+    # passthrough (default): preserve workspace metadata but always remove Git remote
+    # credentials, query strings, and fragments. redact: replace workspace paths with
+    # stable per-client-installation/per-credential pseudonyms and retain only
+    # has_changes. drop: remove workspaces.
+    workspace-policy: "passthrough"
   # CPA-Core-LTS extra feature. After all same-model credentials fail with a
   # precisely classified Codex usage-limit or model-capacity response, try the
   # configured target models in order. Disabled by default.

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -286,6 +286,63 @@ patches:
     state: required
     retire_when: Upstream finalizes one coherent official Codex OAuth identity after every model/header override across HTTP, compact, streaming, WebSocket, and image transports; preserves API-key requests and omitted Version headers; and all listed regressions pass after removing the downstream implementation.
 
+  - id: codex-client-metadata-privacy
+    reason: Current Codex clients transport one canonical x-codex-turn-metadata snapshot plus flat body and direct header compatibility projections. Core must keep those projections coherent after credential selection, avoid the legacy identity-confuse partial rewrite on canonical requests, offer explicit workspace passthrough/redact/drop privacy policies, strip Git remote credentials even in passthrough mode, and prevent workspace enrichment from entering downstream, upstream, deferred-error, or WebSocket request logs.
+    introduced_in: dcb424d4a5d666322c641151a3e37fd3b0dcc864
+    affected_upstream_range: through 93d74a890a44802f656d7f39a573916b2611896e (v7.2.78-37-g93d74a89); upstream still applies the older prompt-cache and installation identity-confuse rewrite without canonical request detection, has no selectable workspace privacy policy, and records Codex turn metadata without an equivalent workspace-aware log sanitizer across HTTP, deferred-error, and WebSocket paths.
+    files:
+      - config.example.yaml
+      - internal/api/middleware/request_logging.go
+      - internal/api/middleware/request_logging_test.go
+      - internal/api/middleware/response_writer.go
+      - internal/codexmetadata/log.go
+      - internal/codexmetadata/log_test.go
+      - internal/codexmetadata/request.go
+      - internal/codexmetadata/request_test.go
+      - internal/config/config.go
+      - internal/config/codex_client_metadata_test.go
+      - internal/runtime/executor/codex_client_metadata.go
+      - internal/runtime/executor/codex_client_metadata_test.go
+      - internal/runtime/executor/codex_executor.go
+      - internal/runtime/executor/codex_executor_cache_test.go
+      - internal/runtime/executor/codex_openai_images.go
+      - internal/runtime/executor/codex_openai_images_test.go
+      - internal/runtime/executor/codex_websockets_executor.go
+      - internal/runtime/executor/codex_websockets_executor_test.go
+      - internal/runtime/executor/helps/logging_helpers.go
+      - internal/runtime/executor/helps/logging_helpers_test.go
+      - internal/watcher/diff/config_diff.go
+      - internal/watcher/diff/config_diff_test.go
+      - sdk/api/handlers/openai/openai_responses_websocket.go
+      - sdk/api/handlers/openai/openai_responses_websocket_test.go
+    regression_tests:
+      - TestNormalizeRequestRepairSanitizesWorkspaceAndRegeneratesProjections
+      - TestNormalizeRequestUsesDirectCanonicalHeaderAsLegacyFallback
+      - TestNormalizeRequestPreservesFlatIdentityWhenCanonicalOmitsConditionalFields
+      - TestNormalizeRequestWorkspaceRedactAndDrop
+      - TestNormalizeRequestStrictRejectsConflictAndMalformedCanonical
+      - TestNormalizeRequestOffSkipsMutationButMarksCanonical
+      - TestNormalizeRequestCollapsesDuplicateClientMetadataCarriers
+      - TestRedactRequestBodyForLogRemovesWorkspacesWithoutMutatingInput
+      - TestRedactRequestBodyForLogFailsClosedForMalformedCanonical
+      - TestRedactRequestBodyForLogCollapsesDuplicateClientMetadataCarriers
+      - TestCodexClientMetadataEffectiveDefaults
+      - TestLoadConfigOptionalCodexClientMetadata
+      - TestCodexExecutorCacheHelperCanonicalMetadataBypassesLegacyIdentityConfuse
+      - TestCodexExecutorCacheHelperStrictMetadataReturnsSafeBadRequest
+      - TestCodexExecutorDirectOpenAIImageRepairsCanonicalMetadata
+      - TestPrepareCodexOpenAIImageBodyPreservesClientMetadata
+      - TestApplyCodexWebsocketHeadersCanonicalMetadataBypassesLegacyIdentityConfuse
+      - TestCaptureRequestInfoRedactsCodexMetadataWithoutChangingHandlerBody
+      - TestExtractDeferredRequestBodyRedactsTruncatedCodexMetadata
+      - TestRecordAPIRequestRedactsCodexWorkspaceMetadataFromDeferredLog
+      - TestRecordAPIWebsocketRequestRedactsCodexWorkspaceMetadata
+      - TestWebsocketTimelineLogRedactsCodexWorkspaceMetadata
+      - TestBuildConfigChangeDetailsCodexClientMetadata
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: Upstream treats canonical Codex turn metadata as the only authoritative snapshot, safely regenerates every compatibility projection after final request shaping, avoids mixed legacy identity rewrites, provides equivalent selectable workspace privacy with unconditional Git credential stripping, removes workspace enrichment from every request-log path without mutating live traffic, and all listed regressions pass after the downstream implementation is removed.
+
   - id: codex-model-not-found-request-scope
     reason: An OpenAI-style 404 with error.type invalid_request_error and error.param model is a request/model routing failure, not evidence of unhealthy Codex credentials; retrying every auth or applying the generic 12-hour model cooldown can suspend the entire model pool.
     introduced_in: ded0314d23dc38656e2fb02220504bd98373813c

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -318,14 +318,17 @@ patches:
     regression_tests:
       - TestNormalizeRequestRepairSanitizesWorkspaceAndRegeneratesProjections
       - TestNormalizeRequestUsesDirectCanonicalHeaderAsLegacyFallback
+      - TestNormalizeRequestUsesThreadIDAsSessionFallback
       - TestNormalizeRequestPreservesFlatIdentityWhenCanonicalOmitsConditionalFields
       - TestNormalizeRequestWorkspaceRedactAndDrop
       - TestNormalizeRequestStrictRejectsConflictAndMalformedCanonical
       - TestNormalizeRequestOffSkipsMutationButMarksCanonical
-      - TestNormalizeRequestCollapsesDuplicateClientMetadataCarriers
+      - TestNormalizeRequestRejectsDuplicateClientMetadataCarriers
+      - TestNormalizeRequestOffMarksCanonicalAcrossDuplicateClientMetadataCarriers
       - TestRedactRequestBodyForLogRemovesWorkspacesWithoutMutatingInput
       - TestRedactRequestBodyForLogFailsClosedForMalformedCanonical
-      - TestRedactRequestBodyForLogCollapsesDuplicateClientMetadataCarriers
+      - TestRedactRequestBodyForLogRedactsEscapedCanonicalKey
+      - TestRedactRequestBodyForLogFailsClosedForDuplicateClientMetadataCarriers
       - TestCodexClientMetadataEffectiveDefaults
       - TestLoadConfigOptionalCodexClientMetadata
       - TestCodexExecutorCacheHelperCanonicalMetadataBypassesLegacyIdentityConfuse

--- a/internal/api/middleware/request_logging.go
+++ b/internal/api/middleware/request_logging.go
@@ -5,6 +5,7 @@ package middleware
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/klauspost/compress/zstd"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/codexmetadata"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 )
@@ -276,8 +278,9 @@ func captureRequestInfo(c *gin.Context, captureBody bool) (*RequestInfo, error) 
 	// Capture headers
 	headers := make(map[string][]string)
 	for key, values := range c.Request.Header {
-		headers[key] = values
+		headers[key] = append([]string(nil), values...)
 	}
+	headers = codexmetadata.RedactHeadersForLog(headers)
 
 	// Capture request body
 	var body []byte
@@ -300,6 +303,7 @@ func captureRequestInfo(c *gin.Context, captureBody bool) (*RequestInfo, error) 
 			c.Request.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 			body = decodeCapturedRequestBodyForLogWithLimit(bodyBytes, c.Request.Header.Get("Content-Encoding"), maxErrorOnlyCapturedRequestBodyBytes)
 		}
+		body = redactCapturedRequestBodyForLog(c.Request.URL.Path, c.Request.Header.Get("Content-Encoding"), body)
 	}
 
 	return &RequestInfo{
@@ -310,6 +314,27 @@ func captureRequestInfo(c *gin.Context, captureBody bool) (*RequestInfo, error) 
 		RequestID: logging.GetGinRequestID(c),
 		Timestamp: time.Now(),
 	}, nil
+}
+
+func redactCapturedRequestBodyForLog(path, encoding string, body []byte) []byte {
+	encoding = strings.TrimSpace(encoding)
+	if isCodexResponsesRequestPath(path) && encoding != "" && !strings.EqualFold(encoding, "identity") && !json.Valid(body) {
+		return []byte("[REDACTED ENCODED OR TRUNCATED CODEX REQUEST BODY]")
+	}
+	return codexmetadata.RedactRequestBodyForLog(body)
+}
+
+func isCodexResponsesRequestPath(path string) bool {
+	path = strings.TrimSpace(path)
+	if index := strings.IndexByte(path, '?'); index >= 0 {
+		path = path[:index]
+	}
+	switch path {
+	case "/v1/responses", "/v1/responses/compact", "/v1/images/generations", "/v1/images/edits", "/backend-api/codex/responses", "/backend-api/codex/responses/compact":
+		return true
+	default:
+		return false
+	}
 }
 
 type restoredRequestBody struct {

--- a/internal/api/middleware/request_logging_test.go
+++ b/internal/api/middleware/request_logging_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -186,6 +187,80 @@ func TestShouldCaptureRequestBody(t *testing.T) {
 			t.Fatalf("%s: got %t, want %t", tests[i].name, got, tests[i].want)
 		}
 	}
+}
+
+func TestCaptureRequestInfoRedactsCodexMetadataWithoutChangingHandlerBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body, canonical := middlewareCodexMetadataFixture(t)
+	request := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("X-Codex-Turn-Metadata", canonical)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = request
+
+	info, err := captureRequestInfo(c, true)
+	if err != nil {
+		t.Fatalf("captureRequestInfo() error = %v", err)
+	}
+	if strings.Contains(string(info.Body), "credential-sentinel") || strings.Contains(string(info.Body), `"workspaces"`) {
+		t.Fatalf("captured downstream body leaked Codex workspace metadata: %s", info.Body)
+	}
+	if got := strings.Join(info.Headers["X-Codex-Turn-Metadata"], ","); strings.Contains(got, "credential-sentinel") || strings.Contains(got, `"workspaces"`) {
+		t.Fatalf("captured downstream headers leaked Codex workspace metadata: %s", got)
+	}
+	restored, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(restored, body) {
+		t.Fatal("request logging sanitizer changed the body delivered to the handler")
+	}
+}
+
+func TestExtractDeferredRequestBodyRedactsTruncatedCodexMetadata(t *testing.T) {
+	body, _ := middlewareCodexMetadataFixture(t)
+	capture := &deferredRequestBodyCapture{body: io.NopCloser(bytes.NewReader(body)), contentLength: int64(len(body))}
+	buffer := make([]byte, len(body))
+	if _, err := io.ReadFull(capture, buffer); err != nil {
+		t.Fatalf("capture read error = %v", err)
+	}
+	wrapper := &ResponseWriterWrapper{requestInfo: &RequestInfo{
+		Headers:             map[string][]string{"Content-Type": {"application/json"}},
+		deferredBodyCapture: capture,
+	}}
+	redacted := wrapper.extractRequestBody(nil)
+	if strings.Contains(string(redacted), "credential-sentinel") || strings.Contains(string(redacted), `"workspaces"`) {
+		t.Fatalf("deferred request log leaked Codex workspace metadata: %s", redacted)
+	}
+}
+
+func TestRedactCapturedRequestBodyForLogFailsClosedForEncodedCodexBody(t *testing.T) {
+	rawCompressed := []byte("compressed-credential-sentinel")
+	for _, path := range []string{"/v1/responses", "/v1/responses/compact", "/v1/images/generations", "/v1/images/edits", "/backend-api/codex/responses/compact"} {
+		redacted := redactCapturedRequestBodyForLog(path, "zstd", rawCompressed)
+		if bytes.Contains(redacted, []byte("credential-sentinel")) {
+			t.Fatalf("encoded Codex request body was retained in logs for %s: %q", path, redacted)
+		}
+		if !bytes.Contains(redacted, []byte("REDACTED ENCODED")) {
+			t.Fatalf("encoded Codex redaction marker missing for %s: %q", path, redacted)
+		}
+	}
+}
+
+func middlewareCodexMetadataFixture(t *testing.T) ([]byte, string) {
+	t.Helper()
+	canonical := `{"thread_id":"thread-1","workspaces":{"/Users/private/project":{"associated_remote_urls":{"origin":"https://user:credential-sentinel@example.com/org/repo.git?token=credential-sentinel"}}}}`
+	body, err := json.Marshal(map[string]any{
+		"model": "gpt-5.6",
+		"client_metadata": map[string]any{
+			"x-codex-turn-metadata": canonical,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body, canonical
 }
 
 func TestDeferredRequestBodyCaptureDoesNotDrainUnreadBody(t *testing.T) {

--- a/internal/api/middleware/response_writer.go
+++ b/internal/api/middleware/response_writer.go
@@ -524,6 +524,7 @@ func (w *ResponseWriterWrapper) extractRequestBody(c *gin.Context) []byte {
 		}
 	}
 	body = decodeCapturedRequestBodyForLogWithLimit(body, encoding, maxDeferredErrorRequestBodyBytes)
+	body = redactCapturedRequestBodyForLog(w.requestInfo.URL, encoding, body)
 	if statusMarker == "" {
 		return body
 	}

--- a/internal/codexmetadata/log.go
+++ b/internal/codexmetadata/log.go
@@ -6,29 +6,54 @@ import (
 	"strings"
 )
 
-const redactedInvalidTurnMetadata = "[REDACTED INVALID CODEX TURN METADATA]"
+const (
+	redactedInvalidTurnMetadata = "[REDACTED INVALID CODEX TURN METADATA]"
+	redactedInvalidRequestBody  = "[REDACTED CODEX REQUEST BODY WITH INVALID TURN METADATA]"
+)
+
+type logMetadataInspection struct {
+	sawClientMetadata bool
+	hasCanonical      bool
+	ambiguous         bool
+}
 
 // RedactRequestBodyForLog removes workspace enrichment from the canonical
 // metadata copy written to logs. The original request body is never modified.
 func RedactRequestBodyForLog(body []byte) []byte {
-	if len(body) == 0 || !bytes.Contains(body, []byte("x-codex-turn-metadata")) {
+	if len(body) == 0 {
 		return body
+	}
+	if !bytes.Contains(body, []byte("x-codex-turn-metadata")) && !bytes.Contains(body, []byte(`\u`)) {
+		return body
+	}
+	inspection, err := inspectLogMetadataCarriers(body)
+	if err != nil {
+		if inspection.sawClientMetadata || bytes.Contains(body, []byte("x-codex-turn-metadata")) {
+			return []byte(redactedInvalidRequestBody)
+		}
+		return body
+	}
+	if !inspection.hasCanonical {
+		return body
+	}
+	if inspection.ambiguous {
+		return []byte(redactedInvalidRequestBody)
 	}
 	envelope, err := requestEnvelope(body)
 	if err != nil {
-		return []byte("[REDACTED CODEX REQUEST BODY WITH INVALID TURN METADATA]")
+		return []byte(redactedInvalidRequestBody)
 	}
 	rawClientMetadata, hasClientMetadata := envelope["client_metadata"]
 	if !hasClientMetadata {
-		return body
+		return []byte(redactedInvalidRequestBody)
 	}
 	var clientMetadata map[string]json.RawMessage
 	if err = json.Unmarshal(rawClientMetadata, &clientMetadata); err != nil || clientMetadata == nil {
-		return []byte("[REDACTED CODEX REQUEST BODY WITH INVALID TURN METADATA]")
+		return []byte(redactedInvalidRequestBody)
 	}
 	rawCanonical, exists := clientMetadata["x-codex-turn-metadata"]
 	if !exists {
-		return body
+		return []byte(redactedInvalidRequestBody)
 	}
 	var canonicalText string
 	if err := json.Unmarshal(rawCanonical, &canonicalText); err != nil {
@@ -51,6 +76,51 @@ func RedactRequestBodyForLog(body []byte) []byte {
 		return []byte("[REDACTED CODEX REQUEST BODY]")
 	}
 	return redacted
+}
+
+func inspectLogMetadataCarriers(body []byte) (logMetadataInspection, error) {
+	var inspection logMetadataInspection
+	members, err := decodeJSONObjectMembers(body)
+	clientMetadataCount := 0
+	canonicalCount := 0
+	for _, member := range members {
+		if member.key != "client_metadata" {
+			continue
+		}
+		inspection.sawClientMetadata = true
+		clientMetadataCount++
+		if bytes.Equal(bytes.TrimSpace(member.value), []byte("null")) {
+			continue
+		}
+		clientMembers, clientErr := decodeJSONObjectMembers(member.value)
+		if clientErr != nil {
+			return inspection, clientErr
+		}
+		seen := make(map[string]struct{}, len(clientMembers))
+		carrierHasCanonical := false
+		carrierHasDuplicate := false
+		for _, clientMember := range clientMembers {
+			if _, duplicate := seen[clientMember.key]; duplicate {
+				carrierHasDuplicate = true
+			}
+			seen[clientMember.key] = struct{}{}
+			if clientMember.key == "x-codex-turn-metadata" {
+				carrierHasCanonical = true
+				canonicalCount++
+			}
+		}
+		if carrierHasCanonical && carrierHasDuplicate {
+			inspection.ambiguous = true
+		}
+	}
+	inspection.hasCanonical = canonicalCount > 0
+	if inspection.hasCanonical && (clientMetadataCount != 1 || canonicalCount != 1) {
+		inspection.ambiguous = true
+	}
+	if err != nil {
+		return inspection, err
+	}
+	return inspection, nil
 }
 
 // RedactHeadersForLog clones a header map and removes workspace enrichment

--- a/internal/codexmetadata/log.go
+++ b/internal/codexmetadata/log.go
@@ -1,0 +1,86 @@
+package codexmetadata
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+const redactedInvalidTurnMetadata = "[REDACTED INVALID CODEX TURN METADATA]"
+
+// RedactRequestBodyForLog removes workspace enrichment from the canonical
+// metadata copy written to logs. The original request body is never modified.
+func RedactRequestBodyForLog(body []byte) []byte {
+	if len(body) == 0 || !bytes.Contains(body, []byte("x-codex-turn-metadata")) {
+		return body
+	}
+	envelope, err := requestEnvelope(body)
+	if err != nil {
+		return []byte("[REDACTED CODEX REQUEST BODY WITH INVALID TURN METADATA]")
+	}
+	rawClientMetadata, hasClientMetadata := envelope["client_metadata"]
+	if !hasClientMetadata {
+		return body
+	}
+	var clientMetadata map[string]json.RawMessage
+	if err = json.Unmarshal(rawClientMetadata, &clientMetadata); err != nil || clientMetadata == nil {
+		return []byte("[REDACTED CODEX REQUEST BODY WITH INVALID TURN METADATA]")
+	}
+	rawCanonical, exists := clientMetadata["x-codex-turn-metadata"]
+	if !exists {
+		return body
+	}
+	var canonicalText string
+	if err := json.Unmarshal(rawCanonical, &canonicalText); err != nil {
+		canonicalText = redactedInvalidTurnMetadata
+	} else {
+		canonicalText = redactTurnMetadataForLog(canonicalText)
+	}
+	encodedCanonical, err := json.Marshal(canonicalText)
+	if err != nil {
+		return []byte("[REDACTED CODEX REQUEST BODY]")
+	}
+	clientMetadata["x-codex-turn-metadata"] = encodedCanonical
+	clientMetadataJSON, err := json.Marshal(clientMetadata)
+	if err != nil {
+		return []byte("[REDACTED CODEX REQUEST BODY]")
+	}
+	envelope["client_metadata"] = clientMetadataJSON
+	redacted, err := json.Marshal(envelope)
+	if err != nil {
+		return []byte("[REDACTED CODEX REQUEST BODY]")
+	}
+	return redacted
+}
+
+// RedactHeadersForLog clones a header map and removes workspace enrichment
+// from direct X-Codex-Turn-Metadata compatibility headers.
+func RedactHeadersForLog(headers map[string][]string) map[string][]string {
+	if headers == nil {
+		return nil
+	}
+	redacted := make(map[string][]string, len(headers))
+	for key, values := range headers {
+		cloned := append([]string(nil), values...)
+		if strings.EqualFold(key, "X-Codex-Turn-Metadata") {
+			for index := range cloned {
+				cloned[index] = redactTurnMetadataForLog(cloned[index])
+			}
+		}
+		redacted[key] = cloned
+	}
+	return redacted
+}
+
+func redactTurnMetadataForLog(raw string) string {
+	canonical, _, err := decodeCanonicalObject(raw)
+	if err != nil {
+		return redactedInvalidTurnMetadata
+	}
+	delete(canonical, "workspaces")
+	redacted, err := marshalASCIIJSON(canonical)
+	if err != nil {
+		return redactedInvalidTurnMetadata
+	}
+	return string(redacted)
+}

--- a/internal/codexmetadata/log_test.go
+++ b/internal/codexmetadata/log_test.go
@@ -1,7 +1,6 @@
 package codexmetadata
 
 import (
-	"bytes"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -58,13 +57,24 @@ func TestRedactHeadersForLogClonesAndSanitizesCanonicalHeader(t *testing.T) {
 	}
 }
 
-func TestRedactRequestBodyForLogCollapsesDuplicateClientMetadataCarriers(t *testing.T) {
-	body := []byte(`{"model":"gpt-5.6","client_metadata":{"x-codex-turn-metadata":"{\"request_kind\":\"turn\",\"thread_id\":\"safe\"}"},"client_metadata":{"x-codex-turn-metadata":"{\"request_kind\":\"turn\",\"thread_id\":\"thread-1\",\"workspaces\":{\"/Users/private/project\":{\"associated_remote_urls\":{\"origin\":\"https://user:credential-sentinel@example.com/repo.git\"}}}}"}}`)
+func TestRedactRequestBodyForLogRedactsEscapedCanonicalKey(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6","clie\u006et_metadata":{"x-codex-turn-metad\u0061ta":"{\"request_kind\":\"turn\",\"thread_id\":\"thread-1\",\"workspaces\":{\"/Users/private/project\":{\"associated_remote_urls\":{\"origin\":\"https://user:credential-sentinel@example.com/repo.git\"}}}}"}}`)
 	redacted := RedactRequestBodyForLog(body)
-	if bytes.Count(redacted, []byte(`"client_metadata"`)) != 1 {
-		t.Fatalf("duplicate client metadata remained in log body: %s", redacted)
-	}
 	if strings.Contains(string(redacted), "credential-sentinel") || strings.Contains(string(redacted), `"workspaces"`) {
+		t.Fatalf("escaped canonical key leaked workspace details: %s", redacted)
+	}
+	if !strings.Contains(string(redacted), "thread-1") {
+		t.Fatalf("escaped canonical key did not preserve safe metadata: %s", redacted)
+	}
+}
+
+func TestRedactRequestBodyForLogFailsClosedForDuplicateClientMetadataCarriers(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6","client_metadata":{"x-codex-turn-metadata":"{\"request_kind\":\"turn\",\"thread_id\":\"thread-1\",\"workspaces\":{\"/Users/private/project\":{\"associated_remote_urls\":{\"origin\":\"https://user:credential-sentinel@example.com/repo.git\"}}}}"},"client_metadata":{"transport_marker":"last"}}`)
+	redacted := RedactRequestBodyForLog(body)
+	if strings.Contains(string(redacted), "credential-sentinel") || strings.Contains(string(redacted), "/Users/private/project") {
 		t.Fatalf("duplicate client metadata leaked workspace details: %s", redacted)
+	}
+	if !strings.Contains(string(redacted), "[REDACTED CODEX REQUEST BODY WITH INVALID TURN METADATA]") {
+		t.Fatalf("duplicate client metadata did not fail closed: %s", redacted)
 	}
 }

--- a/internal/codexmetadata/log_test.go
+++ b/internal/codexmetadata/log_test.go
@@ -1,0 +1,70 @@
+package codexmetadata
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestRedactRequestBodyForLogRemovesWorkspacesWithoutMutatingInput(t *testing.T) {
+	body := requestBodyWithMetadata(t, sampleTurnMetadata, map[string]any{"transport_marker": true})
+	original := string(body)
+	redacted := RedactRequestBodyForLog(body)
+	if string(body) != original {
+		t.Fatal("log sanitizer mutated input body")
+	}
+	if strings.Contains(string(redacted), "secret") || strings.Contains(string(redacted), "/Users/example/project") || strings.Contains(string(redacted), "01234567") {
+		t.Fatalf("redacted body leaked workspace metadata: %s", redacted)
+	}
+	clientMetadata := decodeClientMetadata(t, redacted)
+	var canonical string
+	if err := json.Unmarshal(clientMetadata["x-codex-turn-metadata"], &canonical); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(canonical, `"workspaces"`) {
+		t.Fatalf("canonical log metadata retained workspaces: %s", canonical)
+	}
+	if _, ok := clientMetadata["transport_marker"]; !ok {
+		t.Fatal("log sanitizer dropped unrelated client_metadata")
+	}
+}
+
+func TestRedactRequestBodyForLogFailsClosedForMalformedCanonical(t *testing.T) {
+	body := requestBodyWithRawCanonical(t, `{"workspaces":{"x":"token-secret"}`)
+	redacted := RedactRequestBodyForLog(body)
+	if strings.Contains(string(redacted), "token-secret") {
+		t.Fatalf("malformed canonical value leaked: %s", redacted)
+	}
+	if !strings.Contains(string(redacted), redactedInvalidTurnMetadata) {
+		t.Fatalf("redaction marker missing: %s", redacted)
+	}
+}
+
+func TestRedactHeadersForLogClonesAndSanitizesCanonicalHeader(t *testing.T) {
+	headers := map[string][]string{
+		"X-Codex-Turn-Metadata": {sampleTurnMetadata},
+		"X-Test":                {"keep"},
+	}
+	redacted := RedactHeadersForLog(headers)
+	if strings.Contains(redacted["X-Codex-Turn-Metadata"][0], "secret") || strings.Contains(redacted["X-Codex-Turn-Metadata"][0], `"workspaces"`) {
+		t.Fatalf("header was not sanitized: %s", redacted["X-Codex-Turn-Metadata"][0])
+	}
+	if headers["X-Codex-Turn-Metadata"][0] != sampleTurnMetadata {
+		t.Fatal("header sanitizer mutated input map")
+	}
+	if redacted["X-Test"][0] != "keep" {
+		t.Fatal("unrelated header changed")
+	}
+}
+
+func TestRedactRequestBodyForLogCollapsesDuplicateClientMetadataCarriers(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6","client_metadata":{"x-codex-turn-metadata":"{\"request_kind\":\"turn\",\"thread_id\":\"safe\"}"},"client_metadata":{"x-codex-turn-metadata":"{\"request_kind\":\"turn\",\"thread_id\":\"thread-1\",\"workspaces\":{\"/Users/private/project\":{\"associated_remote_urls\":{\"origin\":\"https://user:credential-sentinel@example.com/repo.git\"}}}}"}}`)
+	redacted := RedactRequestBodyForLog(body)
+	if bytes.Count(redacted, []byte(`"client_metadata"`)) != 1 {
+		t.Fatalf("duplicate client metadata remained in log body: %s", redacted)
+	}
+	if strings.Contains(string(redacted), "credential-sentinel") || strings.Contains(string(redacted), `"workspaces"`) {
+		t.Fatalf("duplicate client metadata leaked workspace details: %s", redacted)
+	}
+}

--- a/internal/codexmetadata/request.go
+++ b/internal/codexmetadata/request.go
@@ -56,12 +56,19 @@ type State struct {
 	CanonicalPresent bool
 	Normalized       bool
 	TurnMetadata     string
+	SessionID        string
+	HasSessionID     bool
 	WindowID         string
 	HasWindowID      bool
 	ParentThreadID   string
 	HasParentThread  bool
 	Subagent         string
 	HasSubagent      bool
+}
+
+type jsonObjectMember struct {
+	key   string
+	value json.RawMessage
 }
 
 // ValidationError is returned for malformed or conflicting canonical metadata.
@@ -170,6 +177,7 @@ func NormalizeRequest(body []byte, directTurnMetadata string, policy Policy) ([]
 
 	state.Normalized = true
 	state.TurnMetadata = canonicalText
+	state.SessionID, state.HasSessionID = canonicalSessionID(canonical)
 	state.WindowID, state.HasWindowID = canonicalString(canonical, "window_id")
 	state.ParentThreadID, state.HasParentThread = canonicalString(canonical, "parent_thread_id")
 	state.Subagent, state.HasSubagent = rawJSONString(clientMetadata, "x-openai-subagent")
@@ -177,10 +185,15 @@ func NormalizeRequest(body []byte, directTurnMetadata string, policy Policy) ([]
 }
 
 func detectCanonicalRequest(body []byte, directTurnMetadata string) bool {
-	if clientMetadata, _, err := clientMetadataObject(body); err == nil {
-		if rawCanonical, exists := clientMetadata["x-codex-turn-metadata"]; exists {
+	carriers, _ := clientMetadataCarriers(body)
+	for _, carrier := range carriers {
+		members, _ := decodeJSONObjectMembers(carrier)
+		for _, member := range members {
+			if member.key != "x-codex-turn-metadata" {
+				continue
+			}
 			var canonicalText string
-			if json.Unmarshal(rawCanonical, &canonicalText) == nil && canonicalHasRequestKind(canonicalText) {
+			if json.Unmarshal(member.value, &canonicalText) == nil && canonicalHasRequestKind(canonicalText) {
 				return true
 			}
 		}
@@ -220,19 +233,50 @@ func (s State) ApplyHeaders(headers http.Header) {
 }
 
 func clientMetadataObject(body []byte) (map[string]json.RawMessage, bool, error) {
-	envelope, err := requestEnvelope(body)
+	carriers, err := clientMetadataCarriers(body)
 	if err != nil {
-		return nil, false, err
+		return nil, false, &ValidationError{Code: "request body is malformed"}
 	}
-	raw, ok := envelope["client_metadata"]
-	if !ok || len(raw) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+	if len(carriers) == 0 {
 		return nil, false, nil
+	}
+	if len(carriers) != 1 {
+		return nil, true, &ValidationError{Code: "duplicate client metadata carriers"}
+	}
+	raw := carriers[0]
+	if len(raw) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, false, nil
+	}
+	members, err := decodeJSONObjectMembers(raw)
+	if err != nil {
+		return nil, true, &ValidationError{Code: "client metadata must be an object"}
+	}
+	seen := make(map[string]struct{}, len(members))
+	for _, member := range members {
+		if _, duplicate := seen[member.key]; duplicate {
+			return nil, true, &ValidationError{Code: "client metadata contains duplicate keys"}
+		}
+		seen[member.key] = struct{}{}
 	}
 	var clientMetadata map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &clientMetadata); err != nil || clientMetadata == nil {
 		return nil, true, &ValidationError{Code: "client metadata must be an object"}
 	}
 	return clientMetadata, true, nil
+}
+
+func clientMetadataCarriers(body []byte) ([]json.RawMessage, error) {
+	if len(body) == 0 {
+		return nil, nil
+	}
+	members, err := decodeJSONObjectMembers(body)
+	carriers := make([]json.RawMessage, 0, 1)
+	for _, member := range members {
+		if member.key == "client_metadata" {
+			carriers = append(carriers, member.value)
+		}
+	}
+	return carriers, err
 }
 
 func requestEnvelope(body []byte) (map[string]json.RawMessage, error) {
@@ -244,6 +288,47 @@ func requestEnvelope(body []byte) (map[string]json.RawMessage, error) {
 		return nil, &ValidationError{Code: "request body is malformed"}
 	}
 	return envelope, nil
+}
+
+func decodeJSONObjectMembers(raw []byte) ([]jsonObjectMember, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	start, err := decoder.Token()
+	if err != nil {
+		return nil, err
+	}
+	if start != json.Delim('{') {
+		return nil, fmt.Errorf("JSON value is not an object")
+	}
+	members := make([]jsonObjectMember, 0, 8)
+	for decoder.More() {
+		keyToken, errKey := decoder.Token()
+		if errKey != nil {
+			return members, errKey
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return members, fmt.Errorf("JSON object key is not a string")
+		}
+		members = append(members, jsonObjectMember{key: key})
+		if err = decoder.Decode(&members[len(members)-1].value); err != nil {
+			return members, err
+		}
+	}
+	end, err := decoder.Token()
+	if err != nil {
+		return members, err
+	}
+	if end != json.Delim('}') {
+		return members, fmt.Errorf("JSON object is not terminated")
+	}
+	if _, err = decoder.Token(); err != io.EOF {
+		if err == nil {
+			return members, fmt.Errorf("JSON object has trailing data")
+		}
+		return members, err
+	}
+	return members, nil
 }
 
 func replaceClientMetadata(body, clientMetadataJSON []byte) ([]byte, error) {
@@ -412,6 +497,16 @@ func canonicalString(object map[string]json.RawMessage, key string) (string, boo
 		return "", false
 	}
 	return value, true
+}
+
+func canonicalSessionID(canonical map[string]json.RawMessage) (string, bool) {
+	for _, key := range []string{"session_id", "thread_id"} {
+		value, exists := canonicalString(canonical, key)
+		if value = strings.TrimSpace(value); exists && value != "" {
+			return value, true
+		}
+	}
+	return "", false
 }
 
 func rawJSONString(object map[string]json.RawMessage, key string) (string, bool) {

--- a/internal/codexmetadata/request.go
+++ b/internal/codexmetadata/request.go
@@ -1,0 +1,633 @@
+package codexmetadata
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+const (
+	ModeOff    = "off"
+	ModeRepair = "repair"
+	ModeStrict = "strict"
+
+	WorkspacePolicyPassthrough = "passthrough"
+	WorkspacePolicyRedact      = "redact"
+	WorkspacePolicyDrop        = "drop"
+
+	maxTurnMetadataBytes      = 128 << 10
+	maxTurnMetadataDepth      = 32
+	maxWorkspaceCount         = 32
+	maxWorkspaceRemoteCount   = 32
+	redactedWorkspaceHashSize = 16
+)
+
+var projectionFields = []struct {
+	canonical        string
+	flat             string
+	deleteWhenAbsent bool
+}{
+	{canonical: "installation_id", flat: "x-codex-installation-id"},
+	{canonical: "session_id", flat: "session_id"},
+	{canonical: "thread_id", flat: "thread_id"},
+	{canonical: "turn_id", flat: "turn_id"},
+	{canonical: "window_id", flat: "x-codex-window-id"},
+	{canonical: "parent_thread_id", flat: "x-codex-parent-thread-id", deleteWhenAbsent: true},
+}
+
+// Policy controls canonical Codex turn metadata normalization.
+type Policy struct {
+	Mode            string
+	WorkspacePolicy string
+	Scope           string
+}
+
+// State captures the canonical compatibility projections rendered for one request.
+type State struct {
+	CanonicalPresent bool
+	Normalized       bool
+	TurnMetadata     string
+	WindowID         string
+	HasWindowID      bool
+	ParentThreadID   string
+	HasParentThread  bool
+	Subagent         string
+	HasSubagent      bool
+}
+
+// ValidationError is returned for malformed or conflicting canonical metadata.
+// It intentionally carries no untrusted metadata value.
+type ValidationError struct {
+	Code string
+}
+
+func (e *ValidationError) Error() string {
+	if e == nil || strings.TrimSpace(e.Code) == "" {
+		return "invalid Codex client metadata"
+	}
+	return "invalid Codex client metadata: " + e.Code
+}
+
+// NormalizeRequest treats body client_metadata.x-codex-turn-metadata as the
+// canonical source, applies workspace privacy policy, and regenerates flat
+// compatibility projections. Header projections are applied separately through
+// State.ApplyHeaders after all provider/model header overrides have run.
+func NormalizeRequest(body []byte, directTurnMetadata string, policy Policy) ([]byte, State, error) {
+	mode := normalizeMode(policy.Mode)
+	directTurnMetadata = strings.TrimSpace(directTurnMetadata)
+	if mode == ModeOff {
+		return body, State{CanonicalPresent: detectCanonicalRequest(body, directTurnMetadata)}, nil
+	}
+
+	clientMetadata, clientMetadataExists, err := clientMetadataObject(body)
+	if err != nil {
+		if directTurnMetadata == "" {
+			if validationErr, ok := err.(*ValidationError); ok && validationErr.Code == "client metadata must be an object" {
+				return body, State{}, nil
+			}
+		}
+		return nil, State{}, err
+	}
+	rawCanonical, bodyCanonicalExists := clientMetadata["x-codex-turn-metadata"]
+	if !bodyCanonicalExists && directTurnMetadata == "" {
+		return body, State{}, nil
+	}
+
+	var canonicalText string
+	if bodyCanonicalExists {
+		if err = json.Unmarshal(rawCanonical, &canonicalText); err != nil {
+			return nil, State{}, &ValidationError{Code: "canonical metadata must be a JSON string"}
+		}
+	} else {
+		canonicalText = directTurnMetadata
+		if !clientMetadataExists {
+			clientMetadata = make(map[string]json.RawMessage)
+		}
+	}
+	canonical, canonicalValue, err := decodeCanonicalObject(canonicalText)
+	if err != nil {
+		return nil, State{}, err
+	}
+	requestKind, canonicalMarker := canonicalString(canonical, "request_kind")
+	if !canonicalMarker || strings.TrimSpace(requestKind) == "" {
+		return body, State{}, nil
+	}
+	state := State{CanonicalPresent: true}
+	if err = validateCanonicalProjectionTypes(canonical); err != nil {
+		return nil, state, err
+	}
+	if mode == ModeStrict {
+		if projectionConflict(clientMetadata, canonical) {
+			return nil, state, &ValidationError{Code: "canonical and flat projections conflict"}
+		}
+		if bodyCanonicalExists && directTurnMetadata != "" {
+			_, directValue, errDirect := decodeCanonicalObject(directTurnMetadata)
+			if errDirect != nil {
+				return nil, state, &ValidationError{Code: "direct canonical header is malformed"}
+			}
+			if !reflect.DeepEqual(canonicalValue, directValue) {
+				return nil, state, &ValidationError{Code: "body and direct canonical metadata conflict"}
+			}
+		}
+	}
+
+	workspaceScope := strings.TrimSpace(policy.Scope)
+	if installationID, ok := canonicalString(canonical, "installation_id"); ok {
+		workspaceScope += "\x00installation:" + installationID
+	}
+	if err = applyWorkspacePolicy(canonical, normalizeWorkspacePolicy(policy.WorkspacePolicy), workspaceScope); err != nil {
+		return nil, state, err
+	}
+	canonicalJSON, err := marshalASCIIJSON(canonical)
+	if err != nil {
+		return nil, state, &ValidationError{Code: "canonical metadata cannot be rendered"}
+	}
+	canonicalText = string(canonicalJSON)
+	encodedCanonical, err := json.Marshal(canonicalText)
+	if err != nil {
+		return nil, state, &ValidationError{Code: "canonical metadata cannot be embedded"}
+	}
+	clientMetadata["x-codex-turn-metadata"] = encodedCanonical
+	regenerateFlatProjections(clientMetadata, canonical)
+
+	clientMetadataJSON, err := json.Marshal(clientMetadata)
+	if err != nil {
+		return nil, state, &ValidationError{Code: "client metadata cannot be rendered"}
+	}
+	updatedBody, err := replaceClientMetadata(body, clientMetadataJSON)
+	if err != nil {
+		return nil, state, &ValidationError{Code: "client metadata cannot be applied"}
+	}
+
+	state.Normalized = true
+	state.TurnMetadata = canonicalText
+	state.WindowID, state.HasWindowID = canonicalString(canonical, "window_id")
+	state.ParentThreadID, state.HasParentThread = canonicalString(canonical, "parent_thread_id")
+	state.Subagent, state.HasSubagent = rawJSONString(clientMetadata, "x-openai-subagent")
+	return updatedBody, state, nil
+}
+
+func detectCanonicalRequest(body []byte, directTurnMetadata string) bool {
+	if clientMetadata, _, err := clientMetadataObject(body); err == nil {
+		if rawCanonical, exists := clientMetadata["x-codex-turn-metadata"]; exists {
+			var canonicalText string
+			if json.Unmarshal(rawCanonical, &canonicalText) == nil && canonicalHasRequestKind(canonicalText) {
+				return true
+			}
+		}
+	}
+	return canonicalHasRequestKind(directTurnMetadata)
+}
+
+func canonicalHasRequestKind(raw string) bool {
+	canonical, _, err := decodeCanonicalObject(strings.TrimSpace(raw))
+	if err != nil {
+		return false
+	}
+	requestKind, exists := canonicalString(canonical, "request_kind")
+	return exists && strings.TrimSpace(requestKind) != ""
+}
+
+// ApplyHeaders regenerates direct compatibility headers from the normalized
+// canonical object. It is a no-op for off mode and legacy requests.
+func (s State) ApplyHeaders(headers http.Header) {
+	if headers == nil || !s.Normalized {
+		return
+	}
+	setHeaderCaseInsensitive(headers, "X-Codex-Turn-Metadata", s.TurnMetadata)
+	if s.HasWindowID {
+		setHeaderCaseInsensitive(headers, "X-Codex-Window-Id", s.WindowID)
+	}
+	if s.HasParentThread {
+		setHeaderCaseInsensitive(headers, "X-Codex-Parent-Thread-Id", s.ParentThreadID)
+	} else {
+		deleteHeaderCaseInsensitive(headers, "X-Codex-Parent-Thread-Id")
+	}
+	if s.HasSubagent {
+		setHeaderCaseInsensitive(headers, "X-OpenAI-Subagent", s.Subagent)
+	} else {
+		deleteHeaderCaseInsensitive(headers, "X-OpenAI-Subagent")
+	}
+}
+
+func clientMetadataObject(body []byte) (map[string]json.RawMessage, bool, error) {
+	envelope, err := requestEnvelope(body)
+	if err != nil {
+		return nil, false, err
+	}
+	raw, ok := envelope["client_metadata"]
+	if !ok || len(raw) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, false, nil
+	}
+	var clientMetadata map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &clientMetadata); err != nil || clientMetadata == nil {
+		return nil, true, &ValidationError{Code: "client metadata must be an object"}
+	}
+	return clientMetadata, true, nil
+}
+
+func requestEnvelope(body []byte) (map[string]json.RawMessage, error) {
+	if len(body) == 0 {
+		return nil, nil
+	}
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(body, &envelope); err != nil || envelope == nil {
+		return nil, &ValidationError{Code: "request body is malformed"}
+	}
+	return envelope, nil
+}
+
+func replaceClientMetadata(body, clientMetadataJSON []byte) ([]byte, error) {
+	envelope, err := requestEnvelope(body)
+	if err != nil {
+		return nil, err
+	}
+	if envelope == nil {
+		return nil, &ValidationError{Code: "request body is malformed"}
+	}
+	envelope["client_metadata"] = bytes.Clone(clientMetadataJSON)
+	return json.Marshal(envelope)
+}
+
+func decodeCanonicalObject(raw string) (map[string]json.RawMessage, any, error) {
+	if len(raw) == 0 || len(raw) > maxTurnMetadataBytes {
+		return nil, nil, &ValidationError{Code: "canonical metadata size is invalid"}
+	}
+	data := []byte(raw)
+	if err := validateJSON(data, maxTurnMetadataDepth); err != nil {
+		return nil, nil, &ValidationError{Code: "canonical metadata is malformed"}
+	}
+	var object map[string]json.RawMessage
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(&object); err != nil || object == nil {
+		return nil, nil, &ValidationError{Code: "canonical metadata must be an object"}
+	}
+	var semantic any
+	decoder = json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(&semantic); err != nil {
+		return nil, nil, &ValidationError{Code: "canonical metadata is malformed"}
+	}
+	if _, ok := semantic.(map[string]any); !ok {
+		return nil, nil, &ValidationError{Code: "canonical metadata must be an object"}
+	}
+	return object, semantic, nil
+}
+
+func validateJSON(raw []byte, maxDepth int) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := validateJSONValue(decoder, 0, maxDepth); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("trailing JSON value")
+		}
+		return err
+	}
+	return nil
+}
+
+func validateJSONValue(decoder *json.Decoder, depth, maxDepth int) error {
+	if depth > maxDepth {
+		return fmt.Errorf("JSON depth exceeds limit")
+	}
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delim, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	switch delim {
+	case '{':
+		seen := make(map[string]struct{})
+		for decoder.More() {
+			keyToken, errKey := decoder.Token()
+			if errKey != nil {
+				return errKey
+			}
+			key, okKey := keyToken.(string)
+			if !okKey {
+				return fmt.Errorf("object key is not a string")
+			}
+			if _, duplicate := seen[key]; duplicate {
+				return fmt.Errorf("duplicate object key")
+			}
+			seen[key] = struct{}{}
+			if err = validateJSONValue(decoder, depth+1, maxDepth); err != nil {
+				return err
+			}
+		}
+		end, errEnd := decoder.Token()
+		if errEnd != nil || end != json.Delim('}') {
+			return fmt.Errorf("unterminated object")
+		}
+	case '[':
+		for decoder.More() {
+			if err = validateJSONValue(decoder, depth+1, maxDepth); err != nil {
+				return err
+			}
+		}
+		end, errEnd := decoder.Token()
+		if errEnd != nil || end != json.Delim(']') {
+			return fmt.Errorf("unterminated array")
+		}
+	default:
+		return fmt.Errorf("unexpected JSON delimiter")
+	}
+	return nil
+}
+
+func projectionConflict(clientMetadata, canonical map[string]json.RawMessage) bool {
+	for _, field := range projectionFields {
+		flatRaw, exists := clientMetadata[field.flat]
+		if !exists {
+			continue
+		}
+		canonicalValue, canonicalExists := canonicalString(canonical, field.canonical)
+		if !canonicalExists {
+			if field.deleteWhenAbsent {
+				return true
+			}
+			continue
+		}
+		var flatValue string
+		if err := json.Unmarshal(flatRaw, &flatValue); err != nil || flatValue != canonicalValue {
+			return true
+		}
+	}
+	return false
+}
+
+func validateCanonicalProjectionTypes(canonical map[string]json.RawMessage) error {
+	for _, field := range projectionFields {
+		raw, exists := canonical[field.canonical]
+		if !exists {
+			continue
+		}
+		var value string
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return &ValidationError{Code: "canonical " + field.canonical + " must be a string"}
+		}
+	}
+	return nil
+}
+
+func regenerateFlatProjections(clientMetadata, canonical map[string]json.RawMessage) {
+	for _, field := range projectionFields {
+		value, exists := canonicalString(canonical, field.canonical)
+		if !exists {
+			if field.deleteWhenAbsent {
+				delete(clientMetadata, field.flat)
+			}
+			continue
+		}
+		encoded, err := json.Marshal(value)
+		if err == nil {
+			clientMetadata[field.flat] = encoded
+		}
+	}
+}
+
+func canonicalString(object map[string]json.RawMessage, key string) (string, bool) {
+	raw, exists := object[key]
+	if !exists {
+		return "", false
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", false
+	}
+	return value, true
+}
+
+func rawJSONString(object map[string]json.RawMessage, key string) (string, bool) {
+	raw, exists := object[key]
+	if !exists {
+		return "", false
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil || strings.TrimSpace(value) == "" {
+		return "", false
+	}
+	return value, true
+}
+
+func applyWorkspacePolicy(canonical map[string]json.RawMessage, policy, scope string) error {
+	rawWorkspaces, exists := canonical["workspaces"]
+	if !exists || bytes.Equal(bytes.TrimSpace(rawWorkspaces), []byte("null")) {
+		return nil
+	}
+	if policy == WorkspacePolicyDrop {
+		delete(canonical, "workspaces")
+		return nil
+	}
+
+	var workspaces map[string]json.RawMessage
+	if err := json.Unmarshal(rawWorkspaces, &workspaces); err != nil || workspaces == nil {
+		return &ValidationError{Code: "workspace metadata is malformed"}
+	}
+	if len(workspaces) > maxWorkspaceCount {
+		return &ValidationError{Code: "workspace count exceeds limit"}
+	}
+
+	normalized := make(map[string]json.RawMessage, len(workspaces))
+	for workspacePath, rawWorkspace := range workspaces {
+		var workspace map[string]json.RawMessage
+		if err := json.Unmarshal(rawWorkspace, &workspace); err != nil || workspace == nil {
+			return &ValidationError{Code: "workspace entry is malformed"}
+		}
+		if policy == WorkspacePolicyRedact {
+			redacted := make(map[string]json.RawMessage, 1)
+			if rawHasChanges, ok := workspace["has_changes"]; ok {
+				var hasChanges bool
+				if json.Unmarshal(rawHasChanges, &hasChanges) == nil {
+					redacted["has_changes"] = rawHasChanges
+				}
+			}
+			workspace = redacted
+			workspacePath = redactedWorkspaceKey(scope, workspacePath)
+		} else if err := sanitizeWorkspaceRemotes(workspace); err != nil {
+			return err
+		}
+		renderedWorkspace, err := json.Marshal(workspace)
+		if err != nil {
+			return &ValidationError{Code: "workspace entry cannot be rendered"}
+		}
+		normalized[workspacePath] = renderedWorkspace
+	}
+	renderedWorkspaces, err := json.Marshal(normalized)
+	if err != nil {
+		return &ValidationError{Code: "workspace metadata cannot be rendered"}
+	}
+	canonical["workspaces"] = renderedWorkspaces
+	return nil
+}
+
+func sanitizeWorkspaceRemotes(workspace map[string]json.RawMessage) error {
+	rawRemotes, exists := workspace["associated_remote_urls"]
+	if !exists || bytes.Equal(bytes.TrimSpace(rawRemotes), []byte("null")) {
+		return nil
+	}
+	var remotes map[string]json.RawMessage
+	if err := json.Unmarshal(rawRemotes, &remotes); err != nil || remotes == nil {
+		return &ValidationError{Code: "workspace remotes are malformed"}
+	}
+	if len(remotes) > maxWorkspaceRemoteCount {
+		return &ValidationError{Code: "workspace remote count exceeds limit"}
+	}
+	for name, rawRemote := range remotes {
+		var remote string
+		if err := json.Unmarshal(rawRemote, &remote); err != nil {
+			delete(remotes, name)
+			continue
+		}
+		encoded, err := json.Marshal(sanitizeGitRemote(remote))
+		if err != nil {
+			delete(remotes, name)
+			continue
+		}
+		remotes[name] = encoded
+	}
+	rendered, err := json.Marshal(remotes)
+	if err != nil {
+		return &ValidationError{Code: "workspace remotes cannot be rendered"}
+	}
+	workspace["associated_remote_urls"] = rendered
+	return nil
+}
+
+func sanitizeGitRemote(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	if !strings.Contains(trimmed, "://") {
+		if colon := strings.Index(trimmed, ":"); colon > 0 {
+			prefix := trimmed[:colon]
+			if at := strings.LastIndex(prefix, "@"); at >= 0 && at+1 < len(prefix) {
+				host := strings.TrimSpace(prefix[at+1:])
+				path := stripQueryAndFragment(strings.TrimLeft(trimmed[colon+1:], "/"))
+				if host != "" && path != "" {
+					return "ssh://" + host + "/" + path
+				}
+			}
+		}
+	}
+	parsed, err := url.Parse(trimmed)
+	if err == nil && parsed.Scheme != "" {
+		if parsed.Host == "" && parsed.Opaque != "" {
+			return "redacted:remote"
+		}
+		parsed.User = nil
+		parsed.RawQuery = ""
+		parsed.ForceQuery = false
+		parsed.Fragment = ""
+		sanitized := parsed.String()
+		if strings.Contains(sanitized, "@") {
+			return "redacted:remote"
+		}
+		return sanitized
+	}
+	withoutQuery := stripQueryAndFragment(trimmed)
+	if strings.Contains(withoutQuery, "@") {
+		return "redacted:remote"
+	}
+	return withoutQuery
+}
+
+func stripQueryAndFragment(value string) string {
+	if index := strings.IndexAny(value, "?#"); index >= 0 {
+		return value[:index]
+	}
+	return value
+}
+
+func redactedWorkspaceKey(scope, workspacePath string) string {
+	sum := sha256.Sum256([]byte("cpa:codex:workspace:v1\x00" + strings.TrimSpace(scope) + "\x00" + workspacePath))
+	return "workspace:" + hex.EncodeToString(sum[:redactedWorkspaceHashSize])
+}
+
+func marshalASCIIJSON(value any) ([]byte, error) {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	if utf8.Valid(raw) && isASCII(raw) {
+		return raw, nil
+	}
+	out := make([]byte, 0, len(raw)+16)
+	for len(raw) > 0 {
+		r, size := utf8.DecodeRune(raw)
+		if r == utf8.RuneError && size == 1 {
+			return nil, fmt.Errorf("invalid UTF-8")
+		}
+		if r <= 0x7f {
+			out = append(out, byte(r))
+		} else if r <= 0xffff {
+			out = fmt.Appendf(out, "\\u%04x", r)
+		} else {
+			high, low := utf16.EncodeRune(r)
+			out = fmt.Appendf(out, "\\u%04x\\u%04x", high, low)
+		}
+		raw = raw[size:]
+	}
+	return out, nil
+}
+
+func isASCII(raw []byte) bool {
+	for _, value := range raw {
+		if value > 0x7f {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeMode(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case ModeOff:
+		return ModeOff
+	case ModeStrict:
+		return ModeStrict
+	default:
+		return ModeRepair
+	}
+}
+
+func normalizeWorkspacePolicy(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case WorkspacePolicyRedact:
+		return WorkspacePolicyRedact
+	case WorkspacePolicyDrop:
+		return WorkspacePolicyDrop
+	default:
+		return WorkspacePolicyPassthrough
+	}
+}
+
+func setHeaderCaseInsensitive(headers http.Header, key, value string) {
+	deleteHeaderCaseInsensitive(headers, key)
+	headers.Set(key, value)
+}
+
+func deleteHeaderCaseInsensitive(headers http.Header, key string) {
+	for existing := range headers {
+		if strings.EqualFold(existing, key) {
+			delete(headers, existing)
+		}
+	}
+}

--- a/internal/codexmetadata/request_test.go
+++ b/internal/codexmetadata/request_test.go
@@ -31,6 +31,9 @@ func TestNormalizeRequestRepairSanitizesWorkspaceAndRegeneratesProjections(t *te
 	if !state.CanonicalPresent || !state.Normalized {
 		t.Fatalf("state = %+v, want canonical normalized", state)
 	}
+	if !state.HasSessionID || state.SessionID != "22222222-2222-4222-8222-222222222222" {
+		t.Fatalf("canonical session state = %+v", state)
+	}
 	if !isASCII([]byte(state.TurnMetadata)) {
 		t.Fatalf("turn metadata is not ASCII-safe: %q", state.TurnMetadata)
 	}
@@ -97,6 +100,17 @@ func TestNormalizeRequestUsesDirectCanonicalHeaderAsLegacyFallback(t *testing.T)
 	assertJSONString(t, clientMetadata, "thread_id", "22222222-2222-4222-8222-222222222222")
 	if strings.Contains(state.TurnMetadata, `"workspaces"`) {
 		t.Fatalf("workspace drop was not applied to header fallback: %s", state.TurnMetadata)
+	}
+}
+
+func TestNormalizeRequestUsesThreadIDAsSessionFallback(t *testing.T) {
+	body := requestBodyWithMetadata(t, `{"request_kind":"turn","thread_id":"thread-only"}`, nil)
+	_, state, err := NormalizeRequest(body, "", Policy{Mode: ModeRepair})
+	if err != nil {
+		t.Fatalf("NormalizeRequest() error = %v", err)
+	}
+	if !state.HasSessionID || state.SessionID != "thread-only" {
+		t.Fatalf("canonical session fallback = %+v", state)
 	}
 }
 
@@ -256,17 +270,21 @@ func TestNormalizeRequestIgnoresUnrelatedNonObjectClientMetadata(t *testing.T) {
 	}
 }
 
-func TestNormalizeRequestCollapsesDuplicateClientMetadataCarriers(t *testing.T) {
-	body := []byte(`{"model":"gpt-5.6","client_metadata":{"transport_marker":"first"},"client_metadata":{"x-codex-turn-metadata":"{\"request_kind\":\"turn\",\"thread_id\":\"thread-1\"}","thread_id":"wrong"}}`)
-	updated, state, err := NormalizeRequest(body, "", Policy{Mode: ModeRepair})
+func TestNormalizeRequestRejectsDuplicateClientMetadataCarriers(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6","client_metadata":{"x-codex-turn-metadata":"{\"request_kind\":\"turn\",\"thread_id\":\"thread-1\"}"},"client_metadata":{"transport_marker":"last"}}`)
+	if _, _, err := NormalizeRequest(body, "", Policy{Mode: ModeRepair}); err == nil {
+		t.Fatal("repair mode accepted ambiguous duplicate client_metadata carriers")
+	}
+}
+
+func TestNormalizeRequestOffMarksCanonicalAcrossDuplicateClientMetadataCarriers(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6","client_metadata":{"x-codex-turn-metadata":"{\"request_kind\":\"turn\",\"thread_id\":\"thread-1\"}"},"client_metadata":{"transport_marker":"last"}}`)
+	updated, state, err := NormalizeRequest(body, "", Policy{Mode: ModeOff})
 	if err != nil {
-		t.Fatalf("NormalizeRequest() error = %v", err)
+		t.Fatalf("NormalizeRequest(off) error = %v", err)
 	}
-	if !state.CanonicalPresent || bytes.Count(updated, []byte(`"client_metadata"`)) != 1 {
-		t.Fatalf("duplicate client_metadata carrier was not collapsed: state=%+v body=%s", state, updated)
-	}
-	if got := decodeClientMetadata(t, updated); string(got["thread_id"]) != `"thread-1"` {
-		t.Fatalf("canonical projection was not repaired: %s", updated)
+	if !state.CanonicalPresent || !bytes.Equal(updated, body) {
+		t.Fatalf("off mode lost duplicate-carrier canonical detection: state=%+v body=%s", state, updated)
 	}
 }
 

--- a/internal/codexmetadata/request_test.go
+++ b/internal/codexmetadata/request_test.go
@@ -1,0 +1,317 @@
+package codexmetadata
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+const sampleTurnMetadata = `{"installation_id":"11111111-1111-4111-8111-111111111111","session_id":"22222222-2222-4222-8222-222222222222","thread_id":"22222222-2222-4222-8222-222222222222","turn_id":"33333333-3333-4333-8333-333333333333","window_id":"22222222-2222-4222-8222-222222222222:1","request_kind":"turn","workspaces":{"/Users/example/project":{"associated_remote_urls":{"origin":"https://user:secret@example.com/org/repo.git?token=leak#fragment","upstream":"git@example.com:upstream/repo.git"},"latest_git_commit_hash":"0123456789abcdef0123456789abcdef01234567","has_changes":false}},"turn_started_at_unix_ms":1700000000000,"workspace_kind":"项目"}`
+
+func TestNormalizeRequestRepairSanitizesWorkspaceAndRegeneratesProjections(t *testing.T) {
+	body := requestBodyWithMetadata(t, sampleTurnMetadata, map[string]any{
+		"thread_id":               "conflicting-thread",
+		"session_id":              "conflicting-session",
+		"turn_id":                 "conflicting-turn",
+		"x-codex-window-id":       "conflicting-window:0",
+		"x-codex-installation-id": "conflicting-installation",
+		"x-openai-subagent":       "collab_spawn",
+		"transport_marker":        true,
+	})
+
+	updated, state, err := NormalizeRequest(body, `{"thread_id":"header-conflict"}`, Policy{
+		Mode:            ModeRepair,
+		WorkspacePolicy: WorkspacePolicyPassthrough,
+	})
+	if err != nil {
+		t.Fatalf("NormalizeRequest() error = %v", err)
+	}
+	if !state.CanonicalPresent || !state.Normalized {
+		t.Fatalf("state = %+v, want canonical normalized", state)
+	}
+	if !isASCII([]byte(state.TurnMetadata)) {
+		t.Fatalf("turn metadata is not ASCII-safe: %q", state.TurnMetadata)
+	}
+	if strings.Contains(state.TurnMetadata, "secret") || strings.Contains(state.TurnMetadata, "token=leak") || strings.Contains(state.TurnMetadata, "#fragment") {
+		t.Fatalf("turn metadata leaked remote credential: %s", state.TurnMetadata)
+	}
+	if !strings.Contains(state.TurnMetadata, `"origin":"https://example.com/org/repo.git"`) {
+		t.Fatalf("sanitized origin missing: %s", state.TurnMetadata)
+	}
+	if !strings.Contains(state.TurnMetadata, `"upstream":"ssh://example.com/upstream/repo.git"`) {
+		t.Fatalf("sanitized scp remote missing: %s", state.TurnMetadata)
+	}
+	if !strings.Contains(state.TurnMetadata, `\u9879\u76ee`) {
+		t.Fatalf("non-ASCII workspace_kind was not escaped: %s", state.TurnMetadata)
+	}
+
+	clientMetadata := decodeClientMetadata(t, updated)
+	assertJSONString(t, clientMetadata, "x-codex-installation-id", "11111111-1111-4111-8111-111111111111")
+	assertJSONString(t, clientMetadata, "session_id", "22222222-2222-4222-8222-222222222222")
+	assertJSONString(t, clientMetadata, "thread_id", "22222222-2222-4222-8222-222222222222")
+	assertJSONString(t, clientMetadata, "turn_id", "33333333-3333-4333-8333-333333333333")
+	assertJSONString(t, clientMetadata, "x-codex-window-id", "22222222-2222-4222-8222-222222222222:1")
+	if _, ok := clientMetadata["transport_marker"]; !ok {
+		t.Fatal("transport-specific client_metadata field was dropped")
+	}
+
+	headers := http.Header{}
+	headers.Set("X-Codex-Turn-Metadata", `{"thread_id":"old"}`)
+	headers.Set("X-Codex-Window-Id", "old:0")
+	headers.Set("X-Codex-Parent-Thread-Id", "old-parent")
+	headers.Set("X-OpenAI-Subagent", "old-subagent")
+	headers.Set("X-ResponsesAPI-Test-Marker", "keep")
+	state.ApplyHeaders(headers)
+	if got := headers.Get("X-Codex-Turn-Metadata"); got != state.TurnMetadata {
+		t.Fatalf("X-Codex-Turn-Metadata = %q, want canonical state", got)
+	}
+	if got := headers.Get("X-Codex-Window-Id"); got != "22222222-2222-4222-8222-222222222222:1" {
+		t.Fatalf("X-Codex-Window-Id = %q", got)
+	}
+	if got := headers.Get("X-Codex-Parent-Thread-Id"); got != "" {
+		t.Fatalf("X-Codex-Parent-Thread-Id = %q, want deleted", got)
+	}
+	if got := headers.Get("X-OpenAI-Subagent"); got != "collab_spawn" {
+		t.Fatalf("X-OpenAI-Subagent = %q, want body compatibility projection", got)
+	}
+	if got := headers.Get("X-ResponsesAPI-Test-Marker"); got != "keep" {
+		t.Fatalf("transport header = %q, want keep", got)
+	}
+}
+
+func TestNormalizeRequestUsesDirectCanonicalHeaderAsLegacyFallback(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6","input":"hello"}`)
+	updated, state, err := NormalizeRequest(body, sampleTurnMetadata, Policy{
+		Mode:            ModeRepair,
+		WorkspacePolicy: WorkspacePolicyDrop,
+	})
+	if err != nil {
+		t.Fatalf("NormalizeRequest() error = %v", err)
+	}
+	if !state.CanonicalPresent || !state.Normalized {
+		t.Fatalf("state = %+v, want normalized header fallback", state)
+	}
+	clientMetadata := decodeClientMetadata(t, updated)
+	assertJSONString(t, clientMetadata, "thread_id", "22222222-2222-4222-8222-222222222222")
+	if strings.Contains(state.TurnMetadata, `"workspaces"`) {
+		t.Fatalf("workspace drop was not applied to header fallback: %s", state.TurnMetadata)
+	}
+}
+
+func TestNormalizeRequestPreservesFlatIdentityWhenCanonicalOmitsConditionalFields(t *testing.T) {
+	canonical := `{"request_kind":"memory","workspace_kind":"memory"}`
+	body := requestBodyWithMetadata(t, canonical, map[string]any{
+		"x-codex-installation-id": "install-flat",
+		"session_id":              "session-flat",
+		"thread_id":               "thread-flat",
+		"turn_id":                 "turn-flat",
+		"x-codex-window-id":       "thread-flat:3",
+	})
+	updated, state, err := NormalizeRequest(body, "", Policy{Mode: ModeRepair})
+	if err != nil {
+		t.Fatalf("NormalizeRequest() error = %v", err)
+	}
+	if state.HasWindowID {
+		t.Fatalf("state unexpectedly derived a window from conditional canonical metadata: %+v", state)
+	}
+	clientMetadata := decodeClientMetadata(t, updated)
+	assertJSONString(t, clientMetadata, "x-codex-installation-id", "install-flat")
+	assertJSONString(t, clientMetadata, "session_id", "session-flat")
+	assertJSONString(t, clientMetadata, "thread_id", "thread-flat")
+	assertJSONString(t, clientMetadata, "turn_id", "turn-flat")
+	assertJSONString(t, clientMetadata, "x-codex-window-id", "thread-flat:3")
+
+	headers := http.Header{"X-Codex-Window-Id": {"thread-flat:3"}}
+	state.ApplyHeaders(headers)
+	if got := headers.Get("X-Codex-Window-Id"); got != "thread-flat:3" {
+		t.Fatalf("conditional flat window header = %q, want preserved", got)
+	}
+}
+
+func TestNormalizeRequestWorkspaceRedactAndDrop(t *testing.T) {
+	body := requestBodyWithMetadata(t, sampleTurnMetadata, nil)
+
+	redacted, state, err := NormalizeRequest(body, "", Policy{
+		Mode:            ModeRepair,
+		WorkspacePolicy: WorkspacePolicyRedact,
+		Scope:           "credential:stable-account",
+	})
+	if err != nil {
+		t.Fatalf("NormalizeRequest(redact) error = %v", err)
+	}
+	if strings.Contains(state.TurnMetadata, "/Users/example/project") || strings.Contains(state.TurnMetadata, "example.com") || strings.Contains(state.TurnMetadata, "01234567") {
+		t.Fatalf("redacted metadata leaked workspace identity: %s", state.TurnMetadata)
+	}
+	if !strings.Contains(state.TurnMetadata, `"workspace:`) || !strings.Contains(state.TurnMetadata, `"has_changes":false`) {
+		t.Fatalf("redacted workspace shape missing: %s", state.TurnMetadata)
+	}
+	redactedAgain, stateAgain, err := NormalizeRequest(body, "", Policy{
+		Mode:            ModeRepair,
+		WorkspacePolicy: WorkspacePolicyRedact,
+		Scope:           "credential:stable-account",
+	})
+	if err != nil || stateAgain.TurnMetadata != state.TurnMetadata || string(redactedAgain) != string(redacted) {
+		t.Fatal("workspace redaction is not deterministic")
+	}
+	_, differentCredential, err := NormalizeRequest(body, "", Policy{
+		Mode:            ModeRepair,
+		WorkspacePolicy: WorkspacePolicyRedact,
+		Scope:           "credential:other-account",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if differentCredential.TurnMetadata == state.TurnMetadata {
+		t.Fatal("workspace pseudonym did not change across credential scopes")
+	}
+	differentInstallationBody := bytes.Replace(body, []byte("11111111-1111-4111-8111-111111111111"), []byte("44444444-4444-4444-8444-444444444444"), -1)
+	_, differentInstallation, err := NormalizeRequest(differentInstallationBody, "", Policy{
+		Mode:            ModeRepair,
+		WorkspacePolicy: WorkspacePolicyRedact,
+		Scope:           "credential:stable-account",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if differentInstallation.TurnMetadata == state.TurnMetadata {
+		t.Fatal("workspace pseudonym did not change across client installations")
+	}
+
+	_, droppedState, err := NormalizeRequest(body, "", Policy{
+		Mode:            ModeRepair,
+		WorkspacePolicy: WorkspacePolicyDrop,
+	})
+	if err != nil {
+		t.Fatalf("NormalizeRequest(drop) error = %v", err)
+	}
+	if strings.Contains(droppedState.TurnMetadata, `"workspaces"`) {
+		t.Fatalf("drop policy retained workspaces: %s", droppedState.TurnMetadata)
+	}
+}
+
+func TestNormalizeRequestStrictRejectsConflictAndMalformedCanonical(t *testing.T) {
+	body := requestBodyWithMetadata(t, sampleTurnMetadata, map[string]any{"thread_id": "wrong"})
+	if _, _, err := NormalizeRequest(body, "", Policy{Mode: ModeStrict}); err == nil {
+		t.Fatal("strict mode accepted conflicting flat projection")
+	}
+
+	malformedBody := requestBodyWithRawCanonical(t, `{"thread_id":"a","thread_id":"b"}`)
+	if _, _, err := NormalizeRequest(malformedBody, "", Policy{Mode: ModeRepair}); err == nil {
+		t.Fatal("repair mode accepted duplicate canonical key")
+	}
+
+	wrongTypeBody := requestBodyWithRawCanonical(t, `{"request_kind":"turn","thread_id":123}`)
+	if _, _, err := NormalizeRequest(wrongTypeBody, "", Policy{Mode: ModeRepair}); err == nil {
+		t.Fatal("repair mode accepted non-string canonical thread_id")
+	}
+}
+
+func TestNormalizeRequestStrictComparesCanonicalMetadataSemantically(t *testing.T) {
+	bodyCanonical := `{"request_kind":"turn","thread_id":"thread-1","turn_started_at_unix_ms":1700000000000}`
+	headerCanonical := `{"turn_started_at_unix_ms":1700000000000,"thread_id":"thread-1","request_kind":"turn"}`
+	body := requestBodyWithMetadata(t, bodyCanonical, map[string]any{"thread_id": "thread-1"})
+	if _, _, err := NormalizeRequest(body, headerCanonical, Policy{Mode: ModeStrict}); err != nil {
+		t.Fatalf("strict mode rejected semantically equal canonical metadata: %v", err)
+	}
+}
+
+func TestNormalizeRequestOffSkipsMutationButMarksCanonical(t *testing.T) {
+	body := requestBodyWithMetadata(t, sampleTurnMetadata, map[string]any{"thread_id": "wrong"})
+	updated, state, err := NormalizeRequest(body, "", Policy{Mode: ModeOff, WorkspacePolicy: WorkspacePolicyDrop})
+	if err != nil {
+		t.Fatalf("NormalizeRequest(off) error = %v", err)
+	}
+	if !state.CanonicalPresent || state.Normalized {
+		t.Fatalf("state = %+v, want canonical present without normalization", state)
+	}
+	if string(updated) != string(body) {
+		t.Fatal("off mode mutated request body")
+	}
+}
+
+func TestNormalizeRequestOffDoesNotRejectMalformedMetadata(t *testing.T) {
+	body := requestBodyWithRawCanonical(t, `{"request_kind":"turn"`)
+	updated, state, err := NormalizeRequest(body, "", Policy{Mode: ModeOff})
+	if err != nil {
+		t.Fatalf("NormalizeRequest(off) error = %v", err)
+	}
+	if state.CanonicalPresent {
+		t.Fatalf("state = %+v, malformed metadata must not be classified as canonical", state)
+	}
+	if !bytes.Equal(updated, body) {
+		t.Fatal("off mode mutated malformed metadata")
+	}
+}
+
+func TestNormalizeRequestIgnoresUnrelatedNonObjectClientMetadata(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6","client_metadata":"legacy-client-value"}`)
+	updated, state, err := NormalizeRequest(body, "", Policy{Mode: ModeRepair})
+	if err != nil {
+		t.Fatalf("NormalizeRequest() error = %v", err)
+	}
+	if state.CanonicalPresent || !bytes.Equal(updated, body) {
+		t.Fatalf("unrelated client_metadata changed: state=%+v body=%s", state, updated)
+	}
+}
+
+func TestNormalizeRequestCollapsesDuplicateClientMetadataCarriers(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6","client_metadata":{"transport_marker":"first"},"client_metadata":{"x-codex-turn-metadata":"{\"request_kind\":\"turn\",\"thread_id\":\"thread-1\"}","thread_id":"wrong"}}`)
+	updated, state, err := NormalizeRequest(body, "", Policy{Mode: ModeRepair})
+	if err != nil {
+		t.Fatalf("NormalizeRequest() error = %v", err)
+	}
+	if !state.CanonicalPresent || bytes.Count(updated, []byte(`"client_metadata"`)) != 1 {
+		t.Fatalf("duplicate client_metadata carrier was not collapsed: state=%+v body=%s", state, updated)
+	}
+	if got := decodeClientMetadata(t, updated); string(got["thread_id"]) != `"thread-1"` {
+		t.Fatalf("canonical projection was not repaired: %s", updated)
+	}
+}
+
+func requestBodyWithMetadata(t *testing.T, canonical string, extra map[string]any) []byte {
+	t.Helper()
+	clientMetadata := map[string]any{"x-codex-turn-metadata": canonical}
+	for key, value := range extra {
+		clientMetadata[key] = value
+	}
+	body, err := json.Marshal(map[string]any{
+		"model":           "gpt-5.6",
+		"client_metadata": clientMetadata,
+		"input":           "hello",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func requestBodyWithRawCanonical(t *testing.T, canonical string) []byte {
+	t.Helper()
+	return requestBodyWithMetadata(t, canonical, nil)
+}
+
+func decodeClientMetadata(t *testing.T, body []byte) map[string]json.RawMessage {
+	t.Helper()
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatal(err)
+	}
+	var clientMetadata map[string]json.RawMessage
+	if err := json.Unmarshal(envelope["client_metadata"], &clientMetadata); err != nil {
+		t.Fatal(err)
+	}
+	return clientMetadata
+}
+
+func assertJSONString(t *testing.T, object map[string]json.RawMessage, key, want string) {
+	t.Helper()
+	var got string
+	if err := json.Unmarshal(object[key], &got); err != nil {
+		t.Fatalf("%s is not a string: %v", key, err)
+	}
+	if got != want {
+		t.Fatalf("%s = %q, want %q", key, got, want)
+	}
+}

--- a/internal/config/codex_client_metadata_test.go
+++ b/internal/config/codex_client_metadata_test.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCodexClientMetadataEffectiveDefaults(t *testing.T) {
+	effective := (CodexClientMetadataConfig{}).Effective()
+	if effective.Mode != CodexClientMetadataModeRepair {
+		t.Fatalf("Mode = %q, want %q", effective.Mode, CodexClientMetadataModeRepair)
+	}
+	if effective.WorkspacePolicy != CodexClientMetadataWorkspacePolicyPassthrough {
+		t.Fatalf("WorkspacePolicy = %q, want %q", effective.WorkspacePolicy, CodexClientMetadataWorkspacePolicyPassthrough)
+	}
+}
+
+func TestCodexClientMetadataEffectiveNormalizesInvalidValues(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     CodexClientMetadataConfig
+		wantMode   string
+		wantPolicy string
+	}{
+		{
+			name:       "explicit strict redact",
+			config:     CodexClientMetadataConfig{Mode: " Strict ", WorkspacePolicy: " REDACT "},
+			wantMode:   CodexClientMetadataModeStrict,
+			wantPolicy: CodexClientMetadataWorkspacePolicyRedact,
+		},
+		{
+			name:       "disabled remove aliases",
+			config:     CodexClientMetadataConfig{Mode: "disabled", WorkspacePolicy: "remove"},
+			wantMode:   CodexClientMetadataModeOff,
+			wantPolicy: CodexClientMetadataWorkspacePolicyDrop,
+		},
+		{
+			name:       "invalid uses safe defaults",
+			config:     CodexClientMetadataConfig{Mode: "unexpected", WorkspacePolicy: "unexpected"},
+			wantMode:   CodexClientMetadataModeRepair,
+			wantPolicy: CodexClientMetadataWorkspacePolicyPassthrough,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			effective := test.config.Effective()
+			if effective.Mode != test.wantMode || effective.WorkspacePolicy != test.wantPolicy {
+				t.Fatalf("Effective() = %+v, want mode=%q workspace=%q", effective, test.wantMode, test.wantPolicy)
+			}
+		})
+	}
+}
+
+func TestLoadConfigOptionalCodexClientMetadata(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(`
+codex:
+  client-metadata:
+    mode: strict
+    workspace-policy: drop
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadConfigOptional(path, false)
+	if err != nil {
+		t.Fatalf("LoadConfigOptional() error = %v", err)
+	}
+	effective := cfg.Codex.ClientMetadata.Effective()
+	if effective.Mode != CodexClientMetadataModeStrict || effective.WorkspacePolicy != CodexClientMetadataWorkspacePolicyDrop {
+		t.Fatalf("client metadata = %+v", effective)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -334,12 +334,19 @@ type CodexHeaderDefaults struct {
 // CodexConfig configures provider-wide Codex request behavior.
 type CodexConfig struct {
 	IdentityConfuse        bool                              `yaml:"identity-confuse" json:"identity-confuse"`
+	ClientMetadata         CodexClientMetadataConfig         `yaml:"client-metadata" json:"client-metadata"`
 	ModelFallback          CodexModelFallbackConfig          `yaml:"model-fallback" json:"model-fallback"`
 	RateLimitContinuity    CodexRateLimitContinuityConfig    `yaml:"rate-limit-continuity" json:"rate-limit-continuity"`
 	AbnormalReasoningRetry CodexAbnormalReasoningRetryConfig `yaml:"abnormal-reasoning-retry" json:"abnormal-reasoning-retry"`
 }
 
 const (
+	CodexClientMetadataModeOff                                                   = "off"
+	CodexClientMetadataModeRepair                                                = "repair"
+	CodexClientMetadataModeStrict                                                = "strict"
+	CodexClientMetadataWorkspacePolicyPassthrough                                = "passthrough"
+	CodexClientMetadataWorkspacePolicyRedact                                     = "redact"
+	CodexClientMetadataWorkspacePolicyDrop                                       = "drop"
 	CodexModelFallbackTriggerUsageLimit                                          = "usage-limit"
 	CodexModelFallbackTriggerCapacity                                            = "capacity"
 	CodexModelFallbackReasoningContinuitySameModelOnly                           = "same-model-only"
@@ -366,6 +373,54 @@ const (
 	CodexAbnormalReasoningHedgedRetryModeQuality                                 = "quality"
 	CodexAbnormalReasoningRetryDefaultStreamBufferMaxBytes                 int64 = 16 << 20
 )
+
+// CodexClientMetadataConfig controls canonical Codex turn metadata handling.
+// Mode off preserves canonical requests unchanged, repair rebuilds compatibility
+// projections from the body canonical object, and strict additionally rejects
+// conflicting projections. WorkspacePolicy controls workspace privacy while
+// passthrough still strips credentials, query strings, and fragments from Git
+// remotes. Redact uses stable client-installation/credential-scoped workspace
+// pseudonyms and retains only has_changes.
+type CodexClientMetadataConfig struct {
+	Mode            string `yaml:"mode,omitempty" json:"mode,omitempty"`
+	WorkspacePolicy string `yaml:"workspace-policy,omitempty" json:"workspace-policy,omitempty"`
+}
+
+// EffectiveCodexClientMetadataConfig is the normalized runtime view. Defaults
+// are derived in memory so existing config files are not rewritten.
+type EffectiveCodexClientMetadataConfig struct {
+	Mode            string
+	WorkspacePolicy string
+}
+
+func (c CodexClientMetadataConfig) Effective() EffectiveCodexClientMetadataConfig {
+	return EffectiveCodexClientMetadataConfig{
+		Mode:            normalizeCodexClientMetadataMode(c.Mode),
+		WorkspacePolicy: normalizeCodexClientMetadataWorkspacePolicy(c.WorkspacePolicy),
+	}
+}
+
+func normalizeCodexClientMetadataMode(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case CodexClientMetadataModeOff, "disable", "disabled":
+		return CodexClientMetadataModeOff
+	case CodexClientMetadataModeStrict:
+		return CodexClientMetadataModeStrict
+	default:
+		return CodexClientMetadataModeRepair
+	}
+}
+
+func normalizeCodexClientMetadataWorkspacePolicy(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case CodexClientMetadataWorkspacePolicyRedact:
+		return CodexClientMetadataWorkspacePolicyRedact
+	case CodexClientMetadataWorkspacePolicyDrop, "remove":
+		return CodexClientMetadataWorkspacePolicyDrop
+	default:
+		return CodexClientMetadataWorkspacePolicyPassthrough
+	}
+}
 
 // CodexModelFallbackConfig controls ordered, opt-in fallback between Codex
 // models after a precisely classified quota or capacity failure.

--- a/internal/runtime/executor/codex_client_metadata.go
+++ b/internal/runtime/executor/codex_client_metadata.go
@@ -1,0 +1,85 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/codexmetadata"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func prepareCodexOutboundMetadata(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth, userPayload, rawJSON []byte, incomingHeaders http.Header) ([]byte, codexIdentityConfuseState, error) {
+	effective := (config.CodexClientMetadataConfig{}).Effective()
+	if cfg != nil {
+		effective = cfg.Codex.ClientMetadata.Effective()
+	}
+	normalizedBody, metadataState, err := codexmetadata.NormalizeRequest(rawJSON, codexIncomingTurnMetadata(ctx, incomingHeaders), codexmetadata.Policy{
+		Mode:            effective.Mode,
+		WorkspacePolicy: effective.WorkspacePolicy,
+		Scope:           codexClientMetadataCredentialScope(auth),
+	})
+	if err != nil {
+		return nil, codexIdentityConfuseState{}, invalidCodexClientMetadataError()
+	}
+	state := codexIdentityConfuseState{clientMetadata: metadataState}
+	if metadataState.CanonicalPresent {
+		return normalizedBody, state, nil
+	}
+
+	legacyBody, legacyState := applyCodexIdentityConfuseBody(cfg, auth, userPayload, normalizedBody)
+	legacyState.clientMetadata = metadataState
+	return legacyBody, legacyState, nil
+}
+
+func codexIncomingTurnMetadata(ctx context.Context, provided http.Header) string {
+	if value := strings.TrimSpace(headerValueCaseInsensitive(provided, "X-Codex-Turn-Metadata")); value != "" {
+		return value
+	}
+	if ctx == nil {
+		return ""
+	}
+	if ginCtx, ok := ctx.Value("gin").(*gin.Context); ok && ginCtx != nil && ginCtx.Request != nil {
+		return strings.TrimSpace(headerValueCaseInsensitive(ginCtx.Request.Header, "X-Codex-Turn-Metadata"))
+	}
+	return ""
+}
+
+func applyCodexOutboundMetadataHeaders(headers http.Header, state *codexIdentityConfuseState) {
+	if state != nil && state.clientMetadata.CanonicalPresent {
+		state.clientMetadata.ApplyHeaders(headers)
+		return
+	}
+	applyCodexIdentityConfuseHeaders(headers, state)
+}
+
+func codexClientMetadataCredentialScope(auth *cliproxyauth.Auth) string {
+	if auth == nil {
+		return "codex:anonymous"
+	}
+	if authID := strings.TrimSpace(auth.ID); authID != "" {
+		return "codex:auth:" + authID
+	}
+	if auth.Metadata != nil {
+		if accountID, ok := auth.Metadata["account_id"].(string); ok {
+			if accountID = strings.TrimSpace(accountID); accountID != "" {
+				return "codex:account:" + accountID
+			}
+		}
+	}
+	if auth.Attributes != nil {
+		if accountID := strings.TrimSpace(auth.Attributes["account_id"]); accountID != "" {
+			return "codex:account:" + accountID
+		}
+	}
+	return "codex:anonymous"
+}
+
+func invalidCodexClientMetadataError() statusErr {
+	return statusErr{
+		code: http.StatusBadRequest,
+		msg:  `{"error":{"message":"invalid Codex client_metadata","type":"invalid_request_error","code":"invalid_client_metadata"}}`,
+	}
+}

--- a/internal/runtime/executor/codex_client_metadata.go
+++ b/internal/runtime/executor/codex_client_metadata.go
@@ -50,6 +50,9 @@ func codexIncomingTurnMetadata(ctx context.Context, provided http.Header) string
 func applyCodexOutboundMetadataHeaders(headers http.Header, state *codexIdentityConfuseState) {
 	if state != nil && state.clientMetadata.CanonicalPresent {
 		state.clientMetadata.ApplyHeaders(headers)
+		if state.clientMetadata.HasSessionID {
+			setCodexSessionHeaderCasePreserved(headers, "Session_id", state.clientMetadata.SessionID)
+		}
 		return
 	}
 	applyCodexIdentityConfuseHeaders(headers, state)

--- a/internal/runtime/executor/codex_client_metadata_test.go
+++ b/internal/runtime/executor/codex_client_metadata_test.go
@@ -1,0 +1,48 @@
+package executor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestCodexClientMetadataCredentialScopePrefersSelectedAuthID(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-1",
+		Metadata: map[string]any{"account_id": "account-1"},
+	}
+	if got := codexClientMetadataCredentialScope(auth); got != "codex:auth:auth-1" {
+		t.Fatalf("credential scope = %q, want selected auth identity", got)
+	}
+}
+
+func TestCodexClientMetadataCredentialScopeFallsBackToAccount(t *testing.T) {
+	auth := &cliproxyauth.Auth{Metadata: map[string]any{"account_id": "account-1"}}
+	if got := codexClientMetadataCredentialScope(auth); got != "codex:account:account-1" {
+		t.Fatalf("credential scope = %q, want account fallback", got)
+	}
+}
+
+func TestCodexIncomingTurnMetadataFallsBackToGinHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	ginCtx.Request.Header.Set("X-Codex-Turn-Metadata", `{"request_kind":"turn","thread_id":"gin-thread"}`)
+	ctx := context.WithValue(context.Background(), "gin", ginCtx)
+
+	got := codexIncomingTurnMetadata(ctx, http.Header{})
+	if got != `{"request_kind":"turn","thread_id":"gin-thread"}` {
+		t.Fatalf("incoming turn metadata = %q, want Gin header fallback", got)
+	}
+}
+
+func TestCodexIncomingTurnMetadataPrefersProvidedHeaders(t *testing.T) {
+	provided := http.Header{"x-codex-turn-metadata": {`{"request_kind":"turn","thread_id":"provided-thread"}`}}
+	if got := codexIncomingTurnMetadata(context.Background(), provided); got != `{"request_kind":"turn","thread_id":"provided-thread"}` {
+		t.Fatalf("incoming turn metadata = %q, want provided header", got)
+	}
+}

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -15,6 +15,7 @@ import (
 
 	codexauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/codex"
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/codexmetadata"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
@@ -1215,7 +1216,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	reporter.SetOutboundServiceTier(upstreamBody)
 	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
 	applyFinalCodexClientHeaders(httpReq.Header, modelHeaderProfile, auth)
-	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
+	applyCodexOutboundMetadataHeaders(httpReq.Header, &identityState)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
 		authID = auth.ID
@@ -1414,7 +1415,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	reporter.SetOutboundServiceTier(upstreamBody)
 	applyCodexHeaders(httpReq, auth, apiKey, false, e.cfg)
 	applyFinalCodexClientHeaders(httpReq.Header, modelHeaderProfile, auth)
-	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
+	applyCodexOutboundMetadataHeaders(httpReq.Header, &identityState)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
 		authID = auth.ID
@@ -1551,7 +1552,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	reporter.SetOutboundServiceTier(upstreamBody)
 	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
 	applyFinalCodexClientHeaders(httpReq.Header, modelHeaderProfile, auth)
-	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
+	applyCodexOutboundMetadataHeaders(httpReq.Header, &identityState)
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
 		authID = auth.ID
@@ -2054,6 +2055,7 @@ type codexIdentityConfuseState struct {
 	originalPromptCacheKey string
 	promptCacheKey         string
 	turnIDs                []codexIdentityReplacement
+	clientMetadata         codexmetadata.State
 }
 
 type codexIdentityReplacement struct {
@@ -2097,7 +2099,11 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 	}
 	rawJSON = helps.SanitizeCodexInputItemIDs(rawJSON)
 	var identityState codexIdentityConfuseState
-	rawJSON, identityState = applyCodexIdentityConfuseBody(e.cfg, auth, userPayload, rawJSON)
+	var errMetadata error
+	rawJSON, identityState, errMetadata = prepareCodexOutboundMetadata(ctx, e.cfg, auth, userPayload, rawJSON, headers)
+	if errMetadata != nil {
+		return nil, nil, codexIdentityConfuseState{}, errMetadata
+	}
 	if identityState.promptCacheKey != "" {
 		cache.ID = identityState.promptCacheKey
 	}

--- a/internal/runtime/executor/codex_executor_cache_test.go
+++ b/internal/runtime/executor/codex_executor_cache_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -248,6 +249,98 @@ func TestCodexExecutorCacheHelper_IdentityConfuseRemapsBodyAndHeaders(t *testing
 	}
 	if gotMetadataWindowID := gjson.Get(gotHeaderMetadata, "window_id").String(); gotMetadataWindowID != expectedPromptCacheKey+":0" {
 		t.Fatalf("X-Codex-Turn-Metadata.window_id = %q, want %q", gotMetadataWindowID, expectedPromptCacheKey+":0")
+	}
+}
+
+func TestCodexExecutorCacheHelperCanonicalMetadataBypassesLegacyIdentityConfuse(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	ginCtx.Request.Header.Set("X-Codex-Turn-Metadata", `{"thread_id":"header-conflict"}`)
+	ctx := context.WithValue(context.Background(), "gin", ginCtx)
+	executor := &CodexExecutor{cfg: &config.Config{
+		Routing: config.RoutingConfig{Strategy: "fill-first"},
+		Codex: config.CodexConfig{
+			IdentityConfuse: true,
+			ClientMetadata: config.CodexClientMetadataConfig{
+				Mode:            config.CodexClientMetadataModeRepair,
+				WorkspacePolicy: config.CodexClientMetadataWorkspacePolicyPassthrough,
+			},
+		},
+	}}
+	auth := &cliproxyauth.Auth{ID: "auth-1", Provider: "codex", Metadata: map[string]any{"account_id": "acct-1"}}
+	rawJSON := []byte(`{"model":"gpt-5-codex","stream":true,"prompt_cache_key":"thread-1","client_metadata":{"x-codex-turn-metadata":"{\"installation_id\":\"install-1\",\"session_id\":\"thread-1\",\"thread_id\":\"thread-1\",\"turn_id\":\"turn-1\",\"window_id\":\"thread-1:1\",\"request_kind\":\"turn\",\"workspaces\":{\"/Users/private/project\":{\"associated_remote_urls\":{\"origin\":\"https://user:secret@example.com/org/repo.git?token=leak#fragment\"},\"has_changes\":false}}}","x-codex-installation-id":"wrong-install","session_id":"wrong-session","thread_id":"wrong-thread","turn_id":"wrong-turn","x-codex-window-id":"wrong-window:0"}}`)
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"model":"gpt-5-codex","prompt_cache_key":"thread-1","client_metadata":{"x-codex-installation-id":"install-1"}}`),
+	}
+
+	httpReq, body, state, err := executor.cacheHelper(ctx, sdktranslator.FromString("openai-response"), "https://example.com/responses", auth, req, req.Payload, rawJSON)
+	if err != nil {
+		t.Fatalf("cacheHelper error: %v", err)
+	}
+	applyCodexHeaders(httpReq, auth, "oauth-token", true, executor.cfg)
+	applyCodexOutboundMetadataHeaders(httpReq.Header, &state)
+
+	if state.enabled || state.promptCacheKey != "" || !state.clientMetadata.CanonicalPresent {
+		t.Fatalf("canonical state unexpectedly enabled legacy identity mapping: %+v", state)
+	}
+	metadata := gjson.GetBytes(body, "client_metadata.x-codex-turn-metadata").String()
+	for key, want := range map[string]string{
+		"installation_id": "install-1",
+		"session_id":      "thread-1",
+		"thread_id":       "thread-1",
+		"turn_id":         "turn-1",
+		"window_id":       "thread-1:1",
+	} {
+		if got := gjson.Get(metadata, key).String(); got != want {
+			t.Fatalf("canonical %s = %q, want %q", key, got, want)
+		}
+	}
+	if strings.Contains(metadata, "secret") || strings.Contains(metadata, "token=leak") || strings.Contains(metadata, "#fragment") {
+		t.Fatalf("canonical workspace remote was not sanitized: %s", metadata)
+	}
+	if got := gjson.Get(metadata, "workspaces./Users/private/project.associated_remote_urls.origin").String(); got != "https://example.com/org/repo.git" {
+		t.Fatalf("sanitized remote = %q", got)
+	}
+	if got := gjson.GetBytes(body, "client_metadata.x-codex-installation-id").String(); got != "install-1" {
+		t.Fatalf("flat installation = %q", got)
+	}
+	if got := gjson.GetBytes(body, "client_metadata.x-codex-window-id").String(); got != "thread-1:1" {
+		t.Fatalf("flat window = %q", got)
+	}
+	if got := httpReq.Header.Get("X-Codex-Window-Id"); got != "thread-1:1" {
+		t.Fatalf("X-Codex-Window-Id = %q", got)
+	}
+	if got := httpReq.Header.Get("X-Codex-Turn-Metadata"); got != state.clientMetadata.TurnMetadata {
+		t.Fatalf("X-Codex-Turn-Metadata does not match normalized canonical metadata")
+	}
+	responseWithIdentityText := []byte(`{"output_text":"install-1 thread-1 turn-1"}`)
+	if got := string(applyCodexIdentityConfuseResponsePayload(responseWithIdentityText, state)); got != string(responseWithIdentityText) {
+		t.Fatalf("canonical response text was changed by legacy identity replacement: %s", got)
+	}
+}
+
+func TestCodexExecutorCacheHelperStrictMetadataReturnsSafeBadRequest(t *testing.T) {
+	executor := &CodexExecutor{cfg: &config.Config{Codex: config.CodexConfig{ClientMetadata: config.CodexClientMetadataConfig{
+		Mode: config.CodexClientMetadataModeStrict,
+	}}}}
+	rawJSON := []byte(`{"model":"gpt-5-codex","client_metadata":{"x-codex-turn-metadata":"{\"request_kind\":\"turn\",\"thread_id\":\"thread-private\"}","thread_id":"conflicting-private"}}`)
+	req := cliproxyexecutor.Request{Model: "gpt-5-codex", Payload: rawJSON}
+
+	_, _, _, err := executor.cacheHelper(context.Background(), sdktranslator.FromString("openai-response"), "https://example.com/responses", &cliproxyauth.Auth{ID: "auth-1"}, req, req.Payload, rawJSON)
+	if err == nil {
+		t.Fatal("strict metadata conflict was accepted")
+	}
+	status, ok := err.(statusErr)
+	if !ok || status.code != http.StatusBadRequest {
+		t.Fatalf("error = %#v, want statusErr 400", err)
+	}
+	if !strings.Contains(status.msg, `"code":"invalid_client_metadata"`) {
+		t.Fatalf("error body missing stable code: %s", status.msg)
+	}
+	if strings.Contains(status.msg, "thread-private") || strings.Contains(status.msg, "conflicting-private") {
+		t.Fatalf("error body leaked client metadata: %s", status.msg)
 	}
 }
 

--- a/internal/runtime/executor/codex_executor_cache_test.go
+++ b/internal/runtime/executor/codex_executor_cache_test.go
@@ -269,10 +269,10 @@ func TestCodexExecutorCacheHelperCanonicalMetadataBypassesLegacyIdentityConfuse(
 		},
 	}}
 	auth := &cliproxyauth.Auth{ID: "auth-1", Provider: "codex", Metadata: map[string]any{"account_id": "acct-1"}}
-	rawJSON := []byte(`{"model":"gpt-5-codex","stream":true,"prompt_cache_key":"thread-1","client_metadata":{"x-codex-turn-metadata":"{\"installation_id\":\"install-1\",\"session_id\":\"thread-1\",\"thread_id\":\"thread-1\",\"turn_id\":\"turn-1\",\"window_id\":\"thread-1:1\",\"request_kind\":\"turn\",\"workspaces\":{\"/Users/private/project\":{\"associated_remote_urls\":{\"origin\":\"https://user:secret@example.com/org/repo.git?token=leak#fragment\"},\"has_changes\":false}}}","x-codex-installation-id":"wrong-install","session_id":"wrong-session","thread_id":"wrong-thread","turn_id":"wrong-turn","x-codex-window-id":"wrong-window:0"}}`)
+	rawJSON := []byte(`{"model":"gpt-5-codex","stream":true,"client_metadata":{"x-codex-turn-metadata":"{\"installation_id\":\"install-1\",\"session_id\":\"thread-1\",\"thread_id\":\"thread-1\",\"turn_id\":\"turn-1\",\"window_id\":\"thread-1:1\",\"request_kind\":\"turn\",\"workspaces\":{\"/Users/private/project\":{\"associated_remote_urls\":{\"origin\":\"https://user:secret@example.com/org/repo.git?token=leak#fragment\"},\"has_changes\":false}}}","x-codex-installation-id":"wrong-install","session_id":"wrong-session","thread_id":"wrong-thread","turn_id":"wrong-turn","x-codex-window-id":"wrong-window:0"}}`)
 	req := cliproxyexecutor.Request{
 		Model:   "gpt-5-codex",
-		Payload: []byte(`{"model":"gpt-5-codex","prompt_cache_key":"thread-1","client_metadata":{"x-codex-installation-id":"install-1"}}`),
+		Payload: []byte(`{"model":"gpt-5-codex","client_metadata":{"x-codex-installation-id":"install-1"}}`),
 	}
 
 	httpReq, body, state, err := executor.cacheHelper(ctx, sdktranslator.FromString("openai-response"), "https://example.com/responses", auth, req, req.Payload, rawJSON)
@@ -311,6 +311,9 @@ func TestCodexExecutorCacheHelperCanonicalMetadataBypassesLegacyIdentityConfuse(
 	}
 	if got := httpReq.Header.Get("X-Codex-Window-Id"); got != "thread-1:1" {
 		t.Fatalf("X-Codex-Window-Id = %q", got)
+	}
+	if got := codexSessionHeaderValue(httpReq.Header); got != "thread-1" {
+		t.Fatalf("Session_id = %q, want canonical session", got)
 	}
 	if got := httpReq.Header.Get("X-Codex-Turn-Metadata"); got != state.clientMetadata.TurnMetadata {
 		t.Fatalf("X-Codex-Turn-Metadata does not match normalized canonical metadata")

--- a/internal/runtime/executor/codex_openai_images.go
+++ b/internal/runtime/executor/codex_openai_images.go
@@ -116,7 +116,7 @@ func (e *CodexExecutor) executeOpenAIImage(ctx context.Context, auth *cliproxyau
 	reporter.SetOutboundServiceTier(body)
 	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
 	applyFinalCodexClientHeaders(httpReq.Header, modelHeaderProfile, auth)
-	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
+	applyCodexOutboundMetadataHeaders(httpReq.Header, &identityState)
 	recordCodexOpenAIImageRequest(ctx, e.cfg, e.Identifier(), auth, url, httpReq.Header.Clone(), body)
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
@@ -215,7 +215,7 @@ func (e *CodexExecutor) executeOpenAIImageStream(ctx context.Context, auth *clip
 	reporter.SetOutboundServiceTier(body)
 	applyCodexHeaders(httpReq, auth, apiKey, true, e.cfg)
 	applyFinalCodexClientHeaders(httpReq.Header, modelHeaderProfile, auth)
-	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
+	applyCodexOutboundMetadataHeaders(httpReq.Header, &identityState)
 	recordCodexOpenAIImageRequest(ctx, e.cfg, e.Identifier(), auth, url, httpReq.Header.Clone(), body)
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
@@ -347,7 +347,7 @@ func (e *CodexExecutor) executeDirectOpenAIImage(ctx context.Context, auth *clip
 	if contentType != "" {
 		httpReq.Header.Set("Content-Type", contentType)
 	}
-	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
+	applyCodexOutboundMetadataHeaders(httpReq.Header, &identityState)
 	recordCodexOpenAIImageRequest(ctx, e.cfg, e.Identifier(), auth, url, httpReq.Header.Clone(), body)
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
@@ -410,7 +410,7 @@ func (e *CodexExecutor) executeDirectOpenAIImageStream(ctx context.Context, auth
 	if contentType != "" {
 		httpReq.Header.Set("Content-Type", contentType)
 	}
-	applyCodexIdentityConfuseHeaders(httpReq.Header, &identityState)
+	applyCodexOutboundMetadataHeaders(httpReq.Header, &identityState)
 	recordCodexOpenAIImageRequest(ctx, e.cfg, e.Identifier(), auth, url, httpReq.Header.Clone(), body)
 
 	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
@@ -668,6 +668,7 @@ func (e *CodexExecutor) prepareCodexOpenAIImageBody(body []byte, req cliproxyexe
 	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
 	requestPath := helps.PayloadRequestPath(opts)
 	out = helps.ApplyPayloadConfigWithRequest(e.cfg, mainModel, "codex", codexOpenAIImageSourceFormat, "", out, body, requestedModel, requestPath, opts.Headers)
+	out = preserveCodexImageClientMetadata(out, req.Payload)
 	out, _ = sjson.SetBytes(out, "model", mainModel)
 	out, _ = sjson.SetBytes(out, "stream", true)
 	out, _ = sjson.DeleteBytes(out, "previous_response_id")
@@ -675,6 +676,18 @@ func (e *CodexExecutor) prepareCodexOpenAIImageBody(body []byte, req cliproxyexe
 	out, _ = sjson.DeleteBytes(out, "safety_identifier")
 	out, _ = sjson.DeleteBytes(out, "stream_options")
 	return normalizeCodexInstructions(out), nil
+}
+
+func preserveCodexImageClientMetadata(body, sourcePayload []byte) []byte {
+	clientMetadata := gjson.GetBytes(sourcePayload, "client_metadata")
+	if !clientMetadata.IsObject() || strings.TrimSpace(clientMetadata.Raw) == "" {
+		return body
+	}
+	updated, err := sjson.SetRawBytes(body, "client_metadata", []byte(clientMetadata.Raw))
+	if err != nil {
+		return body
+	}
+	return updated
 }
 
 func recordCodexOpenAIImageRequest(ctx context.Context, cfg *config.Config, provider string, auth *cliproxyauth.Auth, url string, headers http.Header, body []byte) {

--- a/internal/runtime/executor/codex_openai_images_test.go
+++ b/internal/runtime/executor/codex_openai_images_test.go
@@ -125,6 +125,84 @@ func TestCodexExecutorDirectOpenAIImageGenerationUsesImagesEndpoint(t *testing.T
 	}
 }
 
+func TestCodexExecutorDirectOpenAIImageRepairsCanonicalMetadata(t *testing.T) {
+	var gotBody []byte
+	var gotTurnMetadata string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTurnMetadata = r.Header.Get("X-Codex-Turn-Metadata")
+		var errRead error
+		gotBody, errRead = io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read body: %v", errRead)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"created":1713833628,"data":[{"b64_json":"AA=="}]}`))
+	}))
+	defer server.Close()
+
+	canonical := `{"installation_id":"install-image-1","session_id":"thread-image-1","thread_id":"thread-image-1","turn_id":"turn-image-1","window_id":"thread-image-1:1","request_kind":"turn","workspaces":{"/Users/private/image-project":{"associated_remote_urls":{"origin":"https://user:secret@example.com/org/repo.git"}}}}`
+	payload, errMarshal := json.Marshal(map[string]any{
+		"model":  "gpt-image-1.5",
+		"prompt": "A private workspace image",
+		"client_metadata": map[string]any{
+			"x-codex-turn-metadata": canonical,
+			"thread_id":             "wrong-thread",
+		},
+	})
+	if errMarshal != nil {
+		t.Fatal(errMarshal)
+	}
+	auth := newCodexOpenAIImageTestAuth(server.URL)
+	auth.ID = "image-auth-1"
+	executor := NewCodexExecutor(&config.Config{Codex: config.CodexConfig{ClientMetadata: config.CodexClientMetadataConfig{
+		Mode:            config.CodexClientMetadataModeRepair,
+		WorkspacePolicy: config.CodexClientMetadataWorkspacePolicyDrop,
+	}}})
+	_, errExecute := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-image-1.5",
+		Payload: payload,
+	}, codexOpenAIImageTestOptions(codexImagesGenerationsPath, false))
+	if errExecute != nil {
+		t.Fatalf("Execute() error = %v", errExecute)
+	}
+
+	metadata := gjson.GetBytes(gotBody, "client_metadata.x-codex-turn-metadata").String()
+	if strings.Contains(metadata, `"workspaces"`) || strings.Contains(metadata, "secret@example.com") {
+		t.Fatalf("direct image request retained workspace metadata: %s", metadata)
+	}
+	if got := gjson.GetBytes(gotBody, "client_metadata.thread_id").String(); got != "thread-image-1" {
+		t.Fatalf("client_metadata.thread_id = %q, want thread-image-1", got)
+	}
+	if gotTurnMetadata != metadata {
+		t.Fatalf("X-Codex-Turn-Metadata does not match canonical image metadata: header=%s body=%s", gotTurnMetadata, metadata)
+	}
+}
+
+func TestPrepareCodexOpenAIImageBodyPreservesClientMetadata(t *testing.T) {
+	canonical := `{"installation_id":"install-image-2","session_id":"thread-image-2","thread_id":"thread-image-2","window_id":"thread-image-2:1","request_kind":"turn"}`
+	payload, errMarshal := json.Marshal(map[string]any{
+		"model":  "gpt-image-legacy",
+		"prompt": "image",
+		"client_metadata": map[string]any{
+			"x-codex-turn-metadata": canonical,
+		},
+	})
+	if errMarshal != nil {
+		t.Fatal(errMarshal)
+	}
+	executor := NewCodexExecutor(&config.Config{})
+	body, err := executor.prepareCodexOpenAIImageBody(codexBuildImagesResponsesRequest("image", nil, nil), cliproxyexecutor.Request{
+		Model:   "gpt-image-legacy",
+		Payload: payload,
+	}, codexOpenAIImageTestOptions(codexImagesGenerationsPath, false), codexOpenAIImagesMainModel)
+	if err != nil {
+		t.Fatalf("prepareCodexOpenAIImageBody() error = %v", err)
+	}
+	if got := gjson.GetBytes(body, "client_metadata.x-codex-turn-metadata").String(); got != canonical {
+		t.Fatalf("canonical client metadata = %q, want %q; body=%s", got, canonical, body)
+	}
+}
+
 func TestCodexExecutorDirectOpenAIImageGenerationStreamsImagesEndpoint(t *testing.T) {
 	var gotPath string
 	var gotAccept string

--- a/internal/runtime/executor/codex_websockets_executor.go
+++ b/internal/runtime/executor/codex_websockets_executor.go
@@ -471,12 +471,15 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	}
 	clientBody := body
 	var identityState codexIdentityConfuseState
-	upstreamBody, identityState := applyCodexIdentityConfuseBody(e.cfg, auth, originalPayloadSource, body)
+	upstreamBody, identityState, err := prepareCodexOutboundMetadata(ctx, e.cfg, auth, originalPayloadSource, body, opts.Headers)
+	if err != nil {
+		return resp, err
+	}
 	reporter.SetTranslatedReasoningEffort(clientBody, to.String())
 	reporter.SetOutboundServiceTier(upstreamBody)
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
 	applyFinalCodexClientHeaders(wsHeaders, modelHeaderProfile, auth)
-	applyCodexIdentityConfuseHeaders(wsHeaders, &identityState)
+	applyCodexOutboundMetadataHeaders(wsHeaders, &identityState)
 
 	var authID, authLabel, authType, authValue string
 	if auth != nil {
@@ -743,12 +746,15 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	}
 	clientBody := body
 	var identityState codexIdentityConfuseState
-	upstreamBody, identityState := applyCodexIdentityConfuseBody(e.cfg, auth, originalPayloadSource, body)
+	upstreamBody, identityState, err := prepareCodexOutboundMetadata(ctx, e.cfg, auth, originalPayloadSource, body, opts.Headers)
+	if err != nil {
+		return nil, err
+	}
 	reporter.SetTranslatedReasoningEffort(clientBody, to.String())
 	reporter.SetOutboundServiceTier(upstreamBody)
 	wsHeaders = applyCodexWebsocketHeaders(ctx, wsHeaders, auth, apiKey, e.cfg)
 	applyFinalCodexClientHeaders(wsHeaders, modelHeaderProfile, auth)
-	applyCodexIdentityConfuseHeaders(wsHeaders, &identityState)
+	applyCodexOutboundMetadataHeaders(wsHeaders, &identityState)
 
 	var authID, authLabel, authType, authValue string
 	authID = auth.ID

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -1742,7 +1742,7 @@ func TestApplyCodexWebsocketHeadersCanonicalMetadataBypassesLegacyIdentityConfus
 	auth := &cliproxyauth.Auth{ID: "auth-ws-1", Provider: "codex", Metadata: map[string]any{"account_id": "acct-ws-1"}}
 	req := cliproxyexecutor.Request{
 		Model:   "gpt-5-codex",
-		Payload: []byte(`{"prompt_cache_key":"thread-ws-1"}`),
+		Payload: []byte(`{"input":"hello"}`),
 	}
 	rawBody := []byte(`{"model":"gpt-5-codex","client_metadata":{"x-codex-turn-metadata":"{\"installation_id\":\"install-ws-1\",\"session_id\":\"thread-ws-1\",\"thread_id\":\"thread-ws-1\",\"turn_id\":\"turn-ws-1\",\"window_id\":\"thread-ws-1:2\",\"request_kind\":\"turn\",\"workspaces\":{\"/private/project\":{\"associated_remote_urls\":{\"origin\":\"https://token@example.com/org/repo.git\"}}}}","thread_id":"wrong-thread","x-codex-window-id":"wrong:0"}}`)
 	body, headers := applyCodexPromptCacheHeaders("openai-response", req, rawBody)
@@ -1773,6 +1773,9 @@ func TestApplyCodexWebsocketHeadersCanonicalMetadataBypassesLegacyIdentityConfus
 	}
 	if got := headers.Get("X-Codex-Window-Id"); got != "thread-ws-1:2" {
 		t.Fatalf("X-Codex-Window-Id = %q", got)
+	}
+	if got := codexSessionHeaderValue(headers); got != "thread-ws-1" {
+		t.Fatalf("session_id = %q, want canonical session", got)
 	}
 	if got := headers.Get("X-Codex-Turn-Metadata"); got != state.clientMetadata.TurnMetadata {
 		t.Fatal("websocket canonical header does not match normalized body metadata")

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -1728,6 +1728,57 @@ func TestApplyCodexWebsocketHeadersIdentityConfuseRemapsPromptCacheKey(t *testin
 	}
 }
 
+func TestApplyCodexWebsocketHeadersCanonicalMetadataBypassesLegacyIdentityConfuse(t *testing.T) {
+	cfg := &config.Config{
+		Routing: config.RoutingConfig{SessionAffinity: true},
+		Codex: config.CodexConfig{
+			IdentityConfuse: true,
+			ClientMetadata: config.CodexClientMetadataConfig{
+				Mode:            config.CodexClientMetadataModeRepair,
+				WorkspacePolicy: config.CodexClientMetadataWorkspacePolicyDrop,
+			},
+		},
+	}
+	auth := &cliproxyauth.Auth{ID: "auth-ws-1", Provider: "codex", Metadata: map[string]any{"account_id": "acct-ws-1"}}
+	req := cliproxyexecutor.Request{
+		Model:   "gpt-5-codex",
+		Payload: []byte(`{"prompt_cache_key":"thread-ws-1"}`),
+	}
+	rawBody := []byte(`{"model":"gpt-5-codex","client_metadata":{"x-codex-turn-metadata":"{\"installation_id\":\"install-ws-1\",\"session_id\":\"thread-ws-1\",\"thread_id\":\"thread-ws-1\",\"turn_id\":\"turn-ws-1\",\"window_id\":\"thread-ws-1:2\",\"request_kind\":\"turn\",\"workspaces\":{\"/private/project\":{\"associated_remote_urls\":{\"origin\":\"https://token@example.com/org/repo.git\"}}}}","thread_id":"wrong-thread","x-codex-window-id":"wrong:0"}}`)
+	body, headers := applyCodexPromptCacheHeaders("openai-response", req, rawBody)
+	ctx := contextWithGinHeaders(map[string]string{
+		"X-Codex-Turn-Metadata": `{"thread_id":"header-conflict"}`,
+		"X-Client-Request-Id":   "client-request-1",
+	})
+
+	upstreamBody, state, err := prepareCodexOutboundMetadata(ctx, cfg, auth, req.Payload, body, nil)
+	if err != nil {
+		t.Fatalf("prepareCodexOutboundMetadata() error = %v", err)
+	}
+	headers = applyCodexWebsocketHeaders(ctx, headers, auth, "oauth-token", cfg)
+	applyCodexOutboundMetadataHeaders(headers, &state)
+
+	if state.enabled || !state.clientMetadata.CanonicalPresent {
+		t.Fatalf("canonical websocket state unexpectedly used legacy identity mapping: %+v", state)
+	}
+	metadata := gjson.GetBytes(upstreamBody, "client_metadata.x-codex-turn-metadata").String()
+	if strings.Contains(metadata, `"workspaces"`) || strings.Contains(metadata, "token@example.com") {
+		t.Fatalf("drop policy did not remove websocket workspace metadata: %s", metadata)
+	}
+	if got := gjson.GetBytes(upstreamBody, "client_metadata.thread_id").String(); got != "thread-ws-1" {
+		t.Fatalf("flat thread_id = %q", got)
+	}
+	if got := gjson.GetBytes(upstreamBody, "client_metadata.x-codex-window-id").String(); got != "thread-ws-1:2" {
+		t.Fatalf("flat window_id = %q", got)
+	}
+	if got := headers.Get("X-Codex-Window-Id"); got != "thread-ws-1:2" {
+		t.Fatalf("X-Codex-Window-Id = %q", got)
+	}
+	if got := headers.Get("X-Codex-Turn-Metadata"); got != state.clientMetadata.TurnMetadata {
+		t.Fatal("websocket canonical header does not match normalized body metadata")
+	}
+}
+
 func TestCodexIdentityConfuseResponsePayloadHidesUpstreamAndRestoresClient(t *testing.T) {
 	state := codexIdentityConfuseState{
 		enabled:                true,

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/codexmetadata"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
@@ -108,6 +109,7 @@ func RecordAPIRequest(ctx context.Context, cfg *config.Config, info UpstreamRequ
 	if ginCtx == nil {
 		return
 	}
+	info = redactCodexUpstreamRequestLog(info)
 	if !cfg.RequestLog {
 		deferAPIRequest(ginCtx, info)
 		return
@@ -332,6 +334,7 @@ func RecordAPIWebsocketRequest(ctx context.Context, cfg *config.Config, info Ups
 	if ginCtx == nil {
 		return
 	}
+	info = redactCodexUpstreamRequestLog(info)
 
 	builder := &strings.Builder{}
 	builder.WriteString(fmt.Sprintf("Timestamp: %s\n", time.Now().Format(time.RFC3339Nano)))
@@ -353,6 +356,16 @@ func RecordAPIWebsocketRequest(ctx context.Context, cfg *config.Config, info Ups
 	builder.WriteString("\n")
 
 	appendAPIWebsocketTimeline(ginCtx, []byte(builder.String()))
+}
+
+func redactCodexUpstreamRequestLog(info UpstreamRequestLog) UpstreamRequestLog {
+	if !strings.EqualFold(strings.TrimSpace(info.Provider), "codex") {
+		return info
+	}
+	redacted := info
+	redacted.Body = codexmetadata.RedactRequestBodyForLog(info.Body)
+	redacted.Headers = http.Header(codexmetadata.RedactHeadersForLog(info.Headers))
+	return redacted
 }
 
 // RecordAPIWebsocketHandshake stores the upstream websocket handshake response metadata.

--- a/internal/runtime/executor/helps/logging_helpers_test.go
+++ b/internal/runtime/executor/helps/logging_helpers_test.go
@@ -3,6 +3,7 @@ package helps
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -59,6 +60,90 @@ func TestRecordAPIRequestClonesDeferredBodyWhenRequestLogDisabled(t *testing.T) 
 	if !strings.Contains(captured, `{"model":"original"}`) {
 		t.Fatalf("captured API request = %q, want original body", captured)
 	}
+}
+
+func TestRecordAPIRequestRedactsCodexWorkspaceMetadataFromDeferredLog(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+	ctx := context.WithValue(context.Background(), "gin", ginCtx)
+	body, headerMetadata := codexLoggingMetadataFixture(t)
+	headers := http.Header{"X-Codex-Turn-Metadata": {headerMetadata}}
+	originalBody := bytes.Clone(body)
+	originalHeader := headers.Get("X-Codex-Turn-Metadata")
+
+	RecordAPIRequest(ctx, &config.Config{}, UpstreamRequestLog{
+		URL:      "https://chatgpt.com/backend-api/codex/responses",
+		Method:   http.MethodPost,
+		Body:     body,
+		Headers:  headers,
+		Provider: "codex",
+	})
+
+	value, exists := ginCtx.Get(logging.DeferredAPIRequestContextKey)
+	if !exists {
+		t.Fatal("deferred API request was not captured")
+	}
+	requests := snapshotDeferredAPIRequests(t, value)
+	captured := string(requests[0]())
+	if strings.Contains(captured, "credential-sentinel") || strings.Contains(captured, "/Users/private/project") || strings.Contains(captured, `"workspaces"`) {
+		t.Fatalf("deferred Codex request log leaked workspace metadata: %s", captured)
+	}
+	if !bytes.Equal(body, originalBody) || headers.Get("X-Codex-Turn-Metadata") != originalHeader {
+		t.Fatal("Codex log redaction mutated the outbound request")
+	}
+}
+
+func TestRecordAPIWebsocketRequestRedactsCodexWorkspaceMetadata(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+	ctx := context.WithValue(context.Background(), "gin", ginCtx)
+	body, headerMetadata := codexLoggingMetadataFixture(t)
+	body, err := json.Marshal(map[string]any{
+		"type": "response.create",
+		"client_metadata": map[string]any{
+			"x-codex-turn-metadata": headerMetadata,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	RecordAPIWebsocketRequest(ctx, &config.Config{SDKConfig: config.SDKConfig{RequestLog: true}}, UpstreamRequestLog{
+		URL:      "wss://chatgpt.com/backend-api/codex/responses",
+		Method:   "WEBSOCKET",
+		Body:     body,
+		Headers:  http.Header{"X-Codex-Turn-Metadata": {headerMetadata}},
+		Provider: "codex",
+	})
+
+	value, exists := ginCtx.Get("API_WEBSOCKET_TIMELINE")
+	if !exists {
+		t.Fatal("websocket timeline was not captured")
+	}
+	timeline, ok := value.([]byte)
+	if !ok {
+		t.Fatalf("websocket timeline type = %T", value)
+	}
+	if strings.Contains(string(timeline), "credential-sentinel") || strings.Contains(string(timeline), "/Users/private/project") || strings.Contains(string(timeline), `"workspaces"`) {
+		t.Fatalf("Codex websocket log leaked workspace metadata: %s", timeline)
+	}
+}
+
+func codexLoggingMetadataFixture(t *testing.T) ([]byte, string) {
+	t.Helper()
+	metadata := `{"thread_id":"thread-1","workspaces":{"/Users/private/project":{"associated_remote_urls":{"origin":"https://user:credential-sentinel@example.com/org/repo.git?token=credential-sentinel"},"latest_git_commit_hash":"abcdef","has_changes":false}}}`
+	body, err := json.Marshal(map[string]any{
+		"model": "gpt-5.6",
+		"client_metadata": map[string]any{
+			"x-codex-turn-metadata": metadata,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body, metadata
 }
 
 func TestRecordAPIRequestBoundsDeferredBodyWhenRequestLogDisabled(t *testing.T) {

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -105,6 +105,7 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.Codex.IdentityConfuse != newCfg.Codex.IdentityConfuse {
 		changes = append(changes, fmt.Sprintf("codex.identity-confuse: %t -> %t", oldCfg.Codex.IdentityConfuse, newCfg.Codex.IdentityConfuse))
 	}
+	changes = appendCodexClientMetadataChanges(changes, oldCfg.Codex.ClientMetadata.Effective(), newCfg.Codex.ClientMetadata.Effective())
 	changes = appendCodexModelFallbackChanges(changes, oldCfg.Codex.ModelFallback.Effective(), newCfg.Codex.ModelFallback.Effective())
 	changes = appendCodexRateLimitContinuityChanges(changes, oldCfg.Codex.RateLimitContinuity.Effective(), newCfg.Codex.RateLimitContinuity.Effective())
 	changes = appendCodexAbnormalReasoningRetryChanges(changes, oldCfg.Codex.AbnormalReasoningRetry.Effective(), newCfg.Codex.AbnormalReasoningRetry.Effective())
@@ -429,6 +430,16 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 		}
 	}
 
+	return changes
+}
+
+func appendCodexClientMetadataChanges(changes []string, oldCfg, newCfg config.EffectiveCodexClientMetadataConfig) []string {
+	if oldCfg.Mode != newCfg.Mode {
+		changes = append(changes, fmt.Sprintf("codex.client-metadata.mode: %s -> %s", oldCfg.Mode, newCfg.Mode))
+	}
+	if oldCfg.WorkspacePolicy != newCfg.WorkspacePolicy {
+		changes = append(changes, fmt.Sprintf("codex.client-metadata.workspace-policy: %s -> %s", oldCfg.WorkspacePolicy, newCfg.WorkspacePolicy))
+	}
 	return changes
 }
 

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -176,6 +176,18 @@ func TestBuildConfigChangeDetails_PayloadRules(t *testing.T) {
 	expectContains(t, details, "payload.filter: updated (1 -> 0 rules)")
 }
 
+func TestBuildConfigChangeDetailsCodexClientMetadata(t *testing.T) {
+	oldCfg := &config.Config{}
+	newCfg := &config.Config{Codex: config.CodexConfig{ClientMetadata: config.CodexClientMetadataConfig{
+		Mode:            config.CodexClientMetadataModeStrict,
+		WorkspacePolicy: config.CodexClientMetadataWorkspacePolicyDrop,
+	}}}
+
+	details := BuildConfigChangeDetails(oldCfg, newCfg)
+	expectContains(t, details, "codex.client-metadata.mode: repair -> strict")
+	expectContains(t, details, "codex.client-metadata.workspace-policy: passthrough -> drop")
+}
+
 func TestBuildConfigChangeDetails_CodexAbnormalReasoningRetry(t *testing.T) {
 	streamBuffer := false
 	streamBufferMaxBytes := int64(4096)

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/codexmetadata"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	requestlogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
@@ -119,6 +120,9 @@ func (l *websocketTimelineLog) BeginRequest() {
 func (l *websocketTimelineLog) Append(eventType string, payload []byte, timestamp time.Time) {
 	if l == nil || !l.enabled {
 		return
+	}
+	if strings.EqualFold(strings.TrimSpace(eventType), "request") {
+		payload = codexmetadata.RedactRequestBodyForLog(payload)
 	}
 	data := formatWebsocketTimelineEvent(eventType, payload, timestamp)
 	if len(data) == 0 {

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -1044,6 +1044,25 @@ func TestWebsocketTimelineLogFallsBackToMemoryWithoutSource(t *testing.T) {
 	}
 }
 
+func TestWebsocketTimelineLogRedactsCodexWorkspaceMetadata(t *testing.T) {
+	payload := []byte(`{"type":"response.create","client_metadata":{"x-codex-turn-metadata":"{\"request_kind\":\"turn\",\"thread_id\":\"thread-1\",\"workspaces\":{\"/Users/private/project\":{\"associated_remote_urls\":{\"origin\":\"https://user:credential-sentinel@example.com/org/repo.git\"}}}}"}}`)
+	original := bytes.Clone(payload)
+	timelineLog := newInMemoryWebsocketTimelineLog()
+	timelineLog.BeginRequest()
+	timelineLog.Append("request", payload, time.Now())
+
+	got := timelineLog.String()
+	if strings.Contains(got, "credential-sentinel") || strings.Contains(got, "/Users/private/project") || strings.Contains(got, `"workspaces"`) {
+		t.Fatalf("downstream websocket timeline leaked Codex workspace metadata: %s", got)
+	}
+	if !strings.Contains(got, "thread-1") {
+		t.Fatalf("downstream websocket timeline dropped non-workspace metadata: %s", got)
+	}
+	if !bytes.Equal(payload, original) {
+		t.Fatal("websocket timeline redaction mutated the downstream request")
+	}
+}
+
 func TestRepairResponsesWebsocketToolCallsInsertsCachedOutput(t *testing.T) {
 	cache := newWebsocketToolOutputCache(time.Minute, 10)
 	sessionKey := "session-1"


### PR DESCRIPTION
## 结果

本 PR 将官方 Codex `client_metadata["x-codex-turn-metadata"]` 作为请求身份与 turn metadata 的 canonical source，并在最终 credential、payload 与 header shaping 完成后统一修复 flat body / direct header compatibility projections。同时增加可配置的 workspace 隐私策略，并确保新写入的 HTTP、deferred error、upstream 与 WebSocket request log 不再包含 workspace path、Git remote、commit hash 或 dirty state。

Review follow-up `7ed6e97d` 进一步补齐 canonical-only 请求的 `Session_id` 一致性，并关闭 escaped JSON key、duplicate carrier 与 legacy fallback 边界。

**合并约束：必须使用 Create a merge commit，禁止 squash/rebase。** `docs/lts/downstream-patches.yaml` 的 `introduced_in` 指向实现 commit `dcb424d4a5d666322c641151a3e37fd3b0dcc864`，该 SHA 需要保持可达。

## Type

- [ ] Protected upstream full-sync
- [ ] Staged upstream full-sync
- [ ] LTS protected-delta patch
- [x] LTS feature / downstream patch maintenance
- [ ] Maintenance docs / CI
- [ ] Emergency hotfix

## 主要变更

- 新增 `codex.client-metadata`：
  - `mode: repair`（默认）：canonical body 为准，重建冲突的 flat body 与 direct header projections。
  - `mode: strict`：发现 flat projection 或 direct canonical header 冲突时，返回安全的 `400 invalid_client_metadata`。
  - `mode: off`：不改写 canonical payload；仍识别有效 canonical 请求并跳过旧 `identity-confuse`，避免 mixed identity。
- 新增 `workspace-policy`：
  - `passthrough`（默认）：保留 workspace enrichment，但始终删除 Git remote userinfo、query 和 fragment。
  - `redact`：使用 selected auth、installation ID 与 workspace path 生成稳定 pseudonym，仅保留合法 `has_changes`。
  - `drop`：删除整个 `workspaces`。
- canonical 处理覆盖 HTTP、SSE、`/responses/compact`、WebSocket、Responses image 与 direct image 路径；image 转换不再丢失原始 `client_metadata`。
- canonical-only 请求从 canonical `session_id` 派生 `Session_id`；缺失时回退到 canonical `thread_id`，避免 final Mac client header 生成随机 session 并与 turn metadata 分裂。
- canonical 请求不再进入旧 `identity-confuse` 的 partial body/header/response string replacement；不含非空 `request_kind` 的 legacy metadata 继续沿用旧路径。
- `repair` / `strict` 拒绝歧义的 duplicate `client_metadata` carrier；`off` 保持原文但会扫描所有 carrier，任一有效 canonical metadata 都会阻止 legacy rewrite。
- 日志脱敏只处理 logging copy，不修改 downstream request、真实 upstream body/header 或 WebSocket frame：
  - downstream request body/header；
  - error-only deferred request body；
  - upstream HTTP request 与 deferred request snapshot；
  - downstream/upstream WebSocket request timeline。
- malformed、truncated、escaped-key 或 duplicate-carrier metadata 在日志路径 fail closed，不记录原始 metadata。
- 配置解析、默认值、hot-reload diff、image/WS/HTTP 装配和日志路径均补充回归测试。

## 兼容性与边界

- 默认仍向 upstream 保留官方 workspace metadata；只有 Git remote credential/query/fragment 被无条件移除。需要隐藏 workspace identity 时显式选择 `redact` 或 `drop`。
- `request_kind` 缺失的历史 inner blob 不会被误判为新版 canonical metadata，既有 `identity-confuse` 行为保持不变。
- memory 等条件型 metadata 缺少 installation/window 字段时，不删除已有 flat compatibility projections。
- duplicate JSON object key 本身是歧义输入；`repair` / `strict` 现在返回稳定的安全错误，而不是依赖不同 parser 的 first-wins / last-wins 行为。
- 日志保护仅影响本 PR 合入后新写入的日志；不清理历史 `logs/` 或已转发日志。
- 本 PR 不包含完整 identity pseudonymization v2、`x-codex-turn-state` credential route binding、Codex Header `inherit/fallback/override` 重构、Panel UI 或历史日志清理。
- 未部署、未发布，也未修改 usage statistics、Management usage response shape 或 CPA-Panel-LTS 契约。

## LTS classification review

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| `codex-client-metadata-privacy` | downstream patch | newly-added | 实现 commit `dcb424d4`；review 修复 `7ed6e97d`；新增 canonical normalization、session projection、workspace policy、log sanitizer 与跨传输测试 |
| `codex-oauth-client-identity-finalization` | downstream patch | adapted | canonical metadata headers 在 final client identity / model header override 后应用；既有 OAuth identity 测试与全仓测试通过 |
| `codex-model-header-provider-snapshot` | downstream patch | preserved | 未改变 provider-owned header profile snapshot 或 WebSocket connection key；相关 executor/WS 测试通过 |
| `provider-runtime-usage-seams` | review seam | preserved | request lifecycle/logging metadata 已审查；effective service tier 与 usage attribution 未改，usage 定向测试及全仓测试通过 |

## Protected delta review

- [x] `usage-statistics-enabled` 与 `/v0/management/usage*` 契约未改
- [x] `docs/lts/core-feature-contracts.yaml` 已检查；本变更不修改既有 capability marker
- [x] `docs/lts/downstream-patches.yaml` 已登记新 downstream patch及 review regression tests
- [x] auth identity、request lifecycle、logging metadata、config schema / hot reload 已做显式审查
- [x] OAuth/API-key header finalization、legacy metadata 与 canonical metadata 分流有回归覆盖
- [x] 使用 synthetic metadata fixture；PR、测试与文档不包含本地真实 workspace、installation ID、thread ID 或 Git commit

## Validation

- [x] `go test ./...`
- [x] `go test ./internal/codexmetadata ./internal/config ./internal/watcher ./internal/watcher/diff ./internal/runtime/executor/helps ./internal/api/middleware ./internal/runtime/executor ./sdk/api/handlers/openai ./internal/api ./internal/logging`
- [x] `go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'`
- [x] `go test -race ./internal/codexmetadata ./internal/runtime/executor/helps`
- [x] `go build -o <temporary-file> ./cmd/server`
- [x] `go run ./scripts/ltsregistry --root .`
- [x] `scripts/check-lts-contract.sh`
- [x] `git diff --check`

## Review focus

1. `internal/codexmetadata/request.go` 的 canonical/legacy 判定、duplicate carrier 拒绝、conditional projections、strict 语义与 workspace pseudonym scope。
2. `internal/runtime/executor/codex_client_metadata.go` 在 cache/replay 后、final headers 后的装配顺序，以及 canonical `Session_id` 与 canonical 请求跳过 legacy `identity-confuse` 的边界。
3. `internal/codexmetadata/log.go` 与 middleware/executor/WS timeline 接入是否始终只修改 logging copy，并对 escaped key、malformed、truncated、duplicate carrier fail closed。
4. HTTP、compact、stream、WebSocket 和 image call site 是否保持 canonical body/header 一致。

## Optional real runtime smoke

- [ ] Hugging Face Space smoke：未运行；本 PR 尚未合并、发布或部署。
