### PR TITLE
feat(usage): 为请求明细记录可审计计费依据

### DIFF
--- a/docs/lts/core-feature-contracts.yaml
+++ b/docs/lts/core-feature-contracts.yaml
@@ -27,10 +27,13 @@ features:
     core_files:
       - internal/usage/
       - internal/runtime/executor/helps/usage_helpers.go
+      - internal/redisqueue/plugin.go
+      - internal/pluginhost/adapters.go
       - internal/api/handlers/management/usage.go
       - internal/api/handlers/management/usage_contract_test.go
       - internal/api/server.go
       - config.example.yaml
+      - sdk/pluginapi/types.go
     required_markers:
       - usage-statistics-enabled
       - UsageReporter

--- a/docs/lts/core-feature-contracts.yaml
+++ b/docs/lts/core-feature-contracts.yaml
@@ -35,6 +35,9 @@ features:
       - usage-statistics-enabled
       - UsageReporter
       - RequestDetail
+      - billing_basis
+      - api-token-usd
+      - chatgpt-credits
       - auth_index
       - latency_ms
       - uncached_input_tokens
@@ -83,6 +86,7 @@ features:
       - apis
       - models
       - details
+      - billing_basis
       - reasoning_effort
       - service_tier
       - request_service_tier

--- a/docs/lts/protected-deltas.yaml
+++ b/docs/lts/protected-deltas.yaml
@@ -24,6 +24,7 @@ retained_capabilities:
       - /v0/management/usage
       - /v0/management/usage/export
       - /v0/management/usage/import
+      - billing_basis
     validation:
       - scripts/check-lts-contract.sh
       - go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'
@@ -37,6 +38,7 @@ retained_capabilities:
       - /v0/management/usage/export
       - /v0/management/usage/import
       - /v0/management/usage-statistics-enabled
+      - billing_basis
     validation:
       - management-usage-response-shape-test
       - export-import-roundtrip-test

--- a/internal/api/handlers/management/usage_contract_test.go
+++ b/internal/api/handlers/management/usage_contract_test.go
@@ -58,6 +58,9 @@ func TestUsageManagementResponseShapeAndImportExportRoundTrip(t *testing.T) {
 	if !bytes.Contains(exportedJSON, []byte(`"effective_service_tier":"standard"`)) {
 		t.Fatalf("exported usage missing effective_service_tier: %s", exportedJSON)
 	}
+	if !bytes.Contains(exportedJSON, []byte(`"billing_basis":"api-token-usd"`)) {
+		t.Fatalf("exported usage missing billing_basis: %s", exportedJSON)
+	}
 	if !bytes.Contains(exportedJSON, []byte(`"generate":false`)) {
 		t.Fatalf("exported usage missing explicit generate=false: %s", exportedJSON)
 	}
@@ -230,6 +233,9 @@ func TestUsageManagementImportLegacyExportKeepsServiceTierUnknown(t *testing.T) 
 	if details[0].ServiceTier != "" {
 		t.Fatalf("legacy detail.service_tier = %q, want empty/unknown", details[0].ServiceTier)
 	}
+	if details[0].BillingBasis != coreusage.BillingBasisUnknown {
+		t.Fatalf("legacy detail.billing_basis = %q, want unknown", details[0].BillingBasis)
+	}
 	if details[0].RequestServiceTier != "" || details[0].ResponseServiceTier != "" || details[0].EffectiveServiceTier != "" {
 		t.Fatalf("legacy detail service tiers = request:%q response:%q effective:%q, want empty/unknown", details[0].RequestServiceTier, details[0].ResponseServiceTier, details[0].EffectiveServiceTier)
 	}
@@ -265,6 +271,9 @@ func TestUsageManagementImportLegacyExportKeepsServiceTierUnknown(t *testing.T) 
 	}
 	if bytes.Contains(reexportedJSON, []byte(`"uncached_input_tokens"`)) {
 		t.Fatalf("legacy re-export fabricated uncached_input_tokens: %s", reexportedJSON)
+	}
+	if !bytes.Contains(reexportedJSON, []byte(`"billing_basis":"unknown"`)) {
+		t.Fatalf("legacy re-export missing normalized unknown billing_basis: %s", reexportedJSON)
 	}
 }
 
