### PR TITLE
fix(auth): refresh xAI tokens on bad-credentials responses

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -4482,6 +4482,18 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 							suspendReason = "invalid_grant"
 							shouldSuspendModel = true
 						}
+					} else if isXaiBadCredentialsResultError(auth.Provider, result.Error) {
+						if state.LastError != nil {
+							state.LastError.Code = "unauthorized"
+						}
+						if disableCooling {
+							state.NextRetryAfter = time.Time{}
+						} else {
+							next := now.Add(30 * time.Minute)
+							state.NextRetryAfter = next
+							suspendReason = "unauthorized"
+							shouldSuspendModel = true
+						}
 					} else {
 						switch statusCode {
 						case 401:
@@ -5320,6 +5332,31 @@ func isInvalidGrantResultError(err *Error) bool {
 	return isInvalidGrantErrorMessage(err.Code) || isInvalidGrantErrorMessage(err.Message)
 }
 
+func isXaiBadCredentialsMessage(message string) bool {
+	lower := strings.ToLower(message)
+	return strings.Contains(lower, "bad-credentials") || strings.Contains(lower, "could not be validated")
+}
+
+func isXaiBadCredentialsError(provider string, err error) bool {
+	if err == nil || !strings.EqualFold(strings.TrimSpace(provider), "xai") {
+		return false
+	}
+	if statusCodeFromError(err) != http.StatusForbidden {
+		return false
+	}
+	return isXaiBadCredentialsMessage(err.Error())
+}
+
+func isXaiBadCredentialsResultError(provider string, err *Error) bool {
+	if err == nil || !strings.EqualFold(strings.TrimSpace(provider), "xai") {
+		return false
+	}
+	if statusCodeFromResult(err) != http.StatusForbidden {
+		return false
+	}
+	return isXaiBadCredentialsMessage(err.Code) || isXaiBadCredentialsMessage(err.Message)
+}
+
 func isModelSupportResultError(err *Error) bool {
 	if err == nil {
 		return false
@@ -5684,6 +5721,18 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 	}
 	if isInvalidGrantResultError(resultErr) {
 		auth.StatusMessage = "invalid_grant"
+		if disableCooling {
+			auth.NextRetryAfter = time.Time{}
+		} else {
+			auth.NextRetryAfter = now.Add(30 * time.Minute)
+		}
+		return
+	}
+	if isXaiBadCredentialsResultError(auth.Provider, resultErr) {
+		auth.StatusMessage = "unauthorized"
+		if auth.LastError != nil {
+			auth.LastError.Code = "unauthorized"
+		}
 		if disableCooling {
 			auth.NextRetryAfter = time.Time{}
 		} else {
@@ -7361,13 +7410,14 @@ func clearUnauthorizedModelStates(auth *Auth, now time.Time) []string {
 	return resumed
 }
 
-// tryRefreshAfterUnauthorized refreshes OAuth credentials once after a 401 so the
-// current auth can be retried before fallback/suspend.
+// tryRefreshAfterUnauthorized refreshes OAuth credentials once after a 401, or an
+// xAI 403 bad-credentials response, so the current auth can be retried before
+// fallback/suspend.
 func (m *Manager) tryRefreshAfterUnauthorized(ctx context.Context, auth *Auth, execErr error, alreadyTried bool) (*Auth, bool) {
 	if m == nil || auth == nil || alreadyTried || execErr == nil {
 		return auth, false
 	}
-	if !isUnauthorizedError(execErr) || !authHasRefreshCredential(auth) {
+	if !(isUnauthorizedError(execErr) || isXaiBadCredentialsError(auth.Provider, execErr)) || !authHasRefreshCredential(auth) {
 		return auth, false
 	}
 	log.Debugf("unauthorized response for %s (%s), refreshing credentials before fallback", auth.Provider, auth.ID)

--- a/sdk/cliproxy/auth/xai_bad_credentials_refresh_test.go
+++ b/sdk/cliproxy/auth/xai_bad_credentials_refresh_test.go
@@ -1,0 +1,165 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type xaiBadCredentialsRefreshExecutor struct {
+	mu            sync.Mutex
+	executeCalls  []string
+	refreshCalls  int
+	refreshFail   bool
+	refreshTokens map[string]string
+	forbiddenText string
+}
+
+func (*xaiBadCredentialsRefreshExecutor) Identifier() string { return "xai" }
+
+func (e *xaiBadCredentialsRefreshExecutor) Execute(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.mu.Lock()
+	e.executeCalls = append(e.executeCalls, auth.ID)
+	token := authAccessToken(auth)
+	e.mu.Unlock()
+	if token == "stale-access-token" {
+		message := e.forbiddenText
+		if message == "" {
+			message = "unauthenticated:bad-credentials"
+		}
+		return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusForbidden, Message: message}
+	}
+	return cliproxyexecutor.Response{Payload: []byte(auth.ID + ":" + token)}, nil
+}
+
+func (*xaiBadCredentialsRefreshExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, &Error{HTTPStatus: http.StatusNotImplemented, Message: "not implemented"}
+}
+
+func (e *xaiBadCredentialsRefreshExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.refreshCalls++
+	if e.refreshFail {
+		return nil, &Error{HTTPStatus: http.StatusUnauthorized, Message: "refresh token invalid"}
+	}
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	auth.Metadata["access_token"] = e.refreshTokens[auth.ID]
+	return auth, nil
+}
+
+func (*xaiBadCredentialsRefreshExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusNotImplemented, Message: "not implemented"}
+}
+
+func (*xaiBadCredentialsRefreshExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func (e *xaiBadCredentialsRefreshExecutor) calls() ([]string, int) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]string(nil), e.executeCalls...), e.refreshCalls
+}
+
+func newXaiBadCredentialsRefreshFixture(t *testing.T, refreshFail bool) (*Manager, *xaiBadCredentialsRefreshExecutor, *Auth, *Auth, string) {
+	t.Helper()
+	prev := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(prev) })
+
+	model := "grok-4"
+	primary := &Auth{ID: "aa-primary-xai", Provider: "xai", Metadata: map[string]any{
+		"access_token": "stale-access-token", "refresh_token": "primary-refresh-token",
+	}}
+	backup := &Auth{ID: "bb-backup-xai", Provider: "xai", Metadata: map[string]any{
+		"access_token": "backup-access-token", "refresh_token": "backup-refresh-token",
+	}}
+	executor := &xaiBadCredentialsRefreshExecutor{refreshFail: refreshFail, refreshTokens: map[string]string{primary.ID: "fresh-access-token"}}
+	m := NewManager(nil, nil, nil)
+	m.RegisterExecutor(executor)
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(primary.ID, "xai", []*registry.ModelInfo{{ID: model}})
+	reg.RegisterClient(backup.ID, "xai", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(primary.ID)
+		reg.UnregisterClient(backup.ID)
+	})
+	if _, err := m.Register(context.Background(), primary); err != nil {
+		t.Fatalf("register primary: %v", err)
+	}
+	if _, err := m.Register(context.Background(), backup); err != nil {
+		t.Fatalf("register backup: %v", err)
+	}
+	return m, executor, primary, backup, model
+}
+
+func TestManager_Execute_XaiBadCredentialsRefreshesCurrentAuthBeforeFallback(t *testing.T) {
+	m, executor, primary, backup, model := newXaiBadCredentialsRefreshFixture(t, false)
+	resp, err := m.Execute(context.Background(), []string{"xai"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+	if got := string(resp.Payload); got != primary.ID+":fresh-access-token" {
+		t.Fatalf("payload = %q, want refreshed primary", got)
+	}
+	calls, refreshCalls := executor.calls()
+	if refreshCalls != 1 || len(calls) != 2 || calls[0] != primary.ID || calls[1] != primary.ID {
+		t.Fatalf("execute calls = %v, refresh calls = %d", calls, refreshCalls)
+	}
+	for _, id := range calls {
+		if id == backup.ID {
+			t.Fatal("backup must not run when primary refresh succeeds")
+		}
+	}
+}
+
+func TestManager_Execute_XaiBadCredentialsRefreshFailureFallsBackAndMarksUnauthorized(t *testing.T) {
+	m, executor, primary, backup, model := newXaiBadCredentialsRefreshFixture(t, true)
+	resp, err := m.Execute(context.Background(), []string{"xai"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+	if got := string(resp.Payload); got != backup.ID+":backup-access-token" {
+		t.Fatalf("payload = %q, want backup", got)
+	}
+	calls, refreshCalls := executor.calls()
+	if refreshCalls != 1 || len(calls) != 2 || calls[0] != primary.ID || calls[1] != backup.ID {
+		t.Fatalf("execute calls = %v, refresh calls = %d", calls, refreshCalls)
+	}
+	updated, ok := m.GetByID(primary.ID)
+	if !ok || updated == nil {
+		t.Fatal("primary auth missing")
+	}
+	state := updated.ModelStates[model]
+	if state == nil || !state.Unavailable || state.LastError == nil || state.LastError.Code != "unauthorized" {
+		t.Fatalf("expected unauthorized suspension, got %+v", state)
+	}
+}
+
+func TestManager_Execute_XaiGenericForbiddenDoesNotRefresh(t *testing.T) {
+	m, executor, primary, backup, model := newXaiBadCredentialsRefreshFixture(t, false)
+	executor.forbiddenText = "forbidden"
+
+	resp, err := m.Execute(context.Background(), []string{"xai"}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute error = %v", err)
+	}
+	if got := string(resp.Payload); got != backup.ID+":backup-access-token" {
+		t.Fatalf("payload = %q, want backup", got)
+	}
+	calls, refreshCalls := executor.calls()
+	if refreshCalls != 0 {
+		t.Fatalf("refresh calls = %d, want 0", refreshCalls)
+	}
+	if len(calls) != 2 || calls[0] != primary.ID || calls[1] != backup.ID {
+		t.Fatalf("execute calls = %v, want [primary, backup]", calls)
+	}
+}

--- a/sdk/cliproxy/auth/xai_bad_credentials_test.go
+++ b/sdk/cliproxy/auth/xai_bad_credentials_test.go
@@ -1,0 +1,120 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+func TestIsXaiBadCredentialsError(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		err      error
+		want     bool
+	}{
+		{name: "bad credentials", provider: "xai", err: &Error{HTTPStatus: http.StatusForbidden, Message: "unauthenticated:bad-credentials"}, want: true},
+		{name: "token not validated", provider: " XAI ", err: &Error{HTTPStatus: http.StatusForbidden, Message: "The OAuth2 access token could not be validated."}, want: true},
+		{name: "other provider", provider: "claude", err: &Error{HTTPStatus: http.StatusForbidden, Message: "unauthenticated:bad-credentials"}},
+		{name: "other status", provider: "xai", err: &Error{HTTPStatus: http.StatusPaymentRequired, Message: "unauthenticated:bad-credentials"}},
+		{name: "generic forbidden", provider: "xai", err: &Error{HTTPStatus: http.StatusForbidden, Message: "forbidden"}},
+		{name: "nil error", provider: "xai"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isXaiBadCredentialsError(tt.provider, tt.err); got != tt.want {
+				t.Fatalf("isXaiBadCredentialsError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsXaiBadCredentialsResultErrorReadsCodeAndMessage(t *testing.T) {
+	for _, errResult := range []*Error{
+		{HTTPStatus: http.StatusForbidden, Message: "unauthenticated:bad-credentials"},
+		{HTTPStatus: http.StatusForbidden, Code: "unauthenticated:bad-credentials"},
+		{HTTPStatus: http.StatusForbidden, Message: "The OAuth2 access token could not be validated."},
+	} {
+		if !isXaiBadCredentialsResultError("xai", errResult) {
+			t.Fatalf("expected xAI credential error for %+v", errResult)
+		}
+	}
+	if isXaiBadCredentialsResultError("xai", &Error{HTTPStatus: http.StatusForbidden, Message: "forbidden"}) {
+		t.Fatal("generic xAI 403 must not be classified as bad credentials")
+	}
+}
+
+func TestManager_MarkResult_XaiBadCredentialsMarksModelUnauthorized(t *testing.T) {
+	prev := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(prev) })
+
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "auth-xai-403", Provider: "xai"}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	model := "test-model-xai-403"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, "xai", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(auth.ID) })
+
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: "xai", Model: model,
+		Error: &Error{HTTPStatus: http.StatusForbidden, Message: "unauthenticated:bad-credentials"},
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatal("expected auth to be present")
+	}
+	state := updated.ModelStates[model]
+	if state == nil || !state.Unavailable {
+		t.Fatalf("expected unavailable model state, got %+v", state)
+	}
+	if diff := time.Until(state.NextRetryAfter); diff < 29*time.Minute || diff > 31*time.Minute {
+		t.Fatalf("expected about 30 minute cooldown, got %v", diff)
+	}
+	if state.LastError == nil || state.LastError.Code != "unauthorized" {
+		t.Fatalf("expected model LastError.Code = unauthorized, got %+v", state.LastError)
+	}
+	if count := reg.GetModelCount(model); count != 0 {
+		t.Fatalf("expected registry model suspension, count = %d", count)
+	}
+}
+
+func TestManager_MarkResult_XaiBadCredentialsMarksAuthUnauthorized(t *testing.T) {
+	prev := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(prev) })
+
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "auth-xai-403-auth-level", Provider: "xai"}
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	m.MarkResult(context.Background(), Result{
+		AuthID: auth.ID, Provider: "xai",
+		Error: &Error{HTTPStatus: http.StatusForbidden, Message: "The OAuth2 access token could not be validated."},
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatal("expected auth to be present")
+	}
+	if updated.StatusMessage != "unauthorized" {
+		t.Fatalf("StatusMessage = %q, want unauthorized", updated.StatusMessage)
+	}
+	if updated.LastError == nil || updated.LastError.Code != "unauthorized" {
+		t.Fatalf("expected auth LastError.Code = unauthorized, got %+v", updated.LastError)
+	}
+	if diff := time.Until(updated.NextRetryAfter); diff < 29*time.Minute || diff > 31*time.Minute {
+		t.Fatalf("expected about 30 minute cooldown, got %v", diff)
+	}
+}


