### PR TITLE
fix(runtime): 加固 Gemini、Management 日志与 auth cooldown 边界

### DIFF
--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -626,3 +626,87 @@ patches:
     upstream_issue_or_pr: not-filed
     state: required
     retire_when: Upstream offers a dedicated panel release credential, attaches authorization only to exact HTTPS github.com or api.github.com release requests, preserves a safe migration path for existing GitStore deployments, and all listed regressions pass without the downstream implementation.
+
+  - id: gemini-unknown-method-not-found
+    reason: Gemini-compatible routes must reject unknown RPC method suffixes with a stable 404 invalid_request_error before reading the request body, instead of consuming the body and falling through to generateContent behavior.
+    introduced_in: 6b0f185939f914983514d6a5e62378a8d91164e7
+    affected_upstream_range: through fde40c5a0a2f8f6808bcde498bc6079f32c355ef (v7.2.90-1-gfde40c5a); upstream still dispatches every non-stream and non-count suffix through generateContent and has no method allowlist before body decoding.
+    files:
+      - sdk/api/handlers/gemini/gemini_handlers.go
+      - sdk/api/handlers/gemini/gemini_handlers_test.go
+    regression_tests:
+      - TestGeminiHandlerUnknownMethodReturnsNotFound
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: Upstream validates the Gemini RPC method suffix before reading the body, returns the compatible 404 error shape for unknown methods, preserves generateContent, streamGenerateContent, and countTokens behavior, and the listed regression passes without the downstream implementation.
+
+  - id: count-tokens-not-found-no-cooldown
+    reason: A provider-specific count_tokens endpoint can be absent even when normal generation works, so its 404 must still record the failed request and publish hooks while remaining request-scoped and allowing another credential to serve the count request.
+    introduced_in: 6b0f185939f914983514d6a5e62378a8d91164e7
+    affected_upstream_range: through fde40c5a0a2f8f6808bcde498bc6079f32c355ef (v7.2.90-1-gfde40c5a); upstream commit 36ed0ca5ce4130efcd7532d86c1386ee11ed0e2d / issue #4410 adds related generic endpoint-404 handling through a separate availability-neutral result path, but it does not preserve the CPA-Core-LTS request-scoped 404 classification and fallback contract through the existing MarkResult, recent-request, hook, and error-event flow.
+    files:
+      - sdk/cliproxy/auth/conductor.go
+      - sdk/cliproxy/auth/conductor_overrides_test.go
+    regression_tests:
+      - TestManager_CountTokensGenericNotFoundRecordsFailureWithoutCooldown
+      - TestManager_CountTokensNonNotFoundFailuresKeepCooldownPolicy
+      - TestManager_CountTokensNotFoundContinuesCredentialFallback
+      - TestCountTokensResultErrorScopesOnlyNotFound
+    upstream_issue_or_pr: router-for-me/CLIProxyAPI#4410
+    state: required
+    retire_when: Upstream records count_tokens endpoint 404 failures in counters, recent-request history, hooks, and error events without auth or model cooldown; continues credential fallback; preserves normal 401, 429, and 5xx penalties; composes with the LTS request-scoped model-routing policy; and all listed regressions pass without the downstream implementation.
+
+  - id: management-logs-bounded-response
+    reason: Management log reads need a bounded default and maximum response size without breaking Panel and TUI limits or silently skipping legacy after deltas that exceed one page.
+    introduced_in: 6b0f185939f914983514d6a5e62378a8d91164e7
+    affected_upstream_range: through fde40c5a0a2f8f6808bcde498bc6079f32c355ef (v7.2.90-1-gfde40c5a); upstream leaves an omitted limit unbounded and does not clamp oversized limits or provide lossless bounded pagination for legacy after reads.
+    files:
+      - internal/api/handlers/management/logs.go
+      - internal/api/handlers/management/logs_test.go
+    regression_tests:
+      - TestGetLogsNoLimitUsesBoundedDefault
+      - TestParseLimitClampsToPanelCompatibleMaximum
+      - TestGetLogsOversizedLimitClampsResponse
+      - TestGetLogsAfterPagesBoundedDefaultWithoutLoss
+      - TestGetLogsCursorWithoutLimitUsesBoundedDefault
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: Upstream bounds omitted and oversized Management log reads, keeps explicit Panel limit 10000 and TUI limit 200 compatible, and paginates legacy after deltas without gaps or duplicates while all listed regressions pass without the downstream implementation.
+
+  - id: transient-eof-cooldown
+    reason: Transport EOF and unexpected EOF failures before successful completion indicate a transient upstream path failure and need a bounded 502 cooldown, including stream bootstrap, post-payload accounting, and wsrelay errors that have lost the standard-library sentinel identity.
+    introduced_in: 6b0f185939f914983514d6a5e62378a8d91164e7
+    affected_upstream_range: through fde40c5a0a2f8f6808bcde498bc6079f32c355ef (v7.2.90-1-gfde40c5a); upstream leaves status-less EOF errors at status 0, and AI Studio wraps wsrelay stream errors without preserving error identity, so failed credentials can be selected again immediately.
+    files:
+      - internal/runtime/executor/aistudio_executor.go
+      - sdk/cliproxy/auth/conductor.go
+      - sdk/cliproxy/auth/conductor_overrides_test.go
+    regression_tests:
+      - TestResultErrorFromErrorClassifiesEOFAsTransient
+      - TestManager_EOFTransientCooldownSkipsFailedAuthOnNextRequest
+      - TestManager_StreamEOFTransientCooldownCoversBootstrapAndChunk
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: Upstream preserves EOF sentinel identity where possible, classifies status-less terminal EOF and unexpected EOF errors as transient without overriding explicit HTTP status or context cancellation, prevents pre-delivery credential reselection loops, avoids replay after payload delivery, and all listed regressions pass without the downstream implementation.
+
+  - id: expired-availability-pruning
+    reason: Expired auth and model cooldown state must be pruned before Management availability is displayed so runtime routing, registry state, scheduler state, and persisted cooldown snapshots converge, while future, zero-deadline, disabled, Cloudflare, and independent auth-level warnings remain intact.
+    introduced_in: 6b0f185939f914983514d6a5e62378a8d91164e7
+    affected_upstream_range: through fde40c5a0a2f8f6808bcde498bc6079f32c355ef (v7.2.90-1-gfde40c5a); upstream has no Management-triggered expired availability pruning and does not reconcile manager, model registry, scheduler, and cooldown-store state while separating independent auth-level warnings from model aggregates.
+    files:
+      - internal/api/handlers/management/auth_files.go
+      - internal/api/handlers/management/auth_files_recent_requests_test.go
+      - sdk/cliproxy/auth/conductor.go
+      - sdk/cliproxy/auth/conductor_availability_test.go
+    regression_tests:
+      - TestModelAvailabilityExpiredRequiresPastResettableDeadline
+      - TestAuthAvailabilityExpiredRequiresPastResettableDeadline
+      - TestManagerPruneExpiredAvailabilityKeepsFutureModelState
+      - TestManagerPruneExpiredAvailabilityFullyRecoversAuth
+      - TestManagerPruneExpiredAvailabilityClearsExpiredModelAggregate
+      - TestManagerPruneExpiredAvailabilityPreservesIndependentAuthState
+      - TestManagerPruneExpiredAvailabilityPreservesDisabledModel
+      - TestListAuthFilesPrunesOnlyExplicitlyExpiredAvailability
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: Upstream prunes only explicitly expired resettable auth and model availability, preserves future, zero-deadline, disabled, Cloudflare, and independent auth-level state, reconciles registry, scheduler, and persisted cooldown snapshots without stale races, and all listed regressions pass without the downstream implementation.

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -325,6 +325,7 @@ func (h *Handler) ListAuthFiles(c *gin.Context) {
 		h.listAuthFilesFromDisk(c)
 		return
 	}