@@ -406,6 +415,7 @@ func recordPanelContractUsage(stats *usage.RequestStatistics) {
 	stats.Record(context.Background(), coreusage.Record{
 		APIKey:               "panel-client-key",
 		Provider:             "openai",
+		AuthType:             "api_key",
 		Model:                "gpt-5.4",
 		Alias:                "panel-visible-model",
 		Source:               "auths/openai.json",
@@ -564,6 +574,9 @@ func requirePanelUsageShape(t *testing.T, snapshot usage.StatisticsSnapshot) {
 	}
 	if detail.ReasoningEffort != "medium" {
 		t.Fatalf("detail.reasoning_effort = %q, want medium", detail.ReasoningEffort)
+	}
+	if detail.BillingBasis != coreusage.BillingBasisAPITokenUSD {
+		t.Fatalf("detail.billing_basis = %q, want api-token-usd", detail.BillingBasis)
 	}
 	if detail.ServiceTier != "priority" {
 		t.Fatalf("detail.service_tier = %q, want priority", detail.ServiceTier)

--- a/internal/pluginhost/adapters.go
+++ b/internal/pluginhost/adapters.go
@@ -1855,6 +1855,7 @@ func (a *usageAdapter) HandleUsage(ctx context.Context, record coreusage.Record)
 		ReasoningEffort:      record.ReasoningEffort,
 		ServiceTier:          record.ServiceTier,
 		EffectiveServiceTier: record.EffectiveServiceTier,
+		BillingBasis:         coreusage.ResolveRecordBillingBasis(record),
 		Generate:             coreusage.GenerateEnabled(record.Generate),
 		RequestedAt:          record.RequestedAt,
 		Latency:              record.Latency,

--- a/internal/pluginhost/adapters_test.go
+++ b/internal/pluginhost/adapters_test.go
@@ -2253,6 +2253,33 @@ func TestUsageAdapterPreservesEffectiveServiceTier(t *testing.T) {
 	}
 }
 
+func TestUsageAdapterPreservesBillingBasis(t *testing.T) {
+	var got pluginapi.UsageRecord
+	plugin := usagePluginFunc(func(ctx context.Context, record pluginapi.UsageRecord) {
+		got = record
+	})
+	host := newHostWithRecords(capabilityRecord{
+		id: "usage-billing-basis",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			UsagePlugin: plugin,
+		}},
+	})
+	adapter := &usageAdapter{
+		host:     host,
+		pluginID: "usage-billing-basis",
+	}
+
+	adapter.HandleUsage(context.Background(), coreusage.Record{
+		Provider:     "codex",
+		AuthType:     "oauth",
+		BillingBasis: coreusage.BillingBasisChatGPTCredits,
+	})
+
+	if got.BillingBasis != coreusage.BillingBasisChatGPTCredits {
+		t.Fatalf("plugin BillingBasis = %q, want %q", got.BillingBasis, coreusage.BillingBasisChatGPTCredits)
+	}
+}
+
 func TestUsageManagerRegisterNamedReplacesWithoutDuplicateDispatch(t *testing.T) {
 	manager := coreusage.NewManager(0)
 	defer manager.Stop()

--- a/internal/pluginhost/host_test.go
+++ b/internal/pluginhost/host_test.go
@@ -531,6 +531,27 @@ func TestRPCUsageIncludesEffectiveServiceTier(t *testing.T) {
 	}
 }
 
+func TestRPCUsageIncludesBillingBasis(t *testing.T) {
+	client := &capturePluginClient{}
+	adapter := &rpcPluginAdapter{
+		host:   New(),
+		client: client,
+	}
+
+	adapter.HandleUsage(context.Background(), pluginapi.UsageRecord{
+		Provider:     "codex",
+		BillingBasis: "chatgpt-credits",
+	})
+
+	var record pluginapi.UsageRecord
+	if errDecode := json.Unmarshal(client.requests[pluginabi.MethodUsageHandle], &record); errDecode != nil {
+		t.Fatalf("decode usage request: %v", errDecode)
+	}
+	if record.BillingBasis != "chatgpt-credits" {
+		t.Fatalf("RPC BillingBasis = %q, want chatgpt-credits", record.BillingBasis)
+	}
+}
+
 func TestOptionalRPCMethodUnsupportedDetectionIsNarrow(t *testing.T) {
 	method := pluginabi.MethodRequestInterceptAfter
 	positive := []string{

--- a/internal/redisqueue/plugin.go
+++ b/internal/redisqueue/plugin.go
@@ -128,6 +128,7 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 		RequestServiceTier:   requestServiceTier,
 		ResponseServiceTier:  responseServiceTier,
 		EffectiveServiceTier: effectiveServiceTier,
+		BillingBasis:         coreusage.ResolveRecordBillingBasis(record),
 	})
 	if err != nil {
 		return
@@ -150,6 +151,7 @@ type queuedUsageDetail struct {
 	RequestServiceTier   string `json:"request_service_tier"`
 	ResponseServiceTier  string `json:"response_service_tier,omitempty"`
 	EffectiveServiceTier string `json:"effective_service_tier,omitempty"`
+	BillingBasis         string `json:"billing_basis"`
 }
 
 type requestDetail struct {

--- a/internal/redisqueue/plugin_test.go
+++ b/internal/redisqueue/plugin_test.go
@@ -72,6 +72,40 @@ func TestUsageQueuePluginPayloadIncludesStableFieldsAndSuccess(t *testing.T) {
 	})
 }
 
+func TestUsageQueuePluginPayloadIncludesBillingBasis(t *testing.T) {
+	tests := []struct {
+		name         string
+		provider     string
+		authType     string
+		billingBasis string
+		want         string
+	}{
+		{name: "Codex OAuth", provider: "codex", authType: "oauth", billingBasis: coreusage.BillingBasisChatGPTCredits, want: coreusage.BillingBasisChatGPTCredits},
+		{name: "Codex API key", provider: "codex", authType: "apikey", billingBasis: coreusage.BillingBasisAPITokenUSD, want: coreusage.BillingBasisAPITokenUSD},
+		{name: "custom endpoint classification", provider: "codex", authType: "apikey", billingBasis: coreusage.BillingBasisUnknown, want: coreusage.BillingBasisUnknown},
+		{name: "legacy record fallback", provider: "openai", authType: "apikey", want: coreusage.BillingBasisAPITokenUSD},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withEnabledQueue(t, func() {
+				ctx := internallogging.WithResponseStatusHolder(context.Background())
+				internallogging.SetResponseStatus(ctx, http.StatusOK)
+
+				(&usageQueuePlugin{}).HandleUsage(ctx, coreusage.Record{
+					Provider:     tt.provider,
+					AuthType:     tt.authType,
+					BillingBasis: tt.billingBasis,
+					Detail:       coreusage.Detail{TotalTokens: 1},
+				})
+
+				payload := popSinglePayload(t)
+				requireStringField(t, payload, "billing_basis", tt.want)
+			})
+		})
+	}
+}
+
 func TestUsageQueuePluginKeepsCacheCreationSeparateFromCachedTokens(t *testing.T) {
 	withEnabledQueue(t, func() {
 		ctx := internallogging.WithResponseStatusHolder(context.Background())

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -30,6 +30,7 @@ type UsageReporter struct {
 	authID       string
 	authIndex    string
 	authType     string
+	billingBasis string
 	apiKey       string
 	source       string
 	reasoning    string
@@ -61,6 +62,7 @@ func NewExecutorUsageReporter(ctx context.Context, executor usageExecutor, model
 func NewUsageReporter(ctx context.Context, provider, model string, auth *cliproxyauth.Auth) *UsageReporter {
 	apiKey := APIKeyFromContext(ctx)
 	alias := usage.RequestedModelAliasFromContext(ctx)
+	authType := resolveUsageAuthType(auth)
 	if alias == "" {
 		alias = model
 	}
@@ -71,7 +73,12 @@ func NewUsageReporter(ctx context.Context, provider, model string, auth *cliprox
 		requestedAt: time.Now(),
 		apiKey:      apiKey,
 		source:      resolveUsageSource(auth, apiKey),
-		authType:    resolveUsageAuthType(auth),
+		authType:    authType,
+		billingBasis: usage.ResolveBillingBasisWithBaseURL(
+			provider,
+			authType,
+			resolveUsageBaseURL(auth),
+		),
 		reasoning:   usage.ReasoningEffortFromContext(ctx),
 		serviceTier: usage.ServiceTierFromContext(ctx),
 		generate:    usage.GenerateFromContext(ctx),
@@ -293,6 +300,7 @@ func (r *UsageReporter) buildRecordForModel(model string, detail usage.Detail, f
 		AuthID:              r.authID,
 		AuthIndex:           r.authIndex,
 		AuthType:            r.authType,
+		BillingBasis:        r.billingBasis,
 		ReasoningEffort:     r.reasoning,
 		ServiceTier:         r.serviceTier,
 		RequestServiceTier:  r.serviceTier,
@@ -474,6 +482,13 @@ func resolveUsageAuthType(auth *cliproxyauth.Auth) string {
 		return ""
 	}
 	return auth.AuthKind()
+}
+
+func resolveUsageBaseURL(auth *cliproxyauth.Auth) string {
+	if auth == nil || auth.Attributes == nil {
+		return ""
+	}
+	return strings.TrimSpace(auth.Attributes["base_url"])
 }
 
 // StreamUsageBuffer keeps the latest usage detail observed in a stream.

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 )
 
@@ -707,6 +708,56 @@ func TestUsageReporterResolvesEffectiveServiceTierFromFinalOutboundPayload(t *te
 			record := reporter.buildRecord(usage.Detail{TotalTokens: 1, ResponseServiceTier: tt.response}, false)
 			if record.EffectiveServiceTier != tt.want {
 				t.Fatalf("effective service tier = %q, want %q", record.EffectiveServiceTier, tt.want)
+			}
+		})
+	}
+}
+
+func TestUsageReporterResolvesBillingBasisFromAuthEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		auth     *cliproxyauth.Auth
+		want     string
+	}{
+		{
+			name:     "Codex OAuth uses credits",
+			provider: "codex",
+			auth: &cliproxyauth.Auth{
+				Provider:   "codex",
+				Attributes: map[string]string{"auth_kind": "oauth"},
+			},
+			want: usage.BillingBasisChatGPTCredits,
+		},
+		{
+			name:     "Codex API key without explicit endpoint uses USD",
+			provider: "codex",
+			auth: &cliproxyauth.Auth{
+				Provider:   "codex",
+				Attributes: map[string]string{"api_key": "test-key"},
+			},
+			want: usage.BillingBasisAPITokenUSD,
+		},
+		{
+			name:     "Codex API key custom endpoint fails closed",
+			provider: "codex",
+			auth: &cliproxyauth.Auth{
+				Provider: "codex",
+				Attributes: map[string]string{
+					"api_key":  "test-key",
+					"base_url": "https://proxy.example.com/codex",
+				},
+			},
+			want: usage.BillingBasisUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reporter := NewUsageReporter(context.Background(), tt.provider, "gpt-5.6", tt.auth)
+			record := reporter.buildRecord(usage.Detail{TotalTokens: 1}, false)
+			if record.BillingBasis != tt.want {
+				t.Fatalf("billing basis = %q, want %q", record.BillingBasis, tt.want)
 			}
 		})
 	}

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -100,6 +100,7 @@ type RequestDetail struct {
 	RequestServiceTier   string     `json:"request_service_tier,omitempty"`
 	ResponseServiceTier  string     `json:"response_service_tier,omitempty"`
 	EffectiveServiceTier string     `json:"effective_service_tier,omitempty"`
+	BillingBasis         string     `json:"billing_basis"`
 	Tokens               TokenStats `json:"tokens"`
 	Failed               bool       `json:"failed"`
 	Generate             bool       `json:"generate"`
@@ -129,6 +130,7 @@ func (d *RequestDetail) UnmarshalJSON(data []byte) error {
 
 	*d = RequestDetail(decoded)
 	d.Generate = generate
+	d.BillingBasis = normaliseBillingBasis(d.BillingBasis)
 	return nil
 }
 
@@ -256,6 +258,7 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 		RequestServiceTier:   requestServiceTier,
 		ResponseServiceTier:  responseServiceTier,
 		EffectiveServiceTier: effectiveServiceTier,
+		BillingBasis:         coreusage.ResolveBillingBasis(record.Provider, record.AuthType),
 		Tokens:               detail,
 		Failed:               failed,
 		Generate:             coreusage.GenerateEnabled(record.Generate),
@@ -393,7 +396,7 @@ func (s *RequestStatistics) MergeSnapshot(snapshot StatisticsSnapshot) MergeResu
 			}
 			for _, detail := range modelSnapshot.Details {
 				detail.Tokens = normaliseTokenStats(detail.Tokens)
-				detail = normaliseServiceTierAliases(detail)
+				detail = normaliseRequestDetail(detail)
 				if detail.LatencyMs < 0 {
 					detail.LatencyMs = 0
 				}
@@ -415,7 +418,7 @@ func (s *RequestStatistics) MergeSnapshot(snapshot StatisticsSnapshot) MergeResu
 	return result
 }
 
-func normaliseServiceTierAliases(detail RequestDetail) RequestDetail {
+func normaliseRequestDetail(detail RequestDetail) RequestDetail {
 	if strings.TrimSpace(detail.RequestServiceTier) == "" && strings.TrimSpace(detail.ServiceTier) != "" {
 		detail.RequestServiceTier = detail.ServiceTier
 	}
@@ -423,7 +426,21 @@ func normaliseServiceTierAliases(detail RequestDetail) RequestDetail {
 		detail.ServiceTier = detail.RequestServiceTier
 	}
 	detail.EffectiveServiceTier = coreusage.CanonicalEffectiveServiceTier(detail.EffectiveServiceTier)
+	detail.BillingBasis = normaliseBillingBasis(detail.BillingBasis)
 	return detail
+}
+
+func normaliseBillingBasis(billingBasis string) string {
+	switch strings.ToLower(strings.TrimSpace(billingBasis)) {
+	case coreusage.BillingBasisAPITokenUSD:
+		return coreusage.BillingBasisAPITokenUSD
+	case coreusage.BillingBasisChatGPTCredits:
+		return coreusage.BillingBasisChatGPTCredits
+	case coreusage.BillingBasisUnknown:
+		return coreusage.BillingBasisUnknown
+	default:
+		return coreusage.BillingBasisUnknown
+	}
 }
 
 func (s *RequestStatistics) recordImported(apiName, modelName string, stats *apiStats, detail RequestDetail) {

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -258,7 +258,7 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 		RequestServiceTier:   requestServiceTier,
 		ResponseServiceTier:  responseServiceTier,
 		EffectiveServiceTier: effectiveServiceTier,
-		BillingBasis:         coreusage.ResolveBillingBasis(record.Provider, record.AuthType),
+		BillingBasis:         coreusage.ResolveRecordBillingBasis(record),
 		Tokens:               detail,
 		Failed:               failed,
 		Generate:             coreusage.GenerateEnabled(record.Generate),
@@ -431,16 +431,7 @@ func normaliseRequestDetail(detail RequestDetail) RequestDetail {
 }
 
 func normaliseBillingBasis(billingBasis string) string {
-	switch strings.ToLower(strings.TrimSpace(billingBasis)) {
-	case coreusage.BillingBasisAPITokenUSD:
-		return coreusage.BillingBasisAPITokenUSD
-	case coreusage.BillingBasisChatGPTCredits:
-		return coreusage.BillingBasisChatGPTCredits
-	case coreusage.BillingBasisUnknown:
-		return coreusage.BillingBasisUnknown
-	default:
-		return coreusage.BillingBasisUnknown
-	}
+	return coreusage.CanonicalBillingBasis(billingBasis)
 }
 
 func (s *RequestStatistics) recordImported(apiName, modelName string, stats *apiStats, detail RequestDetail) {

--- a/internal/usage/logger_plugin_test.go
+++ b/internal/usage/logger_plugin_test.go
@@ -97,6 +97,74 @@ func TestRequestStatisticsRecordIncludesUsageMetadata(t *testing.T) {
 	}
 }
 
+func TestRequestStatisticsRecordResolvesBillingBasis(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		authType string
+		want     string
+	}{
+		{name: "Codex OAuth", provider: "codex", authType: "oauth", want: coreusage.BillingBasisChatGPTCredits},
+		{name: "Codex API key", provider: "codex", authType: "api_key", want: coreusage.BillingBasisAPITokenUSD},
+		{name: "OpenAI API key", provider: "openai", authType: "api_key", want: coreusage.BillingBasisAPITokenUSD},
+		{name: "unknown", provider: "openai", authType: "oauth", want: coreusage.BillingBasisUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stats := NewRequestStatistics()
+			stats.Record(context.Background(), coreusage.Record{
+				APIKey:   "test-key",
+				Provider: tt.provider,
+				AuthType: tt.authType,
+				Model:    "gpt-5.4",
+				Detail:   coreusage.Detail{TotalTokens: 1},
+			})
+
+			got := stats.Snapshot().APIs["test-key"].Models["gpt-5.4"].Details[0].BillingBasis
+			if got != tt.want {
+				t.Fatalf("billing_basis = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRequestStatisticsMergeSnapshotNormalisesBillingBasis(t *testing.T) {
+	tests := []struct {
+		name  string
+		basis string
+		want  string
+	}{
+		{name: "API token USD", basis: " API-TOKEN-USD ", want: coreusage.BillingBasisAPITokenUSD},
+		{name: "ChatGPT credits", basis: "chatgpt-credits", want: coreusage.BillingBasisChatGPTCredits},
+		{name: "missing legacy value", want: coreusage.BillingBasisUnknown},
+		{name: "unsupported value", basis: "credits", want: coreusage.BillingBasisUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stats := NewRequestStatistics()
+			result := stats.MergeSnapshot(StatisticsSnapshot{APIs: map[string]APISnapshot{
+				"test-key": {Models: map[string]ModelSnapshot{
+					"gpt-5.4": {Details: []RequestDetail{{
+						Timestamp:    time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC),
+						BillingBasis: tt.basis,
+						Tokens:       TokenStats{TotalTokens: 1},
+					}}},
+				}},
+			}})
+			if result.Added != 1 || result.Skipped != 0 {
+				t.Fatalf("merge result = %+v, want added=1 skipped=0", result)
+			}
+
+			got := stats.Snapshot().APIs["test-key"].Models["gpt-5.4"].Details[0].BillingBasis
+			if got != tt.want {
+				t.Fatalf("billing_basis = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRequestStatisticsRecordDefaultsOmittedGenerateTrue(t *testing.T) {
 	stats := NewRequestStatistics()
 	stats.Record(context.Background(), coreusage.Record{

--- a/internal/usage/logger_plugin_test.go
+++ b/internal/usage/logger_plugin_test.go
@@ -99,13 +99,15 @@ func TestRequestStatisticsRecordIncludesUsageMetadata(t *testing.T) {
 
 func TestRequestStatisticsRecordResolvesBillingBasis(t *testing.T) {
 	tests := []struct {
-		name     string
-		provider string
-		authType string
-		want     string
+		name         string
+		provider     string
+		authType     string
+		billingBasis string
+		want         string
 	}{
 		{name: "Codex OAuth", provider: "codex", authType: "oauth", want: coreusage.BillingBasisChatGPTCredits},
 		{name: "Codex API key", provider: "codex", authType: "api_key", want: coreusage.BillingBasisAPITokenUSD},
+		{name: "Codex custom endpoint classification", provider: "codex", authType: "api_key", billingBasis: coreusage.BillingBasisUnknown, want: coreusage.BillingBasisUnknown},
 		{name: "OpenAI API key", provider: "openai", authType: "api_key", want: coreusage.BillingBasisAPITokenUSD},
 		{name: "unknown", provider: "openai", authType: "oauth", want: coreusage.BillingBasisUnknown},
 	}
@@ -114,11 +116,12 @@ func TestRequestStatisticsRecordResolvesBillingBasis(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			stats := NewRequestStatistics()
 			stats.Record(context.Background(), coreusage.Record{
-				APIKey:   "test-key",
-				Provider: tt.provider,
-				AuthType: tt.authType,
-				Model:    "gpt-5.4",
-				Detail:   coreusage.Detail{TotalTokens: 1},
+				APIKey:       "test-key",
+				Provider:     tt.provider,
+				AuthType:     tt.authType,
+				BillingBasis: tt.billingBasis,
+				Model:        "gpt-5.4",
+				Detail:       coreusage.Detail{TotalTokens: 1},
 			})
 
 			got := stats.Snapshot().APIs["test-key"].Models["gpt-5.4"].Details[0].BillingBasis

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -161,6 +161,9 @@ require_grep 'json:"service_tier,omitempty"' internal/usage
 require_grep 'json:"request_service_tier,omitempty"' internal/usage
 require_grep 'json:"response_service_tier,omitempty"' internal/usage
 require_grep 'json:"effective_service_tier,omitempty"' internal/usage internal/redisqueue
+require_grep 'json:"billing_basis"' internal/usage
+require_grep "BillingBasisAPITokenUSD" sdk/cliproxy/usage internal/usage
+require_grep "BillingBasisChatGPTCredits" sdk/cliproxy/usage internal/usage
 require_grep 'json:"EffectiveServiceTier,omitempty"' sdk/pluginapi/types.go
 require_grep "TestUsageAdapterPreservesEffectiveServiceTier" internal/pluginhost/adapters_test.go
 require_grep "TestRPCUsageIncludesEffectiveServiceTier" internal/pluginhost/host_test.go
@@ -176,6 +179,7 @@ require_grep '"thinking"' internal/api/handlers/management/usage_contract_test.g
 require_grep "request_service_tier" internal/api/handlers/management/usage_contract_test.go
 require_grep "response_service_tier" internal/api/handlers/management/usage_contract_test.go
 require_grep "effective_service_tier" internal/api/handlers/management/usage_contract_test.go
+require_grep "billing_basis" internal/api/handlers/management/usage_contract_test.go
 require_grep '"generate"' internal/api/handlers/management/usage_contract_test.go
 
 go test ./scripts/ltsregistry -count=1

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -161,12 +161,15 @@ require_grep 'json:"service_tier,omitempty"' internal/usage
 require_grep 'json:"request_service_tier,omitempty"' internal/usage
 require_grep 'json:"response_service_tier,omitempty"' internal/usage
 require_grep 'json:"effective_service_tier,omitempty"' internal/usage internal/redisqueue
-require_grep 'json:"billing_basis"' internal/usage
-require_grep "BillingBasisAPITokenUSD" sdk/cliproxy/usage internal/usage
-require_grep "BillingBasisChatGPTCredits" sdk/cliproxy/usage internal/usage
+require_grep 'json:"billing_basis"' internal/usage internal/redisqueue
+require_grep "BillingBasisAPITokenUSD" sdk/cliproxy/usage internal/usage internal/redisqueue
+require_grep "BillingBasisChatGPTCredits" sdk/cliproxy/usage internal/usage internal/redisqueue
 require_grep 'json:"EffectiveServiceTier,omitempty"' sdk/pluginapi/types.go
+require_grep 'json:"BillingBasis,omitempty"' sdk/pluginapi/types.go
 require_grep "TestUsageAdapterPreservesEffectiveServiceTier" internal/pluginhost/adapters_test.go
 require_grep "TestRPCUsageIncludesEffectiveServiceTier" internal/pluginhost/host_test.go
+require_grep "TestUsageAdapterPreservesBillingBasis" internal/pluginhost/adapters_test.go
+require_grep "TestRPCUsageIncludesBillingBasis" internal/pluginhost/host_test.go
 require_grep "TestPublishCodexImageToolUsagePreservesResponseTierPrecedence" internal/runtime/executor/codex_openai_images_test.go
 require_grep 'json:"generate"' internal/usage internal/redisqueue
 require_grep "GenerateEnabled" internal/usage internal/redisqueue sdk/cliproxy/usage

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -18,6 +18,16 @@ const DefaultServiceTier = "default"
 // historical direct-SDK default.
 const AutoServiceTier = "auto"
 
+const (
+	// BillingBasisAPITokenUSD identifies requests billed through an API token in USD.
+	BillingBasisAPITokenUSD = "api-token-usd"
+	// BillingBasisChatGPTCredits identifies requests billed against ChatGPT credits.
+	BillingBasisChatGPTCredits = "chatgpt-credits"
+	// BillingBasisUnknown is used when the provider and authentication type do not
+	// establish a supported billing basis.
+	BillingBasisUnknown = "unknown"
+)
+
 // Record contains the usage statistics captured for a single provider request.
 type Record struct {
 	Provider string
@@ -100,6 +110,28 @@ func ResolveEffectiveServiceTier(responseServiceTier, outboundServiceTier string
 		return CanonicalEffectiveServiceTier(responseServiceTier)
 	}
 	return CanonicalEffectiveServiceTier(outboundServiceTier)
+}
+
+// ResolveBillingBasis returns the stable billing basis implied by the usage
+// record's provider and authentication type. It intentionally uses only these
+// non-secret classification fields and leaves every unsupported combination as
+// unknown.
+func ResolveBillingBasis(provider, authType string) string {
+	authType = strings.ToLower(strings.TrimSpace(authType))
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "codex":
+		switch authType {
+		case "oauth":
+			return BillingBasisChatGPTCredits
+		case "api_key", "api-key", "apikey":
+			return BillingBasisAPITokenUSD
+		}
+	case "openai":
+		if authType == "api_key" || authType == "api-key" || authType == "apikey" {
+			return BillingBasisAPITokenUSD
+		}
+	}
+	return BillingBasisUnknown
 }
 
 // NormalizeUncachedInputTokens clears uncached input data that is unknown or

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -39,6 +39,10 @@ type Record struct {
 	AuthID       string
 	AuthIndex    string
 	AuthType     string
+	// BillingBasis stores the stable, non-secret classification resolved at the
+	// request boundary. Usage sinks should preserve this value rather than
+	// independently reclassifying credentials with less context.
+	BillingBasis string
 	Source       string
 	// ReasoningEffort stores the translated upstream thinking level for request event logs.
 	ReasoningEffort string
@@ -132,6 +136,51 @@ func ResolveBillingBasis(provider, authType string) string {
 		}
 	}
 	return BillingBasisUnknown
+}
+
+// ResolveBillingBasisWithBaseURL resolves billing basis while accounting for
+// explicit endpoint provenance. A Codex API key routed through a configured
+// base URL may belong to a non-OpenAI billing domain, so it fails closed.
+func ResolveBillingBasisWithBaseURL(provider, authType, baseURL string) string {
+	if strings.EqualFold(strings.TrimSpace(provider), "codex") &&
+		isAPIKeyAuthType(authType) && strings.TrimSpace(baseURL) != "" {
+		return BillingBasisUnknown
+	}
+	return ResolveBillingBasis(provider, authType)
+}
+
+// ResolveRecordBillingBasis returns the classification already resolved at the
+// request boundary. Records from older direct SDK callers fall back to the
+// provider/auth resolver for backward compatibility.
+func ResolveRecordBillingBasis(record Record) string {
+	if strings.TrimSpace(record.BillingBasis) != "" {
+		return CanonicalBillingBasis(record.BillingBasis)
+	}
+	return ResolveBillingBasis(record.Provider, record.AuthType)
+}
+
+// CanonicalBillingBasis normalizes supported billing values and fails closed
+// for empty or unrecognized input.
+func CanonicalBillingBasis(billingBasis string) string {
+	switch strings.ToLower(strings.TrimSpace(billingBasis)) {
+	case BillingBasisAPITokenUSD:
+		return BillingBasisAPITokenUSD
+	case BillingBasisChatGPTCredits:
+		return BillingBasisChatGPTCredits
+	case BillingBasisUnknown:
+		return BillingBasisUnknown
+	default:
+		return BillingBasisUnknown
+	}
+}
+
+func isAPIKeyAuthType(authType string) bool {
+	switch strings.ToLower(strings.TrimSpace(authType)) {
+	case "api_key", "api-key", "apikey":
+		return true
+	default:
+		return false
+	}
 }
 
 // NormalizeUncachedInputTokens clears uncached input data that is unknown or

--- a/sdk/cliproxy/usage/manager_test.go
+++ b/sdk/cliproxy/usage/manager_test.go
@@ -179,6 +179,29 @@ func TestResolveBillingBasis(t *testing.T) {
 	}
 }
 
+func TestResolveBillingBasisWithBaseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		authType string
+		baseURL  string
+		want     string
+	}{
+		{name: "Codex OAuth", provider: "codex", authType: "oauth", want: BillingBasisChatGPTCredits},
+		{name: "Codex API key without explicit endpoint", provider: "codex", authType: "apikey", want: BillingBasisAPITokenUSD},
+		{name: "Codex API key custom endpoint", provider: "codex", authType: "apikey", baseURL: "https://proxy.example.com/codex", want: BillingBasisUnknown},
+		{name: "OpenAI API key custom endpoint remains provider classified", provider: "openai", authType: "apikey", baseURL: "https://api.openai.com/v1", want: BillingBasisAPITokenUSD},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ResolveBillingBasisWithBaseURL(tt.provider, tt.authType, tt.baseURL); got != tt.want {
+				t.Fatalf("ResolveBillingBasisWithBaseURL(%q, %q, %q) = %q, want %q", tt.provider, tt.authType, tt.baseURL, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestManagerDequeueClearsConsumedContextAndBackingArray(t *testing.T) {
 	m := NewManager(2)
 	ctx := context.WithValue(context.Background(), struct{}{}, bytesMarker(1))

--- a/sdk/cliproxy/usage/manager_test.go
+++ b/sdk/cliproxy/usage/manager_test.go
@@ -152,6 +152,33 @@ func TestResolveEffectiveServiceTier(t *testing.T) {
 	}
 }
 
+func TestResolveBillingBasis(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		authType string
+		want     string
+	}{
+		{name: "Codex OAuth", provider: "codex", authType: "oauth", want: BillingBasisChatGPTCredits},
+		{name: "Codex API key", provider: " Codex ", authType: " API_KEY ", want: BillingBasisAPITokenUSD},
+		{name: "Codex legacy apikey", provider: "codex", authType: "apikey", want: BillingBasisAPITokenUSD},
+		{name: "OpenAI API key", provider: "openai", authType: "api_key", want: BillingBasisAPITokenUSD},
+		{name: "OpenAI hyphenated API key", provider: "openai", authType: "api-key", want: BillingBasisAPITokenUSD},
+		{name: "Codex missing auth type", provider: "codex", want: BillingBasisUnknown},
+		{name: "OpenAI OAuth", provider: "openai", authType: "oauth", want: BillingBasisUnknown},
+		{name: "other provider", provider: "anthropic", authType: "api_key", want: BillingBasisUnknown},
+		{name: "empty", want: BillingBasisUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ResolveBillingBasis(tt.provider, tt.authType); got != tt.want {
+				t.Fatalf("ResolveBillingBasis(%q, %q) = %q, want %q", tt.provider, tt.authType, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestManagerDequeueClearsConsumedContextAndBackingArray(t *testing.T) {
 	m := NewManager(2)
 	ctx := context.WithValue(context.Background(), struct{}{}, bytesMarker(1))

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -1304,6 +1304,9 @@ type UsageRecord struct {
 	// EffectiveServiceTier records the canonical tier selected for the request.
 	// It is empty when the effective tier cannot be determined safely.
 	EffectiveServiceTier string `json:"EffectiveServiceTier,omitempty"`
+	// BillingBasis records the stable, non-secret billing classification resolved
+	// by the host. It is omitted for legacy callers that do not provide one.
+	BillingBasis string `json:"BillingBasis,omitempty"`
 	// Generate reports whether the client requested actual generation.
 	// The host normalizes omitted usage.Record values to true before delivery.
 	Generate bool

--- a/sdk/pluginapi/types_test.go
+++ b/sdk/pluginapi/types_test.go
@@ -95,6 +95,46 @@ func TestUsageRecordEffectiveServiceTierJSONCompatibility(t *testing.T) {
 	}
 }
 
+func TestUsageRecordBillingBasisJSONCompatibility(t *testing.T) {
+	raw, errMarshal := json.Marshal(UsageRecord{
+		Provider:     "codex",
+		BillingBasis: "chatgpt-credits",
+	})
+	if errMarshal != nil {
+		t.Fatalf("marshal UsageRecord: %v", errMarshal)
+	}
+
+	var fields map[string]json.RawMessage
+	if errUnmarshal := json.Unmarshal(raw, &fields); errUnmarshal != nil {
+		t.Fatalf("decode UsageRecord fields: %v", errUnmarshal)
+	}
+	if _, ok := fields["BillingBasis"]; !ok {
+		t.Fatalf("UsageRecord JSON missing BillingBasis: %s", raw)
+	}
+
+	emptyRaw, errMarshal := json.Marshal(UsageRecord{Provider: "codex"})
+	if errMarshal != nil {
+		t.Fatalf("marshal empty-billing UsageRecord: %v", errMarshal)
+	}
+	var emptyFields map[string]json.RawMessage
+	if errUnmarshal := json.Unmarshal(emptyRaw, &emptyFields); errUnmarshal != nil {
+		t.Fatalf("decode empty-billing UsageRecord fields: %v", errUnmarshal)
+	}
+	if _, ok := emptyFields["BillingBasis"]; ok {
+		t.Fatalf("empty UsageRecord JSON unexpectedly includes BillingBasis: %s", emptyRaw)
+	}
+
+	var legacy struct {
+		Provider string
+	}
+	if errUnmarshal := json.Unmarshal(raw, &legacy); errUnmarshal != nil {
+		t.Fatalf("legacy decoder rejected additive UsageRecord field: %v", errUnmarshal)
+	}
+	if legacy.Provider != "codex" {
+		t.Fatalf("legacy UsageRecord = %+v, want provider codex", legacy)
+	}
+}
+
 func TestMetadataConfigFieldsExposePluginSchema(t *testing.T) {
 	meta := Metadata{
 		Name:             "example",


### PR DESCRIPTION
## 结果与边界

为完整 usage detail 增加稳定的 `billing_basis`，让 Panel、Redis usage queue 与 usage plugins 一致区分 API Token USD、ChatGPT credits 与未知计费域。本 PR 仅开放并持久化分类事实，不计算价格、不换算 credits，也未发布或部署。

## Type

- [x] LTS feature / downstream patch maintenance

## 变更

- `coreusage.Record.BillingBasis` 保存请求边界已解析的非敏感分类；usage sinks 只转发，不各自根据不完整上下文重新推断。
- `UsageReporter` 在持有 auth 与 endpoint provenance 时一次解析：
  - Codex OAuth → `chatgpt-credits`
  - legacy、无显式 endpoint 的 Codex API key → `api-token-usd`
  - 显式 custom `base_url` 的 Codex API key → `unknown`，fail closed
- `RequestDetail.billing_basis` 进入 usage snapshot、Management API、export/import roundtrip；legacy、缺失和非法导入值归一化为 `unknown`。
- Redis `queuedUsageDetail` 新增必填 snake_case `billing_basis`，与 Management usage 保持一致。
- `pluginapi.UsageRecord` additive 新增 `BillingBasis,omitempty`；in-process adapter 与 RPC JSON 均传递该值。
- logger、Redis queue 与 plugin adapter 统一调用 `ResolveRecordBillingBasis`；旧 direct SDK record 缺字段时保留 provider/auth fallback。
- 同步 LTS feature contract 与 contract guard markers。

## 兼容性与隐私

- Management、Redis 和 plugin JSON schema 均为 additive；既有字段及 `/v0/management/usage*` endpoint 不变。
- `UsagePlugin.HandleUsage` 方法签名不变；旧 plugin decoder 会忽略新字段，空值通过 `omitempty` 不改变 legacy RPC payload。
- legacy export 可继续导入，不会凭空推断 USD 计费依据。
- custom Codex endpoint 的 raw URL 不进入 Management usage、Redis queue 或 plugin usage payload，只输出稳定分类。
- 配套 Panel PR #33 消费该字段；缺少字段时 Panel 仍按 `unknown` 处理。

## Protected delta checklist

- [x] `usage-statistics-enabled` still exists
- [x] `internal/usage/` still exists
- [x] `/v0/management/usage` still exists
- [x] `/v0/management/usage/export` still exists
- [x] `/v0/management/usage/import` still exists
- [x] `/v0/management/usage-queue` remains additive
- [x] `docs/lts/core-feature-contracts.yaml` and guard markers aligned
- [x] Usage record creation/schema, Redis queue and plugin transport reviewed and tested
- [x] Management usage response/export/import compatibility reviewed and tested
- [x] CPA-Panel-LTS real-Core smoke passed

## LTS classification review

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| full-usage-statistics / Management usage details | protected capability | adapted | additive `billing_basis`, legacy normalization, roundtrip tests |
| Redis usage queue | protected additive sink | adapted | stable snake_case field and fallback tests |
| plugin usage contract | public additive API | adapted | `omitempty`, in-process/RPC tests, legacy decoder compatibility |
| custom Codex endpoint | conservative billing boundary | hardened | explicit endpoint remains `unknown`; raw URL is not exported |

## Validation

- [x] `scripts/check-lts-contract.sh`
- [x] `go test ./sdk/cliproxy/usage ./internal/runtime/executor/helps ./internal/usage ./internal/redisqueue ./sdk/pluginapi ./internal/pluginhost ./internal/api/handlers/management -count=1`
- [x] `go test ./sdk/cliproxy/... -count=1`
- [x] `go test ./... -count=1`
- [x] server build: `go build -o /tmp/cpa-core-lts-codex-build-smoke ./cmd/server`
- [x] Panel real-Core smoke: `npm run smoke:lts:core -- --no-write-smoke`
- [x] `git diff --check`

## Optional real runtime smoke

- [x] 跳过 Hugging Face Space smoke：本 PR 尚未合并、发布或部署；真实 Panel/Core 联调已由本地 real-Core smoke 覆盖。

## Review focus

请重点确认 custom Codex endpoint 的 fail-closed 分类、`BillingBasis` 在 Management/Redis/plugin 三条 sink 的一致性、additive plugin JSON compatibility，以及 legacy direct SDK fallback。