### PR TITLE
fix(runtime): 隔离 provider 状态、限流与陈旧写回

### DIFF
--- a/internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
+++ b/internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
@@ -1707,6 +1707,64 @@ func TestCodexExecutorAbnormalReasoningRetry_ObserveOnlyStreamingDoesNotBufferUn
 	}
 }
 
+func TestCodexExecutorAbnormalReasoningRetry_NonBufferingStreamOverReconstructionCapDoesNotFailAfterDelta(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  *config.Config
+	}{
+		{
+			name: "observe only",
+			cfg:  codexAbnormalReasoningRetryTestConfigWithAction(config.CodexAbnormalReasoningRetryActionObserveOnly),
+		},
+		{
+			name: "stream buffer disabled",
+			cfg: func() *config.Config {
+				streamBuffer := false
+				return codexAbnormalReasoningRetryTestConfig(nil, &streamBuffer)
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			streamBufferMaxBytes := int64(1)
+			tt.cfg.Codex.AbnormalReasoningRetry.StreamBufferMaxBytes = &streamBufferMaxBytes
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = w.Write([]byte(`data: {"type":"response.output_text.delta","delta":"visible"}` + "\n\n"))
+				_, _ = w.Write([]byte(`data: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"visible"}]}}` + "\n\n"))
+				_, _ = w.Write([]byte(codexCompletedSSE("gpt-5.5", 100)))
+			}))
+			defer server.Close()
+
+			executor := NewCodexExecutor(tt.cfg)
+			result, err := executor.ExecuteStream(context.Background(), codexAbnormalReasoningRetryTestAuth(server.URL), cliproxyexecutor.Request{
+				Model:   "gpt-5.5",
+				Payload: []byte(`{"model":"gpt-5.5","input":"hello"}`),
+			}, cliproxyexecutor.Options{
+				SourceFormat: sdktranslator.FromString("openai-response"),
+				Stream:       true,
+			})
+			if err != nil {
+				t.Fatalf("ExecuteStream error = %v", err)
+			}
+
+			var payload []byte
+			for chunk := range result.Chunks {
+				if chunk.Err != nil {
+					t.Fatalf("stream emitted an error after visible delta: %v", chunk.Err)
+				}
+				payload = append(payload, chunk.Payload...)
+			}
+			if !bytes.Contains(payload, []byte("visible")) {
+				t.Fatalf("stream payload = %s, want visible delta", payload)
+			}
+		})
+	}
+}
+
 func TestCodexExecutorAbnormalReasoningRetry_StreamingBufferMaxBytesAbnormalStillRetriesWithoutFallback(t *testing.T) {
 	streamBufferMaxBytes := int64(1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -1619,7 +1619,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		buffering := abnormalRetry.StreamBuffer()
 		bufferMaxBytes := abnormalRetry.StreamBufferMaxBytes()
 		scannerMaxTokenBytes := int64(52_428_800) // 50 MiB compatibility ceiling.
-		if bufferMaxBytes > 0 && bufferMaxBytes < scannerMaxTokenBytes {
+		if buffering && bufferMaxBytes > 0 && bufferMaxBytes < scannerMaxTokenBytes {
 			scannerMaxTokenBytes = bufferMaxBytes + 1
 			if scannerMaxTokenBytes < 64<<10 {
 				scannerMaxTokenBytes = 64 << 10
@@ -1635,6 +1635,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		var bufferedChunks []cliproxyexecutor.StreamChunk
 		var bufferLimitErr error
 		bufferLimitExceeded := false
+		reconstructionCapExceeded := false
 		var flushBuffered func() bool
 		exceedBufferLimit := func() {
 			if bufferLimitExceeded {
@@ -1724,9 +1725,23 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 				}
 				switch eventType {
 				case "response.output_item.done":
-					if !bufferLimitExceeded {
-						if bufferMaxBytes > 0 && bufferedBytes+outputItemsBytes+int64(len(data)) > bufferMaxBytes {
-							exceedBufferLimit()
+					if !bufferLimitExceeded && !reconstructionCapExceeded {
+						candidateBytes := outputItemsBytes + int64(len(data))
+						if buffering {
+							candidateBytes += bufferedBytes
+						}
+						if bufferMaxBytes > 0 && candidateBytes > bufferMaxBytes {
+							if buffering {
+								exceedBufferLimit()
+							} else {
+								// The client has already received stream deltas. Stop
+								// retaining reconstruction state instead of converting a
+								// delivered response into a terminal error.
+								reconstructionCapExceeded = true
+								outputItemsByIndex = nil
+								outputItemsFallback = nil
+								outputItemsBytes = 0
+							}
 						} else {
 							collectCodexOutputItemDone(data, outputItemsByIndex, &outputItemsFallback)
 							outputItemsBytes += int64(len(data))
@@ -1819,7 +1834,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 			if ctx.Err() != nil {
 				return
 			}
-			if bufferMaxBytes > 0 && strings.Contains(errScan.Error(), "token too long") {
+			if buffering && bufferMaxBytes > 0 && strings.Contains(errScan.Error(), "token too long") {
 				exceedBufferLimit()
 				helps.RecordAPIResponseError(ctx, e.cfg, bufferLimitErr)
 				reporter.PublishFailure(ctx, bufferLimitErr)
@@ -2334,6 +2349,7 @@ func newCodexStatusErr(statusCode int, body []byte) statusErr {
 		msg:                 string(body),
 		modelFallbackReason: classification.ModelFallbackReason,
 		retryAfter:          classification.RetryAfter,
+		codexRateLimitClass: codexRateLimitClass(body),
 	}
 	return err
 }
@@ -2346,6 +2362,37 @@ type CodexUpstreamErrorClassification struct {
 	RetryAfter          *time.Duration
 	RequestInvalid      bool
 	RecordWithoutModel  bool
+}
+
+const (
+	CodexRateLimitClassUsageLimit = "usage-limit"
+	CodexRateLimitClassTransient  = "transient-rate-limit"
+)
+
+// CodexRateLimitClass exposes whether a 429 is a quota exhaustion or a
+// transient upstream rate limit without changing the downstream HTTP payload.
+// The auth conductor can use this optional error capability to avoid treating
+// rate_limit_error/rate_limit_exceeded as usage_limit_reached.
+func (e statusErr) CodexRateLimitClass() string {
+	return e.codexRateLimitClass
+}
+
+func codexRateLimitClass(body []byte) string {
+	if isCodexUsageLimitError(body) {
+		return CodexRateLimitClassUsageLimit
+	}
+	for _, candidate := range []string{
+		gjson.GetBytes(body, "error.type").String(),
+		gjson.GetBytes(body, "error.code").String(),
+		gjson.GetBytes(body, "type").String(),
+		gjson.GetBytes(body, "code").String(),
+	} {
+		switch strings.ToLower(strings.TrimSpace(candidate)) {
+		case "rate_limit_error", "rate_limit_exceeded":
+			return CodexRateLimitClassTransient
+		}
+	}
+	return ""
 }
 
 // ClassifyCodexUpstreamError normalizes Codex quota and capacity responses.

--- a/internal/runtime/executor/codex_executor_retry_test.go
+++ b/internal/runtime/executor/codex_executor_retry_test.go
@@ -95,12 +95,32 @@ func TestNewCodexStatusErrTreatsUsageLimitAsRetryableRateLimit(t *testing.T) {
 	if got := err.ModelFallbackReason(); got != "usage-limit" {
 		t.Fatalf("ModelFallbackReason() = %q, want usage-limit", got)
 	}
+	if got := err.CodexRateLimitClass(); got != CodexRateLimitClassUsageLimit {
+		t.Fatalf("CodexRateLimitClass() = %q, want %q", got, CodexRateLimitClassUsageLimit)
+	}
 }
 
 func TestNewCodexStatusErrDoesNotClassifyTransientRateLimitForModelFallback(t *testing.T) {
 	err := newCodexStatusErr(http.StatusTooManyRequests, []byte(`{"error":{"type":"rate_limit_error","code":"rate_limit_exceeded"}}`))
 	if got := err.ModelFallbackReason(); got != "" {
 		t.Fatalf("ModelFallbackReason() = %q, want empty", got)
+	}
+	classified, ok := any(err).(interface{ CodexRateLimitClass() string })
+	if !ok {
+		t.Fatalf("error %T does not expose CodexRateLimitClass", err)
+	}
+	if got := classified.CodexRateLimitClass(); got != "transient-rate-limit" {
+		t.Fatalf("CodexRateLimitClass() = %q, want transient-rate-limit", got)
+	}
+}
+
+func TestGenericStatusErrDoesNotClassifyCodexRateLimit(t *testing.T) {
+	err := statusErr{
+		code: http.StatusTooManyRequests,
+		msg:  `{"error":{"type":"rate_limit_error","code":"rate_limit_exceeded"}}`,
+	}
+	if got := err.CodexRateLimitClass(); got != "" {
+		t.Fatalf("CodexRateLimitClass() = %q, want empty for a non-Codex status error", got)
 	}
 }
 

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -786,6 +786,7 @@ type statusErr struct {
 	msg                 string
 	retryAfter          *time.Duration
 	modelFallbackReason string
+	codexRateLimitClass string
 }
 
 func (e statusErr) Error() string {

--- a/sdk/cliproxy/auth/codex_transient_rate_limit_test.go
+++ b/sdk/cliproxy/auth/codex_transient_rate_limit_test.go
@@ -1,0 +1,131 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+type classifiedCodexRateLimitError struct {
+	class string
+}
+
+func (e classifiedCodexRateLimitError) Error() string               { return "codex rate limit" }
+func (e classifiedCodexRateLimitError) StatusCode() int             { return http.StatusTooManyRequests }
+func (e classifiedCodexRateLimitError) CodexRateLimitClass() string { return e.class }
+
+func TestResultErrorFromErrorPreservesCodexRateLimitClass(t *testing.T) {
+	const transientClass = "transient-rate-limit"
+	resultErr := resultErrorFromError(classifiedCodexRateLimitError{class: transientClass})
+	if resultErr == nil || resultErr.Code != transientClass {
+		t.Fatalf("result error = %+v, want code %q", resultErr, transientClass)
+	}
+	if resultErr.HTTPStatus != http.StatusTooManyRequests {
+		t.Fatalf("HTTP status = %d, want 429", resultErr.HTTPStatus)
+	}
+}
+
+func TestManagerMarkResultCodexTransientRateLimitDoesNotSetQuota(t *testing.T) {
+	prev := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(prev) })
+
+	const (
+		authID         = "codex-transient-rate-limit-auth"
+		model          = "codex-transient-rate-limit-model"
+		transientClass = "transient-rate-limit"
+	)
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	m := NewManager(nil, nil, nil)
+	if _, err := m.Register(context.Background(), &Auth{ID: authID, Provider: "codex", Status: StatusActive}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	m.MarkResult(context.Background(), Result{
+		AuthID:   authID,
+		Provider: "codex",
+		Model:    model,
+		Error: &Error{
+			HTTPStatus: http.StatusTooManyRequests,
+			Code:       transientClass,
+			Message:    "rate_limit_error",
+		},
+	})
+
+	updated, ok := m.GetByID(authID)
+	if !ok || updated == nil || updated.ModelStates[model] == nil {
+		t.Fatalf("missing updated model state: %+v", updated)
+	}
+	state := updated.ModelStates[model]
+	if state.Quota.Exceeded || state.Quota.Reason != "" {
+		t.Fatalf("transient rate limit was recorded as quota: %+v", state.Quota)
+	}
+	if !state.Unavailable || !state.NextRetryAfter.After(time.Now()) {
+		t.Fatalf("transient cooldown was not recorded: %+v", state)
+	}
+	if count := reg.GetModelCount(model); count != 1 {
+		t.Fatalf("registry model count = %d, want transient error not to suspend it", count)
+	}
+}
+
+func TestManagerMarkResultCodexTransientRateLimitDoesNotEraseActiveQuota(t *testing.T) {
+	prev := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(prev) })
+
+	const (
+		authID         = "codex-transient-after-quota-auth"
+		model          = "codex-transient-after-quota-model"
+		transientClass = "transient-rate-limit"
+	)
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	m := NewManager(nil, nil, nil)
+	if _, err := m.Register(context.Background(), &Auth{ID: authID, Provider: "codex", Status: StatusActive}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	m.MarkResult(context.Background(), Result{
+		AuthID: authID,
+		Model:  model,
+		Error: &Error{
+			HTTPStatus: http.StatusTooManyRequests,
+			Code:       "usage-limit",
+			Message:    "usage_limit_reached",
+		},
+	})
+	if count := reg.GetModelCount(model); count != 0 {
+		t.Fatalf("registry model count after quota = %d, want 0", count)
+	}
+
+	m.MarkResult(context.Background(), Result{
+		AuthID: authID,
+		Model:  model,
+		Error: &Error{
+			HTTPStatus: http.StatusTooManyRequests,
+			Code:       transientClass,
+			Message:    "rate_limit_error",
+		},
+	})
+
+	updated, ok := m.GetByID(authID)
+	if !ok || updated == nil || updated.ModelStates[model] == nil {
+		t.Fatalf("missing updated model state: %+v", updated)
+	}
+	state := updated.ModelStates[model]
+	if !state.Quota.Exceeded || state.Quota.Reason != "quota" || !state.NextRetryAfter.After(time.Now()) {
+		t.Fatalf("active quota was erased by an older transient result: %+v", state)
+	}
+	if state.LastError == nil || state.LastError.Code != "usage-limit" {
+		t.Fatalf("active quota error was replaced by transient state: %+v", state.LastError)
+	}
+	if count := reg.GetModelCount(model); count != 0 {
+		t.Fatalf("registry model count = %d, want manager and registry to retain active quota", count)
+	}
+}

--- a/sdk/cliproxy/auth/codex_transient_rate_limit_test.go
+++ b/sdk/cliproxy/auth/codex_transient_rate_limit_test.go
@@ -73,6 +73,90 @@ func TestManagerMarkResultCodexTransientRateLimitDoesNotSetQuota(t *testing.T) {
 	}
 }
 
+func TestManagerMarkResultCodexRawTransientRateLimitDoesNotSetQuota(t *testing.T) {
+	prev := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(prev) })
+
+	for _, tt := range []struct {
+		name string
+		code string
+	}{
+		{name: "rate-limit-error", code: "rate_limit_error"},
+		{name: "rate-limit-exceeded", code: "rate_limit_exceeded"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			authID := "codex-raw-transient-" + tt.name
+			model := "codex-raw-transient-model-" + tt.name
+			reg := registry.GetGlobalRegistry()
+			reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+			t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+			m := NewManager(nil, nil, nil)
+			if _, err := m.Register(context.Background(), &Auth{ID: authID, Provider: "codex", Status: StatusActive}); err != nil {
+				t.Fatalf("register auth: %v", err)
+			}
+			m.MarkResult(context.Background(), Result{
+				AuthID: authID, Provider: "codex", Model: model,
+				Error: &Error{HTTPStatus: http.StatusTooManyRequests, Code: tt.code, Message: tt.code},
+			})
+
+			updated, ok := m.GetByID(authID)
+			if !ok || updated == nil || updated.ModelStates[model] == nil {
+				t.Fatalf("missing updated model state: %+v", updated)
+			}
+			state := updated.ModelStates[model]
+			if state.Quota.Exceeded || state.Quota.Reason != "" {
+				t.Fatalf("raw transient rate limit was recorded as quota: %+v", state.Quota)
+			}
+			if !state.Unavailable || !state.NextRetryAfter.After(time.Now()) {
+				t.Fatalf("raw transient cooldown was not recorded: %+v", state)
+			}
+			if count := reg.GetModelCount(model); count != 1 {
+				t.Fatalf("registry model count = %d, want transient error not to suspend it", count)
+			}
+		})
+	}
+}
+
+func TestManagerMarkResultCodexTransientRateLimitWithoutModelDoesNotSetQuota(t *testing.T) {
+	prev := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(prev) })
+
+	for _, tt := range []struct {
+		name string
+		code string
+	}{
+		{name: "synthetic", code: "transient-rate-limit"},
+		{name: "rate-limit-error", code: "rate_limit_error"},
+		{name: "rate-limit-exceeded", code: "rate_limit_exceeded"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			authID := "codex-auth-level-transient-" + tt.name
+			m := NewManager(nil, nil, nil)
+			if _, err := m.Register(context.Background(), &Auth{ID: authID, Provider: "codex", Status: StatusActive}); err != nil {
+				t.Fatalf("register auth: %v", err)
+			}
+			m.MarkResult(context.Background(), Result{
+				AuthID: authID, Provider: "codex",
+				Error: &Error{HTTPStatus: http.StatusTooManyRequests, Code: tt.code, Message: tt.code},
+			})
+
+			updated, ok := m.GetByID(authID)
+			if !ok || updated == nil {
+				t.Fatalf("missing updated auth: %+v", updated)
+			}
+			if updated.Quota.Exceeded || updated.Quota.Reason != "" {
+				t.Fatalf("auth-level transient rate limit was recorded as quota: %+v", updated.Quota)
+			}
+			if !updated.Unavailable || !updated.NextRetryAfter.After(time.Now()) {
+				t.Fatalf("auth-level transient cooldown was not recorded: %+v", updated)
+			}
+		})
+	}
+}
+
 func TestManagerMarkResultCodexTransientRateLimitDoesNotEraseActiveQuota(t *testing.T) {
 	prev := quotaCooldownDisabled.Load()
 	quotaCooldownDisabled.Store(false)
@@ -127,5 +211,115 @@ func TestManagerMarkResultCodexTransientRateLimitDoesNotEraseActiveQuota(t *test
 	}
 	if count := reg.GetModelCount(model); count != 0 {
 		t.Fatalf("registry model count = %d, want manager and registry to retain active quota", count)
+	}
+}
+
+func TestManagerMarkResultCodexRawTransientRateLimitDoesNotEraseActiveQuota(t *testing.T) {
+	prev := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(prev) })
+
+	const (
+		authID = "codex-raw-transient-after-quota-auth"
+		model  = "codex-raw-transient-after-quota-model"
+	)
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	m := NewManager(nil, nil, nil)
+	if _, err := m.Register(context.Background(), &Auth{ID: authID, Provider: "codex", Status: StatusActive}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	m.MarkResult(context.Background(), Result{
+		AuthID: authID, Provider: "codex", Model: model,
+		Error: &Error{HTTPStatus: http.StatusTooManyRequests, Code: "usage-limit", Message: "usage_limit_reached"},
+	})
+	m.MarkResult(context.Background(), Result{
+		AuthID: authID, Provider: "codex", Model: model,
+		Error: &Error{HTTPStatus: http.StatusTooManyRequests, Code: "rate_limit_exceeded", Message: "rate_limit_exceeded"},
+	})
+
+	updated, ok := m.GetByID(authID)
+	if !ok || updated == nil || updated.ModelStates[model] == nil {
+		t.Fatalf("missing updated model state: %+v", updated)
+	}
+	state := updated.ModelStates[model]
+	if !state.Quota.Exceeded || state.Quota.Reason != "quota" || !state.NextRetryAfter.After(time.Now()) {
+		t.Fatalf("active quota was erased by raw transient result: %+v", state)
+	}
+	if state.LastError == nil || state.LastError.Code != "usage-limit" {
+		t.Fatalf("active quota error was replaced by raw transient state: %+v", state.LastError)
+	}
+	if count := reg.GetModelCount(model); count != 0 {
+		t.Fatalf("registry model count = %d, want active quota retained", count)
+	}
+}
+
+func TestManagerMarkResultCodexRawTransientRateLimitWithoutModelPreservesActiveQuota(t *testing.T) {
+	prev := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(prev) })
+
+	const authID = "codex-auth-level-raw-transient-after-quota"
+	retryAfter := 30 * time.Minute
+	m := NewManager(nil, nil, nil)
+	if _, err := m.Register(context.Background(), &Auth{ID: authID, Provider: "codex", Status: StatusActive}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	m.MarkResult(context.Background(), Result{
+		AuthID: authID, Provider: "codex",
+		Error:      &Error{HTTPStatus: http.StatusTooManyRequests, Code: "usage-limit", Message: "usage_limit_reached"},
+		RetryAfter: &retryAfter,
+	})
+	before, _ := m.GetByID(authID)
+	m.MarkResult(context.Background(), Result{
+		AuthID: authID, Provider: "codex",
+		Error: &Error{HTTPStatus: http.StatusTooManyRequests, Code: "rate_limit_error", Message: "rate_limit_error"},
+	})
+
+	updated, ok := m.GetByID(authID)
+	if !ok || updated == nil {
+		t.Fatalf("missing updated auth: %+v", updated)
+	}
+	if !updated.Quota.Exceeded || updated.Quota.Reason != "quota" || !updated.NextRetryAfter.Equal(before.NextRetryAfter) {
+		t.Fatalf("active auth-level quota was erased by raw transient result: before=%+v after=%+v", before, updated)
+	}
+	if updated.LastError == nil || updated.LastError.Code != "usage-limit" {
+		t.Fatalf("active auth-level quota error was replaced: %+v", updated.LastError)
+	}
+}
+
+func TestManagerMarkResultNonCodexRawRateLimitRemainsQuota(t *testing.T) {
+	prev := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(prev) })
+
+	const (
+		authID = "xai-raw-rate-limit-auth"
+		model  = "xai-raw-rate-limit-model"
+	)
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "xai", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	m := NewManager(nil, nil, nil)
+	if _, err := m.Register(context.Background(), &Auth{ID: authID, Provider: "xai", Status: StatusActive}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	m.MarkResult(context.Background(), Result{
+		AuthID: authID, Provider: "xai", Model: model,
+		Error: &Error{HTTPStatus: http.StatusTooManyRequests, Code: "rate_limit_error", Message: "rate_limit_error"},
+	})
+
+	updated, ok := m.GetByID(authID)
+	if !ok || updated == nil || updated.ModelStates[model] == nil {
+		t.Fatalf("missing updated model state: %+v", updated)
+	}
+	if !updated.ModelStates[model].Quota.Exceeded || updated.ModelStates[model].Quota.Reason != "quota" {
+		t.Fatalf("non-Codex raw rate limit did not remain quota: %+v", updated.ModelStates[model])
+	}
+	if count := reg.GetModelCount(model); count != 0 {
+		t.Fatalf("registry model count = %d, want non-Codex quota suspension", count)
 	}
 }

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -178,6 +178,50 @@ type Result struct {
 	ModelFallbackReason string
 }
 
+func resultForAuth(auth *Auth, provider, model string, success bool, resultErr *Error) Result {
+	result := Result{
+		Provider: provider,
+		Model:    model,
+		Success:  success,
+		Error:    resultErr,
+	}
+	if auth != nil {
+		result.AuthID = auth.ID
+	}
+	return result
+}
+
+type authGenerationContextKey struct{}
+
+type authGenerationContextValue struct {
+	authID     string
+	generation uint64
+}
+
+func contextWithAuthGeneration(ctx context.Context, auth *Auth) context.Context {
+	if auth == nil || auth.ID == "" || auth.generation == 0 {
+		return ctx
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, authGenerationContextKey{}, authGenerationContextValue{
+		authID:     auth.ID,
+		generation: auth.generation,
+	})
+}
+
+func authGenerationFromContext(ctx context.Context, authID string) uint64 {
+	if ctx == nil || authID == "" {
+		return 0
+	}
+	value, ok := ctx.Value(authGenerationContextKey{}).(authGenerationContextValue)
+	if !ok || value.authID != authID {
+		return 0
+	}
+	return value.generation
+}
+
 // Selector chooses an auth candidate for execution.
 type Selector interface {
 	Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error)
@@ -229,7 +273,9 @@ type Manager struct {
 	hook          Hook
 	mu            sync.RWMutex
 	auths         map[string]*Auth
-	scheduler     *authScheduler
+	// authGeneration is allocated under mu and never persisted.
+	authGeneration uint64
+	scheduler      *authScheduler
 	// pluginScheduler runs outside m.mu before falling back to native selection.
 	pluginScheduler PluginScheduler
 	// homeRuntimeAuths caches auths returned by Home so websocket sessions can
@@ -313,6 +359,14 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 	manager.apiKeyModelAlias.Store(apiKeyModelAliasTable(nil))
 	manager.scheduler = newAuthScheduler(selector)
 	return manager
+}
+
+func (m *Manager) nextAuthGenerationLocked() uint64 {
+	m.authGeneration++
+	if m.authGeneration == 0 {
+		m.authGeneration++
+	}
+	return m.authGeneration
 }
 
 func (m *Manager) SetPluginScheduler(scheduler PluginScheduler) {
@@ -919,6 +973,10 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 	}
 	auth := m.auths[authID]
 	if auth == nil || auth.Disabled || auth.Status == StatusDisabled || m.cooldownDisabledForAuth(auth) {
+		return false
+	}
+	recordProvider := strings.TrimSpace(record.Provider)
+	if recordProvider != "" && !strings.EqualFold(recordProvider, strings.TrimSpace(auth.Provider)) {
 		return false
 	}
 	updatedAt := record.UpdatedAt
@@ -2110,15 +2168,10 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 				failed = true
 				if !isRetryWithoutPenaltyError(chunk.Err) {
 					rerr := resultErrorFromError(chunk.Err)
-					m.MarkResult(ctx, Result{
-						AuthID:              auth.ID,
-						Provider:            provider,
-						Model:               resultModel,
-						Success:             false,
-						Error:               rerr,
-						RetryAfter:          retryAfterFromError(chunk.Err),
-						ModelFallbackReason: modelFallbackReasonFromError(chunk.Err),
-					})
+					result := resultForAuth(auth, provider, resultModel, false, rerr)
+					result.RetryAfter = retryAfterFromError(chunk.Err)
+					result.ModelFallbackReason = modelFallbackReasonFromError(chunk.Err)
+					m.MarkResult(ctx, result)
 				}
 			}
 			if !forward {
@@ -2176,7 +2229,7 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 			}
 		}
 		if !failed {
-			m.MarkResult(ctx, Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: true})
+			m.MarkResult(ctx, resultForAuth(auth, provider, resultModel, true, nil))
 		}
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: headers, Chunks: out, Metadata: cloneSchedulerAnyMap(metadata)}
@@ -2186,6 +2239,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 	if executor == nil {
 		return nil, &Error{Code: "executor_not_found", Message: "executor not registered"}
 	}
