### PR TITLE
fix(store): 加固 Object Store 凭据路径操作

### DIFF
--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -42,4 +42,4 @@ jobs:
       - name: Verify credential DACL hardening
         run: go test ./internal/misc -run TestOpenCredentialFileRestrictsAccessToCurrentUser -count=1
       - name: Verify Object Store Windows auth hardening
-        run: go test -v ./internal/store -run 'TestSecureAuthFileWindows|TestRenderAuthStorageLocksWindowsStagingPaths' -count=1
+        run: go test -v ./internal/store -run 'TestSecureAuthFileWindows|TestRenderAuthStorageLocksWindowsStaging' -count=1

--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -41,3 +41,5 @@ jobs:
           cache: true
       - name: Verify credential DACL hardening
         run: go test ./internal/misc -run TestOpenCredentialFileRestrictsAccessToCurrentUser -count=1
+      - name: Verify Object Store Windows auth hardening
+        run: go test -v ./internal/store -run 'TestSecureAuthFileWindows|TestRenderAuthStorageLocksWindowsStagingPaths' -count=1

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -531,7 +531,7 @@ patches:
     retire_when: Upstream bounds encoded public API request bodies and every decoded Content-Encoding layer, returns 413 for limit violations without bypassing the limit through raw-JSON fallback, routes all affected handlers through the shared bounded reader, and all listed regressions pass after removing the downstream implementation.
 
   - id: object-store-auth-path-containment
-    reason: Object-store auth persistence must never create, overwrite, upload, or delete files outside its managed auth mirror, including traversal, sibling-prefix, absolute-path, pre-existing or dangling symlinks, junctions, and check/write path-swap races.
+    reason: Object-store auth persistence must never create, overwrite, upload, delete, or render credential files outside its managed private roots, including traversal, sibling-prefix, absolute-path, pre-existing or dangling symlinks, junctions, initialized-root replacement, check/write path-swap races, and crash-persistent global-temp copies.
     introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
     affected_upstream_range: through 53c1e7e2dd6ddf973098a4e685e852aeebed9fe3 (v7.2.92); upstream accepts caller-provided absolute auth paths and computes object keys from unchecked filepath.Rel results, so paths outside the mirror can reach local file and remote object operations.
     files:
@@ -560,6 +560,7 @@ patches:
       - TestObjectTokenStoreUploadRejectsPathSwapWithoutExternalReadOrUpload
       - TestObjectTokenStoreUploadMissingAuthDeletesRemoteObject
       - TestObjectTokenStoreListSkipsPathSwappedExternalAuth
+      - TestObjectTokenStoreRejectsAuthRootReplacementAfterPreflight
       - TestRenderAuthStoragePrefersPathFreeRawJSON
       - TestRenderAuthStorageUsesAnonymousDescriptorPath
       - TestSecureAuthOperationsRejectAncestorSymlinkSwap
@@ -568,10 +569,11 @@ patches:
     # Windows-only regression functions are build-tagged and therefore cannot
     # be listed by the host-platform registry guard. The windows-latest job in
     # pr-test-build.yml runs both TestSecureAuthFileWindows* and the isolated
-    # renderer path-lock regression natively and exposes any junction skip.
+    # renderer path-lock, managed-staging cleanup/root-identity regressions
+    # natively and exposes any junction skip.
     upstream_issue_or_pr: not-filed
     state: required
-    retire_when: Upstream validates every object-store auth save, delete, upload, mirror, list, and watcher persistence path against lexical containment; performs actual reads, writes, and deletes with descriptor- or handle-relative no-follow traversal on POSIX and Windows; renders legacy path-based storage through a non-redirectable descriptor or locked handle while preferring path-free storage output; rejects ancestor swaps, symlinks, junctions, reparse points, and final-path replacement; preserves nested auth files; runs the Windows handle implementation natively in CI; and all listed regressions pass without the downstream patch.
+    retire_when: Upstream validates every object-store auth save, delete, upload, mirror, list, and watcher persistence path against lexical containment; pins the initialized auth-root filesystem identity and performs actual reads, writes, and deletes with descriptor- or handle-relative no-follow traversal on POSIX and Windows; renders legacy path-based storage through an anonymous descriptor or a locked, identity-pinned managed private staging root with startup crash-residue cleanup while preferring path-free storage output; rejects ancestor swaps, initialized-root replacement, symlinks, junctions, reparse points, and final-path replacement; preserves nested auth files; runs the Windows handle implementation natively in CI; and all listed regressions pass without the downstream patch.
 
   - id: auth-token-private-file-permissions
     reason: OAuth tokens and service-account credentials must be created with owner-only permissions and must tighten pre-existing wider files before replacing their contents.

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -535,9 +535,16 @@ patches:
     introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
     affected_upstream_range: through 53c1e7e2dd6ddf973098a4e685e852aeebed9fe3 (v7.2.92); upstream accepts caller-provided absolute auth paths and computes object keys from unchecked filepath.Rel results, so paths outside the mirror can reach local file and remote object operations.
     files:
+      - .github/workflows/pr-test-build.yml
       - internal/store/objectstore.go
+      - internal/store/objectstore_render_posix.go
+      - internal/store/objectstore_render_posix_test.go
+      - internal/store/objectstore_render_windows.go
+      - internal/store/objectstore_render_windows_test.go
       - internal/store/objectstore_secure_posix.go
+      - internal/store/objectstore_secure_posix_test.go
       - internal/store/objectstore_secure_windows.go
+      - internal/store/objectstore_secure_windows_test.go
       - internal/store/objectstore_path_test.go
     regression_tests:
       - TestObjectTokenStoreRejectsAuthPathsOutsideAuthDir
@@ -553,9 +560,18 @@ patches:
       - TestObjectTokenStoreUploadRejectsPathSwapWithoutExternalReadOrUpload
       - TestObjectTokenStoreUploadMissingAuthDeletesRemoteObject
       - TestObjectTokenStoreListSkipsPathSwappedExternalAuth
+      - TestRenderAuthStoragePrefersPathFreeRawJSON
+      - TestRenderAuthStorageUsesAnonymousDescriptorPath
+      - TestSecureAuthOperationsRejectAncestorSymlinkSwap
+      - TestSecureAuthRootRejectsAncestorDirectoryReplacement
+      - TestSecureAuthRootRejectsSymlinkLeaf
+    # Windows-only regression functions are build-tagged and therefore cannot
+    # be listed by the host-platform registry guard. The windows-latest job in
+    # pr-test-build.yml runs both TestSecureAuthFileWindows* and the isolated
+    # renderer path-lock regression natively and exposes any junction skip.
     upstream_issue_or_pr: not-filed
     state: required
-    retire_when: Upstream validates every object-store auth save, delete, upload, mirror, list, and watcher persistence path against lexical containment and performs actual reads, writes, and deletes with descriptor- or handle-relative no-follow traversal on POSIX and Windows, rejects symlink, junction, and path-swap escapes, preserves nested auth files, and all listed regressions pass without the downstream patch.
+    retire_when: Upstream validates every object-store auth save, delete, upload, mirror, list, and watcher persistence path against lexical containment; performs actual reads, writes, and deletes with descriptor- or handle-relative no-follow traversal on POSIX and Windows; renders legacy path-based storage through a non-redirectable descriptor or locked handle while preferring path-free storage output; rejects ancestor swaps, symlinks, junctions, reparse points, and final-path replacement; preserves nested auth files; runs the Windows handle implementation natively in CI; and all listed regressions pass without the downstream patch.
 
   - id: auth-token-private-file-permissions
     reason: OAuth tokens and service-account credentials must be created with owner-only permissions and must tighten pre-existing wider files before replacing their contents.

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -531,19 +531,31 @@ patches:
     retire_when: Upstream bounds encoded public API request bodies and every decoded Content-Encoding layer, returns 413 for limit violations without bypassing the limit through raw-JSON fallback, routes all affected handlers through the shared bounded reader, and all listed regressions pass after removing the downstream implementation.
 
   - id: object-store-auth-path-containment
-    reason: Object-store auth persistence must never create, overwrite, upload, or delete files outside its managed auth mirror, including traversal, sibling-prefix, absolute-path, and symlink escapes.
+    reason: Object-store auth persistence must never create, overwrite, upload, or delete files outside its managed auth mirror, including traversal, sibling-prefix, absolute-path, pre-existing or dangling symlinks, junctions, and check/write path-swap races.
     introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
     affected_upstream_range: through 53c1e7e2dd6ddf973098a4e685e852aeebed9fe3 (v7.2.92); upstream accepts caller-provided absolute auth paths and computes object keys from unchecked filepath.Rel results, so paths outside the mirror can reach local file and remote object operations.
     files:
       - internal/store/objectstore.go
+      - internal/store/objectstore_secure_posix.go
+      - internal/store/objectstore_secure_windows.go
       - internal/store/objectstore_path_test.go
     regression_tests:
       - TestObjectTokenStoreRejectsAuthPathsOutsideAuthDir
       - TestObjectTokenStoreAcceptsNestedAuthPathInsideAuthDir
       - TestObjectTokenStoreRejectsSiblingPrefixAndSymlinkEscapes
+      - TestObjectTokenStoreRejectsDanglingLeafSymlinkBeforeCredentialWrite
+      - TestObjectTokenStoreRejectsDirectorySymlinkSwappedAfterValidation
+      - TestObjectTokenStoreMirrorWriteRejectsDirectorySymlinkSwappedAfterValidation
+      - TestRenderAuthStoragePreservesNoOpWriter
+      - TestObjectTokenStoreSecureWriterInstallsNestedAuthFile
+      - TestObjectTokenStoreSecureWriterSupportsLongAuthFileName
+      - TestObjectTokenStoreDeleteRejectsPathSwapWithoutRemoteDelete
+      - TestObjectTokenStoreUploadRejectsPathSwapWithoutExternalReadOrUpload
+      - TestObjectTokenStoreUploadMissingAuthDeletesRemoteObject
+      - TestObjectTokenStoreListSkipsPathSwappedExternalAuth
     upstream_issue_or_pr: not-filed
     state: required
-    retire_when: Upstream validates every object-store auth save, delete, upload, and watcher persistence path against both lexical and resolved filesystem containment, rejects symlink escapes, preserves nested auth files, and all listed regressions pass without the downstream implementation.
+    retire_when: Upstream validates every object-store auth save, delete, upload, mirror, list, and watcher persistence path against lexical containment and performs actual reads, writes, and deletes with descriptor- or handle-relative no-follow traversal on POSIX and Windows, rejects symlink, junction, and path-swap escapes, preserves nested auth files, and all listed regressions pass without the downstream patch.
 
   - id: auth-token-private-file-permissions
     reason: OAuth tokens and service-account credentials must be created with owner-only permissions and must tighten pre-existing wider files before replacing their contents.

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -565,6 +565,7 @@ patches:
       - TestObjectTokenStoreUploadMissingAuthDeletesRemoteObject
       - TestObjectTokenStoreListSkipsPathSwappedExternalAuth
       - TestObjectTokenStoreRejectsAuthRootReplacementAfterPreflight
+      - TestObjectTokenStoreSaveRejectsAuthRootRemovalBeforeUpload
       - TestRenderAuthStoragePrefersPathFreeRawJSON
       - TestRenderAuthStorageUsesAnonymousDescriptorPath
       - TestSecureAuthOperationsRejectAncestorSymlinkSwap

--- a/internal/store/auth_metadata_test.go
+++ b/internal/store/auth_metadata_test.go
@@ -64,8 +64,8 @@ func TestObjectTokenStoreReadAuthFileHydratesMetadata(t *testing.T) {
 		t.Fatalf("write auth file: %v", err)
 	}
 
-	store := &ObjectTokenStore{}
-	auth, err := store.readAuthFile(path, dir)
+	store := &ObjectTokenStore{authDir: dir, authRoot: mustCaptureSecureAuthRootIdentity(t, dir)}
+	auth, err := store.readAuthFile(path)
 	if err != nil {
 		t.Fatalf("readAuthFile() error: %v", err)
 	}

--- a/internal/store/objectstore.go
+++ b/internal/store/objectstore.go
@@ -27,6 +27,11 @@ const (
 	objectStoreAuthPrefix = "auths"
 )
 