+	h.authManager.PruneExpiredAvailability(c.Request.Context(), time.Now())
 	auths := h.authManager.List()
 	files := make([]gin.H, 0, len(auths))
 	for _, auth := range auths {

--- a/internal/api/handlers/management/auth_files_recent_requests_test.go
+++ b/internal/api/handlers/management/auth_files_recent_requests_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -107,5 +108,117 @@ func TestBuildAuthFromFileDataHydratesPrefix(t *testing.T) {
 	}
 	if auth == nil || auth.Prefix != "team" {
 		t.Fatalf("auth = %#v, want hydrated prefix team", auth)
+	}
+}
+
+func TestListAuthFilesPrunesOnlyExplicitlyExpiredAvailability(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	now := time.Now()
+	past := now.Add(-time.Minute)
+	future := now.Add(time.Hour)
+	manager := coreauth.NewManager(&memoryAuthStore{}, nil, nil)
+	for _, auth := range []*coreauth.Auth{
+		{
+			ID:             "expired-auth",
+			Provider:       "claude",
+			Status:         coreauth.StatusError,
+			StatusMessage:  "transient upstream error",
+			Unavailable:    true,
+			NextRetryAfter: past,
+			LastError:      &coreauth.Error{HTTPStatus: http.StatusBadGateway, Message: "EOF"},
+			Attributes:     map[string]string{"runtime_only": "true"},
+		},
+		{
+			ID:             "future-auth",
+			Provider:       "claude",
+			Status:         coreauth.StatusError,
+			StatusMessage:  "quota exhausted",
+			Unavailable:    true,
+			NextRetryAfter: future,
+			Quota:          coreauth.QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: future},
+			LastError:      &coreauth.Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota exhausted"},
+			ModelStates: map[string]*coreauth.ModelState{
+				"expired-model": {Status: coreauth.StatusError, Unavailable: true, NextRetryAfter: past, LastError: &coreauth.Error{HTTPStatus: http.StatusBadGateway, Message: "EOF"}},
+			},
+			Attributes: map[string]string{"runtime_only": "true"},
+		},
+		{
+			ID:            "zero-auth",
+			Provider:      "claude",
+			Status:        coreauth.StatusError,
+			StatusMessage: "quota exhausted without recovery time",
+			Unavailable:   true,
+			Quota:         coreauth.QuotaState{Exceeded: true, Reason: "quota"},
+			LastError:     &coreauth.Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota exhausted"},
+			ModelStates: map[string]*coreauth.ModelState{
+				"expired-model": {Status: coreauth.StatusError, Unavailable: true, NextRetryAfter: past, LastError: &coreauth.Error{HTTPStatus: http.StatusBadGateway, Message: "EOF"}},
+			},
+			Attributes: map[string]string{"runtime_only": "true"},
+		},
+		{
+			ID:             "cloudflare-auth",
+			Provider:       "claude",
+			Status:         coreauth.StatusError,
+			StatusMessage:  "cloudflare challenge",
+			Unavailable:    true,
+			NextRetryAfter: past,
+			Quota:          coreauth.QuotaState{Exceeded: true, Reason: "cloudflare challenge", NextRecoverAt: past},
+			LastError:      &coreauth.Error{HTTPStatus: http.StatusForbidden, Message: "cloudflare challenge"},
+			ModelStates: map[string]*coreauth.ModelState{
+				"expired-model": {Status: coreauth.StatusError, Unavailable: true, NextRetryAfter: past, LastError: &coreauth.Error{HTTPStatus: http.StatusBadGateway, Message: "EOF"}},
+			},
+			Attributes: map[string]string{"runtime_only": "true"},
+		},
+	} {
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatalf("register %s: %v", auth.ID, err)
+		}
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, manager)
+	h.tokenStore = &memoryAuthStore{}
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/v0/management/auth-files", nil)
+	h.ListAuthFiles(ctx)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+
+	var payload struct {
+		Files []map[string]any `json:"files"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	byID := make(map[string]map[string]any, len(payload.Files))
+	for _, entry := range payload.Files {
+		id, _ := entry["id"].(string)
+		byID[id] = entry
+	}
+	expired := byID["expired-auth"]
+	if expired["status"] != string(coreauth.StatusActive) || expired["unavailable"] != false || expired["status_message"] != "" {
+		t.Fatalf("expired entry = %#v, want active without warning", expired)
+	}
+	if _, ok := expired["next_retry_after"]; ok {
+		t.Fatalf("expired entry retained next_retry_after: %#v", expired)
+	}
+	futureEntry := byID["future-auth"]
+	if futureEntry["status"] != string(coreauth.StatusError) || futureEntry["unavailable"] != true {
+		t.Fatalf("future entry = %#v, want preserved error", futureEntry)
+	}
+	if _, ok := futureEntry["next_retry_after"]; !ok {
+		t.Fatalf("future entry lost next_retry_after: %#v", futureEntry)
+	}
+	zero := byID["zero-auth"]
+	if zero["status"] != string(coreauth.StatusError) || zero["unavailable"] != true || zero["status_message"] != "quota exhausted without recovery time" {
+		t.Fatalf("zero-deadline entry = %#v, want preserved warning", zero)
+	}
+	if _, ok := zero["next_retry_after"]; ok {
+		t.Fatalf("zero-deadline entry unexpectedly gained next_retry_after: %#v", zero)
+	}
+	cloudflare := byID["cloudflare-auth"]
+	if cloudflare["status"] != string(coreauth.StatusError) || cloudflare["unavailable"] != true || cloudflare["status_message"] != "cloudflare challenge" {
+		t.Fatalf("cloudflare entry = %#v, want preserved challenge", cloudflare)
 	}
 }

--- a/internal/api/handlers/management/logs.go
+++ b/internal/api/handlers/management/logs.go
@@ -28,15 +28,17 @@ const (
 	logScannerMaxBuffer     = 8 * 1024 * 1024
 	logCursorVersion        = 1
 	logCursorFingerprintMax = 4 * 1024
+	defaultLogLimit         = 1000
+	maxLogLimit             = 10000
 )
 
 // GetLogs returns log lines with optional incremental loading.
 //
 // The legacy timestamp path keeps line-count as the total scanned line count for
 // compatibility. Cursor and tail reads avoid scanning older files, so line-count
-// is the number of returned lines there. A cursor emitted by the legacy path
-// points at the latest complete log boundary; combining after with limit is
-// therefore tail semantics and does not replay lines trimmed by limit.
+// is the number of returned lines there. When a legacy after read exceeds its
+// limit, it returns the earliest page and emits a cursor at the last returned
+// line so the remaining delta can be read without gaps.
 func (h *Handler) GetLogs(c *gin.Context) {
 	if h == nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "handler unavailable"})
@@ -123,7 +125,13 @@ func (h *Handler) GetLogs(c *gin.Context) {
 	if latest == 0 || latest < cutoff {
 		latest = cutoff
 	}
-	nextCursor, errCursor := cursorForLatestLogFile(files, latest)
+	var nextCursor string
+	var errCursor error
+	if acc.truncated && acc.cursorPath != "" {
+		nextCursor, errCursor = newLogCursor(acc.cursorPath, acc.cursorOffset, latest)
+	} else {
+		nextCursor, errCursor = cursorForLatestLogFile(files, latest)
+	}
 	if errCursor != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to prepare log cursor: %v", errCursor)})
 		return
@@ -445,12 +453,15 @@ func (h *Handler) collectLogFiles(dir string) ([]string, error) {
 }
 
 type logAccumulator struct {
-	cutoff  int64
-	limit   int
-	lines   []string
-	total   int
-	latest  int64
-	include bool
+	cutoff       int64
+	limit        int
+	lines        []string
+	total        int
+	latest       int64
+	include      bool
+	truncated    bool
+	cursorPath   string
+	cursorOffset int64
 }
 
 func newLogAccumulator(cutoff int64, limit int) *logAccumulator {
@@ -480,8 +491,18 @@ func (acc *logAccumulator) consumeFile(path string) error {
 	scanner := bufio.NewScanner(file)
 	buf := make([]byte, 0, logScannerInitialBuffer)
 	scanner.Buffer(buf, logScannerMaxBuffer)
+	offset := int64(0)
+	advance := 0
+	scanner.Split(func(data []byte, atEOF bool) (int, []byte, error) {
+		nextAdvance, token, errSplit := bufio.ScanLines(data, atEOF)
+		if token != nil {
+			advance = nextAdvance
+		}
+		return nextAdvance, token, errSplit
+	})
 	for scanner.Scan() {
-		acc.addLine(scanner.Text())
+		offset += int64(advance)
+		acc.addLine(scanner.Text(), path, offset)
 	}
 	if errScan := scanner.Err(); errScan != nil {
 		return errScan
@@ -489,29 +510,32 @@ func (acc *logAccumulator) consumeFile(path string) error {
 	return nil
 }
 
-func (acc *logAccumulator) addLine(raw string) {
+func (acc *logAccumulator) addLine(raw, path string, endOffset int64) {
 	line := strings.TrimRight(raw, "\r")
 	acc.total++
 	ts := parseTimestamp(line)
-	if ts > acc.latest {
-		acc.latest = ts
-	}
 	if ts > 0 {
 		acc.include = acc.cutoff == 0 || ts > acc.cutoff
 		if acc.cutoff == 0 || acc.include {
-			acc.append(line)
+			acc.append(line, path, endOffset, ts)
 		}
 		return
 	}
 	if acc.cutoff == 0 || acc.include {
-		acc.append(line)
+		acc.append(line, path, endOffset, 0)
 	}
 }
 
-func (acc *logAccumulator) append(line string) {
+func (acc *logAccumulator) append(line, path string, endOffset, timestamp int64) {
+	if acc.limit > 0 && len(acc.lines) >= acc.limit {
+		acc.truncated = true
+		return
+	}
 	acc.lines = append(acc.lines, line)
-	if acc.limit > 0 && len(acc.lines) > acc.limit {
-		acc.lines = acc.lines[len(acc.lines)-acc.limit:]
+	acc.cursorPath = path
+	acc.cursorOffset = endOffset
+	if timestamp > acc.latest {
+		acc.latest = timestamp
 	}
 }
 
@@ -1217,7 +1241,7 @@ func parseCutoff(raw string) int64 {
 func parseLimit(raw string) (int, error) {
 	value := strings.TrimSpace(raw)
 	if value == "" {
-		return 0, nil
+		return defaultLogLimit, nil
 	}
 	limit, err := strconv.Atoi(value)
 	if err != nil {
@@ -1225,6 +1249,9 @@ func parseLimit(raw string) (int, error) {
 	}
 	if limit <= 0 {
 		return 0, fmt.Errorf("must be greater than zero")
+	}
+	if limit > maxLogLimit {
+		return maxLogLimit, nil
 	}
 	return limit, nil
 }

--- a/internal/api/handlers/management/logs_test.go
+++ b/internal/api/handlers/management/logs_test.go
@@ -3,6 +3,7 @@ package management
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -179,27 +180,136 @@ func TestGetLogsTailLimitDoesNotScanOlderFilesForLineCount(t *testing.T) {
 	}
 }
 
-func TestGetLogsNoLimitKeepsFullScanBehavior(t *testing.T) {
+func TestGetLogsNoLimitUsesBoundedDefault(t *testing.T) {
 	dir := t.TempDir()
-	writeMainLog(t, dir, "complete\npartial")
+	lines := make([]string, defaultLogLimit+2)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("line-%04d", i)
+	}
+	writeMainLog(t, dir, strings.Join(lines, "\n")+"\n")
 
 	resp := performGetLogs(t, newLogsTestHandler(dir, true), "/v0/management/logs")
-	wantLines := []string{"complete", "partial"}
+	wantLines := lines[len(lines)-defaultLogLimit:]
 	if !reflect.DeepEqual(resp.Lines, wantLines) {
-		t.Fatalf("lines = %#v, want %#v", resp.Lines, wantLines)
+		t.Fatalf("returned %d lines, want bounded default %d", len(resp.Lines), defaultLogLimit)
 	}
-	if resp.LineCount != 2 {
-		t.Fatalf("line-count = %d, want full scan count 2", resp.LineCount)
+	if resp.LineCount != defaultLogLimit {
+		t.Fatalf("line-count = %d, want returned line count %d", resp.LineCount, defaultLogLimit)
 	}
 	if resp.NextCursor == "" {
 		t.Fatal("next-cursor is empty")
 	}
-	cursor, errCursor := decodeLogCursor(resp.NextCursor)
-	if errCursor != nil {
-		t.Fatalf("decode next-cursor: %v", errCursor)
+}
+
+func TestParseLimitClampsToPanelCompatibleMaximum(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want int
+	}{
+		{raw: "", want: defaultLogLimit},
+		{raw: "200", want: 200},
+		{raw: "10000", want: maxLogLimit},
+		{raw: "1000000", want: maxLogLimit},
 	}
-	if cursor.Offset != int64(len("complete\n")) {
-		t.Fatalf("cursor offset = %d, want complete-line boundary", cursor.Offset)
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			got, err := parseLimit(tt.raw)
+			if err != nil {
+				t.Fatalf("parseLimit(%q): %v", tt.raw, err)
+			}
+			if got != tt.want {
+				t.Fatalf("parseLimit(%q) = %d, want %d", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetLogsOversizedLimitClampsResponse(t *testing.T) {
+	dir := t.TempDir()
+	lines := make([]string, maxLogLimit+2)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("line-%05d", i)
+	}
+	writeMainLog(t, dir, strings.Join(lines, "\n")+"\n")
+
+	resp := performGetLogs(t, newLogsTestHandler(dir, true), "/v0/management/logs?limit=1000000")
+	wantLines := lines[len(lines)-maxLogLimit:]
+	if !reflect.DeepEqual(resp.Lines, wantLines) {
+		t.Fatalf("returned %d lines, want clamped maximum %d", len(resp.Lines), maxLogLimit)
+	}
+	if resp.LineCount != maxLogLimit {
+		t.Fatalf("line-count = %d, want %d", resp.LineCount, maxLogLimit)
+	}
+}
+
+func TestGetLogsAfterPagesBoundedDefaultWithoutLoss(t *testing.T) {
+	dir := t.TempDir()
+	base := time.Date(2026, 6, 15, 10, 0, 0, 0, time.Local)
+	lines := make([]string, defaultLogLimit+2)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("[%s] line-%04d", base.Add(time.Duration(i)*time.Second).Format("2006-01-02 15:04:05"), i)
+	}
+	writeMainLog(t, dir, strings.Join(lines, "\n")+"\n")
+
+	cutoff := base.Add(-time.Second).Unix()
+	resp := performGetLogs(t, newLogsTestHandler(dir, true), "/v0/management/logs?after="+strconv.FormatInt(cutoff, 10))
+	wantLines := lines[:defaultLogLimit]
+	if !reflect.DeepEqual(resp.Lines, wantLines) {
+		t.Fatalf("first page = %#v, want first %d lines", resp.Lines, defaultLogLimit)
+	}
+	if resp.LineCount != len(lines) {
+		t.Fatalf("line-count = %d, want legacy scanned count %d", resp.LineCount, len(lines))
+	}
+	if resp.NextCursor == "" {
+		t.Fatal("next-cursor is empty")
+	}
+	wantLatest := base.Add(time.Duration(defaultLogLimit-1) * time.Second).Unix()
+	if resp.LatestTimestamp != wantLatest {
+		t.Fatalf("latest-timestamp = %d, want last returned timestamp %d", resp.LatestTimestamp, wantLatest)
+	}
+
+	next := performGetLogs(t, newLogsTestHandler(dir, true), "/v0/management/logs?cursor="+url.QueryEscape(resp.NextCursor))
+	if !reflect.DeepEqual(next.Lines, lines[defaultLogLimit:]) {
+		t.Fatalf("second page = %#v, want %#v", next.Lines, lines[defaultLogLimit:])
+	}
+	all := append(append([]string{}, resp.Lines...), next.Lines...)
+	if !reflect.DeepEqual(all, lines) {
+		t.Fatalf("combined pages contain a gap or duplicate: got %d lines, want %d", len(all), len(lines))
+	}
+}
+
+func TestGetLogsCursorWithoutLimitUsesBoundedDefault(t *testing.T) {
+	dir := t.TempDir()
+	writeMainLog(t, dir, "initial\n")
+	initial := performGetLogs(t, newLogsTestHandler(dir, true), "/v0/management/logs?limit=1")
+	if initial.NextCursor == "" {
+		t.Fatal("initial next-cursor is empty")
+	}
+	lines := make([]string, defaultLogLimit+2)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("new-%04d", i)
+	}
+	file, err := os.OpenFile(filepath.Join(dir, defaultLogFileName), os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open main log: %v", err)
+	}
+	if _, err = file.WriteString(strings.Join(lines, "\n") + "\n"); err != nil {
+		_ = file.Close()
+		t.Fatalf("append main log: %v", err)
+	}
+	if err = file.Close(); err != nil {
+		t.Fatalf("close main log: %v", err)
+	}
+
+	resp := performGetLogs(t, newLogsTestHandler(dir, true), "/v0/management/logs?cursor="+url.QueryEscape(initial.NextCursor))
+	if len(resp.Lines) != defaultLogLimit {
+		t.Fatalf("returned %d cursor lines, want bounded default %d", len(resp.Lines), defaultLogLimit)
+	}
+	if resp.Lines[0] != lines[0] || resp.Lines[len(resp.Lines)-1] != lines[defaultLogLimit-1] {
+		t.Fatalf("cursor lines boundary = %q/%q, want %q/%q", resp.Lines[0], resp.Lines[len(resp.Lines)-1], lines[0], lines[defaultLogLimit-1])
+	}
+	if resp.NextCursor == "" {
+		t.Fatal("next-cursor is empty")
 	}
 }
 

--- a/internal/runtime/executor/aistudio_executor.go
+++ b/internal/runtime/executor/aistudio_executor.go
@@ -298,7 +298,7 @@ func (e *AIStudioExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth
 				helps.RecordAPIResponseError(ctx, e.cfg, event.Err)
 				reporter.PublishFailure(ctx, event.Err)
 				select {
-				case out <- cliproxyexecutor.StreamChunk{Err: fmt.Errorf("wsrelay: %v", event.Err)}:
+				case out <- cliproxyexecutor.StreamChunk{Err: fmt.Errorf("wsrelay: %w", event.Err)}:
 				case <-ctx.Done():
 				}
 				return false
@@ -354,7 +354,7 @@ func (e *AIStudioExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth
 				helps.RecordAPIResponseError(ctx, e.cfg, event.Err)
 				reporter.PublishFailure(ctx, event.Err)
 				select {
-				case out <- cliproxyexecutor.StreamChunk{Err: fmt.Errorf("wsrelay: %v", event.Err)}:
+				case out <- cliproxyexecutor.StreamChunk{Err: fmt.Errorf("wsrelay: %w", event.Err)}:
 				case <-ctx.Done():
 				}
 				return false

--- a/sdk/api/handlers/gemini/gemini_handlers.go
+++ b/sdk/api/handlers/gemini/gemini_handlers.go
@@ -151,6 +151,17 @@ func (h *GeminiAPIHandler) GeminiHandler(c *gin.Context) {
 	}
 
 	method := action[1]
+	switch method {
+	case "generateContent", "streamGenerateContent", "countTokens":
+	default:
+		c.JSON(http.StatusNotFound, handlers.ErrorResponse{
+			Error: handlers.ErrorDetail{
+				Message: fmt.Sprintf("%s not found.", c.Request.URL.Path),
+				Type:    "invalid_request_error",
+			},
+		})
+		return
+	}
 	rawJSON, errRead := handlers.ReadRequestBody(c)
 	if errRead != nil {
 		c.JSON(handlers.RequestBodyStatusCode(errRead), handlers.ErrorResponse{

--- a/sdk/api/handlers/gemini/gemini_handlers_test.go
+++ b/sdk/api/handlers/gemini/gemini_handlers_test.go
@@ -1,0 +1,47 @@
+package gemini
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+)
+
+type failingRequestBody struct{}
+
+func (failingRequestBody) Read([]byte) (int, error) {
+	return 0, errors.New("request body must not be read")
+}
+
+func TestGeminiHandlerUnknownMethodReturnsNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		body io.Reader
+	}{
+		{name: "valid body", body: strings.NewReader(`{}`)},
+		{name: "unreadable body", body: failingRequestBody{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			recorder := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(recorder)
+			ctx.Params = gin.Params{{Key: "action", Value: "gemini-2.5-pro:unknownMethod"}}
+			ctx.Request = httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-2.5-pro:unknownMethod", tt.body)
+
+			NewGeminiAPIHandler(&handlers.BaseAPIHandler{}).GeminiHandler(ctx)
+
+			if recorder.Code != http.StatusNotFound {
+				t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusNotFound, recorder.Body.String())
+			}
+			if body := recorder.Body.String(); !strings.Contains(body, "invalid_request_error") || !strings.Contains(body, "not found") {
+				t.Fatalf("body = %s, want stable not-found error", body)
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -483,6 +483,76 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 	}
 }
 
+// PruneExpiredAvailability clears availability state only when an explicit
+// cooldown deadline has elapsed. This keeps Management status aligned with
+// scheduler routing without treating zero-deadline or non-resettable failures
+// as recovered.
+func (m *Manager) PruneExpiredAvailability(ctx context.Context, now time.Time) int {
+	if m == nil {
+		return 0
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	changedAuthCount := 0
+	persistCooldownState := false
+	reg := registry.GetGlobalRegistry()
+
+	m.mu.Lock()
+	for _, auth := range m.auths {
+		if auth == nil || auth.Disabled || auth.Status == StatusDisabled {
+			continue
+		}
+		authExpired := authAvailabilityExpired(auth, now)
+		preserveAuthAvailability := !authExpired && authAvailabilityStatePresent(auth) && !authAvailabilityMirrorsExpiredModel(auth, now)
+		prunedModels := make([]string, 0)
+		for model, state := range auth.ModelStates {
+			if !modelAvailabilityExpired(state, now) {
+				continue
+			}
+			resetModelState(state, now)
+			model = strings.TrimSpace(model)
+			if model != "" {
+				prunedModels = append(prunedModels, model)
+				reg.ClearModelQuotaExceeded(auth.ID, model)
+				reg.ResumeClientModel(auth.ID, model)
+			}
+		}
+		if !authExpired && len(prunedModels) == 0 {
+			continue
+		}
+
+		if allModelStatesClean(auth) && (authExpired || !preserveAuthAvailability) {
+			clearAuthStateOnSuccess(auth, now)
+			reg.ClearClientQuotaState(auth.ID)
+		} else if authExpired || !preserveAuthAvailability {
+			recomputeAggregatedAvailability(auth, now)
+			reconcileAuthErrorFromModelStates(auth, now)
+		}
+		auth.UpdatedAt = now
+		if errPersist := m.persist(ctx, auth); errPersist != nil {
+			logEntryWithRequestID(ctx).WithField("auth_id", auth.ID).Warnf("failed to persist auth changes during expired availability pruning: %v", errPersist)
+		}
+		if m.scheduler != nil {
+			// Keep scheduler update in the same manager critical section so a
+			// fresh MarkResult cannot be overwritten by a stale prune snapshot.
+			m.scheduler.upsertAuth(auth)
+		}
+		changedAuthCount++
+		persistCooldownState = persistCooldownState || m.cooldownStore != nil
+	}
+	m.mu.Unlock()
+
+	if persistCooldownState {
+		m.persistCooldownStates(ctx)
+	}
+	return changedAuthCount
+}
+
 // ClearQuotaState clears quota-related auth and registry state for one auth.
 func (m *Manager) ClearQuotaState(ctx context.Context, authID string) bool {
 	if m == nil {
@@ -3249,7 +3319,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			}
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: errExec == nil}
 			if errExec != nil {
-				result.Error = resultErrorFromError(errExec)
+				result.Error = countTokensResultErrorFromError(errExec)
 				if ra := retryAfterFromError(errExec); ra != nil {
 					result.RetryAfter = ra
 				}
@@ -4535,6 +4605,222 @@ func resetModelState(state *ModelState, now time.Time) {
 	state.UpdatedAt = now
 }
 
+func availabilityDeadlinesExpired(nextRetryAfter, nextRecoverAt, now time.Time) bool {
+	hasDeadline := false
+	for _, deadline := range []time.Time{nextRetryAfter, nextRecoverAt} {
+		if deadline.IsZero() {
+			continue
+		}
+		hasDeadline = true
+		if deadline.After(now) {
+			return false
+		}
+	}
+	return hasDeadline
+}
+
+func availabilityStateIsNonResettable(quota QuotaState, lastErr *Error, statusMessage string) bool {
+	if quotaReasonIsNonResettable(quota.Reason) || quotaReasonIsNonResettable(statusMessage) {
+		return true
+	}
+	if lastErr == nil {
+		return false
+	}
+	return isCloudflareChallengeErrorMessage(strings.TrimSpace(lastErr.Code + " " + lastErr.Message))
+}
+
+func authAvailabilityExpired(auth *Auth, now time.Time) bool {
+	if auth == nil || auth.Disabled || auth.Status == StatusDisabled {
+		return false
+	}
+	if availabilityStateIsNonResettable(auth.Quota, auth.LastError, auth.StatusMessage) {
+		return false
+	}
+	if !availabilityDeadlinesExpired(auth.NextRetryAfter, auth.Quota.NextRecoverAt, now) {
+		return false
+	}
+	return auth.Status != StatusActive || auth.Unavailable || auth.StatusMessage != "" || auth.LastError != nil || !quotaStateIsEmpty(auth.Quota) || !auth.NextRetryAfter.IsZero()
+}
+
+func authAvailabilityStatePresent(auth *Auth) bool {
+	if auth == nil {
+		return false
+	}
+	return auth.Status != StatusActive || auth.Unavailable || auth.StatusMessage != "" || auth.LastError != nil || !quotaStateIsEmpty(auth.Quota) || !auth.NextRetryAfter.IsZero()
+}
+
+func authAvailabilityMirrorsExpiredModel(auth *Auth, now time.Time) bool {
+	if auth == nil {
+		return false
+	}
+	for _, state := range auth.ModelStates {
+		if modelAvailabilityExpired(state, now) && authAvailabilityMatchesModelState(auth, state) {
+			return true
+		}
+	}
+	return false
+}
+
+func authAvailabilityMatchesModelState(auth *Auth, state *ModelState) bool {
+	if auth == nil || state == nil || auth.Status != state.Status {
+		return false
+	}
+	authMessage := strings.TrimSpace(auth.StatusMessage)
+	stateMessage := strings.TrimSpace(state.StatusMessage)
+	if authMessage != stateMessage || !availabilityErrorsEqual(auth.LastError, state.LastError) {
+		return false
+	}
+	if authMessage == "" && auth.LastError == nil {
+		return false
+	}
+	if auth.Unavailable && !state.Unavailable {
+		return false
+	}
+	if !auth.NextRetryAfter.IsZero() && !auth.NextRetryAfter.Equal(state.NextRetryAfter) {
+		return false
+	}
+	return availabilityQuotaMatchesModel(auth.Quota, state.Quota)
+}
+
+func availabilityErrorsEqual(left, right *Error) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return left.Code == right.Code && left.Message == right.Message && left.Retryable == right.Retryable && left.HTTPStatus == right.HTTPStatus
+}
+
+func availabilityQuotaMatchesModel(authQuota, modelQuota QuotaState) bool {
+	if quotaStateIsEmpty(authQuota) || quotaStateIsEmpty(modelQuota) {
+		return quotaStateIsEmpty(authQuota) && quotaStateIsEmpty(modelQuota)
+	}
+	if authQuota.Exceeded != modelQuota.Exceeded || authQuota.BackoffLevel != modelQuota.BackoffLevel || !authQuota.NextRecoverAt.Equal(modelQuota.NextRecoverAt) {
+		return false
+	}
+	authReason := strings.ToLower(strings.TrimSpace(authQuota.Reason))
+	modelReason := strings.ToLower(strings.TrimSpace(modelQuota.Reason))
+	return authReason == modelReason || (authReason == "quota" && quotaMessageIsResettable(modelReason))
+}
+
+func modelAvailabilityExpired(state *ModelState, now time.Time) bool {
+	if state == nil || state.Status == StatusDisabled || modelStateIsClean(state) {
+		return false
+	}
+	if availabilityStateIsNonResettable(state.Quota, state.LastError, state.StatusMessage) {
+		return false
+	}
+	return availabilityDeadlinesExpired(state.NextRetryAfter, state.Quota.NextRecoverAt, now)
+}
+
+func allModelStatesClean(auth *Auth) bool {
+	if auth == nil {
+		return true
+	}
+	for _, state := range auth.ModelStates {
+		if !modelStateIsClean(state) {
+			return false
+		}
+	}
+	return true
+}
+
+// recomputeAggregatedAvailability updates only auth-level fields. Unlike
+// updateAggregatedAvailability, it never mutates model state while preserving
+// non-resettable or zero-deadline warnings.
+func recomputeAggregatedAvailability(auth *Auth, now time.Time) {
+	if auth == nil {
+		return
+	}
+	if len(auth.ModelStates) == 0 {
+		clearAggregatedAvailability(auth)
+		return
+	}
+	allUnavailable := true
+	hasState := false
+	earliestRetry := time.Time{}
+	quotaExceeded := false
+	quotaReason := ""
+	quotaRecover := time.Time{}
+	maxBackoffLevel := 0
+	for _, state := range auth.ModelStates {
+		if state == nil {
+			continue
+		}
+		hasState = true
+		stateUnavailable := state.Status == StatusDisabled || (state.Unavailable && !state.NextRetryAfter.IsZero() && state.NextRetryAfter.After(now))
+		if !stateUnavailable {
+			allUnavailable = false
+		} else if !state.NextRetryAfter.IsZero() && (earliestRetry.IsZero() || state.NextRetryAfter.Before(earliestRetry)) {
+			earliestRetry = state.NextRetryAfter
+		}
+		if state.Quota.Exceeded {
+			quotaExceeded = true
+			if quotaReason == "" && strings.TrimSpace(state.Quota.Reason) != "" {
+				quotaReason = state.Quota.Reason
+			}
+			if quotaRecover.IsZero() || (!state.Quota.NextRecoverAt.IsZero() && state.Quota.NextRecoverAt.Before(quotaRecover)) {
+				quotaRecover = state.Quota.NextRecoverAt
+			}
+			if state.Quota.BackoffLevel > maxBackoffLevel {
+				maxBackoffLevel = state.Quota.BackoffLevel
+			}
+		}
+	}
+	if !hasState {
+		clearAggregatedAvailability(auth)
+		return
+	}
+	auth.Unavailable = allUnavailable
+	if allUnavailable {
+		auth.NextRetryAfter = earliestRetry
+	} else {
+		auth.NextRetryAfter = time.Time{}
+	}
+	if quotaExceeded {
+		if quotaReason == "" {
+			quotaReason = "quota"
+		}
+		auth.Quota = QuotaState{Exceeded: true, Reason: quotaReason, NextRecoverAt: quotaRecover, BackoffLevel: maxBackoffLevel}
+	} else {
+		auth.Quota = QuotaState{}
+	}
+}
+
+func reconcileAuthErrorFromModelStates(auth *Auth, now time.Time) {
+	if auth == nil || allModelStatesClean(auth) {
+		return
+	}
+	keys := make([]string, 0, len(auth.ModelStates))
+	for model := range auth.ModelStates {
+		keys = append(keys, model)
+	}
+	sort.Strings(keys)
+	var representative *ModelState
+	for _, model := range keys {
+		state := auth.ModelStates[model]
+		if modelStateIsClean(state) {
+			continue
+		}
+		if representative == nil {
+			representative = state
+		}
+		if state != nil && (state.LastError != nil || strings.TrimSpace(state.StatusMessage) != "") {
+			representative = state
+			break
+		}
+	}
+	auth.Status = StatusError
+	auth.StatusMessage = ""
+	auth.LastError = nil
+	if representative != nil {
+		auth.StatusMessage = representative.StatusMessage
+		auth.LastError = cloneError(representative.LastError)
+		if auth.StatusMessage == "" && auth.LastError != nil {
+			auth.StatusMessage = auth.LastError.Message
+		}
+	}
+	auth.UpdatedAt = now
+}
+
 func modelStateIsClean(state *ModelState) bool {
 	if state == nil {
 		return true
@@ -4833,14 +5119,43 @@ func resultErrorFromError(err error) *Error {
 	if err == nil {
 		return nil
 	}
+	status := statusCodeFromError(err)
+	if status == 0 && isTransientEOFError(err) {
+		status = http.StatusBadGateway
+	}
 	resultErr := &Error{
 		Message:    err.Error(),
-		HTTPStatus: statusCodeFromError(err),
+		HTTPStatus: status,
 	}
 	if isRequestScopedError(err) || isRequestInvalidError(err) {
 		resultErr.Code = requestScopedErrorCode
 	}
 	return resultErr
+}
+
+func countTokensResultErrorFromError(err error) *Error {
+	resultErr := resultErrorFromError(err)
+	if statusCodeFromResult(resultErr) == http.StatusNotFound {
+		resultErr.Code = requestScopedErrorCode
+	}
+	return resultErr
+}
+
+func isTransientEOFError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	message := strings.ToLower(strings.TrimSpace(err.Error()))
+	message = strings.TrimSpace(strings.TrimSuffix(message, " (status=0)"))
+	switch message {
+	case "eof", "unexpected eof":
+		return true
+	default:
+		return strings.HasSuffix(message, ": eof") || strings.HasSuffix(message, ": unexpected eof")
+	}
 }
 
 func isUnauthorizedError(err error) bool {

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -4676,7 +4676,10 @@ func authAvailabilityMatchesModelState(auth *Auth, state *ModelState) bool {
 	if auth.Unavailable && !state.Unavailable {
 		return false
 	}
-	if !auth.NextRetryAfter.IsZero() && !auth.NextRetryAfter.Equal(state.NextRetryAfter) {
+	if auth.Unavailable && !auth.NextRetryAfter.Equal(state.NextRetryAfter) {
+		return false
+	}
+	if !auth.Unavailable && !auth.NextRetryAfter.IsZero() && !auth.NextRetryAfter.Equal(state.NextRetryAfter) {
 		return false
 	}
 	return availabilityQuotaMatchesModel(auth.Quota, state.Quota)

--- a/sdk/cliproxy/auth/conductor_availability_test.go
+++ b/sdk/cliproxy/auth/conductor_availability_test.go
@@ -2,6 +2,9 @@ package auth
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"reflect"
 	"testing"
 	"time"
 
@@ -30,6 +33,378 @@ func TestUpdateAggregatedAvailability_UnavailableWithoutNextRetryDoesNotBlockAut
 	}
 	if !auth.NextRetryAfter.IsZero() {
 		t.Fatalf("auth.NextRetryAfter = %v, want zero", auth.NextRetryAfter)
+	}
+}
+
+func TestModelAvailabilityExpiredRequiresPastResettableDeadline(t *testing.T) {
+	now := time.Now()
+	past := now.Add(-time.Minute)
+	future := now.Add(time.Minute)
+	tests := []struct {
+		name  string
+		state *ModelState
+		want  bool
+	}{
+		{name: "past generic cooldown", state: &ModelState{Status: StatusError, Unavailable: true, NextRetryAfter: past, LastError: &Error{HTTPStatus: http.StatusBadGateway, Message: "EOF"}}, want: true},
+		{name: "past quota", state: &ModelState{Status: StatusError, Unavailable: true, NextRetryAfter: past, Quota: QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: past}, LastError: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "usage_limit_reached"}}, want: true},
+		{name: "future deadline", state: &ModelState{Status: StatusError, Unavailable: true, NextRetryAfter: future, LastError: &Error{HTTPStatus: http.StatusBadGateway, Message: "EOF"}}},
+		{name: "past and future", state: &ModelState{Status: StatusError, Unavailable: true, NextRetryAfter: past, Quota: QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: future}}},
+		{name: "zero deadline", state: &ModelState{Status: StatusError, Unavailable: true, LastError: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota"}}},
+		{name: "disabled model", state: &ModelState{Status: StatusDisabled, Unavailable: true, NextRetryAfter: past}},
+		{name: "cloudflare challenge", state: &ModelState{Status: StatusError, Unavailable: true, NextRetryAfter: past, Quota: QuotaState{Exceeded: true, Reason: "cloudflare challenge", NextRecoverAt: past}, LastError: &Error{HTTPStatus: http.StatusForbidden, Message: "cloudflare challenge"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := modelAvailabilityExpired(tt.state, now); got != tt.want {
+				t.Fatalf("modelAvailabilityExpired() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAuthAvailabilityExpiredRequiresPastResettableDeadline(t *testing.T) {
+	now := time.Now()
+	past := now.Add(-time.Minute)
+	future := now.Add(time.Minute)
+	tests := []struct {
+		name string
+		auth *Auth
+		want bool
+	}{
+		{name: "past generic cooldown", auth: &Auth{Status: StatusError, Unavailable: true, NextRetryAfter: past, LastError: &Error{HTTPStatus: http.StatusBadGateway, Message: "EOF"}}, want: true},
+		{name: "future quota", auth: &Auth{Status: StatusError, Unavailable: true, NextRetryAfter: future, Quota: QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: future}}},
+		{name: "zero deadline", auth: &Auth{Status: StatusError, Unavailable: true, Quota: QuotaState{Exceeded: true, Reason: "quota"}}},
+		{name: "disabled auth", auth: &Auth{Disabled: true, Status: StatusError, Unavailable: true, NextRetryAfter: past}},
+		{name: "disabled status", auth: &Auth{Status: StatusDisabled, Unavailable: true, NextRetryAfter: past}},
+		{name: "cloudflare challenge", auth: &Auth{Status: StatusError, StatusMessage: "cloudflare challenge", Unavailable: true, NextRetryAfter: past, Quota: QuotaState{Exceeded: true, Reason: "cloudflare challenge", NextRecoverAt: past}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := authAvailabilityExpired(tt.auth, now); got != tt.want {
+				t.Fatalf("authAvailabilityExpired() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestManagerPruneExpiredAvailabilityKeepsFutureModelState(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	cooldownStore := &recordingCooldownStateStore{}
+	manager.SetCooldownStateStore(cooldownStore)
+	ctx := context.Background()
+	now := time.Now()
+	past := now.Add(-time.Minute)
+	future := now.Add(time.Hour)
+	authID := "prune-mixed-auth"
+	expiredModel := "prune-expired-model"
+	futureModel := "prune-future-model"
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "claude", []*registry.ModelInfo{{ID: expiredModel}, {ID: futureModel}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+	reg.SetModelQuotaExceeded(authID, expiredModel)
+	reg.SuspendClientModel(authID, expiredModel, "quota")
+	reg.SetModelQuotaExceeded(authID, futureModel)
+	reg.SuspendClientModel(authID, futureModel, "quota")
+
+	auth := &Auth{
+		ID:             authID,
+		Provider:       "claude",
+		Status:         StatusError,
+		StatusMessage:  "quota exhausted",
+		Unavailable:    true,
+		NextRetryAfter: past,
+		Quota:          QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: past},
+		LastError:      &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota exhausted"},
+		ModelStates: map[string]*ModelState{
+			expiredModel: {Status: StatusError, StatusMessage: "quota exhausted", Unavailable: true, NextRetryAfter: past, Quota: QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: past}, LastError: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota exhausted"}},
+			futureModel:  {Status: StatusError, StatusMessage: "quota exhausted", Unavailable: true, NextRetryAfter: future, Quota: QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: future}, LastError: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota exhausted"}},
+		},
+	}
+	if _, err := manager.Register(WithSkipPersist(ctx), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	if got := manager.PruneExpiredAvailability(ctx, now); got != 1 {
+		t.Fatalf("PruneExpiredAvailability() = %d, want 1", got)
+	}
+	updated, ok := manager.GetByID(authID)
+	if !ok || updated == nil {
+		t.Fatal("updated auth missing")
+	}
+	if state := updated.ModelStates[expiredModel]; state == nil || !modelStateIsClean(state) {
+		t.Fatalf("expired model state = %#v, want clean", state)
+	}
+	futureState := updated.ModelStates[futureModel]
+	if futureState == nil || !futureState.Unavailable || !futureState.NextRetryAfter.Equal(future) || !futureState.Quota.Exceeded {
+		t.Fatalf("future model state = %#v, want preserved", futureState)
+	}
+	if updated.Status != StatusError || updated.Unavailable || !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("auth status/unavailable/retry = %q/%v/%v, want error/false/zero while one model is available", updated.Status, updated.Unavailable, updated.NextRetryAfter)
+	}
+	if count := reg.GetModelCount(expiredModel); count != 1 {
+		t.Fatalf("expired model registry count = %d, want 1", count)
+	}
+	if count := reg.GetModelCount(futureModel); count != 0 {
+		t.Fatalf("future model registry count = %d, want 0", count)
+	}
+	if got := cooldownStore.saveCount.Load(); got != 1 {
+		t.Fatalf("cooldown store save count = %d, want 1", got)
+	}
+	cooldownStore.mu.Lock()
+	records := cloneCooldownStateRecords(cooldownStore.records)
+	cooldownStore.mu.Unlock()
+	if len(records) != 1 || records[0].Model != futureModel {
+		t.Fatalf("cooldown records = %#v, want only future model", records)
+	}
+}
+
+func TestManagerPruneExpiredAvailabilityFullyRecoversAuth(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	cooldownStore := &recordingCooldownStateStore{}
+	manager.SetCooldownStateStore(cooldownStore)
+	ctx := context.Background()
+	now := time.Now()
+	past := now.Add(-time.Minute)
+	authID := "prune-clean-auth"
+	model := "prune-clean-model"
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "claude", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+	reg.SetModelQuotaExceeded(authID, model)
+	reg.SuspendClientModel(authID, model, "quota")
+
+	auth := &Auth{
+		ID:             authID,
+		Provider:       "claude",
+		Status:         StatusError,
+		StatusMessage:  "usage_limit_reached",
+		Unavailable:    true,
+		NextRetryAfter: past,
+		Quota:          QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: past, BackoffLevel: 2},
+		LastError:      &Error{HTTPStatus: http.StatusTooManyRequests, Message: "usage_limit_reached"},
+		ModelStates: map[string]*ModelState{
+			model: {Status: StatusError, StatusMessage: "usage_limit_reached", Unavailable: true, NextRetryAfter: past, Quota: QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: past, BackoffLevel: 2}, LastError: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "usage_limit_reached"}},
+		},
+	}
+	if _, err := manager.Register(WithSkipPersist(ctx), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	if got := manager.PruneExpiredAvailability(ctx, now); got != 1 {
+		t.Fatalf("PruneExpiredAvailability() = %d, want 1", got)
+	}
+	updated, ok := manager.GetByID(authID)
+	if !ok || updated == nil {
+		t.Fatal("updated auth missing")
+	}
+	if updated.Status != StatusActive || updated.StatusMessage != "" || updated.Unavailable || !updated.NextRetryAfter.IsZero() || updated.LastError != nil || !quotaStateIsEmpty(updated.Quota) {
+		t.Fatalf("updated auth = %#v, want fully active", updated)
+	}
+	if state := updated.ModelStates[model]; state == nil || !modelStateIsClean(state) {
+		t.Fatalf("model state = %#v, want clean", state)
+	}
+	if count := reg.GetModelCount(model); count != 1 {
+		t.Fatalf("registry model count = %d, want 1", count)
+	}
+	if got := cooldownStore.saveCount.Load(); got != 1 {
+		t.Fatalf("cooldown store save count = %d, want 1", got)
+	}
+	cooldownStore.mu.Lock()
+	defer cooldownStore.mu.Unlock()
+	if len(cooldownStore.records) != 0 {
+		t.Fatalf("cooldown records = %#v, want empty", cooldownStore.records)
+	}
+}
+
+func TestManagerPruneExpiredAvailabilityClearsExpiredModelAggregate(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	ctx := context.Background()
+	now := time.Now()
+	past := now.Add(-time.Minute)
+	authID := "prune-aggregate-auth"
+	expiredModel := "prune-aggregate-expired"
+	cleanModel := "prune-aggregate-clean"
+
+	auth := &Auth{
+		ID:            authID,
+		Provider:      "claude",
+		Status:        StatusError,
+		StatusMessage: "EOF",
+		Unavailable:   false,
+		LastError:     &Error{HTTPStatus: http.StatusBadGateway, Message: "EOF"},
+		ModelStates: map[string]*ModelState{
+			expiredModel: {Status: StatusError, StatusMessage: "EOF", Unavailable: true, NextRetryAfter: past, LastError: &Error{HTTPStatus: http.StatusBadGateway, Message: "EOF"}},
+			cleanModel:   {Status: StatusActive},
+		},
+	}
+	if _, err := manager.Register(WithSkipPersist(ctx), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	if got := manager.PruneExpiredAvailability(ctx, now); got != 1 {
+		t.Fatalf("PruneExpiredAvailability() = %d, want 1", got)
+	}
+	updated, ok := manager.GetByID(authID)
+	if !ok || updated == nil {
+		t.Fatal("updated auth missing")
+	}
+	if updated.Status != StatusActive || updated.StatusMessage != "" || updated.Unavailable || updated.LastError != nil || !updated.NextRetryAfter.IsZero() || !quotaStateIsEmpty(updated.Quota) {
+		t.Fatalf("auth aggregate = %#v, want fully cleared", updated)
+	}
+	if state := updated.ModelStates[expiredModel]; state == nil || !modelStateIsClean(state) {
+		t.Fatalf("expired model state = %#v, want clean", state)
+	}
+	if state := updated.ModelStates[cleanModel]; state == nil || !modelStateIsClean(state) {
+		t.Fatalf("clean model state = %#v, want unchanged clean", state)
+	}
+}
+
+func TestManagerPruneExpiredAvailabilityPreservesIndependentAuthState(t *testing.T) {
+	now := time.Now()
+	past := now.Add(-time.Minute)
+	future := now.Add(time.Hour)
+	tests := []struct {
+		name string
+		auth *Auth
+	}{
+		{
+			name: "future cooldown",
+			auth: &Auth{
+				Status:         StatusError,
+				StatusMessage:  "quota exhausted",
+				Unavailable:    true,
+				NextRetryAfter: future,
+				Quota:          QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: future, BackoffLevel: 2},
+				LastError:      &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota exhausted"},
+			},
+		},
+		{
+			name: "zero deadline unauthorized",
+			auth: &Auth{
+				Status:        StatusError,
+				StatusMessage: "unauthorized",
+				Unavailable:   true,
+				LastError:     &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"},
+			},
+		},
+		{
+			name: "cloudflare challenge",
+			auth: &Auth{
+				Status:         StatusError,
+				StatusMessage:  "cloudflare challenge",
+				Unavailable:    true,
+				NextRetryAfter: past,
+				Quota:          QuotaState{Exceeded: true, Reason: "cloudflare challenge", NextRecoverAt: past, BackoffLevel: 3},
+				LastError:      &Error{HTTPStatus: http.StatusForbidden, Message: "cloudflare challenge"},
+			},
+		},
+	}
+	for index, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := NewManager(nil, nil, nil)
+			cooldownStore := &recordingCooldownStateStore{}
+			manager.SetCooldownStateStore(cooldownStore)
+			ctx := context.Background()
+			authID := fmt.Sprintf("prune-independent-%d", index)
+			model := fmt.Sprintf("prune-independent-model-%d", index)
+			tt.auth.ID = authID
+			tt.auth.Provider = "claude"
+			tt.auth.ModelStates = map[string]*ModelState{
+				model: {Status: StatusError, StatusMessage: "EOF", Unavailable: true, NextRetryAfter: past, LastError: &Error{HTTPStatus: http.StatusBadGateway, Message: "EOF"}},
+			}
+
+			reg := registry.GetGlobalRegistry()
+			reg.RegisterClient(authID, "claude", []*registry.ModelInfo{{ID: model}})
+			t.Cleanup(func() { reg.UnregisterClient(authID) })
+			reg.SuspendClientModel(authID, model, "transient")
+			if _, err := manager.Register(WithSkipPersist(ctx), tt.auth); err != nil {
+				t.Fatalf("register auth: %v", err)
+			}
+			before, ok := manager.GetByID(authID)
+			if !ok || before == nil {
+				t.Fatal("registered auth missing")
+			}
+
+			if got := manager.PruneExpiredAvailability(ctx, now); got != 1 {
+				t.Fatalf("PruneExpiredAvailability() = %d, want 1", got)
+			}
+			updated, ok := manager.GetByID(authID)
+			if !ok || updated == nil {
+				t.Fatal("updated auth missing")
+			}
+			if updated.Status != before.Status || updated.StatusMessage != before.StatusMessage || updated.Unavailable != before.Unavailable || !updated.NextRetryAfter.Equal(before.NextRetryAfter) || !reflect.DeepEqual(updated.Quota, before.Quota) || !reflect.DeepEqual(updated.LastError, before.LastError) {
+				t.Fatalf("auth availability changed:\n got  %#v\n want %#v", updated, before)
+			}
+			if state := updated.ModelStates[model]; state == nil || !modelStateIsClean(state) {
+				t.Fatalf("expired model state = %#v, want clean", state)
+			}
+			if count := reg.GetModelCount(model); count != 1 {
+				t.Fatalf("registry model count = %d, want 1", count)
+			}
+
+			cooldownStore.mu.Lock()
+			records := cloneCooldownStateRecords(cooldownStore.records)
+			cooldownStore.mu.Unlock()
+			if tt.name == "future cooldown" {
+				if len(records) != 1 || records[0].Model != "" || !records[0].NextRetryAfter.Equal(future) {
+					t.Fatalf("cooldown records = %#v, want preserved auth-level record", records)
+				}
+			}
+		})
+	}
+}
+
+func TestManagerPruneExpiredAvailabilityPreservesDisabledModel(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	ctx := context.Background()
+	now := time.Now()
+	past := now.Add(-time.Minute)
+	authID := "prune-disabled-model-auth"
+	expiredModel := "prune-disabled-expired"
+	disabledModel := "prune-disabled-preserved"
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "claude", []*registry.ModelInfo{{ID: expiredModel}, {ID: disabledModel}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+	reg.SuspendClientModel(authID, expiredModel, "quota")
+	reg.SuspendClientModel(authID, disabledModel, "quota")
+
+	auth := &Auth{
+		ID:             authID,
+		Provider:       "claude",
+		Status:         StatusError,
+		StatusMessage:  "quota exhausted",
+		Unavailable:    true,
+		NextRetryAfter: past,
+		ModelStates: map[string]*ModelState{
+			expiredModel:  {Status: StatusError, Unavailable: true, NextRetryAfter: past, LastError: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota"}},
+			disabledModel: {Status: StatusDisabled, Unavailable: true, NextRetryAfter: past},
+		},
+	}
+	if _, err := manager.Register(WithSkipPersist(ctx), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	if got := manager.PruneExpiredAvailability(ctx, now); got != 1 {
+		t.Fatalf("PruneExpiredAvailability() = %d, want 1", got)
+	}
+	updated, ok := manager.GetByID(authID)
+	if !ok || updated == nil {
+		t.Fatal("updated auth missing")
+	}
+	if updated.Status != StatusError {
+		t.Fatalf("auth status = %q, want error while disabled model remains", updated.Status)
+	}
+	if state := updated.ModelStates[disabledModel]; state == nil || state.Status != StatusDisabled || !state.Unavailable || !state.NextRetryAfter.Equal(past) {
+		t.Fatalf("disabled model state = %#v, want preserved", state)
+	}
+	if count := reg.GetModelCount(expiredModel); count != 1 {
+		t.Fatalf("expired model registry count = %d, want 1", count)
+	}
+	if count := reg.GetModelCount(disabledModel); count != 0 {
+		t.Fatalf("disabled model registry count = %d, want 0", count)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_availability_test.go
+++ b/sdk/cliproxy/auth/conductor_availability_test.go
@@ -266,8 +266,9 @@ func TestManagerPruneExpiredAvailabilityPreservesIndependentAuthState(t *testing
 	past := now.Add(-time.Minute)
 	future := now.Add(time.Hour)
 	tests := []struct {
-		name string
-		auth *Auth
+		name         string
+		auth         *Auth
+		expiredState *ModelState
 	}{
 		{
 			name: "future cooldown",
@@ -288,6 +289,7 @@ func TestManagerPruneExpiredAvailabilityPreservesIndependentAuthState(t *testing
 				Unavailable:   true,
 				LastError:     &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"},
 			},
+			expiredState: &ModelState{Status: StatusError, StatusMessage: "unauthorized", Unavailable: true, NextRetryAfter: past, LastError: &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"}},
 		},
 		{
 			name: "cloudflare challenge",
@@ -311,9 +313,11 @@ func TestManagerPruneExpiredAvailabilityPreservesIndependentAuthState(t *testing
 			model := fmt.Sprintf("prune-independent-model-%d", index)
 			tt.auth.ID = authID
 			tt.auth.Provider = "claude"
-			tt.auth.ModelStates = map[string]*ModelState{
-				model: {Status: StatusError, StatusMessage: "EOF", Unavailable: true, NextRetryAfter: past, LastError: &Error{HTTPStatus: http.StatusBadGateway, Message: "EOF"}},
+			expiredState := tt.expiredState
+			if expiredState == nil {
+				expiredState = &ModelState{Status: StatusError, StatusMessage: "EOF", Unavailable: true, NextRetryAfter: past, LastError: &Error{HTTPStatus: http.StatusBadGateway, Message: "EOF"}}
 			}
+			tt.auth.ModelStates = map[string]*ModelState{model: expiredState}
 
 			reg := registry.GetGlobalRegistry()
 			reg.RegisterClient(authID, "claude", []*registry.ModelInfo{{ID: model}})

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -2,7 +2,10 @@ package auth
 
 import (
 	"context"
+	"errors"
+	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -16,6 +19,28 @@ import (
 const requestScopedNotFoundMessage = "Item with id 'rs_0b5f3eb6f51f175c0169ca74e4a85881998539920821603a74' not found. Items are not persisted when `store` is set to false. Try again with `store` set to true, or remove this item from your input."
 
 const codexModelNotFoundMessage = `{"error":{"message":"Model not found gpt-5.6-luna","type":"invalid_request_error","param":"model"}}`
+
+type resultCaptureHook struct {
+	mu      sync.Mutex
+	results []Result
+}
+
+func (*resultCaptureHook) OnAuthRegistered(context.Context, *Auth) {}
+func (*resultCaptureHook) OnAuthUpdated(context.Context, *Auth)    {}
+
+func (h *resultCaptureHook) OnResult(_ context.Context, result Result) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.results = append(h.results, result)
+}
+
+func (h *resultCaptureHook) Results() []Result {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]Result, len(h.results))
+	copy(out, h.results)
+	return out
+}
 
 func TestManager_ShouldRetryAfterError_RespectsAuthRequestRetryOverride(t *testing.T) {
 	m := NewManager(nil, nil, nil)
@@ -171,11 +196,15 @@ func (e *credentialRetryLimitExecutor) Calls() int {
 type authFallbackExecutor struct {
 	id string
 
-	mu                sync.Mutex
-	executeCalls      []string
-	streamCalls       []string
-	executeErrors     map[string]error
-	streamFirstErrors map[string]error
+	mu                 sync.Mutex
+	executeCalls       []string
+	streamCalls        []string
+	executeErrors      map[string]error
+	streamReturnErrors map[string]error
+	streamFirstErrors  map[string]error
+	streamChunkErrors  map[string]error
+	countCalls         []string
+	countErrors        map[string]error
 }
 
 func (e *authFallbackExecutor) Identifier() string {
@@ -196,16 +225,24 @@ func (e *authFallbackExecutor) Execute(_ context.Context, auth *Auth, _ cliproxy
 func (e *authFallbackExecutor) ExecuteStream(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
 	e.mu.Lock()
 	e.streamCalls = append(e.streamCalls, auth.ID)
-	err := e.streamFirstErrors[auth.ID]
+	returnErr := e.streamReturnErrors[auth.ID]
+	firstErr := e.streamFirstErrors[auth.ID]
+	chunkErr := e.streamChunkErrors[auth.ID]
 	e.mu.Unlock()
+	if returnErr != nil {
+		return nil, returnErr
+	}
 
-	ch := make(chan cliproxyexecutor.StreamChunk, 1)
-	if err != nil {
-		ch <- cliproxyexecutor.StreamChunk{Err: err}
+	ch := make(chan cliproxyexecutor.StreamChunk, 2)
+	if firstErr != nil {
+		ch <- cliproxyexecutor.StreamChunk{Err: firstErr}
 		close(ch)
 		return &cliproxyexecutor.StreamResult{Headers: http.Header{"X-Auth": {auth.ID}}, Chunks: ch}, nil
 	}
 	ch <- cliproxyexecutor.StreamChunk{Payload: []byte(auth.ID)}
+	if chunkErr != nil {
+		ch <- cliproxyexecutor.StreamChunk{Err: chunkErr}
+	}
 	close(ch)
 	return &cliproxyexecutor.StreamResult{Headers: http.Header{"X-Auth": {auth.ID}}, Chunks: ch}, nil
 }
@@ -214,8 +251,15 @@ func (e *authFallbackExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, er
 	return auth, nil
 }
 
-func (e *authFallbackExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
-	return cliproxyexecutor.Response{}, &Error{HTTPStatus: 500, Message: "not implemented"}
+func (e *authFallbackExecutor) CountTokens(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.mu.Lock()
+	e.countCalls = append(e.countCalls, auth.ID)
+	err := e.countErrors[auth.ID]
+	e.mu.Unlock()
+	if err != nil {
+		return cliproxyexecutor.Response{}, err
+	}
+	return cliproxyexecutor.Response{Payload: []byte(auth.ID)}, nil
 }
 
 func (e *authFallbackExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
@@ -235,6 +279,14 @@ func (e *authFallbackExecutor) StreamCalls() []string {
 	defer e.mu.Unlock()
 	out := make([]string, len(e.streamCalls))
 	copy(out, e.streamCalls)
+	return out
+}
+
+func (e *authFallbackExecutor) CountCalls() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]string, len(e.countCalls))
+	copy(out, e.countCalls)
 	return out
 }
 
@@ -1581,4 +1633,328 @@ func TestManager_MarkResult_GenericNotFoundStillCooldownsModel(t *testing.T) {
 	if state.NextRetryAfter.Before(before.Add(11 * time.Hour)) {
 		t.Fatalf("generic 404 retry time = %v, want roughly 12 hours", state.NextRetryAfter)
 	}
+}
+
+func TestManager_CountTokensGenericNotFoundRecordsFailureWithoutCooldown(t *testing.T) {
+	hook := &resultCaptureHook{}
+	m := NewManager(nil, nil, hook)
+	m.SetRetryConfig(0, 0, 1)
+	auth := &Auth{ID: "count-404-auth", Provider: "codex"}
+	model := "gpt-5.6-luna"
+	executor := &authFallbackExecutor{
+		id: "codex",
+		countErrors: map[string]error{
+			auth.ID: &Error{HTTPStatus: http.StatusNotFound, Message: "count_tokens endpoint not found"},
+		},
+	}
+	m.RegisterExecutor(executor)
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	_, errCount := m.ExecuteCount(context.Background(), []string{auth.Provider}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if statusCodeFromError(errCount) != http.StatusNotFound {
+		t.Fatalf("count error = %v status=%d, want 404", errCount, statusCodeFromError(errCount))
+	}
+	if got := executor.CountCalls(); len(got) != 1 || got[0] != auth.ID {
+		t.Fatalf("count calls = %v, want [%s]", got, auth.ID)
+	}
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatal("auth missing after count failure")
+	}
+	if updated.Failed != 1 || updated.Unavailable || !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("auth failed/unavailable/retry = %d/%v/%v, want 1/false/zero", updated.Failed, updated.Unavailable, updated.NextRetryAfter)
+	}
+	if state := updated.ModelStates[model]; state != nil {
+		t.Fatalf("count_tokens 404 created cooldown state: %#v", state)
+	}
+	var recentFailed int64
+	for _, bucket := range updated.RecentRequestsSnapshot(time.Now()) {
+		recentFailed += bucket.Failed
+	}
+	if recentFailed != 1 {
+		t.Fatalf("recent failed = %d, want 1", recentFailed)
+	}
+	results := hook.Results()
+	if len(results) != 1 || results[0].Error == nil || !results[0].Error.IsRequestScoped() {
+		t.Fatalf("hook results = %#v, want request-scoped count failure", results)
+	}
+
+	response, errExecute := m.Execute(context.Background(), []string{auth.Provider}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if errExecute != nil {
+		t.Fatalf("normal execute after count 404: %v", errExecute)
+	}
+	if string(response.Payload) != auth.ID {
+		t.Fatalf("normal execute payload = %q, want %q", string(response.Payload), auth.ID)
+	}
+}
+
+func TestManager_CountTokensNonNotFoundFailuresKeepCooldownPolicy(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		wantQuota  bool
+		wantStatus string
+	}{
+		{name: "unauthorized", status: http.StatusUnauthorized, wantStatus: "unauthorized"},
+		{name: "quota", status: http.StatusTooManyRequests, wantQuota: true, wantStatus: "quota"},
+		{name: "transient", status: http.StatusInternalServerError, wantStatus: "transient"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewManager(nil, nil, nil)
+			m.SetRetryConfig(0, 0, 1)
+			auth := &Auth{ID: "count-policy-" + tt.name, Provider: "claude"}
+			model := "count-policy-model-" + tt.name
+			executor := &authFallbackExecutor{
+				id: "claude",
+				countErrors: map[string]error{
+					auth.ID: &Error{HTTPStatus: tt.status, Message: tt.name + " failure"},
+				},
+			}
+			m.RegisterExecutor(executor)
+			reg := registry.GetGlobalRegistry()
+			reg.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+			t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+			if _, err := m.Register(context.Background(), auth); err != nil {
+				t.Fatalf("register auth: %v", err)
+			}
+
+			_, _ = m.ExecuteCount(context.Background(), []string{auth.Provider}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+			updated, ok := m.GetByID(auth.ID)
+			if !ok || updated == nil {
+				t.Fatal("auth missing after count failure")
+			}
+			state := updated.ModelStates[model]
+			if state == nil || !state.Unavailable || state.NextRetryAfter.IsZero() {
+				t.Fatalf("model state = %#v, want cooldown", state)
+			}
+			if state.Quota.Exceeded != tt.wantQuota {
+				t.Fatalf("quota exceeded = %v, want %v", state.Quota.Exceeded, tt.wantQuota)
+			}
+			if !strings.Contains(strings.ToLower(state.StatusMessage), tt.wantStatus) {
+				t.Fatalf("status message = %q, want %q", state.StatusMessage, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestManager_CountTokensNotFoundContinuesCredentialFallback(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(0, 0, 2)
+	model := "count-fallback-model"
+	badAuth := &Auth{ID: "aa-count-404", Provider: "claude"}
+	goodAuth := &Auth{ID: "bb-count-good", Provider: "claude"}
+	executor := &authFallbackExecutor{
+		id: "claude",
+		countErrors: map[string]error{
+			badAuth.ID: &Error{HTTPStatus: http.StatusNotFound, Message: "count endpoint not found"},
+		},
+	}
+	m.RegisterExecutor(executor)
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(badAuth.ID, badAuth.Provider, []*registry.ModelInfo{{ID: model}})
+	reg.RegisterClient(goodAuth.ID, goodAuth.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(badAuth.ID)
+		reg.UnregisterClient(goodAuth.ID)
+	})
+	for _, auth := range []*Auth{badAuth, goodAuth} {
+		if _, err := m.Register(context.Background(), auth); err != nil {
+			t.Fatalf("register %s: %v", auth.ID, err)
+		}
+	}
+
+	response, err := m.ExecuteCount(context.Background(), []string{"claude"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("ExecuteCount: %v", err)
+	}
+	if string(response.Payload) != goodAuth.ID {
+		t.Fatalf("response payload = %q, want %q", string(response.Payload), goodAuth.ID)
+	}
+	if got := executor.CountCalls(); !equalStrings(got, []string{badAuth.ID, goodAuth.ID}) {
+		t.Fatalf("count calls = %v, want bad then good", got)
+	}
+	updatedBad, ok := m.GetByID(badAuth.ID)
+	if !ok || updatedBad == nil {
+		t.Fatal("bad auth missing")
+	}
+	if updatedBad.Unavailable || !updatedBad.NextRetryAfter.IsZero() || updatedBad.ModelStates[model] != nil {
+		t.Fatalf("bad auth was cooled down: %#v", updatedBad)
+	}
+}
+
+func TestCountTokensResultErrorScopesOnlyNotFound(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusTooManyRequests, http.StatusInternalServerError} {
+		resultErr := countTokensResultErrorFromError(&Error{HTTPStatus: status, Message: "failure"})
+		if resultErr.IsRequestScoped() {
+			t.Fatalf("status %d unexpectedly request-scoped", status)
+		}
+	}
+	resultErr := countTokensResultErrorFromError(&Error{HTTPStatus: http.StatusNotFound, Message: "missing count endpoint"})
+	if !resultErr.IsRequestScoped() {
+		t.Fatalf("404 error = %#v, want request-scoped", resultErr)
+	}
+}
+
+func TestResultErrorFromErrorClassifiesEOFAsTransient(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{name: "EOF", err: io.EOF, wantStatus: http.StatusBadGateway},
+		{name: "wrapped unexpected EOF", err: errors.Join(errors.New("transport"), io.ErrUnexpectedEOF), wantStatus: http.StatusBadGateway},
+		{name: "exact EOF message", err: errors.New("EOF"), wantStatus: http.StatusBadGateway},
+		{name: "exact unexpected EOF message", err: errors.New("unexpected EOF"), wantStatus: http.StatusBadGateway},
+		{name: "prefixed unexpected EOF", err: errors.New("transport: unexpected EOF"), wantStatus: http.StatusBadGateway},
+		{name: "wsrelay unexpected EOF", err: errors.New("wsrelay: unexpected EOF (status=0)"), wantStatus: http.StatusBadGateway},
+		{name: "non-terminal EOF text", err: errors.New("unexpected EOF recovery guidance"), wantStatus: 0},
+		{name: "context canceled", err: context.Canceled},
+		{name: "deadline exceeded", err: context.DeadlineExceeded},
+		{name: "explicit status wins", err: &requestScopedStatusError{status: http.StatusConflict, message: "unexpected EOF"}, wantStatus: http.StatusConflict},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resultErrorFromError(tt.err).HTTPStatus; got != tt.wantStatus {
+				t.Fatalf("HTTPStatus = %d, want %d", got, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestManager_EOFTransientCooldownSkipsFailedAuthOnNextRequest(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(0, 0, 2)
+	model := "gpt-5.6-luna"
+	badAuth := &Auth{ID: "aa-eof-auth", Provider: "codex"}
+	goodAuth := &Auth{ID: "bb-good-auth", Provider: "codex"}
+	executor := &authFallbackExecutor{
+		id:            "codex",
+		executeErrors: map[string]error{badAuth.ID: io.EOF},
+	}
+	m.RegisterExecutor(executor)
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(badAuth.ID, badAuth.Provider, []*registry.ModelInfo{{ID: model}})
+	reg.RegisterClient(goodAuth.ID, goodAuth.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(badAuth.ID)
+		reg.UnregisterClient(goodAuth.ID)
+	})
+	for _, auth := range []*Auth{badAuth, goodAuth} {
+		if _, err := m.Register(context.Background(), auth); err != nil {
+			t.Fatalf("register %s: %v", auth.ID, err)
+		}
+	}
+
+	if _, err := m.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{}); err != nil {
+		t.Fatalf("first execute: %v", err)
+	}
+	updatedBad, ok := m.GetByID(badAuth.ID)
+	if !ok || updatedBad == nil {
+		t.Fatal("bad auth missing")
+	}
+	state := updatedBad.ModelStates[model]
+	if state == nil || !state.Unavailable || state.NextRetryAfter.IsZero() || state.LastError == nil || state.LastError.HTTPStatus != http.StatusBadGateway {
+		t.Fatalf("EOF model state = %#v, want transient 502 cooldown", state)
+	}
+	if _, err := m.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{}); err != nil {
+		t.Fatalf("second execute: %v", err)
+	}
+	if got := executor.ExecuteCalls(); len(got) != 3 || got[0] != badAuth.ID || got[1] != goodAuth.ID || got[2] != goodAuth.ID {
+		t.Fatalf("execute calls = %v, want bad/good then good", got)
+	}
+}
+
+func TestManager_StreamEOFTransientCooldownCoversBootstrapAndChunk(t *testing.T) {
+	tests := []struct {
+		name              string
+		returnErrors      map[string]error
+		firstErrors       map[string]error
+		chunkErrors       map[string]error
+		wantFirstCallList []string
+		wantChunkError    bool
+	}{
+		{name: "direct EOF falls back", returnErrors: map[string]error{"aa-eof-auth": io.EOF}, wantFirstCallList: []string{"aa-eof-auth", "bb-good-auth"}},
+		{name: "bootstrap EOF falls back", firstErrors: map[string]error{"aa-eof-auth": io.EOF}, wantFirstCallList: []string{"aa-eof-auth", "bb-good-auth"}},
+		{name: "chunk unexpected EOF cools after delivery", chunkErrors: map[string]error{"aa-eof-auth": io.ErrUnexpectedEOF}, wantFirstCallList: []string{"aa-eof-auth"}, wantChunkError: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewManager(nil, nil, nil)
+			m.SetRetryConfig(0, 0, 2)
+			model := "gpt-5.6-luna"
+			badAuth := &Auth{ID: "aa-eof-auth", Provider: "codex"}
+			goodAuth := &Auth{ID: "bb-good-auth", Provider: "codex"}
+			executor := &authFallbackExecutor{id: "codex", streamReturnErrors: tt.returnErrors, streamFirstErrors: tt.firstErrors, streamChunkErrors: tt.chunkErrors}
+			m.RegisterExecutor(executor)
+
+			reg := registry.GetGlobalRegistry()
+			reg.RegisterClient(badAuth.ID, badAuth.Provider, []*registry.ModelInfo{{ID: model}})
+			reg.RegisterClient(goodAuth.ID, goodAuth.Provider, []*registry.ModelInfo{{ID: model}})
+			t.Cleanup(func() {
+				reg.UnregisterClient(badAuth.ID)
+				reg.UnregisterClient(goodAuth.ID)
+			})
+			for _, auth := range []*Auth{badAuth, goodAuth} {
+				if _, err := m.Register(context.Background(), auth); err != nil {
+					t.Fatalf("register %s: %v", auth.ID, err)
+				}
+			}
+
+			stream, err := m.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{Stream: true})
+			if err != nil {
+				t.Fatalf("first stream: %v", err)
+			}
+			sawChunkError := false
+			for chunk := range stream.Chunks {
+				if errors.Is(chunk.Err, io.ErrUnexpectedEOF) {
+					sawChunkError = true
+				}
+			}
+			if sawChunkError != tt.wantChunkError {
+				t.Fatalf("saw unexpected EOF chunk = %v, want %v", sawChunkError, tt.wantChunkError)
+			}
+			if got := executor.StreamCalls(); !equalStrings(got, tt.wantFirstCallList) {
+				t.Fatalf("first stream calls = %v, want %v", got, tt.wantFirstCallList)
+			}
+			updatedBad, ok := m.GetByID(badAuth.ID)
+			if !ok || updatedBad == nil {
+				t.Fatal("bad auth missing")
+			}
+			state := updatedBad.ModelStates[model]
+			if state == nil || state.LastError == nil || state.LastError.HTTPStatus != http.StatusBadGateway || state.NextRetryAfter.IsZero() {
+				t.Fatalf("stream EOF state = %#v, want transient 502 cooldown", state)
+			}
+
+			stream, err = m.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{Stream: true})
+			if err != nil {
+				t.Fatalf("second stream: %v", err)
+			}
+			for range stream.Chunks {
+			}
+			calls := executor.StreamCalls()
+			if len(calls) != len(tt.wantFirstCallList)+1 || calls[len(calls)-1] != goodAuth.ID {
+				t.Fatalf("stream calls after retry = %v, want final good auth", calls)
+			}
+		})
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## 结论

本 PR 收口五项仍有价值但尚未进入 `main` 的 runtime/API hardening：Gemini unknown method、Management 日志响应上限、`count_tokens` 404、transient EOF cooldown，以及过期 availability 清理。实现按当前 LTS 契约适配，不是 upstream sync，也没有混入 `upstream/main` 新增的 18 个提交。

**合并必须使用 Create a merge commit。** `docs/lts/downstream-patches.yaml` 的五项 `introduced_in` 指向实现 commit `6b0f185939f914983514d6a5e62378a8d91164e7`；禁止 squash 或 rebase。

## 问题与改动

- Gemini route 先校验 `generateContent`、`streamGenerateContent`、`countTokens` allowlist；unknown suffix 在读取 body 前稳定返回 404 `invalid_request_error`。
- Management logs 默认 `limit=1000`、最大 `10000`；Panel 显式 `10000` 与 TUI 显式 `200` 保持兼容。Legacy `after` 超限时返回 earliest page，并以最后实际返回行生成 cursor，避免积压日志被静默跳过。
- `count_tokens` 404 仍记录 failed/recent-request/hook/error event，但作为 request-scoped failure，不创建 auth/model cooldown，并允许下一 credential fallback；401、429、5xx 与普通 Execute generic 404 继续保留原 penalty。
- status-less `EOF` / `unexpected EOF`（含 wrapped、prefixed 和 `wsrelay: unexpected EOF (status=0)`）映射为 transient 502 cooldown；显式 HTTP status、`context.Canceled` 和 `DeadlineExceeded` 优先。已交付 payload 后不重放请求。
- `GET /v0/management/auth-files` 在列表前清理明确到期且可重置的 auth/model availability，并同步 manager、registry、scheduler 与 cooldown snapshot。Future、zero-deadline、disabled、Cloudflare/non-resettable、独立 auth-level warning 均保留；expired model aggregate 不会永久残留在 auth 状态上。
- AI Studio wsrelay stream error 改用 `%w` 保留 error chain。
- 在 downstream patch ledger 登记五项维护边界与 retirement 条件。

## 兼容性与边界

- 不改变 usage statistics、Management usage endpoints、Panel response shape 或配置 schema。
- 不把本 PR当作 upstream intake；`upstream/main=fde40c5a0a2f8f6808bcde498bc6079f32c355ef` 的新增提交留给后续 protected full-sync。
- Upstream `36ed0ca5` / issue `#4410` 提供相关 `count_tokens` endpoint-404 处理，但其 availability-neutral 路径与本 LTS 的 request-scoped `MarkResult`/fallback 契约不同，因此本 PR登记为 downstream adaptation。
- 本 PR未创建 tag、Release，也未部署 HFS/runtime。

## 验证

已在当前 head 通过：

```text
go test -count=1 ./sdk/cliproxy/auth
go test -race -count=1 ./sdk/cliproxy/auth -run 'PruneExpiredAvailability|EOF|CountTokens'
go test -count=1 ./internal/api ./internal/api/handlers/management ./sdk/api/handlers/gemini ./internal/runtime/executor
go test -count=1 ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage|Logs|AuthFiles|Gemini'
go run ./scripts/ltsregistry --root .
scripts/check-lts-contract.sh
go test -count=1 ./...
go build -o /tmp/cpa-core-runtime-api-final-output ./cmd/server
git diff --check origin/main...HEAD
```

两轮只读复审最终均无 P0/P1/P2 blocker。

## Review focus

1. `PruneExpiredAvailability` 对 independent auth-level state 与 model aggregate 的判定。
2. Legacy `after` 分页 cursor 是否保持无缺口、无重复。
3. CountTokens 404 与普通 Execute 404 的 penalty 边界。
4. EOF 在 pre-delivery fallback 与 post-delivery no-replay 两条 stream 路径中的记账。