### PR TITLE
fix(auth): preserve active cooldowns during registry reconciliation

### DIFF
--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -408,10 +408,10 @@ func (m *Manager) RefreshSchedulerAll() {
 // ReconcileRegistryModelStates aligns per-model runtime state with the current
 // registry snapshot for one auth.
 //
-// Supported models are reset to a clean state because re-registration already
-// cleared the registry-side cooldown/suspension snapshot. ModelStates for
-// models that are no longer present in the registry are pruned entirely so
-// renamed/removed models cannot keep auth-level status stale.
+// Active cooldowns for supported models are preserved across re-registration
+// and restored into the registry. ModelStates for models that are no longer
+// present in the registry are pruned entirely so renamed/removed models cannot
+// keep auth-level status stale.
 func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID string) {
 	if m == nil || authID == "" {
 		return
@@ -430,13 +430,21 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 		supported[modelKey] = struct{}{}
 	}
 
+	type registryCooldown struct {
+		model  string
+		reason string
+		quota  bool
+	}
+
 	var snapshot *Auth
+	var cooldowns []registryCooldown
 	now := time.Now()
 
 	m.mu.Lock()
 	auth, ok := m.auths[authID]
 	if ok && auth != nil && len(auth.ModelStates) > 0 {
 		changed := false
+		preserved := false
 		for modelKey, state := range auth.ModelStates {
 			baseModel := canonicalModelKey(modelKey)
 			if baseModel == "" {
@@ -456,30 +464,100 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 			if modelStateIsClean(state) {
 				continue
 			}
+			if state.Unavailable && state.NextRetryAfter.After(now) {
+				preserved = true
+				if reason, quota, suspend := registrySuspensionForModelState(state); suspend {
+					cooldowns = append(cooldowns, registryCooldown{
+						model:  baseModel,
+						reason: reason,
+						quota:  quota,
+					})
+				}
+				continue
+			}
 			resetModelState(state, now)
 			changed = true
 		}
 		if len(auth.ModelStates) == 0 {
 			auth.ModelStates = nil
 		}
-		if changed {
-			updateAggregatedAvailability(auth, now)
-			if !hasModelError(auth, now) {
+		if changed || preserved {
+			previousUnavailable := auth.Unavailable
+			previousNextRetryAfter := auth.NextRetryAfter
+			previousQuota := auth.Quota
+			previousStatus := auth.Status
+			previousStatusMessage := auth.StatusMessage
+			previousLastError := cloneError(auth.LastError)
+			previousUpdatedAt := auth.UpdatedAt
+
+			recomputeAggregatedAvailability(auth, now)
+			if allModelStatesClean(auth) {
 				auth.LastError = nil
 				auth.StatusMessage = ""
 				auth.Status = StatusActive
+			} else {
+				reconcileAuthErrorFromModelStates(auth, now)
 			}
-			auth.UpdatedAt = now
-			if errPersist := m.persist(ctx, auth); errPersist != nil {
-				logEntryWithRequestID(ctx).WithField("auth_id", auth.ID).Warnf("failed to persist auth changes during model state reconciliation: %v", errPersist)
+			aggregateChanged := previousUnavailable != auth.Unavailable ||
+				!previousNextRetryAfter.Equal(auth.NextRetryAfter) ||
+				!cooldownQuotaEqual(previousQuota, auth.Quota) ||
+				previousStatus != auth.Status ||
+				previousStatusMessage != auth.StatusMessage ||
+				!cooldownErrorEqual(previousLastError, auth.LastError)
+			if changed || aggregateChanged {
+				auth.UpdatedAt = now
+				if errPersist := m.persist(ctx, auth); errPersist != nil {
+					logEntryWithRequestID(ctx).WithField("auth_id", auth.ID).Warnf("failed to persist auth changes during model state reconciliation: %v", errPersist)
+				}
+				snapshot = auth.Clone()
+			} else {
+				auth.UpdatedAt = previousUpdatedAt
 			}
-			snapshot = auth.Clone()
 		}
 	}
 	m.mu.Unlock()
 
+	reg := registry.GetGlobalRegistry()
+	for _, cooldown := range cooldowns {
+		if cooldown.quota {
+			reg.SetModelQuotaExceeded(authID, cooldown.model)
+		}
+		reg.SuspendClientModel(authID, cooldown.model, cooldown.reason)
+	}
+
 	if m.scheduler != nil && snapshot != nil {
 		m.scheduler.upsertAuth(snapshot)
+	}
+}
+
+func registrySuspensionForModelState(state *ModelState) (reason string, quota, suspend bool) {
+	if state == nil {
+		return "", false, false
+	}
+	if state.Quota.Exceeded && strings.EqualFold(strings.TrimSpace(state.Quota.Reason), "quota") {
+		return "quota", true, true
+	}
+	if isModelSupportResultError(state.LastError) {
+		return "model_not_supported", false, true
+	}
+	if isInvalidGrantResultError(state.LastError) {
+		return "invalid_grant", false, true
+	}
+	if isCloudflareChallengeResultError(state.LastError) {
+		return "", false, false
+	}
+	if state.LastError != nil && strings.EqualFold(strings.TrimSpace(state.LastError.Code), "unauthorized") {
+		return "unauthorized", false, true
+	}
+	switch statusCodeFromResult(state.LastError) {
+	case http.StatusUnauthorized:
+		return "unauthorized", false, true
+	case http.StatusPaymentRequired, http.StatusForbidden:
+		return "payment_required", false, true
+	case http.StatusNotFound:
+		return "not_found", false, true
+	default:
+		return "", false, false
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_reconcile_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_reconcile_cooldown_test.go
@@ -1,0 +1,177 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+func TestManager_ReconcileRegistryModelStatesPreservesFutureUnauthorizedCooldown(t *testing.T) {
+	const (
+		authID = "reconcile-unauthorized-auth"
+		model  = "reconcile-unauthorized-model"
+	)
+	ctx := context.Background()
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	if _, err := manager.Register(ctx, &Auth{ID: authID, Provider: "codex"}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	manager.MarkResult(ctx, Result{
+		AuthID: authID, Provider: "codex", Model: model,
+		Error: &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"},
+	})
+
+	before, ok := manager.GetByID(authID)
+	if !ok || before.ModelStates[model] == nil {
+		t.Fatal("unauthorized model cooldown was not recorded")
+	}
+	wantRetryAfter := before.ModelStates[model].NextRetryAfter
+	if !wantRetryAfter.After(time.Now()) {
+		t.Fatalf("NextRetryAfter = %v, want future cooldown", wantRetryAfter)
+	}
+	resetAggregatedAuthStateForReconcileTest(t, manager, before)
+
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	if count := reg.GetModelCount(model); count != 1 {
+		t.Fatalf("registry model count after re-registration = %d, want 1", count)
+	}
+
+	manager.ReconcileRegistryModelStates(ctx, authID)
+	after, ok := manager.GetByID(authID)
+	if !ok || after.ModelStates[model] == nil {
+		t.Fatal("unauthorized model cooldown was removed during reconciliation")
+	}
+	state := after.ModelStates[model]
+	if !state.Unavailable || !state.NextRetryAfter.Equal(wantRetryAfter) {
+		t.Fatalf("reconciled model state = %+v, want cooldown until %v", state, wantRetryAfter)
+	}
+	if after.Status != StatusError || !after.Unavailable || !after.NextRetryAfter.Equal(wantRetryAfter) {
+		t.Fatalf("reconciled auth = status %q unavailable %v next %v", after.Status, after.Unavailable, after.NextRetryAfter)
+	}
+	if after.LastError == nil || after.LastError.StatusCode() != http.StatusUnauthorized {
+		t.Fatalf("reconciled auth error = %+v, want unauthorized", after.LastError)
+	}
+	if count := reg.GetModelCount(model); count != 0 {
+		t.Fatalf("registry model count after reconciliation = %d, want 0", count)
+	}
+}
+
+func TestManager_ReconcileRegistryModelStatesPreservesFutureQuotaCooldown(t *testing.T) {
+	const (
+		authID = "reconcile-quota-auth"
+		model  = "reconcile-quota-model"
+	)
+	ctx := context.Background()
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	if _, err := manager.Register(ctx, &Auth{ID: authID, Provider: "codex"}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	retryAfter := 20 * time.Minute
+	manager.MarkResult(ctx, Result{
+		AuthID: authID, Provider: "codex", Model: model,
+		Error: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota"}, RetryAfter: &retryAfter,
+	})
+
+	before, ok := manager.GetByID(authID)
+	if !ok || before.ModelStates[model] == nil {
+		t.Fatal("quota model cooldown was not recorded")
+	}
+	wantRetryAfter := before.ModelStates[model].NextRetryAfter
+	resetAggregatedAuthStateForReconcileTest(t, manager, before)
+
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	manager.ReconcileRegistryModelStates(ctx, authID)
+
+	after, ok := manager.GetByID(authID)
+	if !ok || after.ModelStates[model] == nil {
+		t.Fatal("quota model cooldown was removed during reconciliation")
+	}
+	state := after.ModelStates[model]
+	if !state.Unavailable || !state.Quota.Exceeded || !state.NextRetryAfter.Equal(wantRetryAfter) {
+		t.Fatalf("reconciled model state = %+v, want quota cooldown until %v", state, wantRetryAfter)
+	}
+	if after.Status != StatusError || !after.Unavailable || !after.Quota.Exceeded || !after.NextRetryAfter.Equal(wantRetryAfter) {
+		t.Fatalf("reconciled auth = status %q unavailable %v quota %+v next %v", after.Status, after.Unavailable, after.Quota, after.NextRetryAfter)
+	}
+	if count := reg.GetModelCount(model); count != 0 {
+		t.Fatalf("registry model count after reconciliation = %d, want 0", count)
+	}
+}
+
+func TestManager_ReconcileRegistryModelStatesKeepsCloudflareCooldownRoutingAvailable(t *testing.T) {
+	const (
+		authID = "reconcile-cloudflare-auth"
+		model  = "reconcile-cloudflare-model"
+	)
+	ctx := context.Background()
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "claude", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	if _, err := manager.Register(ctx, &Auth{ID: authID, Provider: "claude"}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	manager.MarkResult(ctx, Result{
+		AuthID: authID, Provider: "claude", Model: model,
+		Error: &Error{HTTPStatus: http.StatusForbidden, Message: "cf-mitigated: challenge"},
+	})
+
+	before, ok := manager.GetByID(authID)
+	if !ok || before.ModelStates[model] == nil {
+		t.Fatal("cloudflare challenge cooldown was not recorded")
+	}
+	wantRetryAfter := before.ModelStates[model].NextRetryAfter
+
+	reg.RegisterClient(authID, "claude", []*registry.ModelInfo{{ID: model}})
+	manager.ReconcileRegistryModelStates(ctx, authID)
+
+	after, ok := manager.GetByID(authID)
+	if !ok || after.ModelStates[model] == nil {
+		t.Fatal("cloudflare challenge cooldown was removed during reconciliation")
+	}
+	if state := after.ModelStates[model]; !state.Unavailable || !state.NextRetryAfter.Equal(wantRetryAfter) {
+		t.Fatalf("reconciled model state = %+v, want transient cooldown until %v", state, wantRetryAfter)
+	}
+	if count := reg.GetModelCount(model); count != 1 {
+		t.Fatalf("registry model count after reconciliation = %d, want 1", count)
+	}
+}
+
+func TestRegistrySuspensionForModelStatePreservesUnauthorizedCodeOnForbidden(t *testing.T) {
+	reason, quota, suspend := registrySuspensionForModelState(&ModelState{
+		Unavailable:    true,
+		NextRetryAfter: time.Now().Add(30 * time.Minute),
+		LastError:      &Error{HTTPStatus: http.StatusForbidden, Code: "unauthorized", Message: "unauthenticated:bad-credentials"},
+		Status:         StatusError,
+		StatusMessage:  "unauthorized",
+	})
+	if !suspend || quota || reason != "unauthorized" {
+		t.Fatalf("suspension = reason %q quota %v suspend %v, want unauthorized/false/true", reason, quota, suspend)
+	}
+}
+
+func resetAggregatedAuthStateForReconcileTest(t *testing.T, manager *Manager, auth *Auth) {
+	t.Helper()
+	incoming := auth.Clone()
+	incoming.Status = StatusActive
+	incoming.StatusMessage = ""
+	incoming.Unavailable = false
+	incoming.NextRetryAfter = time.Time{}
+	incoming.Quota = QuotaState{}
+	incoming.LastError = nil
+	if _, err := manager.Update(context.Background(), incoming); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+}


### PR DESCRIPTION
## 结果

修复 auth model registry 重新注册后的 cooldown 丢失问题。此前 ReconcileRegistryModelStates 会把所有仍受支持但非 clean 的 ModelState 无条件 reset；重新注册同时清空 registry-side suspension，导致尚未到期的 auth/model 被提前重新选中。

现在仅清理已失效或不再受支持的状态，保留 NextRetryAfter 仍在未来的 cooldown，并重建 auth aggregate、registry suspension 与 quota gate。

## 变更

- 保留 supported model 的 future cooldown；过期或无有效 future deadline 的非 clean state 仍按原语义 reset。
- 重新注册后恢复 unauthorized、payment_required、not_found、invalid_grant、model_not_supported 和 quota suspension。
- Cloudflare challenge 仅保留内存 cooldown，不错误写入 registry suspension。
- 使用当前主线的 recomputeAggregatedAvailability 与 reconcileAuthErrorFromModelStates 重建 auth-level status/error。
- 仅当 model state 或 aggregate 实际变化时 persist/scheduler upsert。
- 兼容刚合并的 xAI 修复：HTTP 403 但 Error.Code 为 unauthorized 时仍恢复 unauthorized suspension。
- 增加 unauthorized、quota、Cloudflare 与 xAI-style forbidden/unauthorized-code 回归测试。

## 影响与边界

- 不延长 cooldown，也不恢复已经过期的状态。
- 不保留 registry 中已删除/重命名 model 的 stale state。
- 不修改 Management API、Panel、usage contract、tag、release 或 runtime。
- 这是对 dangling candidate 81e88bc 行为的当前主线重建，没有直接 cherry-pick 旧提交。

## 验证

- 先运行 focused tests，确认当前主线会清空三类 future cooldown。
- go test -count=1 ./sdk/cliproxy/auth -run 'TestManager_ReconcileRegistryModelStates'
- go test -race -count=1 ./sdk/cliproxy/auth
- scripts/check-lts-contract.sh
- go test -count=1 ./...
- go build -o /tmp/cpa-core-lts-reconcile-cooldowns-build ./cmd/server
- git diff --check

以上绿色验证全部通过。

## Review focus

请重点确认 registry suspension reason 的重建边界、Cloudflare 不 suspend 的例外，以及 aggregate 无变化时不产生额外持久化更新。