+	ctx = contextWithAuthGeneration(ctx, auth)
 	ctx = contextWithRequestedModelAlias(ctx, opts, routeModel)
 	var lastErr error
 	didRefreshOnUnauthorized := false
@@ -2224,6 +2278,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			}
 			if refreshed, okRefresh := m.tryRefreshAfterUnauthorized(ctx, auth, errStream, didRefreshOnUnauthorized); okRefresh {
 				auth = refreshed
+				ctx = contextWithAuthGeneration(ctx, auth)
 				didRefreshOnUnauthorized = true
 				markCodexModelFallbackDispatch(execOpts, auth.ID)
 				streamResult, errStream = executor.ExecuteStream(ctx, auth, execReq, execOpts)
@@ -2242,7 +2297,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		}
 		if errStream != nil {
 			rerr := resultErrorFromError(errStream)
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
+			result := resultForAuth(auth, provider, resultModel, false, rerr)
 			result.RetryAfter = retryAfterFromError(errStream)
 			result.ModelFallbackReason = modelFallbackReasonFromError(errStream)
 			m.MarkResult(ctx, result)
@@ -2266,6 +2321,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			if refreshed, okRefresh := m.tryRefreshAfterUnauthorized(ctx, auth, bootstrapErr, didRefreshOnUnauthorized); okRefresh {
 				discardStreamChunks(streamResult.Chunks)
 				auth = refreshed
+				ctx = contextWithAuthGeneration(ctx, auth)
 				didRefreshOnUnauthorized = true
 				markCodexModelFallbackDispatch(execOpts, auth.ID)
 				retryStream, retryErr := executor.ExecuteStream(ctx, auth, execReq, execOpts)
@@ -2288,7 +2344,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			}
 			if isRequestInvalidError(bootstrapErr) {
 				rerr := resultErrorFromError(bootstrapErr)
-				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
+				result := resultForAuth(auth, provider, resultModel, false, rerr)
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
 				result.ModelFallbackReason = modelFallbackReasonFromError(bootstrapErr)
 				m.MarkResult(ctx, result)
@@ -2297,7 +2353,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			}
 			if idx < len(execModels)-1 {
 				rerr := resultErrorFromError(bootstrapErr)
-				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
+				result := resultForAuth(auth, provider, resultModel, false, rerr)
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
 				result.ModelFallbackReason = modelFallbackReasonFromError(bootstrapErr)
 				m.MarkResult(ctx, result)
@@ -2306,7 +2362,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				continue
 			}
 			rerr := resultErrorFromError(bootstrapErr)
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
+			result := resultForAuth(auth, provider, resultModel, false, rerr)
 			result.RetryAfter = retryAfterFromError(bootstrapErr)
 			result.ModelFallbackReason = modelFallbackReasonFromError(bootstrapErr)
 			m.MarkResult(ctx, result)
@@ -2316,7 +2372,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 
 		if closed && len(buffered) == 0 {
 			emptyErr := &Error{Code: "empty_stream", Message: "upstream stream closed before first payload", Retryable: true}
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: emptyErr}
+			result := resultForAuth(auth, provider, resultModel, false, emptyErr)
 			m.MarkResult(ctx, result)
 			if idx < len(execModels)-1 {
 				lastErr = emptyErr
@@ -2541,8 +2597,9 @@ func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 		clearedCooldown = clearCooldownStateForAuth(auth, now)
 	}
 	auth.EnsureIndex()
-	authClone := auth.Clone()
 	m.mu.Lock()
+	auth.generation = m.nextAuthGenerationLocked()
+	authClone := auth.Clone()
 	m.auths[auth.ID] = authClone
 	m.mu.Unlock()
 	if !shouldDeferAPIKeyModelAliasRebuild(ctx) {
@@ -2562,14 +2619,27 @@ func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 
 // Update replaces an existing auth entry and notifies hooks.
 func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
+	saved, _, err := m.update(ctx, auth, 0, false)
+	return saved, err
+}
+
+func (m *Manager) updateIfGeneration(ctx context.Context, auth *Auth, expectedGeneration uint64) (*Auth, bool, error) {
+	return m.update(ctx, auth, expectedGeneration, true)
+}
+
+func (m *Manager) update(ctx context.Context, auth *Auth, expectedGeneration uint64, requireGeneration bool) (*Auth, bool, error) {
 	if auth == nil || auth.ID == "" {
-		return nil, nil
+		return nil, false, nil
 	}
 	m.mu.Lock()
 	existing, ok := m.auths[auth.ID]
 	if !ok || existing == nil {
 		m.mu.Unlock()
-		return nil, nil
+		return nil, false, nil
+	}
+	if requireGeneration && existing.generation != expectedGeneration {
+		m.mu.Unlock()
+		return nil, false, nil
 	}
 	if !auth.indexAssigned && auth.Index == "" {
 		auth.Index = existing.Index
@@ -2578,6 +2648,10 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 	now := time.Now()
 	sameProvider := strings.EqualFold(strings.TrimSpace(existing.Provider), strings.TrimSpace(auth.Provider))
 	if sameProvider {
+		auth.generation = existing.generation
+		if auth.generation == 0 {
+			auth.generation = m.nextAuthGenerationLocked()
+		}
 		auth.Success = existing.Success
 		auth.Failed = existing.Failed
 		auth.recentRequests = existing.recentRequests
@@ -2587,6 +2661,7 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 			}
 		}
 	} else {
+		auth.generation = m.nextAuthGenerationLocked()
 		clearProviderRuntimeState(auth, now)
 	}
 	clearedCooldown := false
@@ -2609,7 +2684,7 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 	if clearedCooldown || !sameProvider {
 		m.persistCooldownStates(ctx)
 	}
-	return auth.Clone(), nil
+	return auth.Clone(), true, nil
 }
 
 // Remove deletes an auth from runtime state without persisting.
