### PR TITLE
fix(usage): preserve legacy zeros and reasoning-only details

### DIFF
--- a/docs/lts/change-control/CHG-20260722-USAGE-SCHEMA-V2.md
+++ b/docs/lts/change-control/CHG-20260722-USAGE-SCHEMA-V2.md
@@ -26,6 +26,13 @@ Both releases used the same version number, so migration is based on explicit
 field evidence rather than release-name, model-name, source-path, or provider
 guesses.
 
+The released exporter wrote `reasoning_tokens` and `cached_tokens` even when
+they were zero. The version 1 importer also accepts those two fields when they
+are omitted and treats them as zero, because this is a lossless compatibility
+extension for older saved or re-serialized no-cache backups. `input_tokens`,
+`output_tokens`, and `total_tokens` remain required, and an explicitly present
+legacy token field must still be a non-null, non-negative integer.
+
 ## Version 1 migration matrix
 
 | Version 1 detail | Decision | Canonical result or error |
@@ -33,11 +40,18 @@ guesses.
 | `uncached_input_tokens` is present, integral, non-negative, and no greater than the released `input_tokens` | Migrate | `input_tokens = uncached + cache_read + cache_creation`; `cached_tokens` mirrors canonical `cache_read_tokens`. |
 | Marker is absent and `cached_tokens`, `cache_read_tokens`, and `cache_creation_tokens` are all zero | Migrate | Preserve `input_tokens`; all cache categories remain zero. This covers released `v1-tls-0.0.13` no-cache exports and markerless no-cache `v1-tls-0.0.15` exports. |
 | Marker is absent and any cache category is non-zero | Reject | `code: usage_v1_cache_semantics_ambiguous`. OpenAI-inclusive and Claude-uncached input semantics cannot be distinguished from the snapshot alone. |
-| Required released field is missing, marker is null/non-integral/negative, marker exceeds input, or another version 1 token rule is invalid | Reject | `code: usage_v1_token_contract_invalid`. |
+| `input_tokens`, `output_tokens`, or `total_tokens` is missing; an optional legacy zero field is explicitly null/mistyped; the marker is invalid; or another version 1 token rule is invalid | Reject | `code: usage_v1_token_contract_invalid`. |
 
 The legacy cache-creation alias (`cached_tokens == cache_creation_tokens`,
 `cache_read_tokens == 0`) is treated as creation-only only when the explicit
 uncached marker makes the conversion auditable.
+
+The reconstructed canonical input is intentionally not required to equal the
+legacy `input_tokens`. Released providers used different version 1 input
+semantics: for example, a Claude detail can carry legacy input `3085`, explicit
+uncached input `3085`, cache read `7`, and cache creation `19514`, which
+canonically reconstructs to input `22606`. Requiring equality would reject a
+released, auditable backup rather than detect corruption.
 
 ## Canonical version 2 contract
 
@@ -66,6 +80,8 @@ reject. OpenAI/Codex producer paths therefore use `input + output` when an
 upstream total is absent, while a producer that still has an exact non-OpenAI
 provider identity may retain its established separate-reasoning fallback.
 Explicit totals below `input + output` are raised to that checked minimum.
+If an OpenAI/Codex payload reports only a positive reasoning count, the producer
+uses that count as the fallback total instead of erasing the only usage signal.
 Unrepresentable token vectors are stored as an all-zero canonical vector, and
 a record that would overflow an aggregate is retried with that zero vector so
 request metadata can be retained without creating a non-roundtrippable export.
@@ -100,7 +116,7 @@ Errors preserve the existing `"error"` text and add one stable top-level
 |---|---|
 | `usage_version_unsupported` | The version is neither released v1 nor canonical v2. |
 | `usage_shape_invalid` | The JSON/root/nested typed shape is invalid, the usage store is unavailable, or the request body cannot be read. |
