### PR TITLE
fix(antigravity): 避免混合工具名称被二次还原

### DIFF
--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_response.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_response.go
@@ -242,7 +242,10 @@ func ConvertAntigravityResponseToOpenAINonStream(ctx context.Context, modelName 
 	responseResult := gjson.GetBytes(rawJSON, "response")
 	if responseResult.Exists() {
 		responseJSON := restoreAntigravityOpenAIFunctionNames([]byte(responseResult.Raw), originalRequestRawJSON)
-		return ConvertGeminiResponseToOpenAINonStream(ctx, modelName, originalRequestRawJSON, requestRawJSON, responseJSON, param)
+		// Function names have already been restored with the collision-aware map.
+		// Do not pass the original request into the generic converter, whose legacy
+		// Claude-style map would otherwise restore mixed tool declarations twice.
+		return ConvertGeminiResponseToOpenAINonStream(ctx, modelName, nil, requestRawJSON, responseJSON, param)
 	}
 	return []byte{}
 }

--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_response_test.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_response_test.go
@@ -144,6 +144,23 @@ func TestConvertAntigravityResponseToOpenAINonStreamRestoresDisambiguatedName(t 
 	}
 }
 
+func TestConvertAntigravityResponseToOpenAINonStreamDoesNotRestoreMixedToolShapeTwice(t *testing.T) {
+	original := []byte(`{"tools":[
+		{"type":"function","name":"a b","function":{"name":"a_b"}},
+		{"type":"function","function":{"name":"a b"}}
+	]}`)
+	mapped := util.SanitizedFunctionNameMap(original)["a_b"]
+	if mapped == "" || mapped == "a_b" {
+		t.Fatalf("expected collision-aware mapped name for a_b, got %q", mapped)
+	}
+	responseJSON := []byte(`{"response":{"candidates":[{"content":{"parts":[{"functionCall":{"name":"` + mapped + `","args":{}}}]}}]}}`)
+
+	output := ConvertAntigravityResponseToOpenAINonStream(context.Background(), "gemini-3-flash", original, nil, responseJSON, nil)
+	if got := gjson.GetBytes(output, "choices.0.message.tool_calls.0.function.name").String(); got != "a_b" {
+		t.Fatalf("function.name = %q, want a_b. Output: %s", got, output)
+	}
+}
+
 func TestConvertAntigravityResponseToOpenAINonStreamIncludesReasoningContent(t *testing.T) {
 	ctx := context.Background()
 	responseJSON := []byte(`{


### PR DESCRIPTION
## 结果与边界

修复 Antigravity non-stream OpenAI chat-completions response 在混合 tool declaration 下重复还原 function name 的问题。当前 PR 相对最新 `main` 仍严格只有两个 translator 文件；不包含已关闭的 runtime/auth PR #192，也不修改 streaming、auth、usage、provider runtime、公共 API、release 或 deployment。

## 修改

- `restoreAntigravityOpenAIFunctionNames` 先使用 collision-aware map 完成一次还原。
- 调用 generic Gemini non-stream converter 时不再传入原始 request，避免 legacy sanitized-name map 对同一个名称二次还原。
- 新增 mixed top-level/function tool shape collision regression，固定最终 function name 只还原一次。

## Exact head

- Base：`14b685e7219ca6b52b863a40a7dbe790faaa4611`
- Head：`d4b49aec888f6a9911b6787350b9794c17dbf603`
- Base-to-head diff：2 files，21 insertions，1 deletion

## 本地验证

以下命令在当前 exact head 通过：

- `go test ./internal/translator/antigravity/openai/chat-completions -count=1`
- `go test ./... -count=1`
- `scripts/check-lts-contract.sh`
- `go build -o /dev/null ./cmd/server`
- `git diff --check origin/main...HEAD`

Fresh GitHub checks 已由本次 push 触发，当前仍需等待全部 terminal success；通过前不得合并。还需一次针对当前 exact head 的独立只读 review PASS，并确认 unresolved review threads 为零。

## Review focus

请确认 generic converter 的 `originalRequestRawJSON` 在此调用路径仅用于 legacy sanitized-name map；传 `nil` 不影响 content、usage、reasoning、image、finish reason 或其他 response projection。

当前状态仅为 branch 已推送、PR open；尚未 merge、tag、release、生成 artifact、deployment 或验证 runtime。
