### PR TITLE
fix(usage): enforce canonical schema v2 imports

### DIFF
--- a/docs/lts/change-control/CHG-20260722-USAGE-SCHEMA-V2.md
+++ b/docs/lts/change-control/CHG-20260722-USAGE-SCHEMA-V2.md
@@ -1,0 +1,154 @@
+# CHG-20260722-USAGE-SCHEMA-V2
+
+Status: implementation candidate; merge and release approval are not implied.
+
+## Change summary
+
+The Management usage export contract advances from version 1 to canonical
+version 2. Import remains backward compatible with released version 1 payloads
+only where the old token semantics can be reconstructed without guessing.
+Every rejected import is validated before mutation, returns the existing
+human-readable `"error"` plus a stable top-level `"code"`, and leaves the
+in-memory snapshot unchanged.
+
+## Released evidence
+
+- `v1-tls-0.0.13` (`6f9533491aec6cced1661a7bbcf7187582e588b8`)
+  exported `version: 1` before `uncached_input_tokens` existed. Its required
+  token fields were `input_tokens`, `output_tokens`, `reasoning_tokens`,
+  `cached_tokens`, and `total_tokens`; zero cache read/creation fields were
+  omitted.
+- `v1-tls-0.0.15` (`e37e61aadb2e57883df54eef9d24af932fd1aa63`)
+  added optional `uncached_input_tokens`. The marker is present only when the
+  runtime knew the provider-specific uncached input contribution.
+
+Both releases used the same version number, so migration is based on explicit
+field evidence rather than release-name, model-name, source-path, or provider
+guesses.
+
+## Version 1 migration matrix
+
+| Version 1 detail | Decision | Canonical result or error |
+|---|---|---|
+| `uncached_input_tokens` is present, integral, non-negative, and no greater than the released `input_tokens` | Migrate | `input_tokens = uncached + cache_read + cache_creation`; `cached_tokens` mirrors canonical `cache_read_tokens`. |
+| Marker is absent and `cached_tokens`, `cache_read_tokens`, and `cache_creation_tokens` are all zero | Migrate | Preserve `input_tokens`; all cache categories remain zero. This covers released `v1-tls-0.0.13` no-cache exports and markerless no-cache `v1-tls-0.0.15` exports. |
+| Marker is absent and any cache category is non-zero | Reject | `code: usage_v1_cache_semantics_ambiguous`. OpenAI-inclusive and Claude-uncached input semantics cannot be distinguished from the snapshot alone. |
+| Required released field is missing, marker is null/non-integral/negative, marker exceeds input, or another version 1 token rule is invalid | Reject | `code: usage_v1_token_contract_invalid`. |
+
+The legacy cache-creation alias (`cached_tokens == cache_creation_tokens`,
+`cache_read_tokens == 0`) is treated as creation-only only when the explicit
+uncached marker makes the conversion auditable.
+
+## Canonical version 2 contract
+
+Required fields must be present even when their value is explicitly zero:
+
+- `input_tokens`
+- `output_tokens`
+- `reasoning_tokens`
+- `cached_tokens`
+- `total_tokens`
+
+`cache_read_tokens` and `cache_creation_tokens` remain optional because zero is
+omitted by the exporter. Canonical details must also satisfy:
+
+- every token count is non-negative;
+- `cached_tokens == cache_read_tokens`;
+- `cache_read_tokens + cache_creation_tokens <= input_tokens`, without integer overflow;
+- `input_tokens + output_tokens <= total_tokens`, without integer overflow.
+
+Reasoning is not added again to the minimum total because OpenAI/Codex output
+already includes its reasoning subset and the snapshot does not persist enough
+provider identity to impose a different formula universally.
+
+Runtime producers must not emit a detail that the version 2 importer would
+reject. OpenAI/Codex producer paths therefore use `input + output` when an
+upstream total is absent, while a producer that still has an exact non-OpenAI
+provider identity may retain its established separate-reasoning fallback.
+Explicit totals below `input + output` are raised to that checked minimum.
+Unrepresentable token vectors are stored as an all-zero canonical vector, and
+a record that would overflow an aggregate is retried with that zero vector so
+request metadata can be retained without creating a non-roundtrippable export.
+
+## Import response contract
+
+Every successful import returns:
+
+```json
+{
+  "added": 1,
+  "skipped": 0,
+  "total_requests": 1,
+  "failed_requests": 0,
+  "schema_version": 2
+}
+```
+
+A successful version 1 migration additionally returns the migration receipt:
+
+```json
+{
+  "migrated_from_version": 1,
+  "migration": "v1_uncached_input_tokens_to_v2"
+}
+```
+
+Errors preserve the existing `"error"` text and add one stable top-level
+`"code"`:
+
+| `code` | Meaning |
+|---|---|
+| `usage_version_unsupported` | The version is neither released v1 nor canonical v2. |
+| `usage_shape_invalid` | The JSON/root/nested typed shape is invalid, the usage store is unavailable, or the request body cannot be read. |
+| `usage_v1_token_contract_invalid` | A version 1 required token field or migration marker is missing, null, non-integral, negative, greater than released input, or otherwise invalid. |
+| `usage_v1_cache_semantics_ambiguous` | A markerless version 1 detail contains non-zero cache data whose input semantics cannot be reconstructed. |
+| `usage_v2_token_contract_invalid` | A version 2 mandatory field is omitted, null, mistyped, or violates canonical invariants, or the retired `uncached_input_tokens` marker is present. |
+| `usage_aggregate_overflow` | The complete candidate merge would overflow a request or token aggregate. |
+
+Nested import containers are validated before typed decoding. `usage`, `apis`,
+each API/model object, `models`, `details`, every detail object, and any present
+day/hour aggregate maps must retain their object/array shape; `null` containers
+are not interpreted as empty data. Missing or `null` `tokens` remain a
+version-specific token-contract error rather than a generic shape error. Schema
+field names are case-sensitive; case-colliding aliases such as `Version`,
+`Usage`, `Details`, or `Tokens` are rejected before Go's case-insensitive struct
+decoder can reinterpret the validated payload. Duplicate object keys are also
+rejected so an earlier value cannot survive struct/map merge semantics after a
+different duplicate value was inspected by the raw-shape pass.
+
+## Atomicity
+
+Parsing, v1 migration, field-presence checks, and canonical validation operate
+on the detached request payload. `MergeSnapshot` builds a complete deduplicated
+candidate list and preflights global, API, model, day, and hour request/token
+aggregates before recording any detail. Any validation or overflow error returns
+without a partial merge.
+
+Missing, `null`, and Go-zero timestamps remain accepted for released-backup
+compatibility. They are preserved as the Go zero sentinel rather than replaced
+with `time.Now()`, so their identity remains explicitly uncertain but repeated
+imports are deterministic. The sentinel may contribute to the existing
+`0001-01-01` / `00` buckets; changing that bucket policy is outside this
+schema-v2 change.
+
+## Cross-repository requirement
+
+`CPA-Panel-LTS` import preflight must implement the same version, required-field,
+markerless-v1, canonical-invariant, stable `code`, and receipt semantics. A green
+mock smoke in either repository does not by itself prove a released Core backup
+roundtrip or a deployed runtime.
+
+## Required validation
+
+```text
+go test -count=1 ./internal/usage
+go test -count=1 ./internal/api/handlers/management -run 'Usage|usage'
+go test -count=1 ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'
+scripts/check-lts-contract.sh
+git diff --check
+go build -o test-output ./cmd/server
+```
+
+The implementation handoff must report which checks were actually run. The
+change-control record does not authorize merge, release, deployment, or legacy
+cache-semantic overrides.

--- a/docs/lts/core-feature-contracts.yaml
+++ b/docs/lts/core-feature-contracts.yaml
@@ -56,7 +56,7 @@ features:
     support: protected
     owner: cpa-core-lts
     upstream_relation: removed-upstream
-    reason: CPA-Panel-LTS and TUI depend on the retained Management usage routes and response fields.
+    reason: CPA-Panel-LTS and TUI depend on the retained Management usage routes and response fields, including canonical version 2 exports, lossless version 1 migration where semantics are provable, stable import error codes, migration receipts, and atomic rejection without partial merges.
     routes:
       - /v0/management/usage
       - /v0/management/usage/export
@@ -69,6 +69,7 @@ features:
       - internal/api/handlers/management/usage_contract_test.go
       - internal/tui/client.go
       - internal/tui/usage_tab.go
+      - docs/lts/change-control/CHG-20260722-USAGE-SCHEMA-V2.md
     required_markers:
       - 'mgmt.GET("/usage"'
       - 'mgmt.GET("/usage/export"'
@@ -87,8 +88,20 @@ features:
       - response_service_tier
       - effective_service_tier
       - generate
+      - CanonicalExportVersion
+      - uncached_input_tokens
+      - schema_version
+      - migrated_from_version
+      - v1_uncached_input_tokens_to_v2
+      - usage_version_unsupported
+      - usage_shape_invalid
+      - usage_v1_token_contract_invalid
+      - usage_v1_cache_semantics_ambiguous
+      - usage_v2_token_contract_invalid
+      - usage_aggregate_overflow
     validation:
       - go test ./internal/api/handlers/management -run 'Usage|usage'
+      - go test ./internal/usage ./internal/api/handlers/management -run 'MigrateV1|CanonicalV2|UsageManagementImport'
       - go test ./test -run 'Usage|usage'
 
   - id: panel-release-asset

--- a/docs/lts/protected-deltas.yaml
+++ b/docs/lts/protected-deltas.yaml
@@ -37,9 +37,22 @@ retained_capabilities:
       - /v0/management/usage/export
       - /v0/management/usage/import
       - /v0/management/usage-statistics-enabled
+      - CanonicalExportVersion
+      - uncached_input_tokens
+      - schema_version
+      - migrated_from_version
+      - code
+      - usage_version_unsupported
+      - usage_shape_invalid
+      - usage_v1_token_contract_invalid
+      - usage_v1_cache_semantics_ambiguous
+      - usage_v2_token_contract_invalid
+      - usage_aggregate_overflow
     validation:
       - management-usage-response-shape-test
       - export-import-roundtrip-test
+      - released-v1-to-v2-migration-matrix
+      - invalid-import-no-partial-merge
     conflict_policy: preserve_management_usage_contract
 
   - id: cpa-panel-lts-compatibility

--- a/internal/api/handlers/management/usage.go
+++ b/internal/api/handlers/management/usage.go
@@ -1,9 +1,12 @@
 package management
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -20,6 +23,16 @@ type usageImportPayload struct {
 	Version int                      `json:"version"`
 	Usage   usage.StatisticsSnapshot `json:"usage"`
 }
+
+const (
+	usageV1MigrationName               = "v1_uncached_input_tokens_to_v2"
+	usageCodeVersionUnsupported        = "usage_version_unsupported"
+	usageCodeShapeInvalid              = "usage_shape_invalid"
+	usageCodeV1TokenContractInvalid    = "usage_v1_token_contract_invalid"
+	usageCodeV1CacheSemanticsAmbiguous = "usage_v1_cache_semantics_ambiguous"
+	usageCodeV2TokenContractInvalid    = "usage_v2_token_contract_invalid"
+	usageCodeAggregateOverflow         = "usage_aggregate_overflow"
+)
 
 // GetUsageStatistics returns the in-memory request statistics snapshot.
 func (h *Handler) GetUsageStatistics(c *gin.Context) {
@@ -40,7 +53,7 @@ func (h *Handler) ExportUsageStatistics(c *gin.Context) {
 		snapshot = h.usageStats.Snapshot()
 	}
 	c.JSON(http.StatusOK, usageExportPayload{
-		Version:    1,
+		Version:    usage.CanonicalExportVersion,
 		ExportedAt: time.Now().UTC(),
 		Usage:      snapshot,
 	})
@@ -49,36 +62,371 @@ func (h *Handler) ExportUsageStatistics(c *gin.Context) {
 // ImportUsageStatistics merges a previously exported usage snapshot into memory.
 func (h *Handler) ImportUsageStatistics(c *gin.Context) {
 	if h == nil || h.usageStats == nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "usage statistics unavailable"})
+		writeUsageImportError(c, usageCodeShapeInvalid, "usage statistics unavailable")
 		return
 	}
 
 	data, err := c.GetRawData()
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read request body"})
+		writeUsageImportError(c, usageCodeShapeInvalid, "failed to read request body")
+		return
+	}
+
+	version, err := usageImportVersion(data)
+	if err != nil {
+		writeUsageImportError(c, usageCodeShapeInvalid, "invalid json")
+		return
+	}
+	if version != 1 && version != usage.CanonicalExportVersion {
+		writeUsageImportError(c, usageCodeVersionUnsupported, "unsupported version")
+		return
+	}
+	if err := validateUsageImportRawShape(data); err != nil {
+		writeUsageImportError(c, usageCodeShapeInvalid, "invalid usage shape")
 		return
 	}
 
 	var payload usageImportPayload
 	if err := json.Unmarshal(data, &payload); err != nil {
-		if errors.Is(err, usage.ErrLegacyUncachedInputTokens) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": usage.ErrLegacyUncachedInputTokens.Error()})
+		if errors.Is(err, usage.ErrInvalidLegacyTokenStats) || errors.Is(err, usage.ErrInvalidCanonicalTokenStats) {
+			writeUsageImportTokenContractError(c, version)
 			return
 		}
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid json"})
+		writeUsageImportError(c, usageCodeShapeInvalid, "invalid json")
 		return
 	}
-	if payload.Version != 0 && payload.Version != 1 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "unsupported version"})
+	if payload.Usage.APIs == nil {
+		writeUsageImportError(c, usageCodeShapeInvalid, "invalid usage.apis")
 		return
 	}
 
-	result := h.usageStats.MergeSnapshot(payload.Usage)
+	migratedFromVersion := 0
+	payload.Version = version
+	if version == 1 {
+		if err := payload.Usage.MigrateV1TokenStats(); err != nil {
+			switch {
+			case errors.Is(err, usage.ErrAmbiguousLegacyTokenStats):
+				writeUsageImportError(c, usageCodeV1CacheSemanticsAmbiguous, usage.ErrAmbiguousLegacyTokenStats.Error())
+			case errors.Is(err, usage.ErrInvalidLegacyTokenStats):
+				writeUsageImportError(c, usageCodeV1TokenContractInvalid, usage.ErrInvalidLegacyTokenStats.Error())
+			default:
+				writeUsageImportError(c, usageCodeV1TokenContractInvalid, "invalid legacy usage payload")
+			}
+			return
+		}
+		if err := payload.Usage.ValidateCanonicalTokenStats(); err != nil {
+			writeUsageImportError(c, usageCodeV1TokenContractInvalid, usage.ErrInvalidCanonicalTokenStats.Error())
+			return
+		}
+		migratedFromVersion = 1
+	} else {
+		if payload.Usage.HasLegacyUncachedInputTokens() {
+			writeUsageImportError(c, usageCodeV2TokenContractInvalid, "canonical usage payload must not contain uncached_input_tokens")
+			return
+		}
+		if err := payload.Usage.ValidateCanonicalV2TokenStats(); err != nil {
+			writeUsageImportError(c, usageCodeV2TokenContractInvalid, usage.ErrInvalidCanonicalTokenStats.Error())
+			return
+		}
+	}
+
+	result, err := h.usageStats.MergeSnapshot(payload.Usage)
+	if err != nil {
+		if errors.Is(err, usage.ErrUsageAggregateOverflow) {
+			writeUsageImportError(c, usageCodeAggregateOverflow, usage.ErrUsageAggregateOverflow.Error())
+			return
+		}
+		writeUsageImportError(c, usageCodeShapeInvalid, "failed to merge usage statistics")
+		return
+	}
 	snapshot := h.usageStats.Snapshot()
