### PR TITLE
fix(auth): 收紧凭据存储边界并恢复 prefix 元数据

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,8 @@
 # Management Web UI
 # ------------------------------------------------------------------------------
 # MANAGEMENT_PASSWORD=change-me-to-a-strong-password
+# Optional token for private or rate-limited CPA Panel GitHub release lookups.
+# CLIPROXYAPI_PANEL_GITHUB_TOKEN=github_pat_your_panel_release_token
 
 # ------------------------------------------------------------------------------
 # Postgres Token Store (optional)

--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@
 # Management Web UI
 # ------------------------------------------------------------------------------
 # MANAGEMENT_PASSWORD=change-me-to-a-strong-password
-# Optional token for private or rate-limited CPA Panel GitHub release lookups.
+# Optional token for authenticated or rate-limited CPA Panel GitHub release lookups.
 # CLIPROXYAPI_PANEL_GITHUB_TOKEN=github_pat_your_panel_release_token
 
 # ------------------------------------------------------------------------------

--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -28,3 +28,16 @@ jobs:
         run: |
           go build -o test-output ./cmd/server
           rm -f test-output
+
+  credential-permissions-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Verify credential DACL hardening
+        run: go test ./internal/misc -run TestOpenCredentialFileRestrictsAccessToCurrentUser -count=1

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -514,3 +514,99 @@ patches:
     upstream_issue_or_pr: not-filed
     state: required
     retire_when: Upstream bounds encoded public API request bodies and every decoded Content-Encoding layer, returns 413 for limit violations without bypassing the limit through raw-JSON fallback, routes all affected handlers through the shared bounded reader, and all listed regressions pass after removing the downstream implementation.
+
+  - id: object-store-auth-path-containment
+    reason: Object-store auth persistence must never create, overwrite, upload, or delete files outside its managed auth mirror, including traversal, sibling-prefix, absolute-path, and symlink escapes.
+    introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
+    affected_upstream_range: through 93d74a890a44802f656d7f39a573916b2611896e (v7.2.88); upstream accepts caller-provided absolute auth paths and computes object keys from unchecked filepath.Rel results, so paths outside the mirror can reach local file and remote object operations.
+    files:
+      - internal/store/objectstore.go
+      - internal/store/objectstore_path_test.go
+    regression_tests:
+      - TestObjectTokenStoreRejectsAuthPathsOutsideAuthDir
+      - TestObjectTokenStoreAcceptsNestedAuthPathInsideAuthDir
+      - TestObjectTokenStoreRejectsSiblingPrefixAndSymlinkEscapes
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: Upstream validates every object-store auth save, delete, upload, and watcher persistence path against both lexical and resolved filesystem containment, rejects symlink escapes, preserves nested auth files, and all listed regressions pass without the downstream implementation.
+
+  - id: auth-token-private-file-permissions
+    reason: OAuth tokens and service-account credentials must be created with owner-only permissions and must tighten pre-existing wider files before replacing their contents.
+    introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
+    affected_upstream_range: through 93d74a890a44802f656d7f39a573916b2611896e (v7.2.88); Claude, Codex, Kimi, Vertex, and xAI token writers still use os.Create, which follows umask for new files and preserves wider permissions on existing files.
+    files:
+      - internal/misc/credential_file.go
+      - internal/auth/claude/token.go
+      - internal/auth/claude/token_permissions_test.go
+      - internal/auth/codex/token.go
+      - internal/auth/codex/token_permissions_test.go
+      - internal/auth/kimi/token.go
+      - internal/auth/kimi/token_permissions_test.go
+      - internal/auth/vertex/vertex_credentials.go
+      - internal/auth/vertex/vertex_credentials_permissions_test.go
+      - internal/auth/xai/token.go
+      - internal/auth/xai/token_permissions_test.go
+    regression_tests:
+      - TestSaveTokenToFileUsesPrivatePermissions
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: Upstream opens every current credential writer with owner-only permissions, tightens existing files before truncation, propagates write and close errors, and the provider-local permission regressions pass without the downstream helper.
+
+  - id: auth-store-list-error-propagation
+    reason: A damaged or unreadable auth JSON file must fail Store.List instead of silently removing that credential from routing, fallback, and usage attribution while startup reports success.
+    introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
+    affected_upstream_range: through 93d74a890a44802f656d7f39a573916b2611896e (v7.2.88); the File and Git token stores still discard read, JSON decode, and stat errors inside filepath.WalkDir callbacks.
+    files:
+      - internal/store/gitstore.go
+      - internal/store/gitstore_test.go
+      - sdk/auth/filestore.go
+      - sdk/auth/filestore_test.go
+    regression_tests:
+      - TestGitTokenStoreListReturnsAuthFileErrors
+      - TestFileTokenStoreListReturnsAuthFileErrors
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: Upstream returns contextual File and Git auth-list errors to Manager.Load, preserves plugin multi-auth behavior, and both listed regressions pass without the downstream implementation.
+
+  - id: auth-store-metadata-hydration
+    reason: Initial File, Git, Object, and Postgres store loading must hydrate the same normalized auth prefix, custom headers, and disabled state as watcher synthesis so prefixed model routing and Management auth-file output do not change after a reload event.
+    introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
+    affected_upstream_range: through 93d74a890a44802f656d7f39a573916b2611896e (v7.2.88); watcher synthesis reads normalized prefix metadata, but initial Store.List paths only apply partial metadata and the Management auth-file response omits Auth.Prefix.
+    files:
+      - sdk/cliproxy/auth/metadata_hydrate.go
+      - sdk/cliproxy/auth/metadata_hydrate_test.go
+      - sdk/auth/filestore.go
+      - sdk/auth/filestore_disabled_test.go
+      - internal/store/gitstore.go
+      - internal/store/objectstore.go
+      - internal/store/postgresstore.go
+      - internal/store/auth_metadata_test.go
+      - internal/api/handlers/management/auth_files.go
+      - internal/api/handlers/management/auth_files_recent_requests_test.go
+    regression_tests:
+      - TestNormalizeAuthPrefix
+      - TestHydrateAuthFromMetadata
+      - TestFileTokenStoreListHydratesMetadataFields
+      - TestGitTokenStoreReadAuthFileHydratesMetadata
+      - TestObjectTokenStoreReadAuthFileHydratesMetadata
+      - TestListAuthFiles_IncludesRecentRequestsBuckets
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: Upstream hydrates normalized single-segment prefixes and shared auth metadata consistently across all initial stores, watcher reload, Management upload/edit, and auth-file listing; prefixed routing remains stable from process start; and all listed regressions pass without the downstream helper.
+
+  - id: panel-release-token-isolation
+    reason: Management panel release lookups must authorize only exact HTTPS GitHub release URLs and should use a dedicated panel token while retaining a guarded legacy GitStore fallback.
+    introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
+    affected_upstream_range: through 93d74a890a44802f656d7f39a573916b2611896e (v7.2.88); upstream decides whether to attach GITSTORE_GIT_TOKEN from the GitStore URL rather than the actual release URL and has no dedicated panel release token.
+    files:
+      - .env.example
+      - internal/managementasset/updater.go
+      - internal/managementasset/updater_test.go
+    regression_tests:
+      - TestFetchLatestAssetUsesDedicatedPanelToken
+      - TestFetchLatestAssetUsesLegacyGitStoreTokenOnlyForGitHub
+      - TestPanelAuthorizationHeaderKeepsLegacySSHGitHubCompatibility
+      - TestFetchLatestAssetDoesNotSendTokensToNonGitHubHosts
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: Upstream offers a dedicated panel release credential, attaches authorization only to exact HTTPS github.com or api.github.com release requests, preserves a safe migration path for existing GitStore deployments, and all listed regressions pass without the downstream implementation.

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -535,7 +535,12 @@ patches:
     introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
     affected_upstream_range: through 93d74a890a44802f656d7f39a573916b2611896e (v7.2.88); Claude, Codex, Kimi, Vertex, and xAI token writers still use os.Create, which follows umask for new files and preserves wider permissions on existing files.
     files:
+      - .github/workflows/pr-test-build.yml
       - internal/misc/credential_file.go
+      - internal/misc/credential_file_posix.go
+      - internal/misc/credential_file_posix_test.go
+      - internal/misc/credential_file_windows.go
+      - internal/misc/credential_file_windows_test.go
       - internal/auth/claude/token.go
       - internal/auth/claude/token_permissions_test.go
       - internal/auth/codex/token.go
@@ -548,6 +553,7 @@ patches:
       - internal/auth/xai/token_permissions_test.go
     regression_tests:
       - TestSaveTokenToFileUsesPrivatePermissions
+      - TestOpenCredentialFileRestrictsAccessToCurrentUser
     upstream_issue_or_pr: not-filed
     state: required
     retire_when: Upstream opens every current credential writer with owner-only permissions, tightens existing files before truncation, propagates write and close errors, and the provider-local permission regressions pass without the downstream helper.
@@ -561,9 +567,13 @@ patches:
       - internal/store/gitstore_test.go
       - sdk/auth/filestore.go
       - sdk/auth/filestore_test.go
+      - internal/watcher/synthesizer/file.go
+      - internal/watcher/synthesizer/file_test.go
     regression_tests:
       - TestGitTokenStoreListReturnsAuthFileErrors
       - TestFileTokenStoreListReturnsAuthFileErrors
+      - TestFileTokenStoreListReturnsPluginParserErrors
+      - TestSynthesizeAuthFilePluginParserErrorDoesNotFallback
     upstream_issue_or_pr: not-filed
     state: required
     retire_when: Upstream returns contextual File and Git auth-list errors to Manager.Load, preserves plugin multi-auth behavior, and both listed regressions pass without the downstream implementation.