-| `usage_v1_token_contract_invalid` | A version 1 required token field or migration marker is missing, null, non-integral, negative, greater than released input, or otherwise invalid. |
+| `usage_v1_token_contract_invalid` | A version 1 required input/output/total field or migration marker is missing or invalid, an optional legacy token field is explicitly null/mistyped, or another version 1 invariant fails. |
 | `usage_v1_cache_semantics_ambiguous` | A markerless version 1 detail contains non-zero cache data whose input semantics cannot be reconstructed. |
 | `usage_v2_token_contract_invalid` | A version 2 mandatory field is omitted, null, mistyped, or violates canonical invariants, or the retired `uncached_input_tokens` marker is present. |
 | `usage_aggregate_overflow` | The complete candidate merge would overflow a request or token aggregate. |

--- a/internal/api/handlers/management/usage_contract_test.go
+++ b/internal/api/handlers/management/usage_contract_test.go
@@ -713,7 +713,7 @@ func TestUsageManagementImportReturnsStableSchemaErrorCodesAtomically(t *testing
 			name: "missing released v1 required field",
 			payload: `{"version":1,"usage":{"apis":{"client":{"models":{"model":{"details":[{
 				"timestamp":"2026-07-21T12:00:00Z",
-				"tokens":{"input_tokens":3,"output_tokens":1,"cached_tokens":0,"total_tokens":4}
+				"tokens":{"input_tokens":3,"reasoning_tokens":0,"cached_tokens":0,"total_tokens":4}
 			}]}}}}}}`,
 			wantCode: "usage_v1_token_contract_invalid",
 		},

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -253,7 +253,10 @@ func normalizeUsageDetailTotal(provider string, detail usage.Detail) usage.Detai
 		}
 	}
 	if fallbackTotal == 0 && detail.ReasoningTokens != 0 {
-		return clearUsageDetailTokens(detail)
+		if detail.ReasoningTokens < 0 {
+			return clearUsageDetailTokens(detail)
+		}
+		fallbackTotal = detail.ReasoningTokens
 	}
 	detail.TotalTokens = fallbackTotal
 	return detail

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -186,6 +186,16 @@ func TestParseOpenAIUsageFallbackDoesNotDoubleCountReasoningSubset(t *testing.T)
 	}
 }
 
