### PR TITLE
feat(codex): 引入仅确认冷却触发的全局回退目标

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -228,12 +228,19 @@ codex:
     reasoning-continuity: "same-model-only"
     # Exact, case-insensitive source model mappings. Targets are tried in order.
     mappings: []
+    # Final targets shared by every source model, tried only after a typed Codex
+    # usage_limit_reached has produced a real quota cooldown and the source mapping
+    # did not deliver a response. FreshBlocked observation and ordinary 429 responses
+    # never use these targets. Targets must still be registered under provider codex.
+    global-targets: []
     # Example:
     # mappings:
     #   - from: "gpt-5.6-sol"
     #     to:
     #       - "gpt-5.6-terra"
     #       - "gpt-5.5"
+    # global-targets:
+    #   - "gpt-5.4"
   # CPA-Core-LTS extra feature. Keep established Codex sessions on an auth/model
   # while a fresh-session usage-limit 429 is observed. Requires
   # routing.session-affinity and a stable session identifier. Disabled by default.

--- a/docs/lts/codex-429-resilience.md
+++ b/docs/lts/codex-429-resilience.md
@@ -34,11 +34,33 @@ codex:
     mappings:
       - from: gpt-5.6-sol
         to: [gpt-5.6-terra, gpt-5.5]
+    global-targets: [gpt-5.4]
 ```
 
 The source mapping is exact and case-insensitive after trimming. Target order is
 significant. Duplicate and source-equivalent targets are removed in memory.
 Existing config files are not rewritten to add defaults.
+
+`global-targets` is a final, shared target list for source models whose normal
+mapping did not deliver a response. It is deliberately stricter than
+`mappings`: Core appends it only when a typed Codex
+`error.type=usage_limit_reached` has produced a currently active, formal quota
+cooldown for every eligible source credential. A `FreshBlocked` observation,
+an ordinary or untyped HTTP 429, `rate_limit_error`, and
+`rate_limit_exceeded` never activate the global targets. This keeps the global
+fallback tied to confirmed exhaustion rather than to the HTTP status alone.
+The typed cooldown provenance is retained internally on `ModelState`; when
+`save-cooldown-status` is enabled it is persisted as the additive
+`model_fallback_reason` field in the `.cds` record. Older records without that
+field fail closed for global fallback until a new typed failure is observed.
+
+Mapped targets keep their existing precedence. Zero-dispatch mapped targets and
+mapped targets that return another typed fallback signal allow selection to
+continue into `global-targets`; a real dispatched request-invalid, auth,
+transient, or other unclassified target error still stops the chain. Global
+targets remain inside the Codex provider boundary and must be registered under
+`codex`; the word "global" means shared by all Codex source mappings, not an
+implicit cross-provider route.
 
 The fallback path is limited to standard Codex response execution. It does not
 apply to compact, image, or video requests. Streaming fallback is only possible
@@ -201,6 +223,7 @@ reasoning continuity.
 ## Retry, usage, and auth state
 
 - Same-model auth selection and ordinary retry run before model fallback.
+- Per-source mappings run before confirmed-cooldown-only `global-targets`.
 - Source and fallback targets share one request-level abnormal-reasoning retry
   counter, hedge state, and `UsageAccumulator`; fallback cannot reset or extend
   the configured retry/hedge budget. A target gets one auth-selection wave,

--- a/docs/lts/codex-429-resilience.md
+++ b/docs/lts/codex-429-resilience.md
@@ -53,6 +53,9 @@ The typed cooldown provenance is retained internally on `ModelState`; when
 `save-cooldown-status` is enabled it is persisted as the additive
 `model_fallback_reason` field in the `.cds` record. Older records without that
 field fail closed for global fallback until a new typed failure is observed.
+Home control-plane dispatch uses a separate credential candidate inventory, so
+`global-targets` also fail closed while Home mode is enabled rather than using
+unrelated local auth cooldown state as proof about remote candidates.
 
 Mapped targets keep their existing precedence. Zero-dispatch mapped targets and
 mapped targets that return another typed fallback signal allow selection to

--- a/docs/lts/core-feature-contracts.yaml
+++ b/docs/lts/core-feature-contracts.yaml
@@ -291,6 +291,7 @@ features:
       - codex.model-fallback.triggers
       - codex.model-fallback.reasoning-continuity
       - codex.model-fallback.mappings
+      - codex.model-fallback.global-targets
     core_files:
       - internal/config/config.go
       - internal/cache/codex_reasoning_replay_scope.go
@@ -302,6 +303,7 @@ features:
       - sdk/api/handlers/handlers_metadata_test.go
       - sdk/api/handlers/openai/openai_responses_websocket.go
       - sdk/cliproxy/auth/codex_model_fallback.go
+      - sdk/cliproxy/auth/cooldown_state.go
       - sdk/cliproxy/auth/conductor.go
       - sdk/cliproxy/executor/types.go
       - config.example.yaml
@@ -319,8 +321,8 @@ features:
       - ResolveCodexReasoningReplaySessionKey
       - responsesWebsocketCanAttestContextReset
       - ModelFallbackZeroDispatch
-      - CodexModelFallbackContextResetReplayMetadataKey
-      - ModelFallbackZeroDispatch
+      - global-targets
+      - model_fallback_reason
     validation:
       - go test ./internal/config ./internal/watcher/diff
       - go test ./internal/runtime/executor -run 'Codex.*ModelFallback|Codex.*Retry|Codex.*Signature'

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -51,6 +51,8 @@ patches:
       - TestManagerExecuteCodexModelFallbackSelectsCredentialForTargetModel
       - TestManagerExecuteCodexGlobalFallbackOnConfirmedUsageLimitCooldown
       - TestManagerExecuteCodexGlobalFallbackIgnoresOrdinary429
+      - TestManagerCodexGlobalFallbackRequiresEveryEligibleSourceCredentialCooldown
+      - TestManagerCodexGlobalFallbackFailsClosedInHomeMode
       - TestManagerExecuteCodexGlobalFallbackIgnoresDisabledSourceCandidates
       - TestManagerCodexRateLimitContinuityFreshBlockedDoesNotUseGlobalFallback
       - TestFileCooldownStateStore_SaveLoadAndCleanStale

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -2,7 +2,7 @@ version: 1
 
 patches:
   - id: codex-model-fallback
-    reason: Codex usage-limit and model-capacity failures need an opt-in ordered model fallback after same-model credentials are exhausted, while cross-model retries must not replay model-private reasoning signatures or replay a stream after client-visible delivery.
+    reason: Codex usage-limit and model-capacity failures need an opt-in ordered model fallback after same-model credentials are exhausted, including a confirmed-usage-cooldown-only global target list when source mappings cannot deliver, while cross-model retries must not replay model-private reasoning signatures or replay a stream after client-visible delivery.
     introduced_in: 0bd5a46fd34dff4711fe5618afe66c93f316897b
     affected_upstream_range: through 53c1e7e2dd6ddf973098a4e685e852aeebed9fe3 (v7.2.92); upstream now drops overlong encrypted reasoning items and reuses normalized Codex payloads, while LTS preserves those request-shaping changes together with its typed configurable cross-model fallback, conservative source/target reasoning-continuity gates, target-model auth reselection, pre-delivery stream safety, and legacy replay migration.
     files:
@@ -34,6 +34,9 @@ patches:
       - sdk/api/handlers/handlers_metadata_test.go
       - sdk/cliproxy/auth/codex_model_fallback.go
       - sdk/cliproxy/auth/codex_model_fallback_test.go
+      - sdk/cliproxy/auth/codex_rate_limit_continuity_test.go
+      - sdk/cliproxy/auth/cooldown_state.go
+      - sdk/cliproxy/auth/cooldown_state_test.go
       - sdk/cliproxy/auth/conductor.go
       - sdk/cliproxy/executor/types.go
       - sdk/api/handlers/openai/openai_responses_websocket.go
@@ -46,7 +49,13 @@ patches:
       - TestCodexExecutorModelFallbackSameModelOnlyBlocksSourceReplayCache
       - TestCodexExecutorModelFallbackContextResetDropsReasoningAndKeepsToolPair
       - TestManagerExecuteCodexModelFallbackSelectsCredentialForTargetModel
+      - TestManagerExecuteCodexGlobalFallbackOnConfirmedUsageLimitCooldown
+      - TestManagerExecuteCodexGlobalFallbackIgnoresOrdinary429
+      - TestManagerExecuteCodexGlobalFallbackIgnoresDisabledSourceCandidates
+      - TestManagerCodexRateLimitContinuityFreshBlockedDoesNotUseGlobalFallback
+      - TestFileCooldownStateStore_SaveLoadAndCleanStale
       - TestManagerExecuteStreamCodexModelFallbackBeforeFirstPayload
+      - TestManagerExecuteStreamCodexGlobalFallbackBeforeFirstPayload
       - TestManagerExecuteStreamCodexModelFallbackDoesNotReplayAfterPayload
       - TestManagerExecuteCodexModelFallbackBlocksCachedClaudeReplayBeforeTargetSelection
       - TestManagerExecuteCodexModelFallbackReplayPreflightUsesAgentScopedExecutorKeyPriority

--- a/docs/lts/protected-deltas.yaml
+++ b/docs/lts/protected-deltas.yaml
@@ -96,6 +96,8 @@ lts_owned_features:
     maintenance_policy: long-term-maintained
     markers:
       - model-fallback
+      - global-targets
+      - model_fallback_reason
       - ModelFallbackReason
       - reasoning-continuity
     validation:

--- a/internal/config/codex_model_fallback_test.go
+++ b/internal/config/codex_model_fallback_test.go
@@ -15,6 +15,7 @@ codex:
     enabled: true
     triggers: [capacity]
     reasoning-continuity: context-reset
+    global-targets: [gpt-global, gpt-backup]
     mappings:
       - from: gpt-source
         to: [gpt-target, gpt-backup]
@@ -37,11 +38,15 @@ codex:
 	if got := effective.TargetsFor("gpt-source", CodexModelFallbackTriggerCapacity); !reflect.DeepEqual(got, []string{"gpt-target", "gpt-backup"}) {
 		t.Fatalf("TargetsFor() = %#v", got)
 	}
+	if !reflect.DeepEqual(effective.GlobalTargets, []string{"gpt-global", "gpt-backup"}) {
+		t.Fatalf("GlobalTargets = %#v", effective.GlobalTargets)
+	}
 }
 
 func TestCodexModelFallbackEffectiveDefaultsAndNormalizesMappings(t *testing.T) {
 	effective := (CodexModelFallbackConfig{
-		Enabled: true,
+		Enabled:       true,
+		GlobalTargets: []string{" gpt-global ", "GPT-GLOBAL", ""},
 		Mappings: []CodexModelFallbackMapping{
 			{From: " gpt-5.6-sol ", To: []string{" gpt-5.6-terra ", "GPT-5.6-TERRA", "gpt-5.6-sol", ""}},
 			{From: "", To: []string{"gpt-5.5"}},
@@ -65,6 +70,12 @@ func TestCodexModelFallbackEffectiveDefaultsAndNormalizesMappings(t *testing.T) 
 	}
 	if got := effective.TargetsFor("gpt-5.6-sol", "rate-limit"); got != nil {
 		t.Fatalf("TargetsFor(transient) = %#v, want nil", got)
+	}
+	if !reflect.DeepEqual(effective.GlobalTargets, []string{"gpt-global"}) {
+		t.Fatalf("GlobalTargets = %#v, want [gpt-global]", effective.GlobalTargets)
+	}
+	if !effective.AllowsTrigger(CodexModelFallbackTriggerUsageLimit) || effective.AllowsTrigger("rate-limit") {
+		t.Fatalf("AllowsTrigger() returned unexpected result for normalized triggers")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -451,6 +451,7 @@ type CodexModelFallbackConfig struct {
 	Triggers            []string                    `yaml:"triggers" json:"triggers"`
 	ReasoningContinuity string                      `yaml:"reasoning-continuity,omitempty" json:"reasoning-continuity,omitempty"`
 	Mappings            []CodexModelFallbackMapping `yaml:"mappings" json:"mappings"`
+	GlobalTargets       []string                    `yaml:"global-targets,omitempty" json:"global-targets,omitempty"`
 }
 
 // CodexModelFallbackMapping defines ordered target models for one requested
@@ -468,6 +469,7 @@ type EffectiveCodexModelFallbackConfig struct {
 	Triggers            []string
 	ReasoningContinuity string
 	Mappings            []CodexModelFallbackMapping
+	GlobalTargets       []string
 }
 
 // Effective returns a normalized model-fallback policy.
@@ -514,29 +516,47 @@ func (c CodexModelFallbackConfig) Effective() EffectiveCodexModelFallbackConfig 
 		}
 		mappings = append(mappings, CodexModelFallbackMapping{From: from, To: to})
 	}
+	globalTargets := make([]string, 0, len(c.GlobalTargets))
+	seenGlobalTargets := make(map[string]struct{}, len(c.GlobalTargets))
+	for _, target := range c.GlobalTargets {
+		target = strings.TrimSpace(target)
+		key := strings.ToLower(target)
+		if target == "" {
+			continue
+		}
+		if _, ok := seenGlobalTargets[key]; ok {
+			continue
+		}
+		seenGlobalTargets[key] = struct{}{}
+		globalTargets = append(globalTargets, target)
+	}
 
 	return EffectiveCodexModelFallbackConfig{
 		Enabled:             c.Enabled,
 		Triggers:            filteredTriggers,
 		ReasoningContinuity: reasoningContinuity,
 		Mappings:            mappings,
+		GlobalTargets:       globalTargets,
 	}
+}
+
+// AllowsTrigger reports whether the normalized fallback policy accepts trigger.
+func (c EffectiveCodexModelFallbackConfig) AllowsTrigger(trigger string) bool {
+	if !c.Enabled {
+		return false
+	}
+	trigger = strings.ToLower(strings.TrimSpace(trigger))
+	for _, candidate := range c.Triggers {
+		if candidate == trigger {
+			return true
+		}
+	}
+	return false
 }
 
 // TargetsFor returns the ordered fallback targets for model and trigger.
 func (c EffectiveCodexModelFallbackConfig) TargetsFor(model, trigger string) []string {
-	if !c.Enabled || strings.TrimSpace(model) == "" || strings.TrimSpace(trigger) == "" {
-		return nil
-	}
-	trigger = strings.ToLower(strings.TrimSpace(trigger))
-	allowed := false
-	for _, candidate := range c.Triggers {
-		if candidate == trigger {
-			allowed = true
-			break
-		}
-	}
-	if !allowed {
+	if strings.TrimSpace(model) == "" || !c.AllowsTrigger(trigger) {
 		return nil
 	}
 	for _, mapping := range c.Mappings {

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -551,6 +551,9 @@ func appendCodexModelFallbackChanges(changes []string, oldCfg, newCfg config.Eff
 	if !reflect.DeepEqual(oldCfg.Mappings, newCfg.Mappings) {
 		changes = append(changes, fmt.Sprintf("codex.model-fallback.mappings: updated (%d -> %d entries)", len(oldCfg.Mappings), len(newCfg.Mappings)))
 	}
+	if !reflect.DeepEqual(oldCfg.GlobalTargets, newCfg.GlobalTargets) {
+		changes = append(changes, fmt.Sprintf("codex.model-fallback.global-targets: updated (%d -> %d entries)", len(oldCfg.GlobalTargets), len(newCfg.GlobalTargets)))
+	}
 	return changes
 }
 

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -259,6 +259,7 @@ func TestBuildConfigChangeDetails_CodexModelFallback(t *testing.T) {
 				Enabled:             true,
 				Triggers:            []string{config.CodexModelFallbackTriggerCapacity},
 				ReasoningContinuity: config.CodexModelFallbackReasoningContinuityContextReset,
+				GlobalTargets:       []string{"gpt-5.4"},
 				Mappings: []config.CodexModelFallbackMapping{
 					{From: "gpt-5.6-sol", To: []string{"gpt-5.6-terra", "gpt-5.5"}},
 				},
@@ -271,6 +272,7 @@ func TestBuildConfigChangeDetails_CodexModelFallback(t *testing.T) {
 	expectContains(t, details, "codex.model-fallback.reasoning-continuity: same-model-only -> context-reset")
 	expectContains(t, details, "codex.model-fallback.triggers: updated (2 -> 1 entries)")
 	expectContains(t, details, "codex.model-fallback.mappings: updated (0 -> 1 entries)")
+	expectContains(t, details, "codex.model-fallback.global-targets: updated (0 -> 1 entries)")
 }
 
 func TestBuildConfigChangeDetails_CodexRateLimitContinuity(t *testing.T) {

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -145,6 +145,8 @@ require_grep "serveManagementControlPanel" internal/api/server.go
 require_grep "BlueSkyXN/CPA-Panel-LTS" internal/managementasset/updater.go internal/managementasset/updater_test.go internal/config/config.go
 require_grep "UsageReporter" internal/runtime/executor/helps/usage_helpers.go
 require_grep "codex.model-fallback" docs/lts/core-feature-contracts.yaml docs/lts/codex-429-resilience.md
+require_grep "global-targets" internal/config/config.go config.example.yaml docs/lts/core-feature-contracts.yaml docs/lts/codex-429-resilience.md
+require_grep "model_fallback_reason" sdk/cliproxy/auth/cooldown_state.go docs/lts/core-feature-contracts.yaml docs/lts/codex-429-resilience.md
 require_grep "CodexModelFallbackSourceModelMetadataKey" sdk/cliproxy/executor/types.go sdk/cliproxy/auth/codex_model_fallback.go
 require_grep "codex.rate-limit-continuity" docs/lts/core-feature-contracts.yaml docs/lts/codex-429-resilience.md
 require_grep "codexRateLimitContinuityStore" sdk/cliproxy/auth/codex_rate_limit_continuity.go docs/lts/core-feature-contracts.yaml

--- a/sdk/cliproxy/auth/codex_model_fallback.go
+++ b/sdk/cliproxy/auth/codex_model_fallback.go
@@ -141,7 +141,7 @@ func (m *Manager) codexModelFallbackPlan(providers []string, req cliproxyexecuto
 }
 
 func (m *Manager) codexModelHasConfirmedUsageLimitCooldown(routeModel string, opts cliproxyexecutor.Options) bool {
-	if m == nil || strings.TrimSpace(routeModel) == "" {
+	if m == nil || strings.TrimSpace(routeModel) == "" || m.HomeEnabled() {
 		return false
 	}
 	now := time.Now()

--- a/sdk/cliproxy/auth/codex_model_fallback.go
+++ b/sdk/cliproxy/auth/codex_model_fallback.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"strings"
 	"sync"
+	"time"
 
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	log "github.com/sirupsen/logrus"
@@ -93,10 +95,6 @@ func (m *Manager) codexModelFallbackPlan(providers []string, req cliproxyexecuto
 	if m == nil || !codexModelFallbackRequestEligible(providers, opts) {
 		return internalconfig.EffectiveCodexModelFallbackConfig{}, "", nil, false
 	}
-	reason := modelFallbackReasonFromError(err)
-	if reason == "" {
-		return internalconfig.EffectiveCodexModelFallbackConfig{}, "", nil, false
-	}
 	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
 	if cfg == nil {
 		return internalconfig.EffectiveCodexModelFallbackConfig{}, "", nil, false
@@ -106,9 +104,17 @@ func (m *Manager) codexModelFallbackPlan(providers []string, req cliproxyexecuto
 	if sourceModel == "" {
 		sourceModel = strings.TrimSpace(req.Model)
 	}
-	targets := effective.TargetsFor(sourceModel, reason)
-	if len(targets) == 0 {
+	confirmedUsageLimit := m.codexModelHasConfirmedUsageLimitCooldown(sourceModel, opts)
+	reason := modelFallbackReasonFromError(err)
+	if reason == "" && confirmedUsageLimit {
+		reason = internalconfig.CodexModelFallbackTriggerUsageLimit
+	}
+	if reason == "" || !effective.AllowsTrigger(reason) {
 		return effective, reason, nil, false
+	}
+	targets := effective.TargetsFor(sourceModel, reason)
+	if confirmedUsageLimit && reason == internalconfig.CodexModelFallbackTriggerUsageLimit {
+		targets = append(targets, effective.GlobalTargets...)
 	}
 	seen := map[string]struct{}{strings.ToLower(sourceModel): {}}
 	filtered := make([]string, 0, len(targets))
@@ -132,6 +138,78 @@ func (m *Manager) codexModelFallbackPlan(providers []string, req cliproxyexecuto
 		return effective, reason, nil, false
 	}
 	return effective, reason, filtered, true
+}
+
+func (m *Manager) codexModelHasConfirmedUsageLimitCooldown(routeModel string, opts cliproxyexecutor.Options) bool {
+	if m == nil || strings.TrimSpace(routeModel) == "" {
+		return false
+	}
+	now := time.Now()
+	registryRef := registry.GetGlobalRegistry()
+	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
+	disallowFreeAuth := disallowFreeAuthFromMetadata(opts.Metadata)
+	excluded := excludedAuthIDsFromMetadata(opts.Metadata)
+	found := false
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, auth := range m.auths {
+		if auth == nil || auth.Disabled || auth.Status == StatusDisabled || executorKeyFromAuth(auth) != "codex" {
+			continue
+		}
+		if pinnedAuthID != "" && auth.ID != pinnedAuthID {
+			continue
+		}
+		if disallowFreeAuth && isFreeCodexAuth(auth) {
+			continue
+		}
+		if _, skip := excluded[auth.ID]; skip {
+			continue
+		}
+		if !m.authSupportsRouteModel(registryRef, auth, routeModel) {
+			continue
+		}
+		modelKey := m.selectionModelForAuth(auth, routeModel)
+		state := codexModelStateByCanonicalKey(auth, modelKey)
+		if state != nil && state.Status == StatusDisabled {
+			continue
+		}
+		found = true
+		if !codexModelStateHasConfirmedUsageLimitCooldown(state, now) {
+			return false
+		}
+	}
+	return found
+}
+
+func codexModelStateByCanonicalKey(auth *Auth, model string) *ModelState {
+	if auth == nil || len(auth.ModelStates) == 0 {
+		return nil
+	}
+	if state := auth.ModelStates[model]; state != nil {
+		return state
+	}
+	key := canonicalModelKey(model)
+	for candidate, state := range auth.ModelStates {
+		if state != nil && canonicalModelKey(candidate) == key {
+			return state
+		}
+	}
+	return nil
+}
+
+func codexModelStateHasConfirmedUsageLimitCooldown(state *ModelState, now time.Time) bool {
+	if state == nil || !state.Unavailable || !state.Quota.Exceeded || !strings.EqualFold(strings.TrimSpace(state.Quota.Reason), "quota") {
+		return false
+	}
+	deadline := state.NextRetryAfter
+	if state.Quota.NextRecoverAt.After(deadline) {
+		deadline = state.Quota.NextRecoverAt
+	}
+	if deadline.IsZero() || !deadline.After(now) {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(state.modelFallbackReason), internalconfig.CodexModelFallbackTriggerUsageLimit)
 }
 
 func withCodexModelFallbackMetadata(opts cliproxyexecutor.Options, sourceModel, targetModel, reasoningContinuity string) cliproxyexecutor.Options {

--- a/sdk/cliproxy/auth/codex_model_fallback_test.go
+++ b/sdk/cliproxy/auth/codex_model_fallback_test.go
@@ -380,6 +380,199 @@ func newCodexModelFallbackTestManager(t *testing.T, executor *codexModelFallback
 	return manager, authID
 }
 
+func newCodexGlobalFallbackTestManager(t *testing.T, executor *codexModelFallbackTestExecutor, mappings []internalconfig.CodexModelFallbackMapping) (*Manager, string) {
+	t.Helper()
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.SetRetryConfig(0, 0, 0)
+	manager.SetConfig(&internalconfig.Config{Codex: internalconfig.CodexConfig{ModelFallback: internalconfig.CodexModelFallbackConfig{
+		Enabled:       true,
+		GlobalTargets: []string{"gpt-global"},
+		Mappings:      mappings,
+	}}})
+	manager.RegisterExecutor(executor)
+	authID := "codex-global-fallback-auth"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: "gpt-source"}, {ID: "gpt-target"}, {ID: "gpt-global"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(authID)
+	})
+	if _, err := manager.Register(context.Background(), &Auth{ID: authID, Provider: "codex", Status: StatusActive}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	return manager, authID
+}
+
+func codexUsageLimitTestError() error {
+	return &codexFallbackTestError{
+		message: "decorated provider usage limit",
+		reason:  internalconfig.CodexModelFallbackTriggerUsageLimit,
+	}
+}
+
+func TestManagerExecuteCodexGlobalFallbackOnConfirmedUsageLimitCooldown(t *testing.T) {
+	executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{"gpt-source": codexUsageLimitTestError()}}
+	manager, _ := newCodexGlobalFallbackTestManager(t, executor, nil)
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := string(resp.Payload); got != "gpt-global" {
+		t.Fatalf("response payload = %q, want gpt-global", got)
+	}
+	calls, metadata := executor.snapshot()
+	if len(calls) != 2 || calls[0] != "gpt-source" || calls[1] != "gpt-global" {
+		t.Fatalf("calls = %#v, want [gpt-source gpt-global]", calls)
+	}
+	if got := metadata["gpt-global"][cliproxyexecutor.CodexModelFallbackSourceModelMetadataKey]; got != "gpt-source" {
+		t.Fatalf("global fallback source metadata = %#v, want gpt-source", got)
+	}
+	if got := metadata["gpt-global"][cliproxyexecutor.RequestedModelMetadataKey]; got != "gpt-source" {
+		t.Fatalf("requested model metadata = %#v, want gpt-source", got)
+	}
+}
+
+func TestManagerExecuteCodexGlobalFallbackIgnoresOrdinary429(t *testing.T) {
+	executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{
+		"gpt-source": &codexFallbackTestError{message: `{"error":{"type":"rate_limit_error"}}`},
+	}}
+	manager, _ := newCodexGlobalFallbackTestManager(t, executor, nil)
+
+	_, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{})
+	if err == nil {
+		t.Fatal("Execute() error = nil, want ordinary 429")
+	}
+	calls, _ := executor.snapshot()
+	if len(calls) != 1 || calls[0] != "gpt-source" {
+		t.Fatalf("calls = %#v, want source only", calls)
+	}
+}
+
+func TestManagerExecuteCodexGlobalFallbackRunsAfterMappedTargetsCannotDispatch(t *testing.T) {
+	executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{"gpt-source": codexUsageLimitTestError()}}
+	manager, _ := newCodexGlobalFallbackTestManager(t, executor, []internalconfig.CodexModelFallbackMapping{{From: "gpt-source", To: []string{"gpt-missing"}}})
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := string(resp.Payload); got != "gpt-global" {
+		t.Fatalf("response payload = %q, want gpt-global", got)
+	}
+	calls, _ := executor.snapshot()
+	if len(calls) != 2 || calls[0] != "gpt-source" || calls[1] != "gpt-global" {
+		t.Fatalf("calls = %#v, want [gpt-source gpt-global]", calls)
+	}
+}
+
+func TestManagerExecuteCodexGlobalFallbackDoesNotBypassSuccessfulMapping(t *testing.T) {
+	executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{"gpt-source": codexUsageLimitTestError()}}
+	manager, _ := newCodexGlobalFallbackTestManager(t, executor, []internalconfig.CodexModelFallbackMapping{{From: "gpt-source", To: []string{"gpt-target"}}})
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := string(resp.Payload); got != "gpt-target" {
+		t.Fatalf("response payload = %q, want gpt-target", got)
+	}
+	calls, _ := executor.snapshot()
+	if len(calls) != 2 || calls[0] != "gpt-source" || calls[1] != "gpt-target" {
+		t.Fatalf("calls = %#v, want [gpt-source gpt-target]", calls)
+	}
+}
+
+func TestManagerExecuteCodexGlobalFallbackUsesExistingConfirmedCooldown(t *testing.T) {
+	executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{}}
+	manager, authID := newCodexGlobalFallbackTestManager(t, executor, nil)
+	now := time.Now()
+	manager.mu.Lock()
+	manager.auths[authID].ModelStates = map[string]*ModelState{
+		"gpt-source": {
+			Status:              StatusError,
+			Unavailable:         true,
+			NextRetryAfter:      now.Add(time.Minute),
+			LastError:           &Error{HTTPStatus: http.StatusTooManyRequests, Message: "decorated provider usage limit"},
+			Quota:               QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: now.Add(time.Minute)},
+			modelFallbackReason: internalconfig.CodexModelFallbackTriggerUsageLimit,
+		},
+	}
+	manager.mu.Unlock()
+	manager.RefreshSchedulerEntry(authID)
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := string(resp.Payload); got != "gpt-global" {
+		t.Fatalf("response payload = %q, want gpt-global", got)
+	}
+	calls, _ := executor.snapshot()
+	if len(calls) != 1 || calls[0] != "gpt-global" {
+		t.Fatalf("calls = %#v, want global target only", calls)
+	}
+}
+
+func TestManagerExecuteCodexGlobalFallbackIgnoresDisabledSourceCandidates(t *testing.T) {
+	executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{"gpt-source": codexUsageLimitTestError()}}
+	manager, _ := newCodexGlobalFallbackTestManager(t, executor, nil)
+	reg := registry.GetGlobalRegistry()
+
+	disabledAuthID := "codex-global-fallback-disabled-auth"
+	reg.RegisterClient(disabledAuthID, "codex", []*registry.ModelInfo{{ID: "gpt-source"}})
+	if _, err := manager.Register(context.Background(), &Auth{ID: disabledAuthID, Provider: "codex", Status: StatusDisabled}); err != nil {
+		t.Fatalf("register disabled auth: %v", err)
+	}
+	disabledModelID := "codex-global-fallback-disabled-model"
+	reg.RegisterClient(disabledModelID, "codex", []*registry.ModelInfo{{ID: "gpt-source"}})
+	if _, err := manager.Register(context.Background(), &Auth{
+		ID:       disabledModelID,
+		Provider: "codex",
+		Status:   StatusActive,
+		ModelStates: map[string]*ModelState{
+			"gpt-source": {Status: StatusDisabled},
+		},
+	}); err != nil {
+		t.Fatalf("register auth with disabled model: %v", err)
+	}
+	t.Cleanup(func() {
+		reg.UnregisterClient(disabledAuthID)
+		reg.UnregisterClient(disabledModelID)
+	})
+
+	resp, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := string(resp.Payload); got != "gpt-global" {
+		t.Fatalf("response payload = %q, want gpt-global", got)
+	}
+}
+
+func TestManagerExecuteStreamCodexGlobalFallbackBeforeFirstPayload(t *testing.T) {
+	executor := &codexModelFallbackTestExecutor{streamErrs: map[string]error{"gpt-source": codexUsageLimitTestError()}}
+	manager, _ := newCodexGlobalFallbackTestManager(t, executor, nil)
+
+	result, err := manager.ExecuteStream(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	var payload []byte
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v", chunk.Err)
+		}
+		payload = append(payload, chunk.Payload...)
+	}
+	if got := string(payload); got != "gpt-global" {
+		t.Fatalf("stream payload = %q, want gpt-global", got)
+	}
+	calls, _ := executor.snapshot()
+	if len(calls) != 2 || calls[0] != "gpt-source" || calls[1] != "gpt-global" {
+		t.Fatalf("calls = %#v, want [gpt-source gpt-global]", calls)
+	}
+}
+
 func TestManagerExecuteCodexModelFallbackOnUsageLimit(t *testing.T) {
 	executor := &codexModelFallbackTestExecutor{
 		executeErrs: map[string]error{

--- a/sdk/cliproxy/auth/codex_model_fallback_test.go
+++ b/sdk/cliproxy/auth/codex_model_fallback_test.go
@@ -513,6 +513,73 @@ func TestManagerExecuteCodexGlobalFallbackUsesExistingConfirmedCooldown(t *testi
 	}
 }
 
+func TestManagerCodexGlobalFallbackRequiresEveryEligibleSourceCredentialCooldown(t *testing.T) {
+	executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{}}
+	manager, firstAuthID := newCodexGlobalFallbackTestManager(t, executor, nil)
+	secondAuthID := "codex-global-fallback-active-auth"
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(secondAuthID, "codex", []*registry.ModelInfo{{ID: "gpt-source"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(secondAuthID)
+	})
+	if _, err := manager.Register(context.Background(), &Auth{ID: secondAuthID, Provider: "codex", Status: StatusActive}); err != nil {
+		t.Fatalf("register second source auth: %v", err)
+	}
+
+	now := time.Now()
+	confirmedState := func() *ModelState {
+		return &ModelState{
+			Status:              StatusError,
+			Unavailable:         true,
+			NextRetryAfter:      now.Add(time.Minute),
+			Quota:               QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: now.Add(time.Minute)},
+			modelFallbackReason: internalconfig.CodexModelFallbackTriggerUsageLimit,
+		}
+	}
+	manager.mu.Lock()
+	manager.auths[firstAuthID].ModelStates = map[string]*ModelState{"gpt-source": confirmedState()}
+	manager.mu.Unlock()
+
+	if manager.codexModelHasConfirmedUsageLimitCooldown("gpt-source", cliproxyexecutor.Options{}) {
+		t.Fatal("confirmed cooldown = true while an eligible source credential remains active")
+	}
+
+	manager.mu.Lock()
+	manager.auths[secondAuthID].ModelStates = map[string]*ModelState{"gpt-source": confirmedState()}
+	manager.mu.Unlock()
+	if !manager.codexModelHasConfirmedUsageLimitCooldown("gpt-source", cliproxyexecutor.Options{}) {
+		t.Fatal("confirmed cooldown = false after every eligible source credential entered typed cooldown")
+	}
+}
+
+func TestManagerCodexGlobalFallbackFailsClosedInHomeMode(t *testing.T) {
+	executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{}}
+	manager, authID := newCodexGlobalFallbackTestManager(t, executor, nil)
+	manager.SetConfig(&internalconfig.Config{
+		Home: internalconfig.HomeConfig{Enabled: true},
+		Codex: internalconfig.CodexConfig{ModelFallback: internalconfig.CodexModelFallbackConfig{
+			Enabled:       true,
+			GlobalTargets: []string{"gpt-global"},
+		}},
+	})
+	now := time.Now()
+	manager.mu.Lock()
+	manager.auths[authID].ModelStates = map[string]*ModelState{
+		"gpt-source": {
+			Status:              StatusError,
+			Unavailable:         true,
+			NextRetryAfter:      now.Add(time.Minute),
+			Quota:               QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: now.Add(time.Minute)},
+			modelFallbackReason: internalconfig.CodexModelFallbackTriggerUsageLimit,
+		},
+	}
+	manager.mu.Unlock()
+
+	if manager.codexModelHasConfirmedUsageLimitCooldown("gpt-source", cliproxyexecutor.Options{}) {
+		t.Fatal("confirmed cooldown = true in Home mode without authoritative control-plane candidate state")
+	}
+}
+
 func TestManagerExecuteCodexGlobalFallbackIgnoresDisabledSourceCandidates(t *testing.T) {
 	executor := &codexModelFallbackTestExecutor{executeErrs: map[string]error{"gpt-source": codexUsageLimitTestError()}}
 	manager, _ := newCodexGlobalFallbackTestManager(t, executor, nil)

--- a/sdk/cliproxy/auth/codex_rate_limit_continuity_test.go
+++ b/sdk/cliproxy/auth/codex_rate_limit_continuity_test.go
@@ -1836,6 +1836,41 @@ func TestManagerCodexRateLimitContinuityPendingFreshSessionUsesModelFallback(t *
 	}
 }
 
+func TestManagerCodexRateLimitContinuityFreshBlockedDoesNotUseGlobalFallback(t *testing.T) {
+	executor := &codexContinuityTestExecutor{failures: make(map[string]error)}
+	manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-source", "gpt-global"}, 2)
+	manager.SetConfig(&internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{SessionAffinity: true},
+		Codex: internalconfig.CodexConfig{
+			RateLimitContinuity: internalconfig.CodexRateLimitContinuityConfig{
+				Enabled:                      true,
+				ObservationWindowSeconds:     10,
+				EstablishedSuccessThreshold:  2,
+				EstablishedSessionTTLSeconds: 3600,
+			},
+			ModelFallback: internalconfig.CodexModelFallbackConfig{
+				Enabled:       true,
+				GlobalTargets: []string{"gpt-global"},
+			},
+		},
+	})
+	key := codexRateLimitContinuityKey{authID: "auth-a", model: "gpt-source"}
+	manager.codexRateLimitContinuity.states[key] = &codexRateLimitContinuityState{
+		suspect:             true,
+		observeUntil:        time.Now().Add(time.Minute),
+		establishedSessions: make(map[string]time.Time),
+		inFlight:            make(map[string]int),
+	}
+
+	_, err := manager.Execute(context.Background(), []string{"codex"}, cliproxyexecutor.Request{Model: "gpt-source"}, codexContinuityConversationOptions("fresh"))
+	if err == nil {
+		t.Fatal("Execute() error = nil, want continuity observation pending")
+	}
+	if calls := executor.snapshot(); len(calls) != 0 {
+		t.Fatalf("calls = %#v, want zero dispatch while FreshBlocked", calls)
+	}
+}
+
 func TestManagerCodexRateLimitContinuityConfirmedCooldownUsesModelFallback(t *testing.T) {
 	executor := &codexContinuityTestExecutor{failures: make(map[string]error)}
 	manager := newCodexContinuityManager(t, executor, []string{"auth-a"}, []string{"gpt-source", "gpt-target"}, 2)

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -881,6 +881,7 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 	state.Status = StatusError
 	state.NextRetryAfter = record.NextRetryAfter
 	state.Quota = quota
+	state.modelFallbackReason = strings.ToLower(strings.TrimSpace(record.ModelFallbackReason))
 	state.UpdatedAt = updatedAt
 	if reason != "" {
 		state.StatusMessage = reason
@@ -910,6 +911,7 @@ func clearCooldownStateForAuth(auth *Auth, now time.Time) bool {
 			state.Unavailable = false
 			state.NextRetryAfter = time.Time{}
 			state.Quota = QuotaState{}
+			state.modelFallbackReason = ""
 			state.UpdatedAt = now
 			changed = true
 		}
@@ -1114,6 +1116,7 @@ func cooldownStateRecordEqual(a, b CooldownStateRecord) bool {
 		a.Model != b.Model ||
 		a.Status != b.Status ||
 		a.Reason != b.Reason ||
+		a.ModelFallbackReason != b.ModelFallbackReason ||
 		!a.NextRetryAfter.Equal(b.NextRetryAfter) ||
 		!a.UpdatedAt.Equal(b.UpdatedAt) ||
 		!cooldownQuotaEqual(a.Quota, b.Quota) {
@@ -1162,16 +1165,17 @@ func modelCooldownStateRecord(auth *Auth, model string, state *ModelState, now t
 		return CooldownStateRecord{}, false
 	}
 	return CooldownStateRecord{
-		Provider:       strings.TrimSpace(auth.Provider),
-		AuthID:         auth.ID,
-		AuthFile:       cooldownAuthFile(auth),
-		Model:          model,
-		Status:         "cooling",
-		NextRetryAfter: state.NextRetryAfter,
-		Reason:         cooldownReason(state.StatusMessage, state.Quota, state.LastError),
-		Quota:          state.Quota,
-		LastError:      cloneError(state.LastError),
-		UpdatedAt:      state.UpdatedAt,
+		Provider:            strings.TrimSpace(auth.Provider),
+		AuthID:              auth.ID,
+		AuthFile:            cooldownAuthFile(auth),
+		Model:               model,
+		Status:              "cooling",
+		NextRetryAfter:      state.NextRetryAfter,
+		Reason:              cooldownReason(state.StatusMessage, state.Quota, state.LastError),
+		Quota:               state.Quota,
+		LastError:           cloneError(state.LastError),
+		ModelFallbackReason: state.modelFallbackReason,
+		UpdatedAt:           state.UpdatedAt,
 	}, true
 }
 
@@ -4523,6 +4527,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				if !isRequestScopedResultError(result.Error) {
 					disableCooling := m.cooldownDisabledForAuth(auth)
 					state := ensureModelState(auth, result.Model)
+					state.modelFallbackReason = strings.ToLower(strings.TrimSpace(result.ModelFallbackReason))
 					state.Unavailable = true
 					state.Status = StatusError
 					state.UpdatedAt = now
@@ -4724,6 +4729,7 @@ func resetModelState(state *ModelState, now time.Time) {
 	state.NextRetryAfter = time.Time{}
 	state.LastError = nil
 	state.Quota = QuotaState{}
+	state.modelFallbackReason = ""
 	state.UpdatedAt = now
 }
 

--- a/sdk/cliproxy/auth/cooldown_state.go
+++ b/sdk/cliproxy/auth/cooldown_state.go
@@ -26,7 +26,9 @@ type CooldownStateRecord struct {
 	Reason         string     `json:"reason,omitempty"`
 	Quota          QuotaState `json:"quota,omitempty"`
 	LastError      *Error     `json:"last_error,omitempty"`
-	UpdatedAt      time.Time  `json:"updated_at"`
+	// ModelFallbackReason is internal cooldown provenance used by request routing.
+	ModelFallbackReason string    `json:"model_fallback_reason,omitempty"`
+	UpdatedAt           time.Time `json:"updated_at"`
 }
 
 // CooldownStateStore persists runtime cooldown state independently from auth tokens.

--- a/sdk/cliproxy/auth/cooldown_state_test.go
+++ b/sdk/cliproxy/auth/cooldown_state_test.go
@@ -129,8 +129,9 @@ func TestFileCooldownStateStore_SaveLoadAndCleanStale(t *testing.T) {
 			NextRecoverAt: nextRetry,
 			BackoffLevel:  1,
 		},
-		LastError: &Error{Message: "rate limited", HTTPStatus: 429},
-		UpdatedAt: updatedAt,
+		LastError:           &Error{Message: "rate limited", HTTPStatus: 429},
+		ModelFallbackReason: "usage-limit",
+		UpdatedAt:           updatedAt,
 	}
 
 	if errSave := store.Save(ctx, []CooldownStateRecord{record}); errSave != nil {
@@ -155,6 +156,9 @@ func TestFileCooldownStateStore_SaveLoadAndCleanStale(t *testing.T) {
 	}
 	if loaded[0].LastError == nil || loaded[0].LastError.HTTPStatus != 429 {
 		t.Fatalf("loaded last error = %+v, want HTTP 429", loaded[0].LastError)
+	}
+	if loaded[0].ModelFallbackReason != "usage-limit" {
+		t.Fatalf("loaded model fallback reason = %q, want usage-limit", loaded[0].ModelFallbackReason)
 	}
 
 	if errSave := store.Save(ctx, nil); errSave != nil {
@@ -269,8 +273,9 @@ func TestManager_RestoreCooldownStates(t *testing.T) {
 					Reason:        "quota",
 					NextRecoverAt: nextRetry,
 				},
-				LastError: &Error{Message: "rate limited", HTTPStatus: 429},
-				UpdatedAt: nextRetry.Add(-time.Minute),
+				LastError:           &Error{Message: "rate limited", HTTPStatus: 429},
+				ModelFallbackReason: "usage-limit",
+				UpdatedAt:           nextRetry.Add(-time.Minute),
 			},
 		},
 	}
@@ -297,6 +302,9 @@ func TestManager_RestoreCooldownStates(t *testing.T) {
 	}
 	if state.LastError == nil || state.LastError.HTTPStatus != 429 {
 		t.Fatalf("restored last error = %+v, want HTTP 429", state.LastError)
+	}
+	if state.modelFallbackReason != "usage-limit" {
+		t.Fatalf("restored model fallback reason = %q, want usage-limit", state.modelFallbackReason)
 	}
 	if got := store.saveCount.Load(); got != 1 {
 		t.Fatalf("restore cleanup saved cooldown state %d times, want 1", got)

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -192,6 +192,10 @@ type ModelState struct {
 	Quota QuotaState `json:"quota"`
 	// UpdatedAt tracks the last update timestamp for this model state.
 	UpdatedAt time.Time `json:"updated_at"`
+
+	// modelFallbackReason preserves the typed provider classification that
+	// established the current cooldown without exposing it as auth API state.
+	modelFallbackReason string
 }
 
 func recentRequestBucketID(now time.Time) int64 {


### PR DESCRIPTION
## 结果与问题

当 Codex 请求模型的同模型 credential 与现有 source mapping 都无法交付时，本 PR 增加一个共享的 `codex.model-fallback.global-targets` 最终兜底列表。

该列表不以 HTTP `429` 为条件。只有 typed `usage_limit_reached` 已经为所有 eligible source credential 建立当前有效的正式 quota cooldown 时才会启用；`FreshBlocked`、bare 429、`rate_limit_error` 和 `rate_limit_exceeded` 均不会触发。

当前状态：PR 已对 `main` 提交，尚未 merge、release 或 deploy。

## Type

- [ ] Protected upstream full-sync
- [ ] Staged upstream full-sync
- [ ] LTS protected-delta patch
- [x] LTS feature / downstream patch maintenance
- [ ] Maintenance docs / CI
- [ ] Emergency hotfix

## Upstream sync info

- Upstream repo: N/A（downstream-only LTS feature maintenance）
- Upstream branch: N/A
- Upstream from SHA: N/A
- Upstream to SHA: N/A
- Sync branch: N/A

## 主要改动

- 为 `codex.model-fallback` 增加 additive `global-targets` 配置；为空时完全禁用并保持旧配置行为。
- 保留执行顺序：same-model auth/retry → source mapping targets → confirmed-cooldown-only global targets。
- 在 `ModelState` 内保留 typed `ModelFallbackReason` provenance；启用 `save-cooldown-status` 时，以 additive `model_fallback_reason` 写入 `.cds` 并在恢复后继续使用，不依赖解析 `LastError.Message`。
- 排除 disabled auth 与 disabled source model，确保“所有 eligible credential 已确认冷却”的判定与 selector 一致。
- Home 模式的 credential 由 control plane 提供，无法由本地 `m.auths` 完整证明；因此 Home 启用时全局 fallback 明确 fail closed，避免本地残留 auth 为远端候选制造错误的“全部已冷却”证明。
- 复用现有 reasoning continuity、context-reset、stream pre-delivery、retry/hedge 与 `UsageAccumulator` 边界；不创建递归 fallback 或独立 retry budget。
- usage 仍按实际 target model/auth 记录，原 requested model 继续由现有 metadata/alias 归因；未修改 `/v0/management/usage*` schema。
- 更新 config example、watcher diff、LTS registry、protected delta、downstream patch ledger 与 contract sentinel。

## 明确边界

- `global` 表示所有 Codex source mappings 共享，不表示跨 provider；target 必须注册在 `codex` provider。
- 仅 confirmed `usage_limit_reached` quota cooldown 可启用 global targets；capacity 仍只走显式 mapping，普通 429 不启用。
- source mapping 成功时不会触达 global target；mapped target 的真实 request-invalid/auth/transient/unclassified error 会停止链路。
- `FreshBlocked` 仍保留现有观察/continuity 行为，不会升级成 global fallback。
- Home 模式下不使用本地 auth 集合推导全局 fallback eligibility；即使本地残留 auth 均处于 cooldown，也会 fail closed。
- 旧 `.cds` 没有 `model_fallback_reason` 时安全地 fail closed，直到观察到新的 typed usage-limit failure。
- 本 PR 未修改 CPA-Panel-LTS；可通过 YAML source 配置，visual editor 支持仍需单独 Panel 变更。

## Protected delta checklist

- [x] `usage-statistics-enabled` still exists
- [x] `internal/usage/` still exists
- [x] `/v0/management/usage` still exists
- [x] `/v0/management/usage/export` still exists
- [x] `/v0/management/usage/import` still exists
- [x] `docs/lts/core-feature-contracts.yaml` reviewed for touched protected or protected-adjacent features
- [x] `docs/lts/downstream-patches.yaml` reviewed for active patch retirement or reapplication
- [x] Usage record creation/schema reviewed or tested: API key, auth source, model, token breakdown, latency, success/failure
- [x] Management usage response shape reviewed or tested: `usage`, `failed_requests`, `apis`, `models`, `details`
- [x] Export/import roundtrip reviewed or tested when usage data shape is touched（schema 未变；usage/import/export regression suite 已通过）
- [x] CPA-Panel-LTS response shape reviewed（Core usage response shape 未变）
- [x] Local auth/config/panel/release/source customizations reviewed

## LTS classification review

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| `codex-model-fallback` | LTS feature / downstream patch | adapted | 新增 `global-targets`、typed cooldown provenance、non-stream/stream/disabled/Home fail-closed/persistence regressions |
| `codex-rate-limit-continuity` | LTS feature | preserved | `FreshBlocked` 明确不使用 global target；原 mapping continuity 行为保留 |
| usage / Management usage | retained capability | preserved | schema 未改；usage/management/test package regression 通过 |

- [x] 本 PR 不新增或修改 ledger 的 `introduced_in` / `retired_in` SHA；该 merge-method 条款不适用。

## Conflict resolution notes

无 upstream sync 或文本冲突。实现接入现有 Codex fallback orchestration，没有在 executor、scheduler 或 `MarkResult` 内发起请求；`MarkResult` 只保留已经产生的 typed cooldown provenance。

## Validation

- [x] `go test -count=1 ./internal/config ./internal/watcher/diff ./internal/runtime/executor ./sdk/cliproxy/auth ./sdk/api/handlers/openai`
- [x] `go test -race -count=1 ./sdk/cliproxy/auth -run 'CodexGlobalFallback|CodexRateLimitContinuityFreshBlockedDoesNotUseGlobalFallback|CooldownStateStore|RestoreCooldownStates'`
- [x] `go test -count=20 ./sdk/cliproxy/auth -run 'CodexGlobalFallback|RateLimitContinuityFreshBlockedDoesNotUseGlobalFallback|CooldownStateStore_SaveLoadAndCleanStale'`
- [x] `scripts/check-lts-contract.sh`（包含 `go run ./scripts/ltsregistry --root .`）
- [x] `go test -count=1 ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'`
- [x] `go build -o /tmp/cpa-core-global-cooldown-fallback-merge-check ./cmd/server`
- [x] `go test -count=1 ./...`
- [x] `git diff --check`

## Optional real runtime smoke

- [x] 明确跳过：未部署该 branch，且本地没有执行真实 Codex quota exhaustion；没有 release/runtime 状态可回读。
- Space: N/A
- Runtime SHA: N/A
- CPA-Core-LTS branch/SHA deployed: N/A
- `/healthz` status: N/A
- `/management.html` status: N/A
- `/v0/management/usage*` status: N/A

## Review focus

1. `codexModelHasConfirmedUsageLimitCooldown` 是否准确复用 selector 的 eligible credential 边界，并严格排除普通 429 / `FreshBlocked`；Home 模式是否按无法证明远端候选状态而 fail closed。
2. `model_fallback_reason` 的 additive `.cds` 兼容性与 reset/restore 生命周期。
3. mapping → global target 的顺序，以及现有 reasoning continuity、stream 和 shared retry/usage budget 是否保持不变。
