### PR TITLE
fix(logs): 用稳定快照续读未完成日志行

### DIFF
--- a/internal/api/handlers/management/logs.go
+++ b/internal/api/handlers/management/logs.go
@@ -70,7 +70,7 @@ func (h *Handler) GetLogs(c *gin.Context) {
 					latest = cursor.LatestTimestamp
 				}
 			}
-			writeLogsResponse(c, []string{}, 0, latest, "", rawCursor != "")
+			writeLogsResponse(c, []string{}, 0, latest, "", rawCursor != "", false)
 			return
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to list log files: %v", err)})
@@ -96,10 +96,10 @@ func (h *Handler) GetLogs(c *gin.Context) {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to read log files: %v", errCursor)})
 				return
 			}
-			writeLogsResponse(c, result.lines, len(result.lines), result.latest, result.nextCursor, true)
+			writeLogsResponse(c, result.lines, len(result.lines), result.latest, result.nextCursor, true, false)
 			return
 		}
-		writeLogsResponse(c, result.lines, len(result.lines), result.latest, result.nextCursor, false)
+		writeLogsResponse(c, result.lines, len(result.lines), result.latest, result.nextCursor, false, result.replaceTrailingPartial)
 		return
 	}
 
@@ -109,7 +109,7 @@ func (h *Handler) GetLogs(c *gin.Context) {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to read log files: %v", errTail)})
 			return
 		}
-		writeLogsResponse(c, result.lines, len(result.lines), result.latest, result.nextCursor, false)
+		writeLogsResponse(c, result.lines, len(result.lines), result.latest, result.nextCursor, false, false)
 		return
 	}
 
@@ -136,7 +136,7 @@ func (h *Handler) GetLogs(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to prepare log cursor: %v", errCursor)})
 		return
 	}
-	writeLogsResponse(c, lines, total, latest, nextCursor, false)
+	writeLogsResponse(c, lines, total, latest, nextCursor, false, false)
 }
 
 // DeleteLogs removes all rotated log files and truncates the active log.
@@ -547,30 +547,34 @@ func (acc *logAccumulator) result() ([]string, int, int64) {
 }
 
 type logCursor struct {
-	Version         int    `json:"v"`
-	File            string `json:"file"`
-	Offset          int64  `json:"offset"`
-	Size            int64  `json:"size"`
-	ModTime         int64  `json:"modTime"`
-	ModTimeUnixNano int64  `json:"modTimeUnixNano,omitempty"`
-	LatestTimestamp int64  `json:"latestTimestamp"`
-	Fingerprint     string `json:"fingerprint"`
+	Version          int    `json:"v"`
+	File             string `json:"file"`
+	Offset           int64  `json:"offset"`
+	Size             int64  `json:"size"`
+	ModTime          int64  `json:"modTime"`
+	ModTimeUnixNano  int64  `json:"modTimeUnixNano,omitempty"`
+	LatestTimestamp  int64  `json:"latestTimestamp"`
+	Fingerprint      string `json:"fingerprint"`
+	PreviewedPartial bool   `json:"previewedPartial,omitempty"`
 }
 
 type completeLogRead struct {
-	lines     []string
-	endOffset int64
-	latest    int64
-	hitLimit  bool
+	lines           []string
+	endOffset       int64
+	latest          int64
+	hitLimit        bool
+	trailingPartial bool
+	cursor          *logCursor
 }
 
 type logReadResult struct {
-	lines      []string
-	latest     int64
-	nextCursor string
+	lines                  []string
+	latest                 int64
+	nextCursor             string
+	replaceTrailingPartial bool
 }
 