@@ -2704,6 +2779,7 @@ func (m *Manager) Load(ctx context.Context) error {
 			continue
 		}
 		auth.EnsureIndex()
+		auth.generation = m.nextAuthGenerationLocked()
 		m.auths[auth.ID] = auth.Clone()
 	}
 	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
@@ -3278,6 +3354,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			lastErr = codexRateLimitObservationPendingError{}
 			continue
 		}
+		attemptCtx = contextWithAuthGeneration(attemptCtx, auth)
 		if m.continuityBeforeDispatchHook != nil {
 			m.continuityBeforeDispatchHook()
 		}
@@ -3305,11 +3382,12 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 		var errPrepare error
 		auth, errPrepare = m.prepareRequestAuth(execCtx, executor, auth)
 		if errPrepare != nil {
-			result := Result{AuthID: auth.ID, Provider: provider, Model: routeModel, Success: false, Error: resultErrorFromError(errPrepare)}
+			result := resultForAuth(auth, provider, routeModel, false, resultErrorFromError(errPrepare))
 			m.MarkResult(execCtx, result)
 			lastErr = errPrepare
 			continue
 		}
+		execCtx = contextWithAuthGeneration(execCtx, auth)
 		var authErr error
 		didRefreshOnUnauthorized := false
 		selectedPublished := false