@@ -577,11 +587,13 @@ patches:
       - sdk/cliproxy/auth/metadata_hydrate_test.go
       - sdk/auth/filestore.go
       - sdk/auth/filestore_disabled_test.go
+      - sdk/auth/filestore_test.go
       - internal/store/gitstore.go
       - internal/store/objectstore.go
       - internal/store/postgresstore.go
       - internal/store/auth_metadata_test.go
       - internal/api/handlers/management/auth_files.go
+      - internal/api/handlers/management/auth_files_patch_fields_test.go
       - internal/api/handlers/management/auth_files_recent_requests_test.go
     regression_tests:
       - TestNormalizeAuthPrefix
@@ -590,6 +602,10 @@ patches:
       - TestGitTokenStoreReadAuthFileHydratesMetadata
       - TestObjectTokenStoreReadAuthFileHydratesMetadata
       - TestListAuthFiles_IncludesRecentRequestsBuckets
+      - TestFileTokenStorePluginAuthOwnsPrefix
+      - TestPatchAuthFileFieldsNormalizesPrefixBeforePersisting
+      - TestPatchAuthFileFieldsRejectsInvalidPrefix
+      - TestBuildAuthFromFileDataHydratesPrefix
     upstream_issue_or_pr: not-filed
     state: required
     retire_when: Upstream hydrates normalized single-segment prefixes and shared auth metadata consistently across all initial stores, watcher reload, Management upload/edit, and auth-file listing; prefixed routing remains stable from process start; and all listed regressions pass without the downstream helper.

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -484,6 +484,9 @@ func (h *Handler) buildAuthFileEntry(auth *coreauth.Auth) gin.H {
 		"source":         "memory",
 		"size":           int64(0),
 	}
+	if prefix := strings.TrimSpace(auth.Prefix); prefix != "" {
+		entry["prefix"] = prefix
+	}
 	entry["success"] = auth.Success
 	entry["failed"] = auth.Failed
 	entry["recent_requests"] = auth.RecentRequestsSnapshot(time.Now())
@@ -1217,7 +1220,7 @@ func (h *Handler) buildAuthFromFileData(path string, data []byte) (*coreauth.Aut
 			auth.Runtime = existing.Runtime
 		}
 	}
-	coreauth.ApplyCustomHeadersFromMetadata(auth)
+	coreauth.HydrateAuthFromMetadata(auth)
 	return auth, nil
 }
 
@@ -1641,7 +1644,7 @@ func syncAuthFileMetadataFields(auth *coreauth.Auth, touchedRoots map[string]str
 	}
 	if _, ok := touchedRoots["prefix"]; ok {
 		if prefix, okString := auth.Metadata["prefix"].(string); okString {
-			auth.Prefix = strings.TrimSpace(prefix)
+			auth.Prefix = coreauth.NormalizeAuthPrefix(prefix)
 		}
 	}
 	if _, ok := touchedRoots["proxy_url"]; ok {

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -1500,6 +1500,23 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 		if targetAuth.Metadata == nil {
 			targetAuth.Metadata = make(map[string]any)
 		}
+		if rootAuthFileField(fieldPath) == "prefix" {
+			if fieldPath != "prefix" {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "prefix does not support nested field paths"})
+				return
+			}
+			rawPrefix, okString := value.(string)
+			if !okString {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "prefix must be a string"})
+				return
+			}
+			normalizedPrefix := coreauth.NormalizeAuthPrefix(rawPrefix)
+			if strings.Trim(strings.TrimSpace(rawPrefix), "/") != "" && normalizedPrefix == "" {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "prefix must be a single path segment"})
+				return
+			}
+			value = normalizedPrefix
+		}
 
 		if fieldPath == "headers" {
 			applyAuthFileHeadersPatch(targetAuth, value)

--- a/internal/api/handlers/management/auth_files_patch_fields_test.go
+++ b/internal/api/handlers/management/auth_files_patch_fields_test.go
@@ -110,6 +110,67 @@ func TestPatchAuthFileFields_MergeHeadersAndDeleteEmptyValues(t *testing.T) {
 	}
 }
 
+func TestPatchAuthFileFieldsNormalizesPrefixBeforePersisting(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	manager := coreauth.NewManager(&memoryAuthStore{}, nil, nil)
+	record := &coreauth.Auth{
+		ID:         "prefix.json",
+		FileName:   "prefix.json",
+		Provider:   "claude",
+		Attributes: map[string]string{"path": "/tmp/prefix.json"},
+		Metadata:   map[string]any{"type": "claude"},
+	}
+	if _, err := manager.Register(context.Background(), record); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/fields", strings.NewReader(`{"name":"prefix.json","prefix":" /team/ "}`))
+	h.PatchAuthFileFields(ctx)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	updated, ok := manager.GetByID("prefix.json")
+	if !ok || updated == nil {
+		t.Fatal("updated auth missing")
+	}
+	if updated.Prefix != "team" || updated.Metadata["prefix"] != "team" {
+		t.Fatalf("prefix/runtime metadata = %q/%#v, want team/team", updated.Prefix, updated.Metadata["prefix"])
+	}
+}
+
+func TestPatchAuthFileFieldsRejectsInvalidPrefix(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	manager := coreauth.NewManager(&memoryAuthStore{}, nil, nil)
+	record := &coreauth.Auth{
+		ID:         "prefix.json",
+		FileName:   "prefix.json",
+		Provider:   "claude",
+		Prefix:     "stable",
+		Attributes: map[string]string{"path": "/tmp/prefix.json"},
+		Metadata:   map[string]any{"type": "claude", "prefix": "stable"},
+	}
+	if _, err := manager.Register(context.Background(), record); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/fields", strings.NewReader(`{"name":"prefix.json","prefix":"team/child"}`))
+	h.PatchAuthFileFields(ctx)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	updated, ok := manager.GetByID("prefix.json")
+	if !ok || updated == nil {
+		t.Fatal("auth missing after rejected patch")
+	}
+	if updated.Prefix != "stable" || updated.Metadata["prefix"] != "stable" {
+		t.Fatalf("rejected patch changed prefix to %q/%#v", updated.Prefix, updated.Metadata["prefix"])
+	}
+}
+
 func TestPatchAuthFileFields_HeadersEmptyMapIsNoop(t *testing.T) {
 	t.Setenv("MANAGEMENT_PASSWORD", "")
 

--- a/internal/api/handlers/management/auth_files_recent_requests_test.go
+++ b/internal/api/handlers/management/auth_files_recent_requests_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -93,5 +94,18 @@ func TestListAuthFiles_IncludesRecentRequestsBuckets(t *testing.T) {
 		if _, ok := bucket["failed"].(float64); !ok {
 			t.Fatalf("expected bucket failed number at %d, got %#v", idx, bucket["failed"])
 		}
+	}
+}
+
+func TestBuildAuthFromFileDataHydratesPrefix(t *testing.T) {
+	dir := t.TempDir()
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: dir}, nil)
+	path := filepath.Join(dir, "prefix.json")
+	auth, err := h.buildAuthFromFileData(path, []byte(`{"type":"claude","prefix":" /team/ "}`))
+	if err != nil {
+		t.Fatalf("buildAuthFromFileData: %v", err)
+	}
+	if auth == nil || auth.Prefix != "team" {
+		t.Fatalf("auth = %#v, want hydrated prefix team", auth)
 	}
 }