-func writeLogsResponse(c *gin.Context, lines []string, lineCount int, latest int64, nextCursor string, cursorReset bool) {
+func writeLogsResponse(c *gin.Context, lines []string, lineCount int, latest int64, nextCursor string, cursorReset, replaceTrailingPartial bool) {
 	if lines == nil {
 		lines = []string{}
 	}
@@ -583,6 +587,9 @@ func writeLogsResponse(c *gin.Context, lines []string, lineCount int, latest int
 	if cursorReset {
 		payload["cursor-reset"] = true
 	}
+	if replaceTrailingPartial {
+		payload["replace-trailing-partial"] = true
+	}
 	c.JSON(http.StatusOK, payload)
 }
 
@@ -591,6 +598,7 @@ func tailLogFiles(files []string, limit int, fallbackLatest int64) (logReadResul
 		lines:  []string{},
 		latest: fallbackLatest,
 	}
+	var tailCursor *logCursor
 	for i := len(files) - 1; i >= 0; i-- {
 		remaining := 0
 		if limit > 0 {
@@ -606,6 +614,10 @@ func tailLogFiles(files []string, limit int, fallbackLatest int64) (logReadResul
 			}
 			return logReadResult{}, errRead
 		}
+		if tailCursor == nil && read.cursor != nil {
+			cursorCopy := *read.cursor
+			tailCursor = &cursorCopy
+		}
 		if len(read.lines) == 0 {
 			continue
 		}
@@ -614,7 +626,14 @@ func tailLogFiles(files []string, limit int, fallbackLatest int64) (logReadResul
 			result.latest = read.latest
 		}
 	}
-	nextCursor, errCursor := cursorForLatestLogFile(files, result.latest)
+	var nextCursor string
+	var errCursor error
+	if tailCursor != nil {
+		tailCursor.LatestTimestamp = result.latest
+		nextCursor, errCursor = encodeLogCursor(*tailCursor)
+	} else {
+		nextCursor, errCursor = cursorForLatestLogFile(files, result.latest)
+	}
 	if errCursor != nil {
 		return logReadResult{}, errCursor
 	}
@@ -623,18 +642,76 @@ func tailLogFiles(files []string, limit int, fallbackLatest int64) (logReadResul
 }
 
 func readTailLogLines(path string, limit int) (completeLogRead, error) {
-	boundary, errBoundary := completeLogBoundary(path)
+	return readTailLogLinesWithSnapshotHook(path, limit, nil)
+}
+
+func readTailLogLinesWithSnapshotHook(path string, limit int, afterSnapshot func()) (completeLogRead, error) {
+	file, errOpen := os.Open(path)
+	if errOpen != nil {
+		return completeLogRead{}, errOpen
+	}
+	defer func() { _ = file.Close() }()
+
+	info, errStat := file.Stat()
+	if errStat != nil {
+		return completeLogRead{}, errStat
+	}
+	if info.IsDir() {
+		return completeLogRead{}, fmt.Errorf("invalid log file")
+	}
+	snapshotSize := info.Size()
+	boundary, errBoundary := completeLogBoundaryFromFile(file, snapshotSize)
 	if errBoundary != nil {
 		return completeLogRead{}, errBoundary
 	}
-	if boundary == 0 {
-		return completeLogRead{lines: []string{}}, nil
+	if afterSnapshot != nil {
+		afterSnapshot()
 	}
-	start, errStart := tailStartOffset(path, boundary, limit)
+	partialLength := snapshotSize - boundary
+	if partialLength < 0 {
+		return completeLogRead{}, fmt.Errorf("invalid log boundary")
+	}
+	completeLimit := limit
+	if partialLength > 0 && completeLimit > 0 {
+		completeLimit--
+	}
+	start, errStart := tailStartOffsetFromFile(file, boundary, completeLimit)
 	if errStart != nil {
 		return completeLogRead{}, errStart
 	}
-	return readCompleteLogLines(path, start, boundary, limit)
+	read := completeLogRead{lines: []string{}, endOffset: boundary}
+	if boundary > 0 && (limit <= 0 || completeLimit > 0) {
+		read, errBoundary = readCompleteLogLinesFromFile(file, snapshotSize, start, boundary, completeLimit)
+		if errBoundary != nil {
+			return completeLogRead{}, errBoundary
+		}
+	}
+	if partialLength > 0 {
+		if partialLength > logScannerMaxBuffer {
+			return completeLogRead{}, fmt.Errorf("log line exceeds %d bytes", logScannerMaxBuffer)
+		}
+		partial := make([]byte, partialLength)
+		n, errRead := file.ReadAt(partial, boundary)
+		if errRead != nil && errRead != io.EOF {
+			return completeLogRead{}, errRead
+		}
+		if int64(n) != partialLength {
+			return completeLogRead{}, fmt.Errorf("log file changed during tail read")
+		}
+		text := strings.TrimRight(string(partial), "\r")
+		read.lines = append(read.lines, text)
+		read.trailingPartial = true
+		if ts := parseTimestamp(text); ts > read.latest {
+			read.latest = ts
+		}
+	}
+	cursor, errCursor := newLogCursorFromFile(path, file, boundary, snapshotSize, info.ModTime(), read.latest)
+	if errCursor != nil {
+		return completeLogRead{}, errCursor
+	}
+	cursor.PreviewedPartial = read.trailingPartial
+	read.cursor = &cursor
+	return read, nil
 }
 
 func tailStartOffset(path string, boundary int64, limit int) (int64, error) {
@@ -648,6 +725,13 @@ func tailStartOffset(path string, boundary int64, limit int) (int64, error) {
 	defer func() {
 		_ = file.Close()
 	}()
+	return tailStartOffsetFromFile(file, boundary, limit)
+}
+
+func tailStartOffsetFromFile(file *os.File, boundary int64, limit int) (int64, error) {
+	if limit <= 0 {
+		return 0, nil
+	}
 	buf := make([]byte, 32*1024)
 	pos := boundary
 	lineBreaks := 0
@@ -742,6 +826,9 @@ func readLogFilesFromCursor(logDir string, files []string, raw string, limit int
 			return result, false, errRead
 		}
 		if len(read.lines) > 0 {
+			if i == startIndex && cursor.PreviewedPartial {
+				result.replaceTrailingPartial = true
+			}
 			result.lines = append(result.lines, read.lines...)
 			if read.latest > result.latest {
 				result.latest = read.latest
@@ -993,7 +1080,12 @@ func safeLogFilePath(logDir, name string) (string, error) {
 }
 
 func newLogCursor(path string, offset, latest int64) (string, error) {
-	info, errStat := os.Stat(path)
+	file, errOpen := os.Open(path)
+	if errOpen != nil {
+		return "", errOpen
+	}
+	defer func() { _ = file.Close() }()
+	info, errStat := file.Stat()
 	if errStat != nil {
 		return "", errStat
 	}
@@ -1003,24 +1095,32 @@ func newLogCursor(path string, offset, latest int64) (string, error) {
 	if offset < 0 || offset > info.Size() {
 		return "", fmt.Errorf("invalid cursor offset")
 	}
-	fingerprintCursor := logCursor{
-		Offset: offset,
-		Size:   info.Size(),
+	cursor, errCursor := newLogCursorFromFile(path, file, offset, info.Size(), info.ModTime(), latest)
+	if errCursor != nil {
+		return "", errCursor
 	}
-	fingerprint, errFingerprint := logFileFingerprint(path, cursorFingerprintBoundary(fingerprintCursor))
+	return encodeLogCursor(cursor)
+}
+
+func newLogCursorFromFile(path string, file *os.File, offset, size int64, modTime time.Time, latest int64) (logCursor, error) {
+	if file == nil || offset < 0 || size < 0 || offset > size {
+		return logCursor{}, fmt.Errorf("invalid cursor offset")
+	}
+	fingerprintCursor := logCursor{Offset: offset, Size: size}
+	fingerprint, errFingerprint := logFileFingerprintFromFile(file, cursorFingerprintBoundary(fingerprintCursor))
 	if errFingerprint != nil {
-		return "", errFingerprint
+		return logCursor{}, errFingerprint
 	}
-	return encodeLogCursor(logCursor{
+	return logCursor{
 		Version:         logCursorVersion,
 		File:            filepath.Base(path),
 		Offset:          offset,
-		Size:            info.Size(),
-		ModTime:         info.ModTime().Unix(),
-		ModTimeUnixNano: info.ModTime().UnixNano(),
+		Size:            size,
+		ModTime:         modTime.Unix(),
+		ModTimeUnixNano: modTime.UnixNano(),
 		LatestTimestamp: latest,
 		Fingerprint:     fingerprint,
-	})
+	}, nil
 }
 
 func cursorFingerprintBoundary(cursor logCursor) int64 {
@@ -1048,6 +1148,13 @@ func logFileFingerprint(path string, boundary int64) (string, error) {
 	defer func() {
 		_ = file.Close()
 	}()
+	return logFileFingerprintFromFile(file, boundary)
+}
+
+func logFileFingerprintFromFile(file *os.File, boundary int64) (string, error) {
+	if file == nil {
+		return "", fmt.Errorf("invalid log file")
+	}
 	info, errStat := file.Stat()
 	if errStat != nil {
 		return "", errStat
@@ -1120,7 +1227,13 @@ func readCompleteLogLines(path string, offset, maxOffset int64, limit int) (comp
 	if info.IsDir() {
 		return completeLogRead{}, fmt.Errorf("invalid log file")
 	}
-	size := info.Size()
+	return readCompleteLogLinesFromFile(file, info.Size(), offset, maxOffset, limit)
+}
+
+func readCompleteLogLinesFromFile(file *os.File, size, offset, maxOffset int64, limit int) (completeLogRead, error) {
+	if file == nil || offset < 0 || size < 0 {
+		return completeLogRead{}, fmt.Errorf("invalid log offset")
+	}
 	if maxOffset < 0 || maxOffset > size {
 		maxOffset = size
 	}
@@ -1196,7 +1309,13 @@ func completeLogBoundary(path string) (int64, error) {
 	if info.IsDir() {
 		return 0, fmt.Errorf("invalid log file")
 	}
-	size := info.Size()
+	return completeLogBoundaryFromFile(file, info.Size())
+}
+
+func completeLogBoundaryFromFile(file *os.File, size int64) (int64, error) {
+	if file == nil || size < 0 {
+		return 0, fmt.Errorf("invalid log file")
+	}
 	if size == 0 {
 		return 0, nil
 	}

--- a/internal/api/handlers/management/logs_test.go
+++ b/internal/api/handlers/management/logs_test.go
@@ -201,6 +201,70 @@ func TestGetLogsNoLimitUsesBoundedDefault(t *testing.T) {
 	}
 }
 
+func TestGetLogsDefaultTailIncludesTrailingPartialLine(t *testing.T) {
+	dir := t.TempDir()
+	writeMainLog(t, dir, "first\npartial")
+
+	resp := performGetLogs(t, newLogsTestHandler(dir, true), "/v0/management/logs")
+	wantLines := []string{"first", "partial"}
+	if !reflect.DeepEqual(resp.Lines, wantLines) {
+		t.Fatalf("lines = %#v, want %#v", resp.Lines, wantLines)
+	}
+	cursor, errCursor := decodeLogCursor(resp.NextCursor)
+	if errCursor != nil {
+		t.Fatalf("decode initial cursor: %v", errCursor)
+	}
+	if !cursor.PreviewedPartial {
+		t.Fatal("initial cursor does not record the previewed partial line")
+	}
+
+	appendMainLog(t, dir, " complete\nnew\n")
+	next := performGetLogs(t, newLogsTestHandler(dir, true), "/v0/management/logs?cursor="+url.QueryEscape(resp.NextCursor))
+	if !reflect.DeepEqual(next.Lines, []string{"partial complete", "new"}) {
+		t.Fatalf("completed partial lines = %#v", next.Lines)
+	}
+	if !next.ReplaceTrailingPartial {
+		t.Fatal("completed partial response did not request replacement of the previewed line")
+	}
+}
+
+func TestReadTailLogLinesUsesSingleSizeSnapshotDuringAppend(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, defaultLogFileName)
+	writeMainLog(t, dir, "partial")
+
+	read, err := readTailLogLinesWithSnapshotHook(path, 10, func() {
+		appendMainLog(t, dir, " complete\nnew\n")
+	})
+	if err != nil {
+		t.Fatalf("readTailLogLinesWithSnapshotHook() error = %v", err)
+	}
+	if !reflect.DeepEqual(read.lines, []string{"partial"}) {
+		t.Fatalf("snapshot lines = %#v, want only the original partial preview", read.lines)
+	}
+	if read.cursor == nil || !read.cursor.PreviewedPartial || read.cursor.Offset != 0 || read.cursor.Size != int64(len("partial")) {
+		t.Fatalf("snapshot cursor = %+v, want previewed partial at original size", read.cursor)
+	}
+
+	rawCursor, err := encodeLogCursor(*read.cursor)
+	if err != nil {
+		t.Fatalf("encode snapshot cursor: %v", err)
+	}
+	next, reset, err := readLogFilesFromCursor(dir, []string{path}, rawCursor, 10)
+	if err != nil {
+		t.Fatalf("readLogFilesFromCursor() error = %v", err)
+	}
+	if reset {
+		t.Fatal("snapshot cursor unexpectedly reset after append")
+	}
+	if !next.replaceTrailingPartial {
+		t.Fatal("completed snapshot partial did not request trailing replacement")
+	}
+	if !reflect.DeepEqual(next.lines, []string{"partial complete", "new"}) {
+		t.Fatalf("incremental lines = %#v, want completed preview plus new line", next.lines)
+	}
+}
+
 func TestParseLimitClampsToPanelCompatibleMaximum(t *testing.T) {
 	tests := []struct {
 		raw  string
@@ -785,11 +849,12 @@ func mustEncodeRawCursor(t *testing.T, cursor logCursor) string {
 }
 
 type logsAPIResponse struct {
-	Lines           []string `json:"lines"`
-	LineCount       int      `json:"line-count"`
-	LatestTimestamp int64    `json:"latest-timestamp"`
-	NextCursor      string   `json:"next-cursor"`
-	CursorReset     bool     `json:"cursor-reset"`
+	Lines                  []string `json:"lines"`
+	LineCount              int      `json:"line-count"`
+	LatestTimestamp        int64    `json:"latest-timestamp"`
+	NextCursor             string   `json:"next-cursor"`
+	CursorReset            bool     `json:"cursor-reset"`
+	ReplaceTrailingPartial bool     `json:"replace-trailing-partial"`
 }
 
 func newLogsTestHandler(dir string, loggingToFile bool) *Handler {


### PR DESCRIPTION
## 结果

让 `/v0/management/logs` 在默认 tail 中展示当前未换行的日志尾部，并在该行后续完成时返回可判定的替换信号，避免 Panel 同时保留 preview 与 completed line。

## 变更

- 在同一个已打开文件描述符上固定 `size`、完整行边界、内容读取和 cursor fingerprint，避免 path swap 或并发 append 混入一次 tail snapshot。
- tail response 可包含一条 trailing partial preview；cursor 记录其起始 offset 与 `previewedPartial` 状态。
- 后续 cursor read 从该 partial 起点重新读取完整行，并在需要时返回 additive 字段 `replace-trailing-partial: true`。
- 保留既有 overlap、rotation、cursor reset、line limit 与 timestamp 语义。
- 增加 partial completion 与 snapshot 期间 append 的回归测试。

## 兼容性与合并顺序

- Baseline：`origin/main` @ `04c59973e63b9e492e4253bea5ab08af8ada035b`。
- `replace-trailing-partial` 是可选 additive response field；旧 Panel 会忽略它，但会在 partial 完成时短暂显示 preview 与 completed line 两条记录。
- 配套 Panel PR：BlueSkyXN/CPA-Panel-LTS#42。应先合入 Panel #42，再合入本 PR。
- 不修改日志文件格式、Management auth、release 或 deployment。

## 验证

- `go test ./internal/api/handlers/management -run 'Log|log' -count=1`：passed
- `go test ./... -count=1`：passed
- `scripts/check-lts-contract.sh`：passed
- `go build -o /dev/null ./cmd/server`：passed
- `git diff --check`：passed

## 剩余验证边界

Unit regression 覆盖同一文件 append 与 cursor replacement；mock Panel smoke 不模拟真实文件级 partial completion。Panel #42 与本 PR 都合入后需再执行一次 `npm run smoke:lts:core` 作为跨仓 readback。本 PR 未创建 tag、release 或 deployment。

## Review focus

请重点检查 fixed-size same-FD snapshot、partial cursor offset/fingerprint、rotation fallback，以及 `limit=1` 时只返回 trailing partial 的行为。