@@ -3347,6 +3425,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				}
 				if refreshed, okRefresh := m.tryRefreshAfterUnauthorized(execCtx, auth, errExec, didRefreshOnUnauthorized); okRefresh {
 					auth = refreshed
+					execCtx = contextWithAuthGeneration(execCtx, auth)
 					didRefreshOnUnauthorized = true
 					markCodexModelFallbackDispatch(execOpts, auth.ID)
 					resp, errExec = executor.Execute(execCtx, auth, execReq, execOpts)
@@ -3363,7 +3442,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 					}
 				}
 			}
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: errExec == nil}
+			result := resultForAuth(auth, provider, resultModel, errExec == nil, nil)
 			if errExec != nil {
 				result.Error = resultErrorFromError(errExec)
 				if ra := retryAfterFromError(errExec); ra != nil {
@@ -3432,7 +3511,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 		}
 
 		tried[auth.ID] = struct{}{}
-		execCtx := ctx
+		execCtx := contextWithAuthGeneration(ctx, auth)
 		if rt := m.roundTripperFor(auth); rt != nil {
 			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
@@ -3447,11 +3526,12 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 		var errPrepare error
 		auth, errPrepare = m.prepareRequestAuth(execCtx, executor, auth)
 		if errPrepare != nil {
-			result := Result{AuthID: auth.ID, Provider: provider, Model: routeModel, Success: false, Error: resultErrorFromError(errPrepare)}
+			result := resultForAuth(auth, provider, routeModel, false, resultErrorFromError(errPrepare))
 			m.MarkResult(execCtx, result)
 			lastErr = errPrepare
 			continue
 		}
+		execCtx = contextWithAuthGeneration(execCtx, auth)
 		var authErr error
 		didRefreshOnUnauthorized := false
 		selectedPublished := false
@@ -3481,6 +3561,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				}
 				if refreshed, okRefresh := m.tryRefreshAfterUnauthorized(execCtx, auth, errExec, didRefreshOnUnauthorized); okRefresh {
 					auth = refreshed
+					execCtx = contextWithAuthGeneration(execCtx, auth)
 					didRefreshOnUnauthorized = true
 					resp, errExec = executor.CountTokens(execCtx, auth, execReq, execOpts)
 					if errExec != nil {
@@ -3493,7 +3574,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 					}
 				}
 			}
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: errExec == nil}
+			result := resultForAuth(auth, provider, resultModel, errExec == nil, nil)
 			if errExec != nil {
 				result.Error = countTokensResultErrorFromError(errExec, execReq.Model)
 				if ra := retryAfterFromError(errExec); ra != nil {
@@ -3570,6 +3651,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			lastErr = codexRateLimitObservationPendingError{}
 			continue
 		}
+		attemptCtx = contextWithAuthGeneration(attemptCtx, auth)
 		if m.continuityBeforeDispatchHook != nil {
 			m.continuityBeforeDispatchHook()
 		}
@@ -3600,11 +3682,12 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 		var errPrepare error
 		auth, errPrepare = m.prepareRequestAuth(execCtx, executor, auth)
 		if errPrepare != nil {
-			result := Result{AuthID: auth.ID, Provider: provider, Model: routeModel, Success: false, Error: resultErrorFromError(errPrepare)}
+			result := resultForAuth(auth, provider, routeModel, false, resultErrorFromError(errPrepare))
 			m.MarkResult(execCtx, result)
 			lastErr = errPrepare
 			continue
 		}
+		execCtx = contextWithAuthGeneration(execCtx, auth)
 		execReq := sanitizeDownstreamWebsocketFallbackRequest(execCtx, auth, req)
 		streamExecutionModel := ""
 		if restoreExecutionModel {
@@ -3755,6 +3838,10 @@ type requestAuthPrepareLock struct {
 	mu sync.Mutex
 }
 
+func authLifecycleChangedError() *Error {
+	return &Error{Code: "auth_lifecycle_changed", Message: "auth changed while preparing request", Retryable: true}
+}
+
 func (m *Manager) prepareRequestAuth(ctx context.Context, executor ProviderExecutor, auth *Auth) (*Auth, error) {
 	if m == nil || executor == nil || auth == nil {
 		return auth, nil
@@ -3779,9 +3866,15 @@ func (m *Manager) prepareRequestAuth(ctx context.Context, executor ProviderExecu
 	defer lock.mu.Unlock()
 
 	target := auth.Clone()
+	managed := false
 	m.mu.RLock()
 	if current := m.auths[id]; current != nil {
+		if auth.generation != 0 && current.generation != auth.generation {
+			m.mu.RUnlock()
+			return auth, authLifecycleChangedError()
+		}
 		target = current.Clone()
+		managed = true
 	}
 	m.mu.RUnlock()
 
@@ -3797,9 +3890,15 @@ func (m *Manager) prepareRequestAuth(ctx context.Context, executor ProviderExecu
 		return target, nil
 	}
 
-	saved, errUpdate := m.Update(ctx, updated)
+	if !managed {
+		return updated, nil
+	}
+	saved, applied, errUpdate := m.updateIfGeneration(ctx, updated, target.generation)
 	if errUpdate != nil {
 		return updated, errUpdate
+	}
+	if !applied {
+		return auth, authLifecycleChangedError()
 	}
 	if saved != nil {
 		return saved, nil
@@ -4559,6 +4658,21 @@ func waitForCooldown(ctx context.Context, wait, maxWait time.Duration) error {
 	}
 }
 
+func resultMatchesAuthGeneration(ctx context.Context, result Result, auth *Auth) bool {
+	if auth != nil {
+		resultProvider := strings.TrimSpace(result.Provider)
+		authProvider := strings.TrimSpace(auth.Provider)
+		if resultProvider != "" && authProvider != "" && !strings.EqualFold(resultProvider, authProvider) {
+			return false
+		}
+	}
+	expectedGeneration := authGenerationFromContext(ctx, result.AuthID)
+	if expectedGeneration == 0 {
+		return true
+	}
+	return auth != nil && auth.generation == expectedGeneration
+}
+
 // MarkResult records an execution result and notifies hooks.
 func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	if result.AuthID == "" {
@@ -4574,6 +4688,12 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	cooldownStateChanged := false
 
 	m.mu.Lock()
+	auth := m.auths[result.AuthID]
+	if !resultMatchesAuthGeneration(ctx, result, auth) {
+		m.mu.Unlock()
+		m.abandonCodexRateLimitContinuityAttempt(ctx)
+		return
+	}
 	// The continuity state transition and the ModelState/cooldown mutation must
 	// be one manager critical section. begin() rechecks the continuity state
 	// before dispatch, so an in-flight candidate cannot clear a newly confirmed
@@ -4582,7 +4702,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	if m.continuityTransitionHook != nil {
 		m.continuityTransitionHook()
 	}
-	if auth, ok := m.auths[result.AuthID]; ok && auth != nil {
+	if auth != nil {
 		now := time.Now()
 		var cooldownRecordsBefore []CooldownStateRecord
 		trackCooldownState := m.cooldownStore != nil
@@ -4808,7 +4928,13 @@ func (m *Manager) recordAvailabilityNeutralResult(ctx context.Context, result Re
 
 	var authSnapshot *Auth
 	m.mu.Lock()
-	if auth, ok := m.auths[result.AuthID]; ok && auth != nil {
+	auth := m.auths[result.AuthID]
+	if !resultMatchesAuthGeneration(ctx, result, auth) {
+		m.mu.Unlock()
+		m.abandonCodexRateLimitContinuityAttempt(ctx)
+		return
+	}
+	if auth != nil {
 		now := time.Now()
 		auth.recordRecentRequest(now, result.Success)
 		if result.Success {
@@ -6427,7 +6553,7 @@ func (m *Manager) selectAuthForRequest(ctx context.Context, provider, model, req
 		}
 		attemptCtx, allowed := m.beginCodexRateLimitContinuityAttempt(ctx, selected, provider, model, opts)
 		if allowed {
-			return selected, attemptCtx, nil
+			return selected, contextWithAuthGeneration(attemptCtx, selected), nil
 		}
 		tried[authID] = struct{}{}
 		if homeMode {
@@ -7223,7 +7349,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 		if ctx.Err() != nil {
 			return cliproxyexecutor.Response{}, false, nil
 		}
-		creditsCtx := WithAntigravityCredits(ctx)
+		creditsCtx := contextWithAuthGeneration(WithAntigravityCredits(ctx), c.auth)
 		if rt := m.roundTripperFor(c.auth); rt != nil {
 			creditsCtx = context.WithValue(creditsCtx, roundTripperContextKey{}, rt)
 			creditsCtx = context.WithValue(creditsCtx, "cliproxy.roundtripper", rt)
@@ -7235,6 +7361,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 			continue
 		}
 		c.auth = preparedAuth
+		creditsCtx = contextWithAuthGeneration(creditsCtx, c.auth)
 		publishSelectedAuthMetadata(creditsOpts.Metadata, c.auth)
 		models, pooled, aliasResult := m.executionModelCandidatesWithAlias(c.auth, routeModel)
 		if len(models) == 0 {
@@ -7245,7 +7372,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 			execReq := req
 			execReq.Model = upstreamModel
 			resp, errExec := c.executor.Execute(creditsCtx, c.auth, execReq, creditsOpts)
-			result := Result{AuthID: c.auth.ID, Provider: c.provider, Model: resultModel, Success: errExec == nil}
+			result := resultForAuth(c.auth, c.provider, resultModel, errExec == nil, nil)
 			if errExec != nil {
 				result.Error = resultErrorFromError(errExec)
 				if ra := retryAfterFromError(errExec); ra != nil {
@@ -7272,7 +7399,7 @@ func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cl
 		if ctx.Err() != nil {
 			return nil, false, nil
 		}
-		creditsCtx := WithAntigravityCredits(ctx)
+		creditsCtx := contextWithAuthGeneration(WithAntigravityCredits(ctx), c.auth)
 		if rt := m.roundTripperFor(c.auth); rt != nil {
 			creditsCtx = context.WithValue(creditsCtx, roundTripperContextKey{}, rt)
 			creditsCtx = context.WithValue(creditsCtx, "cliproxy.roundtripper", rt)
@@ -7283,6 +7410,7 @@ func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cl
 			continue
 		}
 		c.auth = preparedAuth
+		creditsCtx = contextWithAuthGeneration(creditsCtx, c.auth)
 		publishSelectedAuthMetadata(creditsOpts.Metadata, c.auth)
 		models, pooled, aliasResult := m.executionModelCandidatesWithAlias(c.auth, routeModel)
 		if len(models) == 0 {
@@ -7729,6 +7857,7 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 	if auth == nil || exec == nil {
 		return nil, errors.New("auth or executor not found")
 	}
+	expectedGeneration := auth.generation
 
 	// Another request may already have refreshed this credential.
 	if failedAccessToken != "" {
@@ -7749,7 +7878,7 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 		unauthorized := isUnauthorizedError(err)
 		shouldReschedule := false
 		m.mu.Lock()
-		if current := m.auths[id]; current != nil {
+		if current := m.auths[id]; current != nil && current.generation == expectedGeneration {
 			current.LastError = refreshErrorFromError(err)
 			if unauthorized {
 				current.NextRefreshAfter = time.Time{}
@@ -7764,6 +7893,9 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 			if m.scheduler != nil {
 				m.scheduler.upsertAuth(current.Clone())
 			}
+		} else {
+			m.mu.Unlock()
+			return nil, err
 		}
 		m.mu.Unlock()
 		if shouldReschedule {
@@ -7792,7 +7924,10 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 	if m.shouldRefresh(updated, now) {
 		updated.NextRefreshAfter = now.Add(refreshIneffectiveBackoff)
 	}
-	saved, errUpdate := m.Update(ctx, updated)
+	saved, applied, errUpdate := m.updateIfGeneration(ctx, updated, expectedGeneration)
+	if !applied {
+		return nil, nil
+	}
 	for _, model := range modelsToResume {
 		registry.GetGlobalRegistry().ResumeClientModel(id, model)
 	}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -465,6 +465,10 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 				baseModel = strings.TrimSpace(modelKey)
 			}
 			registeredModels, supportedModel := supported[baseModel]
+			if supportedModel {
+				registeredModels = registeredModelsForReconciledState(modelKey, baseModel, registeredModels)
+				supportedModel = len(registeredModels) > 0
+			}
 			if !supportedModel {
 				// Drop state for models that disappeared from the current registry
 				// snapshot. Keeping them around leaks stale errors into auth-level
@@ -565,6 +569,34 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 	if m.scheduler != nil && snapshot != nil {
 		m.scheduler.upsertAuth(snapshot)
 	}
+}
+
+// registeredModelsForReconciledState maps one persisted ModelState back to
+// concrete registry IDs without spreading a suffix-specific cooldown to sibling
+// suffixes. A canonical family state applies to every registration in that
+// family, matching scheduler lookup semantics. Otherwise, exact raw suffix
+// registrations win and a missing suffix may only fall back to an explicitly
+// registered canonical ID.
+func registeredModelsForReconciledState(stateModel, baseModel string, registeredModels []string) []string {
+	stateModel = strings.TrimSpace(stateModel)
+	baseModel = strings.TrimSpace(baseModel)
+	if stateModel == "" || baseModel == "" {
+		return nil
+	}
+	if strings.EqualFold(stateModel, baseModel) {
+		return append([]string(nil), registeredModels...)
+	}
+	for _, registeredModel := range registeredModels {
+		if strings.EqualFold(strings.TrimSpace(registeredModel), stateModel) {
+			return []string{registeredModel}
+		}
+	}
+	for _, registeredModel := range registeredModels {
+		if strings.EqualFold(strings.TrimSpace(registeredModel), baseModel) {
+			return []string{registeredModel}
+		}
+	}
+	return nil
 }
 
 func registrySuspensionForModelState(state *ModelState) (reason string, quota, suspend bool) {
@@ -972,6 +1004,7 @@ func clearProviderRuntimeState(auth *Auth, now time.Time) {
 	auth.NextRefreshAfter = time.Time{}
 	auth.NextRetryAfter = time.Time{}
 	auth.ModelStates = nil
+	auth.Runtime = nil
 	if auth.Disabled || auth.Status == StatusDisabled {
 		auth.Status = StatusDisabled
 	} else {
@@ -2573,7 +2606,7 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 	m.queueRefreshReschedule(auth.ID)
 	_ = m.persist(ctx, auth)
 	m.hook.OnAuthUpdated(ctx, auth.Clone())
-	if clearedCooldown {
+	if clearedCooldown || !sameProvider {
 		m.persistCooldownStates(ctx)
 	}
 	return auth.Clone(), nil
@@ -4589,10 +4622,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 					disableCooling := m.cooldownDisabledForAuth(auth)
 					state := ensureModelState(auth, result.Model)
 					transientRateLimit := isCodexTransientRateLimitResultError(auth.Provider, result.Error)
-					preserveActiveQuota := transientRateLimit &&
-						state.Quota.Exceeded &&
-						strings.EqualFold(strings.TrimSpace(state.Quota.Reason), "quota") &&
-						state.NextRetryAfter.After(now)
+					preserveActiveQuota := transientRateLimit && activeQuotaCooldown(state.Quota, state.NextRetryAfter, now)
 					state.Unavailable = true
 					state.Status = StatusError
 					state.UpdatedAt = now
@@ -5549,9 +5579,15 @@ func isXaiBadCredentialsResultError(provider string, err *Error) bool {
 }
 
 func isCodexTransientRateLimitResultError(provider string, err *Error) bool {
-	return err != nil &&
-		strings.EqualFold(strings.TrimSpace(provider), "codex") &&
-		strings.EqualFold(strings.TrimSpace(err.Code), codexTransientRateLimitClass)
+	if err == nil || !strings.EqualFold(strings.TrimSpace(provider), "codex") {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(err.Code)) {
+	case codexTransientRateLimitClass, "rate_limit_error", "rate_limit_exceeded":
+		return true
+	default:
+		return false
+	}
 }
 
 func isModelSupportResultError(err *Error) bool {
@@ -5991,9 +6027,13 @@ func applyTransientRateLimitAuthFailureState(auth *Auth, resultErr *Error, now t
 	if auth == nil {
 		return
 	}
+	preserveActiveQuota := activeQuotaCooldown(auth.Quota, auth.NextRetryAfter, now)
 	auth.Unavailable = true
 	auth.Status = StatusError
 	auth.UpdatedAt = now
+	if preserveActiveQuota {
+		return
+	}
 	auth.Quota = QuotaState{}
 	auth.LastError = cloneError(resultErr)
 	if resultErr != nil {
@@ -6004,6 +6044,12 @@ func applyTransientRateLimitAuthFailureState(auth *Auth, resultErr *Error, now t
 	} else {
 		auth.NextRetryAfter = nextTransientErrorRetryAfter(now)
 	}
+}
+
+func activeQuotaCooldown(quota QuotaState, nextRetryAfter, now time.Time) bool {
+	return quota.Exceeded &&
+		strings.EqualFold(strings.TrimSpace(quota.Reason), "quota") &&
+		nextRetryAfter.After(now)
 }
 
 // quotaCooldownAfterFailure returns the recovery deadline and backoff level for

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -84,10 +84,11 @@ const (
 	// success but the auth still evaluates as needing refresh (e.g. token expiry
 	// wasn't updated). Without this guard, the auto-refresh loop can tight-loop and
 	// burn CPU at idle.
-	refreshIneffectiveBackoff = 30 * time.Second
-	quotaBackoffBase          = time.Second
-	quotaBackoffMax           = 30 * time.Minute
-	transientErrorCooldown    = time.Minute
+	refreshIneffectiveBackoff    = 30 * time.Second
+	quotaBackoffBase             = time.Second
+	quotaBackoffMax              = 30 * time.Minute
+	transientErrorCooldown       = time.Minute
+	codexTransientRateLimitClass = "transient-rate-limit"
 )
 
 var quotaCooldownDisabled atomic.Bool
@@ -271,6 +272,9 @@ type Manager struct {
 	// continuityBeforeDispatchHook is an internal test seam invoked after
 	// continuity admission and before the final dispatch recheck.
 	continuityBeforeDispatchHook func()
+	// reconcileBeforeRegistryRestoreHook is an internal test seam invoked after
+	// model cooldowns are snapshotted and before they are restored to the registry.
+	reconcileBeforeRegistryRestoreHook func()
 
 	// Optional HTTP RoundTripper provider injected by host.
 	rtProvider RoundTripperProvider
@@ -418,22 +422,32 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 	}
 
 	supportedModels := registry.GetGlobalRegistry().GetModelsForClient(authID)
-	supported := make(map[string]struct{}, len(supportedModels))
+	supported := make(map[string][]string, len(supportedModels))
 	for _, model := range supportedModels {
 		if model == nil {
 			continue
 		}
+		rawModelID := strings.TrimSpace(model.ID)
 		modelKey := canonicalModelKey(model.ID)
-		if modelKey == "" {
+		if modelKey == "" || rawModelID == "" {
 			continue
 		}
-		supported[modelKey] = struct{}{}
+		registered := supported[modelKey]
+		alreadyRegistered := false
+		for _, existingModelID := range registered {
+			if existingModelID == rawModelID {
+				alreadyRegistered = true
+				break
+			}
+		}
+		if !alreadyRegistered {
+			supported[modelKey] = append(registered, rawModelID)
+		}
 	}
 
 	type registryCooldown struct {
-		model  string
-		reason string
-		quota  bool
+		stateModel       string
+		registeredModels []string
 	}
 
 	var snapshot *Auth
@@ -450,7 +464,8 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 			if baseModel == "" {
 				baseModel = strings.TrimSpace(modelKey)
 			}
-			if _, supportedModel := supported[baseModel]; !supportedModel {
+			registeredModels, supportedModel := supported[baseModel]
+			if !supportedModel {
 				// Drop state for models that disappeared from the current registry
 				// snapshot. Keeping them around leaks stale errors into auth-level
 				// status, management output, and websocket fallback checks.
@@ -466,11 +481,10 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 			}
 			if state.Unavailable && state.NextRetryAfter.After(now) {
 				preserved = true
-				if reason, quota, suspend := registrySuspensionForModelState(state); suspend {
+				if _, _, suspend := registrySuspensionForModelState(state); suspend {
 					cooldowns = append(cooldowns, registryCooldown{
-						model:  baseModel,
-						reason: reason,
-						quota:  quota,
+						stateModel:       modelKey,
+						registeredModels: append([]string(nil), registeredModels...),
 					})
 				}
 				continue
@@ -517,13 +531,36 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 	}
 	m.mu.Unlock()
 
-	reg := registry.GetGlobalRegistry()
-	for _, cooldown := range cooldowns {
-		if cooldown.quota {
-			reg.SetModelQuotaExceeded(authID, cooldown.model)
-		}
-		reg.SuspendClientModel(authID, cooldown.model, cooldown.reason)
+	if m.reconcileBeforeRegistryRestoreHook != nil {
+		m.reconcileBeforeRegistryRestoreHook()
 	}
+
+	reg := registry.GetGlobalRegistry()
+	m.mu.Lock()
+	currentAuth := m.auths[authID]
+	for _, cooldown := range cooldowns {
+		if currentAuth == nil {
+			break
+		}
+		state := currentAuth.ModelStates[cooldown.stateModel]
+		if state == nil || !state.Unavailable || !state.NextRetryAfter.After(time.Now()) {
+			continue
+		}
+		reason, quota, suspend := registrySuspensionForModelState(state)
+		if !suspend {
+			continue
+		}
+		for _, registeredModel := range cooldown.registeredModels {
+			if quota {
+				reg.SetModelQuotaExceeded(authID, registeredModel)
+			}
+			reg.SuspendClientModel(authID, registeredModel, reason)
+		}
+	}
+	if snapshot != nil && currentAuth != nil {
+		snapshot = currentAuth.Clone()
+	}
+	m.mu.Unlock()
 
 	if m.scheduler != nil && snapshot != nil {
 		m.scheduler.upsertAuth(snapshot)
@@ -918,6 +955,29 @@ func clearCooldownStateForAuth(auth *Auth, now time.Time) bool {
 		updateAggregatedAvailability(auth, now)
 	}
 	return changed
+}
+
+func clearProviderRuntimeState(auth *Auth, now time.Time) {
+	if auth == nil {
+		return
+	}
+	auth.Success = 0
+	auth.Failed = 0
+	auth.recentRequests = recentRequestRing{}
+	auth.Unavailable = false
+	auth.Quota = QuotaState{}
+	auth.LastError = nil
+	auth.StatusMessage = ""
+	auth.LastRefreshedAt = time.Time{}
+	auth.NextRefreshAfter = time.Time{}
+	auth.NextRetryAfter = time.Time{}
+	auth.ModelStates = nil
+	if auth.Disabled || auth.Status == StatusDisabled {
+		auth.Status = StatusDisabled
+	} else {
+		auth.Status = StatusActive
+	}
+	auth.UpdatedAt = now
 }
 
 func dedupeStrings(values []string) []string {
@@ -2482,15 +2542,20 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 		auth.Index = existing.Index
 		auth.indexAssigned = existing.indexAssigned
 	}
-	auth.Success = existing.Success
-	auth.Failed = existing.Failed
-	auth.recentRequests = existing.recentRequests
-	if !existing.Disabled && existing.Status != StatusDisabled && !auth.Disabled && auth.Status != StatusDisabled {
-		if len(auth.ModelStates) == 0 && len(existing.ModelStates) > 0 {
-			auth.ModelStates = existing.ModelStates
-		}
-	}
 	now := time.Now()
+	sameProvider := strings.EqualFold(strings.TrimSpace(existing.Provider), strings.TrimSpace(auth.Provider))
+	if sameProvider {
+		auth.Success = existing.Success
+		auth.Failed = existing.Failed
+		auth.recentRequests = existing.recentRequests
+		if !existing.Disabled && existing.Status != StatusDisabled && !auth.Disabled && auth.Status != StatusDisabled {
+			if len(auth.ModelStates) == 0 && len(existing.ModelStates) > 0 {
+				auth.ModelStates = existing.ModelStates
+			}
+		}
+	} else {
+		clearProviderRuntimeState(auth, now)
+	}
 	clearedCooldown := false
 	if m.cooldownDisabledForAuth(auth) || auth.Disabled || auth.Status == StatusDisabled {
 		clearedCooldown = clearCooldownStateForAuth(auth, now)
@@ -4523,10 +4588,15 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				if !isRequestScopedResultError(result.Error) {
 					disableCooling := m.cooldownDisabledForAuth(auth)
 					state := ensureModelState(auth, result.Model)
+					transientRateLimit := isCodexTransientRateLimitResultError(auth.Provider, result.Error)
+					preserveActiveQuota := transientRateLimit &&
+						state.Quota.Exceeded &&
+						strings.EqualFold(strings.TrimSpace(state.Quota.Reason), "quota") &&
+						state.NextRetryAfter.After(now)
 					state.Unavailable = true
 					state.Status = StatusError
 					state.UpdatedAt = now
-					if result.Error != nil {
+					if result.Error != nil && !preserveActiveQuota {
 						state.LastError = cloneError(result.Error)
 						state.StatusMessage = result.Error.Message
 						auth.LastError = cloneError(result.Error)
@@ -4564,6 +4634,11 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 						if state.LastError != nil {
 							state.LastError.Code = "unauthorized"
 						}
+						state.StatusMessage = "unauthorized"
+						if auth.LastError != nil {
+							auth.LastError.Code = "unauthorized"
+						}
+						auth.StatusMessage = "unauthorized"
 						if disableCooling {
 							state.NextRetryAfter = time.Time{}
 						} else {
@@ -4571,6 +4646,23 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 							state.NextRetryAfter = next
 							suspendReason = "unauthorized"
 							shouldSuspendModel = true
+						}
+					} else if transientRateLimit {
+						if preserveActiveQuota {
+							setModelQuota = true
+							shouldSuspendModel = true
+							suspendReason = "quota"
+						} else {
+							if state.Quota.Exceeded && strings.EqualFold(strings.TrimSpace(state.Quota.Reason), "quota") {
+								clearModelQuota = true
+								shouldResumeModel = true
+							}
+							state.Quota = QuotaState{}
+							if disableCooling {
+								state.NextRetryAfter = time.Time{}
+							} else {
+								state.NextRetryAfter = nextTransientErrorRetryAfter(now)
+							}
 						}
 					} else {
 						switch statusCode {
@@ -4640,7 +4732,11 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				}
 			} else {
 				disableCooling := m.cooldownDisabledForAuth(auth)
-				applyAuthFailureState(auth, result.Error, result.RetryAfter, now, disableCooling)
+				if isCodexTransientRateLimitResultError(auth.Provider, result.Error) {
+					applyTransientRateLimitAuthFailureState(auth, result.Error, now, disableCooling)
+				} else {
+					applyAuthFailureState(auth, result.Error, result.RetryAfter, now, disableCooling)
+				}
 			}
 		}
 
@@ -5257,10 +5353,27 @@ func resultErrorFromError(err error) *Error {
 			resultErr.HTTPStatus = http.StatusBadGateway
 		}
 	}
+	if class := codexRateLimitClassFromError(err); class != "" {
+		resultErr.Code = class
+	}
 	if isRequestScopedError(err) || isRequestInvalidError(err) {
 		resultErr.Code = requestScopedErrorCode
 	}
 	return resultErr
+}
+
+func codexRateLimitClassFromError(err error) string {
+	if err == nil {
+		return ""
+	}
+	type rateLimitClassifier interface {
+		CodexRateLimitClass() string
+	}
+	var classifier rateLimitClassifier
+	if !errors.As(err, &classifier) || classifier == nil {
+		return ""
+	}
+	return strings.TrimSpace(classifier.CodexRateLimitClass())
 }
 
 func countTokensResultErrorFromError(err error, requestedModel string) *Error {
@@ -5433,6 +5546,12 @@ func isXaiBadCredentialsResultError(provider string, err *Error) bool {
 		return false
 	}
 	return isXaiBadCredentialsMessage(err.Code) || isXaiBadCredentialsMessage(err.Message)
+}
+
+func isCodexTransientRateLimitResultError(provider string, err *Error) bool {
+	return err != nil &&
+		strings.EqualFold(strings.TrimSpace(provider), "codex") &&
+		strings.EqualFold(strings.TrimSpace(err.Code), codexTransientRateLimitClass)
 }
 
 func isModelSupportResultError(err *Error) bool {
@@ -5865,6 +5984,25 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		if auth.StatusMessage == "" {
 			auth.StatusMessage = "request failed"
 		}
+	}
+}
+
+func applyTransientRateLimitAuthFailureState(auth *Auth, resultErr *Error, now time.Time, disableCooling bool) {
+	if auth == nil {
+		return
+	}
+	auth.Unavailable = true
+	auth.Status = StatusError
+	auth.UpdatedAt = now
+	auth.Quota = QuotaState{}
+	auth.LastError = cloneError(resultErr)
+	if resultErr != nil {
+		auth.StatusMessage = resultErr.Message
+	}
+	if disableCooling {
+		auth.NextRetryAfter = time.Time{}
+	} else {
+		auth.NextRetryAfter = nextTransientErrorRetryAfter(now)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_generation_test.go
+++ b/sdk/cliproxy/auth/conductor_generation_test.go
@@ -1,0 +1,602 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"reflect"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type providerTransitionTestExecutor struct {
+	provider       string
+	executeStarted chan struct{}
+	executeRelease chan struct{}
+	prepareStarted chan struct{}
+	prepareRelease chan struct{}
+	refreshStarted chan struct{}
+	refreshRelease chan struct{}
+	refreshErr     error
+}
+
+func (e *providerTransitionTestExecutor) Identifier() string { return e.provider }
+
+func (e *providerTransitionTestExecutor) ShouldPrepareRequestAuth(*Auth) bool {
+	return e.prepareStarted != nil
+}
+
+func (e *providerTransitionTestExecutor) PrepareRequestAuth(_ context.Context, auth *Auth) (*Auth, error) {
+	if e.prepareStarted != nil {
+		close(e.prepareStarted)
+	}
+	if e.prepareRelease != nil {
+		<-e.prepareRelease
+	}
+	updated := auth.Clone()
+	updated.Metadata = map[string]any{"epoch": "old-provider-prepared"}
+	updated.Runtime = "old-provider-prepared-runtime"
+	return updated, nil
+}
+
+func (e *providerTransitionTestExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	if e.executeStarted != nil {
+		close(e.executeStarted)
+	}
+	if e.executeRelease != nil {
+		<-e.executeRelease
+	}
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusTooManyRequests, Message: "old provider quota"}
+}
+
+func (*providerTransitionTestExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, &Error{HTTPStatus: http.StatusNotImplemented, Message: "not implemented"}
+}
+
+func (e *providerTransitionTestExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	if e.refreshStarted != nil {
+		close(e.refreshStarted)
+	}
+	if e.refreshRelease != nil {
+		<-e.refreshRelease
+	}
+	if e.refreshErr != nil {
+		return nil, e.refreshErr
+	}
+	updated := auth.Clone()
+	updated.Metadata = map[string]any{
+		"access_token":  "old-provider-refreshed-token",
+		"refresh_token": "old-provider-refresh-token",
+	}
+	updated.Runtime = "old-provider-refreshed-runtime"
+	return updated, nil
+}
+
+func (*providerTransitionTestExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusNotImplemented, Message: "not implemented"}
+}
+
+func (*providerTransitionTestExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+type providerTransitionTestHook struct {
+	updated atomic.Int32
+	results atomic.Int32
+}
+
+func (*providerTransitionTestHook) OnAuthRegistered(context.Context, *Auth) {}
+
+func (h *providerTransitionTestHook) OnAuthUpdated(context.Context, *Auth) {
+	h.updated.Add(1)
+}
+
+func (h *providerTransitionTestHook) OnResult(context.Context, Result) {
+	h.results.Add(1)
+}
+
+func waitProviderTransitionSignal(t *testing.T, signal <-chan struct{}, name string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", name)
+	}
+}
+
+func transitionTestAuthProvider(t *testing.T, manager *Manager, authID, provider string) *Auth {
+	t.Helper()
+	current, ok := manager.GetByID(authID)
+	if !ok || current == nil {
+		t.Fatalf("auth %q missing before provider transition", authID)
+	}
+	updated := current.Clone()
+	updated.Provider = provider
+	updated.Metadata = map[string]any{
+		"access_token":  "new-provider-token",
+		"refresh_token": "new-provider-refresh-token",
+		"epoch":         "new-provider",
+	}
+	updated.Attributes = map[string]string{"epoch": "new-provider"}
+	updated.Runtime = "new-provider-runtime"
+	saved, err := manager.Update(WithSkipPersist(context.Background()), updated)
+	if err != nil {
+		t.Fatalf("transition auth provider: %v", err)
+	}
+	if saved == nil || saved.Provider != provider {
+		t.Fatalf("provider transition saved auth = %#v, want provider %q", saved, provider)
+	}
+	snapshot, ok := manager.GetByID(authID)
+	if !ok || snapshot == nil {
+		t.Fatalf("auth %q missing after provider transition", authID)
+	}
+	return snapshot
+}
+
+func assertProviderTransitionSnapshotUnchanged(t *testing.T, manager *Manager, authID string, want *Auth) {
+	t.Helper()
+	got, ok := manager.GetByID(authID)
+	if !ok || got == nil {
+		t.Fatalf("auth %q missing after stale writeback", authID)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("auth changed after stale writeback\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestManager_ProviderTransitionRejectsStaleExecutionGeneration(t *testing.T) {
+	const (
+		authID      = "provider-transition-execute"
+		oldProvider = "generation-old-execute"
+		newProvider = "generation-new-execute"
+		model       = "generation-execute-model"
+	)
+
+	store := &countingStore{}
+	hook := &providerTransitionTestHook{}
+	manager := NewManager(store, nil, hook)
+	executor := &providerTransitionTestExecutor{
+		provider:       oldProvider,
+		executeStarted: make(chan struct{}),
+		executeRelease: make(chan struct{}),
+	}
+	manager.RegisterExecutor(executor)
+	manager.SetRetryConfig(0, 0, 1)
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, oldProvider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	auth := &Auth{
+		ID:       authID,
+		Provider: oldProvider,
+		Metadata: map[string]any{
+			"access_token":  "old-provider-token",
+			"refresh_token": "old-provider-refresh-token",
+		},
+		Runtime: "old-provider-runtime",
+	}
+	if _, err := manager.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("register old provider auth: %v", err)
+	}
+
+	executeDone := make(chan error, 1)
+	go func() {
+		_, err := manager.Execute(context.Background(), []string{oldProvider}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+		executeDone <- err
+	}()
+	waitProviderTransitionSignal(t, executor.executeStarted, "old provider execution")
+
+	reg.RegisterClient(authID, newProvider, []*registry.ModelInfo{{ID: model}})
+	want := transitionTestAuthProvider(t, manager, authID, newProvider)
+	store.saveCount.Store(0)
+	hook.updated.Store(0)
+	hook.results.Store(0)
+	if models := reg.GetAvailableModels(newProvider); len(models) != 1 {
+		t.Fatalf("available models before stale result = %d, want 1", len(models))
+	}
+
+	close(executor.executeRelease)
+	select {
+	case err := <-executeDone:
+		if err == nil {
+			t.Fatal("Execute() error = nil, want old provider failure")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for old provider execution to finish")
+	}
+
+	assertProviderTransitionSnapshotUnchanged(t, manager, authID, want)
+	if got := store.saveCount.Load(); got != 0 {
+		t.Fatalf("stale execution persisted auth %d times, want 0", got)
+	}
+	if got := hook.results.Load(); got != 0 {
+		t.Fatalf("stale execution emitted %d result hooks, want 0", got)
+	}
+	if got := hook.updated.Load(); got != 0 {
+		t.Fatalf("stale execution emitted %d auth update hooks, want 0", got)
+	}
+	if models := reg.GetAvailableModels(newProvider); len(models) != 1 {
+		t.Fatalf("available models after stale result = %d, want 1", len(models))
+	}
+}
+
+func TestManager_ProviderTransitionRejectsStaleRequestAuthPreparation(t *testing.T) {
+	const (
+		authID      = "provider-transition-request-prepare"
+		oldProvider = "generation-old-request-prepare"
+		newProvider = "generation-new-request-prepare"
+		model       = "generation-request-prepare-model"
+	)
+
+	store := &countingStore{}
+	hook := &providerTransitionTestHook{}
+	manager := NewManager(store, nil, hook)
+	executor := &providerTransitionTestExecutor{
+		provider:       oldProvider,
+		prepareStarted: make(chan struct{}),
+		prepareRelease: make(chan struct{}),
+	}
+	manager.RegisterExecutor(executor)
+	manager.SetRetryConfig(0, 0, 1)
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, oldProvider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+	if _, err := manager.Register(WithSkipPersist(context.Background()), &Auth{
+		ID:       authID,
+		Provider: oldProvider,
+		Metadata: map[string]any{"epoch": "old-provider"},
+		Runtime:  "old-provider-runtime",
+	}); err != nil {
+		t.Fatalf("register old provider auth: %v", err)
+	}
+
+	executeDone := make(chan error, 1)
+	go func() {
+		_, err := manager.Execute(context.Background(), []string{oldProvider}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+		executeDone <- err
+	}()
+	waitProviderTransitionSignal(t, executor.prepareStarted, "old provider request preparation")
+
+	reg.RegisterClient(authID, newProvider, []*registry.ModelInfo{{ID: model}})
+	want := transitionTestAuthProvider(t, manager, authID, newProvider)
+	store.saveCount.Store(0)
+	hook.updated.Store(0)
+	hook.results.Store(0)
+	close(executor.prepareRelease)
+
+	select {
+	case err := <-executeDone:
+		if err == nil {
+			t.Fatal("Execute() error = nil, want stale request preparation rejection")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for stale request preparation")
+	}
+
+	assertProviderTransitionSnapshotUnchanged(t, manager, authID, want)
+	if got := store.saveCount.Load(); got != 0 {
+		t.Fatalf("stale request preparation persisted auth %d times, want 0", got)
+	}
+	if got := hook.results.Load(); got != 0 {
+		t.Fatalf("stale request preparation emitted %d result hooks, want 0", got)
+	}
+	if got := hook.updated.Load(); got != 0 {
+		t.Fatalf("stale request preparation emitted %d auth update hooks, want 0", got)
+	}
+}
+
+func TestManager_SelectAuthForRequestGenerationRejectsStaleExternalResult(t *testing.T) {
+	const (
+		authID      = "provider-transition-external-result"
+		oldProvider = "generation-old-external-result"
+		newProvider = "generation-new-external-result"
+		model       = "generation-external-result-model"
+	)
+
+	store := &countingStore{}
+	hook := &providerTransitionTestHook{}
+	manager := NewManager(store, nil, hook)
+	manager.RegisterExecutor(&providerTransitionTestExecutor{provider: oldProvider})
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, oldProvider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+	if _, err := manager.Register(WithSkipPersist(context.Background()), &Auth{
+		ID:       authID,
+		Provider: oldProvider,
+	}); err != nil {
+		t.Fatalf("register old provider auth: %v", err)
+	}
+
+	selected, resultCtx, err := manager.SelectAuthForRequest(context.Background(), oldProvider, model, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("SelectAuthForRequest() error = %v", err)
+	}
+	if selected == nil || selected.ID != authID {
+		t.Fatalf("SelectAuthForRequest() auth = %#v, want %q", selected, authID)
+	}
+
+	reg.RegisterClient(authID, newProvider, []*registry.ModelInfo{{ID: model}})
+	want := transitionTestAuthProvider(t, manager, authID, newProvider)
+	store.saveCount.Store(0)
+	hook.updated.Store(0)
+	hook.results.Store(0)
+
+	manager.MarkResult(resultCtx, Result{
+		AuthID:   authID,
+		Provider: oldProvider,
+		Model:    model,
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusTooManyRequests, Message: "old provider quota"},
+	})
+
+	assertProviderTransitionSnapshotUnchanged(t, manager, authID, want)
+	if got := store.saveCount.Load(); got != 0 {
+		t.Fatalf("stale external result persisted auth %d times, want 0", got)
+	}
+	if got := hook.results.Load(); got != 0 {
+		t.Fatalf("stale external result emitted %d result hooks, want 0", got)
+	}
+	if got := hook.updated.Load(); got != 0 {
+		t.Fatalf("stale external result emitted %d auth update hooks, want 0", got)
+	}
+	if models := reg.GetAvailableModels(newProvider); len(models) != 1 {
+		t.Fatalf("available models after stale external result = %d, want 1", len(models))
+	}
+}
+
+func TestManager_MarkResultRejectsStaleProviderWithoutGenerationContext(t *testing.T) {
+	const (
+		authID      = "provider-transition-provider-fence"
+		oldProvider = "generation-old-provider-fence"
+		newProvider = "generation-new-provider-fence"
+		model       = "generation-provider-fence-model"
+	)
+
+	store := &countingStore{}
+	hook := &providerTransitionTestHook{}
+	manager := NewManager(store, nil, hook)
+	if _, err := manager.Register(WithSkipPersist(context.Background()), &Auth{ID: authID, Provider: oldProvider}); err != nil {
+		t.Fatalf("register old provider auth: %v", err)
+	}
+	want := transitionTestAuthProvider(t, manager, authID, newProvider)
+	store.saveCount.Store(0)
+	hook.updated.Store(0)
+	hook.results.Store(0)
+
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   authID,
+		Provider: oldProvider,
+		Model:    model,
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusTooManyRequests, Message: "old provider quota"},
+	})
+
+	assertProviderTransitionSnapshotUnchanged(t, manager, authID, want)
+	if got := store.saveCount.Load(); got != 0 {
+		t.Fatalf("stale provider result persisted auth %d times, want 0", got)
+	}
+	if got := hook.results.Load(); got != 0 {
+		t.Fatalf("stale provider result emitted %d result hooks, want 0", got)
+	}
+}
+
+func TestManager_SelectAuthForRequestGenerationRejectsSameProviderReplacement(t *testing.T) {
+	const (
+		authID   = "provider-transition-same-provider-replacement"
+		provider = "generation-same-provider-replacement"
+		model    = "generation-same-provider-model"
+	)
+
+	store := &countingStore{}
+	hook := &providerTransitionTestHook{}
+	manager := NewManager(store, nil, hook)
+	manager.RegisterExecutor(&providerTransitionTestExecutor{provider: provider})
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+	if _, err := manager.Register(WithSkipPersist(context.Background()), &Auth{
+		ID:       authID,
+		Provider: provider,
+		Metadata: map[string]any{"epoch": "old"},
+	}); err != nil {
+		t.Fatalf("register original auth: %v", err)
+	}
+
+	_, resultCtx, err := manager.SelectAuthForRequest(context.Background(), provider, model, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("SelectAuthForRequest() error = %v", err)
+	}
+	manager.Remove(context.Background(), authID)
+	if _, err = manager.Register(WithSkipPersist(context.Background()), &Auth{
+		ID:       authID,
+		Provider: provider,
+		Metadata: map[string]any{"epoch": "replacement"},
+	}); err != nil {
+		t.Fatalf("register replacement auth: %v", err)
+	}
+	want, ok := manager.GetByID(authID)
+	if !ok || want == nil {
+		t.Fatal("replacement auth missing")
+	}
+	store.saveCount.Store(0)
+	hook.updated.Store(0)
+	hook.results.Store(0)
+
+	manager.MarkResult(resultCtx, Result{
+		AuthID:   authID,
+		Provider: provider,
+		Model:    model,
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusTooManyRequests, Message: "old lifecycle quota"},
+	})
+
+	assertProviderTransitionSnapshotUnchanged(t, manager, authID, want)
+	if got := store.saveCount.Load(); got != 0 {
+		t.Fatalf("stale generation persisted auth %d times, want 0", got)
+	}
+	if got := hook.results.Load(); got != 0 {
+		t.Fatalf("stale generation emitted %d result hooks, want 0", got)
+	}
+}
+
+func TestManager_ProviderTransitionRejectsStaleRefreshSuccessGeneration(t *testing.T) {
+	const (
+		authID      = "provider-transition-refresh-success"
+		oldProvider = "generation-old-refresh-success"
+		newProvider = "generation-new-refresh-success"
+		model       = "generation-refresh-success-model"
+	)
+
+	store := &countingStore{}
+	hook := &providerTransitionTestHook{}
+	manager := NewManager(store, nil, hook)
+	executor := &providerTransitionTestExecutor{
+		provider:       oldProvider,
+		refreshStarted: make(chan struct{}),
+		refreshRelease: make(chan struct{}),
+	}
+	manager.RegisterExecutor(executor)
+
+	oldAuth := &Auth{
+		ID:       authID,
+		Provider: oldProvider,
+		Metadata: map[string]any{
+			"access_token":  "old-provider-token",
+			"refresh_token": "old-provider-refresh-token",
+		},
+		Runtime: "old-provider-runtime",
+		ModelStates: map[string]*ModelState{
+			model: {
+				Status:      StatusError,
+				Unavailable: true,
+				LastError:   &Error{Code: "unauthorized", HTTPStatus: http.StatusUnauthorized, Message: "old provider unauthorized"},
+			},
+		},
+	}
+	if _, err := manager.Register(WithSkipPersist(context.Background()), oldAuth); err != nil {
+		t.Fatalf("register old provider auth: %v", err)
+	}
+
+	type refreshOutcome struct {
+		auth *Auth
+		err  error
+	}
+	refreshDone := make(chan refreshOutcome, 1)
+	go func() {
+		updated, err := manager.refreshAuthForRequest(context.Background(), authID, "")
+		refreshDone <- refreshOutcome{auth: updated, err: err}
+	}()
+	waitProviderTransitionSignal(t, executor.refreshStarted, "old provider refresh")
+
+	want := transitionTestAuthProvider(t, manager, authID, newProvider)
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, newProvider, []*registry.ModelInfo{{ID: model}})
+	reg.SuspendClientModel(authID, model, "new-provider-maintenance")
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+	store.saveCount.Store(0)
+	hook.updated.Store(0)
+	hook.results.Store(0)
+	if models := reg.GetAvailableModels(newProvider); len(models) != 0 {
+		t.Fatalf("available models before stale refresh = %d, want 0", len(models))
+	}
+
+	close(executor.refreshRelease)
+	select {
+	case outcome := <-refreshDone:
+		if outcome.err != nil {
+			t.Fatalf("stale successful refresh returned error: %v", outcome.err)
+		}
+		if outcome.auth != nil {
+			t.Fatalf("stale successful refresh returned auth %#v, want nil", outcome.auth)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for old provider refresh to finish")
+	}
+
+	assertProviderTransitionSnapshotUnchanged(t, manager, authID, want)
+	if got := store.saveCount.Load(); got != 0 {
+		t.Fatalf("stale refresh persisted auth %d times, want 0", got)
+	}
+	if got := hook.updated.Load(); got != 0 {
+		t.Fatalf("stale refresh emitted %d auth update hooks, want 0", got)
+	}
+	if got := hook.results.Load(); got != 0 {
+		t.Fatalf("stale refresh emitted %d result hooks, want 0", got)
+	}
+	if models := reg.GetAvailableModels(newProvider); len(models) != 0 {
+		t.Fatalf("stale refresh resumed new provider model; available models = %d, want 0", len(models))
+	}
+}
+
+func TestManager_ProviderTransitionRejectsStaleRefreshFailureGeneration(t *testing.T) {
+	const (
+		authID      = "provider-transition-refresh-failure"
+		oldProvider = "generation-old-refresh-failure"
+		newProvider = "generation-new-refresh-failure"
+	)
+
+	store := &countingStore{}
+	hook := &providerTransitionTestHook{}
+	manager := NewManager(store, nil, hook)
+	expectedErr := errors.New("old provider refresh failed")
+	executor := &providerTransitionTestExecutor{
+		provider:       oldProvider,
+		refreshStarted: make(chan struct{}),
+		refreshRelease: make(chan struct{}),
+		refreshErr:     expectedErr,
+	}
+	manager.RegisterExecutor(executor)
+
+	oldAuth := &Auth{
+		ID:       authID,
+		Provider: oldProvider,
+		Metadata: map[string]any{
+			"access_token":  "old-provider-token",
+			"refresh_token": "old-provider-refresh-token",
+		},
+		Runtime: "old-provider-runtime",
+	}
+	if _, err := manager.Register(WithSkipPersist(context.Background()), oldAuth); err != nil {
+		t.Fatalf("register old provider auth: %v", err)
+	}
+
+	refreshDone := make(chan error, 1)
+	go func() {
+		_, err := manager.refreshAuthForRequest(context.Background(), authID, "")
+		refreshDone <- err
+	}()
+	waitProviderTransitionSignal(t, executor.refreshStarted, "old provider refresh")
+
+	want := transitionTestAuthProvider(t, manager, authID, newProvider)
+	store.saveCount.Store(0)
+	hook.updated.Store(0)
+	hook.results.Store(0)
+
+	close(executor.refreshRelease)
+	select {
+	case err := <-refreshDone:
+		if !errors.Is(err, expectedErr) {
+			t.Fatalf("refresh error = %v, want %v", err, expectedErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for old provider refresh to finish")
+	}
+
+	assertProviderTransitionSnapshotUnchanged(t, manager, authID, want)
+	if got := store.saveCount.Load(); got != 0 {
+		t.Fatalf("stale failed refresh persisted auth %d times, want 0", got)
+	}
+	if got := hook.updated.Load(); got != 0 {
+		t.Fatalf("stale failed refresh emitted %d auth update hooks, want 0", got)
+	}
+	if got := hook.results.Load(); got != 0 {
+		t.Fatalf("stale failed refresh emitted %d result hooks, want 0", got)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_reconcile_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_reconcile_cooldown_test.go
@@ -111,12 +111,13 @@ func TestManager_ReconcileRegistryModelStatesPreservesFutureQuotaCooldown(t *tes
 
 func TestManager_ReconcileRegistryModelStatesRestoresCooldownForRegisteredThinkingSuffix(t *testing.T) {
 	const (
-		authID = "reconcile-thinking-suffix-auth"
-		model  = "reconcile-thinking-suffix-model(8192)"
+		authID       = "reconcile-thinking-suffix-auth"
+		model        = "reconcile-thinking-suffix-model(8192)"
+		siblingModel = "reconcile-thinking-suffix-model(16384)"
 	)
 	ctx := context.Background()
 	reg := registry.GetGlobalRegistry()
-	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}, {ID: siblingModel}})
 	t.Cleanup(func() { reg.UnregisterClient(authID) })
 
 	manager := NewManager(nil, &FillFirstSelector{}, nil)
@@ -134,14 +135,93 @@ func TestManager_ReconcileRegistryModelStatesRestoresCooldownForRegisteredThinki
 	}
 	resetAggregatedAuthStateForReconcileTest(t, manager, before)
 
-	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}, {ID: siblingModel}})
 	if count := reg.GetModelCount(model); count != 1 {
 		t.Fatalf("registry model count after re-registration = %d, want 1", count)
+	}
+	if count := reg.GetModelCount(siblingModel); count != 1 {
+		t.Fatalf("sibling registry model count after re-registration = %d, want 1", count)
 	}
 
 	manager.ReconcileRegistryModelStates(ctx, authID)
 	if count := reg.GetModelCount(model); count != 0 {
 		t.Fatalf("registry model count after reconciliation = %d, want 0", count)
+	}
+	if count := reg.GetModelCount(siblingModel); count != 1 {
+		t.Fatalf("sibling registry model count after reconciliation = %d, want unaffected suffix to remain available", count)
+	}
+}
+
+func TestManager_ReconcileRegistryModelStatesCanonicalStateAppliesToEntireRegisteredFamily(t *testing.T) {
+	const (
+		authID       = "reconcile-canonical-thinking-auth"
+		model        = "reconcile-canonical-thinking-model"
+		firstSuffix  = "reconcile-canonical-thinking-model(8192)"
+		secondSuffix = "reconcile-canonical-thinking-model(16384)"
+	)
+	ctx := context.Background()
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}, {ID: firstSuffix}, {ID: secondSuffix}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	if _, err := manager.Register(ctx, &Auth{ID: authID, Provider: "codex"}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	manager.MarkResult(ctx, Result{
+		AuthID: authID, Provider: "codex", Model: model,
+		Error: &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"},
+	})
+
+	before, ok := manager.GetByID(authID)
+	if !ok || before.ModelStates[model] == nil {
+		t.Fatal("canonical model cooldown was not recorded")
+	}
+	resetAggregatedAuthStateForReconcileTest(t, manager, before)
+
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}, {ID: firstSuffix}, {ID: secondSuffix}})
+	manager.ReconcileRegistryModelStates(ctx, authID)
+	if count := reg.GetModelCount(model); count != 0 {
+		t.Fatalf("canonical registry count = %d, want canonical cooldown restored", count)
+	}
+	if count := reg.GetModelCount(firstSuffix); count != 0 {
+		t.Fatalf("first suffix registry count = %d, want canonical cooldown restored", count)
+	}
+	if count := reg.GetModelCount(secondSuffix); count != 0 {
+		t.Fatalf("second suffix registry count = %d, want canonical cooldown restored", count)
+	}
+}
+
+func TestManager_ReconcileRegistryModelStatesMissingSuffixFallsBackToRegisteredCanonicalModel(t *testing.T) {
+	const (
+		authID         = "reconcile-missing-suffix-auth"
+		canonicalModel = "reconcile-missing-suffix-model"
+		stateModel     = "reconcile-missing-suffix-model(8192)"
+	)
+	ctx := context.Background()
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: canonicalModel}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	if _, err := manager.Register(ctx, &Auth{ID: authID, Provider: "codex"}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	manager.MarkResult(ctx, Result{
+		AuthID: authID, Provider: "codex", Model: stateModel,
+		Error: &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"},
+	})
+
+	before, ok := manager.GetByID(authID)
+	if !ok || before.ModelStates[stateModel] == nil {
+		t.Fatal("suffix model cooldown was not recorded")
+	}
+	resetAggregatedAuthStateForReconcileTest(t, manager, before)
+
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: canonicalModel}})
+	manager.ReconcileRegistryModelStates(ctx, authID)
+	if count := reg.GetModelCount(canonicalModel); count != 0 {
+		t.Fatalf("canonical registry count = %d, want missing suffix cooldown restored to canonical registration", count)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_reconcile_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_reconcile_cooldown_test.go
@@ -109,6 +109,77 @@ func TestManager_ReconcileRegistryModelStatesPreservesFutureQuotaCooldown(t *tes
 	}
 }
 
+func TestManager_ReconcileRegistryModelStatesRestoresCooldownForRegisteredThinkingSuffix(t *testing.T) {
+	const (
+		authID = "reconcile-thinking-suffix-auth"
+		model  = "reconcile-thinking-suffix-model(8192)"
+	)
+	ctx := context.Background()
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	if _, err := manager.Register(ctx, &Auth{ID: authID, Provider: "codex"}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	manager.MarkResult(ctx, Result{
+		AuthID: authID, Provider: "codex", Model: model,
+		Error: &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"},
+	})
+
+	before, ok := manager.GetByID(authID)
+	if !ok || before.ModelStates[model] == nil {
+		t.Fatal("thinking-suffix cooldown was not recorded")
+	}
+	resetAggregatedAuthStateForReconcileTest(t, manager, before)
+
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	if count := reg.GetModelCount(model); count != 1 {
+		t.Fatalf("registry model count after re-registration = %d, want 1", count)
+	}
+
+	manager.ReconcileRegistryModelStates(ctx, authID)
+	if count := reg.GetModelCount(model); count != 0 {
+		t.Fatalf("registry model count after reconciliation = %d, want 0", count)
+	}
+}
+
+func TestManager_ReconcileRegistryModelStatesDoesNotRestoreCooldownAfterRacedSuccess(t *testing.T) {
+	const (
+		authID = "reconcile-raced-success-auth"
+		model  = "reconcile-raced-success-model"
+	)
+	ctx := context.Background()
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	if _, err := manager.Register(ctx, &Auth{ID: authID, Provider: "codex"}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	manager.MarkResult(ctx, Result{
+		AuthID: authID, Provider: "codex", Model: model,
+		Error: &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"},
+	})
+
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	manager.reconcileBeforeRegistryRestoreHook = func() {
+		manager.reconcileBeforeRegistryRestoreHook = nil
+		manager.MarkResult(ctx, Result{AuthID: authID, Provider: "codex", Model: model, Success: true})
+	}
+
+	manager.ReconcileRegistryModelStates(ctx, authID)
+	if count := reg.GetModelCount(model); count != 1 {
+		t.Fatalf("registry model count after raced success = %d, want 1", count)
+	}
+	updated, ok := manager.GetByID(authID)
+	if !ok || updated.ModelStates[model] == nil || !modelStateIsClean(updated.ModelStates[model]) {
+		t.Fatalf("model state after raced success = %+v, want clean", updated)
+	}
+}
+
 func TestManager_ReconcileRegistryModelStatesKeepsCloudflareCooldownRoutingAvailable(t *testing.T) {
 	const (
 		authID = "reconcile-cloudflare-auth"

--- a/sdk/cliproxy/auth/conductor_update_test.go
+++ b/sdk/cliproxy/auth/conductor_update_test.go
@@ -211,10 +211,12 @@ func TestManager_Update_ActiveInheritsModelStates(t *testing.T) {
 func TestManager_Update_ProviderChangeDoesNotInheritModelStates(t *testing.T) {
 	m := NewManager(nil, nil, nil)
 	staleRetry := time.Now().Add(time.Hour)
+	staleRuntime := &struct{ provider string }{provider: "claude"}
 	if _, err := m.Register(context.Background(), &Auth{
 		ID:       "auth-provider-change",
 		Provider: "claude",
 		Status:   StatusActive,
+		Runtime:  staleRuntime,
 		Success:  5,
 		Failed:   3,
 		ModelStates: map[string]*ModelState{
@@ -239,6 +241,7 @@ func TestManager_Update_ProviderChangeDoesNotInheritModelStates(t *testing.T) {
 		LastRefreshedAt:  staleRetry.Add(-2 * time.Hour),
 		NextRefreshAfter: staleRetry,
 		NextRetryAfter:   staleRetry,
+		Runtime:          staleRuntime,
 		Success:          9,
 		Failed:           7,
 		ModelStates: map[string]*ModelState{
@@ -271,6 +274,66 @@ func TestManager_Update_ProviderChangeDoesNotInheritModelStates(t *testing.T) {
 	}
 	if updated.Success != 0 || updated.Failed != 0 {
 		t.Fatalf("provider change retained provider health counters: success=%d failed=%d", updated.Success, updated.Failed)
+	}
+	if updated.Runtime != nil {
+		t.Fatalf("provider change retained stale runtime: %#v", updated.Runtime)
+	}
+}
+
+func TestManager_Update_ProviderChangePersistsCooldownClear(t *testing.T) {
+	ctx := context.Background()
+	const authID = "auth-provider-change-persisted-cooldown"
+	retryAfter := 30 * time.Minute
+	store := &recordingCooldownStateStore{}
+	manager := NewManager(nil, nil, nil)
+	manager.SetCooldownStateStore(store)
+	if _, err := manager.Register(WithSkipPersist(ctx), &Auth{ID: authID, Provider: "claude", Status: StatusActive}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	manager.MarkResult(ctx, Result{
+		AuthID:     authID,
+		Provider:   "claude",
+		Model:      "shared-model",
+		Error:      &Error{Code: "rate_limit", Message: "quota", HTTPStatus: http.StatusTooManyRequests},
+		RetryAfter: &retryAfter,
+	})
+
+	store.mu.Lock()
+	before := cloneCooldownStateRecords(store.records)
+	store.mu.Unlock()
+	if len(before) == 0 {
+		t.Fatal("provider cooldown was not persisted before provider change")
+	}
+
+	// The incoming auth is already clean, as it is in watcher/management update
+	// paths. The provider transition itself must still persist removal of the old
+	// provider's independent cooldown snapshot.
+	if _, err := manager.Update(ctx, &Auth{ID: authID, Provider: "xai", Status: StatusActive}); err != nil {
+		t.Fatalf("update auth provider: %v", err)
+	}
+
+	store.mu.Lock()
+	persistedAfterUpdate := cloneCooldownStateRecords(store.records)
+	store.mu.Unlock()
+
+	restartStore := &recordingCooldownStateStore{load: persistedAfterUpdate}
+	restarted := NewManager(nil, nil, nil)
+	restarted.SetCooldownStateStore(restartStore)
+	if _, err := restarted.Register(WithSkipPersist(ctx), &Auth{ID: authID, Provider: "xai", Status: StatusActive}); err != nil {
+		t.Fatalf("register auth after restart: %v", err)
+	}
+	if err := restarted.RestoreCooldownStates(ctx); err != nil {
+		t.Fatalf("restore cooldown states: %v", err)
+	}
+	restored, ok := restarted.GetByID(authID)
+	if !ok || restored == nil {
+		t.Fatal("restarted auth missing")
+	}
+	if len(persistedAfterUpdate) != 0 {
+		t.Fatalf("provider change left persisted cooldown records: %#v", persistedAfterUpdate)
+	}
+	if len(restored.ModelStates) != 0 || restored.Unavailable || restored.Quota.Exceeded || !restored.NextRetryAfter.IsZero() {
+		t.Fatalf("old provider cooldown revived after restart: %+v", restored)
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_update_test.go
+++ b/sdk/cliproxy/auth/conductor_update_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -204,6 +205,72 @@ func TestManager_Update_ActiveInheritsModelStates(t *testing.T) {
 	}
 	if state.Quota.BackoffLevel != backoffLevel {
 		t.Fatalf("expected BackoffLevel to be %d, got %d", backoffLevel, state.Quota.BackoffLevel)
+	}
+}
+
+func TestManager_Update_ProviderChangeDoesNotInheritModelStates(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	staleRetry := time.Now().Add(time.Hour)
+	if _, err := m.Register(context.Background(), &Auth{
+		ID:       "auth-provider-change",
+		Provider: "claude",
+		Status:   StatusActive,
+		Success:  5,
+		Failed:   3,
+		ModelStates: map[string]*ModelState{
+			"shared-model": {
+				Unavailable:    true,
+				Status:         StatusError,
+				NextRetryAfter: time.Now().Add(time.Hour),
+			},
+		},
+	}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	if _, err := m.Update(context.Background(), &Auth{
+		ID:               "auth-provider-change",
+		Provider:         "xai",
+		Status:           StatusError,
+		StatusMessage:    "stale provider error",
+		Unavailable:      true,
+		Quota:            QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: staleRetry},
+		LastError:        &Error{Code: "stale", Message: "stale provider error"},
+		LastRefreshedAt:  staleRetry.Add(-2 * time.Hour),
+		NextRefreshAfter: staleRetry,
+		NextRetryAfter:   staleRetry,
+		Success:          9,
+		Failed:           7,
+		ModelStates: map[string]*ModelState{
+			"incoming-stale-model": {
+				Unavailable:    true,
+				Status:         StatusError,
+				NextRetryAfter: staleRetry,
+				Quota:          QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: staleRetry},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("update auth: %v", err)
+	}
+
+	updated, ok := m.GetByID("auth-provider-change")
+	if !ok || updated == nil {
+		t.Fatal("expected updated auth")
+	}
+	if len(updated.ModelStates) != 0 {
+		t.Fatalf("provider change inherited stale ModelStates: %+v", updated.ModelStates)
+	}
+	if updated.Status != StatusActive || updated.Unavailable || updated.StatusMessage != "" || updated.LastError != nil {
+		t.Fatalf("provider change retained stale auth error state: %+v", updated)
+	}
+	if updated.Quota != (QuotaState{}) || !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("provider change retained stale quota/retry state: quota=%+v retry=%v", updated.Quota, updated.NextRetryAfter)
+	}
+	if !updated.LastRefreshedAt.IsZero() || !updated.NextRefreshAfter.IsZero() {
+		t.Fatalf("provider change retained stale refresh state: last=%v next=%v", updated.LastRefreshedAt, updated.NextRefreshAfter)
+	}
+	if updated.Success != 0 || updated.Failed != 0 {
+		t.Fatalf("provider change retained provider health counters: success=%d failed=%d", updated.Success, updated.Failed)
 	}
 }
 

--- a/sdk/cliproxy/auth/cooldown_state_test.go
+++ b/sdk/cliproxy/auth/cooldown_state_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"errors"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sync"
@@ -300,5 +301,108 @@ func TestManager_RestoreCooldownStates(t *testing.T) {
 	}
 	if got := store.saveCount.Load(); got != 1 {
 		t.Fatalf("restore cleanup saved cooldown state %d times, want 1", got)
+	}
+}
+
+func TestManager_RestoreCooldownRecordProviderCompatibility(t *testing.T) {
+	now := time.Now().UTC()
+	nextRetry := now.Add(time.Hour)
+
+	tests := []struct {
+		name           string
+		recordProvider string
+		model          string
+		wantRestored   bool
+	}{
+		{
+			name:           "auth level provider mismatch",
+			recordProvider: "claude",
+			wantRestored:   false,
+		},
+		{
+			name:           "model level provider mismatch",
+			recordProvider: "claude",
+			model:          "grok-4",
+			wantRestored:   false,
+		},
+		{
+			name:           "auth level legacy empty provider",
+			recordProvider: "",
+			wantRestored:   true,
+		},
+		{
+			name:           "model level legacy empty provider",
+			recordProvider: "",
+			model:          "grok-4",
+			wantRestored:   true,
+		},
+		{
+			name:           "auth level matching provider is case insensitive",
+			recordProvider: " XAI ",
+			wantRestored:   true,
+		},
+		{
+			name:           "model level matching provider is case insensitive",
+			recordProvider: "Xai",
+			model:          "grok-4",
+			wantRestored:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manager := NewManager(nil, nil, nil)
+			const authID = "restore-provider-compatibility"
+			if _, err := manager.Register(WithSkipPersist(context.Background()), &Auth{
+				ID:       authID,
+				Provider: "xai",
+				Status:   StatusActive,
+			}); err != nil {
+				t.Fatalf("register auth: %v", err)
+			}
+
+			record := CooldownStateRecord{
+				Provider:       test.recordProvider,
+				AuthID:         authID,
+				Model:          test.model,
+				NextRetryAfter: nextRetry,
+				Reason:         "quota",
+				Quota: QuotaState{
+					Exceeded:      true,
+					Reason:        "quota",
+					NextRecoverAt: nextRetry,
+				},
+				LastError: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "rate limited"},
+				UpdatedAt: now,
+			}
+
+			manager.mu.Lock()
+			restored := manager.restoreCooldownRecordLocked(record, now)
+			manager.mu.Unlock()
+			if restored != test.wantRestored {
+				t.Fatalf("restoreCooldownRecordLocked() = %v, want %v", restored, test.wantRestored)
+			}
+
+			auth, ok := manager.GetByID(authID)
+			if !ok || auth == nil {
+				t.Fatal("auth missing after cooldown restore")
+			}
+			if !test.wantRestored {
+				if auth.Status != StatusActive || auth.Unavailable || !auth.NextRetryAfter.IsZero() || auth.LastError != nil || len(auth.ModelStates) != 0 {
+					t.Fatalf("provider mismatch mutated auth: %#v", auth)
+				}
+				return
+			}
+			if test.model == "" {
+				if auth.Status != StatusError || !auth.Unavailable || !auth.NextRetryAfter.Equal(nextRetry) || auth.LastError == nil {
+					t.Fatalf("legacy auth-level cooldown was not restored: %#v", auth)
+				}
+				return
+			}
+			state := auth.ModelStates[test.model]
+			if state == nil || state.Status != StatusError || !state.Unavailable || !state.NextRetryAfter.Equal(nextRetry) || state.LastError == nil {
+				t.Fatalf("legacy model-level cooldown was not restored: %#v", state)
+			}
+		})
 	}
 }

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -98,6 +98,10 @@ type Auth struct {
 
 	recentRequests recentRequestRing `json:"-"`
 	indexAssigned  bool              `json:"-"`
+	// generation is a process-local lifecycle epoch. It changes when an auth is
+	// registered or changes provider so stale asynchronous work cannot write back
+	// into a replacement auth with the same ID.
+	generation uint64 `json:"-"`
 }
 
 const (

--- a/sdk/cliproxy/auth/xai_bad_credentials_test.go
+++ b/sdk/cliproxy/auth/xai_bad_credentials_test.go
@@ -83,6 +83,15 @@ func TestManager_MarkResult_XaiBadCredentialsMarksModelUnauthorized(t *testing.T
 	if state.LastError == nil || state.LastError.Code != "unauthorized" {
 		t.Fatalf("expected model LastError.Code = unauthorized, got %+v", state.LastError)
 	}
+	if state.StatusMessage != "unauthorized" {
+		t.Fatalf("model StatusMessage = %q, want unauthorized", state.StatusMessage)
+	}
+	if updated.LastError == nil || updated.LastError.Code != "unauthorized" {
+		t.Fatalf("expected auth LastError.Code = unauthorized, got %+v", updated.LastError)
+	}
+	if updated.StatusMessage != "unauthorized" {
+		t.Fatalf("auth StatusMessage = %q, want unauthorized", updated.StatusMessage)
+	}
 	if count := reg.GetModelCount(model); count != 0 {
 		t.Fatalf("expected registry model suspension, count = %d", count)
 	}

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -695,7 +695,8 @@ func (s *Service) prepareCoreAuthForModelRegistration(ctx context.Context, auth 
 	var err error
 	if existing, ok := s.coreManager.GetByID(auth.ID); ok {
 		auth.CreatedAt = existing.CreatedAt
-		if !existing.Disabled && existing.Status != coreauth.StatusDisabled && !auth.Disabled && auth.Status != coreauth.StatusDisabled {
+		sameProvider := strings.EqualFold(strings.TrimSpace(existing.Provider), strings.TrimSpace(auth.Provider))
+		if sameProvider && !existing.Disabled && existing.Status != coreauth.StatusDisabled && !auth.Disabled && auth.Status != coreauth.StatusDisabled {
 			auth.LastRefreshedAt = existing.LastRefreshedAt
 			auth.NextRefreshAfter = existing.NextRefreshAfter
 			if len(auth.ModelStates) == 0 && len(existing.ModelStates) > 0 {

--- a/sdk/cliproxy/service_stale_state_test.go
+++ b/sdk/cliproxy/service_stale_state_test.go
@@ -71,6 +71,69 @@ func TestServiceApplyCoreAuthAddOrUpdate_DeleteReAddDoesNotInheritStaleRuntimeSt
 	}
 }
 
+func TestServiceApplyCoreAuthAddOrUpdate_ProviderChangeDoesNotInheritRuntimeState(t *testing.T) {
+	service := &Service{
+		cfg:         &config.Config{},
+		coreManager: coreauth.NewManager(nil, nil, nil),
+	}
+	const authID = "service-provider-change-auth"
+	staleRetry := time.Now().Add(time.Hour)
+	t.Cleanup(func() { GlobalModelRegistry().UnregisterClient(authID) })
+
+	service.applyCoreAuthAddOrUpdate(context.Background(), &coreauth.Auth{
+		ID:               authID,
+		Provider:         "claude",
+		Status:           coreauth.StatusActive,
+		LastRefreshedAt:  time.Now().Add(-time.Hour),
+		NextRefreshAfter: time.Now().Add(time.Hour),
+		ModelStates: map[string]*coreauth.ModelState{
+			"shared-model": {
+				Unavailable:    true,
+				Status:         coreauth.StatusError,
+				NextRetryAfter: time.Now().Add(time.Hour),
+			},
+		},
+	})
+
+	service.applyCoreAuthAddOrUpdate(context.Background(), &coreauth.Auth{
+		ID:               authID,
+		Provider:         "xai",
+		Status:           coreauth.StatusError,
+		StatusMessage:    "incoming stale provider error",
+		Unavailable:      true,
+		Quota:            coreauth.QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: staleRetry},
+		LastError:        &coreauth.Error{Code: "stale", Message: "incoming stale provider error"},
+		LastRefreshedAt:  staleRetry.Add(-2 * time.Hour),
+		NextRefreshAfter: staleRetry,
+		NextRetryAfter:   staleRetry,
+		ModelStates: map[string]*coreauth.ModelState{
+			"incoming-stale-model": {
+				Unavailable:    true,
+				Status:         coreauth.StatusError,
+				NextRetryAfter: staleRetry,
+				Quota:          coreauth.QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: staleRetry},
+			},
+		},
+	})
+
+	updated, ok := service.coreManager.GetByID(authID)
+	if !ok || updated == nil {
+		t.Fatal("expected updated auth")
+	}
+	if !updated.LastRefreshedAt.IsZero() || !updated.NextRefreshAfter.IsZero() {
+		t.Fatalf("provider change inherited refresh timestamps: last=%v next=%v", updated.LastRefreshedAt, updated.NextRefreshAfter)
+	}
+	if len(updated.ModelStates) != 0 {
+		t.Fatalf("provider change inherited stale ModelStates: %+v", updated.ModelStates)
+	}
+	if updated.Status != coreauth.StatusActive || updated.Unavailable || updated.StatusMessage != "" || updated.LastError != nil {
+		t.Fatalf("provider change retained stale auth error state: %+v", updated)
+	}
+	if updated.Quota != (coreauth.QuotaState{}) || !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("provider change retained stale quota/retry state: quota=%+v retry=%v", updated.Quota, updated.NextRetryAfter)
+	}
+}
+
 func TestForceHomeRuntimeConfigEnablesUsageStatistics(t *testing.T) {
 	cfg := &config.Config{
 		UsageStatisticsEnabled: false,


### PR DESCRIPTION
## 结果与交付边界

收紧 runtime/auth 状态边界：同一 auth ID 改变 provider、被移除后重新注册，或被同 provider 新实例替换时，旧 execution、stream、request-auth preparation、refresh 和外部 scheduler result 都不能再写回当前 auth。旧 provider 的 cooldown、health、runtime hooks也不会迁移到新 provider；Codex transient 429不再被误记为usage quota；thinking suffix cooldown不会扩散到sibling；non-buffering stream超过reconstruction cap后继续透传已交付响应。

当前 exact head为 `201a5ed82be1993d615292edd4d49d59bb5ac8ec`，已合入 target `main` `14b685e7219ca6b52b863a40a7dbe790faaa4611`。本地验证与GitHub exact-head六项checks已通过；尚未 merge、tag、release、生成发布 artifact、deployment或验证线上runtime。

## 根因与修复

### Provider state 与异步写回隔离

- provider transition清空旧 `ModelStates`、quota、retry、refresh/error状态、health counters、recent requests及 `Runtime`；same-provider active update仅继承允许复用的状态。
- 为每个 auth实例维护process-local generation（`json:"-"`，不改变public wire/API）；Register、Load、provider transition以及same-ID重新注册都会更新generation。
- generation通过context绑定到：
  - `Execute` 与 `CountTokens`
  - stream bootstrap、chunk、complete及availability-neutral result
  - unauthorized refresh retry
  - Antigravity credits
  - public `SelectAuthForRequest` / `SelectAuthForRequestByKind`
- `MarkResult`同时执行provider identity fence与generation fence；旧provider或旧实例result不能污染当前auth。
- refresh success/failure比较generation；旧refresh不能覆盖新provider或新实例。
- `prepareRequestAuth`在异步preparer返回后再次校验generation，避免旧 `RequestAuthPreparer` 回滚当前auth。
- provider mismatch在没有generation context的legacy/external调用中仍fail closed；合法same-generation路径保持兼容。

### Cooldown 与限流语义

- provider变化会持久化清除旧 cooldown snapshot。
- persisted cooldown restore只接受provider为空的legacy record，或trim后case-insensitive匹配当前provider的record；provider mismatch在auth/model层均拒绝。
- suffix-specific cooldown优先恢复到exact raw suffix；canonical family仍按scheduler canonical语义恢复；missing suffix仅回退到显式注册的canonical raw ID。
- raw Codex `rate_limit_error` / `rate_limit_exceeded` 与synthetic `transient-rate-limit`均使用transient cooldown；`usage_limit_reached`保持quota。
- non-Codex raw rate-limit code继续使用既有generic quota语义。
- 较晚到达的model-level或auth-level transient结果不会擦除仍有效的quota deadline/error。

### Streaming 与兼容修复

- buffering/retry路径仍在超限时fail closed。
- observe-only或stream buffer disabled路径超过reconstruction cap后停止重建，但继续交付原始stream与terminal event，不在已经可见的delta后转成502。
- xAI bad-credentials model/auth error code与status message统一为 `unauthorized`。
- 不修改HTTP error payload、usage schema、Management route、config key或public package path。

## Red-first 与审查修复

新增回归在production修复前分别复现并失败，最终覆盖：

- provider transition遗留non-nil `Runtime`与persisted cooldown；
- exact suffix误伤sibling、canonical family与missing-suffix fallback；
- raw/synthetic Codex transient误记quota或覆盖active quota；
- non-Codex raw code误分类；
- registry restore与raced success；
- non-buffering stream在可见delta后失败；
- blocked old execution在provider transition后写回；
- public external result携带旧generation写回；
- provider mismatch且没有generation context；
- same-provider remove/re-register的旧result写回；
- blocked request-auth preparation回滚新provider；
- stale refresh success与stale refresh failure；
- persisted cooldown provider mismatch被恢复。

早期review threads对应的 `Runtime`、suffix restore、persisted cooldown clear和raw Codex transient问题，以及后续独立复查发现的stale writeback/provider restore问题，均由当前实现和回归覆盖。

## Exact-head 验证

以下验证均在 `201a5ed82be1993d615292edd4d49d59bb5ac8ec` 上通过：

- `go test ./sdk/cliproxy/auth -count=10`
- `go test -race ./sdk/cliproxy/auth -count=1`
- `go test ./sdk/cliproxy/... -count=1`
- `go test ./internal/runtime/executor -count=1`
- `go test ./internal/api -run 'CodexAlphaSearch' -count=1`
- `go test ./examples/... -count=1`
- `go vet ./sdk/cliproxy/auth`
- `go test ./... -count=1`
- `scripts/check-lts-contract.sh`
- `go build -o /dev/null ./cmd/server`
- `git diff --check`
- GitHub runs `29982630478` / `29982630481`及其余exact-head workflows：六项checks全部passed

## 风险与 Review focus

1. generation是否覆盖所有异步执行、stream、refresh、preparer和public scheduler writeback；
2. provider fence与legacy/external调用兼容性；
3. current-auth更新与外部side effect的ordering；
4. empty-provider legacy cooldown兼容与non-empty provider mismatch拒绝；
5. active quota、transient cooldown与suffix/canonical restore语义；
6. object-store hardening合入后，全仓/auth race tests是否仍保持通过。
