### PR TITLE
fix(xai): 保持客户端声明的工具权限边界

### DIFF
--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -461,17 +461,20 @@ patches:
     retire_when: Upstream removes reasoning.summary for gpt-5.3-codex-spark after all request overrides while preserving reasoning.effort and the listed regressions pass without the downstream implementation.
 
   - id: xai-explicit-tool-choice-none
-    reason: xAI request preparation injects native x_search after removing tool_choice fields for an empty client tool list, so an explicit tool_choice none can be lost and the model may invoke search despite the client prohibition.
+    reason: xAI request preparation must not grant native x_search when the client declared no tools or a restricted allowlist; explicit tool_choice none must remain intact while parallel_tool_calls is removed when no tools survive, and custom declarations and choices must be canonicalized together before orphan pruning.
     introduced_in: ad7244752d324a5b179c3e30a628acf976fa995c
-    affected_upstream_range: through 53c1e7e2dd6ddf973098a4e685e852aeebed9fe3 (v7.2.92); upstream promotes additional_tools and adopts conditional payload mutations, but still normalizes tool_choice before injecting x_search. LTS keeps the explicit none/parallel false guard while absorbing the new tool promotion path.
+    affected_upstream_range: through 53c1e7e2dd6ddf973098a4e685e852aeebed9fe3 (v7.2.92); upstream promotes additional_tools and adopts conditional payload mutations, but still injects x_search without explicit client authorization. LTS preserves only client-declared tools, keeps explicit none, removes parallel_tool_calls when no tools survive, and canonicalizes custom choices before pruning.
     files:
       - internal/runtime/executor/xai_executor.go
       - internal/runtime/executor/xai_executor_test.go
     regression_tests:
-      - TestXAIExecutorPreparePreservesExplicitToolChoiceNoneAfterXSearchInject
+      - TestXAIExecutorPrepareDoesNotInjectUnauthorizedXSearch
+      - TestXAIExecutorPrepareCanonicalizesCustomToolChoices
+      - TestXAIExecutorPrepareAllowedToolsDoesNotExpandWithXSearch
+      - TestXAIExecutorPrepareDropsParallelToolCallsWithoutToolsEvenForExplicitNone
     upstream_issue_or_pr: not-filed
     state: required
-    retire_when: Upstream injects the native x_search tool before the no-tools tool_choice cleanup, preserves explicit tool_choice none and parallel_tool_calls false on the shared HTTP/WebSocket preparation path, and the listed regression passes without the downstream ordering patch.
+    retire_when: Upstream requires explicit authorization for native x_search, does not expand restricted allowlists, preserves explicit tool_choice none while dropping parallel_tool_calls when no tools survive, canonicalizes custom choices before pruning on the shared HTTP/WebSocket preparation path, and all listed regressions pass without the downstream patch.
 
   - id: kimi-claude-delegated-auth-immutability
     reason: Kimi delegates Claude-format requests to the Claude executor, but the selected Auth attributes are shared immutable credential configuration and must not be mutated per request to install the Kimi messages base URL.

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -461,7 +461,7 @@ patches:
     retire_when: Upstream removes reasoning.summary for gpt-5.3-codex-spark after all request overrides while preserving reasoning.effort and the listed regressions pass without the downstream implementation.
 
   - id: xai-explicit-tool-choice-none
-    reason: xAI request preparation must not grant native x_search when the client declared no tools or a restricted allowlist; explicit tool_choice none must remain intact while parallel_tool_calls is removed when no tools survive, and custom declarations and choices must be canonicalized together before orphan pruning.
+    reason: xAI request preparation must not grant native x_search when the client declared no tools or a restricted allowlist; explicit tool_choice none must remain intact, an orphaned restriction must fail closed instead of reverting to auto, parallel_tool_calls must be removed when no tools survive, and custom declarations and choices must be canonicalized together before orphan pruning.
     introduced_in: ad7244752d324a5b179c3e30a628acf976fa995c
     affected_upstream_range: through 53c1e7e2dd6ddf973098a4e685e852aeebed9fe3 (v7.2.92); upstream promotes additional_tools and adopts conditional payload mutations, but still injects x_search without explicit client authorization. LTS preserves only client-declared tools, keeps explicit none, removes parallel_tool_calls when no tools survive, and canonicalizes custom choices before pruning.
     files:
@@ -471,10 +471,11 @@ patches:
       - TestXAIExecutorPrepareDoesNotInjectUnauthorizedXSearch
       - TestXAIExecutorPrepareCanonicalizesCustomToolChoices
       - TestXAIExecutorPrepareAllowedToolsDoesNotExpandWithXSearch
+      - TestXAIExecutorPrepareFailsClosedWhenRestrictedChoiceIsOrphaned
       - TestXAIExecutorPrepareDropsParallelToolCallsWithoutToolsEvenForExplicitNone
     upstream_issue_or_pr: not-filed
     state: required
-    retire_when: Upstream requires explicit authorization for native x_search, does not expand restricted allowlists, preserves explicit tool_choice none while dropping parallel_tool_calls when no tools survive, canonicalizes custom choices before pruning on the shared HTTP/WebSocket preparation path, and all listed regressions pass without the downstream patch.
+    retire_when: Upstream requires explicit authorization for native x_search, does not expand restricted allowlists, converts orphaned forced or allowed choices to an explicit fail-closed policy, preserves explicit tool_choice none while dropping parallel_tool_calls when no tools survive, canonicalizes custom choices before pruning on the shared HTTP/WebSocket preparation path, and all listed regressions pass without the downstream patch.
 
   - id: kimi-claude-delegated-auth-immutability
     reason: Kimi delegates Claude-format requests to the Claude executor, but the selected Auth attributes are shared immutable credential configuration and must not be mutated per request to install the Kimi messages base URL.

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -1370,6 +1370,9 @@ func pruneXAIAllowedToolsChoice(body []byte, available map[xaiToolChoiceKey]stru
 		return failClosedXAIToolChoice(body)
 	}
 	allowedItems := allowed.Array()