--- a/internal/api/handlers/management/auth_files_recent_requests_test.go
+++ b/internal/api/handlers/management/auth_files_recent_requests_test.go
@@ -19,6 +19,7 @@ func TestListAuthFiles_IncludesRecentRequestsBuckets(t *testing.T) {
 	record := &coreauth.Auth{
 		ID:       "runtime-only-auth-1",
 		Provider: "codex",
+		Prefix:   "team",
 		Attributes: map[string]string{
 			"runtime_only": "true",
 		},
@@ -66,6 +67,9 @@ func TestListAuthFiles_IncludesRecentRequestsBuckets(t *testing.T) {
 	}
 	if _, ok := fileEntry["failed"].(float64); !ok {
 		t.Fatalf("expected failed number, got %#v", fileEntry["failed"])
+	}
+	if got, _ := fileEntry["prefix"].(string); got != "team" {
+		t.Fatalf("prefix = %q, want team", got)
 	}
 
 	recentRaw, ok := fileEntry["recent_requests"].([]any)

--- a/internal/auth/claude/token.go
+++ b/internal/auth/claude/token.go
@@ -57,7 +57,7 @@ func (ts *ClaudeTokenStorage) SetMetadata(meta map[string]any) {
 //
 // Returns:
 //   - error: An error if the operation fails, nil otherwise
-func (ts *ClaudeTokenStorage) SaveTokenToFile(authFilePath string) error {
+func (ts *ClaudeTokenStorage) SaveTokenToFile(authFilePath string) (err error) {
 	misc.LogSavingCredentials(authFilePath)
 	ts.Type = "claude"
 
@@ -66,13 +66,16 @@ func (ts *ClaudeTokenStorage) SaveTokenToFile(authFilePath string) error {
 		return fmt.Errorf("failed to create directory: %v", err)
 	}
 
-	// Create the token file
-	f, err := os.Create(authFilePath)
+	// Create the token file with owner-only permissions and tighten an
+	// existing file before replacing its contents.
+	f, err := misc.OpenCredentialFile(authFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to create token file: %w", err)
 	}
 	defer func() {
-		_ = f.Close()
+		if errClose := f.Close(); errClose != nil && err == nil {
+			err = fmt.Errorf("failed to close token file: %w", errClose)
+		}
 	}()
 
 	// Merge metadata using helper

--- a/internal/auth/claude/token_permissions_test.go
+++ b/internal/auth/claude/token_permissions_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package claude
 
 import (

--- a/internal/auth/claude/token_permissions_test.go
+++ b/internal/auth/claude/token_permissions_test.go
@@ -1,0 +1,28 @@
+package claude
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveTokenToFileUsesPrivatePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "claude.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("precreate token file: %v", err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("chmod token file: %v", err)
+	}
+
+	if err := (&ClaudeTokenStorage{}).SaveTokenToFile(path); err != nil {
+		t.Fatalf("SaveTokenToFile: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat token file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("mode = %v, want 0600", got)
+	}
+}

--- a/internal/auth/codex/token.go
+++ b/internal/auth/codex/token.go
@@ -53,19 +53,21 @@ func (ts *CodexTokenStorage) SetMetadata(meta map[string]any) {
 //
 // Returns:
 //   - error: An error if the operation fails, nil otherwise
-func (ts *CodexTokenStorage) SaveTokenToFile(authFilePath string) error {
+func (ts *CodexTokenStorage) SaveTokenToFile(authFilePath string) (err error) {
 	misc.LogSavingCredentials(authFilePath)
 	ts.Type = "codex"
 	if err := os.MkdirAll(filepath.Dir(authFilePath), 0700); err != nil {
 		return fmt.Errorf("failed to create directory: %v", err)
 	}
 
-	f, err := os.Create(authFilePath)
+	f, err := misc.OpenCredentialFile(authFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to create token file: %w", err)
 	}
 	defer func() {
-		_ = f.Close()
+		if errClose := f.Close(); errClose != nil && err == nil {
+			err = fmt.Errorf("failed to close token file: %w", errClose)
+		}
 	}()
 
 	// Merge metadata using helper

--- a/internal/auth/codex/token_permissions_test.go
+++ b/internal/auth/codex/token_permissions_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package codex
 
 import (

--- a/internal/auth/codex/token_permissions_test.go
+++ b/internal/auth/codex/token_permissions_test.go
@@ -1,0 +1,28 @@
+package codex
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveTokenToFileUsesPrivatePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "codex.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("precreate token file: %v", err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("chmod token file: %v", err)
+	}
+
+	if err := (&CodexTokenStorage{}).SaveTokenToFile(path); err != nil {
+		t.Fatalf("SaveTokenToFile: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat token file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("mode = %v, want 0600", got)
+	}
+}

--- a/internal/auth/kimi/token.go
+++ b/internal/auth/kimi/token.go
@@ -79,7 +79,7 @@ type DeviceCodeResponse struct {
 }
 
 // SaveTokenToFile serializes the Kimi token storage to a JSON file.
-func (ts *KimiTokenStorage) SaveTokenToFile(authFilePath string) error {
+func (ts *KimiTokenStorage) SaveTokenToFile(authFilePath string) (err error) {
 	misc.LogSavingCredentials(authFilePath)
 	ts.Type = "kimi"
 
@@ -87,12 +87,14 @@ func (ts *KimiTokenStorage) SaveTokenToFile(authFilePath string) error {
 		return fmt.Errorf("failed to create directory: %v", err)
 	}
 
-	f, err := os.Create(authFilePath)
+	f, err := misc.OpenCredentialFile(authFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to create token file: %w", err)
 	}
 	defer func() {
-		_ = f.Close()
+		if errClose := f.Close(); errClose != nil && err == nil {
+			err = fmt.Errorf("failed to close token file: %w", errClose)
+		}
 	}()
 
 	// Merge metadata using helper

--- a/internal/auth/kimi/token_permissions_test.go
+++ b/internal/auth/kimi/token_permissions_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package kimi
 
 import (

--- a/internal/auth/kimi/token_permissions_test.go
+++ b/internal/auth/kimi/token_permissions_test.go
@@ -1,0 +1,28 @@
+package kimi
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveTokenToFileUsesPrivatePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "kimi.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("precreate token file: %v", err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("chmod token file: %v", err)
+	}
+
+	if err := (&KimiTokenStorage{}).SaveTokenToFile(path); err != nil {
+		t.Fatalf("SaveTokenToFile: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat token file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("mode = %v, want 0600", got)
+	}
+}

--- a/internal/auth/vertex/vertex_credentials.go
+++ b/internal/auth/vertex/vertex_credentials.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
-	log "github.com/sirupsen/logrus"
 )
 
 // VertexCredentialStorage stores the service account JSON for Vertex AI access.
@@ -38,7 +37,7 @@ type VertexCredentialStorage struct {
 
 // SaveTokenToFile writes the credential payload to the given file path in JSON format.
 // It ensures the parent directory exists and logs the operation for transparency.
-func (s *VertexCredentialStorage) SaveTokenToFile(authFilePath string) error {
+func (s *VertexCredentialStorage) SaveTokenToFile(authFilePath string) (err error) {
 	misc.LogSavingCredentials(authFilePath)
 	if s == nil {
 		return fmt.Errorf("vertex credential: storage is nil")
@@ -52,13 +51,13 @@ func (s *VertexCredentialStorage) SaveTokenToFile(authFilePath string) error {
 	if err := os.MkdirAll(filepath.Dir(authFilePath), 0o700); err != nil {
 		return fmt.Errorf("vertex credential: create directory failed: %w", err)
 	}
-	f, err := os.Create(authFilePath)
+	f, err := misc.OpenCredentialFile(authFilePath)
 	if err != nil {
 		return fmt.Errorf("vertex credential: create file failed: %w", err)
 	}
 	defer func() {
-		if errClose := f.Close(); errClose != nil {
-			log.Errorf("vertex credential: failed to close file: %v", errClose)
+		if errClose := f.Close(); errClose != nil && err == nil {
+			err = fmt.Errorf("vertex credential: close file failed: %w", errClose)
 		}
 	}()
 	enc := json.NewEncoder(f)

--- a/internal/auth/vertex/vertex_credentials_permissions_test.go
+++ b/internal/auth/vertex/vertex_credentials_permissions_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package vertex
 
 import (

--- a/internal/auth/vertex/vertex_credentials_permissions_test.go
+++ b/internal/auth/vertex/vertex_credentials_permissions_test.go
@@ -1,0 +1,29 @@
+package vertex
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveTokenToFileUsesPrivatePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vertex.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("precreate credential file: %v", err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("chmod credential file: %v", err)
+	}
+
+	storage := &VertexCredentialStorage{ServiceAccount: map[string]any{"project_id": "test"}}
+	if err := storage.SaveTokenToFile(path); err != nil {
+		t.Fatalf("SaveTokenToFile: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat credential file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("mode = %v, want 0600", got)
+	}
+}

--- a/internal/auth/xai/token.go
+++ b/internal/auth/xai/token.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
-	log "github.com/sirupsen/logrus"
 )
 
 // TokenStorage stores xAI OAuth credentials on disk.
@@ -38,20 +37,20 @@ func (ts *TokenStorage) SetMetadata(meta map[string]any) {
 }
 
 // SaveTokenToFile writes xAI credentials to a JSON auth file.
-func (ts *TokenStorage) SaveTokenToFile(authFilePath string) error {
+func (ts *TokenStorage) SaveTokenToFile(authFilePath string) (err error) {
 	misc.LogSavingCredentials(authFilePath)
 	ts.Type = "xai"
 	ts.AuthKind = "oauth"
 	if errMkdirAll := os.MkdirAll(filepath.Dir(authFilePath), 0o700); errMkdirAll != nil {
 		return fmt.Errorf("xai token storage: create directory: %w", errMkdirAll)
 	}
-	file, err := os.Create(authFilePath)
+	file, err := misc.OpenCredentialFile(authFilePath)
 	if err != nil {
 		return fmt.Errorf("xai token storage: create token file: %w", err)
 	}
 	defer func() {
-		if errClose := file.Close(); errClose != nil {
-			log.Errorf("xai token storage: close token file error: %v", errClose)
+		if errClose := file.Close(); errClose != nil && err == nil {
+			err = fmt.Errorf("xai token storage: close token file: %w", errClose)
 		}
 	}()
 

--- a/internal/auth/xai/token_permissions_test.go
+++ b/internal/auth/xai/token_permissions_test.go
@@ -1,0 +1,28 @@
+package xai
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveTokenToFileUsesPrivatePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "xai.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("precreate token file: %v", err)
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("chmod token file: %v", err)
+	}
+
+	if err := (&TokenStorage{}).SaveTokenToFile(path); err != nil {
+		t.Fatalf("SaveTokenToFile: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat token file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("mode = %v, want 0600", got)
+	}
+}

--- a/internal/auth/xai/token_permissions_test.go
+++ b/internal/auth/xai/token_permissions_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package xai
 
 import (

--- a/internal/managementasset/updater.go
+++ b/internal/managementasset/updater.go
@@ -47,6 +47,41 @@ var (
 	sfGroup             singleflight.Group
 )
 
+func isHTTPSGitHubURL(raw string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || !strings.EqualFold(parsed.Scheme, "https") {
+		return false
+	}
+	host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+	return host == "github.com" || host == "api.github.com"
+}
+
+func isGitHubRepositoryReference(raw string) bool {
+	raw = strings.TrimSpace(raw)
+	if strings.HasPrefix(strings.ToLower(raw), "git@github.com:") {
+		return true
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+	return host == "github.com" || host == "api.github.com"
+}
+
+func panelAuthorizationHeader(releaseURL string) string {
+	if !isHTTPSGitHubURL(releaseURL) {
+		return ""
+	}
+	if token := strings.TrimSpace(os.Getenv("CLIPROXYAPI_PANEL_GITHUB_TOKEN")); token != "" {
+		return "Bearer " + token
+	}
+	if token := strings.TrimSpace(os.Getenv("GITSTORE_GIT_TOKEN")); token != "" && isGitHubRepositoryReference(os.Getenv("GITSTORE_GIT_URL")) {
+		return "Bearer " + token
+	}
+	return ""
+}
+
 // SetCurrentConfig stores the latest configuration snapshot for management asset decisions.
 func SetCurrentConfig(cfg *config.Config) {
 	if cfg == nil {
@@ -350,9 +385,8 @@ func fetchLatestAsset(ctx context.Context, client *http.Client, releaseURL strin
 		"Accept":     "application/vnd.github+json",
 		"User-Agent": httpUserAgent,
 	}
-	gitURL := strings.ToLower(strings.TrimSpace(os.Getenv("GITSTORE_GIT_URL")))
-	if tok := strings.TrimSpace(os.Getenv("GITSTORE_GIT_TOKEN")); tok != "" && strings.Contains(gitURL, "github.com") {
-		headers["Authorization"] = "Bearer " + tok
+	if authorization := panelAuthorizationHeader(releaseURL); authorization != "" {
+		headers["Authorization"] = authorization
 	}
 
 	data, err := httpfetch.GetBytes(ctx, client, releaseURL, headers, 0)

--- a/internal/managementasset/updater_test.go
+++ b/internal/managementasset/updater_test.go
@@ -1,10 +1,59 @@
 package managementasset
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 )
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func githubHostRewritingClient(t *testing.T, serverURL string) *http.Client {
+	t.Helper()
+	target, err := url.Parse(serverURL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	return &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		clone := req.Clone(req.Context())
+		clone.URL.Scheme = target.Scheme
+		clone.URL.Host = target.Host
+		return http.DefaultTransport.RoundTrip(clone)
+	})}
+}
+
+func latestReleaseServer(t *testing.T, gotAuth *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(releaseResponse{Assets: []releaseAsset{{
+			Name:               managementAssetName,
+			BrowserDownloadURL: "https://example.test/management.html",
+			Digest:             "sha256:abcd",
+		}}})
+	}))
+}
+
+func githubReleaseURLForTest(t *testing.T, serverURL string) string {
+	t.Helper()
+	releaseURL, err := url.Parse(serverURL)
+	if err != nil {
+		t.Fatalf("parse release URL: %v", err)
+	}
+	releaseURL.Scheme = "https"
+	releaseURL.Host = "api.github.com"
+	return releaseURL.String()
+}
 
 func TestResolveReleaseURLDefaultsToCPAPanelLTS(t *testing.T) {
 	t.Parallel()
@@ -80,5 +129,71 @@ func TestAutoUpdateSkipReason(t *testing.T) {
 				t.Fatalf("autoUpdateSkipReason() = (%q, %t), want (%q, %t)", gotReason, gotSkip, tt.wantReason, tt.wantSkip)
 			}
 		})
+	}
+}
+
+func TestFetchLatestAssetUsesDedicatedPanelToken(t *testing.T) {
+	t.Setenv("CLIPROXYAPI_PANEL_GITHUB_TOKEN", "panel-token")
+	t.Setenv("GITSTORE_GIT_URL", "")
+	t.Setenv("GITSTORE_GIT_TOKEN", "")
+
+	var gotAuth string
+	server := latestReleaseServer(t, &gotAuth)
+	defer server.Close()
+	client := githubHostRewritingClient(t, server.URL)
+	asset, hash, err := fetchLatestAsset(context.Background(), client, githubReleaseURLForTest(t, server.URL))
+	if err != nil {
+		t.Fatalf("fetchLatestAsset returned error: %v", err)
+	}
+	if gotAuth != "Bearer panel-token" {
+		t.Fatalf("Authorization = %q, want dedicated panel token", gotAuth)
+	}
+	if asset == nil || asset.Name != managementAssetName || hash != "abcd" {
+		t.Fatalf("asset/hash = %#v/%q, want management asset/abcd", asset, hash)
+	}
+}
+
+func TestFetchLatestAssetUsesLegacyGitStoreTokenOnlyForGitHub(t *testing.T) {
+	t.Setenv("CLIPROXYAPI_PANEL_GITHUB_TOKEN", "")
+	t.Setenv("GITSTORE_GIT_URL", "https://github.com/example/private-config.git")
+	t.Setenv("GITSTORE_GIT_TOKEN", "legacy-token")
+
+	var gotAuth string
+	server := latestReleaseServer(t, &gotAuth)
+	defer server.Close()
+	client := githubHostRewritingClient(t, server.URL)
+	if _, _, err := fetchLatestAsset(context.Background(), client, githubReleaseURLForTest(t, server.URL)); err != nil {
+		t.Fatalf("fetchLatestAsset returned error: %v", err)
+	}
+	if gotAuth != "Bearer legacy-token" {
+		t.Fatalf("Authorization = %q, want legacy GitStore token", gotAuth)
+	}
+}
+
+func TestPanelAuthorizationHeaderKeepsLegacySSHGitHubCompatibility(t *testing.T) {
+	t.Setenv("CLIPROXYAPI_PANEL_GITHUB_TOKEN", "")
+	t.Setenv("GITSTORE_GIT_URL", "git@github.com:example/private-config.git")
+	t.Setenv("GITSTORE_GIT_TOKEN", "legacy-token")
+	if got := panelAuthorizationHeader("https://api.github.com/repos/example/panel/releases/latest"); got != "Bearer legacy-token" {
+		t.Fatalf("panelAuthorizationHeader() = %q, want legacy token for SSH GitHub repository", got)
+	}
+}
+
+func TestFetchLatestAssetDoesNotSendTokensToNonGitHubHosts(t *testing.T) {
+	t.Setenv("CLIPROXYAPI_PANEL_GITHUB_TOKEN", "panel-token")
+	t.Setenv("GITSTORE_GIT_URL", "https://github.com/example/private-config.git")
+	t.Setenv("GITSTORE_GIT_TOKEN", "legacy-token")
+
+	var gotAuth string
+	server := latestReleaseServer(t, &gotAuth)
+	defer server.Close()
+	if _, _, err := fetchLatestAsset(context.Background(), server.Client(), server.URL); err != nil {
+		t.Fatalf("fetchLatestAsset returned error: %v", err)
+	}
+	if gotAuth != "" {
+		t.Fatalf("Authorization = %q, want empty for non-GitHub host", gotAuth)
+	}
+	if isHTTPSGitHubURL("https://api.github.com.evil.example/releases/latest") {
+		t.Fatal("lookalike GitHub hostname accepted")
 	}
 }

--- a/internal/misc/credential_file.go
+++ b/internal/misc/credential_file.go
@@ -2,14 +2,14 @@ package misc
 
 import "os"
 
-// OpenCredentialFile opens a credential file for replacement and enforces
-// owner-only permissions on both new and pre-existing files.
+// OpenCredentialFile opens a credential file for replacement and restricts it
+// to the current OS user before truncating any pre-existing contents.
 func OpenCredentialFile(path string) (*os.File, error) {
-	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0o600)
+	file, err := openCredentialFile(path)
 	if err != nil {
 		return nil, err
 	}
-	if err = file.Chmod(0o600); err != nil {
+	if err = restrictCredentialFile(file); err != nil {
 		_ = file.Close()
 		return nil, err
 	}

--- a/internal/misc/credential_file.go
+++ b/internal/misc/credential_file.go
@@ -1,0 +1,21 @@
+package misc
+
+import "os"
+
+// OpenCredentialFile opens a credential file for replacement and enforces
+// owner-only permissions on both new and pre-existing files.
+func OpenCredentialFile(path string) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err = file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	if err = file.Truncate(0); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return file, nil
+}

--- a/internal/misc/credential_file_posix.go
+++ b/internal/misc/credential_file_posix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package misc
+
+import "os"
+
+func openCredentialFile(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0o600)
+}
+
+func restrictCredentialFile(file *os.File) error {
+	return file.Chmod(0o600)
+}

--- a/internal/misc/credential_file_posix_test.go
+++ b/internal/misc/credential_file_posix_test.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package misc
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpenCredentialFileRestrictsAccessToCurrentUser(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "credential.json")
+	if err := os.WriteFile(path, []byte("sensitive"), 0o644); err != nil {
+		t.Fatalf("write existing credential: %v", err)
+	}
+	file, err := OpenCredentialFile(path)
+	if err != nil {
+		t.Fatalf("OpenCredentialFile: %v", err)
+	}
+	if err = file.Close(); err != nil {
+		t.Fatalf("close credential: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat credential: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("credential permissions = %04o, want 0600", got)
+	}
+}

--- a/internal/misc/credential_file_windows.go
+++ b/internal/misc/credential_file_windows.go
@@ -1,0 +1,93 @@
+//go:build windows
+
+package misc
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+func openCredentialFile(path string) (*os.File, error) {
+	pathPtr, err := windows.UTF16PtrFromString(credentialFileWindowsPath(path))
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	handle, err := windows.CreateFile(
+		pathPtr,
+		windows.GENERIC_WRITE|windows.WRITE_DAC|windows.READ_CONTROL,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil,
+		windows.OPEN_ALWAYS,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+	file := os.NewFile(uintptr(handle), path)
+	if file == nil {
+		_ = windows.CloseHandle(handle)
+		return nil, &os.PathError{Op: "open", Path: path, Err: windows.ERROR_INVALID_HANDLE}
+	}
+	return file, nil
+}
+
+func credentialFileWindowsPath(path string) string {
+	if len(path) >= 4 {
+		if strings.HasPrefix(path, `\??\`) || (isWindowsPathSeparator(path[0]) && isWindowsPathSeparator(path[1]) && path[2] == '?' && isWindowsPathSeparator(path[3])) {
+			return path
+		}
+		if isWindowsPathSeparator(path[0]) && isWindowsPathSeparator(path[1]) && path[2] == '.' && isWindowsPathSeparator(path[3]) {
+			return path
+		}
+	}
+	fullPath, err := windows.FullPath(path)
+	if err != nil || len(fullPath) < 248 {
+		return path
+	}
+	if len(fullPath) >= 2 && isWindowsPathSeparator(fullPath[0]) && isWindowsPathSeparator(fullPath[1]) {
+		return `\\?\UNC\` + strings.TrimLeft(fullPath, `\/`)
+	}
+	return `\\?\` + fullPath
+}
+
+func isWindowsPathSeparator(char byte) bool {
+	return char == '\\' || char == '/'
+}
+
+func restrictCredentialFile(file *os.File) error {
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		return fmt.Errorf("get current user SID: %w", err)
+	}
+	sid := user.User.Sid
+	if sid == nil || sid.String() == "" {
+		return fmt.Errorf("get current user SID: empty SID")
+	}
+	securityDescriptor, err := windows.SecurityDescriptorFromString("D:P(A;;FA;;;" + sid.String() + ")")
+	if err != nil {
+		return fmt.Errorf("build credential DACL: %w", err)
+	}
+	dacl, _, err := securityDescriptor.DACL()
+	if err != nil {
+		return fmt.Errorf("read credential DACL: %w", err)
+	}
+	err = windows.SetSecurityInfo(
+		windows.Handle(file.Fd()),
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		dacl,
+		nil,
+	)
+	runtime.KeepAlive(securityDescriptor)
+	if err != nil {
+		return fmt.Errorf("apply credential DACL: %w", err)
+	}
+	return nil
+}

--- a/internal/misc/credential_file_windows_test.go
+++ b/internal/misc/credential_file_windows_test.go
@@ -1,0 +1,125 @@
+//go:build windows
+
+package misc
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestOpenCredentialFileRestrictsAccessToCurrentUser(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing bool
+	}{
+		{name: "new file"},
+		{name: "existing wide file", existing: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "credential.json")
+			if tt.existing {
+				if err := os.WriteFile(path, []byte("sensitive"), 0o666); err != nil {
+					t.Fatalf("write existing credential: %v", err)
+				}
+				wideDescriptor, err := windows.SecurityDescriptorFromString("D:AI(A;;GA;;;WD)")
+				if err != nil {
+					t.Fatalf("build wide DACL: %v", err)
+				}
+				wideDACL, _, err := wideDescriptor.DACL()
+				if err != nil {
+					t.Fatalf("read wide DACL: %v", err)
+				}
+				if err = windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION, nil, nil, wideDACL, nil); err != nil {
+					t.Fatalf("apply wide DACL: %v", err)
+				}
+			}
+
+			file, err := OpenCredentialFile(path)
+			if err != nil {
+				t.Fatalf("OpenCredentialFile: %v", err)
+			}
+			defer file.Close()
+
+			assertCredentialFileDACL(t, file)
+			info, err := file.Stat()
+			if err != nil {
+				t.Fatalf("stat opened credential: %v", err)
+			}
+			if info.Size() != 0 {
+				t.Fatalf("credential size = %d, want 0 after secure truncate", info.Size())
+			}
+			if _, err = file.Write([]byte("{}")); err != nil {
+				t.Fatalf("write credential: %v", err)
+			}
+			if _, err = os.Stat(path); err != nil {
+				t.Fatalf("stat credential: %v", err)
+			}
+		})
+	}
+	t.Run("long path", func(t *testing.T) {
+		dir := t.TempDir()
+		for len(filepath.Join(dir, "credential.json")) < 280 {
+			dir = filepath.Join(dir, strings.Repeat("segment", 4))
+		}
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("create long credential directory: %v", err)
+		}
+		path := filepath.Join(dir, "credential.json")
+		file, err := OpenCredentialFile(path)
+		if err != nil {
+			t.Fatalf("OpenCredentialFile long path: %v", err)
+		}
+		defer file.Close()
+		assertCredentialFileDACL(t, file)
+		if _, err = file.Write([]byte("{}")); err != nil {
+			t.Fatalf("write long-path credential: %v", err)
+		}
+	})
+}
+
+func assertCredentialFileDACL(t *testing.T, file *os.File) {
+	t.Helper()
+	securityDescriptor, err := windows.GetSecurityInfo(
+		windows.Handle(file.Fd()),
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION,
+	)
+	if err != nil {
+		t.Fatalf("GetSecurityInfo: %v", err)
+	}
+	control, _, err := securityDescriptor.Control()
+	if err != nil {
+		t.Fatalf("security descriptor control: %v", err)
+	}
+	if control&windows.SE_DACL_PROTECTED == 0 {
+		t.Fatalf("DACL is not protected: control=%#x", control)
+	}
+	dacl, _, err := securityDescriptor.DACL()
+	if err != nil {
+		t.Fatalf("DACL: %v", err)
+	}
+	if dacl == nil || dacl.AceCount != 1 {
+		t.Fatalf("DACL ACE count = %v, want 1", dacl)
+	}
+	var ace *windows.ACCESS_ALLOWED_ACE
+	if err = windows.GetAce(dacl, 0, &ace); err != nil {
+		t.Fatalf("GetAce: %v", err)
+	}
+	if ace == nil || ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE {
+		t.Fatalf("ACE = %#v, want access-allowed ACE", ace)
+	}
+	currentUser, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		t.Fatalf("GetTokenUser: %v", err)
+	}
+	aceSID := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+	if !aceSID.Equals(currentUser.User.Sid) {
+		t.Fatalf("ACE SID = %s, want current user %s", aceSID.String(), currentUser.User.Sid.String())
+	}
+}

--- a/internal/store/auth_metadata_test.go
+++ b/internal/store/auth_metadata_test.go
@@ -39,10 +39,10 @@ func TestApplyDisabledMetadataMarksAuthDisabled(t *testing.T) {
 	}
 }
 
-func TestGitTokenStoreReadAuthFileUsesDisabledMetadata(t *testing.T) {
+func TestGitTokenStoreReadAuthFileHydratesMetadata(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "disabled.json")
-	if err := os.WriteFile(path, []byte(`{"type":"test","email":"u@example.com","disabled":true}`), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(`{"type":"test","email":"u@example.com","prefix":" /team/ ","disabled":true}`), 0o600); err != nil {
 		t.Fatalf("write auth file: %v", err)
 	}
 
@@ -52,12 +52,15 @@ func TestGitTokenStoreReadAuthFileUsesDisabledMetadata(t *testing.T) {
 		t.Fatalf("readAuthFile() error: %v", err)
 	}
 	assertDisabledAuth(t, auth)
+	if auth.Prefix != "team" {
+		t.Fatalf("Prefix=%q, want team", auth.Prefix)
+	}
 }
 
-func TestObjectTokenStoreReadAuthFileUsesDisabledMetadata(t *testing.T) {
+func TestObjectTokenStoreReadAuthFileHydratesMetadata(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "disabled.json")
-	if err := os.WriteFile(path, []byte(`{"type":"test","email":"u@example.com","disabled":true}`), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(`{"type":"test","email":"u@example.com","prefix":" /team/ ","disabled":true}`), 0o600); err != nil {
 		t.Fatalf("write auth file: %v", err)
 	}
 
@@ -67,6 +70,9 @@ func TestObjectTokenStoreReadAuthFileUsesDisabledMetadata(t *testing.T) {
 		t.Fatalf("readAuthFile() error: %v", err)
 	}
 	assertDisabledAuth(t, auth)
+	if auth.Prefix != "team" {
+		t.Fatalf("Prefix=%q, want team", auth.Prefix)
+	}
 }
 
 func assertDisabledAuth(t *testing.T, auth *cliproxyauth.Auth) {

--- a/internal/store/gitstore.go
+++ b/internal/store/gitstore.go
@@ -373,7 +373,7 @@ func (s *GitTokenStore) List(_ context.Context) ([]*cliproxyauth.Auth, error) {
 		}
 		auth, err := s.readAuthFile(path, dir)
 		if err != nil {
-			return nil
+			return fmt.Errorf("auth gitstore: read auth file %q: %w", path, err)
 		}
 		if auth != nil {
 			entries = append(entries, auth)
@@ -505,11 +505,7 @@ func (s *GitTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth, 
 	if email, ok := metadata["email"].(string); ok && email != "" {
 		auth.Attributes["email"] = email
 	}
-	cliproxyauth.ApplyCustomHeadersFromMetadata(auth)
-	if disabled, ok := metadata["disabled"].(bool); ok && disabled {
-		auth.Disabled = true
-		auth.Status = cliproxyauth.StatusDisabled
-	}
+	cliproxyauth.HydrateAuthFromMetadata(auth)
 	return auth, nil
 }
 

--- a/internal/store/gitstore_test.go
+++ b/internal/store/gitstore_test.go
@@ -1,10 +1,12 @@
 package store
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +19,38 @@ import (
 type testBranchSpec struct {
 	name     string
 	contents string
+}
+
+func TestGitTokenStoreListReturnsAuthFileErrors(t *testing.T) {
+	root := t.TempDir()
+	remoteDir := setupGitRemoteRepository(t, root, "main",
+		testBranchSpec{name: "main", contents: "remote default branch\n"},
+	)
+	authDir := filepath.Join(root, "workspace", "auths")
+	store := NewGitTokenStore(remoteDir, "", "", "")
+	store.SetBaseDir(authDir)
+
+	if err := store.EnsureRepository(); err != nil {
+		t.Fatalf("EnsureRepository: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(authDir, "valid.json"), []byte(`{"type":"custom"}`), 0o600); err != nil {
+		t.Fatalf("write valid auth: %v", err)
+	}
+	brokenPath := filepath.Join(authDir, "broken.json")
+	if err := os.WriteFile(brokenPath, []byte(`{"type":`), 0o600); err != nil {
+		t.Fatalf("write broken auth: %v", err)
+	}
+
+	entries, err := store.List(context.Background())
+	if err == nil {
+		t.Fatal("List succeeded, want error for broken auth file")
+	}
+	if entries != nil {
+		t.Fatalf("entries = %#v, want nil on error", entries)
+	}
+	if !strings.Contains(err.Error(), brokenPath) {
+		t.Fatalf("error = %q, want broken file path", err.Error())
+	}
 }
 
 func TestEnsureRepositoryUsesRemoteDefaultBranchWhenBranchNotConfigured(t *testing.T) {

--- a/internal/store/objectstore.go
+++ b/internal/store/objectstore.go
@@ -450,7 +450,7 @@ func (s *ObjectTokenStore) uploadAuth(ctx context.Context, path string) error {
 	if path == "" {
 		return nil
 	}
-	rel, err := filepath.Rel(s.authDir, path)
+	rel, err := s.authRelativePath(path)
 	if err != nil {
 		return fmt.Errorf("object store: resolve auth relative path: %w", err)
 	}
@@ -472,7 +472,7 @@ func (s *ObjectTokenStore) deleteAuthObject(ctx context.Context, path string) er
 	if path == "" {
 		return nil
 	}
-	rel, err := filepath.Rel(s.authDir, path)
+	rel, err := s.authRelativePath(path)
 	if err != nil {
 		return fmt.Errorf("object store: resolve auth relative path: %w", err)
 	}
@@ -520,11 +520,8 @@ func (s *ObjectTokenStore) resolveAuthPath(auth *cliproxyauth.Auth) (string, err
 		return "", fmt.Errorf("object store: auth is nil")
 	}
 	if auth.Attributes != nil {
-		if path := strings.TrimSpace(auth.Attributes["path"]); path != "" {
-			if filepath.IsAbs(path) {
-				return path, nil
-			}
-			return filepath.Join(s.authDir, path), nil
+		if path := strings.TrimSpace(auth.Attributes[cliproxyauth.AttributePath]); path != "" {
+			return s.authPath(path)
 		}
 	}
 	fileName := strings.TrimSpace(auth.FileName)
@@ -537,7 +534,7 @@ func (s *ObjectTokenStore) resolveAuthPath(auth *cliproxyauth.Auth) (string, err
 	if !strings.HasSuffix(strings.ToLower(fileName), ".json") {
 		fileName += ".json"
 	}
-	return filepath.Join(s.authDir, fileName), nil
+	return s.authPath(fileName)
 }
 
 func (s *ObjectTokenStore) resolveDeletePath(id string) (string, error) {
@@ -545,9 +542,8 @@ func (s *ObjectTokenStore) resolveDeletePath(id string) (string, error) {
 	if id == "" {
 		return "", fmt.Errorf("object store: id is empty")
 	}
-	// Absolute paths are honored as-is; callers must ensure they point inside the mirror.
 	if filepath.IsAbs(id) {
-		return id, nil
+		return s.authPath(id)
 	}
 	// Treat any non-absolute id (including nested like "team/foo") as relative to the mirror authDir.
 	// Normalize separators and guard against path traversal.
@@ -559,7 +555,76 @@ func (s *ObjectTokenStore) resolveDeletePath(id string) (string, error) {
 	if !strings.HasSuffix(strings.ToLower(clean), ".json") {
 		clean += ".json"
 	}
-	return filepath.Join(s.authDir, clean), nil
+	return s.authPath(clean)
+}
+
+func (s *ObjectTokenStore) authPath(path string) (string, error) {
+	if s == nil || strings.TrimSpace(s.authDir) == "" {
+		return "", fmt.Errorf("object store: auth directory not configured")
+	}
+	candidate := path
+	if !filepath.IsAbs(candidate) {
+		candidate = filepath.Join(s.authDir, filepath.FromSlash(candidate))
+	}
+	rel, err := s.authRelativePath(candidate)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(s.authDir, rel), nil
+}
+
+func (s *ObjectTokenStore) authRelativePath(path string) (string, error) {
+	if s == nil || strings.TrimSpace(s.authDir) == "" {
+		return "", fmt.Errorf("object store: auth directory not configured")
+	}
+	authDir, err := filepath.Abs(s.authDir)
+	if err != nil {
+		return "", err
+	}
+	authPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(authDir, authPath)
+	if err != nil {
+		return "", err
+	}
+	if rel == "." || rel == ".." || filepath.IsAbs(rel) || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("auth path %q escapes auth directory", path)
+	}
+	if err = ensureResolvedPathWithin(authDir, authPath); err != nil {
+		return "", err
+	}
+	return rel, nil
+}
+
+func ensureResolvedPathWithin(baseDir, path string) error {
+	resolvedBase, err := filepath.EvalSymlinks(baseDir)
+	if err != nil {
+		return fmt.Errorf("resolve auth directory: %w", err)
+	}
+	current := path
+	for {
+		resolvedCurrent, errResolve := filepath.EvalSymlinks(current)
+		if errResolve == nil {
+			rel, errRel := filepath.Rel(resolvedBase, resolvedCurrent)
+			if errRel != nil {
+				return errRel
+			}
+			if rel == ".." || filepath.IsAbs(rel) || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+				return fmt.Errorf("auth path %q resolves outside auth directory", path)
+			}
+			return nil
+		}
+		if !errors.Is(errResolve, fs.ErrNotExist) {
+			return fmt.Errorf("resolve auth path %q: %w", path, errResolve)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return fmt.Errorf("resolve auth path %q: no existing parent", path)
+		}
+		current = parent
+	}
 }
 
 func (s *ObjectTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth, error) {
@@ -607,11 +672,7 @@ func (s *ObjectTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Aut
 		LastRefreshedAt:  time.Time{},
 		NextRefreshAfter: time.Time{},
 	}
-	cliproxyauth.ApplyCustomHeadersFromMetadata(auth)
-	if disabled, ok := metadata["disabled"].(bool); ok && disabled {
-		auth.Disabled = true
-		auth.Status = cliproxyauth.StatusDisabled
-	}
+	cliproxyauth.HydrateAuthFromMetadata(auth)
 	return auth, nil
 }
 

--- a/internal/store/objectstore.go
+++ b/internal/store/objectstore.go
@@ -599,6 +599,9 @@ func (s *ObjectTokenStore) authRelativePath(path string) (string, error) {
 }
 
 func ensureResolvedPathWithin(baseDir, path string) error {
+	// authDir is created with 0700 permissions. This rejects pre-existing
+	// symlink escapes; descriptor-relative no-follow I/O would be required to
+	// defend against a malicious same-user process swapping entries afterward.
 	resolvedBase, err := filepath.EvalSymlinks(baseDir)
 	if err != nil {
 		return fmt.Errorf("resolve auth directory: %w", err)

--- a/internal/store/objectstore_path_test.go
+++ b/internal/store/objectstore_path_test.go
@@ -1,0 +1,98 @@
+package store
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestObjectTokenStoreRejectsAuthPathsOutsideAuthDir(t *testing.T) {
+	authDir := t.TempDir()
+	outsideDir := t.TempDir()
+	outsidePath := filepath.Join(outsideDir, "token.json")
+	if err := os.WriteFile(outsidePath, []byte(`{"type":"codex"}`), 0o600); err != nil {
+		t.Fatalf("write outside auth: %v", err)
+	}
+	store := &ObjectTokenStore{authDir: authDir}
+
+	checks := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "absolute attribute path",
+			call: func() error {
+				_, err := store.resolveAuthPath(&cliproxyauth.Auth{
+					ID:         "outside",
+					Attributes: map[string]string{cliproxyauth.AttributePath: outsidePath},
+				})
+				return err
+			},
+		},
+		{
+			name: "filename traversal",
+			call: func() error {
+				_, err := store.resolveAuthPath(&cliproxyauth.Auth{ID: "traversal", FileName: "../token.json"})
+				return err
+			},
+		},
+		{
+			name: "absolute delete path",
+			call: func() error {
+				_, err := store.resolveDeletePath(outsidePath)
+				return err
+			},
+		},
+		{name: "upload", call: func() error { return store.uploadAuth(context.Background(), outsidePath) }},
+		{name: "remote delete", call: func() error { return store.deleteAuthObject(context.Background(), outsidePath) }},
+		{name: "persist files", call: func() error { return store.PersistAuthFiles(context.Background(), "", outsidePath) }},
+	}
+
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			if err := check.call(); err == nil {
+				t.Fatal("accepted auth path outside auth directory")
+			}
+		})
+	}
+}
+
+func TestObjectTokenStoreAcceptsNestedAuthPathInsideAuthDir(t *testing.T) {
+	authDir := t.TempDir()
+	store := &ObjectTokenStore{authDir: authDir}
+
+	got, err := store.resolveAuthPath(&cliproxyauth.Auth{ID: "nested", FileName: "team/token"})
+	if err != nil {
+		t.Fatalf("resolveAuthPath returned error: %v", err)
+	}
+	want := filepath.Join(authDir, "team", "token.json")
+	if got != want {
+		t.Fatalf("resolveAuthPath = %q, want %q", got, want)
+	}
+}
+
+func TestObjectTokenStoreRejectsSiblingPrefixAndSymlinkEscapes(t *testing.T) {
+	root := t.TempDir()
+	authDir := filepath.Join(root, "auths")
+	if err := os.MkdirAll(authDir, 0o700); err != nil {
+		t.Fatalf("create auth dir: %v", err)
+	}
+	store := &ObjectTokenStore{authDir: authDir}
+
+	siblingPath := filepath.Join(root, "auths-other", "token.json")
+	if _, err := store.resolveDeletePath(siblingPath); err == nil {
+		t.Fatal("accepted sibling path sharing the auth directory prefix")
+	}
+
+	outsideDir := t.TempDir()
+	linkPath := filepath.Join(authDir, "escape")
+	if err := os.Symlink(outsideDir, linkPath); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if _, err := store.resolveAuthPath(&cliproxyauth.Auth{ID: "symlink", FileName: "escape/token.json"}); err == nil {
+		t.Fatal("accepted auth path through symlink outside auth directory")
+	}
+}

--- a/internal/store/postgresstore.go
+++ b/internal/store/postgresstore.go
@@ -322,11 +322,7 @@ func (s *PostgresStore) List(ctx context.Context) ([]*cliproxyauth.Auth, error) 
 			LastRefreshedAt:  time.Time{},
 			NextRefreshAfter: time.Time{},
 		}
-		cliproxyauth.ApplyCustomHeadersFromMetadata(auth)
-		if disabled, ok := metadata["disabled"].(bool); ok && disabled {
-			auth.Disabled = true
-			auth.Status = cliproxyauth.StatusDisabled
-		}
+		cliproxyauth.HydrateAuthFromMetadata(auth)
 		auths = append(auths, auth)
 	}
 	if err = rows.Err(); err != nil {

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -13,6 +13,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+	log "github.com/sirupsen/logrus"
 )
 
 // FileSynthesizer generates Auth entries from OAuth JSON files.
@@ -87,7 +88,11 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 			FileName: filepath.Base(fullPath),
 			RawJSON:  data,
 		})
-		if errParse == nil && handled {
+		if errParse != nil {
+			log.WithField("file", filepath.Base(fullPath)).Warn("plugin auth parser failed; retaining no synthesized fallback")
+			return nil
+		}
+		if handled {
 			auths = compactPluginAuths(auths)
 			if len(auths) == 0 {
 				return nil

--- a/internal/watcher/synthesizer/file_test.go
+++ b/internal/watcher/synthesizer/file_test.go
@@ -3,6 +3,7 @@ package synthesizer
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -322,6 +323,22 @@ func TestFileSynthesizer_Synthesize_SkipsInvalidFiles(t *testing.T) {
 	}
 	if auths[0].Label != "valid@example.com" {
 		t.Errorf("expected label valid@example.com, got %s", auths[0].Label)
+	}
+}
+
+func TestSynthesizeAuthFilePluginParserErrorDoesNotFallback(t *testing.T) {
+	ctx := &SynthesisContext{
+		Config:      &config.Config{},
+		AuthDir:     t.TempDir(),
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+		PluginAuthParser: multiAuthParserFunc(func(context.Context, pluginapi.AuthParseRequest) ([]*coreauth.Auth, bool, error) {
+			return nil, true, errors.New("plugin parse failed")
+		}),
+	}
+	auths := SynthesizeAuthFile(ctx, filepath.Join(ctx.AuthDir, "plugin.json"), []byte(`{"type":"plugin-provider"}`))
+	if len(auths) != 0 {
+		t.Fatalf("SynthesizeAuthFile() = %#v, want no generic fallback", auths)
 	}
 }
 

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -181,7 +181,7 @@ func (s *FileTokenStore) List(ctx context.Context) ([]*cliproxyauth.Auth, error)
 		}
 		auths, errReadAuths := s.readAuthFiles(path, dir)
 		if errReadAuths != nil {
-			return nil
+			return fmt.Errorf("auth filestore: read auth file %q: %w", path, errReadAuths)
 		}
 		if len(auths) > 0 {
 			entries = append(entries, auths...)
@@ -338,7 +338,7 @@ func (s *FileTokenStore) readAuthFiles(path, baseDir string) ([]*cliproxyauth.Au
 	if email, ok := metadata["email"].(string); ok && email != "" {
 		auth.Attributes["email"] = email
 	}
-	cliproxyauth.ApplyCustomHeadersFromMetadata(auth)
+	cliproxyauth.HydrateAuthFromMetadata(auth)
 	return []*cliproxyauth.Auth{auth}, nil
 }
 

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -249,7 +249,10 @@ func (s *FileTokenStore) readAuthFiles(path, baseDir string) ([]*cliproxyauth.Au
 			FileName: s.idFor(path, baseDir),
 			RawJSON:  data,
 		})
-		if errParse == nil && handled {
+		if errParse != nil {
+			return nil, fmt.Errorf("parse plugin auth: %w", errParse)
+		}
+		if handled {
 			auths = compactPluginAuths(auths)
 			if len(auths) == 0 {
 				return nil, nil

--- a/sdk/auth/filestore_disabled_test.go
+++ b/sdk/auth/filestore_disabled_test.go
@@ -62,3 +62,37 @@ func TestFileTokenStore_Save_DisabledPersistsFlagForTokenStorage(t *testing.T) {
 		t.Fatalf("disabled=%v, want true (raw=%s)", meta["disabled"], string(raw))
 	}
 }
+
+func TestFileTokenStoreListHydratesMetadataFields(t *testing.T) {
+	baseDir := t.TempDir()
+	path := filepath.Join(baseDir, "team.json")
+	raw := []byte(`{
+		"type":"claude",
+		"prefix":" /team/ ",
+		"disabled":true,
+		"headers":{"X-Team":"blue"}
+	}`)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("seed auth file: %v", err)
+	}
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(baseDir)
+	auths, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("List() returned %d auths, want 1", len(auths))
+	}
+	auth := auths[0]
+	if auth.Prefix != "team" {
+		t.Fatalf("Prefix = %q, want team", auth.Prefix)
+	}
+	if !auth.Disabled || auth.Status != cliproxyauth.StatusDisabled {
+		t.Fatalf("Disabled/Status = %v/%q, want true/%q", auth.Disabled, auth.Status, cliproxyauth.StatusDisabled)
+	}
+	if got := auth.Attributes["header:X-Team"]; got != "blue" {
+		t.Fatalf("header:X-Team = %q, want blue", got)
+	}
+}

--- a/sdk/auth/filestore_test.go
+++ b/sdk/auth/filestore_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -84,6 +85,30 @@ func TestExtractAccessToken(t *testing.T) {
 				t.Errorf("extractAccessToken() = %q, want %q", got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestFileTokenStoreListReturnsAuthFileErrors(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "valid.json"), []byte(`{"type":"custom"}`), 0o600); err != nil {
+		t.Fatalf("write valid auth: %v", err)
+	}
+	brokenPath := filepath.Join(dir, "broken.json")
+	if err := os.WriteFile(brokenPath, []byte(`{"type":`), 0o600); err != nil {
+		t.Fatalf("write broken auth: %v", err)
+	}
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(dir)
+	entries, err := store.List(context.Background())
+	if err == nil {
+		t.Fatal("List succeeded, want error for broken auth file")
+	}
+	if entries != nil {
+		t.Fatalf("entries = %#v, want nil on error", entries)
+	}
+	if !strings.Contains(err.Error(), brokenPath) {
+		t.Fatalf("error = %q, want broken file path", err.Error())
 	}
 }
 

--- a/sdk/auth/filestore_test.go
+++ b/sdk/auth/filestore_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -241,6 +242,55 @@ func TestFileTokenStoreListPluginHandledEmptySuppressesBuiltin(t *testing.T) {
 	}
 	if len(auths) != 0 {
 		t.Fatalf("List() len = %d, want plugin-handled empty result", len(auths))
+	}
+}
+
+func TestFileTokenStoreListReturnsPluginParserErrors(t *testing.T) {
+	baseDir := t.TempDir()
+	path := filepath.Join(baseDir, "plugin.json")
+	if err := os.WriteFile(path, []byte(`{"type":"plugin-provider"}`), 0o600); err != nil {
+		t.Fatalf("write auth file: %v", err)
+	}
+
+	RegisterPluginAuthParser(fileStoreMultiAuthParserFunc(func(context.Context, pluginapi.AuthParseRequest) ([]*cliproxyauth.Auth, bool, error) {
+		return nil, true, errors.New("plugin parse failed")
+	}))
+	t.Cleanup(func() { RegisterPluginAuthParser(nil) })
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(baseDir)
+	auths, err := store.List(context.Background())
+	if err == nil {
+		t.Fatal("List succeeded, want plugin parser error")
+	}
+	if auths != nil {
+		t.Fatalf("auths = %#v, want nil on parser error", auths)
+	}
+	if !strings.Contains(err.Error(), "plugin parse failed") || !strings.Contains(err.Error(), path) {
+		t.Fatalf("error = %q, want parser error and file path", err.Error())
+	}
+}
+
+func TestFileTokenStorePluginAuthOwnsPrefix(t *testing.T) {
+	baseDir := t.TempDir()
+	path := filepath.Join(baseDir, "plugin.json")
+	if err := os.WriteFile(path, []byte(`{"type":"plugin-provider","prefix":"source-prefix"}`), 0o600); err != nil {
+		t.Fatalf("write auth file: %v", err)
+	}
+
+	RegisterPluginAuthParser(fileStoreMultiAuthParserFunc(func(context.Context, pluginapi.AuthParseRequest) ([]*cliproxyauth.Auth, bool, error) {
+		return []*cliproxyauth.Auth{{ID: "plugin.json", Provider: "plugin-provider", Prefix: "plugin-prefix"}}, true, nil
+	}))
+	t.Cleanup(func() { RegisterPluginAuthParser(nil) })
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(baseDir)
+	auths, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+	if len(auths) != 1 || auths[0].Prefix != "plugin-prefix" {
+		t.Fatalf("auths = %#v, want plugin-owned prefix", auths)
 	}
 }
 

--- a/sdk/cliproxy/auth/metadata_hydrate.go
+++ b/sdk/cliproxy/auth/metadata_hydrate.go
@@ -1,0 +1,29 @@
+package auth
+
+import "strings"
+
+// NormalizeAuthPrefix applies the same single-segment prefix rules used by
+// auth-file synthesis.
+func NormalizeAuthPrefix(raw string) string {
+	trimmed := strings.Trim(strings.TrimSpace(raw), "/")
+	if trimmed == "" || strings.Contains(trimmed, "/") {
+		return ""
+	}
+	return trimmed
+}
+
+// HydrateAuthFromMetadata applies typed runtime fields mirrored in Metadata.
+// Store backends call this after constructing an Auth from persisted JSON.
+func HydrateAuthFromMetadata(auth *Auth) {
+	if auth == nil || len(auth.Metadata) == 0 {
+		return
+	}
+	if rawPrefix, ok := auth.Metadata["prefix"].(string); ok {
+		auth.Prefix = NormalizeAuthPrefix(rawPrefix)
+	}
+	ApplyCustomHeadersFromMetadata(auth)
+	if disabled, ok := auth.Metadata["disabled"].(bool); ok && disabled {
+		auth.Disabled = true
+		auth.Status = StatusDisabled
+	}
+}

--- a/sdk/cliproxy/auth/metadata_hydrate_test.go
+++ b/sdk/cliproxy/auth/metadata_hydrate_test.go
@@ -1,0 +1,50 @@
+package auth
+
+import "testing"
+
+func TestNormalizeAuthPrefix(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "empty"},
+		{name: "simple", raw: "team", want: "team"},
+		{name: "spaces and slashes", raw: " /team/ ", want: "team"},
+		{name: "nested rejected", raw: "team/child"},
+		{name: "slash only", raw: "///"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeAuthPrefix(tt.raw); got != tt.want {
+				t.Fatalf("NormalizeAuthPrefix(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHydrateAuthFromMetadata(t *testing.T) {
+	auth := &Auth{
+		Status:     StatusActive,
+		Attributes: map[string]string{},
+		Metadata: map[string]any{
+			"prefix":   " /team/ ",
+			"disabled": true,
+			"headers":  map[string]any{"X-Team": "blue"},
+		},
+	}
+	HydrateAuthFromMetadata(auth)
+	if auth.Prefix != "team" {
+		t.Fatalf("Prefix = %q, want team", auth.Prefix)
+	}
+	if !auth.Disabled || auth.Status != StatusDisabled {
+		t.Fatalf("Disabled/Status = %v/%q, want true/%q", auth.Disabled, auth.Status, StatusDisabled)
+	}
+	if got := auth.Attributes["header:X-Team"]; got != "blue" {
+		t.Fatalf("header:X-Team = %q, want blue", got)
+	}
+}
+
+func TestHydrateAuthFromMetadataNilAuth(t *testing.T) {
+	HydrateAuthFromMetadata(nil)
+}


### PR DESCRIPTION
## 结果与边界

修复五组仍存在于当前 `main` 的 auth/storage 安全与一致性缺口：object-store auth 路径逃逸、File/Git auth 列表静默吞错、credential 文件权限过宽、Store 初始加载丢失 `prefix`，以及 Panel release token 与 GitStore credential 的不安全耦合。

这些变更是对历史候选修复的当前 v7/LTS 适配，不是机械 cherry-pick，也不是 upstream full-sync。本 PR 不包含 tag、release、HFS deploy 或 runtime smoke。

## Type

- [ ] Protected upstream full-sync
- [ ] Staged upstream full-sync
- [x] LTS protected-delta patch
- [x] LTS feature / downstream patch maintenance
- [ ] Maintenance docs / CI
- [ ] Emergency hotfix

## Upstream sync info

- Upstream repo: N/A — 非 upstream sync
- Upstream branch: N/A
- Upstream from SHA: N/A
- Upstream to SHA: N/A
- Sync branch: `codex/recover-auth-storage-hardening-20260720`

## 主要变更

- Object store 在 save/delete/upload/watch persistence 前执行 lexical 与 resolved filesystem containment，拒绝绝对路径、`..`、sibling-prefix 和预先存在的 symlink escape。
- File/Git Store 的 `List` 现在向 `Manager.Load` 返回包含坏文件路径的 read/JSON/stat/plugin parser error；watcher plugin parser 同样 fail-closed，不再回退成 generic auth。
- Claude、Codex、Kimi、Vertex、xAI credential writer 在 truncate 前收紧权限：POSIX 使用 `0600`，Windows 使用仅允许 current user 的 protected DACL并保留 extended long-path语义；PR CI 新增 `windows-latest` runtime regression，覆盖 new/existing-wide/long-path 三种场景。
- 新增共享 metadata hydration：File、Git、Object、Postgres 初始加载与 watcher prefix 规则一致；plugin 返回的 typed `Prefix` 保持 authoritative；Management auth-file response additive 返回非空 `prefix`，PATCH 会规范化合法值并对 multi-segment/nested/非字符串 prefix 返回 `400`。
- 新增 `CLIPROXYAPI_PANEL_GITHUB_TOKEN`；Authorization 只会附加到 exact HTTPS `github.com` / `api.github.com` release URL，保留受 host 校验的 legacy GitStore token fallback。
- 在 `docs/lts/downstream-patches.yaml` 登记五项 required downstream patch，避免后续 protected full-sync 丢失。

## 兼容性与影响

- 不改变 usage statistics、Management usage response、usage queue、plugin ABI 或 provider request wire shape。
- `prefix` 是 Management auth-file response 的 additive optional field，与当前 CPA-Panel-LTS client 类型兼容。
- legacy GitStore token fallback继续支持 HTTPS/SSH GitHub repository reference；非 GitHub release URL不携带任何 token。
- dedicated panel token只用于 GitHub release metadata lookup；asset download仍沿用现有公开 asset 行为，本 PR 不宣称完整 private release asset支持。
- 损坏 auth JSON 现在会使 File/Git Store load 显式失败，而不是继续使用不完整 credential 集合；这是有意的 fail-closed 行为。
- Object-store containment阻止预先存在的 symlink escape；能写入 `0700` authDir 的同用户进程仍可在 check/use 间进行 swap。彻底消除此 TOCTOU 需要 descriptor-relative no-follow I/O，不在当前 Store path API 的最小补丁范围内。

## Protected delta checklist

- [x] `usage-statistics-enabled` still exists
- [x] `internal/usage/` still exists
- [x] `/v0/management/usage` still exists
- [x] `/v0/management/usage/export` still exists
- [x] `/v0/management/usage/import` still exists
- [x] `docs/lts/core-feature-contracts.yaml` reviewed; no marker change required
- [x] `docs/lts/downstream-patches.yaml` updated with required patch records
- [x] Usage record creation/schema reviewed and unchanged
- [x] Management usage response shape reviewed and unchanged
- [x] Export/import roundtrip behavior unchanged; usage tests pass
- [x] CPA-Panel-LTS auth-file `prefix` compatibility reviewed
- [x] Local auth/store/panel release-source customizations reviewed

## LTS classification review

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| `object-store-auth-path-containment` | downstream patch | newly-added | lexical + resolved containment and symlink regressions |
| `auth-token-private-file-permissions` | downstream patch | newly-added | five provider-local `0600` regressions |
| `auth-store-list-error-propagation` | downstream patch | newly-added | File/Git damaged JSON load failures are surfaced |
| `auth-store-metadata-hydration` | downstream patch | newly-added | shared prefix/header/disabled hydration plus Management response test |
| `panel-release-token-isolation` | downstream patch | newly-added | dedicated token, exact host gate, legacy SSH compatibility tests |

- [x] `introduced_in` points to implementation commit `177978c4a9fbaf3669c6b2f0c2d5faad19682bf8`; merge must use **Create a merge commit**, not squash/rebase.

## Conflict resolution notes

无 upstream merge 或文本冲突。历史补丁均按当前 v7 module、plugin multi-auth、cursor-era Management API 和现有 Panel release source重新适配；已删除的旧 provider/handler代码没有恢复。

## Validation

- [x] `go test -count=1 ./internal/auth/claude ./internal/auth/codex ./internal/auth/kimi ./internal/auth/vertex ./internal/auth/xai`
- [x] `go test -count=1 ./internal/store ./sdk/auth`
- [x] `go test -count=1 ./sdk/cliproxy/...`
- [x] `go test -count=1 ./internal/api/handlers/management ./internal/managementasset`
- [x] `go test -count=1 ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'`
- [x] `go run ./scripts/ltsregistry --root .`
- [x] `scripts/check-lts-contract.sh`
- [x] `go test -count=1 ./...`
- [x] `go build -o /tmp/cpa-core-lts-auth-storage-final-output ./cmd/server`
- [x] `GOOS=windows GOARCH=amd64 go test -c -o /tmp/cpa-misc-windows.test.exe ./internal/misc`
- [x] `GOOS=windows GOARCH=amd64 go build -o /tmp/cpa-core-windows.exe ./cmd/server`
- [x] `actionlint .github/workflows/pr-test-build.yml`
- [x] PR CI `credential-permissions-windows` on `windows-latest`
- [x] `git diff --check origin/main...HEAD`

## Review focus

1. Windows `CreateFile(WRITE_DAC)` + same-handle protected DACL 是否在 new/existing credential 上都先收紧后 truncate。
2. `internal/store/objectstore.go` 对预先存在 symlink escape 的 containment 与已声明 TOCTOU 边界是否准确。
3. File/Git Store 与 watcher plugin parser fail-closed、plugin-owned prefix 契约是否一致。
4. Management prefix PATCH 的 normalize/`400` 行为是否与 watcher 单段 prefix 规则一致。
5. `internal/managementasset/updater.go` 的 actual release URL host gate、dedicated lookup token与 legacy credential migration边界。

## Optional real runtime smoke

- [x] Hugging Face Space smoke explicitly skipped：本 PR 未发布、未部署，且用户未授权 HFS/runtime 变更。
- Space: N/A
- Runtime SHA: N/A
- CPA-Core-LTS branch/SHA deployed: 未部署
- `/healthz` status: N/A
- `/management.html` status: N/A
- `/v0/management/usage*` status: 本地 targeted tests通过；未做外部 runtime smoke