### PR DESCRIPTION
## 结果

修复 xAI OAuth access token 失效时的错误分类。xAI 会以特定 403 返回 bad-credentials 或 could not be validated；此前 Core 把它当成普通 payment_required cooldown，既不刷新 token，也无法在后续 refresh 成功后恢复 model。

现在仅对 xAI 的这两类明确 credential 错误执行一次同步 refresh，并在 fallback 前重试当前 auth。普通 xAI 403 仍保持原有行为。

## 变更

- 增加严格的 xAI bad-credentials classifier：provider 必须为 xai、HTTP status 必须为 403、message/code 必须包含已知 credential marker。
- 将该错误纳入现有一次性 tryRefreshAfterUnauthorized 流程。
- model-level 与 auth-level failure state 均标记为 unauthorized，保留 30 分钟 cooldown，并使后续成功 refresh 能通过既有 resume path 恢复 model。
- 增加 classifier、refresh-before-fallback、refresh failure、generic 403 negative boundary、model/auth state 回归测试。

## 影响与边界

- 不把所有 403 泛化为 unauthorized，也不改变订阅、权限或策略拒绝的 payment_required 行为。
- 不修改 xAI transport、usage contract、Panel schema、tag、release 或 runtime。
- 这是对 dangling candidate b07561ee 行为的当前主线重建，没有直接 cherry-pick 旧提交。

## 验证

- 先运行 focused tests，确认当前主线因缺少 classifier 而编译失败。
- go test -count=1 ./sdk/cliproxy/auth -run 'XaiBadCredentials|IsXaiBadCredentials'
- go test -race -count=1 ./sdk/cliproxy/auth
- scripts/check-lts-contract.sh
- go test -count=1 ./...
- go build -o /tmp/cpa-core-lts-xai-refresh-build ./cmd/server
- git diff --check

以上绿色验证全部通过。

## Review focus

请重点确认 classifier 不会误捕获普通 xAI 403，以及 refresh 失败后的 unauthorized state 能与现有 clearUnauthorizedModelStates resume path 一致。
