### PR TITLE
test(usage): cover legacy invalid fields

### DIFF
--- a/internal/api/handlers/management/usage_contract_test.go
+++ b/internal/api/handlers/management/usage_contract_test.go
@@ -718,6 +718,38 @@ func TestUsageManagementImportReturnsStableSchemaErrorCodesAtomically(t *testing
 			wantCode: "usage_v1_token_contract_invalid",
 		},
 		{
+			name: "legacy optional reasoning is null",
+			payload: `{"version":1,"usage":{"apis":{"client":{"models":{"model":{"details":[{
+				"timestamp":"2026-07-21T12:00:00Z",
+				"tokens":{"input_tokens":3,"output_tokens":1,"reasoning_tokens":null,"total_tokens":4}
+			}]}}}}}}`,
+			wantCode: "usage_v1_token_contract_invalid",
+		},
+		{
+			name: "legacy optional cached field is mistyped",
+			payload: `{"version":1,"usage":{"apis":{"client":{"models":{"model":{"details":[{
+				"timestamp":"2026-07-21T12:00:00Z",
+				"tokens":{"input_tokens":3,"output_tokens":1,"cached_tokens":"0","total_tokens":4}
+			}]}}}}}}`,
+			wantCode: "usage_v1_token_contract_invalid",
+		},
+		{
+			name: "legacy optional cache read is negative",
+			payload: `{"version":1,"usage":{"apis":{"client":{"models":{"model":{"details":[{
+				"timestamp":"2026-07-21T12:00:00Z",
+				"tokens":{"input_tokens":3,"output_tokens":1,"cache_read_tokens":-1,"total_tokens":4}
+			}]}}}}}}`,
+			wantCode: "usage_v1_token_contract_invalid",
+		},
+		{
+			name: "legacy optional cache creation is fractional",
+			payload: `{"version":1,"usage":{"apis":{"client":{"models":{"model":{"details":[{
+				"timestamp":"2026-07-21T12:00:00Z",
+				"tokens":{"input_tokens":3,"output_tokens":1,"cache_creation_tokens":0.5,"total_tokens":4}
+			}]}}}}}}`,
+			wantCode: "usage_v1_token_contract_invalid",
+		},
+		{
 			name: "legacy marker exceeds released input",
 			payload: `{"version":1,"usage":{"apis":{"client":{"models":{"model":{"details":[{
 				"timestamp":"2026-07-21T12:00:00Z",

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -196,6 +196,16 @@ func TestParseCodexUsagePreservesReasoningOnlyDetail(t *testing.T) {
 	}
 }
 
+func TestParseCodexUsageRejectsNegativeReasoningOnlyFallback(t *testing.T) {
+	detail, ok := ParseCodexUsage([]byte(`{"response":{"usage":{"output_tokens_details":{"reasoning_tokens":-7}}}}`))
+	if !ok {
+		t.Fatal("ParseCodexUsage returned ok=false for an explicit usage object")
+	}
+	if detail != (usage.Detail{}) {
+		t.Fatalf("detail = %+v, want a zero token vector for negative reasoning", detail)
+	}
+}
+
 func TestUsageTotalFallbackFailsClosedOnOverflow(t *testing.T) {
 	detail := normalizeUsageDetailTotal("openai", usage.Detail{
 		InputTokens:  math.MaxInt64,


### PR DESCRIPTION
## Summary

Test-only follow-up to PR #186. It locks the fail-closed boundaries that were already implemented and reviewed but not directly covered by committed negative regressions.

## Exact scope

- Head: `646bd939b19212456381bd3305c2e107559607b8`
- v1 optional `reasoning_tokens: null` -> `usage_v1_token_contract_invalid`
- v1 optional mistyped `cached_tokens` -> rejected
- v1 negative `cache_read_tokens` -> rejected
- v1 fractional `cache_creation_tokens` -> rejected
- negative reasoning-only Codex payload -> zero token vector, never a negative fallback total
- No production code changes

## Validation

```text
go test ./internal/runtime/executor/helps ./internal/api/handlers/management -run 'Usage|usage' -count=1
go test ./... -count=1
scripts/check-lts-contract.sh
git diff --check
```

All commands passed. No release or deployment action is included.