+	if len(allowedItems) == 0 {
+		return failClosedXAIToolChoice(body)
+	}
 	filtered := make([][]byte, 0, len(allowedItems))
 	changed := false
 	for _, tool := range allowedItems {

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -71,11 +71,6 @@ const (
 	xaiUsingAPIAttr = "using_api"
 )
 
-// Always inject native x_search when the client did not declare it so Grok can
-// run X Search server-side. Internal subtool traces are still filtered downstream
-// when this native tool is present (see filterInternalXSearch).
-var xaiXSearchToolJSON = []byte(`{"type":"x_search"}`)
-
 // XAIExecutor is a stateless executor for xAI Grok's Responses API.
 type XAIExecutor struct {
 	cfg *config.Config
@@ -916,12 +911,9 @@ func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliprox
 	clientDeclaredTools := collectXAIClientDeclaredToolKeys(body)
 	body = normalizeXAITools(body)
 	body = promoteXAIAdditionalTools(body)
-	// Drop choices that point at tools removed by normalizeXAITools before we
-	// inject native x_search, so a surviving allowed_tools / forced choice is not
-	// left pointing at a deleted tool once only x_search remains.
+	// Drop choices that point at tools removed by normalizeXAITools.
 	body = normalizeXAINamespaceToolChoice(body)
 	body = pruneXAIOrphanedToolChoice(body)
-	body = ensureXAINativeXSearchTool(body)
 	body = normalizeXAIToolChoiceForTools(body)
 	var replayScope xaiReasoningReplayScope
 	body, replayScope, err = applyXAIReasoningReplayCacheRequired(ctx, from, req, opts, body)
@@ -1332,48 +1324,6 @@ func sanitizeXAIResponsesBody(body []byte, model string) []byte {
 	return body
 }
 
-// ensureXAINativeXSearchTool appends {"type":"x_search"} when the final tools
-// list does not already include native X Search. When tool_choice restricts the
-// model to allowed_tools, x_search is also added there (without duplicates) so
-// Grok can select the injected tool. HTTP and websocket executors both prepare
-// payloads through prepareResponsesRequestTo, so this runs once before the body
-// is submitted upstream.
-func ensureXAINativeXSearchTool(body []byte) []byte {
-	if !gjson.ValidBytes(body) {
-		return body
-	}
-	if !xaiRequestHasNativeXSearch(body) {
-		tools := gjson.GetBytes(body, "tools")
-		if !tools.Exists() || !tools.IsArray() {
-			body, _ = sjson.SetRawBytes(body, "tools", []byte(`[{"type":"x_search"}]`))
-		} else {
-			body, _ = sjson.SetRawBytes(body, "tools.-1", xaiXSearchToolJSON)
-		}
-	}
-	return ensureXAINativeXSearchAllowedTools(body)
-}
-
-// ensureXAINativeXSearchAllowedTools appends x_search to tool_choice.tools when
-// the choice mode is allowed_tools and x_search is not already listed.
-func ensureXAINativeXSearchAllowedTools(body []byte) []byte {
-	choice := gjson.GetBytes(body, "tool_choice")
-	if !choice.IsObject() || choice.Get("type").String() != "allowed_tools" {
-		return body
-	}
-	allowed := choice.Get("tools")
-	if !allowed.Exists() || !allowed.IsArray() {
-		body, _ = sjson.SetRawBytes(body, "tool_choice.tools", []byte(`[{"type":"x_search"}]`))
-		return body
-	}
-	for _, tool := range allowed.Array() {
-		if strings.TrimSpace(tool.Get("type").String()) == xaiXSearchToolType {
-			return body
-		}
-	}
-	body, _ = sjson.SetRawBytes(body, "tool_choice.tools.-1", xaiXSearchToolJSON)
-	return body
-}
-
 // pruneXAIOrphanedToolChoice removes tool_choice entries that no longer match
 // any remaining tool after normalizeXAITools filtering. Forced choices that
 // reference a deleted tool are dropped entirely; allowed_tools lists keep only
@@ -1632,10 +1582,12 @@ func normalizeXAIToolArray(tools gjson.Result) ([]byte, bool, bool) {
 	return helps.JoinRawJSONArray(filtered), true, true
 }
 
-// normalizeXAIToolChoiceForTools drops tool_choice and parallel_tool_calls
-// when tools are absent or empty (including after normalizeXAITools filtering).
-// xAI rejects payloads that include tool_choice without any tools defined.
-// Existence checks avoid unnecessary sjson parse/copy passes.
+// normalizeXAIToolChoiceForTools removes tool choices and parallel calls when
+// tools are absent or empty (including after normalizeXAITools filtering). An
+// explicit tool_choice:none is preserved because it narrows, rather than
+// grants, tool authority; parallel_tool_calls is always removed because it has
+// no meaning without tools. Existence checks avoid unnecessary sjson parse/copy
+// passes.
 func normalizeXAIToolChoiceForTools(body []byte) []byte {
 	tools := gjson.GetBytes(body, "tools")
 	hasTools := tools.Exists() && tools.IsArray() && len(tools.Array()) > 0
@@ -1657,7 +1609,8 @@ func normalizeXAIToolChoiceForTools(body []byte) []byte {
 	if tools.Exists() {
 		body, _ = sjson.DeleteBytes(body, "tools")
 	}
-	if gjson.GetBytes(body, "tool_choice").Exists() {
+	choice := gjson.GetBytes(body, "tool_choice")
+	if choice.Exists() && !(choice.Type == gjson.String && strings.EqualFold(strings.TrimSpace(choice.String()), "none")) {
 		body, _ = sjson.DeleteBytes(body, "tool_choice")
 	}
 	if gjson.GetBytes(body, "parallel_tool_calls").Exists() {
@@ -1676,7 +1629,20 @@ func normalizeXAINamespaceToolChoice(body []byte) []byte {
 	original := body
 	normalizeAtPath := func(path string) bool {
 		toolChoice := gjson.GetBytes(body, path)
-		if !toolChoice.IsObject() || toolChoice.Get("type").String() != xaiFunctionToolType {
+		if !toolChoice.IsObject() {
+			return true
+		}
+		toolType := strings.TrimSpace(toolChoice.Get("type").String())
+		if toolType == xaiCustomToolType {
+			updated, errSet := sjson.SetBytes(body, path+".type", xaiFunctionToolType)
+			if errSet != nil {
+				return false
+			}
+			body = updated
+			toolChoice = gjson.GetBytes(body, path)
+			toolType = xaiFunctionToolType
+		}
+		if toolType != xaiFunctionToolType {
 			return true
 		}
 		namespaceName := strings.TrimSpace(toolChoice.Get("namespace").String())

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -1324,10 +1324,10 @@ func sanitizeXAIResponsesBody(body []byte, model string) []byte {
 	return body
 }
 
-// pruneXAIOrphanedToolChoice removes tool_choice entries that no longer match
-// any remaining tool after normalizeXAITools filtering. Forced choices that
-// reference a deleted tool are dropped entirely; allowed_tools lists keep only
-// choices that still resolve against the post-normalization tools set.
+// pruneXAIOrphanedToolChoice reconciles tool_choice entries with the tools that
+// survive normalizeXAITools filtering. A restriction that loses every target
+// becomes an explicit none choice instead of being deleted: deleting it would
+// restore xAI's default auto policy and broaden authority to unrelated tools.
 func pruneXAIOrphanedToolChoice(body []byte) []byte {
 	if !gjson.ValidBytes(body) {
 		return body
@@ -1355,16 +1355,19 @@ func pruneXAIOrphanedToolChoice(body []byte) []byte {
 		if xaiToolChoiceMatchesAvailable(choice, available) {
 			return body
 		}
-		body, _ = sjson.DeleteBytes(body, "tool_choice")
-		return body
+		return failClosedXAIToolChoice(body)
 	}
+}
+
+func failClosedXAIToolChoice(body []byte) []byte {
+	body, _ = sjson.SetBytes(body, "tool_choice", "none")
+	return body
 }
 
 func pruneXAIAllowedToolsChoice(body []byte, available map[xaiToolChoiceKey]struct{}) []byte {
 	allowed := gjson.GetBytes(body, "tool_choice.tools")
 	if !allowed.Exists() || !allowed.IsArray() {
-		body, _ = sjson.DeleteBytes(body, "tool_choice")
-		return body
+		return failClosedXAIToolChoice(body)
 	}
 	allowedItems := allowed.Array()
 	filtered := make([][]byte, 0, len(allowedItems))
@@ -1380,8 +1383,7 @@ func pruneXAIAllowedToolsChoice(body []byte, available map[xaiToolChoiceKey]stru
 		return body
 	}
 	if len(filtered) == 0 {
-		body, _ = sjson.DeleteBytes(body, "tool_choice")
-		return body
+		return failClosedXAIToolChoice(body)
 	}
 	body, _ = sjson.SetRawBytes(body, "tool_choice.tools", helps.JoinRawJSONArray(filtered))
 	return body

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -566,13 +566,14 @@ func TestXAIExecutorPrepareCanonicalizesCustomToolChoices(t *testing.T) {
 func TestPruneXAIOrphanedToolChoice(t *testing.T) {
 	t.Parallel()
 
-	// Forced choice for a removed tool is dropped.
+	// A forced choice for a removed tool must fail closed instead of widening
+	// the surviving lookup tool back to the default auto policy.
 	out := pruneXAIOrphanedToolChoice([]byte(`{
 		"tools":[{"type":"function","name":"lookup","parameters":{"type":"object"}}],
 		"tool_choice":{"type":"image_generation"}
 	}`))
-	if gjson.GetBytes(out, "tool_choice").Exists() {
-		t.Fatalf("orphaned forced tool_choice should be removed: %s", out)
+	if got := gjson.GetBytes(out, "tool_choice").String(); got != "none" {
+		t.Fatalf("orphaned forced tool_choice = %q, want none: %s", got, out)
 	}
 
 	// allowed_tools keeps only still-available entries.
@@ -595,19 +596,65 @@ func TestPruneXAIOrphanedToolChoice(t *testing.T) {
 		t.Fatalf("allowed_tools.1.type = %q, want web_search; body=%s", got, out)
 	}
 
-	// When every allowed entry is orphaned, drop tool_choice entirely.
+	// When every allowed entry is orphaned, preserve the restriction as none.
 	out = pruneXAIOrphanedToolChoice([]byte(`{
 		"tools":[],
 		"tool_choice":{"type":"allowed_tools","tools":[{"type":"image_generation"}]}
 	}`))
-	if gjson.GetBytes(out, "tool_choice").Exists() {
-		t.Fatalf("fully orphaned allowed_tools should be removed: %s", out)
+	if got := gjson.GetBytes(out, "tool_choice").String(); got != "none" {
+		t.Fatalf("fully orphaned allowed_tools = %q, want none: %s", got, out)
 	}
 
 	// String choices are not tool references.
 	in := []byte(`{"tools":[{"type":"web_search"}],"tool_choice":"auto"}`)
 	if got := pruneXAIOrphanedToolChoice(in); !bytes.Equal(got, in) {
 		t.Fatalf("string tool_choice changed: got=%s want=%s", got, in)
+	}
+}
+
+func TestXAIExecutorPrepareFailsClosedWhenRestrictedChoiceIsOrphaned(t *testing.T) {
+	t.Parallel()
+
+	exec := NewXAIExecutor(&config.Config{})
+	for _, tt := range []struct {
+		name       string
+		toolChoice string
+	}{
+		{
+			name:       "allowed tools",
+			toolChoice: `{"type":"allowed_tools","tools":[{"type":"image_generation"}]}`,
+		},
+		{
+			name:       "forced tool",
+			toolChoice: `{"type":"image_generation"}`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			prepared, err := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+				Model: "grok-4.5",
+				Payload: []byte(`{
+					"model":"grok-4.5",
+					"input":"do not broaden my tool restriction",
+					"tools":[
+						{"type":"image_generation"},
+						{"type":"function","name":"destructive_action","parameters":{"type":"object"}}
+					],
+					"tool_choice":` + tt.toolChoice + `
+				}`),
+			}, cliproxyexecutor.Options{
+				SourceFormat: sdktranslator.FormatOpenAIResponse,
+				Stream:       false,
+			}, false)
+			if err != nil {
+				t.Fatalf("prepareResponsesRequest() error = %v", err)
+			}
+			if got := gjson.GetBytes(prepared.body, "tools.0.name").String(); got != "destructive_action" {
+				t.Fatalf("surviving tool = %q, want destructive_action fixture: %s", got, prepared.body)
+			}
+			if got := gjson.GetBytes(prepared.body, "tool_choice").String(); got != "none" {
+				t.Fatalf("orphaned restricted choice = %q, want none: %s", got, prepared.body)
+			}
+		})
 	}
 }
 
@@ -636,8 +683,8 @@ func TestXAIExecutorPrepareDropsOrphanedToolChoiceWithoutXSearchInject(t *testin
 	if gjson.GetBytes(prepared.body, "tools").Exists() {
 		t.Fatalf("removed-only tools should not be replaced: %s", prepared.body)
 	}
-	if gjson.GetBytes(prepared.body, "tool_choice").Exists() {
-		t.Fatalf("orphaned image_generation tool_choice must not reach upstream: %s", prepared.body)
+	if got := gjson.GetBytes(prepared.body, "tool_choice").String(); got != "none" {
+		t.Fatalf("orphaned image_generation tool_choice = %q, want none: %s", got, prepared.body)
 	}
 }
 

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -134,22 +134,18 @@ func TestXAIExecutorExecuteShapesResponsesRequest(t *testing.T) {
 		t.Fatalf("input.2 exists, want consecutive reasoning item merged; body=%s", string(gotBody))
 	}
 	tools := gjson.GetBytes(gotBody, "tools").Array()
-	if len(tools) != 6 {
-		t.Fatalf("tools length = %d, want 6; body=%s", len(tools), string(gotBody))
+	if len(tools) != 5 {
+		t.Fatalf("tools length = %d, want 5; body=%s", len(tools), string(gotBody))
 	}
 	foundAutomationUpdate := false
 	foundNamespaceCustom := false
-	foundXSearch := false
 	for i, tool := range tools {
 		toolType := tool.Get("type").String()
 		if toolType == "image_generation" {
 			t.Fatalf("tools.%d.type = image_generation, want removed; body=%s", i, string(gotBody))
 		}
-		if toolType != "function" && toolType != "web_search" && toolType != "x_search" {
-			t.Fatalf("tools.%d.type = %q, want function, web_search, or x_search; body=%s", i, toolType, string(gotBody))
-		}
-		if toolType == "x_search" {
-			foundXSearch = true
+		if toolType != "function" && toolType != "web_search" {
+			t.Fatalf("tools.%d.type = %q, want function or web_search; body=%s", i, toolType, string(gotBody))
 		}
 		if toolType == "function" && !tool.Get("parameters").Exists() {
 			t.Fatalf("tools.%d.parameters missing for xAI function tool; body=%s", i, string(gotBody))
@@ -178,9 +174,6 @@ func TestXAIExecutorExecuteShapesResponsesRequest(t *testing.T) {
 	if !foundNamespaceCustom {
 		t.Fatalf("namespace custom tool was not moved to top-level tools; body=%s", string(gotBody))
 	}
-	if !foundXSearch {
-		t.Fatalf("native x_search tool was not injected; body=%s", string(gotBody))
-	}
 	if got := gjson.GetBytes(gotBody, "tool_choice.tools.0.name").String(); got != "codex_app__automation_update" {
 		t.Fatalf("tool_choice.tools.0.name = %q, want codex_app__automation_update; body=%s", got, string(gotBody))
 	}
@@ -193,17 +186,14 @@ func TestXAIExecutorExecuteShapesResponsesRequest(t *testing.T) {
 	if got := gjson.GetBytes(gotBody, "tool_choice.tools.2.type").String(); got != "web_search" {
 		t.Fatalf("tool_choice.tools.2.type = %q, want web_search; body=%s", got, string(gotBody))
 	}
-	if got := gjson.GetBytes(gotBody, "tool_choice.tools.3.type").String(); got != "x_search" {
-		t.Fatalf("tool_choice.tools.3.type = %q, want x_search; body=%s", got, string(gotBody))
-	}
 	xSearchAllowedCount := 0
 	for _, tool := range gjson.GetBytes(gotBody, "tool_choice.tools").Array() {
 		if tool.Get("type").String() == "x_search" {
 			xSearchAllowedCount++
 		}
 	}
-	if xSearchAllowedCount != 1 {
-		t.Fatalf("allowed_tools x_search count = %d, want 1; body=%s", xSearchAllowedCount, string(gotBody))
+	if xSearchAllowedCount != 0 {
+		t.Fatalf("allowed_tools x_search count = %d, want 0; body=%s", xSearchAllowedCount, string(gotBody))
 	}
 	foundEncryptedReasoningInclude := false
 	for _, include := range gjson.GetBytes(gotBody, "include").Array() {
@@ -362,7 +352,7 @@ func TestXAIExecutorExecuteNormalizesCustomToolCallHistory(t *testing.T) {
 		t.Fatalf("input.4 output = %q, want flattened JSON string; body=%s", got, gotBody)
 	}
 	if got := gjson.GetBytes(gotBody, "tools.0.type").String(); got != "x_search" {
-		t.Fatalf("tools.0.type = %q, want x_search; body=%s", got, gotBody)
+		t.Fatalf("tools.0.type = %q, want client-declared x_search; body=%s", got, gotBody)
 	}
 }
 
@@ -494,79 +484,82 @@ func TestXAIExecutorExecuteFiltersInternalXSearchCalls(t *testing.T) {
 	}
 }
 
-func TestEnsureXAINativeXSearchTool(t *testing.T) {
+func TestXAIExecutorPrepareDoesNotInjectUnauthorizedXSearch(t *testing.T) {
 	t.Parallel()
 
-	// Missing tools array: inject a top-level x_search tool.
-	out := ensureXAINativeXSearchTool([]byte(`{"model":"grok-4.5","input":"hi"}`))
-	tools := gjson.GetBytes(out, "tools").Array()
-	if len(tools) != 1 {
-		t.Fatalf("tools length = %d, want 1; body=%s", len(tools), out)
+	exec := NewXAIExecutor(&config.Config{})
+	prepared, err := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+		Model: "grok-4.5",
+		Payload: []byte(`{
+			"model":"grok-4.5",
+			"input":"answer without tools",
+			"tool_choice":"none",
+			"parallel_tool_calls":false
+		}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Stream:       false,
+	}, false)
+	if err != nil {
+		t.Fatalf("prepareResponsesRequest() error = %v", err)
 	}
-	if got := tools[0].Get("type").String(); got != "x_search" {
-		t.Fatalf("tools.0.type = %q, want x_search; body=%s", got, out)
+	if gjson.GetBytes(prepared.body, "tools").Exists() {
+		t.Fatalf("no-tools request gained x_search: %s", prepared.body)
+	}
+	if got := gjson.GetBytes(prepared.body, "tool_choice").String(); got != "none" {
+		t.Fatalf("tool_choice = %q, want none; body=%s", got, prepared.body)
+	}
+}
+
+func TestXAIExecutorPrepareCanonicalizesCustomToolChoices(t *testing.T) {
+	t.Parallel()
+
+	exec := NewXAIExecutor(&config.Config{})
+	prepared, err := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+		Model: "grok-4.5",
+		Payload: []byte(`{
+			"model":"grok-4.5",
+			"input":"run the tool",
+			"tools":[{"type":"custom","name":"apply_change","parameters":{"type":"object"}}],
+			"tool_choice":{"type":"allowed_tools","tools":[{"type":"custom","name":"apply_change"}]}
+		}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Stream:       false,
+	}, false)
+	if err != nil {
+		t.Fatalf("prepareResponsesRequest() error = %v", err)
+	}
+	if got := gjson.GetBytes(prepared.body, "tools.0.type").String(); got != "function" {
+		t.Fatalf("tools.0.type = %q, want function; body=%s", got, prepared.body)
+	}
+	if got := gjson.GetBytes(prepared.body, "tool_choice.tools.0.type").String(); got != "function" {
+		t.Fatalf("tool_choice.tools.0.type = %q, want function; body=%s", got, prepared.body)
+	}
+	if got := gjson.GetBytes(prepared.body, "tool_choice.tools.0.name").String(); got != "apply_change" {
+		t.Fatalf("tool_choice.tools.0.name = %q, want apply_change; body=%s", got, prepared.body)
 	}
 
-	// Existing tools without x_search: append once.
-	out = ensureXAINativeXSearchTool([]byte(`{"tools":[{"type":"web_search"},{"type":"function","name":"lookup","parameters":{"type":"object"}}]}`))
-	tools = gjson.GetBytes(out, "tools").Array()
-	if len(tools) != 3 {
-		t.Fatalf("tools length = %d, want 3; body=%s", len(tools), out)
+	forced, err := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+		Model: "grok-4.5",
+		Payload: []byte(`{
+			"model":"grok-4.5",
+			"input":"run the tool",
+			"tools":[{"type":"custom","name":"apply_change","parameters":{"type":"object"}}],
+			"tool_choice":{"type":"custom","name":"apply_change"}
+		}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Stream:       false,
+	}, false)
+	if err != nil {
+		t.Fatalf("prepareResponsesRequest() forced choice error = %v", err)
 	}
-	if got := tools[2].Get("type").String(); got != "x_search" {
-		t.Fatalf("tools.2.type = %q, want x_search; body=%s", got, out)
+	if got := gjson.GetBytes(forced.body, "tool_choice.type").String(); got != "function" {
+		t.Fatalf("forced tool_choice.type = %q, want function; body=%s", got, forced.body)
 	}
-
-	// Already present: leave body unchanged (no duplicate).
-	in := []byte(`{"tools":[{"type":"function","name":"lookup","parameters":{"type":"object"}},{"type":"x_search"}]}`)
-	out = ensureXAINativeXSearchTool(in)
-	tools = gjson.GetBytes(out, "tools").Array()
-	if len(tools) != 2 {
-		t.Fatalf("tools length = %d, want 2; body=%s", len(tools), out)
-	}
-	xSearchCount := 0
-	for _, tool := range tools {
-		if tool.Get("type").String() == "x_search" {
-			xSearchCount++
-		}
-	}
-	if xSearchCount != 1 {
-		t.Fatalf("x_search count = %d, want 1; body=%s", xSearchCount, out)
-	}
-
-	// allowed_tools without x_search: append once so Grok may select it.
-	out = ensureXAINativeXSearchTool([]byte(`{
-		"tools":[{"type":"function","name":"lookup","parameters":{"type":"object"}}],
-		"tool_choice":{"type":"allowed_tools","tools":[{"type":"function","name":"lookup"}]}
-	}`))
-	if got := gjson.GetBytes(out, "tools.1.type").String(); got != "x_search" {
-		t.Fatalf("tools.1.type = %q, want x_search; body=%s", got, out)
-	}
-	if got := gjson.GetBytes(out, "tool_choice.tools.1.type").String(); got != "x_search" {
-		t.Fatalf("tool_choice.tools.1.type = %q, want x_search; body=%s", got, out)
-	}
-
-	// allowed_tools already lists x_search: do not duplicate.
-	out = ensureXAINativeXSearchTool([]byte(`{
-		"tools":[{"type":"web_search"},{"type":"x_search"}],
-		"tool_choice":{"type":"allowed_tools","tools":[{"type":"web_search"},{"type":"x_search"}]}
-	}`))
-	tools = gjson.GetBytes(out, "tools").Array()
-	if len(tools) != 2 {
-		t.Fatalf("tools length = %d, want 2; body=%s", len(tools), out)
-	}
-	allowed := gjson.GetBytes(out, "tool_choice.tools").Array()
-	if len(allowed) != 2 {
-		t.Fatalf("tool_choice.tools length = %d, want 2; body=%s", len(allowed), out)
-	}
-	xSearchAllowed := 0
-	for _, tool := range allowed {
-		if tool.Get("type").String() == "x_search" {
-			xSearchAllowed++
-		}
-	}
-	if xSearchAllowed != 1 {
-		t.Fatalf("allowed_tools x_search count = %d, want 1; body=%s", xSearchAllowed, out)
+	if got := gjson.GetBytes(forced.body, "tool_choice.name").String(); got != "apply_change" {
+		t.Fatalf("forced tool_choice.name = %q, want apply_change; body=%s", got, forced.body)
 	}
 }
 
@@ -618,14 +611,14 @@ func TestPruneXAIOrphanedToolChoice(t *testing.T) {
 	}
 }
 
-func TestXAIExecutorPrepareDropsOrphanedToolChoiceBeforeXSearchInject(t *testing.T) {
+func TestXAIExecutorPrepareDropsOrphanedToolChoiceWithoutXSearchInject(t *testing.T) {
 	t.Parallel()
 
 	exec := NewXAIExecutor(&config.Config{})
 	prepared, err := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
 		Model: "grok-4.5",
 		// image_generation is stripped by normalizeXAITools; without pruning, the
-		// forced choice would survive next to the injected x_search tool.
+		// forced choice would otherwise survive after its tool is removed.
 		Payload: []byte(`{
 			"model":"grok-4.5",
 			"input":"draw something",
@@ -640,12 +633,8 @@ func TestXAIExecutorPrepareDropsOrphanedToolChoiceBeforeXSearchInject(t *testing
 		t.Fatalf("prepareResponsesRequest() error = %v", err)
 	}
 
-	tools := gjson.GetBytes(prepared.body, "tools").Array()
-	if len(tools) != 1 {
-		t.Fatalf("tools length = %d, want 1; body=%s", len(tools), prepared.body)
-	}
-	if got := tools[0].Get("type").String(); got != "x_search" {
-		t.Fatalf("tools.0.type = %q, want x_search; body=%s", got, prepared.body)
+	if gjson.GetBytes(prepared.body, "tools").Exists() {
+		t.Fatalf("removed-only tools should not be replaced: %s", prepared.body)
 	}
 	if gjson.GetBytes(prepared.body, "tool_choice").Exists() {
 		t.Fatalf("orphaned image_generation tool_choice must not reach upstream: %s", prepared.body)
@@ -757,16 +746,14 @@ func TestXAIExecutorPrepareResponsesRequestAddsObjectTypeToRootUnionBranches(t *
 	}
 }
 
-func TestXAIExecutorPrepareAllowedToolsSyncsInjectedXSearch(t *testing.T) {
+func TestXAIExecutorPrepareAllowedToolsDoesNotExpandWithXSearch(t *testing.T) {
 	t.Parallel()
 
 	exec := NewXAIExecutor(&config.Config{})
 	prepared, err := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
 		Model: "grok-4.5",
-		// Only image_generation remains after client filtering of tool_search-like
-		// tools is not relevant here: normalizeXAITools drops image_generation and
-		// we inject x_search, while allowed_tools must be rewritten so Grok can
-		// choose the injected tool and not a deleted one.
+		// normalizeXAITools drops image_generation and prunes it from the
+		// allowlist without adding a new x_search capability.
 		Payload: []byte(`{
 			"model":"grok-4.5",
 			"input":"search X",
@@ -785,36 +772,30 @@ func TestXAIExecutorPrepareAllowedToolsSyncsInjectedXSearch(t *testing.T) {
 	}
 
 	tools := gjson.GetBytes(prepared.body, "tools").Array()
-	if len(tools) != 2 {
-		t.Fatalf("tools length = %d, want 2; body=%s", len(tools), prepared.body)
+	if len(tools) != 1 {
+		t.Fatalf("tools length = %d, want 1; body=%s", len(tools), prepared.body)
 	}
 	foundLookup := false
-	foundXSearch := false
 	for _, tool := range tools {
 		switch tool.Get("type").String() {
 		case "function":
 			if tool.Get("name").String() == "lookup" {
 				foundLookup = true
 			}
-		case "x_search":
-			foundXSearch = true
 		case "image_generation":
 			t.Fatalf("image_generation must be removed; body=%s", prepared.body)
 		}
 	}
-	if !foundLookup || !foundXSearch {
-		t.Fatalf("expected lookup + x_search tools; body=%s", prepared.body)
+	if !foundLookup {
+		t.Fatalf("expected lookup tool; body=%s", prepared.body)
 	}
 
 	allowed := gjson.GetBytes(prepared.body, "tool_choice.tools").Array()
-	if len(allowed) != 2 {
-		t.Fatalf("tool_choice.tools length = %d, want 2; body=%s", len(allowed), prepared.body)
+	if len(allowed) != 1 {
+		t.Fatalf("tool_choice.tools length = %d, want 1; body=%s", len(allowed), prepared.body)
 	}
 	if got := allowed[0].Get("name").String(); got != "lookup" {
 		t.Fatalf("tool_choice.tools.0.name = %q, want lookup; body=%s", got, prepared.body)
-	}
-	if got := allowed[1].Get("type").String(); got != "x_search" {
-		t.Fatalf("tool_choice.tools.1.type = %q, want x_search; body=%s", got, prepared.body)
 	}
 	for _, tool := range allowed {
 		if tool.Get("type").String() == "image_generation" {
@@ -823,7 +804,7 @@ func TestXAIExecutorPrepareAllowedToolsSyncsInjectedXSearch(t *testing.T) {
 	}
 }
 
-func TestXAIExecutorPreparePreservesExplicitToolChoiceNoneAfterXSearchInject(t *testing.T) {
+func TestXAIExecutorPrepareDropsParallelToolCallsWithoutToolsEvenForExplicitNone(t *testing.T) {
 	t.Parallel()
 
 	exec := NewXAIExecutor(&config.Config{})
@@ -833,7 +814,7 @@ func TestXAIExecutorPreparePreservesExplicitToolChoiceNoneAfterXSearchInject(t *
 			"model":"grok-4.5",
 			"input":"answer without tools",
 			"tool_choice":"none",
-			"parallel_tool_calls":false
+			"parallel_tool_calls":true
 		}`),
 	}, cliproxyexecutor.Options{
 		SourceFormat: sdktranslator.FormatCodex,
@@ -843,15 +824,14 @@ func TestXAIExecutorPreparePreservesExplicitToolChoiceNoneAfterXSearchInject(t *
 		t.Fatalf("prepareResponsesRequest() error = %v", err)
 	}
 
-	if got := gjson.GetBytes(prepared.body, "tools.0.type").String(); got != "x_search" {
-		t.Fatalf("tools.0.type = %q, want x_search; body=%s", got, prepared.body)
+	if gjson.GetBytes(prepared.body, "tools").Exists() {
+		t.Fatalf("tool_choice:none request gained a tool: %s", prepared.body)
 	}
 	if got := gjson.GetBytes(prepared.body, "tool_choice").String(); got != "none" {
 		t.Fatalf("tool_choice = %q, want none; body=%s", got, prepared.body)
 	}
-	parallelToolCalls := gjson.GetBytes(prepared.body, "parallel_tool_calls")
-	if !parallelToolCalls.Exists() || parallelToolCalls.Bool() {
-		t.Fatalf("parallel_tool_calls = %s, want explicit false; body=%s", parallelToolCalls.Raw, prepared.body)
+	if gjson.GetBytes(prepared.body, "parallel_tool_calls").Exists() {
+		t.Fatalf("parallel_tool_calls should be removed when tools are absent: %s", prepared.body)
 	}
 }
 
@@ -2033,8 +2013,8 @@ func TestXAIExecutorExecuteStreamFiltersToolSearchTool(t *testing.T) {
 	}
 
 	tools := gjson.GetBytes(gotBody, "tools").Array()
-	if len(tools) != 6 {
-		t.Fatalf("tools length = %d, want 6; body=%s", len(tools), string(gotBody))
+	if len(tools) != 5 {
+		t.Fatalf("tools length = %d, want 5; body=%s", len(tools), string(gotBody))
 	}
 	if gjson.GetBytes(gotBody, "input.0.content").Exists() {
 		t.Fatalf("input.0.content exists, want removed; body=%s", string(gotBody))
@@ -2056,7 +2036,6 @@ func TestXAIExecutorExecuteStreamFiltersToolSearchTool(t *testing.T) {
 	}
 	foundAutomationUpdate := false
 	foundNamespaceCustom := false
-	foundXSearch := false
 	for i, tool := range tools {
 		toolType := tool.Get("type").String()
 		if toolType == "image_generation" {
@@ -2077,9 +2056,6 @@ func TestXAIExecutorExecuteStreamFiltersToolSearchTool(t *testing.T) {
 		case "codex_app__namespace_custom":
 			foundNamespaceCustom = true
 		}
-		if toolType == "x_search" {
-			foundXSearch = true
-		}
 		if toolType == "web_search" {
 			if tool.Get("external_web_access").Exists() {
 				t.Fatalf("tools.%d.external_web_access exists, want removed; body=%s", i, string(gotBody))
@@ -2094,9 +2070,6 @@ func TestXAIExecutorExecuteStreamFiltersToolSearchTool(t *testing.T) {
 	}
 	if !foundNamespaceCustom {
 		t.Fatalf("namespace custom tool was not moved to top-level tools; body=%s", string(gotBody))
-	}
-	if !foundXSearch {
-		t.Fatalf("native x_search tool was not injected; body=%s", string(gotBody))
 	}
 }
 
@@ -3255,6 +3228,35 @@ func TestNormalizeXAIToolChoiceForTools_DropsOrphanedParallelToolCalls(t *testin
 
 	if gjson.GetBytes(out, "parallel_tool_calls").Exists() {
 		t.Fatalf("parallel_tool_calls should be removed when tools missing even without tool_choice: %s", string(out))
+	}
+}
+
+func TestNormalizeXAIToolChoiceForTools_PreservesNoneButDropsParallelCallsWithoutTools(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "tools missing",
+			body: []byte(`{"model":"grok-4","tool_choice":"none","parallel_tool_calls":true,"input":"hi"}`),
+		},
+		{
+			name: "tools empty",
+			body: []byte(`{"model":"grok-4","tools":[],"tool_choice":"none","parallel_tool_calls":true,"input":"hi"}`),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			out := normalizeXAIToolChoiceForTools(tt.body)
+
+			if got := gjson.GetBytes(out, "tool_choice").String(); got != "none" {
+				t.Fatalf("tool_choice = %q, want none: %s", got, out)
+			}
+			if gjson.GetBytes(out, "parallel_tool_calls").Exists() {
+				t.Fatalf("parallel_tool_calls should be removed without tools: %s", out)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -625,6 +625,10 @@ func TestXAIExecutorPrepareFailsClosedWhenRestrictedChoiceIsOrphaned(t *testing.
 			toolChoice: `{"type":"allowed_tools","tools":[{"type":"image_generation"}]}`,
 		},
 		{
+			name:       "empty allowed tools",
+			toolChoice: `{"type":"allowed_tools","tools":[]}`,
+		},
+		{
 			name:       "forced tool",
 			toolChoice: `{"type":"image_generation"}`,
 		},


### PR DESCRIPTION
## 结果

xAI Responses request preparation 不再在客户端未授权时静默注入 native `x_search`，不再扩张 restricted `allowed_tools`，并在显式限制为空、malformed 或目标全部被 normalization 删除时 fail closed 为 `tool_choice: "none"`，避免剩余工具回到默认 `auto` 后获得调用机会。

## 变更

- 删除 unconditional `x_search` injection 与 allowlist expansion。
- 保留显式 `tool_choice: "none"`；最终没有工具时删除无意义的 `parallel_tool_calls`。
- custom declaration 与 forced/allowed choice 先同步 canonicalize 为 xAI function shape，再做 orphan pruning。
- partially valid `allowed_tools` 只保留仍存在的目标。
- empty、malformed、全部 orphaned 的 `allowed_tools`，以及 orphaned forced choice，均改为显式 `none`；不得通过删除 `tool_choice` 恢复默认 `auto`。
- 保留客户端显式声明 `x_search` 时的既有 internal trace filter。
- 更新 LTS patch contract 与 fail-closed regression。

## 兼容性与行为边界

- Branch baseline：`04c59973e63b9e492e4253bea5ab08af8ada035b`；exact validated head：`4f68b37fc53bb414b73a9fea5278b71b03c78b47`；target `main`：`cc349380fb500c2d552da495a48dd78ee31ccc5c`。
- 这是有意的权限收紧：过去依赖 Core 自动授予 `x_search` 的请求现在必须显式声明该工具。
- orphaned/empty restriction 会得到 `tool_choice: "none"` 而不是被静默删除；仍存活的其他 tool declaration 不会因此变为可调用。
- HTTP、stream 与 WebSocket 共用 `prepareResponsesRequestTo`，采用相同权限规则。
- 不修改 xAI auth、response schema、usage schema、release 或 deployment。

## exact-head 验证

- red-first `TestXAIExecutorPrepareFailsClosedWhenRestrictedChoiceIsOrphaned`：orphaned restriction 修复前失败，修复后 passed。
- empty `allowed_tools.tools: []` + surviving unrelated tool regression：修复前失败，修复后 passed。
- `go test ./internal/runtime/executor -count=1`：passed。
- `go test ./... -count=1`：passed。
- `scripts/check-lts-contract.sh`：passed。
- `go build -o /dev/null ./cmd/server`：passed。
- `git diff --check`：passed。
- GitHub exact-head checks：6/6 `SUCCESS`（agents guard、LTS contract、full test observation、build、Windows credential permissions、translator path guard）。
- 独立只读复查：PASS；GitHub unresolved review threads：0。

## 剩余风险

未向付费 xAI endpoint 发送 live request；验证覆盖本地 HTTP/stream/WebSocket preparation 与 response filtering。客户端若需要搜索，必须显式提供 `x_search` 或受支持的 search tool。本 PR 未创建 tag、release 或 deployment。

## Review focus

1. custom choice canonicalization 与 orphan pruning 顺序；
2. empty 或全部失效的 restricted allowlist 在其他 tool 仍存活时必须保持 `none`；
3. `tool_choice: none`、无工具 payload 与 `parallel_tool_calls` 清理；
4. HTTP/stream/WebSocket 共用路径没有重新注入或扩张权限。