+func TestParseCodexUsagePreservesReasoningOnlyDetail(t *testing.T) {
+	detail, ok := ParseCodexUsage([]byte(`{"response":{"usage":{"output_tokens_details":{"reasoning_tokens":7}}}}`))
+	if !ok {
+		t.Fatal("ParseCodexUsage returned ok=false for reasoning-only usage")
+	}
+	if detail.ReasoningTokens != 7 || detail.TotalTokens != 7 {
+		t.Fatalf("detail = %+v, want reasoning_tokens=7 and total_tokens=7", detail)
+	}
+}
+
 func TestUsageTotalFallbackFailsClosedOnOverflow(t *testing.T) {
 	detail := normalizeUsageDetailTotal("openai", usage.Detail{
 		InputTokens:  math.MaxInt64,

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -175,6 +175,10 @@ const tokenStatsRequiredExportFields = tokenStatsInputPresent |
 	tokenStatsCachedPresent |
 	tokenStatsTotalPresent
 
+const tokenStatsRequiredV1Fields = tokenStatsInputPresent |
+	tokenStatsOutputPresent |
+	tokenStatsTotalPresent
+
 var tokenStatsJSONFields = []struct {
 	name string
 	bit  tokenStatsFieldPresence
@@ -236,6 +240,10 @@ func (tokens TokenStats) hasRequiredExportFields() bool {
 	return tokens.fieldsPresent&tokenStatsRequiredExportFields == tokenStatsRequiredExportFields
 }
 
+func (tokens TokenStats) hasRequiredV1Fields() bool {
+	return tokens.fieldsPresent&tokenStatsRequiredV1Fields == tokenStatsRequiredV1Fields
+}
+
 // MigrateV1TokenStats converts released version 1 details into the canonical
 // version 2 total-input contract. Markerless details are safe only when all
 // cache categories are zero; cached markerless details remain ambiguous across
@@ -259,7 +267,7 @@ func (snapshot *StatisticsSnapshot) MigrateV1TokenStats() error {
 }
 
 func migrateV1TokenStats(tokens *TokenStats) error {
-	if tokens == nil || !tokens.hasRequiredExportFields() || !validLegacyV1TokenStats(*tokens) {
+	if tokens == nil || !tokens.hasRequiredV1Fields() || !validLegacyV1TokenStats(*tokens) {
 		return ErrInvalidLegacyTokenStats
 	}
 

--- a/internal/usage/logger_plugin_test.go
+++ b/internal/usage/logger_plugin_test.go
@@ -604,6 +604,11 @@ func TestMigrateV1TokenStatsReleasedFixtureMatrix(t *testing.T) {
 			wantInput: 4,
 		},
 		{
+			name:      "legacy v1 omitted zero reasoning and cached fields",
+			tokens:    `{"input_tokens":4,"output_tokens":5,"total_tokens":9}`,
+			wantInput: 4,
+		},
+		{
 			name:      "v1-tls-0.0.15 marker-bearing cache read",
 			tokens:    `{"input_tokens":100,"uncached_input_tokens":80,"output_tokens":10,"reasoning_tokens":0,"cached_tokens":20,"cache_read_tokens":20,"total_tokens":110}`,
 			wantInput: 100,


### PR DESCRIPTION
## Type

- [ ] Protected upstream full-sync
- [ ] Staged upstream full-sync
- [x] LTS protected-delta patch
- [ ] LTS feature / downstream patch maintenance
- [ ] Maintenance docs / CI
- [ ] Emergency hotfix

## Upstream sync info

- Upstream repo: N/A — follow-up to LTS usage contract PR #185
- Upstream branch: N/A
- Upstream from SHA: N/A
- Upstream to SHA: N/A
- Sync branch: `codex/core-usage-v2-followup`

## Baseline / head

- Base：Core `main` merge `c9033075bad45d86a54293971bebec164e945e00`
- Head：`026ecfda3870b4aaed944dd29dd87e84b6ceecc1`
- Follow-up：#185 discussion `r3631698356`
- Companion Panel follow-up：BlueSkyXN/CPA-Panel-LTS `codex/panel-usage-v1-followup`

## Protected delta checklist

- [x] `usage-statistics-enabled` and full usage routes remain present
- [x] Management usage response/export/import shapes reviewed
- [x] v1/v2 import and roundtrip behavior tested
- [x] CPA-Panel-LTS companion preflight reviewed and real-Core tested
- [x] `CHG-20260722-USAGE-SCHEMA-V2` updated
- [x] No unrelated auth/config/release/provider behavior changed

## Changes

- v1 仍要求 explicit input/output/total；安全省略的 legacy zero reasoning/cached fields 按零处理，显式 null/mistyped fields继续拒绝。
- v2 mandatory-field presence和 canonical invariants不变。
- OpenAI/Codex reasoning-only payload不再被清成全零；positive reasoning count作为缺失 total 时的可重放 fallback total。
- change-control 明确 released provider v1 input semantics不同，因此不能要求 reconstructed canonical input等于 legacy input。

## Red-first evidence

- minimal v1 omitted-zero fixture在旧实现上返回 `invalid legacy usage token contract`。
- reasoning-only Codex fixture在旧实现上返回 `ok=true` 但 token vector全零。
- 修复后两项 regression通过，并完成 focused/full suite、build、guard和跨仓 smoke。

## LTS classification review

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| `full-usage-statistics-core` | retained capability | adapted | legacy v1 zero-field compatibility and producer regression |
| `management-usage-api` | retained capability | adapted | v2 strictness unchanged; v1 safe extension documented |
| Panel usage contract | review seam | preserved | companion Panel preflight and real-Core smoke |

- [x] No `introduced_in` or `retired_in` reference is changed.

## Validation

- [x] `scripts/check-lts-contract.sh`
- [x] `go test ./internal/runtime/executor/helps ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage' -count=1`
- [x] `go test ./... -count=1`
- [x] `go build -o /dev/null ./cmd/server`
- [x] `git diff --check`

Companion Panel candidate passed `npm run validate:lts`, mock browser smoke and real-Core smoke against this exact source candidate。未执行 release、deployment 或 runtime artifact 更新。