-	c.JSON(http.StatusOK, gin.H{
+	response := gin.H{
 		"added":           result.Added,
 		"skipped":         result.Skipped,
 		"total_requests":  snapshot.TotalRequests,
 		"failed_requests": snapshot.FailureCount,
+		"schema_version":  usage.CanonicalExportVersion,
+	}
+	if migratedFromVersion != 0 {
+		response["migrated_from_version"] = migratedFromVersion
+		response["migration"] = usageV1MigrationName
+	}
+	c.JSON(http.StatusOK, response)
+}
+
+func validateUsageImportRawShape(data []byte) error {
+	root, err := unmarshalUsageObject(data)
+	if err != nil {
+		return err
+	}
+	if err = rejectUsageFieldAliases(root, "version", "usage"); err != nil {
+		return err
+	}
+	usageObject, err := requiredUsageObject(root, "usage")
+	if err != nil {
+		return err
+	}
+	if err = rejectUsageFieldAliases(
+		usageObject,
+		"total_requests",
+		"success_count",
+		"failure_count",
+		"total_tokens",
+		"apis",
+		"requests_by_day",
+		"requests_by_hour",
+		"tokens_by_day",
+		"tokens_by_hour",
+	); err != nil {
+		return err
+	}
+	apis, err := requiredUsageObject(usageObject, "apis")
+	if err != nil {
+		return err
+	}
+	for apiName, rawAPI := range apis {
+		if strings.TrimSpace(apiName) == "" {
+			return errors.New("usage API identity must not be blank")
+		}
+		apiObject, err := unmarshalUsageObject(rawAPI)
+		if err != nil {
+			return err
+		}
+		if err = rejectUsageFieldAliases(apiObject, "total_requests", "total_tokens", "models"); err != nil {
+			return err
+		}
+		models, err := requiredUsageObject(apiObject, "models")
+		if err != nil {
+			return err
+		}
+		for _, rawModel := range models {
+			modelObject, err := unmarshalUsageObject(rawModel)
+			if err != nil {
+				return err
+			}
+			if err = rejectUsageFieldAliases(modelObject, "total_requests", "total_tokens", "details"); err != nil {
+				return err
+			}
+			details, err := requiredUsageArray(modelObject, "details")
+			if err != nil {
+				return err
+			}
+			for _, rawDetail := range details {
+				detailObject, err := unmarshalUsageObject(rawDetail)
+				if err != nil {
+					return err
+				}
+				if err = rejectUsageFieldAliases(
+					detailObject,
+					"timestamp",
+					"latency_ms",
+					"source",
+					"auth_index",
+					"alias",
+					"reasoning_effort",
+					"service_tier",
+					"request_service_tier",
+					"response_service_tier",
+					"effective_service_tier",
+					"tokens",
+					"failed",
+					"generate",
+					"failure_reason",
+					"failure_status",
+				); err != nil {
+					return err
+				}
+				rawTokens, exists := detailObject["tokens"]
+				if !exists || bytes.Equal(bytes.TrimSpace(rawTokens), []byte("null")) {
+					continue
+				}
+				tokenObject, err := unmarshalUsageObject(rawTokens)
+				if err != nil {
+					return err
+				}
+				if err = rejectUsageFieldAliases(
+					tokenObject,
+					"input_tokens",
+					"output_tokens",
+					"reasoning_tokens",
+					"cached_tokens",
+					"cache_read_tokens",
+					"cache_creation_tokens",
+					"total_tokens",
+					"uncached_input_tokens",
+				); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	for _, field := range []string{"requests_by_day", "requests_by_hour", "tokens_by_day", "tokens_by_hour"} {
+		if rawMap, exists := usageObject[field]; exists {
+			if _, err := unmarshalUsageObject(rawMap); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func rejectUsageFieldAliases(object map[string]json.RawMessage, fields ...string) error {
+	for key := range object {
+		for _, field := range fields {
+			if key != field && strings.EqualFold(key, field) {
+				return errors.New("usage field names are case-sensitive")
+			}
+		}
+	}
+	return nil
+}
+
+func requiredUsageObject(object map[string]json.RawMessage, field string) (map[string]json.RawMessage, error) {
+	raw, exists := object[field]
+	if !exists {
+		return nil, errors.New("missing usage object")
+	}
+	return unmarshalUsageObject(raw)
+}
+
+func unmarshalUsageObject(data []byte) (map[string]json.RawMessage, error) {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return nil, errors.New("usage value must be an object")
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(data, &object); err != nil || object == nil {
+		if err != nil {
+			return nil, err
+		}
+		return nil, errors.New("usage value must be an object")
+	}
+	return object, nil
+}
+
+func requiredUsageArray(object map[string]json.RawMessage, field string) ([]json.RawMessage, error) {
+	raw, exists := object[field]
+	if !exists || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, errors.New("missing usage array")
+	}
+	var values []json.RawMessage
+	if err := json.Unmarshal(raw, &values); err != nil || values == nil {
+		if err != nil {
+			return nil, err
+		}
+		return nil, errors.New("usage value must be an array")
+	}
+	return values, nil
+}
+
+func usageImportVersion(data []byte) (int, error) {
+	if err := rejectDuplicateUsageJSONFields(data); err != nil {
+		return 0, err
+	}
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err != nil || envelope == nil {
+		if err != nil {
+			return 0, err
+		}
+		return 0, errors.New("usage import root must be an object")
+	}
+	if err := rejectUsageFieldAliases(envelope, "version", "usage"); err != nil {
+		return 0, err
+	}
+	rawVersion, exists := envelope["version"]
+	if !exists {
+		return 0, nil
+	}
+	if bytes.Equal(bytes.TrimSpace(rawVersion), []byte("null")) {
+		return 0, errors.New("usage import version must be an integer")
+	}
+	var version int
+	if err := json.Unmarshal(rawVersion, &version); err != nil {
+		return 0, err
+	}
+	return version, nil
+}
+
+func rejectDuplicateUsageJSONFields(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	if err := consumeUniqueJSONValue(decoder); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		if err != nil {
+			return err
+		}
+		return errors.New("usage import must contain one JSON value")
+	}
+	return nil
+}
+
+func consumeUniqueJSONValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delimiter, isDelimiter := token.(json.Delim)
+	if !isDelimiter {
+		return nil
+	}
+
+	switch delimiter {
+	case '{':
+		seen := make(map[string]struct{})
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return errors.New("usage object key must be a string")
+			}
+			if _, exists := seen[key]; exists {
+				return errors.New("duplicate usage object key")
+			}
+			seen[key] = struct{}{}
+			if err = consumeUniqueJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		closing, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		if closing != json.Delim('}') {
+			return errors.New("invalid usage object")
+		}
+	case '[':
+		for decoder.More() {
+			if err = consumeUniqueJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		closing, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		if closing != json.Delim(']') {
+			return errors.New("invalid usage array")
+		}
+	default:
+		return errors.New("invalid usage JSON delimiter")
+	}
+	return nil
+}
+
+func writeUsageImportTokenContractError(c *gin.Context, version int) {
+	if version == 1 {
+		writeUsageImportError(c, usageCodeV1TokenContractInvalid, usage.ErrInvalidLegacyTokenStats.Error())
+		return
+	}
+	writeUsageImportError(c, usageCodeV2TokenContractInvalid, usage.ErrInvalidCanonicalTokenStats.Error())
+}
+
+func writeUsageImportError(c *gin.Context, code, message string) {
+	c.JSON(http.StatusBadRequest, gin.H{
+		"error": message,
+		"code":  code,
 	})
 }

--- a/internal/api/handlers/management/usage_contract_test.go
+++ b/internal/api/handlers/management/usage_contract_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -35,8 +37,8 @@ func TestUsageManagementResponseShapeAndImportExportRoundTrip(t *testing.T) {
 	}
 
 	exported := exportUsageStatistics(t, h)
-	if exported.Version != 1 {
-		t.Fatalf("export version = %d, want 1", exported.Version)
+	if exported.Version != 2 {
+		t.Fatalf("export version = %d, want 2", exported.Version)
 	}
 	if exported.ExportedAt.IsZero() {
 		t.Fatalf("exported_at is zero")
@@ -80,7 +82,7 @@ func TestUsageManagementResponseShapeAndImportExportRoundTrip(t *testing.T) {
 		t.Fatalf("legacy decoder rejected additive service-tier fields: %v", err)
 	}
 	legacyDetails := legacyDecoded.Usage.APIs["panel-client-key"].Models["gpt-5.4"].Details
-	if legacyDecoded.Version != 1 || legacyDecoded.Usage.TotalRequests != 1 || len(legacyDetails) != 1 || legacyDetails[0].Source != "auths/openai.json" || legacyDetails[0].Tokens.TotalTokens != 17 {
+	if legacyDecoded.Version != 2 || legacyDecoded.Usage.TotalRequests != 1 || len(legacyDetails) != 1 || legacyDetails[0].Source != "auths/openai.json" || legacyDetails[0].Tokens.TotalTokens != 17 {
 		t.Fatalf("legacy decoded export lost existing fields: version=%d usage=%+v details=%+v", legacyDecoded.Version, legacyDecoded.Usage, legacyDetails)
 	}
 
@@ -93,6 +95,9 @@ func TestUsageManagementResponseShapeAndImportExportRoundTrip(t *testing.T) {
 	}
 	if importResult.TotalRequests != 1 || importResult.FailedRequests != 0 {
 		t.Fatalf("import totals = %+v, want total_requests=1 failed_requests=0", importResult)
+	}
+	if importResult.SchemaVersion != 2 || importResult.MigratedFromVersion != 0 || importResult.Migration != "" {
+		t.Fatalf("canonical import receipt = %+v, want schema_version=2 without migration fields", importResult)
 	}
 	reimported := exportUsageStatistics(t, importHandler)
 	requirePanelUsageShape(t, reimported.Usage)
@@ -152,6 +157,93 @@ func TestUsageManagementFailedDetailIncludesFailureReason(t *testing.T) {
 	}
 }
 
+func TestUsageManagementProducerSnapshotsAlwaysRoundTripAsCanonicalV2(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	prevEnabled := usage.StatisticsEnabled()
+	usage.SetStatisticsEnabled(true)
+	t.Cleanup(func() { usage.SetStatisticsEnabled(prevEnabled) })
+
+	tests := []struct {
+		name        string
+		records     []coreusage.Record
+		wantTotals  []int64
+		wantOverall int64
+	}{
+		{
+			name: "OpenAI reasoning is an output subset",
+			records: []coreusage.Record{{
+				Provider: "openai", Detail: coreusage.Detail{InputTokens: 100, OutputTokens: 20, ReasoningTokens: 5},
+			}},
+			wantTotals:  []int64{120},
+			wantOverall: 120,
+		},
+		{
+			name: "explicit total below minimum is repaired",
+			records: []coreusage.Record{{
+				Provider: "openai", Detail: coreusage.Detail{InputTokens: 10, OutputTokens: 2, TotalTokens: 1},
+			}},
+			wantTotals:  []int64{12},
+			wantOverall: 12,
+		},
+		{
+			name: "unrepresentable detail becomes canonical zero vector",
+			records: []coreusage.Record{{
+				Provider: "openai", Detail: coreusage.Detail{InputTokens: math.MaxInt64, OutputTokens: 1},
+			}},
+			wantTotals: []int64{0},
+		},
+		{
+			name: "record aggregate overflow preserves request with zero tokens",
+			records: []coreusage.Record{
+				{Provider: "openai", Detail: coreusage.Detail{InputTokens: math.MaxInt64, TotalTokens: math.MaxInt64}},
+				{Provider: "openai", Detail: coreusage.Detail{InputTokens: 1, TotalTokens: 1}},
+			},
+			wantTotals:  []int64{math.MaxInt64, 0},
+			wantOverall: math.MaxInt64,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stats := usage.NewRequestStatistics()
+			for index, record := range tt.records {
+				record.APIKey = "producer-key"
+				record.Model = "producer-model"
+				record.RequestedAt = time.Date(2026, 7, 22, 12, index, 0, 0, time.UTC)
+				stats.Record(context.Background(), record)
+			}
+
+			h := &Handler{}
+			h.SetUsageStatistics(stats)
+			exported := exportUsageStatistics(t, h)
+			model := exported.Usage.APIs["producer-key"].Models["producer-model"]
+			if exported.Version != 2 || len(model.Details) != len(tt.wantTotals) {
+				t.Fatalf("export = version:%d details:%d, want version 2 and %d details", exported.Version, len(model.Details), len(tt.wantTotals))
+			}
+			if exported.Usage.TotalTokens != tt.wantOverall {
+				t.Fatalf("export total_tokens = %d, want %d", exported.Usage.TotalTokens, tt.wantOverall)
+			}
+			for index, wantTotal := range tt.wantTotals {
+				if got := model.Details[index].Tokens; got.TotalTokens != wantTotal {
+					t.Fatalf("detail %d tokens = %+v, want total_tokens=%d", index, got, wantTotal)
+				}
+			}
+
+			fresh := usage.NewRequestStatistics()
+			freshHandler := &Handler{}
+			freshHandler.SetUsageStatistics(fresh)
+			receipt := importUsageStatistics(t, freshHandler, exported.Usage)
+			if receipt.Added != int64(len(tt.wantTotals)) || receipt.Skipped != 0 || receipt.SchemaVersion != 2 {
+				t.Fatalf("roundtrip receipt = %+v, want all producer details imported as canonical v2", receipt)
+			}
+			if got := fresh.Snapshot(); !reflect.DeepEqual(got, exported.Usage) {
+				t.Fatalf("roundtrip snapshot mismatch: exported=%+v imported=%+v", exported.Usage, got)
+			}
+		})
+	}
+
+}
+
 func TestUsageManagementImportLegacyExportKeepsServiceTierUnknown(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	const legacyExport = `{
@@ -209,16 +301,22 @@ func TestUsageManagementImportLegacyExportKeepsServiceTierUnknown(t *testing.T) 
 	}
 
 	var importResult struct {
-		Added          int64 `json:"added"`
-		Skipped        int64 `json:"skipped"`
-		TotalRequests  int64 `json:"total_requests"`
-		FailedRequests int64 `json:"failed_requests"`
+		Added               int64  `json:"added"`
+		Skipped             int64  `json:"skipped"`
+		TotalRequests       int64  `json:"total_requests"`
+		FailedRequests      int64  `json:"failed_requests"`
+		SchemaVersion       int    `json:"schema_version"`
+		MigratedFromVersion int    `json:"migrated_from_version"`
+		Migration           string `json:"migration"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &importResult); err != nil {
 		t.Fatalf("unmarshal legacy import response: %v body=%s", err, rec.Body.String())
 	}
 	if importResult.Added != 1 || importResult.Skipped != 0 || importResult.TotalRequests != 1 || importResult.FailedRequests != 0 {
 		t.Fatalf("legacy import result = %+v, want added=1 skipped=0 total_requests=1 failed_requests=0", importResult)
+	}
+	if importResult.SchemaVersion != 2 || importResult.MigratedFromVersion != 1 || importResult.Migration != "v1_uncached_input_tokens_to_v2" {
+		t.Fatalf("legacy import migration receipt = %+v, want v1-to-v2 receipt", importResult)
 	}
 
 	snapshot := stats.Snapshot()
@@ -243,8 +341,8 @@ func TestUsageManagementImportLegacyExportKeepsServiceTierUnknown(t *testing.T) 
 	}
 
 	reexported := exportUsageStatistics(t, h)
-	if reexported.Version != 1 {
-		t.Fatalf("legacy re-export version = %d, want 1", reexported.Version)
+	if reexported.Version != 2 {
+		t.Fatalf("legacy re-export version = %d, want 2", reexported.Version)
 	}
 	reexportedJSON, err := json.Marshal(reexported)
 	if err != nil {
@@ -267,7 +365,7 @@ func TestUsageManagementImportLegacyExportKeepsServiceTierUnknown(t *testing.T) 
 	}
 }
 
-func TestUsageManagementImportRejectsLegacyUncachedInputTokens(t *testing.T) {
+func TestUsageManagementImportMigratesReleasedV1UncachedInputTokensAtomically(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	const legacyExport = `{
 		"version": 1,
@@ -278,18 +376,22 @@ func TestUsageManagementImportRejectsLegacyUncachedInputTokens(t *testing.T) {
 					"claude-sonnet": {
 						"details": [{
 							"timestamp": "2026-07-21T11:59:00Z",
-							"tokens": {
-								"input_tokens": 10,
-								"output_tokens": 1,
-								"total_tokens": 11
+				"tokens": {
+					"input_tokens": 10,
+					"output_tokens": 1,
+					"reasoning_tokens": 0,
+					"cached_tokens": 0,
+					"total_tokens": 11
 							},
 							"failed": false
 						}, {
 							"timestamp": "2026-07-21T12:00:00Z",
-								"tokens": {
-									"input_tokens": 3085,
-									"output_tokens": 253,
-									"cache_read_tokens": 7,
+					"tokens": {
+						"input_tokens": 3085,
+						"output_tokens": 253,
+						"reasoning_tokens": 0,
+						"cached_tokens": 7,
+						"cache_read_tokens": 7,
 									"cache_creation_tokens": 19514,
 									"uncached_input_tokens": 3085,
 									"total_tokens": 22859
@@ -323,21 +425,571 @@ func TestUsageManagementImportRejectsLegacyUncachedInputTokens(t *testing.T) {
 	)
 	h.ImportUsageStatistics(ginCtx)
 
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("legacy token-contract import status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("legacy token-contract import status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
 	}
 	var response struct {
-		Error string `json:"error"`
+		Added               int64  `json:"added"`
+		SchemaVersion       int    `json:"schema_version"`
+		MigratedFromVersion int    `json:"migrated_from_version"`
+		Migration           string `json:"migration"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
-		t.Fatalf("unmarshal legacy token-contract rejection: %v body=%s", err, rec.Body.String())
+		t.Fatalf("unmarshal legacy token-contract migration receipt: %v body=%s", err, rec.Body.String())
 	}
-	if response.Error != "unsupported legacy token contract: uncached_input_tokens" {
-		t.Fatalf("legacy token-contract error = %q", response.Error)
+	if response.Added != 2 || response.SchemaVersion != 2 || response.MigratedFromVersion != 1 || response.Migration != "v1_uncached_input_tokens_to_v2" {
+		t.Fatalf("legacy token-contract migration receipt = %+v", response)
+	}
+	snapshot := stats.Snapshot()
+	if reflect.DeepEqual(snapshot, wantSnapshot) || snapshot.TotalRequests != wantSnapshot.TotalRequests+2 {
+		t.Fatalf("migrated legacy import snapshot = %+v, want two added details", snapshot)
+	}
+	details := snapshot.APIs["legacy-client-key"].Models["claude-sonnet"].Details
+	if len(details) != 2 {
+		t.Fatalf("migrated legacy detail count = %d, want 2", len(details))
+	}
+	if details[0].Tokens.InputTokens != 10 || details[0].Tokens.CacheReadTokens != 0 || details[0].Tokens.CacheCreationTokens != 0 {
+		t.Fatalf("markerless no-cache v1 migration = %+v", details[0].Tokens)
+	}
+	if details[1].Tokens.InputTokens != 22606 || details[1].Tokens.CachedTokens != 7 || details[1].Tokens.CacheReadTokens != 7 || details[1].Tokens.CacheCreationTokens != 19514 {
+		t.Fatalf("marker-bearing cached v1 migration = %+v", details[1].Tokens)
+	}
+
+	beforeDuplicate := stats.Snapshot()
+	repeat := performUsageImport(h, []byte(legacyExport))
+	if repeat.Code != http.StatusOK {
+		t.Fatalf("duplicate v1 import status = %d, want %d body=%s", repeat.Code, http.StatusOK, repeat.Body.String())
+	}
+	var repeatResult struct {
+		Added         int64 `json:"added"`
+		Skipped       int64 `json:"skipped"`
+		TotalRequests int64 `json:"total_requests"`
+		SchemaVersion int   `json:"schema_version"`
+	}
+	if err := json.Unmarshal(repeat.Body.Bytes(), &repeatResult); err != nil {
+		t.Fatalf("unmarshal duplicate v1 receipt: %v body=%s", err, repeat.Body.String())
+	}
+	if repeatResult.Added != 0 || repeatResult.Skipped != 2 || repeatResult.TotalRequests != 3 || repeatResult.SchemaVersion != 2 {
+		t.Fatalf("duplicate v1 import result = %+v, want added=0 skipped=2 total_requests=3 schema_version=2", repeatResult)
+	}
+	if afterDuplicate := stats.Snapshot(); !reflect.DeepEqual(afterDuplicate, beforeDuplicate) {
+		t.Fatalf("duplicate v1 import mutated statistics: before=%+v after=%+v", beforeDuplicate, afterDuplicate)
+	}
+
+	canonical := exportUsageStatistics(t, h)
+	canonicalResult := importUsageStatistics(t, h, canonical.Usage)
+	if canonicalResult.Added != 0 || canonicalResult.Skipped != 3 || canonicalResult.TotalRequests != 3 {
+		t.Fatalf("canonical re-import after v1 migration = %+v, want added=0 skipped=3 total_requests=3", canonicalResult)
+	}
+	if afterCanonical := stats.Snapshot(); !reflect.DeepEqual(afterCanonical, beforeDuplicate) {
+		t.Fatalf("canonical re-import after v1 migration mutated statistics: before=%+v after=%+v", beforeDuplicate, afterCanonical)
+	}
+}
+
+func TestUsageManagementImportRejectsAmbiguousMarkerlessV1CacheTokensAtomically(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const payload = `{
+		"version": 1,
+		"usage": {"apis": {"legacy-client-key": {"models": {"claude-sonnet": {"details": [{
+			"timestamp": "2026-07-21T12:00:00Z",
+			"tokens": {
+				"input_tokens": 1200,
+				"output_tokens": 10,
+				"reasoning_tokens": 0,
+				"cached_tokens": 1024,
+				"cache_creation_tokens": 1024,
+				"total_tokens": 1210
+			}
+		}]}}}}}
+	}`
+
+	stats := usage.NewRequestStatistics()
+	stats.Record(context.Background(), coreusage.Record{
+		APIKey: "existing-client-key", Model: "existing-model", RequestedAt: time.Date(2026, 7, 21, 11, 0, 0, 0, time.UTC),
+		Detail: coreusage.Detail{InputTokens: 4, OutputTokens: 2, TotalTokens: 6},
+	})
+	wantSnapshot := stats.Snapshot()
+	h := &Handler{}
+	h.SetUsageStatistics(stats)
+
+	rec := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(rec)
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "/v0/management/usage/import", bytes.NewBufferString(payload))
+	h.ImportUsageStatistics(ginCtx)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("ambiguous v1 import status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	var response struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("unmarshal ambiguous v1 rejection: %v body=%s", err, rec.Body.String())
+	}
+	if response.Code != "usage_v1_cache_semantics_ambiguous" {
+		t.Fatalf("ambiguous v1 code = %q", response.Code)
 	}
 	if snapshot := stats.Snapshot(); !reflect.DeepEqual(snapshot, wantSnapshot) {
-		t.Fatalf("rejected legacy import mutated existing statistics: got=%+v want=%+v", snapshot, wantSnapshot)
+		t.Fatalf("ambiguous v1 import mutated statistics: got=%+v want=%+v", snapshot, wantSnapshot)
 	}
+}
+
+func TestUsageManagementImportDistinguishesMissingAndExplicitZeroV2TokenFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	missingFields := []string{"input_tokens", "output_tokens", "reasoning_tokens", "cached_tokens", "total_tokens"}
+	complete := map[string]int64{
+		"input_tokens": 0, "output_tokens": 0, "reasoning_tokens": 0, "cached_tokens": 0, "total_tokens": 0,
+	}
+
+	for _, missing := range missingFields {
+		t.Run("missing_"+missing, func(t *testing.T) {
+			tokens := make(map[string]int64, len(complete)-1)
+			for key, value := range complete {
+				if key != missing {
+					tokens[key] = value
+				}
+			}
+			payload := usageImportFixtureJSON(t, 2, tokens)
+			stats, h, before := seededUsageImportHandler()
+			rec := performUsageImport(h, payload)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("missing %s status = %d, want %d body=%s", missing, rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+			var response struct {
+				Code string `json:"code"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+				t.Fatalf("unmarshal missing-field rejection: %v", err)
+			}
+			if response.Code != "usage_v2_token_contract_invalid" {
+				t.Fatalf("missing %s code = %q", missing, response.Code)
+			}
+			if after := stats.Snapshot(); !reflect.DeepEqual(after, before) {
+				t.Fatalf("missing %s import mutated statistics: before=%+v after=%+v", missing, before, after)
+			}
+		})
+	}
+
+	t.Run("explicit_zero", func(t *testing.T) {
+		_, h, _ := seededUsageImportHandler()
+		rec := performUsageImport(h, usageImportFixtureJSON(t, 2, complete))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("explicit-zero v2 status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+		}
+	})
+}
+
+func TestUsageManagementImportReturnsStableSchemaErrorCodesAtomically(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tests := []struct {
+		name     string
+		payload  string
+		wantCode string
+	}{
+		{
+			name:     "invalid JSON",
+			payload:  `{"version":2`,
+			wantCode: "usage_shape_invalid",
+		},
+		{
+			name:     "invalid null root",
+			payload:  `null`,
+			wantCode: "usage_shape_invalid",
+		},
+		{
+			name:     "invalid array root",
+			payload:  `[]`,
+			wantCode: "usage_shape_invalid",
+		},
+		{
+			name:     "invalid version type",
+			payload:  `{"version":null,"usage":{"apis":{}}}`,
+			wantCode: "usage_shape_invalid",
+		},
+		{
+			name:     "unversioned payload",
+			payload:  `{"usage":{"apis":{}}}`,
+			wantCode: "usage_version_unsupported",
+		},
+		{
+			name:     "unsupported version",
+			payload:  `{"version":0,"usage":{"apis":{}}}`,
+			wantCode: "usage_version_unsupported",
+		},
+		{
+			name: "case-colliding version alias",
+			payload: `{"version":2,"Version":1,"usage":{"apis":{"client":{"models":{"model":{"details":[{
+				"timestamp":"2026-07-21T12:00:00Z",
+				"tokens":{"input_tokens":1,"uncached_input_tokens":1,"output_tokens":0,"reasoning_tokens":0,"cached_tokens":0,"total_tokens":1}
+			}]}}}}}}`,
+			wantCode: "usage_shape_invalid",
+		},
+		{
+			name: "case-colliding usage alias",
+			payload: `{"version":2,"usage":{"apis":{}},"Usage":{"apis":{"client":{"models":{"model":{"details":[{
+				"timestamp":"2026-07-21T12:00:00Z",
+				"tokens":{"input_tokens":1,"output_tokens":0,"reasoning_tokens":0,"cached_tokens":0,"total_tokens":1}
+			}]}}}}}}`,
+			wantCode: "usage_shape_invalid",
+		},
+		{
+			name: "duplicate exact usage field",
+			payload: `{"version":2,
+				"usage":{"apis":{"client":{"models":{"model":{"details":[{"timestamp":"2026-07-21T12:00:00Z","tokens":{"input_tokens":1,"output_tokens":0,"reasoning_tokens":0,"cached_tokens":0,"total_tokens":1}}]}}}}},
+				"usage":{"apis":{}}}`,
+			wantCode: "usage_shape_invalid",
+		},
+		{
+			name: "case-colliding details alias",
+			payload: `{"version":2,"usage":{"apis":{"client":{"models":{"model":{
+				"details":[],
+				"Details":[{"timestamp":"2026-07-21T12:00:00Z","tokens":{"input_tokens":1,"output_tokens":0,"reasoning_tokens":0,"cached_tokens":0,"total_tokens":1}}]
+			}}}}}}`,
+			wantCode: "usage_shape_invalid",
+		},
+		{
+			name: "case-colliding tokens alias",
+			payload: `{"version":2,"usage":{"apis":{"client":{"models":{"model":{"details":[{
+				"timestamp":"2026-07-21T12:00:00Z",
+				"tokens":{"input_tokens":0,"output_tokens":0,"reasoning_tokens":0,"cached_tokens":0,"total_tokens":0},
+				"Tokens":{"input_tokens":1,"output_tokens":0,"reasoning_tokens":0,"cached_tokens":0,"total_tokens":1}
+			}]}}}}}}`,
+			wantCode: "usage_shape_invalid",
+		},
+		{
+			name:     "missing APIs",
+			payload:  `{"version":2,"usage":{}}`,
+			wantCode: "usage_shape_invalid",
+		},
+		{
+			name:     "null API container",
+			payload:  `{"version":2,"usage":{"apis":{"client":null}}}`,
+			wantCode: "usage_shape_invalid",
+		},
+		{
+			name:     "null models container",
+			payload:  `{"version":2,"usage":{"apis":{"client":{"models":null}}}}`,
+			wantCode: "usage_shape_invalid",
+		},
+		{
+			name:     "null details container",
+			payload:  `{"version":2,"usage":{"apis":{"client":{"models":{"model":{"details":null}}}}}}`,
+			wantCode: "usage_shape_invalid",
+		},
+		{
+			name:     "null detail entry",
+			payload:  `{"version":2,"usage":{"apis":{"client":{"models":{"model":{"details":[null]}}}}}}`,
+			wantCode: "usage_shape_invalid",
+		},
+		{
+			name:     "null model container",
+			payload:  `{"version":2,"usage":{"apis":{"client":{"models":{"model":null}}}}}`,
+			wantCode: "usage_shape_invalid",
+		},
+		{
+			name:     "missing details container",
+			payload:  `{"version":2,"usage":{"apis":{"client":{"models":{"model":{}}}}}}`,
+			wantCode: "usage_shape_invalid",
+		},
+		{
+			name:     "null aggregate map",
+			payload:  `{"version":2,"usage":{"apis":{},"requests_by_day":null}}`,
+			wantCode: "usage_shape_invalid",
+		},
+		{
+			name:     "blank API identity",
+			payload:  `{"version":2,"usage":{"apis":{"  ":{"models":{}}}}}`,
+			wantCode: "usage_shape_invalid",
+		},
+		{
+			name: "invalid nested typed shape",
+			payload: `{"version":2,"usage":{"apis":{"client":{"models":{"model":{"details":[{
+				"timestamp":17,
+				"tokens":{"input_tokens":0,"output_tokens":0,"reasoning_tokens":0,"cached_tokens":0,"total_tokens":0}
+			}]}}}}}}`,
+			wantCode: "usage_shape_invalid",
+		},
+		{
+			name: "missing released v1 required field",
+			payload: `{"version":1,"usage":{"apis":{"client":{"models":{"model":{"details":[{
+				"timestamp":"2026-07-21T12:00:00Z",
+				"tokens":{"input_tokens":3,"output_tokens":1,"cached_tokens":0,"total_tokens":4}
+			}]}}}}}}`,
+			wantCode: "usage_v1_token_contract_invalid",
+		},
+		{
+			name: "legacy marker exceeds released input",
+			payload: `{"version":1,"usage":{"apis":{"client":{"models":{"model":{"details":[{
+				"timestamp":"2026-07-21T12:00:00Z",
+				"tokens":{"input_tokens":3,"uncached_input_tokens":4,"output_tokens":1,"reasoning_tokens":0,"cached_tokens":0,"total_tokens":4}
+			}]}}}}}}`,
+			wantCode: "usage_v1_token_contract_invalid",
+		},
+		{
+			name: "legacy marker is null",
+			payload: `{"version":1,"usage":{"apis":{"client":{"models":{"model":{"details":[{
+				"timestamp":"2026-07-21T12:00:00Z",
+				"tokens":{"input_tokens":3,"uncached_input_tokens":null,"output_tokens":1,"reasoning_tokens":0,"cached_tokens":0,"total_tokens":4}
+			}]}}}}}}`,
+			wantCode: "usage_v1_token_contract_invalid",
+		},
+		{
+			name: "legacy marker is non-integral",
+			payload: `{"version":1,"usage":{"apis":{"client":{"models":{"model":{"details":[{
+				"timestamp":"2026-07-21T12:00:00Z",
+				"tokens":{"input_tokens":3,"uncached_input_tokens":1.5,"output_tokens":1,"reasoning_tokens":0,"cached_tokens":0,"total_tokens":4}
+			}]}}}}}}`,
+			wantCode: "usage_v1_token_contract_invalid",
+		},
+		{
+			name: "legacy marker is negative",
+			payload: `{"version":1,"usage":{"apis":{"client":{"models":{"model":{"details":[{
+				"timestamp":"2026-07-21T12:00:00Z",
+				"tokens":{"input_tokens":3,"uncached_input_tokens":-1,"output_tokens":1,"reasoning_tokens":0,"cached_tokens":0,"total_tokens":4}
+			}]}}}}}}`,
+			wantCode: "usage_v1_token_contract_invalid",
+		},
+		{
+			name: "legacy field in canonical payload",
+			payload: `{"version":2,"usage":{"apis":{"client":{"models":{"model":{"details":[{
+				"timestamp":"2026-07-21T12:00:00Z",
+				"tokens":{"input_tokens":0,"uncached_input_tokens":0,"output_tokens":0,"reasoning_tokens":0,"cached_tokens":0,"total_tokens":0}
+			}]}}}}}}`,
+			wantCode: "usage_v2_token_contract_invalid",
+		},
+		{
+			name: "canonical mandatory field is null",
+			payload: `{"version":2,"usage":{"apis":{"client":{"models":{"model":{"details":[{
+				"timestamp":"2026-07-21T12:00:00Z",
+				"tokens":{"input_tokens":null,"output_tokens":0,"reasoning_tokens":0,"cached_tokens":0,"total_tokens":0}
+			}]}}}}}}`,
+			wantCode: "usage_v2_token_contract_invalid",
+		},
+		{
+			name: "canonical tokens object is empty",
+			payload: `{"version":2,"usage":{"apis":{"client":{"models":{"model":{"details":[{
+				"timestamp":"2026-07-21T12:00:00Z",
+				"tokens":{}
+			}]}}}}}}`,
+			wantCode: "usage_v2_token_contract_invalid",
+		},
+		{
+			name: "canonical tokens object is missing",
+			payload: `{"version":2,"usage":{"apis":{"client":{"models":{"model":{"details":[{
+				"timestamp":"2026-07-21T12:00:00Z"
+			}]}}}}}}`,
+			wantCode: "usage_v2_token_contract_invalid",
+		},
+		{
+			name: "canonical mandatory field has wrong type",
+			payload: `{"version":2,"usage":{"apis":{"client":{"models":{"model":{"details":[{
+				"timestamp":"2026-07-21T12:00:00Z",
+				"tokens":{"input_tokens":"0","output_tokens":0,"reasoning_tokens":0,"cached_tokens":0,"total_tokens":0}
+			}]}}}}}}`,
+			wantCode: "usage_v2_token_contract_invalid",
+		},
+		{
+			name: "canonical cache relationship overflows int64",
+			payload: `{"version":2,"usage":{"apis":{"client":{"models":{"model":{"details":[{
+				"timestamp":"2026-07-21T12:00:00Z",
+				"tokens":{"input_tokens":9223372036854775807,"output_tokens":0,"reasoning_tokens":0,"cached_tokens":9223372036854775807,"cache_read_tokens":9223372036854775807,"cache_creation_tokens":1,"total_tokens":9223372036854775807}
+			}]}}}}}}`,
+			wantCode: "usage_v2_token_contract_invalid",
+		},
+		{
+			name: "canonical minimum total relationship overflows int64",
+			payload: `{"version":2,"usage":{"apis":{"client":{"models":{"model":{"details":[{
+				"timestamp":"2026-07-21T12:00:00Z",
+				"tokens":{"input_tokens":9223372036854775807,"output_tokens":1,"reasoning_tokens":0,"cached_tokens":0,"total_tokens":9223372036854775807}
+			}]}}}}}}`,
+			wantCode: "usage_v2_token_contract_invalid",
+		},
+		{
+			name: "invalid canonical relationships",
+			payload: `{"version":2,"usage":{"apis":{"client":{"models":{"model":{"details":[{
+				"timestamp":"2026-07-21T12:00:00Z",
+				"tokens":{"input_tokens":10,"output_tokens":2,"reasoning_tokens":0,"cached_tokens":9,"cache_read_tokens":9,"cache_creation_tokens":2,"total_tokens":12}
+			}]}}}}}}`,
+			wantCode: "usage_v2_token_contract_invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stats, h, before := seededUsageImportHandler()
+			rec := performUsageImport(h, []byte(tt.payload))
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+			var response struct {
+				Error string `json:"error"`
+				Code  string `json:"code"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+				t.Fatalf("unmarshal schema rejection: %v body=%s", err, rec.Body.String())
+			}
+			if response.Error == "" || response.Code != tt.wantCode {
+				t.Fatalf("schema rejection = %+v, want code %q", response, tt.wantCode)
+			}
+			if after := stats.Snapshot(); !reflect.DeepEqual(after, before) {
+				t.Fatalf("schema rejection mutated statistics: before=%+v after=%+v", before, after)
+			}
+		})
+	}
+
+}
+
+func TestUsageManagementImportMapsUnavailableAndReadFailureToShapeInvalid(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tests := []struct {
+		name    string
+		handler *Handler
+		body    io.Reader
+	}{
+		{
+			name: "usage store unavailable",
+			body: bytes.NewBufferString(`{"version":2,"usage":{"apis":{}}}`),
+		},
+		{
+			name: "request body read failure",
+			handler: func() *Handler {
+				h := &Handler{}
+				h.SetUsageStatistics(usage.NewRequestStatistics())
+				return h
+			}(),
+			body: failingUsageImportReader{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			ginCtx, _ := gin.CreateTestContext(rec)
+			ginCtx.Request = httptest.NewRequest(http.MethodPost, "/v0/management/usage/import", tt.body)
+			tt.handler.ImportUsageStatistics(ginCtx)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+			var response struct {
+				Code string `json:"code"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+				t.Fatalf("unmarshal rejection: %v body=%s", err, rec.Body.String())
+			}
+			if response.Code != "usage_shape_invalid" {
+				t.Fatalf("code = %q, want usage_shape_invalid", response.Code)
+			}
+		})
+	}
+}
+
+func TestUsageManagementImportRejectsAggregateOverflowAtomically(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	stats := usage.NewRequestStatistics()
+	h := &Handler{}
+	h.SetUsageStatistics(stats)
+
+	first := usageImportFixtureJSON(t, 2, map[string]int64{
+		"input_tokens": math.MaxInt64, "output_tokens": 0, "reasoning_tokens": 0, "cached_tokens": 0, "total_tokens": math.MaxInt64,
+	})
+	if rec := performUsageImport(h, first); rec.Code != http.StatusOK {
+		t.Fatalf("seed max-token import status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	before := stats.Snapshot()
+
+	second := usageImportFixtureJSONAt(t, 2, map[string]int64{
+		"input_tokens": 1, "output_tokens": 0, "reasoning_tokens": 0, "cached_tokens": 0, "total_tokens": 1,
+	}, "2026-07-21T12:01:00Z")
+	rec := performUsageImport(h, second)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("overflow import status = %d, want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	var response struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("unmarshal overflow rejection: %v", err)
+	}
+	if response.Code != "usage_aggregate_overflow" {
+		t.Fatalf("overflow code = %q", response.Code)
+	}
+	if after := stats.Snapshot(); !reflect.DeepEqual(after, before) {
+		t.Fatalf("overflow import mutated statistics: before=%+v after=%+v", before, after)
+	}
+}
+
+func TestUsageManagementImportPreservesUncertainTimestampForDeterministicReimport(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tests := []struct {
+		name      string
+		timestamp string
+	}{
+		{name: "missing timestamp"},
+		{name: "null timestamp", timestamp: `,"timestamp":null`},
+		{name: "Go zero timestamp", timestamp: `,"timestamp":"0001-01-01T00:00:00Z"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := []byte(`{"version":2,"usage":{"apis":{"client":{"models":{"model":{"details":[{"tokens":{"input_tokens":1,"output_tokens":0,"reasoning_tokens":0,"cached_tokens":0,"total_tokens":1}` + tt.timestamp + `}]}}}}}}`)
+			stats := usage.NewRequestStatistics()
+			h := &Handler{}
+			h.SetUsageStatistics(stats)
+
+			first := performUsageImport(h, payload)
+			if first.Code != http.StatusOK {
+				t.Fatalf("first uncertain-timestamp import status = %d, want %d body=%s", first.Code, http.StatusOK, first.Body.String())
+			}
+			second := performUsageImport(h, payload)
+			if second.Code != http.StatusOK {
+				t.Fatalf("second uncertain-timestamp import status = %d, want %d body=%s", second.Code, http.StatusOK, second.Body.String())
+			}
+			var receipt struct {
+				Added   int64 `json:"added"`
+				Skipped int64 `json:"skipped"`
+			}
+			if err := json.Unmarshal(second.Body.Bytes(), &receipt); err != nil {
+				t.Fatalf("unmarshal repeat receipt: %v body=%s", err, second.Body.String())
+			}
+			if receipt.Added != 0 || receipt.Skipped != 1 {
+				t.Fatalf("repeat receipt = %+v, want added=0 skipped=1", receipt)
+			}
+			detail := stats.Snapshot().APIs["client"].Models["model"].Details[0]
+			if !detail.Timestamp.IsZero() {
+				t.Fatalf("stored timestamp = %s, want Go zero time preserved", detail.Timestamp.Format(time.RFC3339Nano))
+			}
+		})
+	}
+
+	t.Run("missing null and Go zero share one uncertain identity", func(t *testing.T) {
+		payloads := [][]byte{
+			[]byte(`{"version":2,"usage":{"apis":{"client":{"models":{"model":{"details":[{"tokens":{"input_tokens":1,"output_tokens":0,"reasoning_tokens":0,"cached_tokens":0,"total_tokens":1}}]}}}}}}`),
+			[]byte(`{"version":2,"usage":{"apis":{"client":{"models":{"model":{"details":[{"timestamp":null,"tokens":{"input_tokens":1,"output_tokens":0,"reasoning_tokens":0,"cached_tokens":0,"total_tokens":1}}]}}}}}}`),
+			[]byte(`{"version":2,"usage":{"apis":{"client":{"models":{"model":{"details":[{"timestamp":"0001-01-01T00:00:00Z","tokens":{"input_tokens":1,"output_tokens":0,"reasoning_tokens":0,"cached_tokens":0,"total_tokens":1}}]}}}}}}`),
+		}
+		stats := usage.NewRequestStatistics()
+		h := &Handler{}
+		h.SetUsageStatistics(stats)
+		for index, payload := range payloads {
+			rec := performUsageImport(h, payload)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("uncertain form %d status = %d, want %d body=%s", index, rec.Code, http.StatusOK, rec.Body.String())
+			}
+			var receipt struct {
+				Added   int64 `json:"added"`
+				Skipped int64 `json:"skipped"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &receipt); err != nil {
+				t.Fatalf("unmarshal uncertain form %d receipt: %v", index, err)
+			}
+			if index == 0 && (receipt.Added != 1 || receipt.Skipped != 0) {
+				t.Fatalf("first uncertain receipt = %+v, want added=1 skipped=0", receipt)
+			}
+			if index > 0 && (receipt.Added != 0 || receipt.Skipped != 1) {
+				t.Fatalf("uncertain replay %d receipt = %+v, want added=0 skipped=1", index, receipt)
+			}
+		}
+	})
 }
 
 func TestUsageManagementImportKeepsDifferentCacheCreationTokenShapes(t *testing.T) {
@@ -346,13 +998,14 @@ func TestUsageManagementImportKeepsDifferentCacheCreationTokenShapes(t *testing.
 	firstShape := usageCacheCreationSnapshot(timestamp, usage.TokenStats{
 		InputTokens:         1200,
 		OutputTokens:        10,
-		CachedTokens:        1024,
 		CacheCreationTokens: 1024,
 		TotalTokens:         1210,
 	})
 	secondShape := usageCacheCreationSnapshot(timestamp, usage.TokenStats{
-		InputTokens:         1200,
+		InputTokens:         2224,
 		OutputTokens:        10,
+		CachedTokens:        1024,
+		CacheReadTokens:     1024,
 		CacheCreationTokens: 1024,
 		TotalTokens:         2234,
 	})
@@ -408,8 +1061,18 @@ func TestUsageManagementImportKeepsDifferentCacheCreationTokenShapes(t *testing.
 	}
 }
 
+type failingUsageImportReader struct{}
+
+func (failingUsageImportReader) Read([]byte) (int, error) {
+	return 0, io.ErrUnexpectedEOF
+}
+
 func usageCacheCreationSnapshot(timestamp time.Time, tokens usage.TokenStats) usage.StatisticsSnapshot {
 	return usage.StatisticsSnapshot{
+		RequestsByDay:  map[string]int64{},
+		RequestsByHour: map[string]int64{},
+		TokensByDay:    map[string]int64{},
+		TokensByHour:   map[string]int64{},
 		APIs: map[string]usage.APISnapshot{
 			"cache-key": {
 				Models: map[string]usage.ModelSnapshot{
@@ -498,14 +1161,17 @@ func exportUsageStatistics(t *testing.T, h *Handler) usageExportPayload {
 }
 
 func importUsageStatistics(t *testing.T, h *Handler, snapshot usage.StatisticsSnapshot) struct {
-	Added          int64 `json:"added"`
-	Skipped        int64 `json:"skipped"`
-	TotalRequests  int64 `json:"total_requests"`
-	FailedRequests int64 `json:"failed_requests"`
+	Added               int64  `json:"added"`
+	Skipped             int64  `json:"skipped"`
+	TotalRequests       int64  `json:"total_requests"`
+	FailedRequests      int64  `json:"failed_requests"`
+	SchemaVersion       int    `json:"schema_version"`
+	MigratedFromVersion int    `json:"migrated_from_version"`
+	Migration           string `json:"migration"`
 } {
 	t.Helper()
 
-	body, err := json.Marshal(usageImportPayload{Version: 1, Usage: snapshot})
+	body, err := json.Marshal(usageImportPayload{Version: 2, Usage: snapshot})
 	if err != nil {
 		t.Fatalf("marshal import payload: %v", err)
 	}
@@ -520,15 +1186,70 @@ func importUsageStatistics(t *testing.T, h *Handler, snapshot usage.StatisticsSn
 	}
 
 	var payload struct {
-		Added          int64 `json:"added"`
-		Skipped        int64 `json:"skipped"`
-		TotalRequests  int64 `json:"total_requests"`
-		FailedRequests int64 `json:"failed_requests"`
+		Added               int64  `json:"added"`
+		Skipped             int64  `json:"skipped"`
+		TotalRequests       int64  `json:"total_requests"`
+		FailedRequests      int64  `json:"failed_requests"`
+		SchemaVersion       int    `json:"schema_version"`
+		MigratedFromVersion int    `json:"migrated_from_version"`
+		Migration           string `json:"migration"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
 		t.Fatalf("unmarshal import response: %v body=%s", err, rec.Body.String())
 	}
 	return payload
+}
+
+func usageImportFixtureJSON(t *testing.T, version int, tokens map[string]int64) []byte {
+	return usageImportFixtureJSONAt(t, version, tokens, "2026-07-21T12:00:00Z")
+}
+
+func usageImportFixtureJSONAt(t *testing.T, version int, tokens map[string]int64, timestamp string) []byte {
+	t.Helper()
+	payload := map[string]any{
+		"version": version,
+		"usage": map[string]any{
+			"apis": map[string]any{
+				"import-client": map[string]any{
+					"models": map[string]any{
+						"gpt-5.6-sol": map[string]any{
+							"details": []any{map[string]any{
+								"timestamp":  timestamp,
+								"source":     "auths/import.json",
+								"auth_index": "0",
+								"tokens":     tokens,
+								"failed":     false,
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal usage import fixture: %v", err)
+	}
+	return data
+}
+
+func seededUsageImportHandler() (*usage.RequestStatistics, *Handler, usage.StatisticsSnapshot) {
+	stats := usage.NewRequestStatistics()
+	stats.Record(context.Background(), coreusage.Record{
+		APIKey: "existing-client-key", Model: "existing-model", RequestedAt: time.Date(2026, 7, 21, 11, 0, 0, 0, time.UTC),
+		Detail: coreusage.Detail{InputTokens: 4, OutputTokens: 2, TotalTokens: 6},
+	})
+	h := &Handler{}
+	h.SetUsageStatistics(stats)
+	return stats, h, stats.Snapshot()
+}
+
+func performUsageImport(h *Handler, payload []byte) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(rec)
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "/v0/management/usage/import", bytes.NewReader(payload))
+	h.ImportUsageStatistics(ginCtx)
+	return rec
 }
 
 func requirePanelUsageShape(t *testing.T, snapshot usage.StatisticsSnapshot) {

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -196,7 +196,7 @@ func (r *UsageReporter) buildAdditionalModelRecord(model string, detail usage.De
 	if model == "" {
 		return usage.Record{}, false
 	}
-	detail = normalizeUsageDetailTotal(detail)
+	detail = normalizeUsageDetailTotal(r.provider, detail)
 	if !hasNonZeroTokenUsage(detail) {
 		return usage.Record{}, false
 	}
@@ -224,21 +224,58 @@ func (r *UsageReporter) publishWithOutcome(ctx context.Context, detail usage.Det
 	if r == nil {
 		return
 	}
-	detail = normalizeUsageDetailTotal(detail)
+	detail = normalizeUsageDetailTotal(r.provider, detail)
 	r.once.Do(func() {
 		r.publishRecord(ctx, r.buildRecord(detail, failed, fail))
 	})
 }
 
-func normalizeUsageDetailTotal(detail usage.Detail) usage.Detail {
+func normalizeUsageDetailTotal(provider string, detail usage.Detail) usage.Detail {
 	if detail.TotalTokens < 0 {
 		detail.TotalTokens = 0
 	}
-	if detail.TotalTokens == 0 {
-		if total, ok := sumNonNegativeUsageTokens(detail.InputTokens, detail.OutputTokens, detail.ReasoningTokens); ok && total > 0 {
-			detail.TotalTokens = total
+	minimumTotal, ok := sumNonNegativeUsageTokens(detail.InputTokens, detail.OutputTokens)
+	if !ok {
+		return clearUsageDetailTokens(detail)
+	}
+	if detail.TotalTokens > 0 {
+		if detail.TotalTokens < minimumTotal {
+			detail.TotalTokens = minimumTotal
+		}
+		return detail
+	}
+
+	fallbackTotal := minimumTotal
+	if !reasoningIsOutputSubset(provider) {
+		fallbackTotal, ok = sumNonNegativeUsageTokens(fallbackTotal, detail.ReasoningTokens)
+		if !ok {
+			return clearUsageDetailTokens(detail)
 		}
 	}
+	if fallbackTotal == 0 && detail.ReasoningTokens != 0 {
+		return clearUsageDetailTokens(detail)
+	}
+	detail.TotalTokens = fallbackTotal
+	return detail
+}
+
+func reasoningIsOutputSubset(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "openai", "codex":
+		return true
+	default:
+		return false
+	}
+}
+
+func clearUsageDetailTokens(detail usage.Detail) usage.Detail {
+	detail.InputTokens = 0
+	detail.OutputTokens = 0
+	detail.ReasoningTokens = 0
+	detail.CachedTokens = 0
+	detail.CacheReadTokens = 0
+	detail.CacheCreationTokens = 0
+	detail.TotalTokens = 0
 	return detail
 }
 
@@ -668,7 +705,7 @@ func parseOpenAIStyleUsageNode(usageNode gjson.Result) usage.Detail {
 	if reasoning.Exists() {
 		detail.ReasoningTokens, _ = parseOptionalStrictUsageTokenCount(reasoning)
 	}
-	return normalizeUsageInputTokenCategories(detail)
+	return normalizeUsageDetailTotal("openai", normalizeUsageInputTokenCategories(detail))
 }
 
 func ParseOpenAIStreamUsage(line []byte) (usage.Detail, bool) {

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -167,20 +167,27 @@ func TestUsageParsersNormalizeInputTotalsAcrossProviderShapes(t *testing.T) {
 }
 
 func TestUsageTotalFallbackDoesNotDoubleCountCacheCategories(t *testing.T) {
-	detail := normalizeUsageDetailTotal(usage.Detail{
+	detail := normalizeUsageDetailTotal("openai", usage.Detail{
 		InputTokens:         100,
 		OutputTokens:        20,
 		ReasoningTokens:     5,
 		CacheReadTokens:     30,
 		CacheCreationTokens: 40,
 	})
-	if detail.TotalTokens != 125 {
-		t.Fatalf("total_tokens = %d, want 125 without double-counting input cache categories", detail.TotalTokens)
+	if detail.TotalTokens != 120 {
+		t.Fatalf("total_tokens = %d, want 120 without double-counting cache or reasoning subsets", detail.TotalTokens)
+	}
+}
+
+func TestParseOpenAIUsageFallbackDoesNotDoubleCountReasoningSubset(t *testing.T) {
+	detail := ParseOpenAIUsage([]byte(`{"usage":{"input_tokens":100,"output_tokens":20,"output_tokens_details":{"reasoning_tokens":5}}}`))
+	if detail.TotalTokens != 120 {
+		t.Fatalf("total_tokens = %d, want 120 because OpenAI output_tokens includes reasoning_tokens", detail.TotalTokens)
 	}
 }
 
 func TestUsageTotalFallbackFailsClosedOnOverflow(t *testing.T) {
-	detail := normalizeUsageDetailTotal(usage.Detail{
+	detail := normalizeUsageDetailTotal("openai", usage.Detail{
 		InputTokens:  math.MaxInt64,
 		OutputTokens: 1,
 	})
@@ -420,7 +427,7 @@ func TestParseClaudeUsageFailsClosedWhenCanonicalInputOverflows(t *testing.T) {
 	if detail.TotalTokens != 0 {
 		t.Fatalf("total_tokens = %d, want 0 when the canonical total is not representable", detail.TotalTokens)
 	}
-	if normalized := normalizeUsageDetailTotal(detail); normalized.TotalTokens != 0 {
+	if normalized := normalizeUsageDetailTotal("claude", detail); normalized.TotalTokens != 0 {
 		t.Fatalf("reporter fallback total_tokens = %d, want 0 rather than a wrapped value", normalized.TotalTokens)
 	}
 }
@@ -509,7 +516,7 @@ func TestParseInteractionsUsageFailsClosedWhenCanonicalInputOverflows(t *testing
 	if detail.TotalTokens != 0 {
 		t.Fatalf("total_tokens = %d, want 0 when the canonical total is not representable", detail.TotalTokens)
 	}
-	if normalized := normalizeUsageDetailTotal(detail); normalized.TotalTokens != 0 {
+	if normalized := normalizeUsageDetailTotal("interactions", detail); normalized.TotalTokens != 0 {
 		t.Fatalf("reporter fallback total_tokens = %d, want 0 rather than a wrapped value", normalized.TotalTokens)
 	}
 }

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -19,10 +19,14 @@ import (
 
 var statisticsEnabled atomic.Bool
 
-// ErrLegacyUncachedInputTokens rejects usage imports encoded with the retired
-// uncached-input token contract. Accepting the field would silently retain the
-// old InputTokens meaning and corrupt normalized cache accounting.
-var ErrLegacyUncachedInputTokens = errors.New("unsupported legacy token contract: uncached_input_tokens")
+const CanonicalExportVersion = 2
+
+var (
+	ErrInvalidLegacyTokenStats    = errors.New("invalid legacy usage token contract")
+	ErrAmbiguousLegacyTokenStats  = errors.New("ambiguous legacy usage token contract: cached version 1 details require uncached_input_tokens")
+	ErrInvalidCanonicalTokenStats = errors.New("invalid canonical usage token contract")
+	ErrUsageAggregateOverflow     = errors.New("usage aggregate overflow")
+)
 
 func init() {
 	statisticsEnabled.Store(true)
@@ -147,26 +151,229 @@ type TokenStats struct {
 	CacheReadTokens     int64 `json:"cache_read_tokens,omitempty"`
 	CacheCreationTokens int64 `json:"cache_creation_tokens,omitempty"`
 	TotalTokens         int64 `json:"total_tokens"`
+
+	fieldsPresent                  tokenStatsFieldPresence
+	legacyUncachedInputTokens      *int64
+	legacyUncachedInputTokensFound bool
 }
 
-// UnmarshalJSON rejects retired token payloads instead of silently treating
-// their old InputTokens semantics as the normalized total-input contract.
+type tokenStatsFieldPresence uint16
+
+const (
+	tokenStatsInputPresent tokenStatsFieldPresence = 1 << iota
+	tokenStatsOutputPresent
+	tokenStatsReasoningPresent
+	tokenStatsCachedPresent
+	tokenStatsCacheReadPresent
+	tokenStatsCacheCreationPresent
+	tokenStatsTotalPresent
+)
+
+const tokenStatsRequiredExportFields = tokenStatsInputPresent |
+	tokenStatsOutputPresent |
+	tokenStatsReasoningPresent |
+	tokenStatsCachedPresent |
+	tokenStatsTotalPresent
+
+var tokenStatsJSONFields = []struct {
+	name string
+	bit  tokenStatsFieldPresence
+}{
+	{name: "input_tokens", bit: tokenStatsInputPresent},
+	{name: "output_tokens", bit: tokenStatsOutputPresent},
+	{name: "reasoning_tokens", bit: tokenStatsReasoningPresent},
+	{name: "cached_tokens", bit: tokenStatsCachedPresent},
+	{name: "cache_read_tokens", bit: tokenStatsCacheReadPresent},
+	{name: "cache_creation_tokens", bit: tokenStatsCacheCreationPresent},
+	{name: "total_tokens", bit: tokenStatsTotalPresent},
+}
+
+// UnmarshalJSON retains field presence and the released v1 migration marker.
+// Import validation uses the private presence mask to distinguish omitted
+// fields from explicit zero without changing the exported JSON schema.
 func (tokens *TokenStats) UnmarshalJSON(data []byte) error {
 	type tokenStatsAlias TokenStats
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(data, &fields); err != nil {
 		return err
 	}
-	if _, exists := fields["uncached_input_tokens"]; exists {
-		return ErrLegacyUncachedInputTokens
-	}
 
 	var decoded tokenStatsAlias
 	if err := json.Unmarshal(data, &decoded); err != nil {
-		return err
+		return fmt.Errorf("%w: token fields must be integers", ErrInvalidCanonicalTokenStats)
 	}
-	*tokens = TokenStats(decoded)
+
+	presence := tokenStatsFieldPresence(0)
+	for _, field := range tokenStatsJSONFields {
+		rawValue, exists := fields[field.name]
+		if !exists {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(string(rawValue)), "null") {
+			return fmt.Errorf("%w: %s must be an integer", ErrInvalidCanonicalTokenStats, field.name)
+		}
+		presence |= field.bit
+	}
+
+	decodedTokens := TokenStats(decoded)
+	decodedTokens.fieldsPresent = presence
+	if rawUncached, exists := fields["uncached_input_tokens"]; exists {
+		decodedTokens.legacyUncachedInputTokensFound = true
+		if strings.EqualFold(strings.TrimSpace(string(rawUncached)), "null") {
+			return fmt.Errorf("%w: uncached_input_tokens must be an integer", ErrInvalidLegacyTokenStats)
+		}
+		var uncachedInputTokens int64
+		if err := json.Unmarshal(rawUncached, &uncachedInputTokens); err != nil {
+			return fmt.Errorf("%w: uncached_input_tokens must be an integer", ErrInvalidLegacyTokenStats)
+		}
+		decodedTokens.legacyUncachedInputTokens = &uncachedInputTokens
+	}
+	*tokens = decodedTokens
 	return nil
+}
+
+func (tokens TokenStats) hasRequiredExportFields() bool {
+	return tokens.fieldsPresent&tokenStatsRequiredExportFields == tokenStatsRequiredExportFields
+}
+
+// MigrateV1TokenStats converts released version 1 details into the canonical
+// version 2 total-input contract. Markerless details are safe only when all
+// cache categories are zero; cached markerless details remain ambiguous across
+// the released OpenAI-inclusive and Claude-uncached input semantics.
+func (snapshot *StatisticsSnapshot) MigrateV1TokenStats() error {
+	if snapshot == nil {
+		return nil
+	}
+	for apiName, apiSnapshot := range snapshot.APIs {
+		for modelName, modelSnapshot := range apiSnapshot.Models {
+			for detailIndex := range modelSnapshot.Details {
+				if err := migrateV1TokenStats(&modelSnapshot.Details[detailIndex].Tokens); err != nil {
+					return err
+				}
+			}
+			apiSnapshot.Models[modelName] = modelSnapshot
+		}
+		snapshot.APIs[apiName] = apiSnapshot
+	}
+	return nil
+}
+
+func migrateV1TokenStats(tokens *TokenStats) error {
+	if tokens == nil || !tokens.hasRequiredExportFields() || !validLegacyV1TokenStats(*tokens) {
+		return ErrInvalidLegacyTokenStats
+	}
+
+	if tokens.legacyUncachedInputTokens == nil {
+		if tokens.legacyUncachedInputTokensFound {
+			return ErrInvalidLegacyTokenStats
+		}
+		if tokens.CachedTokens != 0 || tokens.CacheReadTokens != 0 || tokens.CacheCreationTokens != 0 {
+			return ErrAmbiguousLegacyTokenStats
+		}
+		return nil
+	}
+
+	uncachedInputTokens := *tokens.legacyUncachedInputTokens
+	if uncachedInputTokens < 0 || uncachedInputTokens > tokens.InputTokens {
+		return ErrInvalidLegacyTokenStats
+	}
+	cacheReadTokens := tokens.CacheReadTokens
+	legacyCacheCreationAlias := tokens.CacheCreationTokens > 0 &&
+		cacheReadTokens == 0 &&
+		tokens.CachedTokens == tokens.CacheCreationTokens
+	if cacheReadTokens == 0 && tokens.CachedTokens > 0 && !legacyCacheCreationAlias {
+		cacheReadTokens = tokens.CachedTokens
+	}
+	canonicalInputTokens, ok := sumNonNegativeTokenCounts(
+		uncachedInputTokens,
+		cacheReadTokens,
+		tokens.CacheCreationTokens,
+	)
+	if !ok {
+		return ErrInvalidLegacyTokenStats
+	}
+	tokens.InputTokens = canonicalInputTokens
+	tokens.CacheReadTokens = cacheReadTokens
+	if legacyCacheCreationAlias {
+		tokens.CachedTokens = 0
+	} else {
+		tokens.CachedTokens = cacheReadTokens
+	}
+	tokens.legacyUncachedInputTokens = nil
+	tokens.legacyUncachedInputTokensFound = false
+	return nil
+}
+
+// HasLegacyUncachedInputTokens reports whether a canonical payload still
+// carries the version 1-only migration field.
+func (snapshot StatisticsSnapshot) HasLegacyUncachedInputTokens() bool {
+	for _, apiSnapshot := range snapshot.APIs {
+		for _, modelSnapshot := range apiSnapshot.Models {
+			for _, detail := range modelSnapshot.Details {
+				if detail.Tokens.legacyUncachedInputTokensFound {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// ValidateCanonicalV2TokenStats requires every non-omitempty export field and
+// validates the canonical token relationships for every imported detail.
+func (snapshot StatisticsSnapshot) ValidateCanonicalV2TokenStats() error {
+	for _, apiSnapshot := range snapshot.APIs {
+		for _, modelSnapshot := range apiSnapshot.Models {
+			for _, detail := range modelSnapshot.Details {
+				if !detail.Tokens.hasRequiredExportFields() || !validCanonicalTokenStats(detail.Tokens) {
+					return ErrInvalidCanonicalTokenStats
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// ValidateCanonicalTokenStats validates migrated v1 values after their
+// version-specific presence and ambiguity checks have completed.
+func (snapshot StatisticsSnapshot) ValidateCanonicalTokenStats() error {
+	for _, apiSnapshot := range snapshot.APIs {
+		for _, modelSnapshot := range apiSnapshot.Models {
+			for _, detail := range modelSnapshot.Details {
+				if !validCanonicalTokenStats(detail.Tokens) {
+					return ErrInvalidCanonicalTokenStats
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func validCanonicalTokenStats(tokens TokenStats) bool {
+	if !validLegacyV1TokenStats(tokens) || tokens.CachedTokens != tokens.CacheReadTokens {
+		return false
+	}
+	cacheInputTokens, ok := sumNonNegativeTokenCounts(tokens.CacheReadTokens, tokens.CacheCreationTokens)
+	if !ok || cacheInputTokens > tokens.InputTokens {
+		return false
+	}
+	minimumTotalTokens, ok := sumNonNegativeTokenCounts(tokens.InputTokens, tokens.OutputTokens)
+	return ok && minimumTotalTokens <= tokens.TotalTokens
+}
+
+func validLegacyV1TokenStats(tokens TokenStats) bool {
+	if tokens.InputTokens < 0 ||
+		tokens.OutputTokens < 0 ||
+		tokens.ReasoningTokens < 0 ||
+		tokens.CachedTokens < 0 ||
+		tokens.CacheReadTokens < 0 ||
+		tokens.CacheCreationTokens < 0 ||
+		tokens.TotalTokens < 0 {
+		return false
+	}
+	return tokens.TotalTokens != 0 ||
+		(tokens.InputTokens == 0 && tokens.OutputTokens == 0 && tokens.ReasoningTokens == 0 &&
+			tokens.CachedTokens == 0 && tokens.CacheReadTokens == 0 && tokens.CacheCreationTokens == 0)
 }
 
 // StatisticsSnapshot represents an immutable view of the aggregated metrics.
@@ -226,8 +433,7 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 	if timestamp.IsZero() {
 		timestamp = time.Now()
 	}
-	detail := normaliseDetail(record.Detail)
-	totalTokens := detail.TotalTokens
+	detail := normaliseDetail(record.Provider, record.Detail)
 	statsKey := record.APIKey
 	if statsKey == "" {
 		statsKey = resolveAPIIdentifier(ctx, record)
@@ -236,7 +442,6 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 	if !failed {
 		failed = !resolveSuccess(ctx)
 	}
-	success := !failed
 	failureReason, failureStatus := safeFailureDetail(record, failed)
 	modelName := record.Model
 	if modelName == "" {
@@ -251,26 +456,7 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 		responseServiceTier = strings.TrimSpace(record.Detail.ResponseServiceTier)
 	}
 	effectiveServiceTier := coreusage.CanonicalEffectiveServiceTier(record.EffectiveServiceTier)
-	dayKey := timestamp.Format("2006-01-02")
-	hourKey := timestamp.Hour()
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.totalRequests++
-	if success {
-		s.successCount++
-	} else {
-		s.failureCount++
-	}
-	s.totalTokens = addNonNegativeTokenCounts(s.totalTokens, totalTokens)
-
-	stats, ok := s.apis[statsKey]
-	if !ok {
-		stats = &apiStats{Models: make(map[string]*modelStats)}
-		s.apis[statsKey] = stats
-	}
-	s.updateAPIStats(stats, modelName, RequestDetail{
+	requestDetail := RequestDetail{
 		Timestamp:            timestamp,
 		LatencyMs:            normaliseLatency(record.Latency),
 		Source:               record.Source,
@@ -286,12 +472,27 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 		Generate:             coreusage.GenerateEnabled(record.Generate),
 		FailureReason:        failureReason,
 		FailureStatus:        failureStatus,
-	})
+	}
 
-	s.requestsByDay[dayKey]++
-	s.requestsByHour[hourKey]++
-	s.tokensByDay[dayKey] = addNonNegativeTokenCounts(s.tokensByDay[dayKey], totalTokens)
-	s.tokensByHour[hourKey] = addNonNegativeTokenCounts(s.tokensByHour[hourKey], totalTokens)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	candidate := mergeCandidate{apiName: statsKey, modelName: modelName, detail: requestDetail}
+	if err := s.validateMergeCandidates([]mergeCandidate{candidate}); err != nil {
+		candidate.detail.Tokens = TokenStats{}
+		if err = s.validateMergeCandidates([]mergeCandidate{candidate}); err != nil {
+			return
+		}
+	}
+
+	stats, ok := s.apis[statsKey]
+	if !ok || stats == nil {
+		stats = &apiStats{Models: make(map[string]*modelStats)}
+		s.apis[statsKey] = stats
+	} else if stats.Models == nil {
+		stats.Models = make(map[string]*modelStats)
+	}
+	s.recordImported(statsKey, modelName, stats, candidate.detail)
 }
 
 func (s *RequestStatistics) updateAPIStats(stats *apiStats, model string, detail RequestDetail) {
@@ -373,12 +574,29 @@ type MergeResult struct {
 	Skipped int64 `json:"skipped"`
 }
 
+type mergeCandidate struct {
+	apiName   string
+	modelName string
+	detail    RequestDetail
+}
+
+type mergeAggregateDelta struct {
+	requests int64
+	tokens   int64
+}
+
+type mergeModelKey struct {
+	apiName   string
+	modelName string
+}
+
 // MergeSnapshot merges an exported statistics snapshot into the current store.
-// Existing data is preserved and duplicate request details are skipped.
-func (s *RequestStatistics) MergeSnapshot(snapshot StatisticsSnapshot) MergeResult {
+// Existing data is preserved, duplicate request details are skipped, and every
+// aggregate is checked before any candidate is committed.
+func (s *RequestStatistics) MergeSnapshot(snapshot StatisticsSnapshot) (MergeResult, error) {
 	result := MergeResult{}
 	if s == nil {
-		return result
+		return result, nil
 	}
 
 	s.mu.Lock()
@@ -399,17 +617,11 @@ func (s *RequestStatistics) MergeSnapshot(snapshot StatisticsSnapshot) MergeResu
 		}
 	}
 
+	candidates := make([]mergeCandidate, 0)
 	for apiName, apiSnapshot := range snapshot.APIs {
 		apiName = strings.TrimSpace(apiName)
 		if apiName == "" {
 			continue
-		}
-		stats, ok := s.apis[apiName]
-		if !ok || stats == nil {
-			stats = &apiStats{Models: make(map[string]*modelStats)}
-			s.apis[apiName] = stats
-		} else if stats.Models == nil {
-			stats.Models = make(map[string]*modelStats)
 		}
 		for modelName, modelSnapshot := range apiSnapshot.Models {
 			modelName = strings.TrimSpace(modelName)
@@ -422,22 +634,162 @@ func (s *RequestStatistics) MergeSnapshot(snapshot StatisticsSnapshot) MergeResu
 				if detail.LatencyMs < 0 {
 					detail.LatencyMs = 0
 				}
-				if detail.Timestamp.IsZero() {
-					detail.Timestamp = time.Now()
-				}
 				key := dedupKey(apiName, modelName, detail)
 				if _, exists := seen[key]; exists {
 					result.Skipped++
 					continue
 				}
 				seen[key] = struct{}{}
-				s.recordImported(apiName, modelName, stats, detail)
-				result.Added++
+				candidates = append(candidates, mergeCandidate{apiName: apiName, modelName: modelName, detail: detail})
 			}
 		}
 	}
 
-	return result
+	if err := s.validateMergeCandidates(candidates); err != nil {
+		return MergeResult{}, err
+	}
+	for _, candidate := range candidates {
+		stats, ok := s.apis[candidate.apiName]
+		if !ok || stats == nil {
+			stats = &apiStats{Models: make(map[string]*modelStats)}
+			s.apis[candidate.apiName] = stats
+		} else if stats.Models == nil {
+			stats.Models = make(map[string]*modelStats)
+		}
+		s.recordImported(candidate.apiName, candidate.modelName, stats, candidate.detail)
+		result.Added++
+	}
+
+	return result, nil
+}
+
+func (s *RequestStatistics) validateMergeCandidates(candidates []mergeCandidate) error {
+	global := mergeAggregateDelta{}
+	var successes int64
+	var failures int64
+	apiDeltas := make(map[string]mergeAggregateDelta)
+	modelDeltas := make(map[mergeModelKey]mergeAggregateDelta)
+	requestsByDay := make(map[string]int64)
+	requestsByHour := make(map[int]int64)
+	tokensByDay := make(map[string]int64)
+	tokensByHour := make(map[int]int64)
+
+	for _, candidate := range candidates {
+		var ok bool
+		global, ok = addMergeAggregateDelta(global, candidate.detail.Tokens.TotalTokens)
+		if !ok {
+			return ErrUsageAggregateOverflow
+		}
+		if candidate.detail.Failed {
+			failures, ok = sumNonNegativeTokenCounts(failures, 1)
+		} else {
+			successes, ok = sumNonNegativeTokenCounts(successes, 1)
+		}
+		if !ok {
+			return ErrUsageAggregateOverflow
+		}
+
+		apiDelta := apiDeltas[candidate.apiName]
+		apiDelta, ok = addMergeAggregateDelta(apiDelta, candidate.detail.Tokens.TotalTokens)
+		if !ok {
+			return ErrUsageAggregateOverflow
+		}
+		apiDeltas[candidate.apiName] = apiDelta
+
+		modelKey := mergeModelKey{apiName: candidate.apiName, modelName: candidate.modelName}
+		modelDelta := modelDeltas[modelKey]
+		modelDelta, ok = addMergeAggregateDelta(modelDelta, candidate.detail.Tokens.TotalTokens)
+		if !ok {
+			return ErrUsageAggregateOverflow
+		}
+		modelDeltas[modelKey] = modelDelta
+
+		dayKey := candidate.detail.Timestamp.Format("2006-01-02")
+		hourKey := candidate.detail.Timestamp.Hour()
+		requestsByDay[dayKey], ok = sumNonNegativeTokenCounts(requestsByDay[dayKey], 1)
+		if !ok {
+			return ErrUsageAggregateOverflow
+		}
+		requestsByHour[hourKey], ok = sumNonNegativeTokenCounts(requestsByHour[hourKey], 1)
+		if !ok {
+			return ErrUsageAggregateOverflow
+		}
+		tokensByDay[dayKey], ok = sumNonNegativeTokenCounts(tokensByDay[dayKey], candidate.detail.Tokens.TotalTokens)
+		if !ok {
+			return ErrUsageAggregateOverflow
+		}
+		tokensByHour[hourKey], ok = sumNonNegativeTokenCounts(tokensByHour[hourKey], candidate.detail.Tokens.TotalTokens)
+		if !ok {
+			return ErrUsageAggregateOverflow
+		}
+	}
+
+	if !mergeAggregateFits(s.totalRequests, global.requests) ||
+		!mergeAggregateFits(s.successCount, successes) ||
+		!mergeAggregateFits(s.failureCount, failures) ||
+		!mergeAggregateFits(s.totalTokens, global.tokens) {
+		return ErrUsageAggregateOverflow
+	}
+	for apiName, delta := range apiDeltas {
+		var currentRequests, currentTokens int64
+		if stats := s.apis[apiName]; stats != nil {
+			currentRequests = stats.TotalRequests
+			currentTokens = stats.TotalTokens
+		}
+		if !mergeAggregateFits(currentRequests, delta.requests) || !mergeAggregateFits(currentTokens, delta.tokens) {
+			return ErrUsageAggregateOverflow
+		}
+	}
+	for key, delta := range modelDeltas {
+		var currentRequests, currentTokens int64
+		if stats := s.apis[key.apiName]; stats != nil && stats.Models != nil {
+			if model := stats.Models[key.modelName]; model != nil {
+				currentRequests = model.TotalRequests
+				currentTokens = model.TotalTokens
+			}
+		}
+		if !mergeAggregateFits(currentRequests, delta.requests) || !mergeAggregateFits(currentTokens, delta.tokens) {
+			return ErrUsageAggregateOverflow
+		}
+	}
+	for day, delta := range requestsByDay {
+		if !mergeAggregateFits(s.requestsByDay[day], delta) {
+			return ErrUsageAggregateOverflow
+		}
+	}
+	for hour, delta := range requestsByHour {
+		if !mergeAggregateFits(s.requestsByHour[hour], delta) {
+			return ErrUsageAggregateOverflow
+		}
+	}
+	for day, delta := range tokensByDay {
+		if !mergeAggregateFits(s.tokensByDay[day], delta) {
+			return ErrUsageAggregateOverflow
+		}
+	}
+	for hour, delta := range tokensByHour {
+		if !mergeAggregateFits(s.tokensByHour[hour], delta) {
+			return ErrUsageAggregateOverflow
+		}
+	}
+	return nil
+}
+
+func addMergeAggregateDelta(delta mergeAggregateDelta, tokens int64) (mergeAggregateDelta, bool) {
+	requests, ok := sumNonNegativeTokenCounts(delta.requests, 1)
+	if !ok {
+		return mergeAggregateDelta{}, false
+	}
+	totalTokens, ok := sumNonNegativeTokenCounts(delta.tokens, tokens)
+	if !ok {
+		return mergeAggregateDelta{}, false
+	}
+	return mergeAggregateDelta{requests: requests, tokens: totalTokens}, true
+}
+
+func mergeAggregateFits(current, delta int64) bool {
+	_, ok := sumNonNegativeTokenCounts(current, delta)
+	return ok
 }
 
 func normaliseServiceTierAliases(detail RequestDetail) RequestDetail {
@@ -570,8 +922,8 @@ func resolveSuccess(ctx context.Context) bool {
 
 const httpStatusBadRequest = 400
 
-func normaliseDetail(detail coreusage.Detail) TokenStats {
-	tokens := TokenStats{
+func normaliseDetail(provider string, detail coreusage.Detail) TokenStats {
+	return normaliseTokenStatsForProvider(provider, TokenStats{
 		InputTokens:         nonNegativeTokenCount(detail.InputTokens),
 		OutputTokens:        nonNegativeTokenCount(detail.OutputTokens),
 		ReasoningTokens:     nonNegativeTokenCount(detail.ReasoningTokens),
@@ -579,19 +931,14 @@ func normaliseDetail(detail coreusage.Detail) TokenStats {
 		CacheReadTokens:     nonNegativeTokenCount(detail.CacheReadTokens),
 		CacheCreationTokens: nonNegativeTokenCount(detail.CacheCreationTokens),
 		TotalTokens:         nonNegativeTokenCount(detail.TotalTokens),
-	}
-	if tokens.TotalTokens == 0 {
-		tokens.TotalTokens, _ = sumNonNegativeTokenCounts(tokens.InputTokens, tokens.OutputTokens, tokens.ReasoningTokens)
-	}
-	if tokens.CachedTokens == 0 {
-		if tokens.CacheReadTokens != 0 {
-			tokens.CachedTokens = tokens.CacheReadTokens
-		}
-	}
-	return tokens
+	})
 }
 
 func normaliseTokenStats(tokens TokenStats) TokenStats {
+	return normaliseTokenStatsForProvider("", tokens)
+}
+
+func normaliseTokenStatsForProvider(provider string, tokens TokenStats) TokenStats {
 	tokens.InputTokens = nonNegativeTokenCount(tokens.InputTokens)
 	tokens.OutputTokens = nonNegativeTokenCount(tokens.OutputTokens)
 	tokens.ReasoningTokens = nonNegativeTokenCount(tokens.ReasoningTokens)
@@ -599,10 +946,49 @@ func normaliseTokenStats(tokens TokenStats) TokenStats {
 	tokens.CacheReadTokens = nonNegativeTokenCount(tokens.CacheReadTokens)
 	tokens.CacheCreationTokens = nonNegativeTokenCount(tokens.CacheCreationTokens)
 	tokens.TotalTokens = nonNegativeTokenCount(tokens.TotalTokens)
+	if tokens.CacheReadTokens == 0 && tokens.CachedTokens != 0 {
+		tokens.CacheReadTokens = tokens.CachedTokens
+	}
+	tokens.CachedTokens = tokens.CacheReadTokens
+	cacheInputTokens, ok := sumNonNegativeTokenCounts(tokens.CacheReadTokens, tokens.CacheCreationTokens)
+	if !ok || cacheInputTokens > tokens.InputTokens {
+		tokens.CachedTokens = 0
+		tokens.CacheReadTokens = 0
+		tokens.CacheCreationTokens = 0
+	}
+
+	minimumTotalTokens, ok := sumNonNegativeTokenCounts(tokens.InputTokens, tokens.OutputTokens)
+	if !ok {
+		return TokenStats{}
+	}
 	if tokens.TotalTokens == 0 {
-		tokens.TotalTokens, _ = sumNonNegativeTokenCounts(tokens.InputTokens, tokens.OutputTokens, tokens.ReasoningTokens)
+		fallbackTotal := minimumTotalTokens
+		if !reasoningTokensAreOutputSubset(provider) {
+			fallbackTotal, ok = sumNonNegativeTokenCounts(fallbackTotal, tokens.ReasoningTokens)
+			if !ok {
+				return TokenStats{}
+			}
+		}
+		tokens.TotalTokens = fallbackTotal
+	} else if tokens.TotalTokens < minimumTotalTokens {
+		tokens.TotalTokens = minimumTotalTokens
+	}
+	if tokens.TotalTokens == 0 && tokens.ReasoningTokens != 0 {
+		return TokenStats{}
+	}
+	if !validCanonicalTokenStats(tokens) {
+		return TokenStats{}
 	}
 	return tokens
+}
+
+func reasoningTokensAreOutputSubset(provider string) bool {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "openai", "codex":
+		return true
+	default:
+		return false
+	}
 }
 
 func nonNegativeTokenCount(token int64) int64 {

--- a/internal/usage/logger_plugin_test.go
+++ b/internal/usage/logger_plugin_test.go
@@ -2,7 +2,10 @@ package usage
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"math"
+	"reflect"
 	"testing"
 	"time"
 
@@ -350,12 +353,12 @@ func TestRequestStatisticsMergeSnapshotDedupIgnoresLatencyAndServiceTiers(t *tes
 		},
 	}
 
-	result := stats.MergeSnapshot(first)
+	result := requireMergeSnapshot(t, stats, first)
 	if result.Added != 1 || result.Skipped != 0 {
 		t.Fatalf("first merge = %+v, want added=1 skipped=0", result)
 	}
 
-	result = stats.MergeSnapshot(second)
+	result = requireMergeSnapshot(t, stats, second)
 	if result.Added != 0 || result.Skipped != 1 {
 		t.Fatalf("second merge = %+v, want added=0 skipped=1", result)
 	}
@@ -407,7 +410,7 @@ func TestRequestStatisticsMergeSnapshotNormalisesServiceTierAliases(t *testing.T
 				}},
 			}}
 			stats := NewRequestStatistics()
-			result := stats.MergeSnapshot(snapshot)
+			result := requireMergeSnapshot(t, stats, snapshot)
 			if result.Added != 1 || result.Skipped != 0 {
 				t.Fatalf("merge result = %+v, want added=1 skipped=0", result)
 			}
@@ -465,12 +468,12 @@ func TestRequestStatisticsMergeSnapshotKeepsDifferentCacheCreationTokenShapes(t 
 		t.Run(tt.name, func(t *testing.T) {
 			stats := NewRequestStatistics()
 
-			result := stats.MergeSnapshot(tt.first)
+			result := requireMergeSnapshot(t, stats, tt.first)
 			if result.Added != 1 || result.Skipped != 0 {
 				t.Fatalf("first merge = %+v, want added=1 skipped=0", result)
 			}
 
-			result = stats.MergeSnapshot(tt.second)
+			result = requireMergeSnapshot(t, stats, tt.second)
 			if result.Added != 1 || result.Skipped != 0 {
 				t.Fatalf("second merge = %+v, want added=1 skipped=0", result)
 			}
@@ -497,13 +500,200 @@ func TestRequestStatisticsMergeSnapshotKeepsDifferentCacheCreationTokenShapes(t 
 }
 
 func TestTokenTotalFallbackFailsClosedOnOverflow(t *testing.T) {
-	detail := normaliseDetail(coreusage.Detail{InputTokens: math.MaxInt64, OutputTokens: 1})
-	if detail.TotalTokens != 0 {
-		t.Fatalf("record total_tokens = %d, want 0 when fallback sum is not representable", detail.TotalTokens)
+	detail := normaliseDetail("openai", coreusage.Detail{InputTokens: math.MaxInt64, OutputTokens: 1})
+	if detail != (TokenStats{}) {
+		t.Fatalf("record tokens = %+v, want a canonical zero vector when the minimum total is not representable", detail)
 	}
 	tokens := normaliseTokenStats(TokenStats{InputTokens: math.MaxInt64, OutputTokens: 1})
-	if tokens.TotalTokens != 0 {
-		t.Fatalf("import total_tokens = %d, want 0 when fallback sum is not representable", tokens.TotalTokens)
+	if tokens != (TokenStats{}) {
+		t.Fatalf("import tokens = %+v, want a canonical zero vector when the minimum total is not representable", tokens)
+	}
+}
+
+func TestTokenTotalFallbackProducesCanonicalV2Minimum(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		detail   coreusage.Detail
+		want     int64
+	}{
+		{
+			name:     "OpenAI missing total does not double count reasoning output subset",
+			provider: "openai",
+			detail:   coreusage.Detail{InputTokens: 100, OutputTokens: 20, ReasoningTokens: 5},
+			want:     120,
+		},
+		{
+			name:     "Codex missing total does not double count reasoning output subset",
+			provider: "codex",
+			detail:   coreusage.Detail{InputTokens: 100, OutputTokens: 20, ReasoningTokens: 5},
+			want:     120,
+		},
+		{
+			name:   "generic missing total keeps separate reasoning semantics",
+			detail: coreusage.Detail{InputTokens: 100, OutputTokens: 20, ReasoningTokens: 5},
+			want:   125,
+		},
+		{
+			name:   "explicit total below canonical minimum is repaired",
+			detail: coreusage.Detail{InputTokens: 10, OutputTokens: 2, TotalTokens: 1},
+			want:   12,
+		},
+		{
+			name:   "reasoning-only detail remains representable",
+			detail: coreusage.Detail{ReasoningTokens: 5},
+			want:   5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokens := normaliseDetail(tt.provider, tt.detail)
+			if tokens.TotalTokens != tt.want || !validCanonicalTokenStats(tokens) {
+				t.Fatalf("normalised tokens = %+v, want total_tokens=%d and canonical v2", tokens, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateCanonicalV2TokenStatsDistinguishesMissingFromExplicitZero(t *testing.T) {
+	requiredFields := []string{"input_tokens", "output_tokens", "reasoning_tokens", "cached_tokens", "total_tokens"}
+	for _, missing := range requiredFields {
+		t.Run("missing_"+missing, func(t *testing.T) {
+			fields := map[string]any{
+				"input_tokens": 0, "output_tokens": 0, "reasoning_tokens": 0, "cached_tokens": 0, "total_tokens": 0,
+			}
+			delete(fields, missing)
+			var tokens TokenStats
+			data, err := json.Marshal(fields)
+			if err != nil {
+				t.Fatalf("marshal missing-field fixture: %v", err)
+			}
+			if err = json.Unmarshal(data, &tokens); err != nil {
+				t.Fatalf("unmarshal missing-field fixture: %v", err)
+			}
+			snapshot := cacheCreationSnapshot(time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC), tokens)
+			if err = snapshot.ValidateCanonicalV2TokenStats(); !errors.Is(err, ErrInvalidCanonicalTokenStats) {
+				t.Fatalf("missing %s validation error = %v, want %v", missing, err, ErrInvalidCanonicalTokenStats)
+			}
+		})
+	}
+
+	var explicitZero TokenStats
+	if err := json.Unmarshal([]byte(`{"input_tokens":0,"output_tokens":0,"reasoning_tokens":0,"cached_tokens":0,"total_tokens":0}`), &explicitZero); err != nil {
+		t.Fatalf("unmarshal explicit-zero fixture: %v", err)
+	}
+	snapshot := cacheCreationSnapshot(time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC), explicitZero)
+	if err := snapshot.ValidateCanonicalV2TokenStats(); err != nil {
+		t.Fatalf("explicit-zero v2 validation error = %v", err)
+	}
+}
+
+func TestMigrateV1TokenStatsReleasedFixtureMatrix(t *testing.T) {
+	tests := []struct {
+		name      string
+		tokens    string
+		wantInput int64
+		wantRead  int64
+		wantWrite int64
+		wantErr   error
+	}{
+		{
+			name:      "v1-tls-0.0.13 markerless no-cache",
+			tokens:    `{"input_tokens":4,"output_tokens":5,"reasoning_tokens":0,"cached_tokens":0,"total_tokens":9}`,
+			wantInput: 4,
+		},
+		{
+			name:      "v1-tls-0.0.15 marker-bearing cache read",
+			tokens:    `{"input_tokens":100,"uncached_input_tokens":80,"output_tokens":10,"reasoning_tokens":0,"cached_tokens":20,"cache_read_tokens":20,"total_tokens":110}`,
+			wantInput: 100,
+			wantRead:  20,
+		},
+		{
+			name:      "v1-tls-0.0.15 marker-bearing cache creation alias",
+			tokens:    `{"input_tokens":1200,"uncached_input_tokens":176,"output_tokens":10,"reasoning_tokens":0,"cached_tokens":1024,"cache_creation_tokens":1024,"total_tokens":1210}`,
+			wantInput: 1200,
+			wantWrite: 1024,
+		},
+		{
+			name:      "v1-tls-0.0.15 marker-bearing read and creation",
+			tokens:    `{"input_tokens":3085,"uncached_input_tokens":3085,"output_tokens":253,"reasoning_tokens":0,"cached_tokens":7,"cache_read_tokens":7,"cache_creation_tokens":19514,"total_tokens":22859}`,
+			wantInput: 22606,
+			wantRead:  7,
+			wantWrite: 19514,
+		},
+		{
+			name:      "v1-tls-0.0.15 marker-bearing known zero",
+			tokens:    `{"input_tokens":0,"uncached_input_tokens":0,"output_tokens":0,"reasoning_tokens":0,"cached_tokens":0,"total_tokens":0}`,
+			wantInput: 0,
+		},
+		{
+			name:    "markerless cached_tokens remains ambiguous",
+			tokens:  `{"input_tokens":1200,"output_tokens":10,"reasoning_tokens":0,"cached_tokens":1024,"total_tokens":1210}`,
+			wantErr: ErrAmbiguousLegacyTokenStats,
+		},
+		{
+			name:    "markerless cache_read_tokens remains ambiguous",
+			tokens:  `{"input_tokens":1200,"output_tokens":10,"reasoning_tokens":0,"cached_tokens":0,"cache_read_tokens":1024,"total_tokens":1210}`,
+			wantErr: ErrAmbiguousLegacyTokenStats,
+		},
+		{
+			name:    "markerless cache_creation_tokens remains ambiguous",
+			tokens:  `{"input_tokens":1200,"output_tokens":10,"reasoning_tokens":0,"cached_tokens":0,"cache_creation_tokens":1024,"total_tokens":1210}`,
+			wantErr: ErrAmbiguousLegacyTokenStats,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tokens TokenStats
+			if err := json.Unmarshal([]byte(tt.tokens), &tokens); err != nil {
+				t.Fatalf("unmarshal released v1 fixture: %v", err)
+			}
+			snapshot := cacheCreationSnapshot(time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC), tokens)
+			err := snapshot.MigrateV1TokenStats()
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("MigrateV1TokenStats() error = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("MigrateV1TokenStats() error = %v", err)
+			}
+			if err = snapshot.ValidateCanonicalTokenStats(); err != nil {
+				t.Fatalf("migrated canonical validation error = %v", err)
+			}
+			got := snapshot.APIs["cache-key"].Models["gpt-5.6-sol"].Details[0].Tokens
+			if got.InputTokens != tt.wantInput || got.CacheReadTokens != tt.wantRead || got.CacheCreationTokens != tt.wantWrite || got.CachedTokens != tt.wantRead {
+				t.Fatalf("migrated tokens = %+v, want input/read/write %d/%d/%d", got, tt.wantInput, tt.wantRead, tt.wantWrite)
+			}
+		})
+	}
+}
+
+func TestValidCanonicalTokenStatsEnforcesCacheAndTotalRelationships(t *testing.T) {
+	tests := []struct {
+		name   string
+		tokens TokenStats
+		valid  bool
+	}{
+		{name: "creation only", tokens: TokenStats{InputTokens: 1200, OutputTokens: 10, CacheCreationTokens: 1024, TotalTokens: 1210}, valid: true},
+		{name: "cache read and creation", tokens: TokenStats{InputTokens: 12, OutputTokens: 2, CachedTokens: 3, CacheReadTokens: 3, CacheCreationTokens: 6, TotalTokens: 14}, valid: true},
+		{name: "reasoning is output subset", tokens: TokenStats{InputTokens: 100, OutputTokens: 20, ReasoningTokens: 5, TotalTokens: 120}, valid: true},
+		{name: "cache categories exceed input", tokens: TokenStats{InputTokens: 10, CachedTokens: 9, CacheReadTokens: 9, CacheCreationTokens: 2, TotalTokens: 10}},
+		{name: "cache category sum overflows int64", tokens: TokenStats{InputTokens: math.MaxInt64, CachedTokens: math.MaxInt64, CacheReadTokens: math.MaxInt64, CacheCreationTokens: 1, TotalTokens: math.MaxInt64}},
+		{name: "cached compatibility field mismatches cache read", tokens: TokenStats{InputTokens: 10, CachedTokens: 9, TotalTokens: 10}},
+		{name: "total below input and output", tokens: TokenStats{InputTokens: 10, OutputTokens: 1, TotalTokens: 10}},
+		{name: "minimum total sum overflows int64", tokens: TokenStats{InputTokens: math.MaxInt64, OutputTokens: 1, TotalTokens: math.MaxInt64}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validCanonicalTokenStats(tt.tokens); got != tt.valid {
+				t.Fatalf("validCanonicalTokenStats(%+v) = %t, want %t", tt.tokens, got, tt.valid)
+			}
+		})
 	}
 }
 
@@ -513,16 +703,22 @@ func TestRequestStatisticsAggregatesFailClosedOnTokenOverflow(t *testing.T) {
 		t.Helper()
 		api := snapshot.APIs["cache-key"]
 		model := api.Models["gpt-5.6-sol"]
-		if snapshot.TotalTokens != 0 || api.TotalTokens != 0 || model.TotalTokens != 0 {
+		if snapshot.TotalTokens != math.MaxInt64 || api.TotalTokens != math.MaxInt64 || model.TotalTokens != math.MaxInt64 {
 			t.Fatalf(
-				"overflowed aggregate totals = global:%d api:%d model:%d, want all 0",
+				"aggregate totals = global:%d api:%d model:%d, want the accepted max-int record preserved",
 				snapshot.TotalTokens,
 				api.TotalTokens,
 				model.TotalTokens,
 			)
 		}
-		if snapshot.TokensByDay["2026-07-11"] != 0 || snapshot.TokensByHour["09"] != 0 {
-			t.Fatalf("overflowed token buckets = day:%v hour:%v, want fail-closed zeros", snapshot.TokensByDay, snapshot.TokensByHour)
+		if snapshot.TotalRequests != 2 || len(model.Details) != 2 {
+			t.Fatalf("request totals = total:%d details:%d, want request metadata preserved with fail-closed tokens", snapshot.TotalRequests, len(model.Details))
+		}
+		if model.Details[1].Tokens != (TokenStats{}) {
+			t.Fatalf("overflowing record tokens = %+v, want canonical zero vector", model.Details[1].Tokens)
+		}
+		if snapshot.TokensByDay["2026-07-11"] != math.MaxInt64 || snapshot.TokensByHour["09"] != math.MaxInt64 {
+			t.Fatalf("token buckets = day:%v hour:%v, want the accepted max-int record preserved", snapshot.TokensByDay, snapshot.TokensByHour)
 		}
 	}
 
@@ -541,14 +737,90 @@ func TestRequestStatisticsAggregatesFailClosedOnTokenOverflow(t *testing.T) {
 
 	t.Run("import", func(t *testing.T) {
 		stats := NewRequestStatistics()
-		if result := stats.MergeSnapshot(cacheCreationSnapshot(timestamp, TokenStats{InputTokens: math.MaxInt64, TotalTokens: math.MaxInt64})); result.Added != 1 {
+		if result := requireMergeSnapshot(t, stats, cacheCreationSnapshot(timestamp, TokenStats{InputTokens: math.MaxInt64, TotalTokens: math.MaxInt64})); result.Added != 1 {
 			t.Fatalf("first merge = %+v, want one added detail", result)
 		}
-		if result := stats.MergeSnapshot(cacheCreationSnapshot(timestamp.Add(time.Minute), TokenStats{InputTokens: 1, TotalTokens: 1})); result.Added != 1 {
-			t.Fatalf("second merge = %+v, want one added detail", result)
+		beforeOverflow := stats.Snapshot()
+		if _, err := stats.MergeSnapshot(cacheCreationSnapshot(timestamp.Add(time.Minute), TokenStats{InputTokens: 1, TotalTokens: 1})); !errors.Is(err, ErrUsageAggregateOverflow) {
+			t.Fatalf("second merge error = %v, want %v", err, ErrUsageAggregateOverflow)
 		}
-		assertAggregates(t, stats.Snapshot())
+		if afterOverflow := stats.Snapshot(); !reflect.DeepEqual(afterOverflow, beforeOverflow) {
+			t.Fatalf("overflowing import mutated statistics: before=%+v after=%+v", beforeOverflow, afterOverflow)
+		}
 	})
+}
+
+func TestRequestStatisticsMergeSnapshotRejectsEveryAggregateOverflowAtomically(t *testing.T) {
+	const maxInt64 = int64(math.MaxInt64)
+	timestamp := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name   string
+		failed bool
+		tokens TokenStats
+		seed   func(*RequestStatistics)
+	}{
+		{name: "global requests", seed: func(stats *RequestStatistics) { stats.totalRequests = maxInt64 }},
+		{name: "success requests", seed: func(stats *RequestStatistics) { stats.successCount = maxInt64 }},
+		{name: "failure requests", failed: true, seed: func(stats *RequestStatistics) { stats.failureCount = maxInt64 }},
+		{name: "global tokens", tokens: TokenStats{InputTokens: 1, TotalTokens: 1}, seed: func(stats *RequestStatistics) { stats.totalTokens = maxInt64 }},
+		{name: "api requests", seed: func(stats *RequestStatistics) {
+			stats.apis["cache-key"] = &apiStats{TotalRequests: maxInt64, Models: make(map[string]*modelStats)}
+		}},
+		{name: "api tokens", tokens: TokenStats{InputTokens: 1, TotalTokens: 1}, seed: func(stats *RequestStatistics) {
+			stats.apis["cache-key"] = &apiStats{TotalTokens: maxInt64, Models: make(map[string]*modelStats)}
+		}},
+		{name: "model requests", seed: func(stats *RequestStatistics) {
+			stats.apis["cache-key"] = &apiStats{Models: map[string]*modelStats{"gpt-5.6-sol": {TotalRequests: maxInt64}}}
+		}},
+		{name: "model tokens", tokens: TokenStats{InputTokens: 1, TotalTokens: 1}, seed: func(stats *RequestStatistics) {
+			stats.apis["cache-key"] = &apiStats{Models: map[string]*modelStats{"gpt-5.6-sol": {TotalTokens: maxInt64}}}
+		}},
+		{name: "day requests", seed: func(stats *RequestStatistics) { stats.requestsByDay["2026-07-21"] = maxInt64 }},
+		{name: "hour requests", seed: func(stats *RequestStatistics) { stats.requestsByHour[12] = maxInt64 }},
+		{name: "day tokens", tokens: TokenStats{InputTokens: 1, TotalTokens: 1}, seed: func(stats *RequestStatistics) { stats.tokensByDay["2026-07-21"] = maxInt64 }},
+		{name: "hour tokens", tokens: TokenStats{InputTokens: 1, TotalTokens: 1}, seed: func(stats *RequestStatistics) { stats.tokensByHour[12] = maxInt64 }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stats := NewRequestStatistics()
+			tt.seed(stats)
+			before := stats.Snapshot()
+			detail := RequestDetail{Timestamp: timestamp, Failed: tt.failed, Tokens: tt.tokens}
+			candidate := StatisticsSnapshot{APIs: map[string]APISnapshot{
+				"cache-key": {Models: map[string]ModelSnapshot{
+					"gpt-5.6-sol": {Details: []RequestDetail{detail}},
+				}},
+			}}
+
+			if _, err := stats.MergeSnapshot(candidate); !errors.Is(err, ErrUsageAggregateOverflow) {
+				t.Fatalf("MergeSnapshot() error = %v, want %v", err, ErrUsageAggregateOverflow)
+			}
+			if after := stats.Snapshot(); !reflect.DeepEqual(after, before) {
+				t.Fatalf("overflowing %s merge mutated snapshot: before=%+v after=%+v", tt.name, before, after)
+			}
+		})
+	}
+}
+
+func TestRequestStatisticsMergeSnapshotKeepsZeroTimestampDeterministic(t *testing.T) {
+	stats := NewRequestStatistics()
+	snapshot := cacheCreationSnapshot(time.Time{}, TokenStats{InputTokens: 1, TotalTokens: 1})
+
+	first := requireMergeSnapshot(t, stats, snapshot)
+	if first.Added != 1 || first.Skipped != 0 {
+		t.Fatalf("first zero-timestamp merge = %+v, want added=1 skipped=0", first)
+	}
+	second := requireMergeSnapshot(t, stats, snapshot)
+	if second.Added != 0 || second.Skipped != 1 {
+		t.Fatalf("second zero-timestamp merge = %+v, want added=0 skipped=1", second)
+	}
+
+	detail := stats.Snapshot().APIs["cache-key"].Models["gpt-5.6-sol"].Details[0]
+	if !detail.Timestamp.IsZero() {
+		t.Fatalf("stored timestamp = %s, want Go zero time preserved as uncertain identity", detail.Timestamp.Format(time.RFC3339Nano))
+	}
 }
 
 func TestRequestStatisticsMergeSnapshotKeepsDistinctCacheReadAndCreationTokenShapes(t *testing.T) {
@@ -570,10 +842,10 @@ func TestRequestStatisticsMergeSnapshotKeepsDistinctCacheReadAndCreationTokenSha
 	})
 
 	stats := NewRequestStatistics()
-	if result := stats.MergeSnapshot(creationOnly); result.Added != 1 || result.Skipped != 0 {
+	if result := requireMergeSnapshot(t, stats, creationOnly); result.Added != 1 || result.Skipped != 0 {
 		t.Fatalf("creation-only merge = %+v, want added=1 skipped=0", result)
 	}
-	if result := stats.MergeSnapshot(readAndWrite); result.Added != 1 || result.Skipped != 0 {
+	if result := requireMergeSnapshot(t, stats, readAndWrite); result.Added != 1 || result.Skipped != 0 {
 		t.Fatalf("read-and-write merge = %+v, want added=1 skipped=0", result)
 	}
 
@@ -590,10 +862,10 @@ func TestRequestStatisticsMergeSnapshotTotalOnlyIdentityRemainsDistinct(t *testi
 	second := cacheCreationSnapshot(timestamp, TokenStats{TotalTokens: 200})
 
 	stats := NewRequestStatistics()
-	if result := stats.MergeSnapshot(first); result.Added != 1 || result.Skipped != 0 {
+	if result := requireMergeSnapshot(t, stats, first); result.Added != 1 || result.Skipped != 0 {
 		t.Fatalf("first total-only merge = %+v, want added=1 skipped=0", result)
 	}
-	if result := stats.MergeSnapshot(second); result.Added != 1 || result.Skipped != 0 {
+	if result := requireMergeSnapshot(t, stats, second); result.Added != 1 || result.Skipped != 0 {
 		t.Fatalf("second total-only merge = %+v, want added=1 skipped=0", result)
 	}
 
@@ -621,4 +893,13 @@ func cacheCreationSnapshot(timestamp time.Time, tokens TokenStats) StatisticsSna
 			},
 		},
 	}
+}
+
+func requireMergeSnapshot(t *testing.T, stats *RequestStatistics, snapshot StatisticsSnapshot) MergeResult {
+	t.Helper()
+	result, err := stats.MergeSnapshot(snapshot)
+	if err != nil {
+		t.Fatalf("MergeSnapshot() error = %v", err)
+	}
+	return result
 }

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -123,6 +123,7 @@ grep -R "/v0/management/usage/import" -n \
 require_path internal/api/handlers/management/usage.go
 require_path internal/api/handlers/management/usage_contract_test.go
 require_path internal/runtime/executor/helps/usage_helpers.go
+require_path docs/lts/change-control/CHG-20260722-USAGE-SCHEMA-V2.md
 require_path internal/registry/models/codex_client_models.json
 require_path internal/managementasset/updater.go
 require_path internal/config/config.go
@@ -174,6 +175,38 @@ require_grep "TestRPCUsageIncludesEffectiveServiceTier" internal/pluginhost/host
 require_grep "TestPublishCodexImageToolUsagePreservesResponseTierPrecedence" internal/runtime/executor/codex_openai_images_test.go
 require_grep 'json:"generate"' internal/usage internal/redisqueue
 require_grep "GenerateEnabled" internal/usage internal/redisqueue sdk/cliproxy/usage
+require_grep "CanonicalExportVersion" internal/usage/logger_plugin.go internal/api/handlers/management/usage.go docs/lts/core-feature-contracts.yaml docs/lts/protected-deltas.yaml
+require_grep "uncached_input_tokens" internal/usage/logger_plugin.go internal/api/handlers/management/usage_contract_test.go docs/lts/core-feature-contracts.yaml docs/lts/protected-deltas.yaml
+require_grep '"schema_version"' internal/api/handlers/management/usage.go internal/api/handlers/management/usage_contract_test.go docs/lts/change-control/CHG-20260722-USAGE-SCHEMA-V2.md
+require_grep '"migrated_from_version"' internal/api/handlers/management/usage.go internal/api/handlers/management/usage_contract_test.go docs/lts/change-control/CHG-20260722-USAGE-SCHEMA-V2.md
+require_grep "v1_uncached_input_tokens_to_v2" internal/api/handlers/management/usage.go internal/api/handlers/management/usage_contract_test.go docs/lts/core-feature-contracts.yaml docs/lts/change-control/CHG-20260722-USAGE-SCHEMA-V2.md
+require_grep '"code"' internal/api/handlers/management/usage.go internal/api/handlers/management/usage_contract_test.go docs/lts/change-control/CHG-20260722-USAGE-SCHEMA-V2.md
+for approved_usage_code in \
+  usage_version_unsupported \
+  usage_shape_invalid \
+  usage_v1_token_contract_invalid \
+  usage_v1_cache_semantics_ambiguous \
+  usage_v2_token_contract_invalid \
+  usage_aggregate_overflow; do
+  require_grep "$approved_usage_code" \
+    internal/api/handlers/management/usage.go \
+    internal/api/handlers/management/usage_contract_test.go \
+    docs/lts/core-feature-contracts.yaml \
+    docs/lts/protected-deltas.yaml \
+    docs/lts/change-control/CHG-20260722-USAGE-SCHEMA-V2.md
+done
+forbid_grep 'usage_''import_' \
+  internal/api/handlers/management/usage.go \
+  internal/api/handlers/management/usage_contract_test.go \
+  docs/lts/core-feature-contracts.yaml \
+  docs/lts/protected-deltas.yaml \
+  docs/lts/change-control/CHG-20260722-USAGE-SCHEMA-V2.md
+forbid_grep 'error_''code' \
+  internal/api/handlers/management/usage.go \
+  internal/api/handlers/management/usage_contract_test.go \
+  docs/lts/core-feature-contracts.yaml \
+  docs/lts/protected-deltas.yaml \
+  docs/lts/change-control/CHG-20260722-USAGE-SCHEMA-V2.md
 if git grep -n 'json:"thinking' -- internal/usage; then
   echo "non-canonical usage JSON field thinking found; use reasoning_effort" >&2
   exit 1


### PR DESCRIPTION
## Type

- [ ] Protected upstream full-sync
- [ ] Staged upstream full-sync
- [x] LTS protected-delta patch
- [ ] LTS feature / downstream patch maintenance
- [ ] Maintenance docs / CI
- [ ] Emergency hotfix

## Upstream sync info

- Upstream repo: N/A — downstream LTS usage contract patch
- Upstream branch: N/A
- Upstream from SHA: N/A
- Upstream to SHA: N/A
- Sync branch: `codex/core-usage-schema-v2-fix`

## Baseline and candidate

- Released compatibility baseline：`v1-tls-0.0.15` (`e37e61aadb2e57883df54eef9d24af932fd1aa63`)
- Older markerless fixture baseline：`v1-tls-0.0.13` (`6f9533491aec6cced1661a7bbcf7187582e588b8`)
- `main` baseline：`5d4cd0cd9cd3886398e8b70fe06c2b90b745048a`
- Candidate head：`9c020f94c42ed4bcffddcd4417b75b2fd0ffc363`
- Change control：`CHG-20260722-USAGE-SCHEMA-V2`
- Companion Panel compatibility PR：BlueSkyXN/CPA-Panel-LTS#39

## Protected delta checklist

- [x] `usage-statistics-enabled` still exists
- [x] `internal/usage/` still exists
- [x] `/v0/management/usage` still exists
- [x] `/v0/management/usage/export` still exists
- [x] `/v0/management/usage/import` still exists
- [x] `docs/lts/core-feature-contracts.yaml` reviewed and updated
- [x] `docs/lts/downstream-patches.yaml` reviewed; no active patch retirement/reapplication is introduced
- [x] Usage record creation/schema reviewed and tested, including canonical producer output
- [x] Management usage response shape reviewed and tested
- [x] Export/import roundtrip reviewed and tested
- [x] CPA-Panel-LTS response shape reviewed against the companion v1/v2 candidate
- [x] Local auth/config/panel/release/source customizations reviewed; this PR does not change them

## Contract changes

- `CanonicalExportVersion = 2`; new exports always emit `version: 2`.
- v2 requires explicit `input_tokens`, `output_tokens`, `reasoning_tokens`, `cached_tokens`, and `total_tokens`, including explicit zero; optional zero cache read/creation fields may remain omitted.
- v2 validates cache mirror/sum, total lower bound, non-negative integers, int64 overflow and aggregate overflow.
- v1 migration is evidence-based: valid `uncached_input_tokens` migrates exactly; markerless/no-cache migrates safely; markerless/cache-bearing fails closed; null/non-integer/negative/out-of-range markers are rejected.
- Import performs raw duplicate-key/case-collision checks before typed decoding and validates all nested containers.
- `MergeSnapshot` preflights a detached candidate snapshot; every validation/overflow failure leaves current statistics unchanged.
- Success receipts add `schema_version: 2` and, for v1, exact migration metadata.
- Error bodies retain human-readable `error` and add one of six stable top-level `code` values without echoing credentials or raw payloads.
- Runtime usage producers are canonicalized so a fresh v2 export can always be re-imported; missing/zero timestamps retain deterministic Go-zero identity rather than `time.Now()`.

## Red-first regression evidence

Regression tests were added before production fixes and failed on the prior implementation for missing v2 field presence, non-atomic invalid imports, markerless cache ambiguity, aggregate overflow branches, reasoning double count, producer self-invalid exports, zero-timestamp duplicate drift, nested null, case-fold aliases and duplicate exact JSON keys. The final candidate passes the focused, race, full-suite and build checks below.

## LTS classification review

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| `full-usage-statistics-core` | retained capability | adapted | v2 canonical export, v1 safe migration, producer roundtrip and atomic overflow regressions |
| `management-usage-api` | retained capability | adapted | stable routes, six error codes, migration receipt, nested shape guard and `CHG-20260722-USAGE-SCHEMA-V2` |
| `panel-release-asset` / Panel usage contract | review seam | preserved | companion Panel candidate accepts released v1 and candidate v2; release asset contract unchanged |

- [x] No `introduced_in` or `retired_in` implementation/deletion reference is added or changed; the special merge-commit constraint is not triggered by this PR.

## Conflict resolution notes

This is not an upstream full-sync. It preserves the LTS full usage data path and deliberately rejects ambiguous released-v1 cache semantics instead of inferring provider/model/source. Provider identity and cache-field presence remain deferred to schema v3.

## Compatibility matrix

| Core | Panel | Result |
|---|---|---|
| released `v1-tls-0.0.15` | released `v1-tls-0.0.10` | baseline smoke passed |
| released `v1-tls-0.0.15` | Panel v1/v2 candidate `0c6f8588` | full browser/Core smoke passed |
| this candidate | Panel v1/v2 candidate `0c6f8588` | full roundtrip and migration receipt smoke passed |
| this candidate | released Panel `v1-tls-0.0.10` | expected incompatible: released Panel rejects export version 2 |

Coordinated release order is therefore Panel v1/v2 compatibility first, then Core schema v2.

## Validation

- [x] `scripts/check-lts-contract.sh`
- [x] `go run ./scripts/ltsregistry --root .`
- [x] `go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage' -count=1`
- [x] `go build -o /dev/null ./cmd/server`
- [x] `go test ./... -count=1`
- [x] `git diff --check`

Additional checks:

```text
go test ./internal/runtime/executor/helps ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage' -count=1
go test -race ./internal/usage -run 'EveryAggregateOverflow|ZeroTimestamp|AggregatesFailClosed' -count=1
```

Companion Panel candidate also passed authenticated local Core export/import/re-export and duplicate/rejected-import smoke against this exact head.

## Optional real runtime smoke

- [x] Hugging Face Space smoke explicitly skipped: release/deployment was not authorized and no runtime artifact was changed.
- Space: N/A
- Runtime SHA: N/A
- CPA-Core-LTS branch/SHA deployed: N/A — not deployed
- `/healthz` status: N/A
- `/management.html` status: N/A
- `/v0/management/usage*` status: local candidate smoke passed; no deployed runtime receipt

## Merge / release gates and residual risk

- 本 PR 未合并、未发布、未部署。
- 合并前需要 companion Panel compatibility PR 先落地、最终 head 独立 approval、checks 全绿且 unresolved review thread 为零。
- schema v3 provenance 未包含：provider identity、cache read/creation presence unknown、Panel model-name provider fallback removal 均留待第二阶段。
- 本 PR 不宣称 cache-write usage provenance 完整。