+var (
+	errObjectStoreAuthRootIdentityUnavailable = errors.New("object store: auth root identity is not initialized")
+	errObjectStoreAuthRootChanged             = errors.New("object store: auth root identity changed after initialization")
+)
+
 // ObjectStoreConfig captures configuration for the object storage-backed token store.
 type ObjectStoreConfig struct {
 	Endpoint  string
@@ -48,6 +53,9 @@ type ObjectTokenStore struct {
 	spoolRoot  string
 	configPath string
 	authDir    string
+	authRoot   secureAuthRootIdentity
+	renderDir  string
+	renderRoot secureAuthRootIdentity
 	mu         sync.Mutex
 
 	// beforeAuthWriteHook is a test seam for validating path-swap resistance.
@@ -99,6 +107,14 @@ func NewObjectTokenStore(cfg ObjectStoreConfig) (*ObjectTokenStore, error) {
 	if err = os.MkdirAll(authDir, 0o700); err != nil {
 		return nil, fmt.Errorf("object store: create auth directory: %w", err)
 	}
+	authRoot, err := captureSecureAuthRootIdentity(authDir)
+	if err != nil {
+		return nil, fmt.Errorf("object store: pin auth directory identity: %w", err)
+	}
+	renderDir, renderRoot, err := prepareAuthRenderStaging(absRoot)
+	if err != nil {
+		return nil, fmt.Errorf("object store: prepare auth render staging: %w", err)
+	}
 
 	options := &minio.Options{
 		Creds:  credentials.NewStaticV4(cfg.AccessKey, cfg.SecretKey, ""),
@@ -120,6 +136,9 @@ func NewObjectTokenStore(cfg ObjectStoreConfig) (*ObjectTokenStore, error) {
 		spoolRoot:  absRoot,
 		configPath: filepath.Join(configDir, "config.yaml"),
 		authDir:    authDir,
+		authRoot:   authRoot,
+		renderDir:  renderDir,
+		renderRoot: renderRoot,
 	}, nil
 }
 
@@ -182,7 +201,7 @@ func (s *ObjectTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (s
 		if s.beforeAuthReadHook != nil {
 			s.beforeAuthReadHook()
 		}
-		_, _, errRead := secureReadAuthFile(s.authDir, rel)
+		_, _, errRead := secureReadAuthFile(s.authDir, s.authRoot, rel)
 		if errors.Is(errRead, fs.ErrNotExist) {
 			return "", nil
 		}
@@ -209,7 +228,7 @@ func (s *ObjectTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (s
 		if setter, ok := auth.Storage.(interface{ SetMetadata(map[string]any) }); ok {
 			setter.SetMetadata(auth.Metadata)
 		}
-		raw, writeLocal, err = renderAuthStorage(auth.Storage)
+		raw, writeLocal, err = renderAuthStorage(auth.Storage, s.renderDir, s.renderRoot)
 		if err != nil {
 			return "", err
 		}
@@ -220,7 +239,7 @@ func (s *ObjectTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (s
 		if errMarshal != nil {
 			return "", fmt.Errorf("object store: marshal metadata: %w", errMarshal)
 		}
-		if existing, _, errRead := secureReadAuthFile(s.authDir, rel); errRead == nil {
+		if existing, _, errRead := secureReadAuthFile(s.authDir, s.authRoot, rel); errRead == nil {
 			if jsonEqual(existing, raw) {
 				return path, nil
 			}
@@ -234,7 +253,7 @@ func (s *ObjectTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (s
 		if s.beforeAuthWriteHook != nil {
 			s.beforeAuthWriteHook()
 		}
-		if err = secureWriteAuthFile(s.authDir, rel, raw); err != nil {
+		if err = secureWriteAuthFile(s.authDir, s.authRoot, rel, raw); err != nil {
 			return "", fmt.Errorf("object store: write auth file: %w", err)
 		}
 	}
@@ -261,6 +280,9 @@ func (s *ObjectTokenStore) List(_ context.Context) ([]*cliproxyauth.Auth, error)
 	if dir == "" {
 		return nil, fmt.Errorf("object store: auth directory not configured")
 	}
+	if err := validateSecureAuthRootPath(dir, s.authRoot); err != nil {
+		return nil, fmt.Errorf("object store: validate auth directory: %w", err)
+	}
 	entries := make([]*cliproxyauth.Auth, 0, 32)
 	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -272,7 +294,7 @@ func (s *ObjectTokenStore) List(_ context.Context) ([]*cliproxyauth.Auth, error)
 		if !strings.HasSuffix(strings.ToLower(d.Name()), ".json") {
 			return nil
 		}
-		auth, err := s.readAuthFile(path, dir)
+		auth, err := s.readAuthFile(path)
 		if err != nil {
 			log.WithError(err).Warnf("object store: skip auth %s", path)
 			return nil
@@ -309,7 +331,7 @@ func (s *ObjectTokenStore) Delete(ctx context.Context, id string) error {
 	if s.beforeAuthDeleteHook != nil {
 		s.beforeAuthDeleteHook()
 	}
-	if err = secureRemoveAuthFile(s.authDir, rel); err != nil && !errors.Is(err, fs.ErrNotExist) {
+	if err = secureRemoveAuthFile(s.authDir, s.authRoot, rel); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("object store: delete auth file: %w", err)
 	}
 	if err = s.deleteAuthObjectRelative(ctx, rel); err != nil {
@@ -479,13 +501,13 @@ func (s *ObjectTokenStore) writeAuthMirrorFile(relativePath string, data []byte)
 	if s.beforeAuthWriteHook != nil {
 		s.beforeAuthWriteHook()
 	}
-	if err = secureWriteAuthFile(s.authDir, relativePath, data); err != nil {
+	if err = secureWriteAuthFile(s.authDir, s.authRoot, relativePath, data); err != nil {
 		return "", err
 	}
 	return local, nil
 }
 
-func renderAuthStorage(storage interface{ SaveTokenToFile(string) error }) ([]byte, bool, error) {
+func renderAuthStorage(storage interface{ SaveTokenToFile(string) error }, stagingDir string, stagingRoot secureAuthRootIdentity) ([]byte, bool, error) {
 	// Plugin-backed storage can already render its merged JSON without touching
 	// a pathname. Prefer that capability so atomic path writers do not need a
 	// compatibility staging path at all.
@@ -498,7 +520,7 @@ func renderAuthStorage(storage interface{ SaveTokenToFile(string) error }) ([]by
 	// Legacy TokenStorage exposes only SaveTokenToFile. The OS-specific renderer
 	// gives it a non-redirectable target: an unlinked descriptor alias on POSIX,
 	// or a pre-opened file beneath rename/delete-locked handles on Windows.
-	return renderAuthStorageIsolated(storage)
+	return renderAuthStorageIsolated(storage, stagingDir, stagingRoot)
 }
 
 func (s *ObjectTokenStore) uploadAuth(ctx context.Context, path string) error {
@@ -512,7 +534,7 @@ func (s *ObjectTokenStore) uploadAuth(ctx context.Context, path string) error {
 	if s.beforeAuthReadHook != nil {
 		s.beforeAuthReadHook()
 	}
-	data, _, err := secureReadAuthFile(s.authDir, rel)
+	data, _, err := secureReadAuthFile(s.authDir, s.authRoot, rel)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return s.deleteAuthObjectRelative(ctx, rel)
@@ -702,15 +724,15 @@ func ensureResolvedPathWithin(baseDir, path string) error {
 	return nil
 }
 
-func (s *ObjectTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth, error) {
+func (s *ObjectTokenStore) readAuthFile(path string) (*cliproxyauth.Auth, error) {
 	if s.beforeAuthReadHook != nil {
 		s.beforeAuthReadHook()
 	}
-	rel, err := filepath.Rel(baseDir, path)
+	rel, err := filepath.Rel(s.authDir, path)
 	if err != nil {
 		return nil, fmt.Errorf("resolve auth relative path: %w", err)
 	}
-	data, info, err := secureReadAuthFile(baseDir, rel)
+	data, info, err := secureReadAuthFile(s.authDir, s.authRoot, rel)
 	if err != nil {
 		return nil, fmt.Errorf("read file: %w", err)
 	}
@@ -726,7 +748,7 @@ func (s *ObjectTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Aut
 		provider = "unknown"
 	}
 	rel = normalizeAuthID(rel)
-	localPath := filepath.Join(baseDir, rel)
+	localPath := filepath.Join(s.authDir, rel)
 	attr := map[string]string{
 		cliproxyauth.AttributePath:          localPath,
 		cliproxyauth.AttributeSourceBackend: cliproxyauth.AuthSourceObjectStore,

--- a/internal/store/objectstore.go
+++ b/internal/store/objectstore.go
@@ -30,7 +30,16 @@ const (
 var (
 	errObjectStoreAuthRootIdentityUnavailable = errors.New("object store: auth root identity is not initialized")
 	errObjectStoreAuthRootChanged             = errors.New("object store: auth root identity changed after initialization")
+	errObjectStoreAuthRootUnavailable         = errors.New("object store: initialized auth root is unavailable")
+	errObjectStoreSpoolRootChanged            = errors.New("object store: spool root identity changed during initialization")
 )
+
+func secureAuthRootOpenError(err error, expected secureAuthRootIdentity) error {
+	if err == nil || !expected.valid {
+		return err
+	}
+	return fmt.Errorf("%w: %v", errObjectStoreAuthRootUnavailable, err)
+}
 
 // ObjectStoreConfig captures configuration for the object storage-backed token store.
 type ObjectStoreConfig struct {
@@ -107,11 +116,15 @@ func NewObjectTokenStore(cfg ObjectStoreConfig) (*ObjectTokenStore, error) {
 	if err = os.MkdirAll(authDir, 0o700); err != nil {
 		return nil, fmt.Errorf("object store: create auth directory: %w", err)
 	}
+	spoolRootIdentity, err := captureSecureAuthRootIdentity(absRoot)
+	if err != nil {
+		return nil, fmt.Errorf("object store: pin spool directory identity: %w", err)
+	}
 	authRoot, err := captureSecureAuthRootIdentity(authDir)
 	if err != nil {
 		return nil, fmt.Errorf("object store: pin auth directory identity: %w", err)
 	}
-	renderDir, renderRoot, err := prepareAuthRenderStaging(absRoot)
+	renderDir, renderRoot, err := prepareAuthRenderStaging(absRoot, spoolRootIdentity)
 	if err != nil {
 		return nil, fmt.Errorf("object store: prepare auth render staging: %w", err)
 	}

--- a/internal/store/objectstore.go
+++ b/internal/store/objectstore.go
@@ -486,23 +486,19 @@ func (s *ObjectTokenStore) writeAuthMirrorFile(relativePath string, data []byte)
 }
 
 func renderAuthStorage(storage interface{ SaveTokenToFile(string) error }) ([]byte, bool, error) {
-	stagingDir, err := os.MkdirTemp("", "cpa-object-auth-*")
-	if err != nil {
-		return nil, false, fmt.Errorf("object store: create auth staging directory: %w", err)
-	}
-	defer func() { _ = os.RemoveAll(stagingDir) }()
-	stagingPath := filepath.Join(stagingDir, "credential.json")
-	if err = storage.SaveTokenToFile(stagingPath); err != nil {
-		return nil, false, err
-	}
-	raw, _, err := secureReadAuthFile(stagingDir, filepath.Base(stagingPath))
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return nil, false, nil
+	// Plugin-backed storage can already render its merged JSON without touching
+	// a pathname. Prefer that capability so atomic path writers do not need a
+	// compatibility staging path at all.
+	if renderer, ok := storage.(interface{ RawJSON() []byte }); ok {
+		if raw := bytes.Clone(renderer.RawJSON()); len(bytes.TrimSpace(raw)) > 0 {
+			return raw, true, nil
 		}
-		return nil, false, fmt.Errorf("object store: read staged auth file: %w", err)
 	}
-	return raw, true, nil
+
+	// Legacy TokenStorage exposes only SaveTokenToFile. The OS-specific renderer
+	// gives it a non-redirectable target: an unlinked descriptor alias on POSIX,
+	// or a pre-opened file beneath rename/delete-locked handles on Windows.
+	return renderAuthStorageIsolated(storage)
 }
 
 func (s *ObjectTokenStore) uploadAuth(ctx context.Context, path string) error {

--- a/internal/store/objectstore.go
+++ b/internal/store/objectstore.go
@@ -49,6 +49,11 @@ type ObjectTokenStore struct {
 	configPath string
 	authDir    string
 	mu         sync.Mutex
+
+	// beforeAuthWriteHook is a test seam for validating path-swap resistance.
+	beforeAuthWriteHook  func()
+	beforeAuthReadHook   func()
+	beforeAuthDeleteHook func()
 }
 
 // NewObjectTokenStore initializes an object storage backed token store.
@@ -170,18 +175,31 @@ func (s *ObjectTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (s
 	}
 
 	if auth.Disabled {
-		if _, statErr := os.Stat(path); errors.Is(statErr, fs.ErrNotExist) {
+		rel, errRel := s.authRelativePath(path)
+		if errRel != nil {
+			return "", fmt.Errorf("object store: resolve disabled auth path: %w", errRel)
+		}
+		if s.beforeAuthReadHook != nil {
+			s.beforeAuthReadHook()
+		}
+		_, _, errRead := secureReadAuthFile(s.authDir, rel)
+		if errors.Is(errRead, fs.ErrNotExist) {
 			return "", nil
+		}
+		if errRead != nil {
+			return "", fmt.Errorf("object store: inspect disabled auth file: %w", errRead)
 		}
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
-	if err = os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return "", fmt.Errorf("object store: create auth directory: %w", err)
+	rel, err := s.authRelativePath(path)
+	if err != nil {
+		return "", fmt.Errorf("object store: resolve auth relative path: %w", err)
 	}
 
+	var raw []byte
+	writeLocal := true
 	switch {
 	case auth.Storage != nil:
 		if auth.Metadata == nil {
@@ -191,31 +209,34 @@ func (s *ObjectTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (s
 		if setter, ok := auth.Storage.(interface{ SetMetadata(map[string]any) }); ok {
 			setter.SetMetadata(auth.Metadata)
 		}
-		if err = auth.Storage.SaveTokenToFile(path); err != nil {
+		raw, writeLocal, err = renderAuthStorage(auth.Storage)
+		if err != nil {
 			return "", err
 		}
 	case auth.Metadata != nil:
 		auth.Metadata["disabled"] = auth.Disabled
-		raw, errMarshal := json.Marshal(auth.Metadata)
+		var errMarshal error
+		raw, errMarshal = json.Marshal(auth.Metadata)
 		if errMarshal != nil {
 			return "", fmt.Errorf("object store: marshal metadata: %w", errMarshal)
 		}
-		if existing, errRead := os.ReadFile(path); errRead == nil {
+		if existing, _, errRead := secureReadAuthFile(s.authDir, rel); errRead == nil {
 			if jsonEqual(existing, raw) {
 				return path, nil
 			}
-		} else if errRead != nil && !errors.Is(errRead, fs.ErrNotExist) {
+		} else if !errors.Is(errRead, fs.ErrNotExist) {
 			return "", fmt.Errorf("object store: read existing metadata: %w", errRead)
-		}
-		tmp := path + ".tmp"
-		if errWrite := os.WriteFile(tmp, raw, 0o600); errWrite != nil {
-			return "", fmt.Errorf("object store: write temp auth file: %w", errWrite)
-		}
-		if errRename := os.Rename(tmp, path); errRename != nil {
-			return "", fmt.Errorf("object store: rename auth file: %w", errRename)
 		}
 	default:
 		return "", fmt.Errorf("object store: nothing to persist for %s", auth.ID)
+	}
+	if writeLocal {
+		if s.beforeAuthWriteHook != nil {
+			s.beforeAuthWriteHook()
+		}
+		if err = secureWriteAuthFile(s.authDir, rel, raw); err != nil {
+			return "", fmt.Errorf("object store: write auth file: %w", err)
+		}
 	}
 
 	if auth.Attributes == nil {
@@ -281,10 +302,17 @@ func (s *ObjectTokenStore) Delete(ctx context.Context, id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if err = os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+	rel, err := s.authRelativePath(path)
+	if err != nil {
+		return fmt.Errorf("object store: resolve auth relative path: %w", err)
+	}
+	if s.beforeAuthDeleteHook != nil {
+		s.beforeAuthDeleteHook()
+	}
+	if err = secureRemoveAuthFile(s.authDir, rel); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("object store: delete auth file: %w", err)
 	}
-	if err = s.deleteAuthObject(ctx, path); err != nil {
+	if err = s.deleteAuthObjectRelative(ctx, rel); err != nil {
 		return err
 	}
 	return nil
@@ -426,10 +454,6 @@ func (s *ObjectTokenStore) syncAuthFromBucket(ctx context.Context) error {
 			log.WithField("key", object.Key).Warn("object store: skip auth outside mirror")
 			continue
 		}
-		local := filepath.Join(s.authDir, cleanRel)
-		if err := os.MkdirAll(filepath.Dir(local), 0o700); err != nil {
-			return fmt.Errorf("object store: prepare auth subdir: %w", err)
-		}
 		reader, errGet := s.client.GetObject(ctx, s.cfg.Bucket, object.Key, minio.GetObjectOptions{})
 		if errGet != nil {
 			return fmt.Errorf("object store: download auth %s: %w", object.Key, errGet)
@@ -439,11 +463,46 @@ func (s *ObjectTokenStore) syncAuthFromBucket(ctx context.Context) error {
 		if errRead != nil {
 			return fmt.Errorf("object store: read auth %s: %w", object.Key, errRead)
 		}
-		if errWrite := os.WriteFile(local, data, 0o600); errWrite != nil {
-			return fmt.Errorf("object store: write auth %s: %w", local, errWrite)
+		_, errWrite := s.writeAuthMirrorFile(cleanRel, data)
+		if errWrite != nil {
+			return fmt.Errorf("object store: write auth %s: %w", cleanRel, errWrite)
 		}
 	}
 	return nil
+}
+
+func (s *ObjectTokenStore) writeAuthMirrorFile(relativePath string, data []byte) (string, error) {
+	local, err := s.authPath(relativePath)
+	if err != nil {
+		return "", err
+	}
+	if s.beforeAuthWriteHook != nil {
+		s.beforeAuthWriteHook()
+	}
+	if err = secureWriteAuthFile(s.authDir, relativePath, data); err != nil {
+		return "", err
+	}
+	return local, nil
+}
+
+func renderAuthStorage(storage interface{ SaveTokenToFile(string) error }) ([]byte, bool, error) {
+	stagingDir, err := os.MkdirTemp("", "cpa-object-auth-*")
+	if err != nil {
+		return nil, false, fmt.Errorf("object store: create auth staging directory: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(stagingDir) }()
+	stagingPath := filepath.Join(stagingDir, "credential.json")
+	if err = storage.SaveTokenToFile(stagingPath); err != nil {
+		return nil, false, err
+	}
+	raw, _, err := secureReadAuthFile(stagingDir, filepath.Base(stagingPath))
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("object store: read staged auth file: %w", err)
+	}
+	return raw, true, nil
 }
 
 func (s *ObjectTokenStore) uploadAuth(ctx context.Context, path string) error {
@@ -454,15 +513,18 @@ func (s *ObjectTokenStore) uploadAuth(ctx context.Context, path string) error {
 	if err != nil {
 		return fmt.Errorf("object store: resolve auth relative path: %w", err)
 	}
-	data, err := os.ReadFile(path)
+	if s.beforeAuthReadHook != nil {
+		s.beforeAuthReadHook()
+	}
+	data, _, err := secureReadAuthFile(s.authDir, rel)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return s.deleteAuthObject(ctx, path)
+			return s.deleteAuthObjectRelative(ctx, rel)
 		}
 		return fmt.Errorf("object store: read auth file: %w", err)
 	}
 	if len(data) == 0 {
-		return s.deleteAuthObject(ctx, path)
+		return s.deleteAuthObjectRelative(ctx, rel)
 	}
 	key := objectStoreAuthPrefix + "/" + filepath.ToSlash(rel)
 	return s.putObject(ctx, key, data, "application/json")
@@ -476,6 +538,10 @@ func (s *ObjectTokenStore) deleteAuthObject(ctx context.Context, path string) er
 	if err != nil {
 		return fmt.Errorf("object store: resolve auth relative path: %w", err)
 	}
+	return s.deleteAuthObjectRelative(ctx, rel)
+}
+
+func (s *ObjectTokenStore) deleteAuthObjectRelative(ctx context.Context, rel string) error {
 	key := objectStoreAuthPrefix + "/" + filepath.ToSlash(rel)
 	return s.deleteObject(ctx, key)
 }
@@ -599,39 +665,56 @@ func (s *ObjectTokenStore) authRelativePath(path string) (string, error) {
 }
 
 func ensureResolvedPathWithin(baseDir, path string) error {
-	// authDir is created with 0700 permissions. This rejects pre-existing
-	// symlink escapes; descriptor-relative no-follow I/O would be required to
-	// defend against a malicious same-user process swapping entries afterward.
-	resolvedBase, err := filepath.EvalSymlinks(baseDir)
+	// This preflight rejects pre-existing symlink components, including dangling
+	// leaf symlinks. Auth-file writes additionally use descriptor- or
+	// handle-relative no-follow I/O to close the check/write race.
+	absBase, err := filepath.Abs(baseDir)
 	if err != nil {
 		return fmt.Errorf("resolve auth directory: %w", err)
 	}
-	current := path
-	for {
-		resolvedCurrent, errResolve := filepath.EvalSymlinks(current)
-		if errResolve == nil {
-			rel, errRel := filepath.Rel(resolvedBase, resolvedCurrent)
-			if errRel != nil {
-				return errRel
-			}
-			if rel == ".." || filepath.IsAbs(rel) || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-				return fmt.Errorf("auth path %q resolves outside auth directory", path)
-			}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("resolve auth path %q: %w", path, err)
+	}
+	rel, err := filepath.Rel(absBase, absPath)
+	if err != nil {
+		return err
+	}
+	if rel == "." || rel == ".." || filepath.IsAbs(rel) || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("auth path %q escapes auth directory", path)
+	}
+
+	current := absBase
+	for _, component := range strings.Split(rel, string(os.PathSeparator)) {
+		if component == "" || component == "." {
+			continue
+		}
+		current = filepath.Join(current, component)
+		info, errLstat := os.Lstat(current)
+		if errors.Is(errLstat, fs.ErrNotExist) {
+			// Once a component is absent, no deeper pre-existing symlink can be
+			// traversed by the eventual create.
 			return nil
 		}
-		if !errors.Is(errResolve, fs.ErrNotExist) {
-			return fmt.Errorf("resolve auth path %q: %w", path, errResolve)
+		if errLstat != nil {
+			return fmt.Errorf("inspect auth path %q: %w", path, errLstat)
 		}
-		parent := filepath.Dir(current)
-		if parent == current {
-			return fmt.Errorf("resolve auth path %q: no existing parent", path)
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("auth path %q contains symlink component %q", path, current)
 		}
-		current = parent
 	}
+	return nil
 }
 
 func (s *ObjectTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth, error) {
-	data, err := os.ReadFile(path)
+	if s.beforeAuthReadHook != nil {
+		s.beforeAuthReadHook()
+	}
+	rel, err := filepath.Rel(baseDir, path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve auth relative path: %w", err)
+	}
+	data, info, err := secureReadAuthFile(baseDir, rel)
 	if err != nil {
 		return nil, fmt.Errorf("read file: %w", err)
 	}
@@ -646,17 +729,10 @@ func (s *ObjectTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Aut
 	if provider == "" {
 		provider = "unknown"
 	}
-	info, err := os.Stat(path)
-	if err != nil {
-		return nil, fmt.Errorf("stat auth file: %w", err)
-	}
-	rel, errRel := filepath.Rel(baseDir, path)
-	if errRel != nil {
-		rel = filepath.Base(path)
-	}
 	rel = normalizeAuthID(rel)
+	localPath := filepath.Join(baseDir, rel)
 	attr := map[string]string{
-		cliproxyauth.AttributePath:          path,
+		cliproxyauth.AttributePath:          localPath,
 		cliproxyauth.AttributeSourceBackend: cliproxyauth.AuthSourceObjectStore,
 	}
 	if email := strings.TrimSpace(valueAsString(metadata["email"])); email != "" {

--- a/internal/store/objectstore_path_test.go
+++ b/internal/store/objectstore_path_test.go
@@ -35,6 +35,12 @@ type noOpTokenStorage struct{}
 
 func (*noOpTokenStorage) SaveTokenToFile(string) error { return nil }
 
+type successfulTokenStorage struct{}
+
+func (*successfulTokenStorage) SaveTokenToFile(path string) error {
+	return os.WriteFile(path, []byte(`{"type":"test"}`), 0o600)
+}
+
 type rawJSONTokenStorage struct {
 	called bool
 }
@@ -458,7 +464,7 @@ func TestObjectTokenStoreRejectsAuthRootReplacementAfterPreflight(t *testing.T) 
 		},
 	}
 
-	for _, replacement := range []string{"symlink", "directory"} {
+	for _, replacement := range []string{"symlink", "directory", "missing"} {
 		for _, operation := range operations {
 			t.Run(replacement+"/"+operation.name, func(t *testing.T) {
 				remotePutCalls := 0
@@ -487,12 +493,14 @@ func TestObjectTokenStoreRejectsAuthRootReplacementAfterPreflight(t *testing.T) 
 					if err := os.WriteFile(localPath, []byte(`{"type":"local"}`), 0o600); err != nil {
 						t.Fatalf("write original auth: %v", err)
 					}
-					outsidePath := filepath.Join(replacementFixtureAuthDir, "team", "token.json")
-					if err := os.MkdirAll(filepath.Dir(outsidePath), 0o700); err != nil {
-						t.Fatalf("create replacement auth directory: %v", err)
-					}
-					if err := os.WriteFile(outsidePath, []byte(`{"type":"external"}`), 0o600); err != nil {
-						t.Fatalf("write replacement auth: %v", err)
+					if replacement != "missing" {
+						outsidePath := filepath.Join(replacementFixtureAuthDir, "team", "token.json")
+						if err := os.MkdirAll(filepath.Dir(outsidePath), 0o700); err != nil {
+							t.Fatalf("create replacement auth directory: %v", err)
+						}
+						if err := os.WriteFile(outsidePath, []byte(`{"type":"external"}`), 0o600); err != nil {
+							t.Fatalf("write replacement auth: %v", err)
+						}
 					}
 				}
 
@@ -503,11 +511,14 @@ func TestObjectTokenStoreRejectsAuthRootReplacementAfterPreflight(t *testing.T) 
 				if replacement == "directory" && !errors.Is(err, errObjectStoreAuthRootChanged) {
 					t.Fatalf("auth operation error = %v, want root identity change", err)
 				}
+				if replacement == "missing" && !errors.Is(err, errObjectStoreAuthRootUnavailable) {
+					t.Fatalf("auth operation error = %v, want unavailable initialized root", err)
+				}
 
 				replacementPath := filepath.Join(replacementObservedAuthDir, "team", "token.json")
-				if operation.name == "write" {
+				if operation.name == "write" || replacement == "missing" {
 					if _, err := os.Stat(replacementPath); !errors.Is(err, fs.ErrNotExist) {
-						t.Fatalf("write reached replacement auth root: %v", err)
+						t.Fatalf("operation reached unavailable/replacement auth root: %v", err)
 					}
 				} else if got, err := os.ReadFile(replacementPath); err != nil || string(got) != `{"type":"external"}` {
 					t.Fatalf("replacement auth changed: data=%q err=%v", got, err)
@@ -526,6 +537,59 @@ func TestObjectTokenStoreRejectsAuthRootReplacementAfterPreflight(t *testing.T) 
 				}
 			})
 		}
+	}
+}
+
+func TestObjectTokenStoreSaveRejectsAuthRootRemovalBeforeUpload(t *testing.T) {
+	remotePutCalls := 0
+	remoteDeleteCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasPrefix(r.URL.RawQuery, "location") {
+			_, _ = w.Write([]byte(`<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></LocationConstraint>`))
+			return
+		}
+		switch r.Method {
+		case http.MethodPut:
+			remotePutCalls++
+		case http.MethodDelete:
+			remoteDeleteCalls++
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	managedRoot := filepath.Join(t.TempDir(), "managed")
+	store, err := NewObjectTokenStore(ObjectStoreConfig{
+		Endpoint:  strings.TrimPrefix(server.URL, "http://"),
+		Bucket:    "test-bucket",
+		AccessKey: "access",
+		SecretKey: "secret",
+		LocalRoot: managedRoot,
+	})
+	if err != nil {
+		t.Fatalf("create object token store: %v", err)
+	}
+	movedRoot := managedRoot + "-moved"
+	store.beforeAuthReadHook = func() {
+		if err := os.Rename(managedRoot, movedRoot); err != nil {
+			t.Fatalf("move initialized object-store root before upload: %v", err)
+		}
+	}
+
+	_, err = store.Save(context.Background(), &cliproxyauth.Auth{
+		ID:       "root-removed-before-upload",
+		FileName: filepath.Join("team", "token.json"),
+		Storage:  &successfulTokenStorage{},
+	})
+	if !errors.Is(err, errObjectStoreAuthRootUnavailable) {
+		t.Fatalf("Save() error = %v, want unavailable initialized root", err)
+	}
+	if remotePutCalls != 0 || remoteDeleteCalls != 0 {
+		t.Fatalf("remote mutations after root removal: PUT=%d DELETE=%d", remotePutCalls, remoteDeleteCalls)
+	}
+	writtenPath := filepath.Join(movedRoot, "auths", "team", "token.json")
+	if got, err := os.ReadFile(writtenPath); err != nil || string(got) != `{"type":"test"}` {
+		t.Fatalf("credential written before root removal = %q, err=%v", got, err)
 	}
 }
 
@@ -576,6 +640,9 @@ func newAuthRootReplacementStore(t *testing.T, serverURL, replacement string) (*
 			if err = os.Symlink(replacementRoot, managedRoot); err != nil {
 				t.Fatalf("replace object-store root with symlink: %v", err)
 			}
+			return
+		}
+		if replacement == "missing" {
 			return
 		}
 		if err = os.Rename(replacementRoot, managedRoot); err != nil {
@@ -640,7 +707,9 @@ func mustCaptureSecureAuthRootIdentity(t *testing.T, authDir string) secureAuthR
 
 func mustPrepareAuthRenderStaging(t *testing.T) (string, secureAuthRootIdentity) {
 	t.Helper()
-	stagingDir, stagingRoot, err := prepareAuthRenderStaging(t.TempDir())
+	spoolRoot := t.TempDir()
+	spoolIdentity := mustCaptureSecureAuthRootIdentity(t, spoolRoot)
+	stagingDir, stagingRoot, err := prepareAuthRenderStaging(spoolRoot, spoolIdentity)
 	if err != nil {
 		t.Fatalf("prepare auth render staging: %v", err)
 	}

--- a/internal/store/objectstore_path_test.go
+++ b/internal/store/objectstore_path_test.go
@@ -2,12 +2,47 @@ package store
 
 import (
 	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
+
+var errObjectStoreTestWrite = errors.New("stop after credential write")
+
+type writeThenFailTokenStorage struct {
+	called bool
+}
+
+func (s *writeThenFailTokenStorage) SaveTokenToFile(path string) error {
+	s.called = true
+	if err := os.WriteFile(path, []byte(`{"type":"test"}`), 0o600); err != nil {
+		return err
+	}
+	return errObjectStoreTestWrite
+}
+
+type noOpTokenStorage struct{}
+
+func (*noOpTokenStorage) SaveTokenToFile(string) error { return nil }
+
+func TestRenderAuthStoragePreservesNoOpWriter(t *testing.T) {
+	raw, wrote, err := renderAuthStorage(&noOpTokenStorage{})
+	if err != nil {
+		t.Fatalf("render no-op token storage: %v", err)
+	}
+	if wrote {
+		t.Fatalf("render no-op token storage reported a file with contents %q", raw)
+	}
+}
 
 func TestObjectTokenStoreRejectsAuthPathsOutsideAuthDir(t *testing.T) {
 	authDir := t.TempDir()
@@ -74,6 +109,49 @@ func TestObjectTokenStoreAcceptsNestedAuthPathInsideAuthDir(t *testing.T) {
 	}
 }
 
+func TestObjectTokenStoreSecureWriterInstallsNestedAuthFile(t *testing.T) {
+	authDir := t.TempDir()
+	store := &ObjectTokenStore{authDir: authDir}
+
+	path, err := store.writeAuthMirrorFile("team/token.json", []byte(`{"type":"codex"}`))
+	if err != nil {
+		t.Fatalf("first secure mirror write: %v", err)
+	}
+	if want := filepath.Join(authDir, "team", "token.json"); path != want {
+		t.Fatalf("secure mirror path = %q, want %q", path, want)
+	}
+	if err = os.WriteFile(filepath.Join(authDir, "team", "unrelated.json"), []byte(`{"keep":true}`), 0o600); err != nil {
+		t.Fatalf("write unrelated auth fixture: %v", err)
+	}
+	if _, err = store.writeAuthMirrorFile("team/token.json", []byte(`{"type":"replacement"}`)); err != nil {
+		t.Fatalf("replace secure mirror file: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read secure mirror file: %v", err)
+	}
+	if string(got) != `{"type":"replacement"}` {
+		t.Fatalf("secure mirror contents = %q, want replacement", got)
+	}
+	if _, err = os.Stat(filepath.Join(authDir, "team", "unrelated.json")); err != nil {
+		t.Fatalf("secure replacement disturbed sibling file: %v", err)
+	}
+}
+
+func TestObjectTokenStoreSecureWriterSupportsLongAuthFileName(t *testing.T) {
+	authDir := t.TempDir()
+	store := &ObjectTokenStore{authDir: authDir}
+	fileName := strings.Repeat("a", 240) + ".json"
+
+	path, err := store.writeAuthMirrorFile(fileName, []byte(`{"type":"codex"}`))
+	if err != nil {
+		t.Fatalf("secure mirror write with long auth filename: %v", err)
+	}
+	if got, errRead := os.ReadFile(path); errRead != nil || string(got) != `{"type":"codex"}` {
+		t.Fatalf("long auth filename contents = %q, err = %v", got, errRead)
+	}
+}
+
 func TestObjectTokenStoreRejectsSiblingPrefixAndSymlinkEscapes(t *testing.T) {
 	root := t.TempDir()
 	authDir := filepath.Join(root, "auths")
@@ -94,5 +172,266 @@ func TestObjectTokenStoreRejectsSiblingPrefixAndSymlinkEscapes(t *testing.T) {
 	}
 	if _, err := store.resolveAuthPath(&cliproxyauth.Auth{ID: "symlink", FileName: "escape/token.json"}); err == nil {
 		t.Fatal("accepted auth path through symlink outside auth directory")
+	}
+}
+
+func TestObjectTokenStoreRejectsDanglingLeafSymlinkBeforeCredentialWrite(t *testing.T) {
+	root := t.TempDir()
+	authDir := filepath.Join(root, "auths")
+	outsideDir := filepath.Join(root, "outside")
+	if err := os.MkdirAll(authDir, 0o700); err != nil {
+		t.Fatalf("create auth dir: %v", err)
+	}
+	if err := os.MkdirAll(outsideDir, 0o700); err != nil {
+		t.Fatalf("create outside dir: %v", err)
+	}
+
+	outsidePath := filepath.Join(outsideDir, "created-by-symlink.json")
+	linkPath := filepath.Join(authDir, "dangling.json")
+	if err := os.Symlink(outsidePath, linkPath); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	storage := &writeThenFailTokenStorage{}
+	store := &ObjectTokenStore{authDir: authDir}
+	_, err := store.Save(context.Background(), &cliproxyauth.Auth{
+		ID:       "dangling",
+		FileName: "dangling.json",
+		Storage:  storage,
+	})
+	if err == nil {
+		t.Fatal("Save() accepted dangling symlink auth path")
+	}
+	if storage.called {
+		t.Fatal("credential storage was invoked for dangling symlink auth path")
+	}
+	if _, errStat := os.Stat(outsidePath); !errors.Is(errStat, os.ErrNotExist) {
+		t.Fatalf("outside target was created through dangling symlink: %v", errStat)
+	}
+}
+
+func TestObjectTokenStoreRejectsDirectorySymlinkSwappedAfterValidation(t *testing.T) {
+	root := t.TempDir()
+	authDir := filepath.Join(root, "auths")
+	outsideDir := filepath.Join(root, "outside")
+	if err := os.MkdirAll(authDir, 0o700); err != nil {
+		t.Fatalf("create auth dir: %v", err)
+	}
+	if err := os.MkdirAll(outsideDir, 0o700); err != nil {
+		t.Fatalf("create outside dir: %v", err)
+	}
+
+	store := &ObjectTokenStore{authDir: authDir}
+	store.beforeAuthWriteHook = func() {
+		if err := os.Symlink(outsideDir, filepath.Join(authDir, "team")); err != nil {
+			t.Fatalf("swap auth directory with symlink: %v", err)
+		}
+	}
+
+	_, err := store.Save(context.Background(), &cliproxyauth.Auth{
+		ID:       "swapped",
+		FileName: "team/token.json",
+		Metadata: map[string]any{"type": "codex"},
+	})
+	if err == nil {
+		t.Fatal("Save() followed a directory symlink introduced after path validation")
+	}
+	if _, errStat := os.Stat(filepath.Join(outsideDir, "token.json")); !errors.Is(errStat, os.ErrNotExist) {
+		t.Fatalf("outside target was created after path swap: %v", errStat)
+	}
+}
+
+func TestObjectTokenStoreMirrorWriteRejectsDirectorySymlinkSwappedAfterValidation(t *testing.T) {
+	root := t.TempDir()
+	authDir := filepath.Join(root, "auths")
+	outsideDir := filepath.Join(root, "outside")
+	if err := os.MkdirAll(authDir, 0o700); err != nil {
+		t.Fatalf("create auth dir: %v", err)
+	}
+	if err := os.MkdirAll(outsideDir, 0o700); err != nil {
+		t.Fatalf("create outside dir: %v", err)
+	}
+
+	store := &ObjectTokenStore{authDir: authDir}
+	store.beforeAuthWriteHook = func() {
+		if err := os.Symlink(outsideDir, filepath.Join(authDir, "remote")); err != nil {
+			t.Fatalf("swap mirror directory with symlink: %v", err)
+		}
+	}
+
+	if _, err := store.writeAuthMirrorFile("remote/token.json", []byte(`{"type":"test"}`)); err == nil {
+		t.Fatal("bucket mirror write followed a directory symlink introduced after validation")
+	}
+	if _, errStat := os.Stat(filepath.Join(outsideDir, "token.json")); !errors.Is(errStat, os.ErrNotExist) {
+		t.Fatalf("bucket mirror wrote outside authDir after path swap: %v", errStat)
+	}
+}
+
+func TestObjectTokenStoreDeleteRejectsPathSwapWithoutRemoteDelete(t *testing.T) {
+	remoteDeleteCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasPrefix(r.URL.RawQuery, "location") {
+			_, _ = w.Write([]byte(`<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></LocationConstraint>`))
+			return
+		}
+		if r.Method == http.MethodDelete {
+			remoteDeleteCalls++
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	store, authDir, outsideDir := newPathSwapObjectStore(t, server.URL)
+	localDir := filepath.Join(authDir, "team")
+	localPath := filepath.Join(localDir, "token.json")
+	if err := os.MkdirAll(localDir, 0o700); err != nil {
+		t.Fatalf("create local auth directory: %v", err)
+	}
+	if err := os.WriteFile(localPath, []byte(`{"type":"local"}`), 0o600); err != nil {
+		t.Fatalf("write local auth: %v", err)
+	}
+	externalPath := filepath.Join(outsideDir, "token.json")
+	if err := os.WriteFile(externalPath, []byte(`{"type":"external"}`), 0o600); err != nil {
+		t.Fatalf("write external auth: %v", err)
+	}
+	store.beforeAuthDeleteHook = pathSwapHook(t, authDir, "team", outsideDir)
+
+	if err := store.Delete(context.Background(), "team/token.json"); err == nil {
+		t.Fatal("Delete() followed a directory symlink introduced after validation")
+	}
+	if got, err := os.ReadFile(externalPath); err != nil || string(got) != `{"type":"external"}` {
+		t.Fatalf("external auth changed after Delete(): data=%q err=%v", got, err)
+	}
+	if remoteDeleteCalls != 0 {
+		t.Fatalf("remote delete calls = %d, want 0", remoteDeleteCalls)
+	}
+}
+
+func TestObjectTokenStoreUploadRejectsPathSwapWithoutExternalReadOrUpload(t *testing.T) {
+	remotePutCalls := 0
+	var uploadedPayload []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasPrefix(r.URL.RawQuery, "location") {
+			_, _ = w.Write([]byte(`<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></LocationConstraint>`))
+			return
+		}
+		if r.Method == http.MethodPut {
+			remotePutCalls++
+			uploadedPayload, _ = io.ReadAll(r.Body)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	store, authDir, outsideDir := newPathSwapObjectStore(t, server.URL)
+	localDir := filepath.Join(authDir, "team")
+	localPath := filepath.Join(localDir, "token.json")
+	if err := os.MkdirAll(localDir, 0o700); err != nil {
+		t.Fatalf("create local auth directory: %v", err)
+	}
+	if err := os.WriteFile(localPath, []byte(`{"type":"local"}`), 0o600); err != nil {
+		t.Fatalf("write local auth: %v", err)
+	}
+	externalPath := filepath.Join(outsideDir, "token.json")
+	if err := os.WriteFile(externalPath, []byte(`{"type":"external"}`), 0o600); err != nil {
+		t.Fatalf("write external auth: %v", err)
+	}
+	store.beforeAuthReadHook = pathSwapHook(t, authDir, "team", outsideDir)
+
+	if err := store.uploadAuth(context.Background(), localPath); err == nil {
+		t.Fatal("uploadAuth() followed a directory symlink introduced after validation")
+	}
+	if remotePutCalls != 0 {
+		t.Fatalf("remote upload calls = %d, want 0; uploaded payload=%q", remotePutCalls, uploadedPayload)
+	}
+}
+
+func TestObjectTokenStoreUploadMissingAuthDeletesRemoteObject(t *testing.T) {
+	remoteDeleteCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasPrefix(r.URL.RawQuery, "location") {
+			_, _ = w.Write([]byte(`<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></LocationConstraint>`))
+			return
+		}
+		if r.Method == http.MethodDelete {
+			remoteDeleteCalls++
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	store, authDir, _ := newPathSwapObjectStore(t, server.URL)
+	if err := store.uploadAuth(context.Background(), filepath.Join(authDir, "missing.json")); err != nil {
+		t.Fatalf("upload missing auth: %v", err)
+	}
+	if remoteDeleteCalls != 1 {
+		t.Fatalf("remote delete calls = %d, want 1", remoteDeleteCalls)
+	}
+}
+
+func TestObjectTokenStoreListSkipsPathSwappedExternalAuth(t *testing.T) {
+	store, authDir, outsideDir := newPathSwapObjectStore(t, "")
+	localDir := filepath.Join(authDir, "team")
+	if err := os.MkdirAll(localDir, 0o700); err != nil {
+		t.Fatalf("create local auth directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, "token.json"), []byte(`{"type":"local"}`), 0o600); err != nil {
+		t.Fatalf("write local auth: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(outsideDir, "token.json"), []byte(`{"type":"external","email":"external@example.com"}`), 0o600); err != nil {
+		t.Fatalf("write external auth: %v", err)
+	}
+	store.beforeAuthReadHook = pathSwapHook(t, authDir, "team", outsideDir)
+
+	auths, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(auths) != 0 {
+		t.Fatalf("List() loaded path-swapped external auth: %#v", auths)
+	}
+}
+
+func newPathSwapObjectStore(t *testing.T, serverURL string) (*ObjectTokenStore, string, string) {
+	t.Helper()
+	root := t.TempDir()
+	authDir := filepath.Join(root, "auths")
+	outsideDir := filepath.Join(root, "outside")
+	if err := os.MkdirAll(authDir, 0o700); err != nil {
+		t.Fatalf("create auth directory: %v", err)
+	}
+	if err := os.MkdirAll(outsideDir, 0o700); err != nil {
+		t.Fatalf("create outside directory: %v", err)
+	}
+	store := &ObjectTokenStore{authDir: authDir}
+	if serverURL != "" {
+		client, err := minio.New(strings.TrimPrefix(serverURL, "http://"), &minio.Options{
+			Creds:  credentials.NewStaticV4("access", "secret", ""),
+			Secure: false,
+		})
+		if err != nil {
+			t.Fatalf("create minio client: %v", err)
+		}
+		store.client = client
+		store.cfg.Bucket = "test-bucket"
+	}
+	return store, authDir, outsideDir
+}
+
+func pathSwapHook(t *testing.T, authDir, component, outsideDir string) func() {
+	t.Helper()
+	called := false
+	return func() {
+		if called {
+			return
+		}
+		called = true
+		path := filepath.Join(authDir, component)
+		if err := os.Rename(path, path+"-original"); err != nil {
+			t.Fatalf("move validated auth directory: %v", err)
+		}
+		if err := os.Symlink(outsideDir, path); err != nil {
+			t.Fatalf("replace validated auth directory with symlink: %v", err)
+		}
 	}
 }

--- a/internal/store/objectstore_path_test.go
+++ b/internal/store/objectstore_path_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -46,7 +47,8 @@ func (s *rawJSONTokenStorage) SaveTokenToFile(string) error {
 func (*rawJSONTokenStorage) RawJSON() []byte { return []byte(`{"type":"plugin"}`) }
 
 func TestRenderAuthStoragePreservesNoOpWriter(t *testing.T) {
-	raw, wrote, err := renderAuthStorage(&noOpTokenStorage{})
+	stagingDir, stagingRoot := mustPrepareAuthRenderStaging(t)
+	raw, wrote, err := renderAuthStorage(&noOpTokenStorage{}, stagingDir, stagingRoot)
 	if err != nil {
 		t.Fatalf("render no-op token storage: %v", err)
 	}
@@ -57,7 +59,8 @@ func TestRenderAuthStoragePreservesNoOpWriter(t *testing.T) {
 
 func TestRenderAuthStoragePrefersPathFreeRawJSON(t *testing.T) {
 	storage := &rawJSONTokenStorage{}
-	raw, wrote, err := renderAuthStorage(storage)
+	stagingDir, stagingRoot := mustPrepareAuthRenderStaging(t)
+	raw, wrote, err := renderAuthStorage(storage, stagingDir, stagingRoot)
 	if err != nil {
 		t.Fatalf("render raw JSON token storage: %v", err)
 	}
@@ -76,7 +79,7 @@ func TestObjectTokenStoreRejectsAuthPathsOutsideAuthDir(t *testing.T) {
 	if err := os.WriteFile(outsidePath, []byte(`{"type":"codex"}`), 0o600); err != nil {
 		t.Fatalf("write outside auth: %v", err)
 	}
-	store := &ObjectTokenStore{authDir: authDir}
+	store := &ObjectTokenStore{authDir: authDir, authRoot: mustCaptureSecureAuthRootIdentity(t, authDir)}
 
 	checks := []struct {
 		name string
@@ -122,7 +125,7 @@ func TestObjectTokenStoreRejectsAuthPathsOutsideAuthDir(t *testing.T) {
 
 func TestObjectTokenStoreAcceptsNestedAuthPathInsideAuthDir(t *testing.T) {
 	authDir := t.TempDir()
-	store := &ObjectTokenStore{authDir: authDir}
+	store := &ObjectTokenStore{authDir: authDir, authRoot: mustCaptureSecureAuthRootIdentity(t, authDir)}
 
 	got, err := store.resolveAuthPath(&cliproxyauth.Auth{ID: "nested", FileName: "team/token"})
 	if err != nil {
@@ -136,7 +139,7 @@ func TestObjectTokenStoreAcceptsNestedAuthPathInsideAuthDir(t *testing.T) {
 
 func TestObjectTokenStoreSecureWriterInstallsNestedAuthFile(t *testing.T) {
 	authDir := t.TempDir()
-	store := &ObjectTokenStore{authDir: authDir}
+	store := &ObjectTokenStore{authDir: authDir, authRoot: mustCaptureSecureAuthRootIdentity(t, authDir)}
 
 	path, err := store.writeAuthMirrorFile("team/token.json", []byte(`{"type":"codex"}`))
 	if err != nil {
@@ -165,7 +168,7 @@ func TestObjectTokenStoreSecureWriterInstallsNestedAuthFile(t *testing.T) {
 
 func TestObjectTokenStoreSecureWriterSupportsLongAuthFileName(t *testing.T) {
 	authDir := t.TempDir()
-	store := &ObjectTokenStore{authDir: authDir}
+	store := &ObjectTokenStore{authDir: authDir, authRoot: mustCaptureSecureAuthRootIdentity(t, authDir)}
 	fileName := strings.Repeat("a", 240) + ".json"
 
 	path, err := store.writeAuthMirrorFile(fileName, []byte(`{"type":"codex"}`))
@@ -183,7 +186,7 @@ func TestObjectTokenStoreRejectsSiblingPrefixAndSymlinkEscapes(t *testing.T) {
 	if err := os.MkdirAll(authDir, 0o700); err != nil {
 		t.Fatalf("create auth dir: %v", err)
 	}
-	store := &ObjectTokenStore{authDir: authDir}
+	store := &ObjectTokenStore{authDir: authDir, authRoot: mustCaptureSecureAuthRootIdentity(t, authDir)}
 
 	siblingPath := filepath.Join(root, "auths-other", "token.json")
 	if _, err := store.resolveDeletePath(siblingPath); err == nil {
@@ -218,7 +221,7 @@ func TestObjectTokenStoreRejectsDanglingLeafSymlinkBeforeCredentialWrite(t *test
 	}
 
 	storage := &writeThenFailTokenStorage{}
-	store := &ObjectTokenStore{authDir: authDir}
+	store := &ObjectTokenStore{authDir: authDir, authRoot: mustCaptureSecureAuthRootIdentity(t, authDir)}
 	_, err := store.Save(context.Background(), &cliproxyauth.Auth{
 		ID:       "dangling",
 		FileName: "dangling.json",
@@ -246,7 +249,7 @@ func TestObjectTokenStoreRejectsDirectorySymlinkSwappedAfterValidation(t *testin
 		t.Fatalf("create outside dir: %v", err)
 	}
 
-	store := &ObjectTokenStore{authDir: authDir}
+	store := &ObjectTokenStore{authDir: authDir, authRoot: mustCaptureSecureAuthRootIdentity(t, authDir)}
 	store.beforeAuthWriteHook = func() {
 		if err := os.Symlink(outsideDir, filepath.Join(authDir, "team")); err != nil {
 			t.Fatalf("swap auth directory with symlink: %v", err)
@@ -277,7 +280,7 @@ func TestObjectTokenStoreMirrorWriteRejectsDirectorySymlinkSwappedAfterValidatio
 		t.Fatalf("create outside dir: %v", err)
 	}
 
-	store := &ObjectTokenStore{authDir: authDir}
+	store := &ObjectTokenStore{authDir: authDir, authRoot: mustCaptureSecureAuthRootIdentity(t, authDir)}
 	store.beforeAuthWriteHook = func() {
 		if err := os.Symlink(outsideDir, filepath.Join(authDir, "remote")); err != nil {
 			t.Fatalf("swap mirror directory with symlink: %v", err)
@@ -417,6 +420,171 @@ func TestObjectTokenStoreListSkipsPathSwappedExternalAuth(t *testing.T) {
 	}
 }
 
+func TestObjectTokenStoreRejectsAuthRootReplacementAfterPreflight(t *testing.T) {
+	type operation struct {
+		name string
+		run  func(context.Context, *ObjectTokenStore, string, func()) error
+	}
+	operations := []operation{
+		{
+			name: "write",
+			run: func(_ context.Context, store *ObjectTokenStore, _ string, hook func()) error {
+				store.beforeAuthWriteHook = hook
+				_, err := store.writeAuthMirrorFile("team/token.json", []byte(`{"type":"replacement"}`))
+				return err
+			},
+		},
+		{
+			name: "read",
+			run: func(ctx context.Context, store *ObjectTokenStore, authDir string, hook func()) error {
+				store.beforeAuthReadHook = hook
+				return store.uploadAuth(ctx, filepath.Join(authDir, "team", "token.json"))
+			},
+		},
+		{
+			name: "delete",
+			run: func(ctx context.Context, store *ObjectTokenStore, _ string, hook func()) error {
+				store.beforeAuthDeleteHook = hook
+				return store.Delete(ctx, "team/token.json")
+			},
+		},
+		{
+			name: "list",
+			run: func(ctx context.Context, store *ObjectTokenStore, _ string, hook func()) error {
+				hook()
+				_, err := store.List(ctx)
+				return err
+			},
+		},
+	}
+
+	for _, replacement := range []string{"symlink", "directory"} {
+		for _, operation := range operations {
+			t.Run(replacement+"/"+operation.name, func(t *testing.T) {
+				remotePutCalls := 0
+				remoteDeleteCalls := 0
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodGet && strings.HasPrefix(r.URL.RawQuery, "location") {
+						_, _ = w.Write([]byte(`<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></LocationConstraint>`))
+						return
+					}
+					switch r.Method {
+					case http.MethodPut:
+						remotePutCalls++
+					case http.MethodDelete:
+						remoteDeleteCalls++
+					}
+					w.WriteHeader(http.StatusNoContent)
+				}))
+				defer server.Close()
+
+				store, authDir, originalAuthDir, replacementFixtureAuthDir, replacementObservedAuthDir, hook := newAuthRootReplacementStore(t, server.URL, replacement)
+				localPath := filepath.Join(authDir, "team", "token.json")
+				if operation.name != "write" {
+					if err := os.MkdirAll(filepath.Dir(localPath), 0o700); err != nil {
+						t.Fatalf("create original auth directory: %v", err)
+					}
+					if err := os.WriteFile(localPath, []byte(`{"type":"local"}`), 0o600); err != nil {
+						t.Fatalf("write original auth: %v", err)
+					}
+					outsidePath := filepath.Join(replacementFixtureAuthDir, "team", "token.json")
+					if err := os.MkdirAll(filepath.Dir(outsidePath), 0o700); err != nil {
+						t.Fatalf("create replacement auth directory: %v", err)
+					}
+					if err := os.WriteFile(outsidePath, []byte(`{"type":"external"}`), 0o600); err != nil {
+						t.Fatalf("write replacement auth: %v", err)
+					}
+				}
+
+				err := operation.run(context.Background(), store, authDir, hook)
+				if err == nil {
+					t.Fatal("auth operation accepted a replacement root after store initialization")
+				}
+				if replacement == "directory" && !errors.Is(err, errObjectStoreAuthRootChanged) {
+					t.Fatalf("auth operation error = %v, want root identity change", err)
+				}
+
+				replacementPath := filepath.Join(replacementObservedAuthDir, "team", "token.json")
+				if operation.name == "write" {
+					if _, err := os.Stat(replacementPath); !errors.Is(err, fs.ErrNotExist) {
+						t.Fatalf("write reached replacement auth root: %v", err)
+					}
+				} else if got, err := os.ReadFile(replacementPath); err != nil || string(got) != `{"type":"external"}` {
+					t.Fatalf("replacement auth changed: data=%q err=%v", got, err)
+				}
+
+				originalPath := filepath.Join(originalAuthDir, "team", "token.json")
+				if operation.name == "write" {
+					if _, err := os.Stat(originalPath); !errors.Is(err, fs.ErrNotExist) {
+						t.Fatalf("failed write changed original auth root: %v", err)
+					}
+				} else if got, err := os.ReadFile(originalPath); err != nil || string(got) != `{"type":"local"}` {
+					t.Fatalf("original auth changed: data=%q err=%v", got, err)
+				}
+				if remotePutCalls != 0 || remoteDeleteCalls != 0 {
+					t.Fatalf("remote mutations after root replacement: PUT=%d DELETE=%d", remotePutCalls, remoteDeleteCalls)
+				}
+			})
+		}
+	}
+}
+
+func newAuthRootReplacementStore(t *testing.T, serverURL, replacement string) (*ObjectTokenStore, string, string, string, string, func()) {
+	t.Helper()
+	container := t.TempDir()
+	managedRoot := filepath.Join(container, "managed")
+	store, err := NewObjectTokenStore(ObjectStoreConfig{
+		Endpoint:  strings.TrimPrefix(serverURL, "http://"),
+		Bucket:    "test-bucket",
+		AccessKey: "access",
+		SecretKey: "secret",
+		LocalRoot: managedRoot,
+	})
+	if err != nil {
+		t.Fatalf("create object token store: %v", err)
+	}
+
+	originalRoot := managedRoot + "-original"
+	replacementRoot := filepath.Join(t.TempDir(), "replacement")
+	replacementAuthDir := filepath.Join(replacementRoot, "auths")
+	replacementObservedAuthDir := replacementAuthDir
+	if err = os.MkdirAll(replacementAuthDir, 0o700); err != nil {
+		t.Fatalf("create replacement root: %v", err)
+	}
+	if replacement == "symlink" {
+		probe := managedRoot + "-symlink-probe"
+		if err = os.Symlink(replacementRoot, probe); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+		if err = os.Remove(probe); err != nil {
+			t.Fatalf("remove symlink probe: %v", err)
+		}
+	} else {
+		replacementObservedAuthDir = filepath.Join(managedRoot, "auths")
+	}
+
+	called := false
+	hook := func() {
+		if called {
+			return
+		}
+		called = true
+		if err = os.Rename(managedRoot, originalRoot); err != nil {
+			t.Fatalf("move initialized object-store root: %v", err)
+		}
+		if replacement == "symlink" {
+			if err = os.Symlink(replacementRoot, managedRoot); err != nil {
+				t.Fatalf("replace object-store root with symlink: %v", err)
+			}
+			return
+		}
+		if err = os.Rename(replacementRoot, managedRoot); err != nil {
+			t.Fatalf("replace object-store root with directory: %v", err)
+		}
+	}
+	return store, store.authDir, filepath.Join(originalRoot, "auths"), replacementAuthDir, replacementObservedAuthDir, hook
+}
+
 func newPathSwapObjectStore(t *testing.T, serverURL string) (*ObjectTokenStore, string, string) {
 	t.Helper()
 	root := t.TempDir()
@@ -428,7 +596,7 @@ func newPathSwapObjectStore(t *testing.T, serverURL string) (*ObjectTokenStore, 
 	if err := os.MkdirAll(outsideDir, 0o700); err != nil {
 		t.Fatalf("create outside directory: %v", err)
 	}
-	store := &ObjectTokenStore{authDir: authDir}
+	store := &ObjectTokenStore{authDir: authDir, authRoot: mustCaptureSecureAuthRootIdentity(t, authDir)}
 	if serverURL != "" {
 		client, err := minio.New(strings.TrimPrefix(serverURL, "http://"), &minio.Options{
 			Creds:  credentials.NewStaticV4("access", "secret", ""),
@@ -458,5 +626,34 @@ func pathSwapHook(t *testing.T, authDir, component, outsideDir string) func() {
 		if err := os.Symlink(outsideDir, path); err != nil {
 			t.Fatalf("replace validated auth directory with symlink: %v", err)
 		}
+	}
+}
+
+func mustCaptureSecureAuthRootIdentity(t *testing.T, authDir string) secureAuthRootIdentity {
+	t.Helper()
+	identity, err := captureSecureAuthRootIdentity(authDir)
+	if err != nil {
+		t.Fatalf("capture secure auth root identity: %v", err)
+	}
+	return identity
+}
+
+func mustPrepareAuthRenderStaging(t *testing.T) (string, secureAuthRootIdentity) {
+	t.Helper()
+	stagingDir, stagingRoot, err := prepareAuthRenderStaging(t.TempDir())
+	if err != nil {
+		t.Fatalf("prepare auth render staging: %v", err)
+	}
+	return stagingDir, stagingRoot
+}
+
+func assertFileContents(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(got) != want {
+		t.Fatalf("contents of %s = %q, want %q", path, got, want)
 	}
 }

--- a/internal/store/objectstore_path_test.go
+++ b/internal/store/objectstore_path_test.go
@@ -34,6 +34,17 @@ type noOpTokenStorage struct{}
 
 func (*noOpTokenStorage) SaveTokenToFile(string) error { return nil }
 
+type rawJSONTokenStorage struct {
+	called bool
+}
+
+func (s *rawJSONTokenStorage) SaveTokenToFile(string) error {
+	s.called = true
+	return errors.New("path writer must not be called")
+}
+
+func (*rawJSONTokenStorage) RawJSON() []byte { return []byte(`{"type":"plugin"}`) }
+
 func TestRenderAuthStoragePreservesNoOpWriter(t *testing.T) {
 	raw, wrote, err := renderAuthStorage(&noOpTokenStorage{})
 	if err != nil {
@@ -41,6 +52,20 @@ func TestRenderAuthStoragePreservesNoOpWriter(t *testing.T) {
 	}
 	if wrote {
 		t.Fatalf("render no-op token storage reported a file with contents %q", raw)
+	}
+}
+
+func TestRenderAuthStoragePrefersPathFreeRawJSON(t *testing.T) {
+	storage := &rawJSONTokenStorage{}
+	raw, wrote, err := renderAuthStorage(storage)
+	if err != nil {
+		t.Fatalf("render raw JSON token storage: %v", err)
+	}
+	if !wrote || string(raw) != `{"type":"plugin"}` {
+		t.Fatalf("rendered raw JSON = %q, wrote=%v", raw, wrote)
+	}
+	if storage.called {
+		t.Fatal("path-based token writer was called despite RawJSON support")
 	}
 }
 

--- a/internal/store/objectstore_render_posix.go
+++ b/internal/store/objectstore_render_posix.go
@@ -12,7 +12,7 @@ import (
 // through an anonymous file descriptor. The provider sees only /dev/fd (or
 // /proc/self/fd), so another process cannot replace a staging pathname with a
 // symlink between validation and the credential write.
-func prepareAuthRenderStaging(string) (string, secureAuthRootIdentity, error) {
+func prepareAuthRenderStaging(string, secureAuthRootIdentity) (string, secureAuthRootIdentity, error) {
 	return "", secureAuthRootIdentity{}, nil
 }
 

--- a/internal/store/objectstore_render_posix.go
+++ b/internal/store/objectstore_render_posix.go
@@ -1,0 +1,63 @@
+//go:build !windows
+
+package store
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// renderAuthStorageIsolated captures legacy path-based TokenStorage output
+// through an anonymous file descriptor. The provider sees only /dev/fd (or
+// /proc/self/fd), so another process cannot replace a staging pathname with a
+// symlink between validation and the credential write.
+func renderAuthStorageIsolated(storage interface{ SaveTokenToFile(string) error }) ([]byte, bool, error) {
+	file, err := os.CreateTemp("", "cpa-object-auth-*")
+	if err != nil {
+		return nil, false, fmt.Errorf("object store: create auth staging file: %w", err)
+	}
+	backingPath := file.Name()
+	defer func() {
+		_ = file.Close()
+		if backingPath != "" {
+			_ = os.Remove(backingPath)
+		}
+	}()
+	if err = file.Chmod(0o600); err != nil {
+		return nil, false, fmt.Errorf("object store: restrict auth staging file: %w", err)
+	}
+	if err = os.Remove(backingPath); err != nil {
+		return nil, false, fmt.Errorf("object store: unlink auth staging file: %w", err)
+	}
+	backingPath = ""
+
+	descriptorPath := ""
+	for _, directory := range []string{"/dev/fd", "/proc/self/fd"} {
+		if info, errStat := os.Stat(directory); errStat == nil && info.IsDir() {
+			descriptorPath = fmt.Sprintf("%s/%d", directory, file.Fd())
+			break
+		}
+	}
+	if descriptorPath == "" {
+		return nil, false, fmt.Errorf("object store: no file-descriptor path is available for auth rendering")
+	}
+	if err = storage.SaveTokenToFile(descriptorPath); err != nil {
+		return nil, false, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return nil, false, fmt.Errorf("object store: stat rendered auth file: %w", err)
+	}
+	if info.Size() == 0 {
+		return nil, false, nil
+	}
+	if _, err = file.Seek(0, io.SeekStart); err != nil {
+		return nil, false, fmt.Errorf("object store: rewind rendered auth file: %w", err)
+	}
+	raw, err := io.ReadAll(file)
+	if err != nil {
+		return nil, false, fmt.Errorf("object store: read rendered auth file: %w", err)
+	}
+	return raw, true, nil
+}

--- a/internal/store/objectstore_render_posix.go
+++ b/internal/store/objectstore_render_posix.go
@@ -12,7 +12,11 @@ import (
 // through an anonymous file descriptor. The provider sees only /dev/fd (or
 // /proc/self/fd), so another process cannot replace a staging pathname with a
 // symlink between validation and the credential write.
-func renderAuthStorageIsolated(storage interface{ SaveTokenToFile(string) error }) ([]byte, bool, error) {
+func prepareAuthRenderStaging(string) (string, secureAuthRootIdentity, error) {
+	return "", secureAuthRootIdentity{}, nil
+}
+
+func renderAuthStorageIsolated(storage interface{ SaveTokenToFile(string) error }, _ string, _ secureAuthRootIdentity) ([]byte, bool, error) {
 	file, err := os.CreateTemp("", "cpa-object-auth-*")
 	if err != nil {
 		return nil, false, fmt.Errorf("object store: create auth staging file: %w", err)

--- a/internal/store/objectstore_render_posix_test.go
+++ b/internal/store/objectstore_render_posix_test.go
@@ -28,7 +28,7 @@ func (s *descriptorAuthStorage) SaveTokenToFile(path string) error {
 
 func TestRenderAuthStorageUsesAnonymousDescriptorPath(t *testing.T) {
 	storage := &descriptorAuthStorage{}
-	raw, wrote, err := renderAuthStorage(storage)
+	raw, wrote, err := renderAuthStorage(storage, "", secureAuthRootIdentity{})
 	if err != nil {
 		t.Fatalf("render descriptor auth storage: %v", err)
 	}

--- a/internal/store/objectstore_render_posix_test.go
+++ b/internal/store/objectstore_render_posix_test.go
@@ -1,0 +1,41 @@
+//go:build !windows
+
+package store
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
+)
+
+type descriptorAuthStorage struct {
+	path string
+}
+
+func (s *descriptorAuthStorage) SaveTokenToFile(path string) error {
+	s.path = path
+	file, err := misc.OpenCredentialFile(path)
+	if err != nil {
+		return err
+	}
+	if _, err = file.Write([]byte(`{"type":"descriptor"}`)); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}
+
+func TestRenderAuthStorageUsesAnonymousDescriptorPath(t *testing.T) {
+	storage := &descriptorAuthStorage{}
+	raw, wrote, err := renderAuthStorage(storage)
+	if err != nil {
+		t.Fatalf("render descriptor auth storage: %v", err)
+	}
+	if !wrote || string(raw) != `{"type":"descriptor"}` {
+		t.Fatalf("rendered descriptor auth = %q, wrote=%v", raw, wrote)
+	}
+	if !strings.HasPrefix(storage.path, "/dev/fd/") && !strings.HasPrefix(storage.path, "/proc/self/fd/") {
+		t.Fatalf("storage path = %q, want an anonymous descriptor alias", storage.path)
+	}
+}

--- a/internal/store/objectstore_render_windows.go
+++ b/internal/store/objectstore_render_windows.go
@@ -23,23 +23,36 @@ const (
 	authRenderFileSuffix     = ".tmp"
 )
 
-func prepareAuthRenderStaging(spoolRoot string) (string, secureAuthRootIdentity, error) {
-	stagingDir := filepath.Join(spoolRoot, authRenderStagingDirName)
-	if err := os.Mkdir(stagingDir, 0o700); err != nil && !os.IsExist(err) {
-		return "", secureAuthRootIdentity{}, fmt.Errorf("create managed auth staging directory: %w", err)
+func prepareAuthRenderStaging(spoolRoot string, expectedSpoolRoot secureAuthRootIdentity) (string, secureAuthRootIdentity, error) {
+	if !expectedSpoolRoot.valid {
+		return "", secureAuthRootIdentity{}, fmt.Errorf("managed spool root identity is not initialized")
 	}
-	info, err := os.Lstat(stagingDir)
+	absSpoolRoot, err := filepath.Abs(spoolRoot)
 	if err != nil {
-		return "", secureAuthRootIdentity{}, fmt.Errorf("inspect managed auth staging directory: %w", err)
+		return "", secureAuthRootIdentity{}, fmt.Errorf("resolve managed spool root: %w", err)
 	}
-	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
-		return "", secureAuthRootIdentity{}, fmt.Errorf("managed auth staging path is not a regular directory")
+	spoolHandle, err := openSecureWindowsRoot(absSpoolRoot)
+	if err != nil {
+		return "", secureAuthRootIdentity{}, fmt.Errorf("open managed spool root: %w", err)
 	}
-
-	directoryHandle, err := openLockedWindowsRenderDirectory(stagingDir, secureAuthRootIdentity{})
+	defer func() { _ = windows.CloseHandle(spoolHandle) }()
+	actualSpoolRoot, err := secureAuthRootIdentityForHandle(spoolHandle)
 	if err != nil {
 		return "", secureAuthRootIdentity{}, err
 	}
+	if actualSpoolRoot.volumeSerial != expectedSpoolRoot.volumeSerial || actualSpoolRoot.fileIndex != expectedSpoolRoot.fileIndex {
+		return "", secureAuthRootIdentity{}, errObjectStoreSpoolRootChanged
+	}
+
+	directoryHandle, err := openOrCreateSecureWindowsDirectoryAt(spoolHandle, authRenderStagingDirName)
+	if err != nil {
+		return "", secureAuthRootIdentity{}, fmt.Errorf("open managed auth staging directory: %w", err)
+	}
+	if err = restrictWindowsRenderHandle(directoryHandle); err != nil {
+		_ = windows.CloseHandle(directoryHandle)
+		return "", secureAuthRootIdentity{}, err
+	}
+	stagingDir := filepath.Join(absSpoolRoot, authRenderStagingDirName)
 	directory := os.NewFile(uintptr(directoryHandle), stagingDir)
 	if directory == nil {
 		_ = windows.CloseHandle(directoryHandle)

--- a/internal/store/objectstore_render_windows.go
+++ b/internal/store/objectstore_render_windows.go
@@ -3,44 +3,107 @@
 package store
 
 import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
 
+const (
+	authRenderStagingDirName = ".auth-render-staging"
+	authRenderFilePrefix     = ".credential-"
+	authRenderFileSuffix     = ".tmp"
+)
+
+func prepareAuthRenderStaging(spoolRoot string) (string, secureAuthRootIdentity, error) {
+	stagingDir := filepath.Join(spoolRoot, authRenderStagingDirName)
+	if err := os.Mkdir(stagingDir, 0o700); err != nil && !os.IsExist(err) {
+		return "", secureAuthRootIdentity{}, fmt.Errorf("create managed auth staging directory: %w", err)
+	}
+	info, err := os.Lstat(stagingDir)
+	if err != nil {
+		return "", secureAuthRootIdentity{}, fmt.Errorf("inspect managed auth staging directory: %w", err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return "", secureAuthRootIdentity{}, fmt.Errorf("managed auth staging path is not a regular directory")
+	}
+
+	directoryHandle, err := openLockedWindowsRenderDirectory(stagingDir, secureAuthRootIdentity{})
+	if err != nil {
+		return "", secureAuthRootIdentity{}, err
+	}
+	directory := os.NewFile(uintptr(directoryHandle), stagingDir)
+	if directory == nil {
+		_ = windows.CloseHandle(directoryHandle)
+		return "", secureAuthRootIdentity{}, fmt.Errorf("wrap managed auth staging directory handle")
+	}
+	defer func() { _ = directory.Close() }()
+
+	identity, err := secureAuthRootIdentityForHandle(directoryHandle)
+	if err != nil {
+		return "", secureAuthRootIdentity{}, err
+	}
+	entries, err := directory.ReadDir(-1)
+	if err != nil {
+		return "", secureAuthRootIdentity{}, fmt.Errorf("list managed auth staging directory: %w", err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasPrefix(name, authRenderFilePrefix) || !strings.HasSuffix(name, authRenderFileSuffix) {
+			return "", secureAuthRootIdentity{}, fmt.Errorf("managed auth staging directory contains unexpected entry %q", name)
+		}
+		fileHandle, errOpen := openSecureWindowsAuthFileAt(directoryHandle, name, windows.DELETE|windows.SYNCHRONIZE)
+		if errOpen != nil {
+			return "", secureAuthRootIdentity{}, fmt.Errorf("open stale auth staging file %q: %w", name, errOpen)
+		}
+		errDelete := deleteWindowsFileByHandle(fileHandle)
+		errClose := windows.CloseHandle(fileHandle)
+		if errDelete != nil {
+			return "", secureAuthRootIdentity{}, fmt.Errorf("delete stale auth staging file %q: %w", name, errDelete)
+		}
+		if errClose != nil {
+			return "", secureAuthRootIdentity{}, fmt.Errorf("close stale auth staging file %q: %w", name, errClose)
+		}
+	}
+	return stagingDir, identity, nil
+}
+
 // renderAuthStorageIsolated captures legacy path-based TokenStorage output in
 // a file whose parent and leaf are held open without FILE_SHARE_DELETE. The
 // provider can open the same regular file for writing, but neither pathname can
 // be replaced by a junction or reparse point while credential bytes are written.
-func renderAuthStorageIsolated(storage interface{ SaveTokenToFile(string) error }) ([]byte, bool, error) {
-	stagingDir, err := os.MkdirTemp("", "cpa-object-auth-*")
-	if err != nil {
-		return nil, false, fmt.Errorf("object store: create auth staging directory: %w", err)
+func renderAuthStorageIsolated(storage interface{ SaveTokenToFile(string) error }, stagingDir string, stagingRoot secureAuthRootIdentity) ([]byte, bool, error) {
+	if strings.TrimSpace(stagingDir) == "" || !stagingRoot.valid {
+		return nil, false, fmt.Errorf("object store: managed auth staging directory is not initialized")
 	}
-	defer func() { _ = os.RemoveAll(stagingDir) }()
-
-	directoryHandle, err := openLockedWindowsRenderDirectory(stagingDir)
+	directoryHandle, err := openLockedWindowsRenderDirectory(stagingDir, stagingRoot)
 	if err != nil {
 		return nil, false, err
 	}
 	defer func() { _ = windows.CloseHandle(directoryHandle) }()
 
-	stagingPath := filepath.Join(stagingDir, "credential.json")
-	fileHandle, err := createLockedWindowsRenderFile(stagingPath)
+	stagingName, fileHandle, err := createLockedWindowsRenderFileAt(directoryHandle)
 	if err != nil {
 		return nil, false, err
 	}
+	stagingPath := filepath.Join(stagingDir, stagingName)
 	file := os.NewFile(uintptr(fileHandle), stagingPath)
 	if file == nil {
 		_ = windows.CloseHandle(fileHandle)
 		return nil, false, fmt.Errorf("object store: create auth staging file: invalid handle")
 	}
-	defer func() { _ = file.Close() }()
+	defer func() {
+		_ = deleteWindowsFileByHandle(fileHandle)
+		_ = file.Close()
+	}()
 
 	if err = storage.SaveTokenToFile(stagingPath); err != nil {
 		return nil, false, err
@@ -62,7 +125,7 @@ func renderAuthStorageIsolated(storage interface{ SaveTokenToFile(string) error 
 	return raw, true, nil
 }
 
-func openLockedWindowsRenderDirectory(path string) (windows.Handle, error) {
+func openLockedWindowsRenderDirectory(path string, expectedRoot secureAuthRootIdentity) (windows.Handle, error) {
 	pathPtr, err := windows.UTF16PtrFromString(path)
 	if err != nil {
 		return 0, fmt.Errorf("object store: encode auth staging directory: %w", err)
@@ -83,6 +146,12 @@ func openLockedWindowsRenderDirectory(path string) (windows.Handle, error) {
 		_ = windows.CloseHandle(handle)
 		return 0, fmt.Errorf("object store: validate auth staging directory: %w", err)
 	}
+	if expectedRoot.valid {
+		if err = validateSecureAuthRootIdentity(handle, expectedRoot); err != nil {
+			_ = windows.CloseHandle(handle)
+			return 0, fmt.Errorf("object store: validate managed auth staging identity: %w", err)
+		}
+	}
 	if err = restrictWindowsRenderHandle(handle); err != nil {
 		_ = windows.CloseHandle(handle)
 		return 0, err
@@ -90,37 +159,57 @@ func openLockedWindowsRenderDirectory(path string) (windows.Handle, error) {
 	return handle, nil
 }
 
-func createLockedWindowsRenderFile(path string) (windows.Handle, error) {
-	pathPtr, err := windows.UTF16PtrFromString(path)
-	if err != nil {
-		return 0, fmt.Errorf("object store: encode auth staging file: %w", err)
-	}
+func createLockedWindowsRenderFileAt(parent windows.Handle) (string, windows.Handle, error) {
 	descriptor, err := currentUserOnlySecurityDescriptor()
 	if err != nil {
-		return 0, err
+		return "", 0, err
 	}
-	attributes := &windows.SecurityAttributes{
-		Length:             uint32(unsafe.Sizeof(windows.SecurityAttributes{})),
-		SecurityDescriptor: descriptor,
+	for attempt := 0; attempt < 16; attempt++ {
+		var random [8]byte
+		if _, err = rand.Read(random[:]); err != nil {
+			return "", 0, fmt.Errorf("object store: generate auth staging file name: %w", err)
+		}
+		name := authRenderFilePrefix + hex.EncodeToString(random[:]) + authRenderFileSuffix
+		objectName, errName := windows.NewNTUnicodeString(name)
+		if errName != nil {
+			return "", 0, fmt.Errorf("object store: encode auth staging file name: %w", errName)
+		}
+		attributes := &windows.OBJECT_ATTRIBUTES{
+			Length:             uint32(unsafe.Sizeof(windows.OBJECT_ATTRIBUTES{})),
+			RootDirectory:      parent,
+			ObjectName:         objectName,
+			Attributes:         windows.OBJ_CASE_INSENSITIVE | windows.OBJ_DONT_REPARSE,
+			SecurityDescriptor: descriptor,
+		}
+		var handle windows.Handle
+		var status windows.IO_STATUS_BLOCK
+		var allocationSize int64
+		err = windows.NtCreateFile(
+			&handle,
+			windows.FILE_GENERIC_READ|windows.FILE_READ_ATTRIBUTES|windows.DELETE|windows.READ_CONTROL|windows.WRITE_DAC,
+			attributes,
+			&status,
+			&allocationSize,
+			windows.FILE_ATTRIBUTE_HIDDEN|windows.FILE_ATTRIBUTE_TEMPORARY,
+			windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+			windows.FILE_CREATE,
+			windows.FILE_NON_DIRECTORY_FILE|windows.FILE_OPEN_REPARSE_POINT|windows.FILE_SYNCHRONOUS_IO_NONALERT,
+			0,
+			0,
+		)
+		runtime.KeepAlive(descriptor)
+		if err == nil {
+			if err = rejectWindowsReparseHandle(handle); err != nil {
+				_ = windows.CloseHandle(handle)
+				return "", 0, fmt.Errorf("object store: validate auth staging file: %w", err)
+			}
+			return name, handle, nil
+		}
+		if !errors.Is(err, windows.STATUS_OBJECT_NAME_COLLISION) {
+			return "", 0, fmt.Errorf("object store: create auth staging file: %w", err)
+		}
 	}
-	handle, err := windows.CreateFile(
-		pathPtr,
-		windows.GENERIC_READ|windows.READ_CONTROL|windows.WRITE_DAC,
-		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
-		attributes,
-		windows.CREATE_NEW,
-		windows.FILE_ATTRIBUTE_TEMPORARY|windows.FILE_FLAG_OPEN_REPARSE_POINT,
-		0,
-	)
-	runtime.KeepAlive(descriptor)
-	if err != nil {
-		return 0, fmt.Errorf("object store: create auth staging file: %w", err)
-	}
-	if err = rejectWindowsReparseHandle(handle); err != nil {
-		_ = windows.CloseHandle(handle)
-		return 0, fmt.Errorf("object store: validate auth staging file: %w", err)
-	}
-	return handle, nil
+	return "", 0, fmt.Errorf("object store: create auth staging file: exhausted unique names")
 }
 
 func restrictWindowsRenderHandle(handle windows.Handle) error {

--- a/internal/store/objectstore_render_windows.go
+++ b/internal/store/objectstore_render_windows.go
@@ -1,0 +1,149 @@
+//go:build windows
+
+package store
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// renderAuthStorageIsolated captures legacy path-based TokenStorage output in
+// a file whose parent and leaf are held open without FILE_SHARE_DELETE. The
+// provider can open the same regular file for writing, but neither pathname can
+// be replaced by a junction or reparse point while credential bytes are written.
+func renderAuthStorageIsolated(storage interface{ SaveTokenToFile(string) error }) ([]byte, bool, error) {
+	stagingDir, err := os.MkdirTemp("", "cpa-object-auth-*")
+	if err != nil {
+		return nil, false, fmt.Errorf("object store: create auth staging directory: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(stagingDir) }()
+
+	directoryHandle, err := openLockedWindowsRenderDirectory(stagingDir)
+	if err != nil {
+		return nil, false, err
+	}
+	defer func() { _ = windows.CloseHandle(directoryHandle) }()
+
+	stagingPath := filepath.Join(stagingDir, "credential.json")
+	fileHandle, err := createLockedWindowsRenderFile(stagingPath)
+	if err != nil {
+		return nil, false, err
+	}
+	file := os.NewFile(uintptr(fileHandle), stagingPath)
+	if file == nil {
+		_ = windows.CloseHandle(fileHandle)
+		return nil, false, fmt.Errorf("object store: create auth staging file: invalid handle")
+	}
+	defer func() { _ = file.Close() }()
+
+	if err = storage.SaveTokenToFile(stagingPath); err != nil {
+		return nil, false, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return nil, false, fmt.Errorf("object store: stat rendered auth file: %w", err)
+	}
+	if info.Size() == 0 {
+		return nil, false, nil
+	}
+	if _, err = file.Seek(0, io.SeekStart); err != nil {
+		return nil, false, fmt.Errorf("object store: rewind rendered auth file: %w", err)
+	}
+	raw, err := io.ReadAll(file)
+	if err != nil {
+		return nil, false, fmt.Errorf("object store: read rendered auth file: %w", err)
+	}
+	return raw, true, nil
+}
+
+func openLockedWindowsRenderDirectory(path string) (windows.Handle, error) {
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, fmt.Errorf("object store: encode auth staging directory: %w", err)
+	}
+	handle, err := windows.CreateFile(
+		pathPtr,
+		windows.GENERIC_READ|windows.READ_CONTROL|windows.WRITE_DAC,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("object store: lock auth staging directory: %w", err)
+	}
+	if err = rejectWindowsReparseHandle(handle); err != nil {
+		_ = windows.CloseHandle(handle)
+		return 0, fmt.Errorf("object store: validate auth staging directory: %w", err)
+	}
+	if err = restrictWindowsRenderHandle(handle); err != nil {
+		_ = windows.CloseHandle(handle)
+		return 0, err
+	}
+	return handle, nil
+}
+
+func createLockedWindowsRenderFile(path string) (windows.Handle, error) {
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return 0, fmt.Errorf("object store: encode auth staging file: %w", err)
+	}
+	descriptor, err := currentUserOnlySecurityDescriptor()
+	if err != nil {
+		return 0, err
+	}
+	attributes := &windows.SecurityAttributes{
+		Length:             uint32(unsafe.Sizeof(windows.SecurityAttributes{})),
+		SecurityDescriptor: descriptor,
+	}
+	handle, err := windows.CreateFile(
+		pathPtr,
+		windows.GENERIC_READ|windows.READ_CONTROL|windows.WRITE_DAC,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		attributes,
+		windows.CREATE_NEW,
+		windows.FILE_ATTRIBUTE_TEMPORARY|windows.FILE_FLAG_OPEN_REPARSE_POINT,
+		0,
+	)
+	runtime.KeepAlive(descriptor)
+	if err != nil {
+		return 0, fmt.Errorf("object store: create auth staging file: %w", err)
+	}
+	if err = rejectWindowsReparseHandle(handle); err != nil {
+		_ = windows.CloseHandle(handle)
+		return 0, fmt.Errorf("object store: validate auth staging file: %w", err)
+	}
+	return handle, nil
+}
+
+func restrictWindowsRenderHandle(handle windows.Handle) error {
+	descriptor, err := currentUserOnlySecurityDescriptor()
+	if err != nil {
+		return err
+	}
+	dacl, _, err := descriptor.DACL()
+	if err != nil {
+		return fmt.Errorf("object store: read auth staging DACL: %w", err)
+	}
+	err = windows.SetSecurityInfo(
+		handle,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil,
+		nil,
+		dacl,
+		nil,
+	)
+	runtime.KeepAlive(descriptor)
+	if err != nil {
+		return fmt.Errorf("object store: restrict auth staging path: %w", err)
+	}
+	return nil
+}

--- a/internal/store/objectstore_render_windows.go
+++ b/internal/store/objectstore_render_windows.go
@@ -80,7 +80,7 @@ func prepareAuthRenderStaging(spoolRoot string) (string, secureAuthRootIdentity,
 // a file whose parent and leaf are held open without FILE_SHARE_DELETE. The
 // provider can open the same regular file for writing, but neither pathname can
 // be replaced by a junction or reparse point while credential bytes are written.
-func renderAuthStorageIsolated(storage interface{ SaveTokenToFile(string) error }, stagingDir string, stagingRoot secureAuthRootIdentity) ([]byte, bool, error) {
+func renderAuthStorageIsolated(storage interface{ SaveTokenToFile(string) error }, stagingDir string, stagingRoot secureAuthRootIdentity) (raw []byte, wrote bool, err error) {
 	if strings.TrimSpace(stagingDir) == "" || !stagingRoot.valid {
 		return nil, false, fmt.Errorf("object store: managed auth staging directory is not initialized")
 	}
@@ -100,9 +100,25 @@ func renderAuthStorageIsolated(storage interface{ SaveTokenToFile(string) error 
 		_ = windows.CloseHandle(fileHandle)
 		return nil, false, fmt.Errorf("object store: create auth staging file: invalid handle")
 	}
-	defer func() {
-		_ = deleteWindowsFileByHandle(fileHandle)
+	fileIdentity, err := secureAuthRootIdentityForHandle(fileHandle)
+	if err != nil {
 		_ = file.Close()
+		return nil, false, fmt.Errorf("object store: capture auth staging file identity: %w", err)
+	}
+	defer func() {
+		closeErr := file.Close()
+		removeErr := removeLockedWindowsRenderFileAt(directoryHandle, stagingName, fileIdentity)
+		if closeErr != nil {
+			closeErr = fmt.Errorf("object store: close auth staging file: %w", closeErr)
+		}
+		if removeErr != nil {
+			removeErr = fmt.Errorf("object store: remove auth staging file: %w", removeErr)
+		}
+		if cleanupErr := errors.Join(closeErr, removeErr); cleanupErr != nil {
+			err = errors.Join(err, cleanupErr)
+			raw = nil
+			wrote = false
+		}
 	}()
 
 	if err = storage.SaveTokenToFile(stagingPath); err != nil {
@@ -118,11 +134,27 @@ func renderAuthStorageIsolated(storage interface{ SaveTokenToFile(string) error 
 	if _, err = file.Seek(0, io.SeekStart); err != nil {
 		return nil, false, fmt.Errorf("object store: rewind rendered auth file: %w", err)
 	}
-	raw, err := io.ReadAll(file)
+	raw, err = io.ReadAll(file)
 	if err != nil {
 		return nil, false, fmt.Errorf("object store: read rendered auth file: %w", err)
 	}
 	return raw, true, nil
+}
+
+func removeLockedWindowsRenderFileAt(parent windows.Handle, name string, expected secureAuthRootIdentity) error {
+	handle, err := openSecureWindowsAuthFileAt(parent, name, windows.DELETE|windows.SYNCHRONIZE)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = windows.CloseHandle(handle) }()
+	actual, err := secureAuthRootIdentityForHandle(handle)
+	if err != nil {
+		return err
+	}
+	if !expected.valid || actual.volumeSerial != expected.volumeSerial || actual.fileIndex != expected.fileIndex {
+		return fmt.Errorf("auth staging file identity changed before cleanup")
+	}
+	return deleteWindowsFileByHandle(handle)
 }
 
 func openLockedWindowsRenderDirectory(path string, expectedRoot secureAuthRootIdentity) (windows.Handle, error) {
@@ -186,7 +218,7 @@ func createLockedWindowsRenderFileAt(parent windows.Handle) (string, windows.Han
 		var allocationSize int64
 		err = windows.NtCreateFile(
 			&handle,
-			windows.FILE_GENERIC_READ|windows.FILE_READ_ATTRIBUTES|windows.DELETE|windows.READ_CONTROL|windows.WRITE_DAC,
+			windows.FILE_GENERIC_READ|windows.FILE_READ_ATTRIBUTES|windows.READ_CONTROL|windows.WRITE_DAC,
 			attributes,
 			&status,
 			&allocationSize,

--- a/internal/store/objectstore_render_windows_test.go
+++ b/internal/store/objectstore_render_windows_test.go
@@ -1,0 +1,48 @@
+//go:build windows
+
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
+)
+
+type lockedWindowsAuthStorage struct {
+	removeErr    error
+	renameDirErr error
+}
+
+func (s *lockedWindowsAuthStorage) SaveTokenToFile(path string) error {
+	s.removeErr = os.Remove(path)
+	dir := filepath.Dir(path)
+	s.renameDirErr = os.Rename(dir, dir+"-moved")
+	file, err := misc.OpenCredentialFile(path)
+	if err != nil {
+		return err
+	}
+	if _, err = file.Write([]byte(`{"type":"locked"}`)); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}
+
+func TestRenderAuthStorageLocksWindowsStagingPaths(t *testing.T) {
+	storage := &lockedWindowsAuthStorage{}
+	raw, wrote, err := renderAuthStorage(storage)
+	if err != nil {
+		t.Fatalf("render locked Windows auth storage: %v", err)
+	}
+	if !wrote || string(raw) != `{"type":"locked"}` {
+		t.Fatalf("rendered locked auth = %q, wrote=%v", raw, wrote)
+	}
+	if storage.removeErr == nil {
+		t.Fatal("pre-opened staging file could be removed while credentials were rendered")
+	}
+	if storage.renameDirErr == nil {
+		t.Fatal("pre-opened staging directory could be renamed while credentials were rendered")
+	}
+}

--- a/internal/store/objectstore_render_windows_test.go
+++ b/internal/store/objectstore_render_windows_test.go
@@ -5,11 +5,13 @@ package store
 import (
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
+	"golang.org/x/sys/windows"
 )
 
 type lockedWindowsAuthStorage struct {
@@ -35,7 +37,9 @@ func (s *lockedWindowsAuthStorage) SaveTokenToFile(path string) error {
 }
 
 func TestRenderAuthStorageLocksWindowsStagingPaths(t *testing.T) {
-	stagingDir, stagingRoot, err := prepareAuthRenderStaging(t.TempDir())
+	spoolRoot := t.TempDir()
+	spoolIdentity := mustCaptureSecureAuthRootIdentity(t, spoolRoot)
+	stagingDir, stagingRoot, err := prepareAuthRenderStaging(spoolRoot, spoolIdentity)
 	if err != nil {
 		t.Fatalf("prepare managed Windows auth staging: %v", err)
 	}
@@ -71,7 +75,8 @@ func TestRenderAuthStorageLocksWindowsStagingPaths(t *testing.T) {
 
 func TestRenderAuthStorageLocksWindowsStagingCleanup(t *testing.T) {
 	spoolRoot := t.TempDir()
-	stagingDir, _, err := prepareAuthRenderStaging(spoolRoot)
+	spoolIdentity := mustCaptureSecureAuthRootIdentity(t, spoolRoot)
+	stagingDir, _, err := prepareAuthRenderStaging(spoolRoot, spoolIdentity)
 	if err != nil {
 		t.Fatalf("prepare initial managed Windows auth staging: %v", err)
 	}
@@ -79,7 +84,7 @@ func TestRenderAuthStorageLocksWindowsStagingCleanup(t *testing.T) {
 	if err = os.WriteFile(stalePath, []byte(`{"type":"stale"}`), 0o600); err != nil {
 		t.Fatalf("write simulated crash residue: %v", err)
 	}
-	stagingDir, stagingRoot, err := prepareAuthRenderStaging(spoolRoot)
+	stagingDir, stagingRoot, err := prepareAuthRenderStaging(spoolRoot, spoolIdentity)
 	if err != nil {
 		t.Fatalf("clean simulated crash residue: %v", err)
 	}
@@ -111,7 +116,8 @@ func TestRenderAuthStorageLocksWindowsStagingCleanup(t *testing.T) {
 
 func TestRenderAuthStorageLocksWindowsStagingRootReplacement(t *testing.T) {
 	spoolRoot := t.TempDir()
-	stagingDir, stagingRoot, err := prepareAuthRenderStaging(spoolRoot)
+	spoolIdentity := mustCaptureSecureAuthRootIdentity(t, spoolRoot)
+	stagingDir, stagingRoot, err := prepareAuthRenderStaging(spoolRoot, spoolIdentity)
 	if err != nil {
 		t.Fatalf("prepare managed Windows auth staging: %v", err)
 	}
@@ -136,5 +142,111 @@ func TestRenderAuthStorageLocksWindowsStagingRootReplacement(t *testing.T) {
 	}
 	if len(entries) != 0 {
 		t.Fatalf("replacement auth staging directory received files: %v", entries)
+	}
+}
+
+func TestRenderAuthStorageLocksWindowsStagingInitializationRootReplacement(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*testing.T) (string, secureAuthRootIdentity, string)
+	}{
+		{
+			name: "ordinary spool directory",
+			setup: func(t *testing.T) (string, secureAuthRootIdentity, string) {
+				parent := t.TempDir()
+				spoolRoot := filepath.Join(parent, "spool")
+				if err := os.Mkdir(spoolRoot, 0o700); err != nil {
+					t.Fatalf("create initialized spool root: %v", err)
+				}
+				identity := mustCaptureSecureAuthRootIdentity(t, spoolRoot)
+				replacementRoot := filepath.Join(parent, "replacement")
+				residue := filepath.Join(replacementRoot, authRenderStagingDirName, authRenderFilePrefix+"outside"+authRenderFileSuffix)
+				if err := os.MkdirAll(filepath.Dir(residue), 0o700); err != nil {
+					t.Fatalf("create replacement staging root: %v", err)
+				}
+				if err := os.WriteFile(residue, []byte("outside"), 0o600); err != nil {
+					t.Fatalf("write replacement staging residue: %v", err)
+				}
+				setWindowsPathWideDACL(t, filepath.Dir(residue))
+				if err := os.Rename(spoolRoot, spoolRoot+"-original"); err != nil {
+					t.Fatalf("move initialized spool root: %v", err)
+				}
+				if err := os.Rename(replacementRoot, spoolRoot); err != nil {
+					t.Fatalf("install replacement spool root: %v", err)
+				}
+				return spoolRoot, identity, filepath.Join(spoolRoot, authRenderStagingDirName, filepath.Base(residue))
+			},
+		},
+		{
+			name: "ancestor junction",
+			setup: func(t *testing.T) (string, secureAuthRootIdentity, string) {
+				root := t.TempDir()
+				ancestor := filepath.Join(root, "managed")
+				spoolRoot := filepath.Join(ancestor, "spool")
+				if err := os.MkdirAll(spoolRoot, 0o700); err != nil {
+					t.Fatalf("create initialized spool root: %v", err)
+				}
+				identity := mustCaptureSecureAuthRootIdentity(t, spoolRoot)
+				outsideAncestor := filepath.Join(root, "outside")
+				residue := filepath.Join(outsideAncestor, "spool", authRenderStagingDirName, authRenderFilePrefix+"outside"+authRenderFileSuffix)
+				if err := os.MkdirAll(filepath.Dir(residue), 0o700); err != nil {
+					t.Fatalf("create outside staging root: %v", err)
+				}
+				if err := os.WriteFile(residue, []byte("outside"), 0o600); err != nil {
+					t.Fatalf("write outside staging residue: %v", err)
+				}
+				setWindowsPathWideDACL(t, filepath.Dir(residue))
+				if err := os.Rename(ancestor, ancestor+"-original"); err != nil {
+					t.Fatalf("move initialized spool ancestor: %v", err)
+				}
+				if output, err := exec.Command("cmd", "/c", "mklink", "/J", ancestor, outsideAncestor).CombinedOutput(); err != nil {
+					t.Skipf("mklink /J unavailable: %v (%s)", err, strings.TrimSpace(string(output)))
+				}
+				return spoolRoot, identity, residue
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			spoolRoot, identity, outsideResidue := test.setup(t)
+			if _, _, err := prepareAuthRenderStaging(spoolRoot, identity); err == nil {
+				t.Fatal("managed staging initialization accepted a replaced spool root")
+			}
+			if got, err := os.ReadFile(outsideResidue); err != nil || string(got) != "outside" {
+				t.Fatalf("outside staging residue changed: data=%q err=%v", got, err)
+			}
+			assertWindowsPathDACLUnprotected(t, filepath.Dir(outsideResidue))
+		})
+	}
+}
+
+func setWindowsPathWideDACL(t *testing.T, path string) {
+	t.Helper()
+	descriptor, err := windows.SecurityDescriptorFromString("D:AI(A;;GA;;;WD)")
+	if err != nil {
+		t.Fatalf("build wide staging DACL: %v", err)
+	}
+	dacl, _, err := descriptor.DACL()
+	if err != nil {
+		t.Fatalf("read wide staging DACL: %v", err)
+	}
+	if err = windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION, nil, nil, dacl, nil); err != nil {
+		t.Fatalf("apply wide staging DACL: %v", err)
+	}
+}
+
+func assertWindowsPathDACLUnprotected(t *testing.T, path string) {
+	t.Helper()
+	descriptor, err := windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		t.Fatalf("read staging DACL: %v", err)
+	}
+	control, _, err := descriptor.Control()
+	if err != nil {
+		t.Fatalf("read staging DACL control: %v", err)
+	}
+	if control&windows.SE_DACL_PROTECTED != 0 {
+		t.Fatalf("outside staging DACL was unexpectedly protected: control=%#x", control)
 	}
 }

--- a/internal/store/objectstore_render_windows_test.go
+++ b/internal/store/objectstore_render_windows_test.go
@@ -3,8 +3,10 @@
 package store
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/misc"
@@ -13,9 +15,11 @@ import (
 type lockedWindowsAuthStorage struct {
 	removeErr    error
 	renameDirErr error
+	path         string
 }
 
 func (s *lockedWindowsAuthStorage) SaveTokenToFile(path string) error {
+	s.path = path
 	s.removeErr = os.Remove(path)
 	dir := filepath.Dir(path)
 	s.renameDirErr = os.Rename(dir, dir+"-moved")
@@ -31,8 +35,12 @@ func (s *lockedWindowsAuthStorage) SaveTokenToFile(path string) error {
 }
 
 func TestRenderAuthStorageLocksWindowsStagingPaths(t *testing.T) {
+	stagingDir, stagingRoot, err := prepareAuthRenderStaging(t.TempDir())
+	if err != nil {
+		t.Fatalf("prepare managed Windows auth staging: %v", err)
+	}
 	storage := &lockedWindowsAuthStorage{}
-	raw, wrote, err := renderAuthStorage(storage)
+	raw, wrote, err := renderAuthStorage(storage, stagingDir, stagingRoot)
 	if err != nil {
 		t.Fatalf("render locked Windows auth storage: %v", err)
 	}
@@ -44,5 +52,89 @@ func TestRenderAuthStorageLocksWindowsStagingPaths(t *testing.T) {
 	}
 	if storage.renameDirErr == nil {
 		t.Fatal("pre-opened staging directory could be renamed while credentials were rendered")
+	}
+	if filepath.Dir(storage.path) != stagingDir {
+		t.Fatalf("auth staging path = %q, want managed directory %q", storage.path, stagingDir)
+	}
+	name := filepath.Base(storage.path)
+	if !strings.HasPrefix(name, authRenderFilePrefix) || !strings.HasSuffix(name, authRenderFileSuffix) || strings.HasSuffix(strings.ToLower(name), ".json") {
+		t.Fatalf("auth staging filename = %q, want non-JSON managed temp name", name)
+	}
+	entries, err := os.ReadDir(stagingDir)
+	if err != nil {
+		t.Fatalf("read managed auth staging after render: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("managed auth staging retained normal-path files: %v", entries)
+	}
+}
+
+func TestRenderAuthStorageLocksWindowsStagingCleanup(t *testing.T) {
+	spoolRoot := t.TempDir()
+	stagingDir, _, err := prepareAuthRenderStaging(spoolRoot)
+	if err != nil {
+		t.Fatalf("prepare initial managed Windows auth staging: %v", err)
+	}
+	stalePath := filepath.Join(stagingDir, authRenderFilePrefix+"crash"+authRenderFileSuffix)
+	if err = os.WriteFile(stalePath, []byte(`{"type":"stale"}`), 0o600); err != nil {
+		t.Fatalf("write simulated crash residue: %v", err)
+	}
+	stagingDir, stagingRoot, err := prepareAuthRenderStaging(spoolRoot)
+	if err != nil {
+		t.Fatalf("clean simulated crash residue: %v", err)
+	}
+	if _, err = os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Fatalf("simulated crash residue still exists: %v", err)
+	}
+
+	if _, _, err = renderAuthStorage(&writeThenFailTokenStorage{}, stagingDir, stagingRoot); !errors.Is(err, errObjectStoreTestWrite) {
+		t.Fatalf("render writer error = %v, want %v", err, errObjectStoreTestWrite)
+	}
+	if _, _, err = renderAuthStorage(&noOpTokenStorage{}, stagingDir, stagingRoot); err != nil {
+		t.Fatalf("render no-op storage: %v", err)
+	}
+	entries, err := os.ReadDir(stagingDir)
+	if err != nil {
+		t.Fatalf("read managed auth staging after cleanup paths: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("managed auth staging retained error/no-op files: %v", entries)
+	}
+
+	directory, err := os.Open(stagingDir)
+	if err != nil {
+		t.Fatalf("open managed auth staging directory: %v", err)
+	}
+	defer directory.Close()
+	assertObjectStoreCurrentUserOnlyDACL(t, directory)
+}
+
+func TestRenderAuthStorageLocksWindowsStagingRootReplacement(t *testing.T) {
+	spoolRoot := t.TempDir()
+	stagingDir, stagingRoot, err := prepareAuthRenderStaging(spoolRoot)
+	if err != nil {
+		t.Fatalf("prepare managed Windows auth staging: %v", err)
+	}
+	originalDir := stagingDir + "-original"
+	if err = os.Rename(stagingDir, originalDir); err != nil {
+		t.Fatalf("move initialized auth staging directory: %v", err)
+	}
+	if err = os.Mkdir(stagingDir, 0o700); err != nil {
+		t.Fatalf("install replacement auth staging directory: %v", err)
+	}
+
+	storage := &lockedWindowsAuthStorage{}
+	if _, _, err = renderAuthStorage(storage, stagingDir, stagingRoot); !errors.Is(err, errObjectStoreAuthRootChanged) {
+		t.Fatalf("render with replacement staging root error = %v, want root identity change", err)
+	}
+	if storage.path != "" {
+		t.Fatalf("credential writer received replacement-root path %q", storage.path)
+	}
+	entries, err := os.ReadDir(stagingDir)
+	if err != nil {
+		t.Fatalf("read replacement auth staging directory: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("replacement auth staging directory received files: %v", entries)
 	}
 }

--- a/internal/store/objectstore_secure_posix.go
+++ b/internal/store/objectstore_secure_posix.go
@@ -16,10 +16,14 @@ import (
 )
 
 // secureWriteAuthFile creates every path component relative to an opened auth
-// root and installs the file with renameat. O_NOFOLLOW prevents a same-user
-// symlink swap from redirecting either a directory traversal or the final write.
+// root and installs the file with renameat. The root and its canonical ancestors
+// are opened component by component without following symlinks.
 func secureWriteAuthFile(baseDir, relativePath string, data []byte) error {
-	dirFD, leaf, err := openSecureAuthParent(baseDir, relativePath, true)
+	return secureWriteAuthFileWithRootHook(baseDir, relativePath, data, nil)
+}
+
+func secureWriteAuthFileWithRootHook(baseDir, relativePath string, data []byte, afterRootSnapshot func()) error {
+	dirFD, leaf, err := openSecureAuthParentWithRootHook(baseDir, relativePath, true, afterRootSnapshot)
 	if err != nil {
 		return err
 	}
@@ -70,7 +74,11 @@ func secureWriteAuthFile(baseDir, relativePath string, data []byte) error {
 // secureReadAuthFile opens each path component from an auth-root descriptor and
 // reads a regular final file without following symlinks.
 func secureReadAuthFile(baseDir, relativePath string) ([]byte, fs.FileInfo, error) {
-	dirFD, leaf, err := openSecureAuthParent(baseDir, relativePath, false)
+	return secureReadAuthFileWithRootHook(baseDir, relativePath, nil)
+}
+
+func secureReadAuthFileWithRootHook(baseDir, relativePath string, afterRootSnapshot func()) ([]byte, fs.FileInfo, error) {
+	dirFD, leaf, err := openSecureAuthParentWithRootHook(baseDir, relativePath, false, afterRootSnapshot)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -99,7 +107,11 @@ func secureReadAuthFile(baseDir, relativePath string) ([]byte, fs.FileInfo, erro
 // secureRemoveAuthFile removes a final path relative to an auth-root
 // descriptor. Parent traversal never follows symlinks.
 func secureRemoveAuthFile(baseDir, relativePath string) error {
-	dirFD, leaf, err := openSecureAuthParent(baseDir, relativePath, false)
+	return secureRemoveAuthFileWithRootHook(baseDir, relativePath, nil)
+}
+
+func secureRemoveAuthFileWithRootHook(baseDir, relativePath string, afterRootSnapshot func()) error {
+	dirFD, leaf, err := openSecureAuthParentWithRootHook(baseDir, relativePath, false, afterRootSnapshot)
 	if err != nil {
 		return err
 	}
@@ -111,18 +123,18 @@ func secureRemoveAuthFile(baseDir, relativePath string) error {
 }
 
 func openSecureAuthParent(baseDir, relativePath string, create bool) (int, string, error) {
-	absBase, err := filepath.Abs(baseDir)
-	if err != nil {
-		return -1, "", fmt.Errorf("resolve auth directory: %w", err)
-	}
+	return openSecureAuthParentWithRootHook(baseDir, relativePath, create, nil)
+}
+
+func openSecureAuthParentWithRootHook(baseDir, relativePath string, create bool, afterRootSnapshot func()) (int, string, error) {
 	parts, err := secureAuthPathParts(relativePath)
 	if err != nil {
 		return -1, "", err
 	}
 
-	dirFD, err := unix.Open(absBase, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	dirFD, err := openSecureAuthRootWithHook(baseDir, afterRootSnapshot)
 	if err != nil {
-		return -1, "", fmt.Errorf("open auth directory: %w", err)
+		return -1, "", err
 	}
 	keepOpen := false
 	defer func() {
@@ -147,6 +159,99 @@ func openSecureAuthParent(baseDir, relativePath string, create bool) (int, strin
 	}
 	keepOpen = true
 	return dirFD, parts[len(parts)-1], nil
+}
+
+func openSecureAuthRootWithHook(baseDir string, afterRootSnapshot func()) (int, error) {
+	absBase, err := filepath.Abs(baseDir)
+	if err != nil {
+		return -1, fmt.Errorf("resolve auth directory: %w", err)
+	}
+
+	// Resolve parent aliases such as macOS /var -> /private/var, but keep the
+	// auth-root leaf unresolved so a root symlink is still rejected. The later
+	// descriptor walk and identity check close swaps after this snapshot.
+	canonicalParent, err := filepath.EvalSymlinks(filepath.Dir(absBase))
+	if err != nil {
+		return -1, fmt.Errorf("resolve auth directory parent: %w", err)
+	}
+	canonicalBase := filepath.Join(canonicalParent, filepath.Base(absBase))
+	expectedInfo, err := os.Lstat(canonicalBase)
+	if err != nil {
+		return -1, fmt.Errorf("inspect auth directory: %w", err)
+	}
+	if !expectedInfo.IsDir() {
+		return -1, fmt.Errorf("auth directory %q is not a directory", baseDir)
+	}
+	if afterRootSnapshot != nil {
+		afterRootSnapshot()
+	}
+
+	components, err := secureAbsolutePathParts(canonicalBase)
+	if err != nil {
+		return -1, err
+	}
+	dirFD, err := unix.Open(string(os.PathSeparator), unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return -1, fmt.Errorf("open filesystem root: %w", err)
+	}
+	keepOpen := false
+	defer func() {
+		if !keepOpen {
+			_ = unix.Close(dirFD)
+		}
+	}()
+
+	for _, component := range components {
+		nextFD, errOpen := unix.Openat(dirFD, component, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		if errOpen != nil {
+			return -1, fmt.Errorf("open auth root component %q: %w", component, errOpen)
+		}
+		_ = unix.Close(dirFD)
+		dirFD = nextFD
+	}
+
+	openedInfo, err := fileInfoForDescriptor(dirFD, canonicalBase)
+	if err != nil {
+		return -1, fmt.Errorf("inspect opened auth directory: %w", err)
+	}
+	if !os.SameFile(expectedInfo, openedInfo) {
+		return -1, fmt.Errorf("auth directory changed while opening")
+	}
+	keepOpen = true
+	return dirFD, nil
+}
+
+func secureAbsolutePathParts(path string) ([]string, error) {
+	clean := filepath.Clean(path)
+	if !filepath.IsAbs(clean) {
+		return nil, fmt.Errorf("invalid absolute auth path %q", path)
+	}
+	if clean == string(os.PathSeparator) {
+		return nil, nil
+	}
+	trimmed := strings.TrimPrefix(clean, string(os.PathSeparator))
+	parts := strings.Split(trimmed, string(os.PathSeparator))
+	for _, component := range parts {
+		if component == "" || component == "." || component == ".." {
+			return nil, fmt.Errorf("invalid auth root component %q", component)
+		}
+	}
+	return parts, nil
+}
+
+func fileInfoForDescriptor(fd int, name string) (fs.FileInfo, error) {
+	dupFD, err := unix.Dup(fd)
+	if err != nil {
+		return nil, err
+	}
+	unix.CloseOnExec(dupFD)
+	file := os.NewFile(uintptr(dupFD), name)
+	if file == nil {
+		_ = unix.Close(dupFD)
+		return nil, fmt.Errorf("wrap auth directory descriptor")
+	}
+	defer func() { _ = file.Close() }()
+	return file.Stat()
 }
 
 func secureAuthPathParts(relativePath string) ([]string, error) {

--- a/internal/store/objectstore_secure_posix.go
+++ b/internal/store/objectstore_secure_posix.go
@@ -55,7 +55,7 @@ func validateSecureAuthRootIdentity(dirFD int, expected secureAuthRootIdentity) 
 func validateSecureAuthRootPath(baseDir string, expected secureAuthRootIdentity) error {
 	dirFD, err := openSecureAuthRootWithHook(baseDir, nil)
 	if err != nil {
-		return err
+		return secureAuthRootOpenError(err, expected)
 	}
 	defer func() { _ = unix.Close(dirFD) }()
 	return validateSecureAuthRootIdentity(dirFD, expected)
@@ -180,7 +180,7 @@ func openSecureAuthParentWithRootHook(baseDir string, expectedRoot secureAuthRoo
 
 	dirFD, err := openSecureAuthRootWithHook(baseDir, afterRootSnapshot)
 	if err != nil {
-		return -1, "", err
+		return -1, "", secureAuthRootOpenError(err, expectedRoot)
 	}
 	if err = validateSecureAuthRootIdentity(dirFD, expectedRoot); err != nil {
 		_ = unix.Close(dirFD)

--- a/internal/store/objectstore_secure_posix.go
+++ b/internal/store/objectstore_secure_posix.go
@@ -15,15 +15,61 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+type secureAuthRootIdentity struct {
+	device uint64
+	inode  uint64
+	valid  bool
+}
+
+func captureSecureAuthRootIdentity(baseDir string) (secureAuthRootIdentity, error) {
+	dirFD, err := openSecureAuthRootWithHook(baseDir, nil)
+	if err != nil {
+		return secureAuthRootIdentity{}, err
+	}
+	defer func() { _ = unix.Close(dirFD) }()
+	return secureAuthRootIdentityForDescriptor(dirFD)
+}
+
+func secureAuthRootIdentityForDescriptor(dirFD int) (secureAuthRootIdentity, error) {
+	var stat unix.Stat_t
+	if err := unix.Fstat(dirFD, &stat); err != nil {
+		return secureAuthRootIdentity{}, fmt.Errorf("inspect auth directory identity: %w", err)
+	}
+	return secureAuthRootIdentity{device: uint64(stat.Dev), inode: uint64(stat.Ino), valid: true}, nil
+}
+
+func validateSecureAuthRootIdentity(dirFD int, expected secureAuthRootIdentity) error {
+	if !expected.valid {
+		return errObjectStoreAuthRootIdentityUnavailable
+	}
+	actual, err := secureAuthRootIdentityForDescriptor(dirFD)
+	if err != nil {
+		return err
+	}
+	if actual.device != expected.device || actual.inode != expected.inode {
+		return errObjectStoreAuthRootChanged
+	}
+	return nil
+}
+
+func validateSecureAuthRootPath(baseDir string, expected secureAuthRootIdentity) error {
+	dirFD, err := openSecureAuthRootWithHook(baseDir, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unix.Close(dirFD) }()
+	return validateSecureAuthRootIdentity(dirFD, expected)
+}
+
 // secureWriteAuthFile creates every path component relative to an opened auth
 // root and installs the file with renameat. The root and its canonical ancestors
 // are opened component by component without following symlinks.
-func secureWriteAuthFile(baseDir, relativePath string, data []byte) error {
-	return secureWriteAuthFileWithRootHook(baseDir, relativePath, data, nil)
+func secureWriteAuthFile(baseDir string, expectedRoot secureAuthRootIdentity, relativePath string, data []byte) error {
+	return secureWriteAuthFileWithRootHook(baseDir, expectedRoot, relativePath, data, nil)
 }
 
-func secureWriteAuthFileWithRootHook(baseDir, relativePath string, data []byte, afterRootSnapshot func()) error {
-	dirFD, leaf, err := openSecureAuthParentWithRootHook(baseDir, relativePath, true, afterRootSnapshot)
+func secureWriteAuthFileWithRootHook(baseDir string, expectedRoot secureAuthRootIdentity, relativePath string, data []byte, afterRootSnapshot func()) error {
+	dirFD, leaf, err := openSecureAuthParentWithRootHook(baseDir, expectedRoot, relativePath, true, afterRootSnapshot)
 	if err != nil {
 		return err
 	}
@@ -73,12 +119,12 @@ func secureWriteAuthFileWithRootHook(baseDir, relativePath string, data []byte, 
 
 // secureReadAuthFile opens each path component from an auth-root descriptor and
 // reads a regular final file without following symlinks.
-func secureReadAuthFile(baseDir, relativePath string) ([]byte, fs.FileInfo, error) {
-	return secureReadAuthFileWithRootHook(baseDir, relativePath, nil)
+func secureReadAuthFile(baseDir string, expectedRoot secureAuthRootIdentity, relativePath string) ([]byte, fs.FileInfo, error) {
+	return secureReadAuthFileWithRootHook(baseDir, expectedRoot, relativePath, nil)
 }
 
-func secureReadAuthFileWithRootHook(baseDir, relativePath string, afterRootSnapshot func()) ([]byte, fs.FileInfo, error) {
-	dirFD, leaf, err := openSecureAuthParentWithRootHook(baseDir, relativePath, false, afterRootSnapshot)
+func secureReadAuthFileWithRootHook(baseDir string, expectedRoot secureAuthRootIdentity, relativePath string, afterRootSnapshot func()) ([]byte, fs.FileInfo, error) {
+	dirFD, leaf, err := openSecureAuthParentWithRootHook(baseDir, expectedRoot, relativePath, false, afterRootSnapshot)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -106,12 +152,12 @@ func secureReadAuthFileWithRootHook(baseDir, relativePath string, afterRootSnaps
 
 // secureRemoveAuthFile removes a final path relative to an auth-root
 // descriptor. Parent traversal never follows symlinks.
-func secureRemoveAuthFile(baseDir, relativePath string) error {
-	return secureRemoveAuthFileWithRootHook(baseDir, relativePath, nil)
+func secureRemoveAuthFile(baseDir string, expectedRoot secureAuthRootIdentity, relativePath string) error {
+	return secureRemoveAuthFileWithRootHook(baseDir, expectedRoot, relativePath, nil)
 }
 
-func secureRemoveAuthFileWithRootHook(baseDir, relativePath string, afterRootSnapshot func()) error {
-	dirFD, leaf, err := openSecureAuthParentWithRootHook(baseDir, relativePath, false, afterRootSnapshot)
+func secureRemoveAuthFileWithRootHook(baseDir string, expectedRoot secureAuthRootIdentity, relativePath string, afterRootSnapshot func()) error {
+	dirFD, leaf, err := openSecureAuthParentWithRootHook(baseDir, expectedRoot, relativePath, false, afterRootSnapshot)
 	if err != nil {
 		return err
 	}
@@ -122,11 +168,11 @@ func secureRemoveAuthFileWithRootHook(baseDir, relativePath string, afterRootSna
 	return nil
 }
 
-func openSecureAuthParent(baseDir, relativePath string, create bool) (int, string, error) {
-	return openSecureAuthParentWithRootHook(baseDir, relativePath, create, nil)
+func openSecureAuthParent(baseDir string, expectedRoot secureAuthRootIdentity, relativePath string, create bool) (int, string, error) {
+	return openSecureAuthParentWithRootHook(baseDir, expectedRoot, relativePath, create, nil)
 }
 
-func openSecureAuthParentWithRootHook(baseDir, relativePath string, create bool, afterRootSnapshot func()) (int, string, error) {
+func openSecureAuthParentWithRootHook(baseDir string, expectedRoot secureAuthRootIdentity, relativePath string, create bool, afterRootSnapshot func()) (int, string, error) {
 	parts, err := secureAuthPathParts(relativePath)
 	if err != nil {
 		return -1, "", err
@@ -134,6 +180,10 @@ func openSecureAuthParentWithRootHook(baseDir, relativePath string, create bool,
 
 	dirFD, err := openSecureAuthRootWithHook(baseDir, afterRootSnapshot)
 	if err != nil {
+		return -1, "", err
+	}
+	if err = validateSecureAuthRootIdentity(dirFD, expectedRoot); err != nil {
+		_ = unix.Close(dirFD)
 		return -1, "", err
 	}
 	keepOpen := false

--- a/internal/store/objectstore_secure_posix.go
+++ b/internal/store/objectstore_secure_posix.go
@@ -1,0 +1,185 @@
+//go:build !windows
+
+package store
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// secureWriteAuthFile creates every path component relative to an opened auth
+// root and installs the file with renameat. O_NOFOLLOW prevents a same-user
+// symlink swap from redirecting either a directory traversal or the final write.
+func secureWriteAuthFile(baseDir, relativePath string, data []byte) error {
+	dirFD, leaf, err := openSecureAuthParent(baseDir, relativePath, true)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unix.Close(dirFD) }()
+
+	tempName, tempFD, err := createSecureTempAt(dirFD, leaf)
+	if err != nil {
+		return err
+	}
+	installed := false
+	defer func() {
+		_ = unix.Close(tempFD)
+		if !installed {
+			_ = unix.Unlinkat(dirFD, tempName, 0)
+		}
+	}()
+
+	for written := 0; written < len(data); {
+		n, errWrite := unix.Write(tempFD, data[written:])
+		if errWrite != nil {
+			return fmt.Errorf("write auth temp file: %w", errWrite)
+		}
+		if n == 0 {
+			return io.ErrShortWrite
+		}
+		written += n
+	}
+	if errChmod := unix.Fchmod(tempFD, 0o600); errChmod != nil {
+		return fmt.Errorf("restrict auth temp file: %w", errChmod)
+	}
+	if errSync := unix.Fsync(tempFD); errSync != nil {
+		return fmt.Errorf("sync auth temp file: %w", errSync)
+	}
+	if errClose := unix.Close(tempFD); errClose != nil {
+		return fmt.Errorf("close auth temp file: %w", errClose)
+	}
+	tempFD = -1
+	if errRename := unix.Renameat(dirFD, tempName, dirFD, leaf); errRename != nil {
+		return fmt.Errorf("install auth file: %w", errRename)
+	}
+	installed = true
+	if errSync := unix.Fsync(dirFD); errSync != nil {
+		return fmt.Errorf("sync auth directory: %w", errSync)
+	}
+	return nil
+}
+
+// secureReadAuthFile opens each path component from an auth-root descriptor and
+// reads a regular final file without following symlinks.
+func secureReadAuthFile(baseDir, relativePath string) ([]byte, fs.FileInfo, error) {
+	dirFD, leaf, err := openSecureAuthParent(baseDir, relativePath, false)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = unix.Close(dirFD) }()
+
+	fd, err := unix.Openat(dirFD, leaf, unix.O_RDONLY|unix.O_NONBLOCK|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open auth file: %w", err)
+	}
+	file := os.NewFile(uintptr(fd), leaf)
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, nil, fmt.Errorf("stat auth file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, nil, fmt.Errorf("auth file %q is not a regular file", relativePath)
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read auth file: %w", err)
+	}
+	return data, info, nil
+}
+
+// secureRemoveAuthFile removes a final path relative to an auth-root
+// descriptor. Parent traversal never follows symlinks.
+func secureRemoveAuthFile(baseDir, relativePath string) error {
+	dirFD, leaf, err := openSecureAuthParent(baseDir, relativePath, false)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unix.Close(dirFD) }()
+	if err := unix.Unlinkat(dirFD, leaf, 0); err != nil {
+		return fmt.Errorf("remove auth file: %w", err)
+	}
+	return nil
+}
+
+func openSecureAuthParent(baseDir, relativePath string, create bool) (int, string, error) {
+	absBase, err := filepath.Abs(baseDir)
+	if err != nil {
+		return -1, "", fmt.Errorf("resolve auth directory: %w", err)
+	}
+	parts, err := secureAuthPathParts(relativePath)
+	if err != nil {
+		return -1, "", err
+	}
+
+	dirFD, err := unix.Open(absBase, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return -1, "", fmt.Errorf("open auth directory: %w", err)
+	}
+	keepOpen := false
+	defer func() {
+		if !keepOpen {
+			_ = unix.Close(dirFD)
+		}
+	}()
+
+	for _, component := range parts[:len(parts)-1] {
+		nextFD, errOpen := unix.Openat(dirFD, component, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		if errOpen == unix.ENOENT && create {
+			if errMkdir := unix.Mkdirat(dirFD, component, 0o700); errMkdir != nil && errMkdir != unix.EEXIST {
+				return -1, "", fmt.Errorf("create auth directory component %q: %w", component, errMkdir)
+			}
+			nextFD, errOpen = unix.Openat(dirFD, component, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		}
+		if errOpen != nil {
+			return -1, "", fmt.Errorf("open auth directory component %q: %w", component, errOpen)
+		}
+		_ = unix.Close(dirFD)
+		dirFD = nextFD
+	}
+	keepOpen = true
+	return dirFD, parts[len(parts)-1], nil
+}
+
+func secureAuthPathParts(relativePath string) ([]string, error) {
+	if relativePath == "" || filepath.IsAbs(relativePath) {
+		return nil, fmt.Errorf("invalid auth relative path %q", relativePath)
+	}
+	clean := filepath.Clean(relativePath)
+	if clean != relativePath || clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(os.PathSeparator)) {
+		return nil, fmt.Errorf("invalid auth relative path %q", relativePath)
+	}
+	parts := strings.Split(clean, string(os.PathSeparator))
+	for _, component := range parts {
+		if component == "" || component == "." || component == ".." {
+			return nil, fmt.Errorf("invalid auth path component %q", component)
+		}
+	}
+	return parts, nil
+}
+
+func createSecureTempAt(dirFD int, _ string) (string, int, error) {
+	for attempt := 0; attempt < 16; attempt++ {
+		var random [8]byte
+		if _, err := rand.Read(random[:]); err != nil {
+			return "", -1, fmt.Errorf("generate auth temp name: %w", err)
+		}
+		name := ".auth-tmp-" + hex.EncodeToString(random[:])
+		fd, err := unix.Openat(dirFD, name, unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0o600)
+		if err == nil {
+			return name, fd, nil
+		}
+		if err != unix.EEXIST {
+			return "", -1, fmt.Errorf("create auth temp file: %w", err)
+		}
+	}
+	return "", -1, fmt.Errorf("create auth temp file: exhausted unique names")
+}

--- a/internal/store/objectstore_secure_posix_test.go
+++ b/internal/store/objectstore_secure_posix_test.go
@@ -1,0 +1,163 @@
+//go:build !windows
+
+package store
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSecureAuthOperationsRejectAncestorSymlinkSwap(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*testing.T, string, string, func()) error
+	}{
+		{
+			name: "read",
+			run: func(t *testing.T, baseDir, relativePath string, hook func()) error {
+				t.Helper()
+				data, _, err := secureReadAuthFileWithRootHook(baseDir, relativePath, hook)
+				if len(data) != 0 {
+					t.Fatalf("secure read returned outside data %q", data)
+				}
+				return err
+			},
+		},
+		{
+			name: "write",
+			run: func(_ *testing.T, baseDir, relativePath string, hook func()) error {
+				return secureWriteAuthFileWithRootHook(baseDir, relativePath, []byte("replacement"), hook)
+			},
+		},
+		{
+			name: "delete",
+			run: func(_ *testing.T, baseDir, relativePath string, hook func()) error {
+				return secureRemoveAuthFileWithRootHook(baseDir, relativePath, hook)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newSecureAuthAncestorSwapFixture(t)
+			if err := test.run(t, fixture.authDir, fixture.relativePath, fixture.swapToOutsideSymlink); err == nil {
+				t.Fatalf("secure %s accepted an auth-root ancestor symlink swap", test.name)
+			}
+			assertFileContents(t, fixture.outsideFile, "outside")
+			assertFileContents(t, fixture.originalFileAfterSwap, "inside")
+		})
+	}
+}
+
+func TestSecureAuthRootRejectsAncestorDirectoryReplacement(t *testing.T) {
+	fixture := newSecureAuthAncestorSwapFixture(t)
+	err := secureWriteAuthFileWithRootHook(fixture.authDir, fixture.relativePath, []byte("replacement"), func() {
+		if errRename := os.Rename(fixture.ancestor, fixture.originalAncestor); errRename != nil {
+			t.Fatalf("move original auth ancestor: %v", errRename)
+		}
+		if errRename := os.Rename(fixture.outsideAncestor, fixture.ancestor); errRename != nil {
+			t.Fatalf("replace auth ancestor with outside directory: %v", errRename)
+		}
+	})
+	if err == nil {
+		t.Fatal("secure write accepted a different auth root after canonicalization")
+	}
+	assertFileContents(t, filepath.Join(fixture.ancestor, "auths", fixture.relativePath), "outside")
+	assertFileContents(t, fixture.originalFileAfterSwap, "inside")
+}
+
+func TestSecureAuthRootRejectsSymlinkLeaf(t *testing.T) {
+	root := t.TempDir()
+	relativePath := filepath.Join("team", "token.json")
+	outsideAuthDir := filepath.Join(root, "outside-auths")
+	if err := os.MkdirAll(filepath.Join(outsideAuthDir, "team"), 0o700); err != nil {
+		t.Fatalf("create outside auth directory: %v", err)
+	}
+	outsideFile := filepath.Join(outsideAuthDir, relativePath)
+	if err := os.WriteFile(outsideFile, []byte("outside"), 0o600); err != nil {
+		t.Fatalf("write outside auth fixture: %v", err)
+	}
+	authDir := filepath.Join(root, "auths")
+	if err := os.Symlink(outsideAuthDir, authDir); err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+		t.Fatalf("create auth-root symlink: %v", err)
+	}
+
+	data, _, err := secureReadAuthFile(authDir, relativePath)
+	if err == nil {
+		t.Fatalf("secure read accepted an auth-root symlink and returned %q", data)
+	}
+	assertFileContents(t, outsideFile, "outside")
+}
+
+type secureAuthAncestorSwapFixture struct {
+	authDir               string
+	relativePath          string
+	ancestor              string
+	originalAncestor      string
+	outsideAncestor       string
+	outsideFile           string
+	originalFileAfterSwap string
+	swapToOutsideSymlink  func()
+}
+
+func newSecureAuthAncestorSwapFixture(t *testing.T) secureAuthAncestorSwapFixture {
+	t.Helper()
+	root := t.TempDir()
+	ancestor := filepath.Join(root, "managed")
+	originalAncestor := filepath.Join(root, "managed-original")
+	outsideAncestor := filepath.Join(root, "outside")
+	relativePath := filepath.Join("team", "token.json")
+	authDir := filepath.Join(ancestor, "auths")
+	outsideAuthDir := filepath.Join(outsideAncestor, "auths")
+	if err := os.MkdirAll(filepath.Join(authDir, "team"), 0o700); err != nil {
+		t.Fatalf("create managed auth directory: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(outsideAuthDir, "team"), 0o700); err != nil {
+		t.Fatalf("create outside auth directory: %v", err)
+	}
+	insideFile := filepath.Join(authDir, relativePath)
+	outsideFile := filepath.Join(outsideAuthDir, relativePath)
+	if err := os.WriteFile(insideFile, []byte("inside"), 0o600); err != nil {
+		t.Fatalf("write managed auth fixture: %v", err)
+	}
+	if err := os.WriteFile(outsideFile, []byte("outside"), 0o600); err != nil {
+		t.Fatalf("write outside auth fixture: %v", err)
+	}
+
+	return secureAuthAncestorSwapFixture{
+		authDir:               authDir,
+		relativePath:          relativePath,
+		ancestor:              ancestor,
+		originalAncestor:      originalAncestor,
+		outsideAncestor:       outsideAncestor,
+		outsideFile:           outsideFile,
+		originalFileAfterSwap: filepath.Join(originalAncestor, "auths", relativePath),
+		swapToOutsideSymlink: func() {
+			if err := os.Rename(ancestor, originalAncestor); err != nil {
+				t.Fatalf("move original auth ancestor: %v", err)
+			}
+			if err := os.Symlink(outsideAncestor, ancestor); err != nil {
+				if errors.Is(err, os.ErrPermission) {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+				t.Fatalf("replace auth ancestor with symlink: %v", err)
+			}
+		},
+	}
+}
+
+func assertFileContents(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(got) != want {
+		t.Fatalf("contents of %s = %q, want %q", path, got, want)
+	}
+}

--- a/internal/store/objectstore_secure_posix_test.go
+++ b/internal/store/objectstore_secure_posix_test.go
@@ -12,13 +12,13 @@ import (
 func TestSecureAuthOperationsRejectAncestorSymlinkSwap(t *testing.T) {
 	tests := []struct {
 		name string
-		run  func(*testing.T, string, string, func()) error
+		run  func(*testing.T, string, secureAuthRootIdentity, string, func()) error
 	}{
 		{
 			name: "read",
-			run: func(t *testing.T, baseDir, relativePath string, hook func()) error {
+			run: func(t *testing.T, baseDir string, root secureAuthRootIdentity, relativePath string, hook func()) error {
 				t.Helper()
-				data, _, err := secureReadAuthFileWithRootHook(baseDir, relativePath, hook)
+				data, _, err := secureReadAuthFileWithRootHook(baseDir, root, relativePath, hook)
 				if len(data) != 0 {
 					t.Fatalf("secure read returned outside data %q", data)
 				}
@@ -27,14 +27,14 @@ func TestSecureAuthOperationsRejectAncestorSymlinkSwap(t *testing.T) {
 		},
 		{
 			name: "write",
-			run: func(_ *testing.T, baseDir, relativePath string, hook func()) error {
-				return secureWriteAuthFileWithRootHook(baseDir, relativePath, []byte("replacement"), hook)
+			run: func(_ *testing.T, baseDir string, root secureAuthRootIdentity, relativePath string, hook func()) error {
+				return secureWriteAuthFileWithRootHook(baseDir, root, relativePath, []byte("replacement"), hook)
 			},
 		},
 		{
 			name: "delete",
-			run: func(_ *testing.T, baseDir, relativePath string, hook func()) error {
-				return secureRemoveAuthFileWithRootHook(baseDir, relativePath, hook)
+			run: func(_ *testing.T, baseDir string, root secureAuthRootIdentity, relativePath string, hook func()) error {
+				return secureRemoveAuthFileWithRootHook(baseDir, root, relativePath, hook)
 			},
 		},
 	}
@@ -42,7 +42,8 @@ func TestSecureAuthOperationsRejectAncestorSymlinkSwap(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			fixture := newSecureAuthAncestorSwapFixture(t)
-			if err := test.run(t, fixture.authDir, fixture.relativePath, fixture.swapToOutsideSymlink); err == nil {
+			root := mustCaptureSecureAuthRootIdentity(t, fixture.authDir)
+			if err := test.run(t, fixture.authDir, root, fixture.relativePath, fixture.swapToOutsideSymlink); err == nil {
 				t.Fatalf("secure %s accepted an auth-root ancestor symlink swap", test.name)
 			}
 			assertFileContents(t, fixture.outsideFile, "outside")
@@ -53,7 +54,8 @@ func TestSecureAuthOperationsRejectAncestorSymlinkSwap(t *testing.T) {
 
 func TestSecureAuthRootRejectsAncestorDirectoryReplacement(t *testing.T) {
 	fixture := newSecureAuthAncestorSwapFixture(t)
-	err := secureWriteAuthFileWithRootHook(fixture.authDir, fixture.relativePath, []byte("replacement"), func() {
+	root := mustCaptureSecureAuthRootIdentity(t, fixture.authDir)
+	err := secureWriteAuthFileWithRootHook(fixture.authDir, root, fixture.relativePath, []byte("replacement"), func() {
 		if errRename := os.Rename(fixture.ancestor, fixture.originalAncestor); errRename != nil {
 			t.Fatalf("move original auth ancestor: %v", errRename)
 		}
@@ -87,7 +89,8 @@ func TestSecureAuthRootRejectsSymlinkLeaf(t *testing.T) {
 		t.Fatalf("create auth-root symlink: %v", err)
 	}
 
-	data, _, err := secureReadAuthFile(authDir, relativePath)
+	rootIdentity := mustCaptureSecureAuthRootIdentity(t, outsideAuthDir)
+	data, _, err := secureReadAuthFile(authDir, rootIdentity, relativePath)
 	if err == nil {
 		t.Fatalf("secure read accepted an auth-root symlink and returned %q", data)
 	}
@@ -148,16 +151,5 @@ func newSecureAuthAncestorSwapFixture(t *testing.T) secureAuthAncestorSwapFixtur
 				t.Fatalf("replace auth ancestor with symlink: %v", err)
 			}
 		},
-	}
-}
-
-func assertFileContents(t *testing.T, path, want string) {
-	t.Helper()
-	got, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read %s: %v", path, err)
-	}
-	if string(got) != want {
-		t.Fatalf("contents of %s = %q, want %q", path, got, want)
 	}
 }

--- a/internal/store/objectstore_secure_windows.go
+++ b/internal/store/objectstore_secure_windows.go
@@ -81,7 +81,7 @@ func validateSecureAuthRootPath(baseDir string, expected secureAuthRootIdentity)
 	}
 	handle, err := openSecureWindowsRoot(absBase)
 	if err != nil {
-		return err
+		return secureAuthRootOpenError(err, expected)
 	}
 	defer func() { _ = windows.CloseHandle(handle) }()
 	return validateSecureAuthRootIdentity(handle, expected)
@@ -186,7 +186,7 @@ func openSecureWindowsAuthParent(baseDir string, expectedRoot secureAuthRootIden
 	}
 	dirHandle, err := openSecureWindowsRoot(absBase)
 	if err != nil {
-		return 0, "", err
+		return 0, "", secureAuthRootOpenError(err, expectedRoot)
 	}
 	if err = validateSecureAuthRootIdentity(dirHandle, expectedRoot); err != nil {
 		_ = windows.CloseHandle(dirHandle)

--- a/internal/store/objectstore_secure_windows.go
+++ b/internal/store/objectstore_secure_windows.go
@@ -257,7 +257,7 @@ func openSecureWindowsAuthFileAt(parent windows.Handle, leaf string, access uint
 	var allocationSize int64
 	err = windows.NtCreateFile(
 		&handle,
-		access,
+		access|windows.FILE_READ_ATTRIBUTES,
 		attributes,
 		&status,
 		&allocationSize,
@@ -305,7 +305,7 @@ func createSecureWindowsTempAt(parent windows.Handle, _ string) (string, windows
 		var allocationSize int64
 		err = windows.NtCreateFile(
 			&handle,
-			windows.FILE_GENERIC_WRITE|windows.DELETE|windows.READ_CONTROL|windows.WRITE_DAC,
+			windows.FILE_GENERIC_WRITE|windows.FILE_READ_ATTRIBUTES|windows.DELETE|windows.READ_CONTROL|windows.WRITE_DAC,
 			attributes,
 			&status,
 			&allocationSize,
@@ -320,7 +320,7 @@ func createSecureWindowsTempAt(parent windows.Handle, _ string) (string, windows
 		if err == nil {
 			if err = rejectWindowsReparseHandle(handle); err != nil {
 				_ = windows.CloseHandle(handle)
-				return "", 0, err
+				return "", 0, fmt.Errorf("validate auth temp file: %w", err)
 			}
 			return name, handle, nil
 		}

--- a/internal/store/objectstore_secure_windows.go
+++ b/internal/store/objectstore_secure_windows.go
@@ -1,0 +1,435 @@
+//go:build windows
+
+package store
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type windowsFileRenameInformation struct {
+	ReplaceIfExists uint32
+	RootDirectory   windows.Handle
+	FileNameLength  uint32
+	FileName        [1]uint16
+}
+
+type windowsFileDispositionInformationEx struct {
+	Flags uint32
+}
+
+// secureWriteAuthFile binds every traversal and the final replacement to
+// directory handles. OBJ_DONT_REPARSE and FILE_OPEN_REPARSE_POINT prevent a
+// junction or symlink swap from redirecting the write outside the auth root.
+func secureWriteAuthFile(baseDir, relativePath string, data []byte) error {
+	dirHandle, leaf, err := openSecureWindowsAuthParent(baseDir, relativePath, true)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = windows.CloseHandle(dirHandle) }()
+
+	_, tempHandle, err := createSecureWindowsTempAt(dirHandle, leaf)
+	if err != nil {
+		return err
+	}
+	installed := false
+	defer func() {
+		if !installed {
+			_ = deleteWindowsFileByHandle(tempHandle)
+		}
+		_ = windows.CloseHandle(tempHandle)
+	}()
+
+	if err = writeWindowsHandle(tempHandle, data); err != nil {
+		return fmt.Errorf("write auth temp file: %w", err)
+	}
+	if err = windows.FlushFileBuffers(tempHandle); err != nil {
+		return fmt.Errorf("sync auth temp file: %w", err)
+	}
+	if err = renameWindowsFileAt(tempHandle, dirHandle, leaf); err != nil {
+		return fmt.Errorf("install auth file: %w", err)
+	}
+	installed = true
+	return nil
+}
+
+// secureReadAuthFile opens a regular final file beneath a no-reparse auth root.
+func secureReadAuthFile(baseDir, relativePath string) ([]byte, fs.FileInfo, error) {
+	dirHandle, leaf, err := openSecureWindowsAuthParent(baseDir, relativePath, false)
+	if err != nil {
+		return nil, nil, normalizeWindowsNotExist(err)
+	}
+	defer func() { _ = windows.CloseHandle(dirHandle) }()
+
+	fileHandle, err := openSecureWindowsAuthFileAt(dirHandle, leaf, windows.FILE_GENERIC_READ)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open auth file: %w", normalizeWindowsNotExist(err))
+	}
+	file := os.NewFile(uintptr(fileHandle), leaf)
+	defer func() { _ = file.Close() }()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, nil, fmt.Errorf("stat auth file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, nil, fmt.Errorf("auth file %q is not a regular file", relativePath)
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read auth file: %w", err)
+	}
+	return data, info, nil
+}
+
+// secureRemoveAuthFile opens the final path relative to a no-reparse parent
+// handle, rejects reparse points, and deletes only through that file handle.
+func secureRemoveAuthFile(baseDir, relativePath string) error {
+	dirHandle, leaf, err := openSecureWindowsAuthParent(baseDir, relativePath, false)
+	if err != nil {
+		return normalizeWindowsNotExist(err)
+	}
+	defer func() { _ = windows.CloseHandle(dirHandle) }()
+
+	fileHandle, err := openSecureWindowsAuthFileAt(dirHandle, leaf, windows.DELETE|windows.SYNCHRONIZE)
+	if err != nil {
+		return fmt.Errorf("open auth file for removal: %w", normalizeWindowsNotExist(err))
+	}
+	defer func() { _ = windows.CloseHandle(fileHandle) }()
+	if err := deleteWindowsFileByHandle(fileHandle); err != nil {
+		return fmt.Errorf("remove auth file: %w", err)
+	}
+	return nil
+}
+
+func validWindowsAuthPathComponent(component string) bool {
+	return component != "" && component != "." && component != ".." &&
+		!strings.ContainsAny(component, `:/\\`)
+}
+
+func openSecureWindowsAuthParent(baseDir, relativePath string, create bool) (windows.Handle, string, error) {
+	absBase, err := filepath.Abs(baseDir)
+	if err != nil {
+		return 0, "", fmt.Errorf("resolve auth directory: %w", err)
+	}
+	parts, err := secureWindowsAuthPathParts(relativePath)
+	if err != nil {
+		return 0, "", err
+	}
+	dirHandle, err := openSecureWindowsRoot(absBase)
+	if err != nil {
+		return 0, "", err
+	}
+	keepOpen := false
+	defer func() {
+		if !keepOpen {
+			_ = windows.CloseHandle(dirHandle)
+		}
+	}()
+
+	for _, component := range parts[:len(parts)-1] {
+		var nextHandle windows.Handle
+		if create {
+			nextHandle, err = openOrCreateSecureWindowsDirectoryAt(dirHandle, component)
+		} else {
+			nextHandle, err = openSecureWindowsDirectory(dirHandle, component, windows.FILE_OPEN)
+		}
+		if err != nil {
+			return 0, "", fmt.Errorf("open auth directory component %q: %w", component, err)
+		}
+		_ = windows.CloseHandle(dirHandle)
+		dirHandle = nextHandle
+	}
+	keepOpen = true
+	return dirHandle, parts[len(parts)-1], nil
+}
+
+func secureWindowsAuthPathParts(relativePath string) ([]string, error) {
+	if relativePath == "" || filepath.IsAbs(relativePath) {
+		return nil, fmt.Errorf("invalid auth relative path %q", relativePath)
+	}
+	clean := filepath.Clean(relativePath)
+	if clean != relativePath || clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(os.PathSeparator)) {
+		return nil, fmt.Errorf("invalid auth relative path %q", relativePath)
+	}
+	parts := strings.Split(clean, string(os.PathSeparator))
+	for _, component := range parts {
+		if !validWindowsAuthPathComponent(component) {
+			return nil, fmt.Errorf("invalid auth path component %q", component)
+		}
+	}
+	return parts, nil
+}
+
+func openSecureWindowsRoot(path string) (windows.Handle, error) {
+	fullPath, err := windows.FullPath(path)
+	if err != nil {
+		return 0, fmt.Errorf("resolve auth directory: %w", err)
+	}
+	handle, err := openSecureWindowsDirectory(0, windowsNTPath(fullPath), windows.FILE_OPEN)
+	if err != nil {
+		return 0, fmt.Errorf("open auth directory: %w", err)
+	}
+	return handle, nil
+}
+
+func openOrCreateSecureWindowsDirectoryAt(parent windows.Handle, component string) (windows.Handle, error) {
+	handle, err := openSecureWindowsDirectory(parent, component, windows.FILE_OPEN)
+	if err == nil {
+		return handle, nil
+	}
+	if !errors.Is(err, windows.STATUS_OBJECT_NAME_NOT_FOUND) && !errors.Is(err, windows.STATUS_OBJECT_PATH_NOT_FOUND) {
+		return 0, err
+	}
+	handle, err = openSecureWindowsDirectory(parent, component, windows.FILE_CREATE)
+	if errors.Is(err, windows.STATUS_OBJECT_NAME_COLLISION) {
+		return openSecureWindowsDirectory(parent, component, windows.FILE_OPEN)
+	}
+	return handle, err
+}
+
+func openSecureWindowsDirectory(parent windows.Handle, name string, disposition uint32) (windows.Handle, error) {
+	objectName, err := windows.NewNTUnicodeString(name)
+	if err != nil {
+		return 0, err
+	}
+	securityDescriptor, err := currentUserOnlySecurityDescriptor()
+	if err != nil {
+		return 0, err
+	}
+	attributes := &windows.OBJECT_ATTRIBUTES{
+		Length:             uint32(unsafe.Sizeof(windows.OBJECT_ATTRIBUTES{})),
+		RootDirectory:      parent,
+		ObjectName:         objectName,
+		Attributes:         windows.OBJ_CASE_INSENSITIVE | windows.OBJ_DONT_REPARSE,
+		SecurityDescriptor: securityDescriptor,
+	}
+	var handle windows.Handle
+	var status windows.IO_STATUS_BLOCK
+	var allocationSize int64
+	err = windows.NtCreateFile(
+		&handle,
+		windows.FILE_GENERIC_READ|windows.FILE_GENERIC_WRITE|windows.READ_CONTROL|windows.WRITE_DAC,
+		attributes,
+		&status,
+		&allocationSize,
+		windows.FILE_ATTRIBUTE_DIRECTORY,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		disposition,
+		windows.FILE_DIRECTORY_FILE|windows.FILE_OPEN_REPARSE_POINT|windows.FILE_SYNCHRONOUS_IO_NONALERT,
+		0,
+		0,
+	)
+	runtime.KeepAlive(securityDescriptor)
+	if err != nil {
+		return 0, err
+	}
+	if err = rejectWindowsReparseHandle(handle); err != nil {
+		_ = windows.CloseHandle(handle)
+		return 0, err
+	}
+	return handle, nil
+}
+
+func openSecureWindowsAuthFileAt(parent windows.Handle, leaf string, access uint32) (windows.Handle, error) {
+	objectName, err := windows.NewNTUnicodeString(leaf)
+	if err != nil {
+		return 0, err
+	}
+	attributes := &windows.OBJECT_ATTRIBUTES{
+		Length:        uint32(unsafe.Sizeof(windows.OBJECT_ATTRIBUTES{})),
+		RootDirectory: parent,
+		ObjectName:    objectName,
+		Attributes:    windows.OBJ_CASE_INSENSITIVE | windows.OBJ_DONT_REPARSE,
+	}
+	var handle windows.Handle
+	var status windows.IO_STATUS_BLOCK
+	var allocationSize int64
+	err = windows.NtCreateFile(
+		&handle,
+		access,
+		attributes,
+		&status,
+		&allocationSize,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		windows.FILE_OPEN,
+		windows.FILE_NON_DIRECTORY_FILE|windows.FILE_OPEN_REPARSE_POINT|windows.FILE_SYNCHRONOUS_IO_NONALERT,
+		0,
+		0,
+	)
+	if err != nil {
+		return 0, err
+	}
+	if err = rejectWindowsReparseHandle(handle); err != nil {
+		_ = windows.CloseHandle(handle)
+		return 0, err
+	}
+	return handle, nil
+}
+
+func createSecureWindowsTempAt(parent windows.Handle, _ string) (string, windows.Handle, error) {
+	securityDescriptor, err := currentUserOnlySecurityDescriptor()
+	if err != nil {
+		return "", 0, err
+	}
+	for attempt := 0; attempt < 16; attempt++ {
+		var random [8]byte
+		if _, err = rand.Read(random[:]); err != nil {
+			return "", 0, fmt.Errorf("generate auth temp name: %w", err)
+		}
+		name := ".auth-tmp-" + hex.EncodeToString(random[:])
+		objectName, errName := windows.NewNTUnicodeString(name)
+		if errName != nil {
+			return "", 0, errName
+		}
+		attributes := &windows.OBJECT_ATTRIBUTES{
+			Length:             uint32(unsafe.Sizeof(windows.OBJECT_ATTRIBUTES{})),
+			RootDirectory:      parent,
+			ObjectName:         objectName,
+			Attributes:         windows.OBJ_CASE_INSENSITIVE | windows.OBJ_DONT_REPARSE,
+			SecurityDescriptor: securityDescriptor,
+		}
+		var handle windows.Handle
+		var status windows.IO_STATUS_BLOCK
+		var allocationSize int64
+		err = windows.NtCreateFile(
+			&handle,
+			windows.FILE_GENERIC_WRITE|windows.DELETE|windows.READ_CONTROL|windows.WRITE_DAC,
+			attributes,
+			&status,
+			&allocationSize,
+			windows.FILE_ATTRIBUTE_HIDDEN|windows.FILE_ATTRIBUTE_TEMPORARY,
+			windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+			windows.FILE_CREATE,
+			windows.FILE_NON_DIRECTORY_FILE|windows.FILE_OPEN_REPARSE_POINT|windows.FILE_SYNCHRONOUS_IO_NONALERT|windows.FILE_WRITE_THROUGH,
+			0,
+			0,
+		)
+		runtime.KeepAlive(securityDescriptor)
+		if err == nil {
+			if err = rejectWindowsReparseHandle(handle); err != nil {
+				_ = windows.CloseHandle(handle)
+				return "", 0, err
+			}
+			return name, handle, nil
+		}
+		if !errors.Is(err, windows.STATUS_OBJECT_NAME_COLLISION) {
+			return "", 0, fmt.Errorf("create auth temp file: %w", err)
+		}
+	}
+	return "", 0, fmt.Errorf("create auth temp file: exhausted unique names")
+}
+
+func currentUserOnlySecurityDescriptor() (*windows.SECURITY_DESCRIPTOR, error) {
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		return nil, fmt.Errorf("get current user SID: %w", err)
+	}
+	if user.User.Sid == nil || user.User.Sid.String() == "" {
+		return nil, fmt.Errorf("get current user SID: empty SID")
+	}
+	descriptor, err := windows.SecurityDescriptorFromString("D:P(A;;FA;;;" + user.User.Sid.String() + ")")
+	if err != nil {
+		return nil, fmt.Errorf("build auth file DACL: %w", err)
+	}
+	return descriptor, nil
+}
+
+func rejectWindowsReparseHandle(handle windows.Handle) error {
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &info); err != nil {
+		return err
+	}
+	if info.FileAttributes&windows.FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+		return fmt.Errorf("auth path contains a reparse point")
+	}
+	return nil
+}
+
+func writeWindowsHandle(handle windows.Handle, data []byte) error {
+	for written := 0; written < len(data); {
+		var count uint32
+		if err := windows.WriteFile(handle, data[written:], &count, nil); err != nil {
+			return err
+		}
+		if count == 0 {
+			return io.ErrShortWrite
+		}
+		written += int(count)
+	}
+	return nil
+}
+
+func renameWindowsFileAt(fileHandle, parent windows.Handle, leaf string) error {
+	fileName, err := windows.UTF16FromString(leaf)
+	if err != nil {
+		return err
+	}
+	if len(fileName)-1 > windows.MAX_LONG_PATH {
+		return fmt.Errorf("auth file name is too long")
+	}
+	fileNameLength := (len(fileName) - 1) * 2
+	var layout windowsFileRenameInformation
+	bufferSize := int(unsafe.Offsetof(layout.FileName)) + fileNameLength
+	buffer := make([]byte, bufferSize)
+	info := (*windowsFileRenameInformation)(unsafe.Pointer(&buffer[0]))
+	info.ReplaceIfExists = windows.FILE_RENAME_REPLACE_IF_EXISTS | windows.FILE_RENAME_POSIX_SEMANTICS
+	info.RootDirectory = parent
+	info.FileNameLength = uint32(fileNameLength)
+	copy((*[windows.MAX_LONG_PATH]uint16)(unsafe.Pointer(&info.FileName[0]))[:fileNameLength/2:fileNameLength/2], fileName[:len(fileName)-1])
+	var status windows.IO_STATUS_BLOCK
+	return windows.NtSetInformationFile(fileHandle, &status, &buffer[0], uint32(bufferSize), windows.FileRenameInformation)
+}
+
+func normalizeWindowsNotExist(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, windows.STATUS_NO_SUCH_FILE) ||
+		errors.Is(err, windows.STATUS_OBJECT_NAME_NOT_FOUND) ||
+		errors.Is(err, windows.STATUS_OBJECT_PATH_NOT_FOUND) {
+		return fmt.Errorf("%w: %v", fs.ErrNotExist, err)
+	}
+	return err
+}
+
+func deleteWindowsFileByHandle(handle windows.Handle) error {
+	info := windowsFileDispositionInformationEx{
+		Flags: windows.FILE_DISPOSITION_DELETE |
+			windows.FILE_DISPOSITION_POSIX_SEMANTICS |
+			windows.FILE_DISPOSITION_IGNORE_READONLY_ATTRIBUTE,
+	}
+	var status windows.IO_STATUS_BLOCK
+	return windows.NtSetInformationFile(
+		handle,
+		&status,
+		(*byte)(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+		windows.FileDispositionInformationEx,
+	)
+}
+
+func windowsNTPath(path string) string {
+	path = strings.ReplaceAll(path, "/", `\`)
+	switch {
+	case strings.HasPrefix(path, `\\?\UNC\`):
+		return `\??\UNC\` + strings.TrimPrefix(path, `\\?\UNC\`)
+	case strings.HasPrefix(path, `\\?\`):
+		return `\??\` + strings.TrimPrefix(path, `\\?\`)
+	case strings.HasPrefix(path, `\\`):
+		return `\??\UNC\` + strings.TrimPrefix(path, `\\`)
+	default:
+		return `\??\` + path
+	}
+}

--- a/internal/store/objectstore_secure_windows.go
+++ b/internal/store/objectstore_secure_windows.go
@@ -29,11 +29,69 @@ type windowsFileDispositionInformationEx struct {
 	Flags uint32
 }
 
+type secureAuthRootIdentity struct {
+	volumeSerial uint32
+	fileIndex    uint64
+	valid        bool
+}
+
+func captureSecureAuthRootIdentity(baseDir string) (secureAuthRootIdentity, error) {
+	absBase, err := filepath.Abs(baseDir)
+	if err != nil {
+		return secureAuthRootIdentity{}, fmt.Errorf("resolve auth directory: %w", err)
+	}
+	handle, err := openSecureWindowsRoot(absBase)
+	if err != nil {
+		return secureAuthRootIdentity{}, err
+	}
+	defer func() { _ = windows.CloseHandle(handle) }()
+	return secureAuthRootIdentityForHandle(handle)
+}
+
+func secureAuthRootIdentityForHandle(handle windows.Handle) (secureAuthRootIdentity, error) {
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &info); err != nil {
+		return secureAuthRootIdentity{}, fmt.Errorf("inspect auth directory identity: %w", err)
+	}
+	return secureAuthRootIdentity{
+		volumeSerial: info.VolumeSerialNumber,
+		fileIndex:    uint64(info.FileIndexHigh)<<32 | uint64(info.FileIndexLow),
+		valid:        true,
+	}, nil
+}
+
+func validateSecureAuthRootIdentity(handle windows.Handle, expected secureAuthRootIdentity) error {
+	if !expected.valid {
+		return errObjectStoreAuthRootIdentityUnavailable
+	}
+	actual, err := secureAuthRootIdentityForHandle(handle)
+	if err != nil {
+		return err
+	}
+	if actual.volumeSerial != expected.volumeSerial || actual.fileIndex != expected.fileIndex {
+		return errObjectStoreAuthRootChanged
+	}
+	return nil
+}
+
+func validateSecureAuthRootPath(baseDir string, expected secureAuthRootIdentity) error {
+	absBase, err := filepath.Abs(baseDir)
+	if err != nil {
+		return fmt.Errorf("resolve auth directory: %w", err)
+	}
+	handle, err := openSecureWindowsRoot(absBase)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = windows.CloseHandle(handle) }()
+	return validateSecureAuthRootIdentity(handle, expected)
+}
+
 // secureWriteAuthFile binds every traversal and the final replacement to
 // directory handles. OBJ_DONT_REPARSE and FILE_OPEN_REPARSE_POINT prevent a
 // junction or symlink swap from redirecting the write outside the auth root.
-func secureWriteAuthFile(baseDir, relativePath string, data []byte) error {
-	dirHandle, leaf, err := openSecureWindowsAuthParent(baseDir, relativePath, true)
+func secureWriteAuthFile(baseDir string, expectedRoot secureAuthRootIdentity, relativePath string, data []byte) error {
+	dirHandle, leaf, err := openSecureWindowsAuthParent(baseDir, expectedRoot, relativePath, true)
 	if err != nil {
 		return err
 	}
@@ -65,8 +123,8 @@ func secureWriteAuthFile(baseDir, relativePath string, data []byte) error {
 }
 
 // secureReadAuthFile opens a regular final file beneath a no-reparse auth root.
-func secureReadAuthFile(baseDir, relativePath string) ([]byte, fs.FileInfo, error) {
-	dirHandle, leaf, err := openSecureWindowsAuthParent(baseDir, relativePath, false)
+func secureReadAuthFile(baseDir string, expectedRoot secureAuthRootIdentity, relativePath string) ([]byte, fs.FileInfo, error) {
+	dirHandle, leaf, err := openSecureWindowsAuthParent(baseDir, expectedRoot, relativePath, false)
 	if err != nil {
 		return nil, nil, normalizeWindowsNotExist(err)
 	}
@@ -94,8 +152,8 @@ func secureReadAuthFile(baseDir, relativePath string) ([]byte, fs.FileInfo, erro
 
 // secureRemoveAuthFile opens the final path relative to a no-reparse parent
 // handle, rejects reparse points, and deletes only through that file handle.
-func secureRemoveAuthFile(baseDir, relativePath string) error {
-	dirHandle, leaf, err := openSecureWindowsAuthParent(baseDir, relativePath, false)
+func secureRemoveAuthFile(baseDir string, expectedRoot secureAuthRootIdentity, relativePath string) error {
+	dirHandle, leaf, err := openSecureWindowsAuthParent(baseDir, expectedRoot, relativePath, false)
 	if err != nil {
 		return normalizeWindowsNotExist(err)
 	}
@@ -117,7 +175,7 @@ func validWindowsAuthPathComponent(component string) bool {
 		!strings.ContainsAny(component, `:/\\`)
 }
 
-func openSecureWindowsAuthParent(baseDir, relativePath string, create bool) (windows.Handle, string, error) {
+func openSecureWindowsAuthParent(baseDir string, expectedRoot secureAuthRootIdentity, relativePath string, create bool) (windows.Handle, string, error) {
 	absBase, err := filepath.Abs(baseDir)
 	if err != nil {
 		return 0, "", fmt.Errorf("resolve auth directory: %w", err)
@@ -128,6 +186,10 @@ func openSecureWindowsAuthParent(baseDir, relativePath string, create bool) (win
 	}
 	dirHandle, err := openSecureWindowsRoot(absBase)
 	if err != nil {
+		return 0, "", err
+	}
+	if err = validateSecureAuthRootIdentity(dirHandle, expectedRoot); err != nil {
+		_ = windows.CloseHandle(dirHandle)
 		return 0, "", err
 	}
 	keepOpen := false

--- a/internal/store/objectstore_secure_windows_test.go
+++ b/internal/store/objectstore_secure_windows_test.go
@@ -1,0 +1,197 @@
+//go:build windows
+
+package store
+
+import (
+	"bytes"
+	"errors"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestSecureAuthFileWindowsNestedLifecycle(t *testing.T) {
+	baseDir := t.TempDir()
+	credentialPath := filepath.Join("team", "token.json")
+	siblingPath := filepath.Join("team", "sibling.json")
+
+	if err := secureWriteAuthFile(baseDir, credentialPath, []byte("first")); err != nil {
+		t.Fatalf("write nested auth file: %v", err)
+	}
+	data, info, err := secureReadAuthFile(baseDir, credentialPath)
+	if err != nil {
+		t.Fatalf("read nested auth file: %v", err)
+	}
+	if !bytes.Equal(data, []byte("first")) {
+		t.Fatalf("nested auth file = %q, want %q", data, "first")
+	}
+	if !info.Mode().IsRegular() {
+		t.Fatalf("nested auth file mode = %v, want regular file", info.Mode())
+	}
+
+	if err = secureWriteAuthFile(baseDir, siblingPath, []byte("sibling")); err != nil {
+		t.Fatalf("write sibling auth file: %v", err)
+	}
+	if err = secureWriteAuthFile(baseDir, credentialPath, []byte("replacement")); err != nil {
+		t.Fatalf("replace nested auth file: %v", err)
+	}
+	data, _, err = secureReadAuthFile(baseDir, credentialPath)
+	if err != nil {
+		t.Fatalf("read replacement auth file: %v", err)
+	}
+	if !bytes.Equal(data, []byte("replacement")) {
+		t.Fatalf("replacement auth file = %q, want %q", data, "replacement")
+	}
+	siblingData, _, err := secureReadAuthFile(baseDir, siblingPath)
+	if err != nil {
+		t.Fatalf("read sibling auth file: %v", err)
+	}
+	if !bytes.Equal(siblingData, []byte("sibling")) {
+		t.Fatalf("sibling auth file = %q, want %q", siblingData, "sibling")
+	}
+
+	if err = secureRemoveAuthFile(baseDir, credentialPath); err != nil {
+		t.Fatalf("remove nested auth file: %v", err)
+	}
+	if _, _, err = secureReadAuthFile(baseDir, credentialPath); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("read removed auth file error = %v, want fs.ErrNotExist", err)
+	}
+	siblingData, _, err = secureReadAuthFile(baseDir, siblingPath)
+	if err != nil {
+		t.Fatalf("read sibling after removing replacement: %v", err)
+	}
+	if !bytes.Equal(siblingData, []byte("sibling")) {
+		t.Fatalf("sibling after removing replacement = %q, want %q", siblingData, "sibling")
+	}
+}
+
+func TestSecureAuthFileWindowsMissingLeaf(t *testing.T) {
+	baseDir := t.TempDir()
+	for _, relativePath := range []string{
+		"missing.json",
+		filepath.Join("missing-parent", "missing.json"),
+	} {
+		t.Run(relativePath, func(t *testing.T) {
+			if _, _, err := secureReadAuthFile(baseDir, relativePath); !errors.Is(err, fs.ErrNotExist) {
+				t.Fatalf("read missing auth file error = %v, want fs.ErrNotExist", err)
+			}
+			if err := secureRemoveAuthFile(baseDir, relativePath); !errors.Is(err, fs.ErrNotExist) {
+				t.Fatalf("remove missing auth file error = %v, want fs.ErrNotExist", err)
+			}
+		})
+	}
+}
+
+func TestSecureAuthFileWindowsFinalDACL(t *testing.T) {
+	baseDir := t.TempDir()
+	relativePath := "token.json"
+	path := filepath.Join(baseDir, relativePath)
+	if err := os.WriteFile(path, []byte("existing"), 0o666); err != nil {
+		t.Fatalf("write existing auth file: %v", err)
+	}
+	wideDescriptor, err := windows.SecurityDescriptorFromString("D:AI(A;;GA;;;WD)")
+	if err != nil {
+		t.Fatalf("build wide DACL: %v", err)
+	}
+	wideDACL, _, err := wideDescriptor.DACL()
+	if err != nil {
+		t.Fatalf("read wide DACL: %v", err)
+	}
+	if err = windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION, nil, nil, wideDACL, nil); err != nil {
+		t.Fatalf("apply wide DACL: %v", err)
+	}
+
+	if err = secureWriteAuthFile(baseDir, relativePath, []byte("replacement")); err != nil {
+		t.Fatalf("replace auth file: %v", err)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open replacement auth file: %v", err)
+	}
+	defer file.Close()
+	assertObjectStoreCurrentUserOnlyDACL(t, file)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read replacement auth file: %v", err)
+	}
+	if !bytes.Equal(data, []byte("replacement")) {
+		t.Fatalf("replacement auth file = %q, want %q", data, "replacement")
+	}
+}
+
+func TestSecureAuthFileWindowsRejectsDirectoryJunction(t *testing.T) {
+	baseDir := t.TempDir()
+	outsideDir := t.TempDir()
+	outsidePath := filepath.Join(outsideDir, "escape.json")
+	if err := os.WriteFile(outsidePath, []byte("outside"), 0o600); err != nil {
+		t.Fatalf("write outside auth file: %v", err)
+	}
+	junctionPath := filepath.Join(baseDir, "junction")
+	if output, err := exec.Command("cmd", "/c", "mklink", "/J", junctionPath, outsideDir).CombinedOutput(); err != nil {
+		t.Skipf("mklink /J unavailable: %v (%s)", err, bytes.TrimSpace(output))
+	}
+
+	relativePath := filepath.Join("junction", "escape.json")
+	if err := secureWriteAuthFile(baseDir, relativePath, []byte("sensitive")); err == nil {
+		t.Fatal("write through directory junction succeeded, want rejection")
+	}
+	if _, _, err := secureReadAuthFile(baseDir, relativePath); err == nil {
+		t.Fatal("read through directory junction succeeded, want rejection")
+	}
+	if err := secureRemoveAuthFile(baseDir, relativePath); err == nil {
+		t.Fatal("remove through directory junction succeeded, want rejection")
+	}
+	outsideData, err := os.ReadFile(outsidePath)
+	if err != nil {
+		t.Fatalf("read outside auth file after rejected operations: %v", err)
+	}
+	if !bytes.Equal(outsideData, []byte("outside")) {
+		t.Fatalf("outside auth file = %q, want %q", outsideData, "outside")
+	}
+}
+
+func assertObjectStoreCurrentUserOnlyDACL(t *testing.T, file *os.File) {
+	t.Helper()
+	securityDescriptor, err := windows.GetSecurityInfo(
+		windows.Handle(file.Fd()),
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION,
+	)
+	if err != nil {
+		t.Fatalf("GetSecurityInfo: %v", err)
+	}
+	control, _, err := securityDescriptor.Control()
+	if err != nil {
+		t.Fatalf("security descriptor control: %v", err)
+	}
+	if control&windows.SE_DACL_PROTECTED == 0 {
+		t.Fatalf("DACL is not protected: control=%#x", control)
+	}
+	dacl, _, err := securityDescriptor.DACL()
+	if err != nil {
+		t.Fatalf("DACL: %v", err)
+	}
+	if dacl == nil || dacl.AceCount != 1 {
+		t.Fatalf("DACL ACE count = %v, want 1", dacl)
+	}
+	var ace *windows.ACCESS_ALLOWED_ACE
+	if err = windows.GetAce(dacl, 0, &ace); err != nil {
+		t.Fatalf("GetAce: %v", err)
+	}
+	if ace == nil || ace.Header.AceType != windows.ACCESS_ALLOWED_ACE_TYPE {
+		t.Fatalf("ACE = %#v, want access-allowed ACE", ace)
+	}
+	currentUser, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		t.Fatalf("GetTokenUser: %v", err)
+	}
+	aceSID := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+	if !aceSID.Equals(currentUser.User.Sid) {
+		t.Fatalf("ACE SID = %s, want current user %s", aceSID.String(), currentUser.User.Sid.String())
+	}
+}

--- a/internal/store/objectstore_secure_windows_test.go
+++ b/internal/store/objectstore_secure_windows_test.go
@@ -89,6 +89,24 @@ func TestSecureAuthFileWindowsMissingLeaf(t *testing.T) {
 	}
 }
 
+func TestSecureAuthFileWindowsMissingInitializedRoot(t *testing.T) {
+	parent := t.TempDir()
+	baseDir := filepath.Join(parent, "auths")
+	if err := os.Mkdir(baseDir, 0o700); err != nil {
+		t.Fatalf("create initialized auth root: %v", err)
+	}
+	root := mustCaptureSecureAuthRootIdentity(t, baseDir)
+	if err := os.Rename(baseDir, baseDir+"-moved"); err != nil {
+		t.Fatalf("move initialized auth root: %v", err)
+	}
+	if _, _, err := secureReadAuthFile(baseDir, root, "missing.json"); !errors.Is(err, errObjectStoreAuthRootUnavailable) || errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("read missing initialized root error = %v, want root unavailable only", err)
+	}
+	if err := secureRemoveAuthFile(baseDir, root, "missing.json"); !errors.Is(err, errObjectStoreAuthRootUnavailable) || errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("remove missing initialized root error = %v, want root unavailable only", err)
+	}
+}
+
 func TestSecureAuthFileWindowsFinalDACL(t *testing.T) {
 	baseDir := t.TempDir()
 	root := mustCaptureSecureAuthRootIdentity(t, baseDir)

--- a/internal/store/objectstore_secure_windows_test.go
+++ b/internal/store/objectstore_secure_windows_test.go
@@ -17,13 +17,14 @@ import (
 
 func TestSecureAuthFileWindowsNestedLifecycle(t *testing.T) {
 	baseDir := t.TempDir()
+	root := mustCaptureSecureAuthRootIdentity(t, baseDir)
 	credentialPath := filepath.Join("team", "token.json")
 	siblingPath := filepath.Join("team", "sibling.json")
 
-	if err := secureWriteAuthFile(baseDir, credentialPath, []byte("first")); err != nil {
+	if err := secureWriteAuthFile(baseDir, root, credentialPath, []byte("first")); err != nil {
 		t.Fatalf("write nested auth file: %v", err)
 	}
-	data, info, err := secureReadAuthFile(baseDir, credentialPath)
+	data, info, err := secureReadAuthFile(baseDir, root, credentialPath)
 	if err != nil {
 		t.Fatalf("read nested auth file: %v", err)
 	}
@@ -34,20 +35,20 @@ func TestSecureAuthFileWindowsNestedLifecycle(t *testing.T) {
 		t.Fatalf("nested auth file mode = %v, want regular file", info.Mode())
 	}
 
-	if err = secureWriteAuthFile(baseDir, siblingPath, []byte("sibling")); err != nil {
+	if err = secureWriteAuthFile(baseDir, root, siblingPath, []byte("sibling")); err != nil {
 		t.Fatalf("write sibling auth file: %v", err)
 	}
-	if err = secureWriteAuthFile(baseDir, credentialPath, []byte("replacement")); err != nil {
+	if err = secureWriteAuthFile(baseDir, root, credentialPath, []byte("replacement")); err != nil {
 		t.Fatalf("replace nested auth file: %v", err)
 	}
-	data, _, err = secureReadAuthFile(baseDir, credentialPath)
+	data, _, err = secureReadAuthFile(baseDir, root, credentialPath)
 	if err != nil {
 		t.Fatalf("read replacement auth file: %v", err)
 	}
 	if !bytes.Equal(data, []byte("replacement")) {
 		t.Fatalf("replacement auth file = %q, want %q", data, "replacement")
 	}
-	siblingData, _, err := secureReadAuthFile(baseDir, siblingPath)
+	siblingData, _, err := secureReadAuthFile(baseDir, root, siblingPath)
 	if err != nil {
 		t.Fatalf("read sibling auth file: %v", err)
 	}
@@ -55,13 +56,13 @@ func TestSecureAuthFileWindowsNestedLifecycle(t *testing.T) {
 		t.Fatalf("sibling auth file = %q, want %q", siblingData, "sibling")
 	}
 
-	if err = secureRemoveAuthFile(baseDir, credentialPath); err != nil {
+	if err = secureRemoveAuthFile(baseDir, root, credentialPath); err != nil {
 		t.Fatalf("remove nested auth file: %v", err)
 	}
-	if _, _, err = secureReadAuthFile(baseDir, credentialPath); !errors.Is(err, fs.ErrNotExist) {
+	if _, _, err = secureReadAuthFile(baseDir, root, credentialPath); !errors.Is(err, fs.ErrNotExist) {
 		t.Fatalf("read removed auth file error = %v, want fs.ErrNotExist", err)
 	}
-	siblingData, _, err = secureReadAuthFile(baseDir, siblingPath)
+	siblingData, _, err = secureReadAuthFile(baseDir, root, siblingPath)
 	if err != nil {
 		t.Fatalf("read sibling after removing replacement: %v", err)
 	}
@@ -72,15 +73,16 @@ func TestSecureAuthFileWindowsNestedLifecycle(t *testing.T) {
 
 func TestSecureAuthFileWindowsMissingLeaf(t *testing.T) {
 	baseDir := t.TempDir()
+	root := mustCaptureSecureAuthRootIdentity(t, baseDir)
 	for _, relativePath := range []string{
 		"missing.json",
 		filepath.Join("missing-parent", "missing.json"),
 	} {
 		t.Run(relativePath, func(t *testing.T) {
-			if _, _, err := secureReadAuthFile(baseDir, relativePath); !errors.Is(err, fs.ErrNotExist) {
+			if _, _, err := secureReadAuthFile(baseDir, root, relativePath); !errors.Is(err, fs.ErrNotExist) {
 				t.Fatalf("read missing auth file error = %v, want fs.ErrNotExist", err)
 			}
-			if err := secureRemoveAuthFile(baseDir, relativePath); !errors.Is(err, fs.ErrNotExist) {
+			if err := secureRemoveAuthFile(baseDir, root, relativePath); !errors.Is(err, fs.ErrNotExist) {
 				t.Fatalf("remove missing auth file error = %v, want fs.ErrNotExist", err)
 			}
 		})
@@ -89,6 +91,7 @@ func TestSecureAuthFileWindowsMissingLeaf(t *testing.T) {
 
 func TestSecureAuthFileWindowsFinalDACL(t *testing.T) {
 	baseDir := t.TempDir()
+	root := mustCaptureSecureAuthRootIdentity(t, baseDir)
 	relativePath := "token.json"
 	path := filepath.Join(baseDir, relativePath)
 	if err := os.WriteFile(path, []byte("existing"), 0o666); err != nil {
@@ -106,7 +109,7 @@ func TestSecureAuthFileWindowsFinalDACL(t *testing.T) {
 		t.Fatalf("apply wide DACL: %v", err)
 	}
 
-	if err = secureWriteAuthFile(baseDir, relativePath, []byte("replacement")); err != nil {
+	if err = secureWriteAuthFile(baseDir, root, relativePath, []byte("replacement")); err != nil {
 		t.Fatalf("replace auth file: %v", err)
 	}
 	file, err := os.Open(path)
@@ -126,6 +129,7 @@ func TestSecureAuthFileWindowsFinalDACL(t *testing.T) {
 
 func TestSecureAuthFileWindowsRejectsDirectoryJunction(t *testing.T) {
 	baseDir := t.TempDir()
+	root := mustCaptureSecureAuthRootIdentity(t, baseDir)
 	outsideDir := t.TempDir()
 	outsidePath := filepath.Join(outsideDir, "escape.json")
 	if err := os.WriteFile(outsidePath, []byte("outside"), 0o600); err != nil {
@@ -137,13 +141,13 @@ func TestSecureAuthFileWindowsRejectsDirectoryJunction(t *testing.T) {
 	}
 
 	relativePath := filepath.Join("junction", "escape.json")
-	if err := secureWriteAuthFile(baseDir, relativePath, []byte("sensitive")); err == nil {
+	if err := secureWriteAuthFile(baseDir, root, relativePath, []byte("sensitive")); err == nil {
 		t.Fatal("write through directory junction succeeded, want rejection")
 	}
-	if _, _, err := secureReadAuthFile(baseDir, relativePath); err == nil {
+	if _, _, err := secureReadAuthFile(baseDir, root, relativePath); err == nil {
 		t.Fatal("read through directory junction succeeded, want rejection")
 	}
-	if err := secureRemoveAuthFile(baseDir, relativePath); err == nil {
+	if err := secureRemoveAuthFile(baseDir, root, relativePath); err == nil {
 		t.Fatal("remove through directory junction succeeded, want rejection")
 	}
 	outsideData, err := os.ReadFile(outsidePath)
@@ -152,6 +156,75 @@ func TestSecureAuthFileWindowsRejectsDirectoryJunction(t *testing.T) {
 	}
 	if !bytes.Equal(outsideData, []byte("outside")) {
 		t.Fatalf("outside auth file = %q, want %q", outsideData, "outside")
+	}
+}
+
+func TestSecureAuthFileWindowsRejectsInitializedRootReplacement(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(string, secureAuthRootIdentity, string) error
+	}{
+		{
+			name: "read",
+			run: func(baseDir string, root secureAuthRootIdentity, relativePath string) error {
+				data, _, err := secureReadAuthFile(baseDir, root, relativePath)
+				if len(data) != 0 {
+					t.Fatalf("secure read returned replacement-root data %q", data)
+				}
+				return err
+			},
+		},
+		{
+			name: "write",
+			run: func(baseDir string, root secureAuthRootIdentity, relativePath string) error {
+				return secureWriteAuthFile(baseDir, root, relativePath, []byte("sensitive"))
+			},
+		},
+		{
+			name: "delete",
+			run: func(baseDir string, root secureAuthRootIdentity, relativePath string) error {
+				return secureRemoveAuthFile(baseDir, root, relativePath)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			parent := t.TempDir()
+			baseDir := filepath.Join(parent, "auths")
+			originalDir := filepath.Join(parent, "auths-original")
+			replacementDir := filepath.Join(parent, "auths-replacement")
+			relativePath := filepath.Join("team", "token.json")
+			if err := os.MkdirAll(filepath.Join(baseDir, "team"), 0o700); err != nil {
+				t.Fatalf("create initialized auth root: %v", err)
+			}
+			if err := os.MkdirAll(filepath.Join(replacementDir, "team"), 0o700); err != nil {
+				t.Fatalf("create replacement auth root: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(baseDir, relativePath), []byte("inside"), 0o600); err != nil {
+				t.Fatalf("write initialized auth fixture: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(replacementDir, relativePath), []byte("outside"), 0o600); err != nil {
+				t.Fatalf("write replacement auth fixture: %v", err)
+			}
+			root := mustCaptureSecureAuthRootIdentity(t, baseDir)
+			if err := os.Rename(baseDir, originalDir); err != nil {
+				t.Fatalf("move initialized auth root: %v", err)
+			}
+			if err := os.Rename(replacementDir, baseDir); err != nil {
+				t.Fatalf("install replacement auth root: %v", err)
+			}
+
+			err := test.run(baseDir, root, relativePath)
+			if err == nil {
+				t.Fatal("secure auth operation accepted a replacement root identity")
+			}
+			if !errors.Is(err, errObjectStoreAuthRootChanged) {
+				t.Fatalf("secure auth operation error = %v, want root identity change", err)
+			}
+			assertFileContents(t, filepath.Join(originalDir, relativePath), "inside")
+			assertFileContents(t, filepath.Join(baseDir, relativePath), "outside")
+		})
 	}
 }
 


### PR DESCRIPTION
## 结果与交付边界

把 Object Store auth mirror 的 read、write、replace、delete、mirror、upload、list 与 provider serialization 绑定到初始化时固定的目录 identity 和 descriptor/handle，阻止 traversal、symlink、junction/reparse point、ancestor/root replacement 与 validation-to-I/O path swap 把凭据操作导向 mirror 之外。auth root 不可用时 fail closed；不会误判为缺失 leaf，也不会继续触发错误的 remote PUT/DELETE。

当前 PR exact head 为 `7dd274c19798825a7d940edb9c38dc7daee66bb3`，base `main` 为 `0d5e2c82544902f088a91eab1279c37b085a247f`。代码、native Windows CI 与独立复查已通过；尚未 merge、tag、release、生成发布 artifact、deployment 或验证线上 runtime。

## 根因与修复

旧实现先做 lexical/path validation，随后又回到 path-based I/O；provider `TokenStorage.SaveTokenToFile(path)` 还需要受控的临时 pathname。当前实现按平台关闭这些窗口：

- **固定 auth root identity**：构造时记录 POSIX device/inode 或 Windows volume serial/file index；后续所有 auth I/O 重新打开 root 后先校验 identity，再进行 handle-relative traversal。
- **POSIX auth I/O**：从可信 descriptor 逐组件 `openat(... O_NOFOLLOW ...)`，nested read/write/delete/replace 均相对已验证 root FD；拒绝 symlink、ancestor swap、root rename/replacement。
- **Windows auth I/O**：使用 `NtCreateFile`、`OBJ_DONT_REPARSE`、`FILE_OPEN_REPARSE_POINT`、handle-relative rename/delete 与 current-user-only DACL；root、junction/reparse point 与最终 leaf identity 均 fail closed。
- **Provider fast path**：支持 `RawJSON()` 的 storage 直接 clone merged JSON，不再创建 pathname。
- **POSIX legacy provider rendering**：创建 owner-only anonymous FD，通过 `/dev/fd/<fd>` 或 `/proc/self/fd/<fd>` 兼容既有 writer，避免持久 credential staging file。
- **Windows legacy provider rendering**：在固定 spool root 下维护 `.auth-render-staging`；先校验 pinned spool identity，再 handle-relative open/create staging root和随机非 `.json` flat file；限制 DACL，覆盖正常、error、no-op、startup residue 清理。
- **Cleanup ordering**：provider reader 关闭后才 handle-relative reopen，比较 file identity 后删除，兼容 Windows share rules并拒绝 replacement。
- **Root unavailable 语义**：新增独立 `errObjectStoreAuthRootUnavailable`，不与 `fs.ErrNotExist` 混淆；只有真正缺失的 auth leaf 保留 remote-delete 语义。
- **Remote mutation gate**：local validation/root identity 失败后，不执行 remote PUT/DELETE；包含 local write 完成、upload 前 root 被移走的窗口。

## 兼容性

- nested auth directory、atomic replace、sibling file、equal metadata no-op、真正缺失 local leaf触发 remote delete、object-key mapping、JSON bytes、owner-only mode与长合法文件名保持兼容。
- built-in provider storage继续使用既有 `SaveTokenToFile` / `misc.OpenCredentialFile`；plugin merged metadata/provider type由 `RawJSON()` path-free fast path保留。
- 不修改 Object Store API、config schema、usage contract、Management route或公开 package path。

## Red-first 与 native Windows 历史

本 PR 保留并解释两轮真实 Windows failure，不用 cross-compile 或后续 green 隐去：

1. Run `29978372448`：nested lifecycle与final DACL出现 `Access is denied`。根因是对 write/delete-oriented handle调用 `GetFileInformationByHandle` 时未请求 `FILE_READ_ATTRIBUTES`；补齐 access mask 后通过。
2. Run `29980730558`：provider reopen出现 `The process cannot access the file because it is being used by another process`。根因是初始 staging handle请求 `DELETE`，而 legacy provider reopen不共享 DELETE；修复为 reader关闭后 handle-relative reopen、identity compare、delete。
3. 后续复查发现 missing initialized root可能被误判为leaf missing，以及首次 Windows staging init未锚定 pinned spool root；当前 head分别通过 typed root-unavailable error与 spool-root identity gate修复。

最新 native Windows run `29982059160` 在 exact head源码树上通过，关键测试均未 skip：

- `TestRenderAuthStorageLocksWindowsStagingPaths`
- `TestRenderAuthStorageLocksWindowsStagingCleanup`
- `TestRenderAuthStorageLocksWindowsStagingRootReplacement`
- `TestRenderAuthStorageLocksWindowsStagingInitializationRootReplacement/ordinary_spool_directory`
- `TestRenderAuthStorageLocksWindowsStagingInitializationRootReplacement/ancestor_junction`
- `TestSecureAuthFileWindowsNestedLifecycle`
- `TestSecureAuthFileWindowsMissingInitializedRoot`
- `TestSecureAuthFileWindowsFinalDACL`
- `TestSecureAuthFileWindowsRejectsDirectoryJunction`
- `TestSecureAuthFileWindowsRejectsInitializedRootReplacement`

## Exact-head 验证

以下验证均针对 `7dd274c19798825a7d940edb9c38dc7daee66bb3`：

- `go test ./internal/store -count=1`：passed
- `go test -race ./internal/store -count=1`：passed
- `go test ./... -count=1`：passed
- `scripts/check-lts-contract.sh`：passed
- `go build -o /dev/null ./cmd/server`：passed
- `actionlint .github/workflows/pr-test-build.yml`：passed
- Windows amd64/arm64 `go test -c` 与 Windows amd64 `go vet ./internal/store`：passed
- Linux amd64/arm64与FreeBSD amd64 cross-compile：passed
- `git diff --check`：passed
- GitHub exact-head六项 checks：passed
- 独立 diff-focused安全复查：未发现新的 P0–P3 finding；旧 threads对应问题已由当前实现和测试关闭

## Review focus

1. initialized auth/spool root identity是否在任何 path-based mutation前完成校验；
2. root unavailable与leaf missing是否保持不同的 local/remote语义；
3. POSIX anonymous FD及Windows managed staging是否兼容 legacy provider writer，同时不暴露可替换 credential path；
4. Windows access/share flags、DACL、handle-relative cleanup和identity comparison；
5. local rejection后 outside file、staging residue和remote object是否都保持不变。
