### PR TITLE
sync(lts): 吸收 upstream v7.2.105 并适配 weighted routing 保护契约

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -200,7 +200,10 @@ quota-exceeded:
 
 # Routing strategy for selecting credentials when multiple match.
 routing:
-  strategy: "round-robin" # round-robin (default), fill-first
+  strategy: "round-robin" # round-robin (default), weighted-round-robin, fill-first
+  # weighted-round-robin uses each credential's integer weight (default 1, maximum 1,000,000).
+  # Non-positive weights exclude the credential while this strategy is active.
+  # For OAuth/file credentials, add a top-level numeric "weight" field to the auth JSON.
   # Enable universal session-sticky routing for all clients.
   # Explicit Claude Code, Codex, OpenCode, and pi session headers are preferred,
   # followed by prompt_cache_key, Responses conversation IDs, legacy body IDs,
@@ -278,6 +281,7 @@ nonstream-keepalive-interval: 0
 # Gemini API keys
 # gemini-api-key:
 #   - api-key: "AIzaSy...01"
+#     weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "test" # optional: require calls like "test/gemini-3-pro-preview" to target this credential
 #     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
 #     base-url: "https://generativelanguage.googleapis.com"
@@ -301,6 +305,7 @@ nonstream-keepalive-interval: 0
 # send Gemini generateContent/streamGenerateContent requests when the client enters through the interactions API.
 # interactions-api-key:
 #   - api-key: "AIzaSy...03"
+#     weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "native" # optional: require calls like "native/gemini-3-pro-preview" to target this credential
 #     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
 #     base-url: "https://generativelanguage.googleapis.com"
@@ -317,6 +322,7 @@ nonstream-keepalive-interval: 0
 # Codex API keys
 # codex-api-key:
 #   - api-key: "sk-atSM..."
+#     weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "test" # optional: require calls like "test/gpt-5-codex" to target this credential
 #     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
 #     base-url: "https://www.example.com" # use the custom codex API endpoint
@@ -339,6 +345,7 @@ nonstream-keepalive-interval: 0
 # Uses the native xAI executor, including its Responses namespace-tool handling.
 # xai-api-key:
 #   - api-key: "xai-..."
+#     weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "xai" # optional: require calls like "xai/grok-4.5" to target this credential
 #     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
 #     base-url: "https://api.x.ai/v1" # xAI-compatible Responses API endpoint
@@ -360,6 +367,7 @@ nonstream-keepalive-interval: 0
 # claude-api-key:
 #   - api-key: "sk-atSM..." # use the official claude API key, no need to set the base url
 #   - api-key: "sk-atSM..."
+#     weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "test" # optional: require calls like "test/claude-sonnet-latest" to target this credential
 #     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
 #     base-url: "https://www.example.com" # use the custom claude API endpoint
@@ -429,6 +437,7 @@ nonstream-keepalive-interval: 0
 #       X-Custom-Header: "custom-value"
 #     api-key-entries:
 #       - api-key: "sk-or-v1-...b780"
+#         weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #         proxy-url: "socks5://proxy.example.com:1080" # optional: per-key proxy override
 #         # proxy-url: "direct" # optional: explicit direct connect for this credential
 #       - api-key: "sk-or-v1-...b781" # without proxy-url
@@ -456,6 +465,7 @@ nonstream-keepalive-interval: 0
 # Vertex API keys (Vertex-compatible endpoints, base-url is optional)
 # vertex-api-key:
 #   - api-key: "vk-123..."                        # x-goog-api-key header
+#     weight: 5                                    # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "test"                              # optional: require calls like "test/vertex-pro" to target this credential
 #     base-url: "https://example.com/api"         # optional, e.g. https://zenmux.ai/api; falls back to Google Vertex when omitted
 #     proxy-url: "socks5://proxy.example.com:1080" # optional per-key proxy override

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -293,6 +293,8 @@ nonstream-keepalive-interval: 0
 #       - name: "gemini-2.5-flash" # upstream model name
 #         alias: "gemini-flash"    # client alias mapped to the upstream model
 #         display-name: "Gemini Flash" # optional catalog display name
+#         thinking:                  # optional: exact thinking capability for this configured model
+#           levels: ["high", "medium", "low", "none", "auto"]
 #     excluded-models:
 #       - "gemini-2.5-pro"     # exclude specific models from this provider (exact match)
 #       - "gemini-2.5-*"       # wildcard matching prefix (e.g. gemini-2.5-flash, gemini-2.5-pro)
@@ -316,6 +318,8 @@ nonstream-keepalive-interval: 0
 #     models:
 #       - name: "gemini-2.5-flash" # upstream model name
 #         alias: "native-gemini-flash" # client alias mapped to the upstream model
+#         thinking:                  # optional: exact thinking capability for this configured model
+#           levels: ["high", "medium", "low", "none", "auto"]
 #     excluded-models:
 #       - "gemini-2.5-pro"
 
@@ -335,6 +339,8 @@ nonstream-keepalive-interval: 0
 #         alias: "codex-latest" # client alias mapped to the upstream model
 #         display-name: "Codex Latest" # optional catalog display name
 #         force-mapping: true    # optional: rewrite response model fields back to the alias
+#         thinking:              # optional: exact thinking capability for this configured model
+#           levels: ["xhigh", "high", "medium", "low"]
 #     excluded-models:
 #       - "gpt-5.1"         # exclude specific models (exact match)
 #       - "gpt-5-*"         # wildcard matching prefix (e.g. gpt-5-medium, gpt-5-codex)
@@ -359,6 +365,8 @@ nonstream-keepalive-interval: 0
 #         alias: "grok-latest"   # client alias mapped to the upstream model
 #         display-name: "Grok Latest" # optional catalog display name
 #         force-mapping: true     # optional: rewrite response model fields back to the alias
+#         thinking:               # optional: exact thinking capability for this configured model
+#           levels: ["xhigh", "high", "medium", "low"]
 #     excluded-models:
 #       - "grok-4.1"             # exclude specific models (exact match)
 #       - "grok-3-*"             # wildcard matching prefix
@@ -380,6 +388,8 @@ nonstream-keepalive-interval: 0
 #         alias: "claude-sonnet-latest"      # client alias mapped to the upstream model
 #         display-name: "Claude Sonnet"      # optional catalog display name
 #         force-mapping: true                 # optional: rewrite response model fields back to the alias
+#         thinking:                           # optional: exact thinking capability for this configured model
+#           levels: ["max", "xhigh", "high", "medium", "low", "minimal", "none", "auto"]
 #     excluded-models:
 #       - "claude-opus-4-5-20251101" # exclude specific models (exact match)
 #       - "claude-3-*"               # wildcard matching prefix (e.g. claude-3-7-sonnet-20250219)
@@ -476,6 +486,8 @@ nonstream-keepalive-interval: 0
 #       - name: "gemini-2.5-flash"                # upstream model name
 #         alias: "vertex-flash"                   # client-visible alias
 #         display-name: "Vertex Flash"            # optional catalog display name
+#         thinking:                                # optional: exact thinking capability for this configured model
+#           levels: ["high", "medium", "low", "none", "auto"]
 #       - name: "gemini-2.5-pro"
 #         alias: "vertex-pro"
 #     excluded-models:                            # optional: models to exclude from listing

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -206,7 +206,10 @@ quota-exceeded:
 
 # Routing strategy for selecting credentials when multiple match.
 routing:
-  strategy: "round-robin" # round-robin (default), fill-first
+  strategy: "round-robin" # round-robin (default), weighted-round-robin, fill-first
+  # weighted-round-robin uses each credential's integer weight (default 1, maximum 1,000,000).
+  # Non-positive weights exclude the credential while this strategy is active.
+  # For OAuth/file credentials, add a top-level numeric "weight" field to the auth JSON.
   # Enable universal session-sticky routing for all clients.
   # Explicit Claude Code, Codex, OpenCode, and pi session headers are preferred,
   # followed by canonical Codex client_metadata, prompt_cache_key, Responses
@@ -408,6 +411,7 @@ nonstream-keepalive-interval: 0
 # Gemini API keys
 # gemini-api-key:
 #   - api-key: "AIzaSy...01"
+#     weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "test" # optional: require calls like "test/gemini-3-pro-preview" to target this credential
 #     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
 #     base-url: "https://generativelanguage.googleapis.com"
@@ -419,6 +423,8 @@ nonstream-keepalive-interval: 0
 #       - name: "gemini-2.5-flash" # upstream model name
 #         alias: "gemini-flash"    # client alias mapped to the upstream model
 #         display-name: "Gemini Flash" # optional catalog display name
+#         thinking:                  # optional: exact thinking capability for this configured model
+#           levels: ["high", "medium", "low", "none", "auto"]
 #     excluded-models:
 #       - "gemini-2.5-pro"     # exclude specific models from this provider (exact match)
 #       - "gemini-2.5-*"       # wildcard matching prefix (e.g. gemini-2.5-flash, gemini-2.5-pro)
@@ -431,6 +437,7 @@ nonstream-keepalive-interval: 0
 # send Gemini generateContent/streamGenerateContent requests when the client enters through the interactions API.
 # interactions-api-key:
 #   - api-key: "AIzaSy...03"
+#     weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "native" # optional: require calls like "native/gemini-3-pro-preview" to target this credential
 #     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
 #     base-url: "https://generativelanguage.googleapis.com"
@@ -441,12 +448,15 @@ nonstream-keepalive-interval: 0
 #     models:
 #       - name: "gemini-2.5-flash" # upstream model name
 #         alias: "native-gemini-flash" # client alias mapped to the upstream model
+#         thinking:                  # optional: exact thinking capability for this configured model
+#           levels: ["high", "medium", "low", "none", "auto"]
 #     excluded-models:
 #       - "gemini-2.5-pro"
 
 # Codex API keys
 # codex-api-key:
 #   - api-key: "sk-atSM..."
+#     weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "test" # optional: require calls like "test/gpt-5-codex" to target this credential
 #     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
 #     base-url: "https://www.example.com" # use the custom codex API endpoint
@@ -459,6 +469,8 @@ nonstream-keepalive-interval: 0
 #         alias: "codex-latest" # client alias mapped to the upstream model
 #         display-name: "Codex Latest" # optional catalog display name
 #         force-mapping: true    # optional: rewrite response model fields back to the alias
+#         thinking:              # optional: exact thinking capability for this configured model
+#           levels: ["xhigh", "high", "medium", "low"]
 #     excluded-models:
 #       - "gpt-5.1"         # exclude specific models (exact match)
 #       - "gpt-5-*"         # wildcard matching prefix (e.g. gpt-5-medium, gpt-5-codex)
@@ -469,6 +481,7 @@ nonstream-keepalive-interval: 0
 # Uses the native xAI executor, including its Responses namespace-tool handling.
 # xai-api-key:
 #   - api-key: "xai-..."
+#     weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "xai" # optional: require calls like "xai/grok-4.5" to target this credential
 #     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
 #     base-url: "https://api.x.ai/v1" # xAI-compatible Responses API endpoint
@@ -482,6 +495,8 @@ nonstream-keepalive-interval: 0
 #         alias: "grok-latest"   # client alias mapped to the upstream model
 #         display-name: "Grok Latest" # optional catalog display name
 #         force-mapping: true     # optional: rewrite response model fields back to the alias
+#         thinking:               # optional: exact thinking capability for this configured model
+#           levels: ["xhigh", "high", "medium", "low"]
 #     excluded-models:
 #       - "grok-4.1"             # exclude specific models (exact match)
 #       - "grok-3-*"             # wildcard matching prefix
@@ -490,6 +505,7 @@ nonstream-keepalive-interval: 0
 # claude-api-key:
 #   - api-key: "sk-atSM..." # use the official claude API key, no need to set the base url
 #   - api-key: "sk-atSM..."
+#     weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "test" # optional: require calls like "test/claude-sonnet-latest" to target this credential
 #     disable-cooling: false # optional: per-auth override for auth/model cooldown scheduling
 #     base-url: "https://www.example.com" # use the custom claude API endpoint
@@ -502,6 +518,8 @@ nonstream-keepalive-interval: 0
 #         alias: "claude-sonnet-latest"      # client alias mapped to the upstream model
 #         display-name: "Claude Sonnet"      # optional catalog display name
 #         force-mapping: true                 # optional: rewrite response model fields back to the alias
+#         thinking:                           # optional: exact thinking capability for this configured model
+#           levels: ["max", "xhigh", "high", "medium", "low", "minimal", "none", "auto"]
 #     excluded-models:
 #       - "claude-opus-4-5-20251101" # exclude specific models (exact match)
 #       - "claude-3-*"               # wildcard matching prefix (e.g. claude-3-7-sonnet-20250219)
@@ -562,6 +580,7 @@ nonstream-keepalive-interval: 0
 #       X-Custom-Header: "custom-value"
 #     api-key-entries:
 #       - api-key: "sk-or-v1-...b780"
+#         weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #         proxy-url: "socks5://proxy.example.com:1080" # optional: per-key proxy override
 #         # proxy-url: "direct" # optional: explicit direct connect for this credential
 #       - api-key: "sk-or-v1-...b781" # without proxy-url
@@ -589,6 +608,7 @@ nonstream-keepalive-interval: 0
 # Vertex API keys (Vertex-compatible endpoints, base-url is optional)
 # vertex-api-key:
 #   - api-key: "vk-123..."                        # x-goog-api-key header
+#     weight: 5                                    # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "test"                              # optional: require calls like "test/vertex-pro" to target this credential
 #     base-url: "https://example.com/api"         # optional, e.g. https://zenmux.ai/api; falls back to Google Vertex when omitted
 #     proxy-url: "socks5://proxy.example.com:1080" # optional per-key proxy override
@@ -599,6 +619,8 @@ nonstream-keepalive-interval: 0
 #       - name: "gemini-2.5-flash"                # upstream model name
 #         alias: "vertex-flash"                   # client-visible alias
 #         display-name: "Vertex Flash"            # optional catalog display name
+#         thinking:                                # optional: exact thinking capability for this configured model
+#           levels: ["high", "medium", "low", "none", "auto"]
 #       - name: "gemini-2.5-pro"
 #         alias: "vertex-pro"
 #     excluded-models:                            # optional: models to exclude from listing

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -628,7 +628,7 @@ patches:
   - id: auth-store-list-error-propagation
     reason: A damaged or unreadable auth JSON file must fail Store.List instead of silently removing that credential from routing, fallback, and usage attribution while startup reports success.
     introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
-    affected_upstream_range: through 53c1e7e2dd6ddf973098a4e685e852aeebed9fe3 (v7.2.92); the File and Git token stores still discard read, JSON decode, and stat errors inside filepath.WalkDir callbacks.
+    affected_upstream_range: through 4a2eb54dc6bf943196be4fb515e6a9407a4db143 (v7.2.105); upstream now validates credential weights but expects FileTokenStore.List to silently skip an invalid persisted plugin source. LTS instead keeps fail-closed list error propagation so damaged JSON, parser failures, and invalid source weights cannot silently remove credentials from routing and attribution.
     files:
       - internal/store/gitstore.go
       - internal/store/gitstore_test.go
@@ -642,6 +642,7 @@ patches:
       - TestGitTokenStoreListReturnsAuthFileErrors
       - TestFileTokenStoreListReturnsAuthFileErrors
       - TestFileTokenStoreListReturnsPluginParserErrors
+      - TestFileTokenStoreListReturnsInvalidPluginSourceWeight
       - TestSynthesizeAuthFilePluginParserErrorDoesNotFallback
     upstream_issue_or_pr: not-filed
     state: required

--- a/internal/api/handlers/management/auth_files_crud.go
+++ b/internal/api/handlers/management/auth_files_crud.go
@@ -498,7 +498,11 @@ func (h *Handler) buildAuthFromFileData(path string, data []byte) (*coreauth.Aut
 			Now:         time.Now(),
 			IDGenerator: synthesizer.NewStableIDGenerator(),
 		}
-		if generated := synthesizer.SynthesizeAuthFile(sctx, path, data); len(generated) > 0 && generated[0] != nil {
+		generated, errSynthesize := synthesizer.SynthesizeAuthFile(sctx, path, data)
+		if errSynthesize != nil {
+			return nil, fmt.Errorf("invalid auth file: %w", errSynthesize)
+		}
+		if len(generated) > 0 && generated[0] != nil {
 			auth = generated[0].Clone()
 		}
 	}

--- a/internal/api/handlers/management/auth_files_fields.go
+++ b/internal/api/handlers/management/auth_files_fields.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/credentialweight"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
@@ -272,7 +273,25 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 			targetAuth.Metadata = make(map[string]any)
 		}
 
-		if fieldPath == "headers" {
+		if fieldPath == coreauth.AttributeWeight {
+			if value == nil {
+				delete(targetAuth.Metadata, coreauth.AttributeWeight)
+			} else {
+				if _, okNumber := value.(json.Number); !okNumber {
+					c.JSON(http.StatusBadRequest, gin.H{"error": "weight must be an integer"})
+					return
+				}
+				weight, errWeight := credentialweight.ParseValue(value)
+				if errWeight != nil {
+					c.JSON(http.StatusBadRequest, gin.H{"error": errWeight.Error()})
+					return
+				}
+				targetAuth.Metadata[coreauth.AttributeWeight] = weight
+			}
+		} else if rootAuthFileField(fieldPath) == coreauth.AttributeWeight {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "weight does not support nested fields"})
+			return
+		} else if fieldPath == "headers" {
 			applyAuthFileHeadersPatch(targetAuth, value)
 		} else if errSet := setAuthFileMetadataValue(targetAuth.Metadata, fieldPath, value); errSet != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": errSet.Error()})
@@ -429,6 +448,9 @@ func syncAuthFileMetadataFields(auth *coreauth.Auth, touchedRoots map[string]str
 	if _, ok := touchedRoots["priority"]; ok {
 		syncAuthFilePriorityAttribute(auth)
 	}
+	if _, ok := touchedRoots[coreauth.AttributeWeight]; ok {
+		syncAuthFileWeightAttribute(auth)
+	}
 	if _, ok := touchedRoots["note"]; ok {
 		syncAuthFileNoteAttribute(auth)
 	}
@@ -474,6 +496,21 @@ func syncAuthFilePriorityAttribute(auth *coreauth.Auth) {
 		return
 	}
 	auth.Attributes["priority"] = strconv.Itoa(priority)
+}
+
+func syncAuthFileWeightAttribute(auth *coreauth.Auth) {
+	if auth == nil {
+		return
+	}
+	if auth.Attributes == nil {
+		auth.Attributes = make(map[string]string)
+	}
+	weight, errWeight := credentialweight.ParseValue(auth.Metadata[coreauth.AttributeWeight])
+	if errWeight != nil {
+		delete(auth.Attributes, coreauth.AttributeWeight)
+		return
+	}
+	auth.Attributes[coreauth.AttributeWeight] = strconv.FormatInt(weight, 10)
 }
 
 func authFileIntValue(value any) (int, bool) {

--- a/internal/api/handlers/management/auth_files_fields.go
+++ b/internal/api/handlers/management/auth_files_fields.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/credentialweight"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
@@ -289,7 +290,25 @@ func (h *Handler) PatchAuthFileFields(c *gin.Context) {
 			value = normalizedPrefix
 		}
 
-		if fieldPath == "headers" {
+		if fieldPath == coreauth.AttributeWeight {
+			if value == nil {
+				delete(targetAuth.Metadata, coreauth.AttributeWeight)
+			} else {
+				if _, okNumber := value.(json.Number); !okNumber {
+					c.JSON(http.StatusBadRequest, gin.H{"error": "weight must be an integer"})
+					return
+				}
+				weight, errWeight := credentialweight.ParseValue(value)
+				if errWeight != nil {
+					c.JSON(http.StatusBadRequest, gin.H{"error": errWeight.Error()})
+					return
+				}
+				targetAuth.Metadata[coreauth.AttributeWeight] = weight
+			}
+		} else if rootAuthFileField(fieldPath) == coreauth.AttributeWeight {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "weight does not support nested fields"})
+			return
+		} else if fieldPath == "headers" {
 			applyAuthFileHeadersPatch(targetAuth, value)
 		} else if errSet := setAuthFileMetadataValue(targetAuth.Metadata, fieldPath, value); errSet != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": errSet.Error()})
@@ -446,6 +465,9 @@ func syncAuthFileMetadataFields(auth *coreauth.Auth, touchedRoots map[string]str
 	if _, ok := touchedRoots["priority"]; ok {
 		syncAuthFilePriorityAttribute(auth)
 	}
+	if _, ok := touchedRoots[coreauth.AttributeWeight]; ok {
+		syncAuthFileWeightAttribute(auth)
+	}
 	if _, ok := touchedRoots["note"]; ok {
 		syncAuthFileNoteAttribute(auth)
 	}
@@ -491,6 +513,21 @@ func syncAuthFilePriorityAttribute(auth *coreauth.Auth) {
 		return
 	}
 	auth.Attributes["priority"] = strconv.Itoa(priority)
+}
+
+func syncAuthFileWeightAttribute(auth *coreauth.Auth) {
+	if auth == nil {
+		return
+	}
+	if auth.Attributes == nil {
+		auth.Attributes = make(map[string]string)
+	}
+	weight, errWeight := credentialweight.ParseValue(auth.Metadata[coreauth.AttributeWeight])
+	if errWeight != nil {
+		delete(auth.Attributes, coreauth.AttributeWeight)
+		return
+	}
+	auth.Attributes[coreauth.AttributeWeight] = strconv.FormatInt(weight, 10)
 }
 
 func authFileIntValue(value any) (int, bool) {

--- a/internal/api/handlers/management/auth_files_patch_fields_test.go
+++ b/internal/api/handlers/management/auth_files_patch_fields_test.go
@@ -276,3 +276,96 @@ func TestPatchAuthFileFields_ArbitraryFieldsPersistToFile(t *testing.T) {
 		t.Fatalf("fgh.ijk = %#v, want true", got)
 	}
 }
+
+func TestPatchAuthFileFields_WeightPersistsAndSyncsRuntime(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+
+	authDir := t.TempDir()
+	fileName := "weighted.json"
+	filePath := filepath.Join(authDir, fileName)
+	store := fileauth.NewFileTokenStore()
+	store.SetBaseDir(authDir)
+	manager := coreauth.NewManager(store, nil, nil)
+	record := &coreauth.Auth{
+		ID:         fileName,
+		FileName:   fileName,
+		Provider:   "codex",
+		Attributes: map[string]string{"path": filePath},
+		Metadata:   map[string]any{"type": "codex"},
+	}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, manager)
+
+	patch := func(weight string) *httptest.ResponseRecorder {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rec)
+		body := `{"name":"weighted.json","weight":` + weight + `}`
+		ctx.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/fields", strings.NewReader(body))
+		ctx.Request.Header.Set("Content-Type", "application/json")
+		h.PatchAuthFileFields(ctx)
+		return rec
+	}
+
+	if rec := patch("7"); rec.Code != http.StatusOK {
+		t.Fatalf("update status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	updated, ok := manager.GetByID(fileName)
+	if !ok || updated.Attributes[coreauth.AttributeWeight] != "7" {
+		t.Fatalf("runtime weight = %#v, want 7", updated)
+	}
+	raw, errRead := os.ReadFile(filePath)
+	if errRead != nil {
+		t.Fatalf("ReadFile() error = %v", errRead)
+	}
+	var persisted map[string]any
+	if errUnmarshal := json.Unmarshal(raw, &persisted); errUnmarshal != nil {
+		t.Fatalf("Unmarshal() error = %v", errUnmarshal)
+	}
+	if persisted["weight"] != float64(7) {
+		t.Fatalf("persisted weight = %#v, want 7", persisted["weight"])
+	}
+
+	if rec := patch("null"); rec.Code != http.StatusOK {
+		t.Fatalf("reset status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	updated, _ = manager.GetByID(fileName)
+	if _, exists := updated.Attributes[coreauth.AttributeWeight]; exists {
+		t.Fatal("runtime weight remains after reset")
+	}
+	raw, errRead = os.ReadFile(filePath)
+	if errRead != nil {
+		t.Fatalf("ReadFile() after reset error = %v", errRead)
+	}
+	persisted = nil
+	if errUnmarshal := json.Unmarshal(raw, &persisted); errUnmarshal != nil {
+		t.Fatalf("Unmarshal() after reset error = %v", errUnmarshal)
+	}
+	if _, exists := persisted["weight"]; exists {
+		t.Fatal("persisted weight remains after reset")
+	}
+}
+
+func TestPatchAuthFileFields_RejectsInvalidWeights(t *testing.T) {
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	record := &coreauth.Auth{ID: "auth.json", FileName: "auth.json", Provider: "codex", Metadata: map[string]any{"type": "codex"}}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+	h := NewHandlerWithoutConfigFilePath(&config.Config{}, manager)
+
+	for _, weight := range []string{"1.5", "1000001", "9223372036854775808", `"7"`} {
+		rec := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rec)
+		body := `{"name":"auth.json","weight":` + weight + `}`
+		ctx.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/fields", strings.NewReader(body))
+		ctx.Request.Header.Set("Content-Type", "application/json")
+		h.PatchAuthFileFields(ctx)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("weight %s status = %d, want 400; body=%s", weight, rec.Code, rec.Body.String())
+		}
+	}
+}

--- a/internal/api/handlers/management/auth_files_patch_fields_test.go
+++ b/internal/api/handlers/management/auth_files_patch_fields_test.go
@@ -337,3 +337,96 @@ func TestPatchAuthFileFields_ArbitraryFieldsPersistToFile(t *testing.T) {
 		t.Fatalf("fgh.ijk = %#v, want true", got)
 	}
 }
+
+func TestPatchAuthFileFields_WeightPersistsAndSyncsRuntime(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+
+	authDir := t.TempDir()
+	fileName := "weighted.json"
+	filePath := filepath.Join(authDir, fileName)
+	store := fileauth.NewFileTokenStore()
+	store.SetBaseDir(authDir)
+	manager := coreauth.NewManager(store, nil, nil)
+	record := &coreauth.Auth{
+		ID:         fileName,
+		FileName:   fileName,
+		Provider:   "codex",
+		Attributes: map[string]string{"path": filePath},
+		Metadata:   map[string]any{"type": "codex"},
+	}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, manager)
+
+	patch := func(weight string) *httptest.ResponseRecorder {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rec)
+		body := `{"name":"weighted.json","weight":` + weight + `}`
+		ctx.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/fields", strings.NewReader(body))
+		ctx.Request.Header.Set("Content-Type", "application/json")
+		h.PatchAuthFileFields(ctx)
+		return rec
+	}
+
+	if rec := patch("7"); rec.Code != http.StatusOK {
+		t.Fatalf("update status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	updated, ok := manager.GetByID(fileName)
+	if !ok || updated.Attributes[coreauth.AttributeWeight] != "7" {
+		t.Fatalf("runtime weight = %#v, want 7", updated)
+	}
+	raw, errRead := os.ReadFile(filePath)
+	if errRead != nil {
+		t.Fatalf("ReadFile() error = %v", errRead)
+	}
+	var persisted map[string]any
+	if errUnmarshal := json.Unmarshal(raw, &persisted); errUnmarshal != nil {
+		t.Fatalf("Unmarshal() error = %v", errUnmarshal)
+	}
+	if persisted["weight"] != float64(7) {
+		t.Fatalf("persisted weight = %#v, want 7", persisted["weight"])
+	}
+
+	if rec := patch("null"); rec.Code != http.StatusOK {
+		t.Fatalf("reset status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	updated, _ = manager.GetByID(fileName)
+	if _, exists := updated.Attributes[coreauth.AttributeWeight]; exists {
+		t.Fatal("runtime weight remains after reset")
+	}
+	raw, errRead = os.ReadFile(filePath)
+	if errRead != nil {
+		t.Fatalf("ReadFile() after reset error = %v", errRead)
+	}
+	persisted = nil
+	if errUnmarshal := json.Unmarshal(raw, &persisted); errUnmarshal != nil {
+		t.Fatalf("Unmarshal() after reset error = %v", errUnmarshal)
+	}
+	if _, exists := persisted["weight"]; exists {
+		t.Fatal("persisted weight remains after reset")
+	}
+}
+
+func TestPatchAuthFileFields_RejectsInvalidWeights(t *testing.T) {
+	store := &memoryAuthStore{}
+	manager := coreauth.NewManager(store, nil, nil)
+	record := &coreauth.Auth{ID: "auth.json", FileName: "auth.json", Provider: "codex", Metadata: map[string]any{"type": "codex"}}
+	if _, errRegister := manager.Register(context.Background(), record); errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+	h := NewHandlerWithoutConfigFilePath(&config.Config{}, manager)
+
+	for _, weight := range []string{"1.5", "1000001", "9223372036854775808", `"7"`} {
+		rec := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rec)
+		body := `{"name":"auth.json","weight":` + weight + `}`
+		ctx.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/auth-files/fields", strings.NewReader(body))
+		ctx.Request.Header.Set("Content-Type", "application/json")
+		h.PatchAuthFileFields(ctx)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("weight %s status = %d, want 400; body=%s", weight, rec.Code, rec.Body.String())
+		}
+	}
+}

--- a/internal/api/handlers/management/config_basic.go
+++ b/internal/api/handlers/management/config_basic.go
@@ -284,6 +284,8 @@ func normalizeRoutingStrategy(strategy string) (string, bool) {
 	switch normalized {
 	case "", "round-robin", "roundrobin", "rr":
 		return "round-robin", true
+	case "weighted-round-robin", "weightedroundrobin", "wrr":
+		return "weighted-round-robin", true
 	case "fill-first", "fillfirst", "ff":
 		return "fill-first", true
 	default:

--- a/internal/api/handlers/management/config_basic_weight_test.go
+++ b/internal/api/handlers/management/config_basic_weight_test.go
@@ -1,0 +1,12 @@
+package management
+
+import "testing"
+
+func TestNormalizeRoutingStrategyWeightedRoundRobin(t *testing.T) {
+	for _, input := range []string{"weighted-round-robin", "weightedroundrobin", "wrr"} {
+		got, ok := normalizeRoutingStrategy(input)
+		if !ok || got != "weighted-round-robin" {
+			t.Fatalf("normalizeRoutingStrategy(%q) = %q, %v; want weighted-round-robin, true", input, got, ok)
+		}
+	}
+}

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -1,6 +1,7 @@
 package management
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -8,6 +9,32 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 )
+
+func parseCredentialWeightPatch(raw json.RawMessage) (*int, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("weight is missing")
+	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, nil
+	}
+	var weight int
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	if errDecode := decoder.Decode(&weight); errDecode != nil {
+		return nil, fmt.Errorf("weight must be an integer")
+	}
+	if errValidate := config.ValidateCredentialWeight(&weight); errValidate != nil {
+		return nil, errValidate
+	}
+	return &weight, nil
+}
+
+func rejectInvalidCredentialWeight(c *gin.Context, field string, weight *int) bool {
+	if errValidate := config.ValidateCredentialWeight(weight); errValidate != nil {
+		c.JSON(400, gin.H{"error": fmt.Sprintf("%s: %v", field, errValidate)})
+		return true
+	}
+	return false
+}
 
 // Generic helpers for list[string]
 func (h *Handler) putStringList(c *gin.Context, set func([]string), after func()) {
@@ -139,6 +166,11 @@ func (h *Handler) PutGeminiKeys(c *gin.Context) {
 		}
 		arr = obj.Items
 	}
+	for index := range arr {
+		if rejectInvalidCredentialWeight(c, fmt.Sprintf("gemini-api-key[%d].weight", index), arr[index].Weight) {
+			return
+		}
+	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.cfg.GeminiKey = append([]config.GeminiKey(nil), arr...)
@@ -148,6 +180,7 @@ func (h *Handler) PutGeminiKeys(c *gin.Context) {
 func (h *Handler) PatchGeminiKey(c *gin.Context) {
 	type geminiKeyPatch struct {
 		APIKey         *string            `json:"api-key"`
+		Weight         json.RawMessage    `json:"weight"`
 		Prefix         *string            `json:"prefix"`
 		BaseURL        *string            `json:"base-url"`
 		ProxyURL       *string            `json:"proxy-url"`
@@ -196,6 +229,14 @@ func (h *Handler) PatchGeminiKey(c *gin.Context) {
 			return
 		}
 		entry.APIKey = trimmed
+	}
+	if len(body.Value.Weight) > 0 {
+		weight, errWeight := parseCredentialWeightPatch(body.Value.Weight)
+		if errWeight != nil {
+			c.JSON(400, gin.H{"error": errWeight.Error()})
+			return
+		}
+		entry.Weight = weight
 	}
 	if body.Value.Prefix != nil {
 		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
@@ -298,6 +339,11 @@ func (h *Handler) PutInteractionsKeys(c *gin.Context) {
 		}
 		arr = obj.Items
 	}
+	for index := range arr {
+		if rejectInvalidCredentialWeight(c, fmt.Sprintf("interactions-api-key[%d].weight", index), arr[index].Weight) {
+			return
+		}
+	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.cfg.InteractionsKey = append([]config.GeminiKey(nil), arr...)
@@ -307,6 +353,7 @@ func (h *Handler) PutInteractionsKeys(c *gin.Context) {
 func (h *Handler) PatchInteractionsKey(c *gin.Context) {
 	type geminiKeyPatch struct {
 		APIKey         *string            `json:"api-key"`
+		Weight         json.RawMessage    `json:"weight"`
 		Prefix         *string            `json:"prefix"`
 		BaseURL        *string            `json:"base-url"`
 		ProxyURL       *string            `json:"proxy-url"`
@@ -356,6 +403,14 @@ func (h *Handler) PatchInteractionsKey(c *gin.Context) {
 			return
 		}
 		entry.APIKey = trimmed
+	}
+	if len(body.Value.Weight) > 0 {
+		weight, errWeight := parseCredentialWeightPatch(body.Value.Weight)
+		if errWeight != nil {
+			c.JSON(400, gin.H{"error": errWeight.Error()})
+			return
+		}
+		entry.Weight = weight
 	}
 	if body.Value.Prefix != nil {
 		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
@@ -459,6 +514,9 @@ func (h *Handler) PutClaudeKeys(c *gin.Context) {
 	}
 	for i := range arr {
 		normalizeClaudeKey(&arr[i])
+		if rejectInvalidCredentialWeight(c, fmt.Sprintf("claude-api-key[%d].weight", i), arr[i].Weight) {
+			return
+		}
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -469,6 +527,7 @@ func (h *Handler) PutClaudeKeys(c *gin.Context) {
 func (h *Handler) PatchClaudeKey(c *gin.Context) {
 	type claudeKeyPatch struct {
 		APIKey                  *string               `json:"api-key"`
+		Weight                  json.RawMessage       `json:"weight"`
 		Prefix                  *string               `json:"prefix"`
 		BaseURL                 *string               `json:"base-url"`
 		ProxyURL                *string               `json:"proxy-url"`
@@ -510,6 +569,14 @@ func (h *Handler) PatchClaudeKey(c *gin.Context) {
 	entry := h.cfg.ClaudeKey[targetIndex]
 	if body.Value.APIKey != nil {
 		entry.APIKey = strings.TrimSpace(*body.Value.APIKey)
+	}
+	if len(body.Value.Weight) > 0 {
+		weight, errWeight := parseCredentialWeightPatch(body.Value.Weight)
+		if errWeight != nil {
+			c.JSON(400, gin.H{"error": errWeight.Error()})
+			return
+		}
+		entry.Weight = weight
 	}
 	if body.Value.Prefix != nil {
 		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
@@ -615,9 +682,16 @@ func (h *Handler) PutOpenAICompat(c *gin.Context) {
 	filtered := make([]config.OpenAICompatibility, 0, len(arr))
 	for i := range arr {
 		normalizeOpenAICompatibilityEntry(&arr[i])
-		if strings.TrimSpace(arr[i].BaseURL) != "" {
-			filtered = append(filtered, arr[i])
+		if strings.TrimSpace(arr[i].BaseURL) == "" {
+			continue
 		}
+		for keyIndex := range arr[i].APIKeyEntries {
+			field := fmt.Sprintf("openai-compatibility[%d].api-key-entries[%d].weight", i, keyIndex)
+			if rejectInvalidCredentialWeight(c, field, arr[i].APIKeyEntries[keyIndex].Weight) {
+				return
+			}
+		}
+		filtered = append(filtered, arr[i])
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -690,6 +764,12 @@ func (h *Handler) PatchOpenAICompat(c *gin.Context) {
 		entry.BaseURL = trimmed
 	}
 	if body.Value.APIKeyEntries != nil {
+		for keyIndex := range *body.Value.APIKeyEntries {
+			weight := (*body.Value.APIKeyEntries)[keyIndex].Weight
+			if rejectInvalidCredentialWeight(c, fmt.Sprintf("api-key-entries[%d].weight", keyIndex), weight) {
+				return
+			}
+		}
 		entry.APIKeyEntries = append([]config.OpenAICompatibilityAPIKey(nil), (*body.Value.APIKeyEntries)...)
 	}
 	if body.Value.Models != nil {
@@ -759,6 +839,9 @@ func (h *Handler) PutVertexCompatKeys(c *gin.Context) {
 			c.JSON(400, gin.H{"error": fmt.Sprintf("vertex-api-key[%d].api-key is required", i)})
 			return
 		}
+		if rejectInvalidCredentialWeight(c, fmt.Sprintf("vertex-api-key[%d].weight", i), arr[i].Weight) {
+			return
+		}
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -769,6 +852,7 @@ func (h *Handler) PutVertexCompatKeys(c *gin.Context) {
 func (h *Handler) PatchVertexCompatKey(c *gin.Context) {
 	type vertexCompatPatch struct {
 		APIKey         *string                     `json:"api-key"`
+		Weight         json.RawMessage             `json:"weight"`
 		Prefix         *string                     `json:"prefix"`
 		BaseURL        *string                     `json:"base-url"`
 		ProxyURL       *string                     `json:"proxy-url"`
@@ -818,6 +902,14 @@ func (h *Handler) PatchVertexCompatKey(c *gin.Context) {
 			return
 		}
 		entry.APIKey = trimmed
+	}
+	if len(body.Value.Weight) > 0 {
+		weight, errWeight := parseCredentialWeightPatch(body.Value.Weight)
+		if errWeight != nil {
+			c.JSON(400, gin.H{"error": errWeight.Error()})
+			return
+		}
+		entry.Weight = weight
 	}
 	if body.Value.Prefix != nil {
 		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
@@ -1114,6 +1206,9 @@ func (h *Handler) PutCodexKeys(c *gin.Context) {
 		if entry.BaseURL == "" {
 			continue
 		}
+		if rejectInvalidCredentialWeight(c, fmt.Sprintf("codex-api-key[%d].weight", i), entry.Weight) {
+			return
+		}
 		filtered = append(filtered, entry)
 	}
 	h.mu.Lock()
@@ -1125,6 +1220,7 @@ func (h *Handler) PutCodexKeys(c *gin.Context) {
 func (h *Handler) PatchCodexKey(c *gin.Context) {
 	type codexKeyPatch struct {
 		APIKey         *string              `json:"api-key"`
+		Weight         json.RawMessage      `json:"weight"`
 		Prefix         *string              `json:"prefix"`
 		BaseURL        *string              `json:"base-url"`
 		ProxyURL       *string              `json:"proxy-url"`
@@ -1165,6 +1261,14 @@ func (h *Handler) PatchCodexKey(c *gin.Context) {
 	entry := h.cfg.CodexKey[targetIndex]
 	if body.Value.APIKey != nil {
 		entry.APIKey = strings.TrimSpace(*body.Value.APIKey)
+	}
+	if len(body.Value.Weight) > 0 {
+		weight, errWeight := parseCredentialWeightPatch(body.Value.Weight)
+		if errWeight != nil {
+			c.JSON(400, gin.H{"error": errWeight.Error()})
+			return
+		}
+		entry.Weight = weight
 	}
 	if body.Value.Prefix != nil {
 		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
@@ -1279,6 +1383,9 @@ func (h *Handler) PutXAIKeys(c *gin.Context) {
 		if entry.BaseURL == "" {
 			continue
 		}
+		if rejectInvalidCredentialWeight(c, fmt.Sprintf("xai-api-key[%d].weight", i), entry.Weight) {
+			return
+		}
 		filtered = append(filtered, entry)
 	}
 	h.mu.Lock()
@@ -1292,6 +1399,7 @@ func (h *Handler) PatchXAIKey(c *gin.Context) {
 	type xaiKeyPatch struct {
 		APIKey         *string            `json:"api-key"`
 		Priority       *int               `json:"priority"`
+		Weight         json.RawMessage    `json:"weight"`
 		Prefix         *string            `json:"prefix"`
 		BaseURL        *string            `json:"base-url"`
 		Websockets     *bool              `json:"websockets"`
@@ -1337,6 +1445,14 @@ func (h *Handler) PatchXAIKey(c *gin.Context) {
 	}
 	if body.Value.Priority != nil {
 		entry.Priority = *body.Value.Priority
+	}
+	if len(body.Value.Weight) > 0 {
+		weight, errWeight := parseCredentialWeightPatch(body.Value.Weight)
+		if errWeight != nil {
+			c.JSON(400, gin.H{"error": errWeight.Error()})
+			return
+		}
+		entry.Weight = weight
 	}
 	if body.Value.Prefix != nil {
 		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)

--- a/internal/api/handlers/management/config_weight_test.go
+++ b/internal/api/handlers/management/config_weight_test.go
@@ -1,0 +1,104 @@
+package management
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestPatchAPIKeyWeightForEveryFamily(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*config.Config)
+		patch func(*Handler, *gin.Context)
+		get   func(*config.Config) *int
+	}{
+		{name: "gemini", setup: func(cfg *config.Config) { cfg.GeminiKey = []config.GeminiKey{{APIKey: "key"}} }, patch: (*Handler).PatchGeminiKey, get: func(cfg *config.Config) *int { return cfg.GeminiKey[0].Weight }},
+		{name: "interactions", setup: func(cfg *config.Config) { cfg.InteractionsKey = []config.GeminiKey{{APIKey: "key"}} }, patch: (*Handler).PatchInteractionsKey, get: func(cfg *config.Config) *int { return cfg.InteractionsKey[0].Weight }},
+		{name: "claude", setup: func(cfg *config.Config) { cfg.ClaudeKey = []config.ClaudeKey{{APIKey: "key"}} }, patch: (*Handler).PatchClaudeKey, get: func(cfg *config.Config) *int { return cfg.ClaudeKey[0].Weight }},
+		{name: "vertex", setup: func(cfg *config.Config) {
+			cfg.VertexCompatAPIKey = []config.VertexCompatKey{{APIKey: "key", BaseURL: "https://example.com"}}
+		}, patch: (*Handler).PatchVertexCompatKey, get: func(cfg *config.Config) *int { return cfg.VertexCompatAPIKey[0].Weight }},
+		{name: "codex", setup: func(cfg *config.Config) {
+			cfg.CodexKey = []config.CodexKey{{APIKey: "key", BaseURL: "https://example.com"}}
+		}, patch: (*Handler).PatchCodexKey, get: func(cfg *config.Config) *int { return cfg.CodexKey[0].Weight }},
+		{name: "xai", setup: func(cfg *config.Config) {
+			cfg.XAIKey = []config.XAIKey{{APIKey: "key", BaseURL: "https://example.com"}}
+		}, patch: (*Handler).PatchXAIKey, get: func(cfg *config.Config) *int { return cfg.XAIKey[0].Weight }},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			test.setup(cfg)
+			h := &Handler{cfg: cfg, configFilePath: writeTestConfigFile(t)}
+
+			rec := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(rec)
+			ctx.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/key", strings.NewReader(`{"index":0,"value":{"weight":7}}`))
+			ctx.Request.Header.Set("Content-Type", "application/json")
+			test.patch(h, ctx)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+			}
+			if weight := test.get(cfg); weight == nil || *weight != 7 {
+				t.Fatalf("weight = %v, want 7", weight)
+			}
+		})
+	}
+}
+
+func TestPatchAPIKeyWeightResetAndStrictValidation(t *testing.T) {
+	initial := 5
+	cfg := &config.Config{GeminiKey: []config.GeminiKey{{APIKey: "key", Weight: &initial}}}
+	h := &Handler{cfg: cfg, configFilePath: writeTestConfigFile(t)}
+
+	patch := func(raw string) *httptest.ResponseRecorder {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rec)
+		body := fmt.Sprintf(`{"index":0,"value":{"weight":%s}}`, raw)
+		ctx.Request = httptest.NewRequest(http.MethodPatch, "/v0/management/gemini-api-key", strings.NewReader(body))
+		ctx.Request.Header.Set("Content-Type", "application/json")
+		h.PatchGeminiKey(ctx)
+		return rec
+	}
+
+	for _, invalid := range []string{"1.5", "1000001", "9223372036854775808", `"7"`} {
+		rec := patch(invalid)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("weight %s status = %d, want 400; body=%s", invalid, rec.Code, rec.Body.String())
+		}
+		if cfg.GeminiKey[0].Weight == nil || *cfg.GeminiKey[0].Weight != initial {
+			t.Fatalf("invalid weight %s changed config", invalid)
+		}
+	}
+
+	if rec := patch("null"); rec.Code != http.StatusOK {
+		t.Fatalf("reset status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if cfg.GeminiKey[0].Weight != nil {
+		t.Fatalf("reset weight = %v, want nil default", cfg.GeminiKey[0].Weight)
+	}
+}
+
+func TestPutAPIKeyWeightRejectsAboveMaximum(t *testing.T) {
+	h := &Handler{cfg: &config.Config{}, configFilePath: writeTestConfigFile(t)}
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodPut, "/v0/management/gemini-api-key", strings.NewReader(`[{"api-key":"key","weight":1000001}]`))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+	h.PutGeminiKeys(ctx)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+	if len(h.cfg.GeminiKey) != 0 {
+		t.Fatal("invalid PUT changed config")
+	}
+}

--- a/internal/cache/antigravity_reasoning_replay_cache_test.go
+++ b/internal/cache/antigravity_reasoning_replay_cache_test.go
@@ -17,6 +17,7 @@ type fakeAntigravityReasoningReplayKVClient struct {
 	mu          sync.Mutex
 	values      map[string][]byte
 	expireCount int
+	casErr      error
 }
 
 func newFakeAntigravityReasoningReplayKVClient() *fakeAntigravityReasoningReplayKVClient {
@@ -40,6 +41,9 @@ func (c *fakeAntigravityReasoningReplayKVClient) KVSet(_ context.Context, key st
 func (c *fakeAntigravityReasoningReplayKVClient) KVCompareAndSwap(_ context.Context, key string, expected []byte, expectedExists bool, value []byte, _ time.Duration) (bool, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.casErr != nil {
+		return false, c.casErr
+	}
 	current, exists := c.values[key]
 	if exists != expectedExists || (exists && !bytes.Equal(current, expected)) {
 		return false, nil
@@ -387,6 +391,32 @@ func TestAntigravityReasoningReplayHomeGenerationRejectsSuccessfulValueABA(t *te
 	}
 	if swapped, errSwap := ReplaceAntigravityReasoningReplayItemsIfUnchanged(context.Background(), model, session, staleSnapshot, [][]byte{itemB}); errSwap != nil || swapped {
 		t.Fatalf("stale A snapshot passed Home ABA guard: swapped=%v err=%v", swapped, errSwap)
+	}
+}
+
+func TestAntigravityReasoningReplayHomeReportsCASErrors(t *testing.T) {
+	// The cache layer keeps reporting CAS failures honestly. Deciding that a
+	// replay failure must not fail the request is the executor's job, so this
+	// layer must not start swallowing errors.
+	client := newFakeAntigravityReasoningReplayKVClient()
+	client.casErr = fmt.Errorf("ERR unknown command 'cas'")
+	useFakeAntigravityReasoningReplayKVClient(t, client, true)
+	const model, session = "gemini-3.6-flash-high", "home-cas-error"
+
+	_, _, found, errGet := GetAntigravityReasoningReplayItemsWithSnapshotRequired(context.Background(), model, session)
+	if errGet == nil {
+		t.Fatal("GetAntigravityReasoningReplayItemsWithSnapshotRequired() error = nil, want the CAS error")
+	}
+	if found {
+		t.Fatal("GetAntigravityReasoningReplayItemsWithSnapshotRequired() found = true, want false")
+	}
+
+	snapshot := AntigravityReasoningReplaySnapshot{loaded: true}
+	if _, errReplace := ReplaceAntigravityReasoningReplayItemsIfUnchanged(context.Background(), model, session, snapshot, [][]byte{antigravityReplayTestItem("home-cas-error-sig-1")}); errReplace == nil {
+		t.Fatal("ReplaceAntigravityReasoningReplayItemsIfUnchanged() error = nil, want the CAS error")
+	}
+	if _, errDelete := DeleteAntigravityReasoningReplayItemsIfUnchanged(context.Background(), model, session, snapshot); errDelete == nil {
+		t.Fatal("DeleteAntigravityReasoningReplayItemsIfUnchanged() error = nil, want the CAS error")
 	}
 }
 

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -51,6 +51,15 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 		return cfg, nil
 	}
 
+	if errValidate := validateCredentialWeightYAML(data); errValidate != nil {
+		if optional {
+			cfgOptional := &Config{CredentialInFlight: DefaultCredentialInFlightConfig()}
+			cfgOptional.NormalizePluginsConfig()
+			return cfgOptional, nil
+		}
+		return nil, errValidate
+	}
+
 	// Unmarshal the YAML data into the Config struct.
 	var cfg Config
 	// Set defaults before unmarshal so that absent keys keep defaults.
@@ -84,6 +93,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 		return nil, errValidate
 	}
 	if errValidate := cfg.Codex.LiveMediaRelay.Validate(); errValidate != nil {
+		return nil, errValidate
+	}
+	if errValidate := cfg.ValidateCredentialWeights(); errValidate != nil {
 		return nil, errValidate
 	}
 

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -51,6 +51,15 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 		return cfg, nil
 	}
 
+	if errValidate := validateCredentialWeightYAML(data); errValidate != nil {
+		if optional {
+			cfgOptional := &Config{CredentialInFlight: DefaultCredentialInFlightConfig()}
+			cfgOptional.NormalizePluginsConfig()
+			return cfgOptional, nil
+		}
+		return nil, errValidate
+	}
+
 	// Unmarshal the YAML data into the Config struct.
 	var cfg Config
 	// Set defaults before unmarshal so that absent keys keep defaults.
@@ -87,6 +96,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 		return nil, errValidate
 	}
 	if errValidate := cfg.Codex.LiveMediaRelay.Validate(); errValidate != nil {
+		return nil, errValidate
+	}
+	if errValidate := cfg.ValidateCredentialWeights(); errValidate != nil {
 		return nil, errValidate
 	}
 

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -203,7 +203,7 @@ type QuotaExceeded struct {
 // RoutingConfig configures how credentials are selected for requests.
 type RoutingConfig struct {
 	// Strategy selects the credential selection strategy.
-	// Supported values: "round-robin" (default), "fill-first".
+	// Supported values: "round-robin" (default), "weighted-round-robin", "fill-first".
 	Strategy string `yaml:"strategy,omitempty" json:"strategy,omitempty"`
 
 	// SessionAffinity enables universal session-sticky routing for all clients.
@@ -317,6 +317,10 @@ type ClaudeKey struct {
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
 
+	// Weight controls proportional selection under weighted-round-robin.
+	// An omitted value defaults to 1; non-positive values exclude this credential; maximum 1,000,000.
+	Weight *int `yaml:"weight,omitempty" json:"weight,omitempty"`
+
 	// Prefix optionally namespaces models for this credential (e.g., "teamA/claude-sonnet-4").
 	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
 
@@ -388,6 +392,10 @@ type CodexKey struct {
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
 
+	// Weight controls proportional selection under weighted-round-robin.
+	// An omitted value defaults to 1; non-positive values exclude this credential; maximum 1,000,000.
+	Weight *int `yaml:"weight,omitempty" json:"weight,omitempty"`
+
 	// Prefix optionally namespaces models for this credential (e.g., "teamA/gpt-5-codex").
 	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
 
@@ -456,6 +464,10 @@ type GeminiKey struct {
 	// Priority controls selection preference when multiple credentials match.
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
+
+	// Weight controls proportional selection under weighted-round-robin.
+	// An omitted value defaults to 1; non-positive values exclude this credential; maximum 1,000,000.
+	Weight *int `yaml:"weight,omitempty" json:"weight,omitempty"`
 
 	// Prefix optionally namespaces models for this credential (e.g., "teamA/gemini-3-pro-preview").
 	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
@@ -542,6 +554,10 @@ type OpenAICompatibility struct {
 type OpenAICompatibilityAPIKey struct {
 	// APIKey is the authentication key for accessing the external API services.
 	APIKey string `yaml:"api-key" json:"api-key"`
+
+	// Weight controls proportional selection under weighted-round-robin.
+	// An omitted value defaults to 1; non-positive values exclude this credential; maximum 1,000,000.
+	Weight *int `yaml:"weight,omitempty" json:"weight,omitempty"`
 
 	// ProxyURL overrides the global proxy setting for this API key if provided.
 	ProxyURL string `yaml:"proxy-url,omitempty" json:"proxy-url,omitempty"`

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -359,6 +359,10 @@ func (k ClaudeKey) GetAPIKey() string { return k.APIKey }
 
 func (k ClaudeKey) GetBaseURL() string { return k.BaseURL }
 
+func (k ClaudeKey) GetPrefix() string { return k.Prefix }
+
+func (k ClaudeKey) GetProxyURL() string { return k.ProxyURL }
+
 // ClaudeModel describes a mapping between an alias and the actual upstream model name.
 type ClaudeModel struct {
 	// Name is the upstream model identifier used when issuing requests.
@@ -372,6 +376,9 @@ type ClaudeModel struct {
 
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
+
+	// Thinking configures the thinking/reasoning capability for this model.
+	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
 }
 
 func (m ClaudeModel) GetName() string { return m.Name }
@@ -381,6 +388,8 @@ func (m ClaudeModel) GetAlias() string { return m.Alias }
 func (m ClaudeModel) GetDisplayName() string { return m.DisplayName }
 
 func (m ClaudeModel) GetForceMapping() bool { return m.ForceMapping }
+
+func (m ClaudeModel) GetThinking() *registry.ThinkingSupport { return m.Thinking }
 
 // CodexKey represents the configuration for a Codex API key,
 // including the API key itself and an optional base URL for the API endpoint.
@@ -426,6 +435,10 @@ func (k CodexKey) GetAPIKey() string { return k.APIKey }
 
 func (k CodexKey) GetBaseURL() string { return k.BaseURL }
 
+func (k CodexKey) GetPrefix() string { return k.Prefix }
+
+func (k CodexKey) GetProxyURL() string { return k.ProxyURL }
+
 // CodexModel describes a mapping between an alias and the actual upstream model name.
 type CodexModel struct {
 	// Name is the upstream model identifier used when issuing requests.
@@ -439,6 +452,9 @@ type CodexModel struct {
 
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
+
+	// Thinking configures the thinking/reasoning capability for this model.
+	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
 }
 
 func (m CodexModel) GetName() string { return m.Name }
@@ -448,6 +464,8 @@ func (m CodexModel) GetAlias() string { return m.Alias }
 func (m CodexModel) GetDisplayName() string { return m.DisplayName }
 
 func (m CodexModel) GetForceMapping() bool { return m.ForceMapping }
+
+func (m CodexModel) GetThinking() *registry.ThinkingSupport { return m.Thinking }
 
 // XAIKey uses the Codex API key structure for native xAI execution.
 type XAIKey = CodexKey
@@ -495,6 +513,10 @@ func (k GeminiKey) GetAPIKey() string { return k.APIKey }
 
 func (k GeminiKey) GetBaseURL() string { return k.BaseURL }
 
+func (k GeminiKey) GetPrefix() string { return k.Prefix }
+
+func (k GeminiKey) GetProxyURL() string { return k.ProxyURL }
+
 // GeminiModel describes a mapping between an alias and the actual upstream model name.
 type GeminiModel struct {
 	// Name is the upstream model identifier used when issuing requests.
@@ -508,6 +530,9 @@ type GeminiModel struct {
 
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
+
+	// Thinking configures the thinking/reasoning capability for this model.
+	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
 }
 
 func (m GeminiModel) GetName() string { return m.Name }
@@ -517,6 +542,8 @@ func (m GeminiModel) GetAlias() string { return m.Alias }
 func (m GeminiModel) GetDisplayName() string { return m.DisplayName }
 
 func (m GeminiModel) GetForceMapping() bool { return m.ForceMapping }
+
+func (m GeminiModel) GetThinking() *registry.ThinkingSupport { return m.Thinking }
 
 // OpenAICompatibility represents the configuration for OpenAI API compatibility
 // with external providers, allowing model aliases to be routed through OpenAI API format.
@@ -600,3 +627,5 @@ func (m OpenAICompatibilityModel) GetAlias() string { return m.Alias }
 func (m OpenAICompatibilityModel) GetDisplayName() string { return m.DisplayName }
 
 func (m OpenAICompatibilityModel) GetForceMapping() bool { return m.ForceMapping }
+
+func (m OpenAICompatibilityModel) GetThinking() *registry.ThinkingSupport { return m.Thinking }

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -228,7 +228,7 @@ type QuotaExceeded struct {
 // RoutingConfig configures how credentials are selected for requests.
 type RoutingConfig struct {
 	// Strategy selects the credential selection strategy.
-	// Supported values: "round-robin" (default), "fill-first".
+	// Supported values: "round-robin" (default), "weighted-round-robin", "fill-first".
 	Strategy string `yaml:"strategy,omitempty" json:"strategy,omitempty"`
 
 	// SessionAffinity enables universal session-sticky routing for all clients.
@@ -344,6 +344,10 @@ type ClaudeKey struct {
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
 
+	// Weight controls proportional selection under weighted-round-robin.
+	// An omitted value defaults to 1; non-positive values exclude this credential; maximum 1,000,000.
+	Weight *int `yaml:"weight,omitempty" json:"weight,omitempty"`
+
 	// Prefix optionally namespaces models for this credential (e.g., "teamA/claude-sonnet-4").
 	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
 
@@ -382,6 +386,10 @@ func (k ClaudeKey) GetAPIKey() string { return k.APIKey }
 
 func (k ClaudeKey) GetBaseURL() string { return k.BaseURL }
 
+func (k ClaudeKey) GetPrefix() string { return k.Prefix }
+
+func (k ClaudeKey) GetProxyURL() string { return k.ProxyURL }
+
 // ClaudeModel describes a mapping between an alias and the actual upstream model name.
 type ClaudeModel struct {
 	// Name is the upstream model identifier used when issuing requests.
@@ -395,6 +403,9 @@ type ClaudeModel struct {
 
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
+
+	// Thinking configures the thinking/reasoning capability for this model.
+	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
 }
 
 func (m ClaudeModel) GetName() string { return m.Name }
@@ -405,6 +416,8 @@ func (m ClaudeModel) GetDisplayName() string { return m.DisplayName }
 
 func (m ClaudeModel) GetForceMapping() bool { return m.ForceMapping }
 
+func (m ClaudeModel) GetThinking() *registry.ThinkingSupport { return m.Thinking }
+
 // CodexKey represents the configuration for a Codex API key,
 // including the API key itself and an optional base URL for the API endpoint.
 type CodexKey struct {
@@ -414,6 +427,10 @@ type CodexKey struct {
 	// Priority controls selection preference when multiple credentials match.
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
+
+	// Weight controls proportional selection under weighted-round-robin.
+	// An omitted value defaults to 1; non-positive values exclude this credential; maximum 1,000,000.
+	Weight *int `yaml:"weight,omitempty" json:"weight,omitempty"`
 
 	// Prefix optionally namespaces models for this credential (e.g., "teamA/gpt-5-codex").
 	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
@@ -445,6 +462,10 @@ func (k CodexKey) GetAPIKey() string { return k.APIKey }
 
 func (k CodexKey) GetBaseURL() string { return k.BaseURL }
 
+func (k CodexKey) GetPrefix() string { return k.Prefix }
+
+func (k CodexKey) GetProxyURL() string { return k.ProxyURL }
+
 // CodexModel describes a mapping between an alias and the actual upstream model name.
 type CodexModel struct {
 	// Name is the upstream model identifier used when issuing requests.
@@ -458,6 +479,9 @@ type CodexModel struct {
 
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
+
+	// Thinking configures the thinking/reasoning capability for this model.
+	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
 }
 
 func (m CodexModel) GetName() string { return m.Name }
@@ -467,6 +491,8 @@ func (m CodexModel) GetAlias() string { return m.Alias }
 func (m CodexModel) GetDisplayName() string { return m.DisplayName }
 
 func (m CodexModel) GetForceMapping() bool { return m.ForceMapping }
+
+func (m CodexModel) GetThinking() *registry.ThinkingSupport { return m.Thinking }
 
 // XAIKey uses the Codex API key structure for native xAI execution.
 type XAIKey = CodexKey
@@ -483,6 +509,10 @@ type GeminiKey struct {
 	// Priority controls selection preference when multiple credentials match.
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
+
+	// Weight controls proportional selection under weighted-round-robin.
+	// An omitted value defaults to 1; non-positive values exclude this credential; maximum 1,000,000.
+	Weight *int `yaml:"weight,omitempty" json:"weight,omitempty"`
 
 	// Prefix optionally namespaces models for this credential (e.g., "teamA/gemini-3-pro-preview").
 	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
@@ -510,6 +540,10 @@ func (k GeminiKey) GetAPIKey() string { return k.APIKey }
 
 func (k GeminiKey) GetBaseURL() string { return k.BaseURL }
 
+func (k GeminiKey) GetPrefix() string { return k.Prefix }
+
+func (k GeminiKey) GetProxyURL() string { return k.ProxyURL }
+
 // GeminiModel describes a mapping between an alias and the actual upstream model name.
 type GeminiModel struct {
 	// Name is the upstream model identifier used when issuing requests.
@@ -523,6 +557,9 @@ type GeminiModel struct {
 
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
+
+	// Thinking configures the thinking/reasoning capability for this model.
+	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
 }
 
 func (m GeminiModel) GetName() string { return m.Name }
@@ -532,6 +569,8 @@ func (m GeminiModel) GetAlias() string { return m.Alias }
 func (m GeminiModel) GetDisplayName() string { return m.DisplayName }
 
 func (m GeminiModel) GetForceMapping() bool { return m.ForceMapping }
+
+func (m GeminiModel) GetThinking() *registry.ThinkingSupport { return m.Thinking }
 
 // OpenAICompatibility represents the configuration for OpenAI API compatibility
 // with external providers, allowing model aliases to be routed through OpenAI API format.
@@ -569,6 +608,10 @@ type OpenAICompatibility struct {
 type OpenAICompatibilityAPIKey struct {
 	// APIKey is the authentication key for accessing the external API services.
 	APIKey string `yaml:"api-key" json:"api-key"`
+
+	// Weight controls proportional selection under weighted-round-robin.
+	// An omitted value defaults to 1; non-positive values exclude this credential; maximum 1,000,000.
+	Weight *int `yaml:"weight,omitempty" json:"weight,omitempty"`
 
 	// ProxyURL overrides the global proxy setting for this API key if provided.
 	ProxyURL string `yaml:"proxy-url,omitempty" json:"proxy-url,omitempty"`
@@ -611,3 +654,5 @@ func (m OpenAICompatibilityModel) GetAlias() string { return m.Alias }
 func (m OpenAICompatibilityModel) GetDisplayName() string { return m.DisplayName }
 
 func (m OpenAICompatibilityModel) GetForceMapping() bool { return m.ForceMapping }
+
+func (m OpenAICompatibilityModel) GetThinking() *registry.ThinkingSupport { return m.Thinking }

--- a/internal/config/config_yaml.go
+++ b/internal/config/config_yaml.go
@@ -311,6 +311,11 @@ func appendPath(path []string, key string) []string {
 // represents a known default value that should not be written to the config file.
 // This prevents non-zero defaults from polluting the config.
 func isKnownDefaultValue(path []string, node *yaml.Node) bool {
+	// Weight is pointer-backed, so an explicit zero is meaningful and must be preserved.
+	if len(path) > 0 && path[len(path)-1] == "weight" && node != nil && node.Kind == yaml.ScalarNode && node.Tag == "!!int" {
+		return false
+	}
+
 	// First check if it's a zero value
 	if isZeroValueNode(node) {
 		return true

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -16,6 +16,10 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 		return nil, fmt.Errorf("config payload is empty")
 	}
 
+	if errValidate := validateCredentialWeightYAML(data); errValidate != nil {
+		return nil, errValidate
+	}
+
 	var cfg Config
 	// Keep defaults aligned with LoadConfigOptional.
 	cfg.Host = "" // Default empty: binds to all interfaces (IPv4 + IPv6)
@@ -40,6 +44,9 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 
 	cfg.CredentialConcurrency = cfg.CredentialConcurrency.WithDefaults()
 	if errValidate := cfg.CredentialInFlight.Validate(); errValidate != nil {
+		return nil, errValidate
+	}
+	if errValidate := cfg.ValidateCredentialWeights(); errValidate != nil {
 		return nil, errValidate
 	}
 

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -16,6 +16,10 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 		return nil, fmt.Errorf("config payload is empty")
 	}
 
+	if errValidate := validateCredentialWeightYAML(data); errValidate != nil {
+		return nil, errValidate
+	}
+
 	var cfg Config
 	// Keep defaults aligned with LoadConfigOptional.
 	cfg.Host = "" // Default empty: binds to all interfaces (IPv4 + IPv6)
@@ -43,6 +47,9 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 
 	cfg.CredentialConcurrency = cfg.CredentialConcurrency.WithDefaults()
 	if errValidate := cfg.CredentialInFlight.Validate(); errValidate != nil {
+		return nil, errValidate
+	}
+	if errValidate := cfg.ValidateCredentialWeights(); errValidate != nil {
 		return nil, errValidate
 	}
 

--- a/internal/config/vertex_compat.go
+++ b/internal/config/vertex_compat.go
@@ -17,6 +17,10 @@ type VertexCompatKey struct {
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
 
+	// Weight controls proportional selection under weighted-round-robin.
+	// An omitted value defaults to 1; non-positive values exclude this credential; maximum 1,000,000.
+	Weight *int `yaml:"weight,omitempty" json:"weight,omitempty"`
+
 	// Prefix optionally namespaces model aliases for this credential (e.g., "teamA/vertex-pro").
 	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
 

--- a/internal/config/vertex_compat.go
+++ b/internal/config/vertex_compat.go
@@ -1,6 +1,10 @@
 package config
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
 
 // VertexCompatKey represents the configuration for Vertex AI-compatible API keys.
 // This supports third-party services that use Vertex AI-style endpoint paths
@@ -16,6 +20,10 @@ type VertexCompatKey struct {
 	// Priority controls selection preference when multiple credentials match.
 	// Higher values are preferred; defaults to 0.
 	Priority int `yaml:"priority,omitempty" json:"priority,omitempty"`
+
+	// Weight controls proportional selection under weighted-round-robin.
+	// An omitted value defaults to 1; non-positive values exclude this credential; maximum 1,000,000.
+	Weight *int `yaml:"weight,omitempty" json:"weight,omitempty"`
 
 	// Prefix optionally namespaces model aliases for this credential (e.g., "teamA/vertex-pro").
 	Prefix string `yaml:"prefix,omitempty" json:"prefix,omitempty"`
@@ -39,8 +47,10 @@ type VertexCompatKey struct {
 	ExcludedModels []string `yaml:"excluded-models,omitempty" json:"excluded-models,omitempty"`
 }
 
-func (k VertexCompatKey) GetAPIKey() string  { return k.APIKey }
-func (k VertexCompatKey) GetBaseURL() string { return k.BaseURL }
+func (k VertexCompatKey) GetAPIKey() string   { return k.APIKey }
+func (k VertexCompatKey) GetBaseURL() string  { return k.BaseURL }
+func (k VertexCompatKey) GetPrefix() string   { return k.Prefix }
+func (k VertexCompatKey) GetProxyURL() string { return k.ProxyURL }
 
 // VertexCompatModel represents a model configuration for Vertex compatibility,
 // including the actual model name and its alias for API routing.
@@ -56,12 +66,18 @@ type VertexCompatModel struct {
 
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
+
+	// Thinking configures the thinking/reasoning capability for this model.
+	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
 }
 
 func (m VertexCompatModel) GetName() string        { return m.Name }
 func (m VertexCompatModel) GetAlias() string       { return m.Alias }
 func (m VertexCompatModel) GetDisplayName() string { return m.DisplayName }
 func (m VertexCompatModel) GetForceMapping() bool  { return m.ForceMapping }
+func (m VertexCompatModel) GetThinking() *registry.ThinkingSupport {
+	return m.Thinking
+}
 
 // SanitizeVertexCompatKeys deduplicates and normalizes Vertex-compatible API key credentials.
 func (cfg *Config) SanitizeVertexCompatKeys() {

--- a/internal/config/vertex_compat.go
+++ b/internal/config/vertex_compat.go
@@ -1,6 +1,10 @@
 package config
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
 
 // VertexCompatKey represents the configuration for Vertex AI-compatible API keys.
 // This supports third-party services that use Vertex AI-style endpoint paths
@@ -43,8 +47,10 @@ type VertexCompatKey struct {
 	ExcludedModels []string `yaml:"excluded-models,omitempty" json:"excluded-models,omitempty"`
 }
 
-func (k VertexCompatKey) GetAPIKey() string  { return k.APIKey }
-func (k VertexCompatKey) GetBaseURL() string { return k.BaseURL }
+func (k VertexCompatKey) GetAPIKey() string   { return k.APIKey }
+func (k VertexCompatKey) GetBaseURL() string  { return k.BaseURL }
+func (k VertexCompatKey) GetPrefix() string   { return k.Prefix }
+func (k VertexCompatKey) GetProxyURL() string { return k.ProxyURL }
 
 // VertexCompatModel represents a model configuration for Vertex compatibility,
 // including the actual model name and its alias for API routing.
@@ -60,12 +66,18 @@ type VertexCompatModel struct {
 
 	// ForceMapping rewrites upstream response model fields back to Alias.
 	ForceMapping bool `yaml:"force-mapping,omitempty" json:"force-mapping,omitempty"`
+
+	// Thinking configures the thinking/reasoning capability for this model.
+	Thinking *registry.ThinkingSupport `yaml:"thinking,omitempty" json:"thinking,omitempty"`
 }
 
 func (m VertexCompatModel) GetName() string        { return m.Name }
 func (m VertexCompatModel) GetAlias() string       { return m.Alias }
 func (m VertexCompatModel) GetDisplayName() string { return m.DisplayName }
 func (m VertexCompatModel) GetForceMapping() bool  { return m.ForceMapping }
+func (m VertexCompatModel) GetThinking() *registry.ThinkingSupport {
+	return m.Thinking
+}
 
 // SanitizeVertexCompatKeys deduplicates and normalizes Vertex-compatible API key credentials.
 func (cfg *Config) SanitizeVertexCompatKeys() {

--- a/internal/config/weight.go
+++ b/internal/config/weight.go
@@ -1,0 +1,153 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/credentialweight"
+	"gopkg.in/yaml.v3"
+)
+
+// MaxCredentialWeight is the largest positive credential routing weight.
+const MaxCredentialWeight = int(credentialweight.Max)
+
+// ValidateCredentialWeight validates one optional config credential weight.
+func ValidateCredentialWeight(weight *int) error {
+	if weight == nil {
+		return nil
+	}
+	_, errNormalize := credentialweight.Normalize(int64(*weight))
+	return errNormalize
+}
+
+func validateCredentialWeightYAML(data []byte) error {
+	var document yaml.Node
+	if errUnmarshal := yaml.Unmarshal(data, &document); errUnmarshal != nil {
+		return nil
+	}
+	if len(document.Content) == 0 {
+		return nil
+	}
+	root := document.Content[0]
+	families := map[string]struct{}{
+		"gemini-api-key": {}, "interactions-api-key": {}, "claude-api-key": {},
+		"vertex-api-key": {}, "codex-api-key": {}, "xai-api-key": {},
+	}
+	for index := 0; root != nil && root.Kind == yaml.MappingNode && index+1 < len(root.Content); index += 2 {
+		name := root.Content[index].Value
+		value := root.Content[index+1]
+		if _, ok := families[name]; ok {
+			if errValidate := validateWeightSequenceNode(value, name); errValidate != nil {
+				return errValidate
+			}
+			continue
+		}
+		if name == "openai-compatibility" {
+			if errValidate := validateOpenAICompatibilityWeightNodes(value); errValidate != nil {
+				return errValidate
+			}
+		}
+	}
+	return nil
+}
+
+func validateWeightSequenceNode(sequence *yaml.Node, path string) error {
+	if sequence == nil || sequence.Kind != yaml.SequenceNode {
+		return nil
+	}
+	for index, item := range sequence.Content {
+		if errValidate := validateWeightMappingNode(item, fmt.Sprintf("%s[%d]", path, index)); errValidate != nil {
+			return errValidate
+		}
+	}
+	return nil
+}
+
+func validateWeightMappingNode(mapping *yaml.Node, path string) error {
+	if mapping == nil || mapping.Kind != yaml.MappingNode {
+		return nil
+	}
+	for index := 0; index+1 < len(mapping.Content); index += 2 {
+		if mapping.Content[index].Value != "weight" {
+			continue
+		}
+		value := mapping.Content[index+1]
+		if value.Kind != yaml.ScalarNode || value.Tag != "!!int" {
+			return fmt.Errorf("%s.weight: weight must be an integer", path)
+		}
+		var weight int64
+		if errDecode := value.Decode(&weight); errDecode != nil {
+			return fmt.Errorf("%s.weight: weight must be an integer", path)
+		}
+		if _, errNormalize := credentialweight.Normalize(weight); errNormalize != nil {
+			return fmt.Errorf("%s.weight: %w", path, errNormalize)
+		}
+	}
+	return nil
+}
+
+func validateOpenAICompatibilityWeightNodes(sequence *yaml.Node) error {
+	if sequence == nil || sequence.Kind != yaml.SequenceNode {
+		return nil
+	}
+	for providerIndex, provider := range sequence.Content {
+		if provider == nil || provider.Kind != yaml.MappingNode {
+			continue
+		}
+		for index := 0; index+1 < len(provider.Content); index += 2 {
+			if provider.Content[index].Value != "api-key-entries" {
+				continue
+			}
+			path := fmt.Sprintf("openai-compatibility[%d].api-key-entries", providerIndex)
+			if errValidate := validateWeightSequenceNode(provider.Content[index+1], path); errValidate != nil {
+				return errValidate
+			}
+		}
+	}
+	return nil
+}
+
+// ValidateCredentialWeights validates weights for every API-key family.
+func (cfg *Config) ValidateCredentialWeights() error {
+	if cfg == nil {
+		return nil
+	}
+	for index := range cfg.GeminiKey {
+		if errValidate := ValidateCredentialWeight(cfg.GeminiKey[index].Weight); errValidate != nil {
+			return fmt.Errorf("gemini-api-key[%d].weight: %w", index, errValidate)
+		}
+	}
+	for index := range cfg.InteractionsKey {
+		if errValidate := ValidateCredentialWeight(cfg.InteractionsKey[index].Weight); errValidate != nil {
+			return fmt.Errorf("interactions-api-key[%d].weight: %w", index, errValidate)
+		}
+	}
+	for index := range cfg.ClaudeKey {
+		if errValidate := ValidateCredentialWeight(cfg.ClaudeKey[index].Weight); errValidate != nil {
+			return fmt.Errorf("claude-api-key[%d].weight: %w", index, errValidate)
+		}
+	}
+	for index := range cfg.VertexCompatAPIKey {
+		if errValidate := ValidateCredentialWeight(cfg.VertexCompatAPIKey[index].Weight); errValidate != nil {
+			return fmt.Errorf("vertex-api-key[%d].weight: %w", index, errValidate)
+		}
+	}
+	for index := range cfg.CodexKey {
+		if errValidate := ValidateCredentialWeight(cfg.CodexKey[index].Weight); errValidate != nil {
+			return fmt.Errorf("codex-api-key[%d].weight: %w", index, errValidate)
+		}
+	}
+	for index := range cfg.XAIKey {
+		if errValidate := ValidateCredentialWeight(cfg.XAIKey[index].Weight); errValidate != nil {
+			return fmt.Errorf("xai-api-key[%d].weight: %w", index, errValidate)
+		}
+	}
+	for providerIndex := range cfg.OpenAICompatibility {
+		for keyIndex := range cfg.OpenAICompatibility[providerIndex].APIKeyEntries {
+			weight := cfg.OpenAICompatibility[providerIndex].APIKeyEntries[keyIndex].Weight
+			if errValidate := ValidateCredentialWeight(weight); errValidate != nil {
+				return fmt.Errorf("openai-compatibility[%d].api-key-entries[%d].weight: %w", providerIndex, keyIndex, errValidate)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/config/weight_test.go
+++ b/internal/config/weight_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAPIKeyWeightValidation(t *testing.T) {
+	tests := []struct {
+		name   string
+		weight string
+		valid  bool
+	}{
+		{name: "negative excludes", weight: "-1", valid: true},
+		{name: "maximum", weight: "1000000", valid: true},
+		{name: "fraction", weight: "1.5", valid: false},
+		{name: "above maximum", weight: "1000001", valid: false},
+		{name: "integer overflow", weight: "9223372036854775808", valid: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, errParse := ParseConfigBytes([]byte("gemini-api-key:\n  - api-key: key\n    weight: " + test.weight + "\n"))
+			if (errParse == nil) != test.valid {
+				t.Fatalf("ParseConfigBytes(weight=%s) error = %v, want valid=%v", test.weight, errParse, test.valid)
+			}
+		})
+	}
+}
+
+func TestAPIKeyWeightParsingAndZeroPersistence(t *testing.T) {
+	cfg, errParse := ParseConfigBytes([]byte(`xai-api-key:
+  - api-key: key
+    base-url: https://api.x.ai/v1
+    weight: 0
+`))
+	if errParse != nil {
+		t.Fatalf("ParseConfigBytes() error = %v", errParse)
+	}
+	if len(cfg.XAIKey) != 1 || cfg.XAIKey[0].Weight == nil || *cfg.XAIKey[0].Weight != 0 {
+		t.Fatalf("parsed weight = %#v, want explicit zero", cfg.XAIKey)
+	}
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if errWrite := os.WriteFile(configPath, []byte(`xai-api-key:
+  - api-key: key
+    base-url: https://api.x.ai/v1
+`), 0644); errWrite != nil {
+		t.Fatalf("WriteFile() error = %v", errWrite)
+	}
+	if errSave := SaveConfigPreserveComments(configPath, cfg); errSave != nil {
+		t.Fatalf("SaveConfigPreserveComments() error = %v", errSave)
+	}
+	saved, errRead := os.ReadFile(configPath)
+	if errRead != nil {
+		t.Fatalf("ReadFile() error = %v", errRead)
+	}
+	if !strings.Contains(string(saved), "weight: 0") {
+		t.Fatalf("saved config does not preserve explicit zero weight:\n%s", saved)
+	}
+}

--- a/internal/config/xai_api_key_test.go
+++ b/internal/config/xai_api_key_test.go
@@ -26,6 +26,7 @@ func TestParseConfigBytesXAIAPIKeyMatchesCodexShape(t *testing.T) {
 	cfg, errParse := ParseConfigBytes([]byte(`xai-api-key:
   - api-key: " xai-key "
     priority: 3
+    weight: 5
     prefix: " team-xai "
     base-url: " https://api.x.ai/v1 "
     websockets: true
@@ -55,6 +56,9 @@ func TestParseConfigBytesXAIAPIKeyMatchesCodexShape(t *testing.T) {
 	}
 	if entry.Priority != 3 {
 		t.Fatalf("priority = %d, want 3", entry.Priority)
+	}
+	if entry.Weight == nil || *entry.Weight != 5 {
+		t.Fatalf("weight = %v, want 5", entry.Weight)
 	}
 	if entry.Prefix != "team-xai" {
 		t.Fatalf("prefix = %q, want team-xai", entry.Prefix)

--- a/internal/credentialweight/weight.go
+++ b/internal/credentialweight/weight.go
@@ -1,0 +1,100 @@
+// Package credentialweight defines shared credential weight validation and parsing.
+package credentialweight
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+const (
+	// Default is used when a credential does not define a weight.
+	Default int64 = 1
+	// Max bounds scheduler arithmetic while allowing practical proportional routing.
+	Max int64 = 1_000_000
+)
+
+// Normalize validates and normalizes an explicit weight. Non-positive values are
+// valid and normalize to zero, which excludes the credential from weighted routing.
+func Normalize(weight int64) (int64, error) {
+	if weight <= 0 {
+		return 0, nil
+	}
+	if weight > Max {
+		return 0, fmt.Errorf("weight must not exceed %d", Max)
+	}
+	return weight, nil
+}
+
+// ParseString parses a scheduler attribute. An empty value uses the default weight.
+func ParseString(raw string) (int64, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return Default, nil
+	}
+	weight, errParse := strconv.ParseInt(raw, 10, 64)
+	if errParse != nil {
+		return 0, fmt.Errorf("weight must be an integer: %w", errParse)
+	}
+	return Normalize(weight)
+}
+
+// ParseValue parses a JSON-compatible auth-file metadata value.
+func ParseValue(value any) (int64, error) {
+	switch typed := value.(type) {
+	case int:
+		return Normalize(int64(typed))
+	case int8:
+		return Normalize(int64(typed))
+	case int16:
+		return Normalize(int64(typed))
+	case int32:
+		return Normalize(int64(typed))
+	case int64:
+		return Normalize(typed)
+	case uint:
+		if uint64(typed) > uint64(Max) {
+			return 0, fmt.Errorf("weight must not exceed %d", Max)
+		}
+		return int64(typed), nil
+	case uint8:
+		return int64(typed), nil
+	case uint16:
+		return int64(typed), nil
+	case uint32:
+		if uint64(typed) > uint64(Max) {
+			return 0, fmt.Errorf("weight must not exceed %d", Max)
+		}
+		return int64(typed), nil
+	case uint64:
+		if typed > uint64(Max) {
+			return 0, fmt.Errorf("weight must not exceed %d", Max)
+		}
+		return int64(typed), nil
+	case float64:
+		if math.IsNaN(typed) || math.IsInf(typed, 0) || math.Trunc(typed) != typed {
+			return 0, fmt.Errorf("weight must be an integer")
+		}
+		if typed <= 0 {
+			return 0, nil
+		}
+		if typed > float64(Max) {
+			return 0, fmt.Errorf("weight must not exceed %d", Max)
+		}
+		return int64(typed), nil
+	case float32:
+		return ParseValue(float64(typed))
+	case json.Number:
+		weight, errParse := typed.Int64()
+		if errParse != nil {
+			return 0, fmt.Errorf("weight must be an integer: %w", errParse)
+		}
+		return Normalize(weight)
+	case string:
+		return ParseString(typed)
+	default:
+		return 0, fmt.Errorf("weight must be an integer")
+	}
+}

--- a/internal/credentialweight/weight_test.go
+++ b/internal/credentialweight/weight_test.go
@@ -1,0 +1,33 @@
+package credentialweight
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseValueValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   any
+		want    int64
+		wantErr bool
+	}{
+		{name: "default string", value: "", want: Default},
+		{name: "negative excluded", value: json.Number("-5"), want: 0},
+		{name: "fraction rejected", value: json.Number("1.5"), wantErr: true},
+		{name: "maximum", value: json.Number("1000000"), want: Max},
+		{name: "above maximum", value: json.Number("1000001"), wantErr: true},
+		{name: "int64 overflow", value: json.Number("9223372036854775808"), wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, errParse := ParseValue(test.value)
+			if (errParse != nil) != test.wantErr {
+				t.Fatalf("ParseValue(%v) error = %v, wantErr=%v", test.value, errParse, test.wantErr)
+			}
+			if !test.wantErr && got != test.want {
+				t.Fatalf("ParseValue(%v) = %d, want %d", test.value, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/home/client.go
+++ b/internal/home/client.go
@@ -1628,6 +1628,15 @@ func (c *Client) subscriptionParameters() ([]string, time.Duration) {
 	return args, cfg.CPAHeartbeatTimeout
 }
 
+func (c *Client) markMembershipTakeoverEligible() {
+	if c == nil {
+		return
+	}
+	if !c.recoveryState.CompareAndSwap(uint32(recoveryStateStable), uint32(recoveryStateTakeoverEligible)) {
+		c.recoveryState.CompareAndSwap(uint32(recoveryStateSwitching), uint32(recoveryStateSwitchingTakeover))
+	}
+}
+
 func (c *Client) rebuildCommandPoolAndProbe(ctx context.Context) error {
 	c.promoteSubscription()
 	if errPing := c.Ping(ctx); errPing != nil {
@@ -1726,6 +1735,10 @@ func (c *Client) RunConfigSubscriberLifetime(ctx context.Context, onConfig func(
 		}
 		return c.endConfigSubscriberLifetimeWithSubscription(errACK, pubsub, "failed ACK")
 	}
+	// A protocol-one ACK means Home already committed this membership. Preserve it if the command probe fails.
+	if len(args) > 1 {
+		c.markMembershipTakeoverEligible()
+	}
 
 	if errProbe := c.rebuildCommandPoolAndProbe(ctx); errProbe != nil {
 		if ctx.Err() == nil {
@@ -1745,9 +1758,7 @@ func (c *Client) RunConfigSubscriberLifetime(ctx context.Context, onConfig func(
 		if errReceive != nil {
 			if ctx.Err() == nil {
 				if c.heartbeatOK.Load() {
-					if !c.recoveryState.CompareAndSwap(uint32(recoveryStateStable), uint32(recoveryStateTakeoverEligible)) {
-						c.recoveryState.CompareAndSwap(uint32(recoveryStateSwitching), uint32(recoveryStateSwitchingTakeover))
-					}
+					c.markMembershipTakeoverEligible()
 				}
 				if isTimeoutError(errReceive) {
 					c.markSubscriptionTimeout()

--- a/internal/home/client.go
+++ b/internal/home/client.go
@@ -93,6 +93,15 @@ var (
 	ErrDispatchFenced        = errors.New("home auth dispatch is fenced")
 )
 
+// IsMembershipTakeoverUnavailableError reports whether Home cannot preserve the previous membership state.
+func IsMembershipTakeoverUnavailableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "membership_takeover_unavailable") || strings.Contains(message, "wrong number of arguments for 'subscribe' command")
+}
+
 type clusterNode struct {
 	IP          string    `json:"ip"`
 	Port        int       `json:"port"`
@@ -127,6 +136,15 @@ type subscriptionCloser interface {
 	Close() error
 }
 
+type recoveryState uint32
+
+const (
+	recoveryStateStable recoveryState = iota
+	recoveryStateTakeoverEligible
+	recoveryStateSwitching
+	recoveryStateSwitchingTakeover
+)
+
 type Client struct {
 	mu sync.Mutex
 
@@ -139,12 +157,15 @@ type Client struct {
 	sub         *redis.Client
 	release     *redis.Client
 	connections map[*homeDispatchConn]struct{}
+	closing     chan struct{}
 	lifecycle   config.CredentialConcurrencyConfig
 	limiter     atomic.Pointer[config.CredentialConcurrencyConfig]
 	managed     bool
 
 	heartbeatOK       atomic.Bool
 	dispatchFenced    atomic.Bool
+	ambiguousDispatch atomic.Bool
+	recoveryState     atomic.Uint32
 	clusterNodes      []clusterNode
 	reconnectFailures int
 }
@@ -164,13 +185,15 @@ func (c *Client) NewLifetime() *Client {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return &Client{
+	next := &Client{
 		homeCfg:           c.homeCfg,
 		seedHost:          c.seedHost,
 		seedPort:          c.seedPort,
 		clusterNodes:      append([]clusterNode(nil), c.clusterNodes...),
 		reconnectFailures: c.reconnectFailures,
 	}
+	next.recoveryState.Store(c.recoveryState.Load())
+	return next
 }
 
 func (c *Client) Enabled() bool {
@@ -203,10 +226,14 @@ func (c *Client) Close() {
 	commandClient, subscriptionClient, connections := c.detachClientsLocked()
 	releaseClient := c.release
 	c.release = nil
+	closing := c.closing
 	c.mu.Unlock()
 	closeDetachedClients(commandClient, subscriptionClient, connections)
 	if releaseClient != nil {
 		_ = releaseClient.Close()
+	}
+	if closing != nil {
+		<-closing
 	}
 }
 
@@ -227,6 +254,7 @@ func (c *Client) AbortAmbiguousDispatch() {
 	if c == nil {
 		return
 	}
+	c.ambiguousDispatch.Store(true)
 	c.dispatchFenced.Store(true)
 	c.heartbeatOK.Store(false)
 	c.mu.Lock()
@@ -251,6 +279,21 @@ func (c *Client) AbortAmbiguousDispatch() {
 		go func() {
 			_ = releaseClient.Close()
 		}()
+	}
+}
+
+// AmbiguousDispatch reports whether this lifetime observed an issued dispatch with an unknown delivery result.
+func (c *Client) AmbiguousDispatch() bool {
+	return c != nil && c.ambiguousDispatch.Load()
+}
+
+// SuppressTakeover forces the next subscriber lifetime through normal membership recovery.
+func (c *Client) SuppressTakeover() {
+	if c == nil {
+		return
+	}
+	if !c.recoveryState.CompareAndSwap(uint32(recoveryStateTakeoverEligible), uint32(recoveryStateStable)) {
+		c.recoveryState.CompareAndSwap(uint32(recoveryStateSwitchingTakeover), uint32(recoveryStateSwitching))
 	}
 }
 
@@ -284,12 +327,38 @@ func (c *Client) closeClientsLocked() {
 	commandClient, subscriptionClient, connections := c.detachClientsLocked()
 	releaseClient := c.release
 	c.release = nil
+	previousClosing := c.closing
+	done := make(chan struct{})
+	c.closing = done
 	go func() {
+		defer close(done)
+		if previousClosing != nil {
+			<-previousClosing
+		}
 		closeDetachedClients(commandClient, subscriptionClient, connections)
 		if releaseClient != nil {
 			_ = releaseClient.Close()
 		}
 	}()
+}
+
+func (c *Client) waitForClientsClosed() {
+	for {
+		c.mu.Lock()
+		closing := c.closing
+		c.mu.Unlock()
+		if closing == nil {
+			return
+		}
+		<-closing
+		c.mu.Lock()
+		if c.closing == closing {
+			c.closing = nil
+			c.mu.Unlock()
+			return
+		}
+		c.mu.Unlock()
+	}
 }
 
 // SetManagedLifetime defers client shutdown to the Service lifetime owner.
@@ -341,6 +410,7 @@ func (c *Client) ensureClients() error {
 	if !c.Enabled() {
 		return ErrDisabled
 	}
+	c.waitForClientsClosed()
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.dispatchFenced.Load() {
@@ -685,6 +755,9 @@ func (c *Client) switchToNodeLocked(node clusterNode) bool {
 	}
 	c.homeCfg.Host = host
 	c.homeCfg.Port = node.Port
+	if !c.recoveryState.CompareAndSwap(uint32(recoveryStateStable), uint32(recoveryStateSwitching)) {
+		c.recoveryState.CompareAndSwap(uint32(recoveryStateTakeoverEligible), uint32(recoveryStateSwitchingTakeover))
+	}
 	c.closeClientsLocked()
 	return true
 }
@@ -1233,6 +1306,10 @@ func (c *Client) concurrencyReleaseClient() (*redis.Client, error) {
 	if c == nil || c.dispatchFenced.Load() {
 		return nil, ErrDispatchFenced
 	}
+	state := recoveryState(c.recoveryState.Load())
+	if state == recoveryStateSwitching || state == recoveryStateSwitchingTakeover {
+		return nil, ErrNotConnected
+	}
 	if !c.Enabled() {
 		return nil, ErrDisabled
 	}
@@ -1241,6 +1318,10 @@ func (c *Client) concurrencyReleaseClient() (*redis.Client, error) {
 	defer c.mu.Unlock()
 	if c.dispatchFenced.Load() {
 		return nil, ErrDispatchFenced
+	}
+	state = recoveryState(c.recoveryState.Load())
+	if state == recoveryStateSwitching || state == recoveryStateSwitchingTakeover {
+		return nil, ErrNotConnected
 	}
 	if c.release != nil {
 		return c.release, nil
@@ -1525,13 +1606,21 @@ func (c *Client) subscriptionParameters() ([]string, time.Duration) {
 	args := []string{redisChannelConfig}
 	if cfg.LifecycleConfigRevision > 0 {
 		args = append(args, strconv.FormatInt(cfg.LifecycleConfigRevision, 10))
+		state := recoveryState(c.recoveryState.Load())
+		if state == recoveryStateTakeoverEligible || state == recoveryStateSwitchingTakeover {
+			args = append(args, "takeover")
+		}
 	}
 	return args, cfg.CPAHeartbeatTimeout
 }
 
 func (c *Client) rebuildCommandPoolAndProbe(ctx context.Context) error {
 	c.promoteSubscription()
-	return c.Ping(ctx)
+	if errPing := c.Ping(ctx); errPing != nil {
+		return errPing
+	}
+	c.recoveryState.Store(uint32(recoveryStateStable))
+	return nil
 }
 
 func (c *Client) promoteSubscription() {
@@ -1641,6 +1730,11 @@ func (c *Client) RunConfigSubscriberLifetime(ctx context.Context, onConfig func(
 		event, errReceive := pubsub.ReceiveTimeout(ctx, receiveTimeout)
 		if errReceive != nil {
 			if ctx.Err() == nil {
+				if c.heartbeatOK.Load() {
+					if !c.recoveryState.CompareAndSwap(uint32(recoveryStateStable), uint32(recoveryStateTakeoverEligible)) {
+						c.recoveryState.CompareAndSwap(uint32(recoveryStateSwitching), uint32(recoveryStateSwitchingTakeover))
+					}
+				}
 				if isTimeoutError(errReceive) {
 					c.markSubscriptionTimeout()
 				} else {

--- a/internal/home/client.go
+++ b/internal/home/client.go
@@ -18,6 +18,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 	"github.com/redis/go-redis/v9/maintnotifications"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -100,8 +101,17 @@ func IsMembershipTakeoverUnavailableError(err error) bool {
 	if err == nil {
 		return false
 	}
-	message := strings.ToLower(err.Error())
-	return strings.Contains(message, "membership_takeover_unavailable") || strings.Contains(message, "wrong number of arguments for 'subscribe' command")
+	message := strings.TrimSpace(strings.ToLower(err.Error()))
+	return message == "membership_takeover_unavailable" || message == "err membership_takeover_unavailable"
+}
+
+// IsLegacyMembershipProtocolError reports whether Home rejected the secure subscription argument count.
+func IsLegacyMembershipProtocolError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.TrimSpace(strings.ToLower(err.Error()))
+	return message == "wrong number of arguments for 'subscribe' command" || message == "err wrong number of arguments for 'subscribe' command"
 }
 
 type clusterNode struct {
@@ -168,15 +178,18 @@ type Client struct {
 	dispatchFenced    atomic.Bool
 	ambiguousDispatch atomic.Bool
 	recoveryState     atomic.Uint32
+	instanceID        string
+	legacyMembership  bool
 	clusterNodes      []clusterNode
 	reconnectFailures int
 }
 
 func New(homeCfg config.HomeConfig) *Client {
 	return &Client{
-		homeCfg:  homeCfg,
-		seedHost: strings.TrimSpace(homeCfg.Host),
-		seedPort: homeCfg.Port,
+		homeCfg:    homeCfg,
+		seedHost:   strings.TrimSpace(homeCfg.Host),
+		seedPort:   homeCfg.Port,
+		instanceID: uuid.NewString(),
 	}
 }
 
@@ -193,9 +206,42 @@ func (c *Client) NewLifetime() *Client {
 		seedPort:          c.seedPort,
 		clusterNodes:      append([]clusterNode(nil), c.clusterNodes...),
 		reconnectFailures: c.reconnectFailures,
+		instanceID:        c.instanceID,
+		legacyMembership:  c.legacyMembership,
 	}
 	next.recoveryState.Store(c.recoveryState.Load())
 	return next
+}
+
+// MembershipInstanceID returns the process-scoped Home membership identity.
+func (c *Client) MembershipInstanceID() string {
+	if c == nil {
+		return ""
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.instanceID
+}
+
+// LegacyMembership reports whether this subscriber has downgraded to the legacy protocol.
+func (c *Client) LegacyMembership() bool {
+	if c == nil {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.legacyMembership
+}
+
+// EnableLegacyMembership permanently downgrades this subscriber lifetime chain.
+func (c *Client) EnableLegacyMembership() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.legacyMembership = true
+	c.mu.Unlock()
+	c.SuppressTakeover()
 }
 
 func (c *Client) Enabled() bool {
@@ -1615,15 +1661,21 @@ func (c *Client) subscriptionParameters() ([]string, time.Duration) {
 	}
 	c.mu.Lock()
 	cfg := c.lifecycle.WithDefaults()
+	instanceID := c.instanceID
+	legacyMembership := c.legacyMembership
 	c.mu.Unlock()
 
 	args := []string{redisChannelConfig}
 	if cfg.LifecycleConfigRevision > 0 {
 		args = append(args, strconv.FormatInt(cfg.LifecycleConfigRevision, 10))
+		if legacyMembership {
+			return args, cfg.CPAHeartbeatTimeout
+		}
 		state := recoveryState(c.recoveryState.Load())
 		if state == recoveryStateTakeoverEligible || state == recoveryStateSwitchingTakeover {
 			args = append(args, "takeover")
 		}
+		args = append(args, instanceID)
 	}
 	return args, cfg.CPAHeartbeatTimeout
 }

--- a/internal/home/client.go
+++ b/internal/home/client.go
@@ -82,6 +82,8 @@ func IsAmbiguousDispatchError(err error) bool {
 	return errors.As(err, &dispatchErr) && dispatchErr.Ambiguous
 }
 
+var errClusterDiscoveryTransport = errors.New("home cluster discovery transport failed")
+
 var (
 	ErrDisabled              = errors.New("home client disabled")
 	ErrNotConnected          = errors.New("home not connected")
@@ -658,20 +660,21 @@ func (c *Client) clusterDiscoveryEnabledLocked() bool {
 	return !c.homeCfg.DisableClusterDiscovery
 }
 
-func (c *Client) refreshBestClusterNode(ctx context.Context) {
+func (c *Client) refreshBestClusterNode(ctx context.Context) error {
 	if !c.clusterDiscoveryEnabled() {
-		return
+		return nil
 	}
 	switched, errRefresh := c.refreshClusterNodes(ctx)
 	if errRefresh != nil {
 		log.Debugf("home cluster nodes unavailable: %v", errRefresh)
-		return
+		return errRefresh
 	}
 	if switched {
 		if addr, ok := c.addr(); ok {
 			log.Infof("home cluster target switched to %s", addr)
 		}
 	}
+	return nil
 }
 
 func (c *Client) refreshClusterNodes(ctx context.Context) (bool, error) {
@@ -683,11 +686,20 @@ func (c *Client) refreshClusterNodes(ctx context.Context) (bool, error) {
 	}
 	cmd, errClient := c.commandClient()
 	if errClient != nil {
-		return false, errClient
+		return false, fmt.Errorf("%w: %w", errClusterDiscoveryTransport, errClient)
 	}
-	raw, errDo := cmd.Do(ctx, "CLUSTER", "NODES").Text()
+	nodesCommand := cmd.Do(ctx, "CLUSTER", "NODES")
+	errDo := nodesCommand.Err()
 	if errDo != nil {
+		var redisErr redis.Error
+		if !errors.As(errDo, &redisErr) {
+			return false, fmt.Errorf("%w: %w", errClusterDiscoveryTransport, errDo)
+		}
 		return false, errDo
+	}
+	raw, errText := nodesCommand.Text()
+	if errText != nil {
+		return false, errText
 	}
 
 	nodes, errParse := parseClusterNodesPayload([]byte(raw))
@@ -844,7 +856,9 @@ func (c *Client) resetReconnectFailures() {
 }
 
 func (c *Client) GetConfig(ctx context.Context) ([]byte, error) {
-	c.refreshBestClusterNode(ctx)
+	if errRefresh := c.refreshBestClusterNode(ctx); errors.Is(errRefresh, errClusterDiscoveryTransport) {
+		return nil, errRefresh
+	}
 	cmd, errClient := c.commandClient()
 	if errClient != nil {
 		return nil, errClient

--- a/internal/home/client.go
+++ b/internal/home/client.go
@@ -82,6 +82,8 @@ func IsAmbiguousDispatchError(err error) bool {
 	return errors.As(err, &dispatchErr) && dispatchErr.Ambiguous
 }
 
+var errClusterDiscoveryTransport = errors.New("home cluster discovery transport failed")
+
 var (
 	ErrDisabled              = errors.New("home client disabled")
 	ErrNotConnected          = errors.New("home not connected")
@@ -92,6 +94,15 @@ var (
 	ErrPluginSyncUnsupported = errors.New("home plugin sync is unsupported")
 	ErrDispatchFenced        = errors.New("home auth dispatch is fenced")
 )
+
+// IsMembershipTakeoverUnavailableError reports whether Home cannot preserve the previous membership state.
+func IsMembershipTakeoverUnavailableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "membership_takeover_unavailable") || strings.Contains(message, "wrong number of arguments for 'subscribe' command")
+}
 
 type clusterNode struct {
 	IP          string    `json:"ip"`
@@ -127,6 +138,15 @@ type subscriptionCloser interface {
 	Close() error
 }
 
+type recoveryState uint32
+
+const (
+	recoveryStateStable recoveryState = iota
+	recoveryStateTakeoverEligible
+	recoveryStateSwitching
+	recoveryStateSwitchingTakeover
+)
+
 type Client struct {
 	mu sync.Mutex
 
@@ -139,12 +159,15 @@ type Client struct {
 	sub         *redis.Client
 	release     *redis.Client
 	connections map[*homeDispatchConn]struct{}
+	closing     chan struct{}
 	lifecycle   config.CredentialConcurrencyConfig
 	limiter     atomic.Pointer[config.CredentialConcurrencyConfig]
 	managed     bool
 
 	heartbeatOK       atomic.Bool
 	dispatchFenced    atomic.Bool
+	ambiguousDispatch atomic.Bool
+	recoveryState     atomic.Uint32
 	clusterNodes      []clusterNode
 	reconnectFailures int
 }
@@ -164,13 +187,15 @@ func (c *Client) NewLifetime() *Client {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return &Client{
+	next := &Client{
 		homeCfg:           c.homeCfg,
 		seedHost:          c.seedHost,
 		seedPort:          c.seedPort,
 		clusterNodes:      append([]clusterNode(nil), c.clusterNodes...),
 		reconnectFailures: c.reconnectFailures,
 	}
+	next.recoveryState.Store(c.recoveryState.Load())
+	return next
 }
 
 func (c *Client) Enabled() bool {
@@ -203,10 +228,14 @@ func (c *Client) Close() {
 	commandClient, subscriptionClient, connections := c.detachClientsLocked()
 	releaseClient := c.release
 	c.release = nil
+	closing := c.closing
 	c.mu.Unlock()
 	closeDetachedClients(commandClient, subscriptionClient, connections)
 	if releaseClient != nil {
 		_ = releaseClient.Close()
+	}
+	if closing != nil {
+		<-closing
 	}
 }
 
@@ -227,6 +256,7 @@ func (c *Client) AbortAmbiguousDispatch() {
 	if c == nil {
 		return
 	}
+	c.ambiguousDispatch.Store(true)
 	c.dispatchFenced.Store(true)
 	c.heartbeatOK.Store(false)
 	c.mu.Lock()
@@ -251,6 +281,21 @@ func (c *Client) AbortAmbiguousDispatch() {
 		go func() {
 			_ = releaseClient.Close()
 		}()
+	}
+}
+
+// AmbiguousDispatch reports whether this lifetime observed an issued dispatch with an unknown delivery result.
+func (c *Client) AmbiguousDispatch() bool {
+	return c != nil && c.ambiguousDispatch.Load()
+}
+
+// SuppressTakeover forces the next subscriber lifetime through normal membership recovery.
+func (c *Client) SuppressTakeover() {
+	if c == nil {
+		return
+	}
+	if !c.recoveryState.CompareAndSwap(uint32(recoveryStateTakeoverEligible), uint32(recoveryStateStable)) {
+		c.recoveryState.CompareAndSwap(uint32(recoveryStateSwitchingTakeover), uint32(recoveryStateSwitching))
 	}
 }
 
@@ -284,12 +329,38 @@ func (c *Client) closeClientsLocked() {
 	commandClient, subscriptionClient, connections := c.detachClientsLocked()
 	releaseClient := c.release
 	c.release = nil
+	previousClosing := c.closing
+	done := make(chan struct{})
+	c.closing = done
 	go func() {
+		defer close(done)
+		if previousClosing != nil {
+			<-previousClosing
+		}
 		closeDetachedClients(commandClient, subscriptionClient, connections)
 		if releaseClient != nil {
 			_ = releaseClient.Close()
 		}
 	}()
+}
+
+func (c *Client) waitForClientsClosed() {
+	for {
+		c.mu.Lock()
+		closing := c.closing
+		c.mu.Unlock()
+		if closing == nil {
+			return
+		}
+		<-closing
+		c.mu.Lock()
+		if c.closing == closing {
+			c.closing = nil
+			c.mu.Unlock()
+			return
+		}
+		c.mu.Unlock()
+	}
 }
 
 // SetManagedLifetime defers client shutdown to the Service lifetime owner.
@@ -341,6 +412,7 @@ func (c *Client) ensureClients() error {
 	if !c.Enabled() {
 		return ErrDisabled
 	}
+	c.waitForClientsClosed()
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.dispatchFenced.Load() {
@@ -588,20 +660,21 @@ func (c *Client) clusterDiscoveryEnabledLocked() bool {
 	return !c.homeCfg.DisableClusterDiscovery
 }
 
-func (c *Client) refreshBestClusterNode(ctx context.Context) {
+func (c *Client) refreshBestClusterNode(ctx context.Context) error {
 	if !c.clusterDiscoveryEnabled() {
-		return
+		return nil
 	}
 	switched, errRefresh := c.refreshClusterNodes(ctx)
 	if errRefresh != nil {
 		log.Debugf("home cluster nodes unavailable: %v", errRefresh)
-		return
+		return errRefresh
 	}
 	if switched {
 		if addr, ok := c.addr(); ok {
 			log.Infof("home cluster target switched to %s", addr)
 		}
 	}
+	return nil
 }
 
 func (c *Client) refreshClusterNodes(ctx context.Context) (bool, error) {
@@ -613,11 +686,20 @@ func (c *Client) refreshClusterNodes(ctx context.Context) (bool, error) {
 	}
 	cmd, errClient := c.commandClient()
 	if errClient != nil {
-		return false, errClient
+		return false, fmt.Errorf("%w: %w", errClusterDiscoveryTransport, errClient)
 	}
-	raw, errDo := cmd.Do(ctx, "CLUSTER", "NODES").Text()
+	nodesCommand := cmd.Do(ctx, "CLUSTER", "NODES")
+	errDo := nodesCommand.Err()
 	if errDo != nil {
+		var redisErr redis.Error
+		if !errors.As(errDo, &redisErr) {
+			return false, fmt.Errorf("%w: %w", errClusterDiscoveryTransport, errDo)
+		}
 		return false, errDo
+	}
+	raw, errText := nodesCommand.Text()
+	if errText != nil {
+		return false, errText
 	}
 
 	nodes, errParse := parseClusterNodesPayload([]byte(raw))
@@ -685,6 +767,9 @@ func (c *Client) switchToNodeLocked(node clusterNode) bool {
 	}
 	c.homeCfg.Host = host
 	c.homeCfg.Port = node.Port
+	if !c.recoveryState.CompareAndSwap(uint32(recoveryStateStable), uint32(recoveryStateSwitching)) {
+		c.recoveryState.CompareAndSwap(uint32(recoveryStateTakeoverEligible), uint32(recoveryStateSwitchingTakeover))
+	}
 	c.closeClientsLocked()
 	return true
 }
@@ -771,7 +856,9 @@ func (c *Client) resetReconnectFailures() {
 }
 
 func (c *Client) GetConfig(ctx context.Context) ([]byte, error) {
-	c.refreshBestClusterNode(ctx)
+	if errRefresh := c.refreshBestClusterNode(ctx); errors.Is(errRefresh, errClusterDiscoveryTransport) {
+		return nil, errRefresh
+	}
 	cmd, errClient := c.commandClient()
 	if errClient != nil {
 		return nil, errClient
@@ -1233,6 +1320,10 @@ func (c *Client) concurrencyReleaseClient() (*redis.Client, error) {
 	if c == nil || c.dispatchFenced.Load() {
 		return nil, ErrDispatchFenced
 	}
+	state := recoveryState(c.recoveryState.Load())
+	if state == recoveryStateTakeoverEligible || state == recoveryStateSwitching || state == recoveryStateSwitchingTakeover {
+		return nil, ErrNotConnected
+	}
 	if !c.Enabled() {
 		return nil, ErrDisabled
 	}
@@ -1241,6 +1332,10 @@ func (c *Client) concurrencyReleaseClient() (*redis.Client, error) {
 	defer c.mu.Unlock()
 	if c.dispatchFenced.Load() {
 		return nil, ErrDispatchFenced
+	}
+	state = recoveryState(c.recoveryState.Load())
+	if state == recoveryStateTakeoverEligible || state == recoveryStateSwitching || state == recoveryStateSwitchingTakeover {
+		return nil, ErrNotConnected
 	}
 	if c.release != nil {
 		return c.release, nil
@@ -1525,13 +1620,30 @@ func (c *Client) subscriptionParameters() ([]string, time.Duration) {
 	args := []string{redisChannelConfig}
 	if cfg.LifecycleConfigRevision > 0 {
 		args = append(args, strconv.FormatInt(cfg.LifecycleConfigRevision, 10))
+		state := recoveryState(c.recoveryState.Load())
+		if state == recoveryStateTakeoverEligible || state == recoveryStateSwitchingTakeover {
+			args = append(args, "takeover")
+		}
 	}
 	return args, cfg.CPAHeartbeatTimeout
 }
 
+func (c *Client) markMembershipTakeoverEligible() {
+	if c == nil {
+		return
+	}
+	if !c.recoveryState.CompareAndSwap(uint32(recoveryStateStable), uint32(recoveryStateTakeoverEligible)) {
+		c.recoveryState.CompareAndSwap(uint32(recoveryStateSwitching), uint32(recoveryStateSwitchingTakeover))
+	}
+}
+
 func (c *Client) rebuildCommandPoolAndProbe(ctx context.Context) error {
 	c.promoteSubscription()
-	return c.Ping(ctx)
+	if errPing := c.Ping(ctx); errPing != nil {
+		return errPing
+	}
+	c.recoveryState.Store(uint32(recoveryStateStable))
+	return nil
 }
 
 func (c *Client) promoteSubscription() {
@@ -1623,6 +1735,10 @@ func (c *Client) RunConfigSubscriberLifetime(ctx context.Context, onConfig func(
 		}
 		return c.endConfigSubscriberLifetimeWithSubscription(errACK, pubsub, "failed ACK")
 	}
+	// A protocol-one ACK means Home already committed this membership. Preserve it if the command probe fails.
+	if len(args) > 1 {
+		c.markMembershipTakeoverEligible()
+	}
 
 	if errProbe := c.rebuildCommandPoolAndProbe(ctx); errProbe != nil {
 		if ctx.Err() == nil {
@@ -1641,6 +1757,9 @@ func (c *Client) RunConfigSubscriberLifetime(ctx context.Context, onConfig func(
 		event, errReceive := pubsub.ReceiveTimeout(ctx, receiveTimeout)
 		if errReceive != nil {
 			if ctx.Err() == nil {
+				if c.heartbeatOK.Load() {
+					c.markMembershipTakeoverEligible()
+				}
 				if isTimeoutError(errReceive) {
 					c.markSubscriptionTimeout()
 				} else {

--- a/internal/home/client.go
+++ b/internal/home/client.go
@@ -1307,7 +1307,7 @@ func (c *Client) concurrencyReleaseClient() (*redis.Client, error) {
 		return nil, ErrDispatchFenced
 	}
 	state := recoveryState(c.recoveryState.Load())
-	if state == recoveryStateSwitching || state == recoveryStateSwitchingTakeover {
+	if state == recoveryStateTakeoverEligible || state == recoveryStateSwitching || state == recoveryStateSwitchingTakeover {
 		return nil, ErrNotConnected
 	}
 	if !c.Enabled() {
@@ -1320,7 +1320,7 @@ func (c *Client) concurrencyReleaseClient() (*redis.Client, error) {
 		return nil, ErrDispatchFenced
 	}
 	state = recoveryState(c.recoveryState.Load())
-	if state == recoveryStateSwitching || state == recoveryStateSwitchingTakeover {
+	if state == recoveryStateTakeoverEligible || state == recoveryStateSwitching || state == recoveryStateSwitchingTakeover {
 		return nil, ErrNotConnected
 	}
 	if c.release != nil {

--- a/internal/home/client.go
+++ b/internal/home/client.go
@@ -94,7 +94,23 @@ var (
 	ErrModelsNotFound        = errors.New("home models not found")
 	ErrPluginSyncUnsupported = errors.New("home plugin sync is unsupported")
 	ErrDispatchFenced        = errors.New("home auth dispatch is fenced")
+	// ErrCompareAndSwapUnsupported reports that this Home predates the CAS command.
+	ErrCompareAndSwapUnsupported = errors.New("home compare-and-swap is unsupported")
 )
+
+// isHomeCommandUnsupported reports whether Home rejected a command it does not
+// implement. It mirrors isHomeAppLogUnsupported in internal/logging; the two are
+// kept separate so the packages stay decoupled.
+func isHomeCommandUnsupported(err error) bool {
+	for err != nil {
+		message := strings.ToLower(strings.TrimSpace(err.Error()))
+		if strings.Contains(message, "unknown command") || strings.Contains(message, "unsupported command") {
+			return true
+		}
+		err = errors.Unwrap(err)
+	}
+	return false
+}
 
 // IsMembershipTakeoverUnavailableError reports whether Home cannot preserve the previous membership state.
 func IsMembershipTakeoverUnavailableError(err error) bool {
@@ -177,6 +193,13 @@ type Client struct {
 	heartbeatOK       atomic.Bool
 	dispatchFenced    atomic.Bool
 	ambiguousDispatch atomic.Bool
+	// casUnsupported latches when Home does not implement the CAS command.
+	// It is deliberately NOT carried across NewLifetime: CAS support is a
+	// property of the Home deployment, so re-probing once per client lifetime
+	// lets a Home upgrade take effect on the next reconnect instead of
+	// requiring a CPA restart. The probe costs one round trip that returns an
+	// error without performing any write.
+	casUnsupported    atomic.Bool
 	recoveryState     atomic.Uint32
 	instanceID        string
 	legacyMembership  bool
@@ -1033,35 +1056,44 @@ func (c *Client) KVSetNX(ctx context.Context, key string, value []byte, ttl time
 }
 
 // KVCompareAndSwap atomically replaces a value only when its current state matches the expected state.
+//
+// It uses Home's dedicated CAS command:
+//
+//	CAS <key> <expected-exists 0|1> <expected-value> <new-value> [PX <ttl-ms>]
+//
+// Omitting PX stores the value without a TTL. Home replies integer 1 when the
+// swap happened and integer 0 when the state did not match. Deployments that
+// predate CAS reject the command, which latches ErrCompareAndSwapUnsupported for
+// this client lifetime so later calls skip the round trip.
 func (c *Client) KVCompareAndSwap(ctx context.Context, key string, expected []byte, expectedExists bool, value []byte, ttl time.Duration) (bool, error) {
+	if c == nil {
+		return false, ErrNotConnected
+	}
+	if c.casUnsupported.Load() {
+		return false, ErrCompareAndSwapUnsupported
+	}
 	cmd, errClient := c.commandClient()
 	if errClient != nil {
 		return false, errClient
 	}
-	const script = `
-local current = redis.call("GET", KEYS[1])
-if ARGV[1] == "1" then
-  if not current or current ~= ARGV[2] then
-    return 0
-  end
-elseif current then
-  return 0
-end
-local ttl = tonumber(ARGV[4])
-if ttl and ttl > 0 then
-  redis.call("SET", KEYS[1], ARGV[3], "PX", ttl)
-else
-  redis.call("SET", KEYS[1], ARGV[3])
-end
-return 1
-`
 	expectedFlag := "0"
 	if expectedExists {
 		expectedFlag = "1"
 	}
-	result, errEval := cmd.Eval(ctx, script, []string{key}, expectedFlag, expected, value, durationCeil(ttl, time.Millisecond)).Int64()
-	if errEval != nil {
-		return false, errEval
+	args := make([]any, 0, 7)
+	args = append(args, "CAS", key, expectedFlag, expected, value)
+	if milliseconds := durationCeil(ttl, time.Millisecond); milliseconds > 0 {
+		args = append(args, "PX", milliseconds)
+	}
+	result, errCAS := cmd.Do(ctx, args...).Int64()
+	if errCAS != nil {
+		if isHomeCommandUnsupported(errCAS) {
+			if c.casUnsupported.CompareAndSwap(false, true) {
+				log.Warnf("home kv: this Home does not implement the CAS command; Antigravity and Codex reasoning replay are disabled until Home is upgraded")
+			}
+			return false, ErrCompareAndSwapUnsupported
+		}
+		return false, errCAS
 	}
 	return result == 1, nil
 }

--- a/internal/home/client.go
+++ b/internal/home/client.go
@@ -18,6 +18,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 	"github.com/redis/go-redis/v9/maintnotifications"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -82,6 +83,8 @@ func IsAmbiguousDispatchError(err error) bool {
 	return errors.As(err, &dispatchErr) && dispatchErr.Ambiguous
 }
 
+var errClusterDiscoveryTransport = errors.New("home cluster discovery transport failed")
+
 var (
 	ErrDisabled              = errors.New("home client disabled")
 	ErrNotConnected          = errors.New("home not connected")
@@ -91,7 +94,41 @@ var (
 	ErrModelsNotFound        = errors.New("home models not found")
 	ErrPluginSyncUnsupported = errors.New("home plugin sync is unsupported")
 	ErrDispatchFenced        = errors.New("home auth dispatch is fenced")
+	// ErrCompareAndSwapUnsupported reports that this Home predates the CAS command.
+	ErrCompareAndSwapUnsupported = errors.New("home compare-and-swap is unsupported")
 )
+
+// isHomeCommandUnsupported reports whether Home rejected a command it does not
+// implement. It mirrors isHomeAppLogUnsupported in internal/logging; the two are
+// kept separate so the packages stay decoupled.
+func isHomeCommandUnsupported(err error) bool {
+	for err != nil {
+		message := strings.ToLower(strings.TrimSpace(err.Error()))
+		if strings.Contains(message, "unknown command") || strings.Contains(message, "unsupported command") {
+			return true
+		}
+		err = errors.Unwrap(err)
+	}
+	return false
+}
+
+// IsMembershipTakeoverUnavailableError reports whether Home cannot preserve the previous membership state.
+func IsMembershipTakeoverUnavailableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.TrimSpace(strings.ToLower(err.Error()))
+	return message == "membership_takeover_unavailable" || message == "err membership_takeover_unavailable"
+}
+
+// IsLegacyMembershipProtocolError reports whether Home rejected the secure subscription argument count.
+func IsLegacyMembershipProtocolError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.TrimSpace(strings.ToLower(err.Error()))
+	return message == "wrong number of arguments for 'subscribe' command" || message == "err wrong number of arguments for 'subscribe' command"
+}
 
 type clusterNode struct {
 	IP          string    `json:"ip"`
@@ -127,6 +164,15 @@ type subscriptionCloser interface {
 	Close() error
 }
 
+type recoveryState uint32
+
+const (
+	recoveryStateStable recoveryState = iota
+	recoveryStateTakeoverEligible
+	recoveryStateSwitching
+	recoveryStateSwitchingTakeover
+)
+
 type Client struct {
 	mu sync.Mutex
 
@@ -139,21 +185,34 @@ type Client struct {
 	sub         *redis.Client
 	release     *redis.Client
 	connections map[*homeDispatchConn]struct{}
+	closing     chan struct{}
 	lifecycle   config.CredentialConcurrencyConfig
 	limiter     atomic.Pointer[config.CredentialConcurrencyConfig]
 	managed     bool
 
 	heartbeatOK       atomic.Bool
 	dispatchFenced    atomic.Bool
+	ambiguousDispatch atomic.Bool
+	// casUnsupported latches when Home does not implement the CAS command.
+	// It is deliberately NOT carried across NewLifetime: CAS support is a
+	// property of the Home deployment, so re-probing once per client lifetime
+	// lets a Home upgrade take effect on the next reconnect instead of
+	// requiring a CPA restart. The probe costs one round trip that returns an
+	// error without performing any write.
+	casUnsupported    atomic.Bool
+	recoveryState     atomic.Uint32
+	instanceID        string
+	legacyMembership  bool
 	clusterNodes      []clusterNode
 	reconnectFailures int
 }
 
 func New(homeCfg config.HomeConfig) *Client {
 	return &Client{
-		homeCfg:  homeCfg,
-		seedHost: strings.TrimSpace(homeCfg.Host),
-		seedPort: homeCfg.Port,
+		homeCfg:    homeCfg,
+		seedHost:   strings.TrimSpace(homeCfg.Host),
+		seedPort:   homeCfg.Port,
+		instanceID: uuid.NewString(),
 	}
 }
 
@@ -164,13 +223,48 @@ func (c *Client) NewLifetime() *Client {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return &Client{
+	next := &Client{
 		homeCfg:           c.homeCfg,
 		seedHost:          c.seedHost,
 		seedPort:          c.seedPort,
 		clusterNodes:      append([]clusterNode(nil), c.clusterNodes...),
 		reconnectFailures: c.reconnectFailures,
+		instanceID:        c.instanceID,
+		legacyMembership:  c.legacyMembership,
 	}
+	next.recoveryState.Store(c.recoveryState.Load())
+	return next
+}
+
+// MembershipInstanceID returns the process-scoped Home membership identity.
+func (c *Client) MembershipInstanceID() string {
+	if c == nil {
+		return ""
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.instanceID
+}
+
+// LegacyMembership reports whether this subscriber has downgraded to the legacy protocol.
+func (c *Client) LegacyMembership() bool {
+	if c == nil {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.legacyMembership
+}
+
+// EnableLegacyMembership permanently downgrades this subscriber lifetime chain.
+func (c *Client) EnableLegacyMembership() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.legacyMembership = true
+	c.mu.Unlock()
+	c.SuppressTakeover()
 }
 
 func (c *Client) Enabled() bool {
@@ -203,10 +297,14 @@ func (c *Client) Close() {
 	commandClient, subscriptionClient, connections := c.detachClientsLocked()
 	releaseClient := c.release
 	c.release = nil
+	closing := c.closing
 	c.mu.Unlock()
 	closeDetachedClients(commandClient, subscriptionClient, connections)
 	if releaseClient != nil {
 		_ = releaseClient.Close()
+	}
+	if closing != nil {
+		<-closing
 	}
 }
 
@@ -227,6 +325,7 @@ func (c *Client) AbortAmbiguousDispatch() {
 	if c == nil {
 		return
 	}
+	c.ambiguousDispatch.Store(true)
 	c.dispatchFenced.Store(true)
 	c.heartbeatOK.Store(false)
 	c.mu.Lock()
@@ -251,6 +350,21 @@ func (c *Client) AbortAmbiguousDispatch() {
 		go func() {
 			_ = releaseClient.Close()
 		}()
+	}
+}
+
+// AmbiguousDispatch reports whether this lifetime observed an issued dispatch with an unknown delivery result.
+func (c *Client) AmbiguousDispatch() bool {
+	return c != nil && c.ambiguousDispatch.Load()
+}
+
+// SuppressTakeover forces the next subscriber lifetime through normal membership recovery.
+func (c *Client) SuppressTakeover() {
+	if c == nil {
+		return
+	}
+	if !c.recoveryState.CompareAndSwap(uint32(recoveryStateTakeoverEligible), uint32(recoveryStateStable)) {
+		c.recoveryState.CompareAndSwap(uint32(recoveryStateSwitchingTakeover), uint32(recoveryStateSwitching))
 	}
 }
 
@@ -284,12 +398,38 @@ func (c *Client) closeClientsLocked() {
 	commandClient, subscriptionClient, connections := c.detachClientsLocked()
 	releaseClient := c.release
 	c.release = nil
+	previousClosing := c.closing
+	done := make(chan struct{})
+	c.closing = done
 	go func() {
+		defer close(done)
+		if previousClosing != nil {
+			<-previousClosing
+		}
 		closeDetachedClients(commandClient, subscriptionClient, connections)
 		if releaseClient != nil {
 			_ = releaseClient.Close()
 		}
 	}()
+}
+
+func (c *Client) waitForClientsClosed() {
+	for {
+		c.mu.Lock()
+		closing := c.closing
+		c.mu.Unlock()
+		if closing == nil {
+			return
+		}
+		<-closing
+		c.mu.Lock()
+		if c.closing == closing {
+			c.closing = nil
+			c.mu.Unlock()
+			return
+		}
+		c.mu.Unlock()
+	}
 }
 
 // SetManagedLifetime defers client shutdown to the Service lifetime owner.
@@ -341,6 +481,7 @@ func (c *Client) ensureClients() error {
 	if !c.Enabled() {
 		return ErrDisabled
 	}
+	c.waitForClientsClosed()
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.dispatchFenced.Load() {
@@ -588,20 +729,21 @@ func (c *Client) clusterDiscoveryEnabledLocked() bool {
 	return !c.homeCfg.DisableClusterDiscovery
 }
 
-func (c *Client) refreshBestClusterNode(ctx context.Context) {
+func (c *Client) refreshBestClusterNode(ctx context.Context) error {
 	if !c.clusterDiscoveryEnabled() {
-		return
+		return nil
 	}
 	switched, errRefresh := c.refreshClusterNodes(ctx)
 	if errRefresh != nil {
 		log.Debugf("home cluster nodes unavailable: %v", errRefresh)
-		return
+		return errRefresh
 	}
 	if switched {
 		if addr, ok := c.addr(); ok {
 			log.Infof("home cluster target switched to %s", addr)
 		}
 	}
+	return nil
 }
 
 func (c *Client) refreshClusterNodes(ctx context.Context) (bool, error) {
@@ -613,11 +755,20 @@ func (c *Client) refreshClusterNodes(ctx context.Context) (bool, error) {
 	}
 	cmd, errClient := c.commandClient()
 	if errClient != nil {
-		return false, errClient
+		return false, fmt.Errorf("%w: %w", errClusterDiscoveryTransport, errClient)
 	}
-	raw, errDo := cmd.Do(ctx, "CLUSTER", "NODES").Text()
+	nodesCommand := cmd.Do(ctx, "CLUSTER", "NODES")
+	errDo := nodesCommand.Err()
 	if errDo != nil {
+		var redisErr redis.Error
+		if !errors.As(errDo, &redisErr) {
+			return false, fmt.Errorf("%w: %w", errClusterDiscoveryTransport, errDo)
+		}
 		return false, errDo
+	}
+	raw, errText := nodesCommand.Text()
+	if errText != nil {
+		return false, errText
 	}
 
 	nodes, errParse := parseClusterNodesPayload([]byte(raw))
@@ -685,6 +836,9 @@ func (c *Client) switchToNodeLocked(node clusterNode) bool {
 	}
 	c.homeCfg.Host = host
 	c.homeCfg.Port = node.Port
+	if !c.recoveryState.CompareAndSwap(uint32(recoveryStateStable), uint32(recoveryStateSwitching)) {
+		c.recoveryState.CompareAndSwap(uint32(recoveryStateTakeoverEligible), uint32(recoveryStateSwitchingTakeover))
+	}
 	c.closeClientsLocked()
 	return true
 }
@@ -771,7 +925,9 @@ func (c *Client) resetReconnectFailures() {
 }
 
 func (c *Client) GetConfig(ctx context.Context) ([]byte, error) {
-	c.refreshBestClusterNode(ctx)
+	if errRefresh := c.refreshBestClusterNode(ctx); errors.Is(errRefresh, errClusterDiscoveryTransport) {
+		return nil, errRefresh
+	}
 	cmd, errClient := c.commandClient()
 	if errClient != nil {
 		return nil, errClient
@@ -900,35 +1056,44 @@ func (c *Client) KVSetNX(ctx context.Context, key string, value []byte, ttl time
 }
 
 // KVCompareAndSwap atomically replaces a value only when its current state matches the expected state.
+//
+// It uses Home's dedicated CAS command:
+//
+//	CAS <key> <expected-exists 0|1> <expected-value> <new-value> [PX <ttl-ms>]
+//
+// Omitting PX stores the value without a TTL. Home replies integer 1 when the
+// swap happened and integer 0 when the state did not match. Deployments that
+// predate CAS reject the command, which latches ErrCompareAndSwapUnsupported for
+// this client lifetime so later calls skip the round trip.
 func (c *Client) KVCompareAndSwap(ctx context.Context, key string, expected []byte, expectedExists bool, value []byte, ttl time.Duration) (bool, error) {
+	if c == nil {
+		return false, ErrNotConnected
+	}
+	if c.casUnsupported.Load() {
+		return false, ErrCompareAndSwapUnsupported
+	}
 	cmd, errClient := c.commandClient()
 	if errClient != nil {
 		return false, errClient
 	}
-	const script = `
-local current = redis.call("GET", KEYS[1])
-if ARGV[1] == "1" then
-  if not current or current ~= ARGV[2] then
-    return 0
-  end
-elseif current then
-  return 0
-end
-local ttl = tonumber(ARGV[4])
-if ttl and ttl > 0 then
-  redis.call("SET", KEYS[1], ARGV[3], "PX", ttl)
-else
-  redis.call("SET", KEYS[1], ARGV[3])
-end
-return 1
-`
 	expectedFlag := "0"
 	if expectedExists {
 		expectedFlag = "1"
 	}
-	result, errEval := cmd.Eval(ctx, script, []string{key}, expectedFlag, expected, value, durationCeil(ttl, time.Millisecond)).Int64()
-	if errEval != nil {
-		return false, errEval
+	args := make([]any, 0, 7)
+	args = append(args, "CAS", key, expectedFlag, expected, value)
+	if milliseconds := durationCeil(ttl, time.Millisecond); milliseconds > 0 {
+		args = append(args, "PX", milliseconds)
+	}
+	result, errCAS := cmd.Do(ctx, args...).Int64()
+	if errCAS != nil {
+		if isHomeCommandUnsupported(errCAS) {
+			if c.casUnsupported.CompareAndSwap(false, true) {
+				log.Warnf("home kv: this Home does not implement the CAS command; Antigravity and Codex reasoning replay are disabled until Home is upgraded")
+			}
+			return false, ErrCompareAndSwapUnsupported
+		}
+		return false, errCAS
 	}
 	return result == 1, nil
 }
@@ -1233,6 +1398,10 @@ func (c *Client) concurrencyReleaseClient() (*redis.Client, error) {
 	if c == nil || c.dispatchFenced.Load() {
 		return nil, ErrDispatchFenced
 	}
+	state := recoveryState(c.recoveryState.Load())
+	if state == recoveryStateTakeoverEligible || state == recoveryStateSwitching || state == recoveryStateSwitchingTakeover {
+		return nil, ErrNotConnected
+	}
 	if !c.Enabled() {
 		return nil, ErrDisabled
 	}
@@ -1241,6 +1410,10 @@ func (c *Client) concurrencyReleaseClient() (*redis.Client, error) {
 	defer c.mu.Unlock()
 	if c.dispatchFenced.Load() {
 		return nil, ErrDispatchFenced
+	}
+	state = recoveryState(c.recoveryState.Load())
+	if state == recoveryStateTakeoverEligible || state == recoveryStateSwitching || state == recoveryStateSwitchingTakeover {
+		return nil, ErrNotConnected
 	}
 	if c.release != nil {
 		return c.release, nil
@@ -1522,18 +1695,41 @@ func (c *Client) subscriptionParameters() ([]string, time.Duration) {
 	}
 	c.mu.Lock()
 	cfg := c.lifecycle.WithDefaults()
+	instanceID := c.instanceID
+	legacyMembership := c.legacyMembership
 	c.mu.Unlock()
 
 	args := []string{redisChannelConfig}
 	if cfg.LifecycleConfigRevision > 0 {
 		args = append(args, strconv.FormatInt(cfg.LifecycleConfigRevision, 10))
+		if legacyMembership {
+			return args, cfg.CPAHeartbeatTimeout
+		}
+		state := recoveryState(c.recoveryState.Load())
+		if state == recoveryStateTakeoverEligible || state == recoveryStateSwitchingTakeover {
+			args = append(args, "takeover")
+		}
+		args = append(args, instanceID)
 	}
 	return args, cfg.CPAHeartbeatTimeout
 }
 
+func (c *Client) markMembershipTakeoverEligible() {
+	if c == nil {
+		return
+	}
+	if !c.recoveryState.CompareAndSwap(uint32(recoveryStateStable), uint32(recoveryStateTakeoverEligible)) {
+		c.recoveryState.CompareAndSwap(uint32(recoveryStateSwitching), uint32(recoveryStateSwitchingTakeover))
+	}
+}
+
 func (c *Client) rebuildCommandPoolAndProbe(ctx context.Context) error {
 	c.promoteSubscription()
-	return c.Ping(ctx)
+	if errPing := c.Ping(ctx); errPing != nil {
+		return errPing
+	}
+	c.recoveryState.Store(uint32(recoveryStateStable))
+	return nil
 }
 
 func (c *Client) promoteSubscription() {
@@ -1625,6 +1821,10 @@ func (c *Client) RunConfigSubscriberLifetime(ctx context.Context, onConfig func(
 		}
 		return c.endConfigSubscriberLifetimeWithSubscription(errACK, pubsub, "failed ACK")
 	}
+	// A protocol-one ACK means Home already committed this membership. Preserve it if the command probe fails.
+	if len(args) > 1 {
+		c.markMembershipTakeoverEligible()
+	}
 
 	if errProbe := c.rebuildCommandPoolAndProbe(ctx); errProbe != nil {
 		if ctx.Err() == nil {
@@ -1643,6 +1843,9 @@ func (c *Client) RunConfigSubscriberLifetime(ctx context.Context, onConfig func(
 		event, errReceive := pubsub.ReceiveTimeout(ctx, receiveTimeout)
 		if errReceive != nil {
 			if ctx.Err() == nil {
+				if c.heartbeatOK.Load() {
+					c.markMembershipTakeoverEligible()
+				}
 				if isTimeoutError(errReceive) {
 					c.markSubscriptionTimeout()
 				} else {

--- a/internal/home/client_test.go
+++ b/internal/home/client_test.go
@@ -153,6 +153,82 @@ func TestRefreshClusterNodesDisabledSkipsRedisCommand(t *testing.T) {
 	}
 }
 
+func TestGetConfigSkipsSecondDialAfterClusterTransportFailure(t *testing.T) {
+	client := New(config.HomeConfig{Enabled: true, Host: "127.0.0.1", Port: 1})
+	var dialMu sync.Mutex
+	dialAttempts := 0
+	options := &redis.Options{
+		Addr:                  "127.0.0.1:1",
+		DialTimeout:           time.Second,
+		MaxRetries:            -1,
+		DialerRetries:         1,
+		ContextTimeoutEnabled: true,
+		Dialer: func(context.Context, string, string) (net.Conn, error) {
+			dialMu.Lock()
+			dialAttempts++
+			dialMu.Unlock()
+			return nil, errors.New("test Home unavailable")
+		},
+	}
+	client.cmdOptions = cloneRedisOptions(options)
+	client.cmd = redis.NewClient(options)
+	t.Cleanup(client.Close)
+
+	_, errGet := client.GetConfig(context.Background())
+	if !errors.Is(errGet, errClusterDiscoveryTransport) {
+		t.Fatalf("GetConfig() error = %v, want cluster discovery transport error", errGet)
+	}
+	dialMu.Lock()
+	attempts := dialAttempts
+	dialMu.Unlock()
+	if attempts != 1 {
+		t.Fatalf("GetConfig() dial attempts = %d, want 1", attempts)
+	}
+}
+
+func TestGetConfigContinuesAfterClusterDiscoveryResponseError(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+	}{
+		{name: "protocol error", response: "-ERR cluster command unsupported\r\n"},
+		{name: "response type error", response: ":1\r\n"},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			client, commands := newRedisCommandTestClient(t, func(args []string) string {
+				switch {
+				case len(args) >= 2 && strings.EqualFold(args[0], "CLUSTER") && strings.EqualFold(args[1], "NODES"):
+					return testCase.response
+				case len(args) >= 2 && strings.EqualFold(args[0], "GET") && args[1] == redisKeyConfig:
+					payload := "host: 127.0.0.1\n"
+					return fmt.Sprintf("$%d\r\n%s\r\n", len(payload), payload)
+				default:
+					return "-ERR unexpected command\r\n"
+				}
+			})
+			client.mu.Lock()
+			client.homeCfg.DisableClusterDiscovery = false
+			client.mu.Unlock()
+
+			raw, errGet := client.GetConfig(context.Background())
+			if errGet != nil {
+				t.Fatalf("GetConfig() error = %v", errGet)
+			}
+			if string(raw) != "host: 127.0.0.1\n" {
+				t.Fatalf("GetConfig() = %q", raw)
+			}
+			if count := commands.CountCommandKey("CLUSTER", "NODES"); count != 1 {
+				t.Fatalf("CLUSTER NODES count = %d, want 1", count)
+			}
+			if count := commands.CountCommandKey("GET", redisKeyConfig); count != 1 {
+				t.Fatalf("GET config count = %d, want 1", count)
+			}
+		})
+	}
+}
+
 func TestFailoverAfterReconnectFailureDisabledDoesNotSwitchToClusterNode(t *testing.T) {
 	client := New(config.HomeConfig{
 		Enabled:                 true,

--- a/internal/home/client_test.go
+++ b/internal/home/client_test.go
@@ -243,18 +243,31 @@ func TestEnsureClientsWaitsForPreviousTargetClose(t *testing.T) {
 	client.Close()
 }
 
-func TestConcurrencyReleaseDoesNotOpenSwitchingTarget(t *testing.T) {
-	client := New(config.HomeConfig{Enabled: true, Host: "next.example.com", Port: 8327})
-	client.recoveryState.Store(uint32(recoveryStateSwitching))
-	errRelease := client.PushConcurrencyRelease(context.Background(), ConcurrencyReleaseFrame{CredentialID: "cred-a", Model: "model-a", ReleaseSeq: 1})
-	if !errors.Is(errRelease, ErrNotConnected) {
-		t.Fatalf("PushConcurrencyRelease() error = %v, want %v", errRelease, ErrNotConnected)
+func TestConcurrencyReleaseDoesNotOpenBeforeMembershipReady(t *testing.T) {
+	tests := []struct {
+		name  string
+		state recoveryState
+	}{
+		{name: "takeover pending", state: recoveryStateTakeoverEligible},
+		{name: "target switching", state: recoveryStateSwitching},
+		{name: "target switching with takeover", state: recoveryStateSwitchingTakeover},
 	}
-	client.mu.Lock()
-	releaseClient := client.release
-	client.mu.Unlock()
-	if releaseClient != nil {
-		t.Fatal("release client was opened before the switched target became ready")
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			client := New(config.HomeConfig{Enabled: true, Host: "next.example.com", Port: 8327})
+			client.recoveryState.Store(uint32(testCase.state))
+			errRelease := client.PushConcurrencyRelease(context.Background(), ConcurrencyReleaseFrame{CredentialID: "cred-a", Model: "model-a", ReleaseSeq: 1})
+			if !errors.Is(errRelease, ErrNotConnected) {
+				t.Fatalf("PushConcurrencyRelease() error = %v, want %v", errRelease, ErrNotConnected)
+			}
+			client.mu.Lock()
+			releaseClient := client.release
+			client.mu.Unlock()
+			if releaseClient != nil {
+				t.Fatal("release client was opened before the membership became ready")
+			}
+		})
 	}
 }
 

--- a/internal/home/client_test.go
+++ b/internal/home/client_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginstore"
@@ -252,6 +253,11 @@ func TestFailoverAfterReconnectFailureDisabledDoesNotSwitchToClusterNode(t *test
 
 func TestNewLifetimePreservesClusterFailoverState(t *testing.T) {
 	client := New(config.HomeConfig{Enabled: true, Host: "seed.example.com", Port: 8327})
+	instanceID := client.MembershipInstanceID()
+	if _, errParse := uuid.Parse(instanceID); errParse != nil {
+		t.Fatalf("membership instance ID = %q: %v", instanceID, errParse)
+	}
+	client.EnableLegacyMembership()
 	client.mu.Lock()
 	client.homeCfg.Host = "failed.example.com"
 	client.clusterNodes = []clusterNode{
@@ -265,6 +271,12 @@ func TestNewLifetimePreservesClusterFailoverState(t *testing.T) {
 	next := client.NewLifetime()
 	if next == nil {
 		t.Fatal("NewLifetime() = nil")
+	}
+	if next.MembershipInstanceID() != instanceID || !next.LegacyMembership() {
+		t.Fatalf("membership state = instance %q legacy %t, want %q true", next.MembershipInstanceID(), next.LegacyMembership(), instanceID)
+	}
+	if fresh := New(config.HomeConfig{}); fresh.MembershipInstanceID() == instanceID || fresh.LegacyMembership() {
+		t.Fatalf("fresh membership state = instance %q legacy %t", fresh.MembershipInstanceID(), fresh.LegacyMembership())
 	}
 	if got, _ := next.addr(); got != "failed.example.com:8327" {
 		t.Fatalf("addr() = %q, want failed.example.com:8327", got)
@@ -362,16 +374,19 @@ func TestAmbiguousDispatchSuppressesTakeoverForNextLifetime(t *testing.T) {
 }
 
 func TestMembershipTakeoverUnavailableError(t *testing.T) {
-	for _, message := range []string{
-		"ERR membership_takeover_unavailable",
-		"ERR wrong number of arguments for 'subscribe' command",
-	} {
-		if !IsMembershipTakeoverUnavailableError(errors.New(message)) {
-			t.Fatalf("takeover unavailable error %q was not recognized", message)
-		}
+	if !IsMembershipTakeoverUnavailableError(errors.New("ERR membership_takeover_unavailable")) {
+		t.Fatal("takeover unavailable error was not recognized")
 	}
-	if IsMembershipTakeoverUnavailableError(errors.New("ERR connection refused")) {
-		t.Fatal("unrelated error was recognized as takeover unavailable")
+	if IsMembershipTakeoverUnavailableError(errors.New("ERR wrong number of arguments for 'subscribe' command")) {
+		t.Fatal("legacy protocol error was recognized as takeover unavailable")
+	}
+	if !IsLegacyMembershipProtocolError(errors.New("ERR wrong number of arguments for 'subscribe' command")) {
+		t.Fatal("legacy protocol error was not recognized")
+	}
+	for _, errUnrelated := range []error{errors.New("ERR connection refused"), errors.New("ERR duplicate certificate"), context.DeadlineExceeded} {
+		if IsMembershipTakeoverUnavailableError(errUnrelated) || IsLegacyMembershipProtocolError(errUnrelated) {
+			t.Fatalf("unrelated error %q was classified as a membership protocol error", errUnrelated)
+		}
 	}
 }
 
@@ -1257,7 +1272,7 @@ func TestConfigSubscriberUsesAppliedLifecycleRevisionAndRebuildsCommands(t *test
 		t.Fatalf("SetLifecycleConfig() error = %v", errSet)
 	}
 	args, timeout := client.subscriptionParameters()
-	if !reflect.DeepEqual(args, []string{"config", "9"}) {
+	if !reflect.DeepEqual(args, []string{"config", "9", client.MembershipInstanceID()}) {
 		t.Fatalf("subscribe args = %#v", args)
 	}
 	if timeout != 4*time.Second {
@@ -1265,8 +1280,13 @@ func TestConfigSubscriberUsesAppliedLifecycleRevisionAndRebuildsCommands(t *test
 	}
 	client.recoveryState.Store(uint32(recoveryStateSwitchingTakeover))
 	args, _ = client.subscriptionParameters()
-	if !reflect.DeepEqual(args, []string{"config", "9", "takeover"}) {
+	if !reflect.DeepEqual(args, []string{"config", "9", "takeover", client.MembershipInstanceID()}) {
 		t.Fatalf("takeover subscribe args = %#v", args)
+	}
+	client.EnableLegacyMembership()
+	args, _ = client.subscriptionParameters()
+	if !reflect.DeepEqual(args, []string{"config", "9"}) {
+		t.Fatalf("legacy subscribe args = %#v", args)
 	}
 	client.recoveryState.Store(uint32(recoveryStateStable))
 	client.promoteSubscription()
@@ -1386,8 +1406,8 @@ func TestRunConfigSubscriberLifetimeReturnsAfterHeartbeatLoss(t *testing.T) {
 	if count := commands.CountCommandKey("SUBSCRIBE", redisChannelConfig); count != 1 {
 		t.Fatalf("SUBSCRIBE config count = %d, want 1", count)
 	}
-	if got := findRedisCommand(commands.All(), "SUBSCRIBE"); !reflect.DeepEqual(got, []string{"subscribe", "config", "1", "takeover"}) {
-		t.Fatalf("SUBSCRIBE wire command = %#v, want []string{\"subscribe\", \"config\", \"1\", \"takeover\"}", got)
+	if got := findRedisCommand(commands.All(), "SUBSCRIBE"); !reflect.DeepEqual(got, []string{"subscribe", "config", "1", "takeover", client.MembershipInstanceID()}) {
+		t.Fatalf("SUBSCRIBE wire command = %#v", got)
 	}
 }
 
@@ -2007,8 +2027,8 @@ func TestRunConfigSubscriberLifetimePreservesTakeoverWhenFreshCommandProbeFails(
 	if got := recoveryState(client.recoveryState.Load()); got != recoveryStateTakeoverEligible {
 		t.Fatalf("recovery state = %d, want %d", got, recoveryStateTakeoverEligible)
 	}
-	if got := findRedisCommand(commands.All(), "SUBSCRIBE"); !reflect.DeepEqual(got, []string{"subscribe", "config", "9"}) {
-		t.Fatalf("initial SUBSCRIBE wire command = %#v, want []string{\"subscribe\", \"config\", \"9\"}", got)
+	if got := findRedisCommand(commands.All(), "SUBSCRIBE"); !reflect.DeepEqual(got, []string{"subscribe", "config", "9", client.MembershipInstanceID()}) {
+		t.Fatalf("initial SUBSCRIBE wire command = %#v", got)
 	}
 
 	next := client.NewLifetime()
@@ -2016,7 +2036,7 @@ func TestRunConfigSubscriberLifetimePreservesTakeoverWhenFreshCommandProbeFails(
 		t.Fatal(errSet)
 	}
 	args, _ := next.subscriptionParameters()
-	if !reflect.DeepEqual(args, []string{"config", "9", "takeover"}) {
+	if !reflect.DeepEqual(args, []string{"config", "9", "takeover", client.MembershipInstanceID()}) {
 		t.Fatalf("replacement SUBSCRIBE args = %#v, want takeover", args)
 	}
 }

--- a/internal/home/client_test.go
+++ b/internal/home/client_test.go
@@ -153,6 +153,82 @@ func TestRefreshClusterNodesDisabledSkipsRedisCommand(t *testing.T) {
 	}
 }
 
+func TestGetConfigSkipsSecondDialAfterClusterTransportFailure(t *testing.T) {
+	client := New(config.HomeConfig{Enabled: true, Host: "127.0.0.1", Port: 1})
+	var dialMu sync.Mutex
+	dialAttempts := 0
+	options := &redis.Options{
+		Addr:                  "127.0.0.1:1",
+		DialTimeout:           time.Second,
+		MaxRetries:            -1,
+		DialerRetries:         1,
+		ContextTimeoutEnabled: true,
+		Dialer: func(context.Context, string, string) (net.Conn, error) {
+			dialMu.Lock()
+			dialAttempts++
+			dialMu.Unlock()
+			return nil, errors.New("test Home unavailable")
+		},
+	}
+	client.cmdOptions = cloneRedisOptions(options)
+	client.cmd = redis.NewClient(options)
+	t.Cleanup(client.Close)
+
+	_, errGet := client.GetConfig(context.Background())
+	if !errors.Is(errGet, errClusterDiscoveryTransport) {
+		t.Fatalf("GetConfig() error = %v, want cluster discovery transport error", errGet)
+	}
+	dialMu.Lock()
+	attempts := dialAttempts
+	dialMu.Unlock()
+	if attempts != 1 {
+		t.Fatalf("GetConfig() dial attempts = %d, want 1", attempts)
+	}
+}
+
+func TestGetConfigContinuesAfterClusterDiscoveryResponseError(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+	}{
+		{name: "protocol error", response: "-ERR cluster command unsupported\r\n"},
+		{name: "response type error", response: ":1\r\n"},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			client, commands := newRedisCommandTestClient(t, func(args []string) string {
+				switch {
+				case len(args) >= 2 && strings.EqualFold(args[0], "CLUSTER") && strings.EqualFold(args[1], "NODES"):
+					return testCase.response
+				case len(args) >= 2 && strings.EqualFold(args[0], "GET") && args[1] == redisKeyConfig:
+					payload := "host: 127.0.0.1\n"
+					return fmt.Sprintf("$%d\r\n%s\r\n", len(payload), payload)
+				default:
+					return "-ERR unexpected command\r\n"
+				}
+			})
+			client.mu.Lock()
+			client.homeCfg.DisableClusterDiscovery = false
+			client.mu.Unlock()
+
+			raw, errGet := client.GetConfig(context.Background())
+			if errGet != nil {
+				t.Fatalf("GetConfig() error = %v", errGet)
+			}
+			if string(raw) != "host: 127.0.0.1\n" {
+				t.Fatalf("GetConfig() = %q", raw)
+			}
+			if count := commands.CountCommandKey("CLUSTER", "NODES"); count != 1 {
+				t.Fatalf("CLUSTER NODES count = %d, want 1", count)
+			}
+			if count := commands.CountCommandKey("GET", redisKeyConfig); count != 1 {
+				t.Fatalf("GET config count = %d, want 1", count)
+			}
+		})
+	}
+}
+
 func TestFailoverAfterReconnectFailureDisabledDoesNotSwitchToClusterNode(t *testing.T) {
 	client := New(config.HomeConfig{
 		Enabled:                 true,
@@ -214,6 +290,88 @@ func TestNewLifetimePreservesClusterFailoverState(t *testing.T) {
 	switched, addr := next.failoverAfterReconnectFailure()
 	if !switched || addr != "healthy.example.com:8327" {
 		t.Fatalf("failover = %t, %q, want true, healthy.example.com:8327", switched, addr)
+	}
+}
+
+func TestEnsureClientsWaitsForPreviousTargetClose(t *testing.T) {
+	client := New(config.HomeConfig{Enabled: true, Host: "next.example.com", Port: 8327})
+	closing := make(chan struct{})
+	client.closing = closing
+	done := make(chan error, 1)
+	go func() {
+		done <- client.ensureClients()
+	}()
+
+	select {
+	case errEnsure := <-done:
+		t.Fatalf("ensureClients() returned before previous target closed: %v", errEnsure)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(closing)
+	select {
+	case errEnsure := <-done:
+		if errEnsure != nil {
+			t.Fatal(errEnsure)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ensureClients() did not continue after previous target closed")
+	}
+	client.Close()
+}
+
+func TestConcurrencyReleaseDoesNotOpenBeforeMembershipReady(t *testing.T) {
+	tests := []struct {
+		name  string
+		state recoveryState
+	}{
+		{name: "takeover pending", state: recoveryStateTakeoverEligible},
+		{name: "target switching", state: recoveryStateSwitching},
+		{name: "target switching with takeover", state: recoveryStateSwitchingTakeover},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			client := New(config.HomeConfig{Enabled: true, Host: "next.example.com", Port: 8327})
+			client.recoveryState.Store(uint32(testCase.state))
+			errRelease := client.PushConcurrencyRelease(context.Background(), ConcurrencyReleaseFrame{CredentialID: "cred-a", Model: "model-a", ReleaseSeq: 1})
+			if !errors.Is(errRelease, ErrNotConnected) {
+				t.Fatalf("PushConcurrencyRelease() error = %v, want %v", errRelease, ErrNotConnected)
+			}
+			client.mu.Lock()
+			releaseClient := client.release
+			client.mu.Unlock()
+			if releaseClient != nil {
+				t.Fatal("release client was opened before the membership became ready")
+			}
+		})
+	}
+}
+
+func TestAmbiguousDispatchSuppressesTakeoverForNextLifetime(t *testing.T) {
+	client := New(config.HomeConfig{Enabled: true, Host: "next.example.com", Port: 8327})
+	client.recoveryState.Store(uint32(recoveryStateSwitchingTakeover))
+	client.AbortAmbiguousDispatch()
+	if !client.AmbiguousDispatch() {
+		t.Fatal("ambiguous dispatch was not recorded")
+	}
+	client.SuppressTakeover()
+	next := client.NewLifetime()
+	if got := recoveryState(next.recoveryState.Load()); got != recoveryStateSwitching {
+		t.Fatalf("next recovery state = %d, want %d", got, recoveryStateSwitching)
+	}
+}
+
+func TestMembershipTakeoverUnavailableError(t *testing.T) {
+	for _, message := range []string{
+		"ERR membership_takeover_unavailable",
+		"ERR wrong number of arguments for 'subscribe' command",
+	} {
+		if !IsMembershipTakeoverUnavailableError(errors.New(message)) {
+			t.Fatalf("takeover unavailable error %q was not recognized", message)
+		}
+	}
+	if IsMembershipTakeoverUnavailableError(errors.New("ERR connection refused")) {
+		t.Fatal("unrelated error was recognized as takeover unavailable")
 	}
 }
 
@@ -1105,6 +1263,12 @@ func TestConfigSubscriberUsesAppliedLifecycleRevisionAndRebuildsCommands(t *test
 	if timeout != 4*time.Second {
 		t.Fatalf("receive timeout = %s", timeout)
 	}
+	client.recoveryState.Store(uint32(recoveryStateSwitchingTakeover))
+	args, _ = client.subscriptionParameters()
+	if !reflect.DeepEqual(args, []string{"config", "9", "takeover"}) {
+		t.Fatalf("takeover subscribe args = %#v", args)
+	}
+	client.recoveryState.Store(uint32(recoveryStateStable))
 	client.promoteSubscription()
 	client.mu.Lock()
 	commandClient := client.cmd
@@ -1177,8 +1341,9 @@ func TestRunConfigSubscriberLifetimeReturnsAfterHeartbeatLoss(t *testing.T) {
 	client.mu.Lock()
 	client.clusterNodes = []clusterNode{{IP: "failover.example.com", Port: 8327}}
 	client.mu.Unlock()
+	client.recoveryState.Store(uint32(recoveryStateSwitchingTakeover))
 
-	ready := make(chan struct{}, 1)
+	ready := make(chan bool, 1)
 	errRun := client.RunConfigSubscriberLifetime(context.Background(), func(raw []byte) error {
 		parsed, errParse := config.ParseConfigBytes(raw)
 		if errParse != nil {
@@ -1188,12 +1353,15 @@ func TestRunConfigSubscriberLifetimeReturnsAfterHeartbeatLoss(t *testing.T) {
 			return errSet
 		}
 		return nil
-	}, func() { ready <- struct{}{} })
+	}, func() { ready <- recoveryState(client.recoveryState.Load()) == recoveryStateStable })
 	if errRun == nil {
 		t.Fatal("RunConfigSubscriberLifetime() error = nil after heartbeat loss")
 	}
 	select {
-	case <-ready:
+	case cleared := <-ready:
+		if !cleared {
+			t.Fatal("successful subscription ACK and command probe did not clear takeover state")
+		}
 	default:
 		t.Fatalf("RunConfigSubscriberLifetime() did not invoke onReady after subscription ACK: %v; commands=%#v", errRun, commands.All())
 	}
@@ -1202,6 +1370,9 @@ func TestRunConfigSubscriberLifetimeReturnsAfterHeartbeatLoss(t *testing.T) {
 	}
 	if got, _ := client.addr(); got != "failover.example.com:8327" {
 		t.Fatalf("addr() = %q, want failover.example.com:8327 after heartbeat timeout", got)
+	}
+	if got := recoveryState(client.recoveryState.Load()); got != recoveryStateSwitchingTakeover {
+		t.Fatalf("recovery state = %d, want %d", got, recoveryStateSwitchingTakeover)
 	}
 	client.mu.Lock()
 	commandClient, subscriptionClient := client.cmd, client.sub
@@ -1215,8 +1386,8 @@ func TestRunConfigSubscriberLifetimeReturnsAfterHeartbeatLoss(t *testing.T) {
 	if count := commands.CountCommandKey("SUBSCRIBE", redisChannelConfig); count != 1 {
 		t.Fatalf("SUBSCRIBE config count = %d, want 1", count)
 	}
-	if got := findRedisCommand(commands.All(), "SUBSCRIBE"); !reflect.DeepEqual(got, []string{"subscribe", "config", "1"}) {
-		t.Fatalf("SUBSCRIBE wire command = %#v, want []string{\"subscribe\", \"config\", \"1\"}", got)
+	if got := findRedisCommand(commands.All(), "SUBSCRIBE"); !reflect.DeepEqual(got, []string{"subscribe", "config", "1", "takeover"}) {
+		t.Fatalf("SUBSCRIBE wire command = %#v, want []string{\"subscribe\", \"config\", \"1\", \"takeover\"}", got)
 	}
 }
 
@@ -1797,9 +1968,9 @@ func TestRunConfigSubscriberLifetimeRebuildsFreshCommandPoolBeforeReady(t *testi
 	}
 }
 
-func TestRunConfigSubscriberLifetimeDoesNotReadyWhenFreshCommandProbeFails(t *testing.T) {
+func TestRunConfigSubscriberLifetimePreservesTakeoverWhenFreshCommandProbeFails(t *testing.T) {
 	configPayload := "host: 127.0.0.1\n"
-	client, _ := newRedisCommandTestClient(t, func(args []string) string {
+	client, commands := newRedisCommandTestClient(t, func(args []string) string {
 		switch {
 		case len(args) >= 1 && strings.EqualFold(args[0], "HELLO"):
 			return "%6\r\n$6\r\nserver\r\n$5\r\nredis\r\n$5\r\nproto\r\n:3\r\n$2\r\nid\r\n:1\r\n$4\r\nmode\r\n$10\r\nstandalone\r\n$4\r\nrole\r\n$6\r\nmaster\r\n$7\r\nmodules\r\n*0\r\n"
@@ -1813,6 +1984,10 @@ func TestRunConfigSubscriberLifetimeDoesNotReadyWhenFreshCommandProbeFails(t *te
 			return "+OK\r\n"
 		}
 	})
+	lifecycle := config.CredentialConcurrencyConfig{LifecycleConfigRevision: 9}
+	if errSet := client.SetLifecycleConfig(lifecycle); errSet != nil {
+		t.Fatal(errSet)
+	}
 	ready := make(chan struct{}, 1)
 	errRun := client.RunConfigSubscriberLifetime(context.Background(), func([]byte) error { return nil }, func() { ready <- struct{}{} })
 	if errRun == nil {
@@ -1828,6 +2003,21 @@ func TestRunConfigSubscriberLifetimeDoesNotReadyWhenFreshCommandProbeFails(t *te
 	client.mu.Unlock()
 	if commandClient != nil || subscriptionClient != nil {
 		t.Fatalf("clients retained after fresh command probe failure: command=%v subscription=%v", commandClient != nil, subscriptionClient != nil)
+	}
+	if got := recoveryState(client.recoveryState.Load()); got != recoveryStateTakeoverEligible {
+		t.Fatalf("recovery state = %d, want %d", got, recoveryStateTakeoverEligible)
+	}
+	if got := findRedisCommand(commands.All(), "SUBSCRIBE"); !reflect.DeepEqual(got, []string{"subscribe", "config", "9"}) {
+		t.Fatalf("initial SUBSCRIBE wire command = %#v, want []string{\"subscribe\", \"config\", \"9\"}", got)
+	}
+
+	next := client.NewLifetime()
+	if errSet := next.SetLifecycleConfig(lifecycle); errSet != nil {
+		t.Fatal(errSet)
+	}
+	args, _ := next.subscriptionParameters()
+	if !reflect.DeepEqual(args, []string{"config", "9", "takeover"}) {
+		t.Fatalf("replacement SUBSCRIBE args = %#v, want takeover", args)
 	}
 }
 

--- a/internal/home/client_test.go
+++ b/internal/home/client_test.go
@@ -217,6 +217,75 @@ func TestNewLifetimePreservesClusterFailoverState(t *testing.T) {
 	}
 }
 
+func TestEnsureClientsWaitsForPreviousTargetClose(t *testing.T) {
+	client := New(config.HomeConfig{Enabled: true, Host: "next.example.com", Port: 8327})
+	closing := make(chan struct{})
+	client.closing = closing
+	done := make(chan error, 1)
+	go func() {
+		done <- client.ensureClients()
+	}()
+
+	select {
+	case errEnsure := <-done:
+		t.Fatalf("ensureClients() returned before previous target closed: %v", errEnsure)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(closing)
+	select {
+	case errEnsure := <-done:
+		if errEnsure != nil {
+			t.Fatal(errEnsure)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ensureClients() did not continue after previous target closed")
+	}
+	client.Close()
+}
+
+func TestConcurrencyReleaseDoesNotOpenSwitchingTarget(t *testing.T) {
+	client := New(config.HomeConfig{Enabled: true, Host: "next.example.com", Port: 8327})
+	client.recoveryState.Store(uint32(recoveryStateSwitching))
+	errRelease := client.PushConcurrencyRelease(context.Background(), ConcurrencyReleaseFrame{CredentialID: "cred-a", Model: "model-a", ReleaseSeq: 1})
+	if !errors.Is(errRelease, ErrNotConnected) {
+		t.Fatalf("PushConcurrencyRelease() error = %v, want %v", errRelease, ErrNotConnected)
+	}
+	client.mu.Lock()
+	releaseClient := client.release
+	client.mu.Unlock()
+	if releaseClient != nil {
+		t.Fatal("release client was opened before the switched target became ready")
+	}
+}
+
+func TestAmbiguousDispatchSuppressesTakeoverForNextLifetime(t *testing.T) {
+	client := New(config.HomeConfig{Enabled: true, Host: "next.example.com", Port: 8327})
+	client.recoveryState.Store(uint32(recoveryStateSwitchingTakeover))
+	client.AbortAmbiguousDispatch()
+	if !client.AmbiguousDispatch() {
+		t.Fatal("ambiguous dispatch was not recorded")
+	}
+	client.SuppressTakeover()
+	next := client.NewLifetime()
+	if got := recoveryState(next.recoveryState.Load()); got != recoveryStateSwitching {
+		t.Fatalf("next recovery state = %d, want %d", got, recoveryStateSwitching)
+	}
+}
+
+func TestMembershipTakeoverUnavailableError(t *testing.T) {
+	for _, message := range []string{
+		"ERR membership_takeover_unavailable",
+		"ERR wrong number of arguments for 'subscribe' command",
+	} {
+		if !IsMembershipTakeoverUnavailableError(errors.New(message)) {
+			t.Fatalf("takeover unavailable error %q was not recognized", message)
+		}
+	}
+	if IsMembershipTakeoverUnavailableError(errors.New("ERR connection refused")) {
+		t.Fatal("unrelated error was recognized as takeover unavailable")
+	}
+}
+
 func TestBuildKVSetArgs(t *testing.T) {
 	args, errArgs := buildKVSetArgs("key", []byte("value"), KVSetOptions{EX: 2 * time.Second, NX: true})
 	if errArgs != nil {
@@ -1105,6 +1174,12 @@ func TestConfigSubscriberUsesAppliedLifecycleRevisionAndRebuildsCommands(t *test
 	if timeout != 4*time.Second {
 		t.Fatalf("receive timeout = %s", timeout)
 	}
+	client.recoveryState.Store(uint32(recoveryStateSwitchingTakeover))
+	args, _ = client.subscriptionParameters()
+	if !reflect.DeepEqual(args, []string{"config", "9", "takeover"}) {
+		t.Fatalf("takeover subscribe args = %#v", args)
+	}
+	client.recoveryState.Store(uint32(recoveryStateStable))
 	client.promoteSubscription()
 	client.mu.Lock()
 	commandClient := client.cmd
@@ -1177,8 +1252,9 @@ func TestRunConfigSubscriberLifetimeReturnsAfterHeartbeatLoss(t *testing.T) {
 	client.mu.Lock()
 	client.clusterNodes = []clusterNode{{IP: "failover.example.com", Port: 8327}}
 	client.mu.Unlock()
+	client.recoveryState.Store(uint32(recoveryStateSwitchingTakeover))
 
-	ready := make(chan struct{}, 1)
+	ready := make(chan bool, 1)
 	errRun := client.RunConfigSubscriberLifetime(context.Background(), func(raw []byte) error {
 		parsed, errParse := config.ParseConfigBytes(raw)
 		if errParse != nil {
@@ -1188,12 +1264,15 @@ func TestRunConfigSubscriberLifetimeReturnsAfterHeartbeatLoss(t *testing.T) {
 			return errSet
 		}
 		return nil
-	}, func() { ready <- struct{}{} })
+	}, func() { ready <- recoveryState(client.recoveryState.Load()) == recoveryStateStable })
 	if errRun == nil {
 		t.Fatal("RunConfigSubscriberLifetime() error = nil after heartbeat loss")
 	}
 	select {
-	case <-ready:
+	case cleared := <-ready:
+		if !cleared {
+			t.Fatal("successful subscription ACK and command probe did not clear takeover state")
+		}
 	default:
 		t.Fatalf("RunConfigSubscriberLifetime() did not invoke onReady after subscription ACK: %v; commands=%#v", errRun, commands.All())
 	}
@@ -1202,6 +1281,9 @@ func TestRunConfigSubscriberLifetimeReturnsAfterHeartbeatLoss(t *testing.T) {
 	}
 	if got, _ := client.addr(); got != "failover.example.com:8327" {
 		t.Fatalf("addr() = %q, want failover.example.com:8327 after heartbeat timeout", got)
+	}
+	if got := recoveryState(client.recoveryState.Load()); got != recoveryStateSwitchingTakeover {
+		t.Fatalf("recovery state = %d, want %d", got, recoveryStateSwitchingTakeover)
 	}
 	client.mu.Lock()
 	commandClient, subscriptionClient := client.cmd, client.sub
@@ -1215,8 +1297,8 @@ func TestRunConfigSubscriberLifetimeReturnsAfterHeartbeatLoss(t *testing.T) {
 	if count := commands.CountCommandKey("SUBSCRIBE", redisChannelConfig); count != 1 {
 		t.Fatalf("SUBSCRIBE config count = %d, want 1", count)
 	}
-	if got := findRedisCommand(commands.All(), "SUBSCRIBE"); !reflect.DeepEqual(got, []string{"subscribe", "config", "1"}) {
-		t.Fatalf("SUBSCRIBE wire command = %#v, want []string{\"subscribe\", \"config\", \"1\"}", got)
+	if got := findRedisCommand(commands.All(), "SUBSCRIBE"); !reflect.DeepEqual(got, []string{"subscribe", "config", "1", "takeover"}) {
+		t.Fatalf("SUBSCRIBE wire command = %#v, want []string{\"subscribe\", \"config\", \"1\", \"takeover\"}", got)
 	}
 }
 

--- a/internal/home/client_test.go
+++ b/internal/home/client_test.go
@@ -534,9 +534,9 @@ func TestKVSetConditionUnmetReturnsFalse(t *testing.T) {
 	}
 }
 
-func TestKVCompareAndSwapReturnsScriptResult(t *testing.T) {
+func TestKVCompareAndSwapSendsCASCommand(t *testing.T) {
 	client, commands := newRedisCommandTestClient(t, func(args []string) string {
-		if len(args) > 0 && strings.EqualFold(args[0], "EVAL") {
+		if len(args) > 0 && strings.EqualFold(args[0], "CAS") {
 			return ":1\r\n"
 		}
 		return "-ERR unexpected command\r\n"
@@ -549,8 +549,70 @@ func TestKVCompareAndSwapReturnsScriptResult(t *testing.T) {
 	if !swapped {
 		t.Fatal("KVCompareAndSwap() swapped = false, want true")
 	}
-	if lastCommand := commands.Last(); len(lastCommand) < 2 || !strings.EqualFold(lastCommand[0], "EVAL") {
-		t.Fatalf("last command = %#v, want EVAL", lastCommand)
+	want := []string{"CAS", "key", "1", "old", "new", "PX", "1500"}
+	if lastCommand := commands.Last(); !reflect.DeepEqual(lastCommand, want) {
+		t.Fatalf("last command = %#v, want %#v", lastCommand, want)
+	}
+}
+
+func TestKVCompareAndSwapOmitsPXWithoutTTL(t *testing.T) {
+	client, commands := newRedisCommandTestClient(t, func(args []string) string {
+		if len(args) > 0 && strings.EqualFold(args[0], "CAS") {
+			return ":1\r\n"
+		}
+		return "-ERR unexpected command\r\n"
+	})
+
+	if _, errCAS := client.KVCompareAndSwap(context.Background(), "key", nil, false, []byte("new"), 0); errCAS != nil {
+		t.Fatalf("KVCompareAndSwap() error = %v", errCAS)
+	}
+	// An absent expected value is sent as an empty bulk string, and no TTL means
+	// no PX, which tells Home to store the value without an expiry.
+	want := []string{"CAS", "key", "0", "", "new"}
+	if lastCommand := commands.Last(); !reflect.DeepEqual(lastCommand, want) {
+		t.Fatalf("last command = %#v, want %#v", lastCommand, want)
+	}
+}
+
+func TestKVCompareAndSwapReportsMismatch(t *testing.T) {
+	client, _ := newRedisCommandTestClient(t, func(args []string) string {
+		if len(args) > 0 && strings.EqualFold(args[0], "CAS") {
+			return ":0\r\n"
+		}
+		return "-ERR unexpected command\r\n"
+	})
+
+	swapped, errCAS := client.KVCompareAndSwap(context.Background(), "key", []byte("old"), true, []byte("new"), time.Minute)
+	if errCAS != nil {
+		t.Fatalf("KVCompareAndSwap() error = %v", errCAS)
+	}
+	if swapped {
+		t.Fatal("KVCompareAndSwap() swapped = true, want false")
+	}
+}
+
+func TestKVCompareAndSwapLatchesUnsupportedHome(t *testing.T) {
+	client, commands := newRedisCommandTestClient(t, func(args []string) string {
+		if len(args) > 0 && strings.EqualFold(args[0], "CAS") {
+			return "-ERR unknown command 'cas'\r\n"
+		}
+		return "-ERR unexpected command\r\n"
+	})
+
+	_, errFirst := client.KVCompareAndSwap(context.Background(), "key", nil, false, []byte("new"), time.Minute)
+	if !errors.Is(errFirst, ErrCompareAndSwapUnsupported) {
+		t.Fatalf("KVCompareAndSwap() first error = %v, want ErrCompareAndSwapUnsupported", errFirst)
+	}
+	if sent := commands.CountCommandKey("CAS", "key"); sent != 1 {
+		t.Fatalf("CAS sent %d times, want 1", sent)
+	}
+
+	_, errSecond := client.KVCompareAndSwap(context.Background(), "key", nil, false, []byte("new"), time.Minute)
+	if !errors.Is(errSecond, ErrCompareAndSwapUnsupported) {
+		t.Fatalf("KVCompareAndSwap() second error = %v, want ErrCompareAndSwapUnsupported", errSecond)
+	}
+	if sent := commands.CountCommandKey("CAS", "key"); sent != 1 {
+		t.Fatalf("CAS sent %d times after latching, want 1", sent)
 	}
 }
 

--- a/internal/home/client_test.go
+++ b/internal/home/client_test.go
@@ -1968,9 +1968,9 @@ func TestRunConfigSubscriberLifetimeRebuildsFreshCommandPoolBeforeReady(t *testi
 	}
 }
 
-func TestRunConfigSubscriberLifetimeDoesNotReadyWhenFreshCommandProbeFails(t *testing.T) {
+func TestRunConfigSubscriberLifetimePreservesTakeoverWhenFreshCommandProbeFails(t *testing.T) {
 	configPayload := "host: 127.0.0.1\n"
-	client, _ := newRedisCommandTestClient(t, func(args []string) string {
+	client, commands := newRedisCommandTestClient(t, func(args []string) string {
 		switch {
 		case len(args) >= 1 && strings.EqualFold(args[0], "HELLO"):
 			return "%6\r\n$6\r\nserver\r\n$5\r\nredis\r\n$5\r\nproto\r\n:3\r\n$2\r\nid\r\n:1\r\n$4\r\nmode\r\n$10\r\nstandalone\r\n$4\r\nrole\r\n$6\r\nmaster\r\n$7\r\nmodules\r\n*0\r\n"
@@ -1984,6 +1984,10 @@ func TestRunConfigSubscriberLifetimeDoesNotReadyWhenFreshCommandProbeFails(t *te
 			return "+OK\r\n"
 		}
 	})
+	lifecycle := config.CredentialConcurrencyConfig{LifecycleConfigRevision: 9}
+	if errSet := client.SetLifecycleConfig(lifecycle); errSet != nil {
+		t.Fatal(errSet)
+	}
 	ready := make(chan struct{}, 1)
 	errRun := client.RunConfigSubscriberLifetime(context.Background(), func([]byte) error { return nil }, func() { ready <- struct{}{} })
 	if errRun == nil {
@@ -1999,6 +2003,21 @@ func TestRunConfigSubscriberLifetimeDoesNotReadyWhenFreshCommandProbeFails(t *te
 	client.mu.Unlock()
 	if commandClient != nil || subscriptionClient != nil {
 		t.Fatalf("clients retained after fresh command probe failure: command=%v subscription=%v", commandClient != nil, subscriptionClient != nil)
+	}
+	if got := recoveryState(client.recoveryState.Load()); got != recoveryStateTakeoverEligible {
+		t.Fatalf("recovery state = %d, want %d", got, recoveryStateTakeoverEligible)
+	}
+	if got := findRedisCommand(commands.All(), "SUBSCRIBE"); !reflect.DeepEqual(got, []string{"subscribe", "config", "9"}) {
+		t.Fatalf("initial SUBSCRIBE wire command = %#v, want []string{\"subscribe\", \"config\", \"9\"}", got)
+	}
+
+	next := client.NewLifetime()
+	if errSet := next.SetLifecycleConfig(lifecycle); errSet != nil {
+		t.Fatal(errSet)
+	}
+	args, _ := next.subscriptionParameters()
+	if !reflect.DeepEqual(args, []string{"config", "9", "takeover"}) {
+		t.Fatalf("replacement SUBSCRIBE args = %#v, want takeover", args)
 	}
 }
 

--- a/internal/home/client_test.go
+++ b/internal/home/client_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginstore"
@@ -153,6 +154,82 @@ func TestRefreshClusterNodesDisabledSkipsRedisCommand(t *testing.T) {
 	}
 }
 
+func TestGetConfigSkipsSecondDialAfterClusterTransportFailure(t *testing.T) {
+	client := New(config.HomeConfig{Enabled: true, Host: "127.0.0.1", Port: 1})
+	var dialMu sync.Mutex
+	dialAttempts := 0
+	options := &redis.Options{
+		Addr:                  "127.0.0.1:1",
+		DialTimeout:           time.Second,
+		MaxRetries:            -1,
+		DialerRetries:         1,
+		ContextTimeoutEnabled: true,
+		Dialer: func(context.Context, string, string) (net.Conn, error) {
+			dialMu.Lock()
+			dialAttempts++
+			dialMu.Unlock()
+			return nil, errors.New("test Home unavailable")
+		},
+	}
+	client.cmdOptions = cloneRedisOptions(options)
+	client.cmd = redis.NewClient(options)
+	t.Cleanup(client.Close)
+
+	_, errGet := client.GetConfig(context.Background())
+	if !errors.Is(errGet, errClusterDiscoveryTransport) {
+		t.Fatalf("GetConfig() error = %v, want cluster discovery transport error", errGet)
+	}
+	dialMu.Lock()
+	attempts := dialAttempts
+	dialMu.Unlock()
+	if attempts != 1 {
+		t.Fatalf("GetConfig() dial attempts = %d, want 1", attempts)
+	}
+}
+
+func TestGetConfigContinuesAfterClusterDiscoveryResponseError(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+	}{
+		{name: "protocol error", response: "-ERR cluster command unsupported\r\n"},
+		{name: "response type error", response: ":1\r\n"},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			client, commands := newRedisCommandTestClient(t, func(args []string) string {
+				switch {
+				case len(args) >= 2 && strings.EqualFold(args[0], "CLUSTER") && strings.EqualFold(args[1], "NODES"):
+					return testCase.response
+				case len(args) >= 2 && strings.EqualFold(args[0], "GET") && args[1] == redisKeyConfig:
+					payload := "host: 127.0.0.1\n"
+					return fmt.Sprintf("$%d\r\n%s\r\n", len(payload), payload)
+				default:
+					return "-ERR unexpected command\r\n"
+				}
+			})
+			client.mu.Lock()
+			client.homeCfg.DisableClusterDiscovery = false
+			client.mu.Unlock()
+
+			raw, errGet := client.GetConfig(context.Background())
+			if errGet != nil {
+				t.Fatalf("GetConfig() error = %v", errGet)
+			}
+			if string(raw) != "host: 127.0.0.1\n" {
+				t.Fatalf("GetConfig() = %q", raw)
+			}
+			if count := commands.CountCommandKey("CLUSTER", "NODES"); count != 1 {
+				t.Fatalf("CLUSTER NODES count = %d, want 1", count)
+			}
+			if count := commands.CountCommandKey("GET", redisKeyConfig); count != 1 {
+				t.Fatalf("GET config count = %d, want 1", count)
+			}
+		})
+	}
+}
+
 func TestFailoverAfterReconnectFailureDisabledDoesNotSwitchToClusterNode(t *testing.T) {
 	client := New(config.HomeConfig{
 		Enabled:                 true,
@@ -176,6 +253,11 @@ func TestFailoverAfterReconnectFailureDisabledDoesNotSwitchToClusterNode(t *test
 
 func TestNewLifetimePreservesClusterFailoverState(t *testing.T) {
 	client := New(config.HomeConfig{Enabled: true, Host: "seed.example.com", Port: 8327})
+	instanceID := client.MembershipInstanceID()
+	if _, errParse := uuid.Parse(instanceID); errParse != nil {
+		t.Fatalf("membership instance ID = %q: %v", instanceID, errParse)
+	}
+	client.EnableLegacyMembership()
 	client.mu.Lock()
 	client.homeCfg.Host = "failed.example.com"
 	client.clusterNodes = []clusterNode{
@@ -189,6 +271,12 @@ func TestNewLifetimePreservesClusterFailoverState(t *testing.T) {
 	next := client.NewLifetime()
 	if next == nil {
 		t.Fatal("NewLifetime() = nil")
+	}
+	if next.MembershipInstanceID() != instanceID || !next.LegacyMembership() {
+		t.Fatalf("membership state = instance %q legacy %t, want %q true", next.MembershipInstanceID(), next.LegacyMembership(), instanceID)
+	}
+	if fresh := New(config.HomeConfig{}); fresh.MembershipInstanceID() == instanceID || fresh.LegacyMembership() {
+		t.Fatalf("fresh membership state = instance %q legacy %t", fresh.MembershipInstanceID(), fresh.LegacyMembership())
 	}
 	if got, _ := next.addr(); got != "failed.example.com:8327" {
 		t.Fatalf("addr() = %q, want failed.example.com:8327", got)
@@ -214,6 +302,91 @@ func TestNewLifetimePreservesClusterFailoverState(t *testing.T) {
 	switched, addr := next.failoverAfterReconnectFailure()
 	if !switched || addr != "healthy.example.com:8327" {
 		t.Fatalf("failover = %t, %q, want true, healthy.example.com:8327", switched, addr)
+	}
+}
+
+func TestEnsureClientsWaitsForPreviousTargetClose(t *testing.T) {
+	client := New(config.HomeConfig{Enabled: true, Host: "next.example.com", Port: 8327})
+	closing := make(chan struct{})
+	client.closing = closing
+	done := make(chan error, 1)
+	go func() {
+		done <- client.ensureClients()
+	}()
+
+	select {
+	case errEnsure := <-done:
+		t.Fatalf("ensureClients() returned before previous target closed: %v", errEnsure)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(closing)
+	select {
+	case errEnsure := <-done:
+		if errEnsure != nil {
+			t.Fatal(errEnsure)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ensureClients() did not continue after previous target closed")
+	}
+	client.Close()
+}
+
+func TestConcurrencyReleaseDoesNotOpenBeforeMembershipReady(t *testing.T) {
+	tests := []struct {
+		name  string
+		state recoveryState
+	}{
+		{name: "takeover pending", state: recoveryStateTakeoverEligible},
+		{name: "target switching", state: recoveryStateSwitching},
+		{name: "target switching with takeover", state: recoveryStateSwitchingTakeover},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			client := New(config.HomeConfig{Enabled: true, Host: "next.example.com", Port: 8327})
+			client.recoveryState.Store(uint32(testCase.state))
+			errRelease := client.PushConcurrencyRelease(context.Background(), ConcurrencyReleaseFrame{CredentialID: "cred-a", Model: "model-a", ReleaseSeq: 1})
+			if !errors.Is(errRelease, ErrNotConnected) {
+				t.Fatalf("PushConcurrencyRelease() error = %v, want %v", errRelease, ErrNotConnected)
+			}
+			client.mu.Lock()
+			releaseClient := client.release
+			client.mu.Unlock()
+			if releaseClient != nil {
+				t.Fatal("release client was opened before the membership became ready")
+			}
+		})
+	}
+}
+
+func TestAmbiguousDispatchSuppressesTakeoverForNextLifetime(t *testing.T) {
+	client := New(config.HomeConfig{Enabled: true, Host: "next.example.com", Port: 8327})
+	client.recoveryState.Store(uint32(recoveryStateSwitchingTakeover))
+	client.AbortAmbiguousDispatch()
+	if !client.AmbiguousDispatch() {
+		t.Fatal("ambiguous dispatch was not recorded")
+	}
+	client.SuppressTakeover()
+	next := client.NewLifetime()
+	if got := recoveryState(next.recoveryState.Load()); got != recoveryStateSwitching {
+		t.Fatalf("next recovery state = %d, want %d", got, recoveryStateSwitching)
+	}
+}
+
+func TestMembershipTakeoverUnavailableError(t *testing.T) {
+	if !IsMembershipTakeoverUnavailableError(errors.New("ERR membership_takeover_unavailable")) {
+		t.Fatal("takeover unavailable error was not recognized")
+	}
+	if IsMembershipTakeoverUnavailableError(errors.New("ERR wrong number of arguments for 'subscribe' command")) {
+		t.Fatal("legacy protocol error was recognized as takeover unavailable")
+	}
+	if !IsLegacyMembershipProtocolError(errors.New("ERR wrong number of arguments for 'subscribe' command")) {
+		t.Fatal("legacy protocol error was not recognized")
+	}
+	for _, errUnrelated := range []error{errors.New("ERR connection refused"), errors.New("ERR duplicate certificate"), context.DeadlineExceeded} {
+		if IsMembershipTakeoverUnavailableError(errUnrelated) || IsLegacyMembershipProtocolError(errUnrelated) {
+			t.Fatalf("unrelated error %q was classified as a membership protocol error", errUnrelated)
+		}
 	}
 }
 
@@ -361,9 +534,9 @@ func TestKVSetConditionUnmetReturnsFalse(t *testing.T) {
 	}
 }
 
-func TestKVCompareAndSwapReturnsScriptResult(t *testing.T) {
+func TestKVCompareAndSwapSendsCASCommand(t *testing.T) {
 	client, commands := newRedisCommandTestClient(t, func(args []string) string {
-		if len(args) > 0 && strings.EqualFold(args[0], "EVAL") {
+		if len(args) > 0 && strings.EqualFold(args[0], "CAS") {
 			return ":1\r\n"
 		}
 		return "-ERR unexpected command\r\n"
@@ -376,8 +549,70 @@ func TestKVCompareAndSwapReturnsScriptResult(t *testing.T) {
 	if !swapped {
 		t.Fatal("KVCompareAndSwap() swapped = false, want true")
 	}
-	if lastCommand := commands.Last(); len(lastCommand) < 2 || !strings.EqualFold(lastCommand[0], "EVAL") {
-		t.Fatalf("last command = %#v, want EVAL", lastCommand)
+	want := []string{"CAS", "key", "1", "old", "new", "PX", "1500"}
+	if lastCommand := commands.Last(); !reflect.DeepEqual(lastCommand, want) {
+		t.Fatalf("last command = %#v, want %#v", lastCommand, want)
+	}
+}
+
+func TestKVCompareAndSwapOmitsPXWithoutTTL(t *testing.T) {
+	client, commands := newRedisCommandTestClient(t, func(args []string) string {
+		if len(args) > 0 && strings.EqualFold(args[0], "CAS") {
+			return ":1\r\n"
+		}
+		return "-ERR unexpected command\r\n"
+	})
+
+	if _, errCAS := client.KVCompareAndSwap(context.Background(), "key", nil, false, []byte("new"), 0); errCAS != nil {
+		t.Fatalf("KVCompareAndSwap() error = %v", errCAS)
+	}
+	// An absent expected value is sent as an empty bulk string, and no TTL means
+	// no PX, which tells Home to store the value without an expiry.
+	want := []string{"CAS", "key", "0", "", "new"}
+	if lastCommand := commands.Last(); !reflect.DeepEqual(lastCommand, want) {
+		t.Fatalf("last command = %#v, want %#v", lastCommand, want)
+	}
+}
+
+func TestKVCompareAndSwapReportsMismatch(t *testing.T) {
+	client, _ := newRedisCommandTestClient(t, func(args []string) string {
+		if len(args) > 0 && strings.EqualFold(args[0], "CAS") {
+			return ":0\r\n"
+		}
+		return "-ERR unexpected command\r\n"
+	})
+
+	swapped, errCAS := client.KVCompareAndSwap(context.Background(), "key", []byte("old"), true, []byte("new"), time.Minute)
+	if errCAS != nil {
+		t.Fatalf("KVCompareAndSwap() error = %v", errCAS)
+	}
+	if swapped {
+		t.Fatal("KVCompareAndSwap() swapped = true, want false")
+	}
+}
+
+func TestKVCompareAndSwapLatchesUnsupportedHome(t *testing.T) {
+	client, commands := newRedisCommandTestClient(t, func(args []string) string {
+		if len(args) > 0 && strings.EqualFold(args[0], "CAS") {
+			return "-ERR unknown command 'cas'\r\n"
+		}
+		return "-ERR unexpected command\r\n"
+	})
+
+	_, errFirst := client.KVCompareAndSwap(context.Background(), "key", nil, false, []byte("new"), time.Minute)
+	if !errors.Is(errFirst, ErrCompareAndSwapUnsupported) {
+		t.Fatalf("KVCompareAndSwap() first error = %v, want ErrCompareAndSwapUnsupported", errFirst)
+	}
+	if sent := commands.CountCommandKey("CAS", "key"); sent != 1 {
+		t.Fatalf("CAS sent %d times, want 1", sent)
+	}
+
+	_, errSecond := client.KVCompareAndSwap(context.Background(), "key", nil, false, []byte("new"), time.Minute)
+	if !errors.Is(errSecond, ErrCompareAndSwapUnsupported) {
+		t.Fatalf("KVCompareAndSwap() second error = %v, want ErrCompareAndSwapUnsupported", errSecond)
+	}
+	if sent := commands.CountCommandKey("CAS", "key"); sent != 1 {
+		t.Fatalf("CAS sent %d times after latching, want 1", sent)
 	}
 }
 
@@ -1137,12 +1372,23 @@ func TestConfigSubscriberUsesAppliedLifecycleRevisionAndRebuildsCommands(t *test
 		t.Fatalf("SetLifecycleConfig() error = %v", errSet)
 	}
 	args, timeout := client.subscriptionParameters()
-	if !reflect.DeepEqual(args, []string{"config", "9"}) {
+	if !reflect.DeepEqual(args, []string{"config", "9", client.MembershipInstanceID()}) {
 		t.Fatalf("subscribe args = %#v", args)
 	}
 	if timeout != 4*time.Second {
 		t.Fatalf("receive timeout = %s", timeout)
 	}
+	client.recoveryState.Store(uint32(recoveryStateSwitchingTakeover))
+	args, _ = client.subscriptionParameters()
+	if !reflect.DeepEqual(args, []string{"config", "9", "takeover", client.MembershipInstanceID()}) {
+		t.Fatalf("takeover subscribe args = %#v", args)
+	}
+	client.EnableLegacyMembership()
+	args, _ = client.subscriptionParameters()
+	if !reflect.DeepEqual(args, []string{"config", "9"}) {
+		t.Fatalf("legacy subscribe args = %#v", args)
+	}
+	client.recoveryState.Store(uint32(recoveryStateStable))
 	client.promoteSubscription()
 	client.mu.Lock()
 	commandClient := client.cmd
@@ -1215,8 +1461,9 @@ func TestRunConfigSubscriberLifetimeReturnsAfterHeartbeatLoss(t *testing.T) {
 	client.mu.Lock()
 	client.clusterNodes = []clusterNode{{IP: "failover.example.com", Port: 8327}}
 	client.mu.Unlock()
+	client.recoveryState.Store(uint32(recoveryStateSwitchingTakeover))
 
-	ready := make(chan struct{}, 1)
+	ready := make(chan bool, 1)
 	errRun := client.RunConfigSubscriberLifetime(context.Background(), func(raw []byte) error {
 		parsed, errParse := config.ParseConfigBytes(raw)
 		if errParse != nil {
@@ -1226,12 +1473,15 @@ func TestRunConfigSubscriberLifetimeReturnsAfterHeartbeatLoss(t *testing.T) {
 			return errSet
 		}
 		return nil
-	}, func() { ready <- struct{}{} })
+	}, func() { ready <- recoveryState(client.recoveryState.Load()) == recoveryStateStable })
 	if errRun == nil {
 		t.Fatal("RunConfigSubscriberLifetime() error = nil after heartbeat loss")
 	}
 	select {
-	case <-ready:
+	case cleared := <-ready:
+		if !cleared {
+			t.Fatal("successful subscription ACK and command probe did not clear takeover state")
+		}
 	default:
 		t.Fatalf("RunConfigSubscriberLifetime() did not invoke onReady after subscription ACK: %v; commands=%#v", errRun, commands.All())
 	}
@@ -1240,6 +1490,9 @@ func TestRunConfigSubscriberLifetimeReturnsAfterHeartbeatLoss(t *testing.T) {
 	}
 	if got, _ := client.addr(); got != "failover.example.com:8327" {
 		t.Fatalf("addr() = %q, want failover.example.com:8327 after heartbeat timeout", got)
+	}
+	if got := recoveryState(client.recoveryState.Load()); got != recoveryStateSwitchingTakeover {
+		t.Fatalf("recovery state = %d, want %d", got, recoveryStateSwitchingTakeover)
 	}
 	client.mu.Lock()
 	commandClient, subscriptionClient := client.cmd, client.sub
@@ -1253,8 +1506,8 @@ func TestRunConfigSubscriberLifetimeReturnsAfterHeartbeatLoss(t *testing.T) {
 	if count := commands.CountCommandKey("SUBSCRIBE", redisChannelConfig); count != 1 {
 		t.Fatalf("SUBSCRIBE config count = %d, want 1", count)
 	}
-	if got := findRedisCommand(commands.All(), "SUBSCRIBE"); !reflect.DeepEqual(got, []string{"subscribe", "config", "1"}) {
-		t.Fatalf("SUBSCRIBE wire command = %#v, want []string{\"subscribe\", \"config\", \"1\"}", got)
+	if got := findRedisCommand(commands.All(), "SUBSCRIBE"); !reflect.DeepEqual(got, []string{"subscribe", "config", "1", "takeover", client.MembershipInstanceID()}) {
+		t.Fatalf("SUBSCRIBE wire command = %#v", got)
 	}
 }
 
@@ -1835,9 +2088,9 @@ func TestRunConfigSubscriberLifetimeRebuildsFreshCommandPoolBeforeReady(t *testi
 	}
 }
 
-func TestRunConfigSubscriberLifetimeDoesNotReadyWhenFreshCommandProbeFails(t *testing.T) {
+func TestRunConfigSubscriberLifetimePreservesTakeoverWhenFreshCommandProbeFails(t *testing.T) {
 	configPayload := "host: 127.0.0.1\n"
-	client, _ := newRedisCommandTestClient(t, func(args []string) string {
+	client, commands := newRedisCommandTestClient(t, func(args []string) string {
 		switch {
 		case len(args) >= 1 && strings.EqualFold(args[0], "HELLO"):
 			return "%6\r\n$6\r\nserver\r\n$5\r\nredis\r\n$5\r\nproto\r\n:3\r\n$2\r\nid\r\n:1\r\n$4\r\nmode\r\n$10\r\nstandalone\r\n$4\r\nrole\r\n$6\r\nmaster\r\n$7\r\nmodules\r\n*0\r\n"
@@ -1851,6 +2104,10 @@ func TestRunConfigSubscriberLifetimeDoesNotReadyWhenFreshCommandProbeFails(t *te
 			return "+OK\r\n"
 		}
 	})
+	lifecycle := config.CredentialConcurrencyConfig{LifecycleConfigRevision: 9}
+	if errSet := client.SetLifecycleConfig(lifecycle); errSet != nil {
+		t.Fatal(errSet)
+	}
 	ready := make(chan struct{}, 1)
 	errRun := client.RunConfigSubscriberLifetime(context.Background(), func([]byte) error { return nil }, func() { ready <- struct{}{} })
 	if errRun == nil {
@@ -1866,6 +2123,21 @@ func TestRunConfigSubscriberLifetimeDoesNotReadyWhenFreshCommandProbeFails(t *te
 	client.mu.Unlock()
 	if commandClient != nil || subscriptionClient != nil {
 		t.Fatalf("clients retained after fresh command probe failure: command=%v subscription=%v", commandClient != nil, subscriptionClient != nil)
+	}
+	if got := recoveryState(client.recoveryState.Load()); got != recoveryStateTakeoverEligible {
+		t.Fatalf("recovery state = %d, want %d", got, recoveryStateTakeoverEligible)
+	}
+	if got := findRedisCommand(commands.All(), "SUBSCRIBE"); !reflect.DeepEqual(got, []string{"subscribe", "config", "9", client.MembershipInstanceID()}) {
+		t.Fatalf("initial SUBSCRIBE wire command = %#v", got)
+	}
+
+	next := client.NewLifetime()
+	if errSet := next.SetLifecycleConfig(lifecycle); errSet != nil {
+		t.Fatal(errSet)
+	}
+	args, _ := next.subscriptionParameters()
+	if !reflect.DeepEqual(args, []string{"config", "9", "takeover", client.MembershipInstanceID()}) {
+		t.Fatalf("replacement SUBSCRIBE args = %#v, want takeover", args)
 	}
 }
 

--- a/internal/home/concurrency_release.go
+++ b/internal/home/concurrency_release.go
@@ -61,6 +61,17 @@ func (f *releaseFlusher) SetConfigProvider(provider func() internalconfig.Creden
 	f.signal()
 }
 
+// SetSender replaces the Home lifetime used for subsequent release attempts.
+func (f *releaseFlusher) SetSender(send func(context.Context, ConcurrencyReleaseFrame) error) {
+	if f == nil {
+		return
+	}
+	f.mu.Lock()
+	f.send = send
+	f.mu.Unlock()
+	f.signal()
+}
+
 // MarkDirty records the latest cumulative sequence for one release group and
 // returns a ticket completed when Home acknowledges that sequence.
 func (f *releaseFlusher) MarkDirty(group executionregistry.ReleaseGroup, sequence int64) *executionregistry.ReleaseTicket {
@@ -174,11 +185,12 @@ func (f *releaseFlusher) timings() releaseFlusherTimings {
 }
 
 func (f *releaseFlusher) flush(ctx context.Context) bool {
-	if f == nil || f.send == nil {
+	if f == nil {
 		return false
 	}
 
 	f.mu.Lock()
+	send := f.send
 	pending := make(map[executionregistry.ReleaseGroup]int64, len(f.groups))
 	for group, state := range f.groups {
 		if state.Latest > state.Acked {
@@ -186,10 +198,13 @@ func (f *releaseFlusher) flush(ctx context.Context) bool {
 		}
 	}
 	f.mu.Unlock()
+	if send == nil {
+		return false
+	}
 
 	failed := false
 	for group, sequence := range pending {
-		errSend := f.send(ctx, ConcurrencyReleaseFrame{
+		errSend := send(ctx, ConcurrencyReleaseFrame{
 			CredentialID: group.CredentialID,
 			Model:        group.Model,
 			ReleaseSeq:   sequence,

--- a/internal/home/concurrency_release_test.go
+++ b/internal/home/concurrency_release_test.go
@@ -474,3 +474,32 @@ func TestScopeEndBlocksDrainUntilReleaseSinkFlushesFinalSequence(t *testing.T) {
 		t.Fatalf("final flushed sequence = %d, want 1", got)
 	}
 }
+
+func TestReleaseFlusherSenderReplacementPreservesTicket(t *testing.T) {
+	flusher := newReleaseFlusher(time.Hour, time.Hour, func(context.Context, ConcurrencyReleaseFrame) error {
+		return errors.New("old Home unavailable")
+	})
+	group := executionregistry.ReleaseGroup{CredentialID: "cred-1", Model: "gpt"}
+	ticket := flusher.MarkDirty(group, 1)
+	if ticket == nil {
+		t.Fatal("MarkDirty() ticket = nil")
+	}
+	if failed := flusher.flush(context.Background()); !failed {
+		t.Fatal("old sender release attempt did not fail")
+	}
+
+	flusher.SetSender(func(_ context.Context, frame ConcurrencyReleaseFrame) error {
+		if frame.CredentialID != group.CredentialID || frame.Model != group.Model || frame.ReleaseSeq != 1 {
+			t.Fatalf("replacement sender frame = %#v", frame)
+		}
+		return nil
+	})
+	if failed := flusher.flush(context.Background()); failed {
+		t.Fatal("replacement sender release attempt failed")
+	}
+	waitCtx, cancelWait := context.WithTimeout(context.Background(), time.Second)
+	defer cancelWait()
+	if errWait := ticket.Wait(waitCtx); errWait != nil {
+		t.Fatalf("ticket did not survive sender replacement: %v", errWait)
+	}
+}

--- a/internal/logging/requestmeta.go
+++ b/internal/logging/requestmeta.go
@@ -10,6 +10,14 @@ import (
 type endpointKey struct{}
 type responseStatusKey struct{}
 type responseHeadersKey struct{}
+type clientRequestMetadataKey struct{}
+
+// ClientRequestMetadata stores immutable downstream request metadata for asynchronous consumers.
+type ClientRequestMetadata struct {
+	ClientIP      string
+	XForwardedFor string
+	UserAgent     string
+}
 
 type responseStatusHolder struct {
 	status atomic.Int32
@@ -35,6 +43,25 @@ func GetEndpoint(ctx context.Context) string {
 		return endpoint
 	}
 	return ""
+}
+
+// WithClientRequestMetadata stores a snapshot of downstream request metadata in ctx.
+func WithClientRequestMetadata(ctx context.Context, metadata ClientRequestMetadata) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, clientRequestMetadataKey{}, metadata)
+}
+
+// GetClientRequestMetadata returns downstream request metadata stored in ctx.
+func GetClientRequestMetadata(ctx context.Context) ClientRequestMetadata {
+	if ctx == nil {
+		return ClientRequestMetadata{}
+	}
+	if metadata, ok := ctx.Value(clientRequestMetadataKey{}).(ClientRequestMetadata); ok {
+		return metadata
+	}
+	return ClientRequestMetadata{}
 }
 
 func WithResponseStatusHolder(ctx context.Context) context.Context {

--- a/internal/modelconfig/model_hash.go
+++ b/internal/modelconfig/model_hash.go
@@ -1,0 +1,125 @@
+package modelconfig
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+// ComputeOpenAICompatModelsHash returns a stable hash for OpenAI-compatible models.
+func ComputeOpenAICompatModelsHash(models []config.OpenAICompatibilityModel) string {
+	keys := modelRoutingKeys(func(out func(key string)) {
+		for _, model := range models {
+			name := strings.TrimSpace(model.Name)
+			alias := strings.TrimSpace(model.Alias)
+			if name == "" && alias == "" {
+				continue
+			}
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("image=%t", model.Image) + "|" + fmt.Sprintf("force-mapping=%t", model.ForceMapping) + "|input=" + strings.Join(normalizeModalities(model.InputModalities), ",") + "|output=" + strings.Join(normalizeModalities(model.OutputModalities), ",") + thinkingHashSuffix(model.Thinking))
+		}
+	})
+	return hashJoined(keys)
+}
+
+// ComputeVertexCompatModelsHash returns a stable hash for Vertex-compatible models.
+func ComputeVertexCompatModelsHash(models []config.VertexCompatModel) string {
+	keys := modelRoutingKeys(func(out func(key string)) {
+		for _, model := range models {
+			name := strings.TrimSpace(model.Name)
+			alias := strings.TrimSpace(model.Alias)
+			if name == "" && alias == "" {
+				continue
+			}
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("force-mapping=%t", model.ForceMapping) + thinkingHashSuffix(model.Thinking))
+		}
+	})
+	return hashJoined(keys)
+}
+
+// ComputeClaudeModelsHash returns a stable hash for Claude model aliases.
+func ComputeClaudeModelsHash(models []config.ClaudeModel) string {
+	keys := modelRoutingKeys(func(out func(key string)) {
+		for _, model := range models {
+			name := strings.TrimSpace(model.Name)
+			alias := strings.TrimSpace(model.Alias)
+			if name == "" && alias == "" {
+				continue
+			}
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("force-mapping=%t", model.ForceMapping) + thinkingHashSuffix(model.Thinking))
+		}
+	})
+	return hashJoined(keys)
+}
+
+// ComputeCodexModelsHash returns a stable hash for Codex model aliases.
+func ComputeCodexModelsHash(models []config.CodexModel) string {
+	keys := modelRoutingKeys(func(out func(key string)) {
+		for _, model := range models {
+			name := strings.TrimSpace(model.Name)
+			alias := strings.TrimSpace(model.Alias)
+			if name == "" && alias == "" {
+				continue
+			}
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("force-mapping=%t", model.ForceMapping) + thinkingHashSuffix(model.Thinking))
+		}
+	})
+	return hashJoined(keys)
+}
+
+// ComputeGeminiModelsHash returns a stable hash for Gemini model aliases.
+func ComputeGeminiModelsHash(models []config.GeminiModel) string {
+	keys := modelRoutingKeys(func(out func(key string)) {
+		for _, model := range models {
+			name := strings.TrimSpace(model.Name)
+			alias := strings.TrimSpace(model.Alias)
+			if name == "" && alias == "" {
+				continue
+			}
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("force-mapping=%t", model.ForceMapping) + thinkingHashSuffix(model.Thinking))
+		}
+	})
+	return hashJoined(keys)
+}
+
+func normalizeModalities(raw []string) []string {
+	seen := make(map[string]struct{}, len(raw))
+	out := make([]string, 0, len(raw))
+	for _, value := range raw {
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func thinkingHashSuffix(support *registry.ThinkingSupport) string {
+	data, _ := json.Marshal(support)
+	return "|thinking=" + string(data)
+}
+
+func modelRoutingKeys(collect func(out func(key string))) []string {
+	keys := make([]string, 0)
+	collect(func(key string) {
+		keys = append(keys, key)
+	})
+	return keys
+}
+
+func hashJoined(keys []string) string {
+	if len(keys) == 0 {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(strings.Join(keys, "\n")))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/modelconfig/model_info.go
+++ b/internal/modelconfig/model_info.go
@@ -1,0 +1,55 @@
+package modelconfig
+
+import (
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+)
+
+// ResolveModelInfo returns a private capability snapshot for a configured model.
+// Static capabilities come from the suffix-free upstream name, while explicit
+// configuration takes precedence.
+func ResolveModelInfo(name, modelType string, support *registry.ThinkingSupport) *registry.ModelInfo {
+	trimmedName := strings.TrimSpace(name)
+	baseName := strings.TrimSpace(thinking.ParseSuffix(trimmedName).ModelName)
+	info := registry.LookupStaticModelInfo(baseName)
+	if info == nil {
+		info = &registry.ModelInfo{}
+	}
+	info.ID = trimmedName
+	info.Type = strings.TrimSpace(modelType)
+	if support != nil {
+		info.Thinking = NormalizeThinkingSupport(support)
+	}
+	info.UserDefined = false
+	return info
+}
+
+// NormalizeThinkingSupport clones and normalizes configured reasoning levels.
+func NormalizeThinkingSupport(raw *registry.ThinkingSupport) *registry.ThinkingSupport {
+	if raw == nil {
+		return nil
+	}
+	normalized := *raw
+	normalized.Levels = nil
+	seen := make(map[string]struct{}, len(raw.Levels))
+	for _, value := range raw.Levels {
+		level := strings.ToLower(strings.TrimSpace(value))
+		if level == "" {
+			continue
+		}
+		switch level {
+		case "none":
+			normalized.ZeroAllowed = true
+		case "auto":
+			normalized.DynamicAllowed = true
+		}
+		if _, exists := seen[level]; exists {
+			continue
+		}
+		seen[level] = struct{}{}
+		normalized.Levels = append(normalized.Levels, level)
+	}
+	return &normalized
+}

--- a/internal/modelconfig/model_info_test.go
+++ b/internal/modelconfig/model_info_test.go
@@ -1,0 +1,61 @@
+package modelconfig
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+func TestResolveModelInfoUsesSuffixFreeStaticCapabilities(t *testing.T) {
+	info := ResolveModelInfo("claude-opus-4-6(high)", "claude", nil)
+	if info == nil || info.Thinking == nil {
+		t.Fatalf("ResolveModelInfo() = %+v, want inherited thinking support", info)
+	}
+	if info.ID != "claude-opus-4-6(high)" {
+		t.Fatalf("model ID = %q, want configured upstream name", info.ID)
+	}
+	if info.UserDefined {
+		t.Fatal("resolved capability snapshot must not be user-defined")
+	}
+}
+
+func TestResolveModelInfoExplicitThinkingOverridesAndClones(t *testing.T) {
+	support := &registry.ThinkingSupport{Levels: []string{" XHIGH ", "xhigh", " High "}}
+	info := ResolveModelInfo("custom-model", "codex", support)
+	if info == nil || info.Thinking == nil {
+		t.Fatalf("ResolveModelInfo() = %+v, want explicit thinking support", info)
+	}
+	if got := info.Thinking.Levels; len(got) != 2 || got[0] != "xhigh" || got[1] != "high" {
+		t.Fatalf("normalized levels = %v, want [xhigh high]", got)
+	}
+	support.Levels[0] = "low"
+	if info.Thinking.Levels[0] != "xhigh" {
+		t.Fatal("resolved thinking support shares mutable config storage")
+	}
+}
+
+func TestNormalizeThinkingSupportDerivesSpecialLevelFlags(t *testing.T) {
+	support := NormalizeThinkingSupport(&registry.ThinkingSupport{Levels: []string{"low", "none", "auto"}})
+	if support == nil {
+		t.Fatal("NormalizeThinkingSupport() = nil")
+	}
+	if !support.ZeroAllowed {
+		t.Fatal("none level did not enable ZeroAllowed")
+	}
+	if !support.DynamicAllowed {
+		t.Fatal("auto level did not enable DynamicAllowed")
+	}
+}
+
+func TestResolveModelInfoUnknownModelKeepsMissingCapability(t *testing.T) {
+	info := ResolveModelInfo("unknown-configured-model", "claude", nil)
+	if info == nil {
+		t.Fatal("ResolveModelInfo() = nil")
+	}
+	if info.Thinking != nil {
+		t.Fatalf("unknown model thinking = %+v, want nil", info.Thinking)
+	}
+	if info.UserDefined {
+		t.Fatal("unknown configured model must use its exact bound capability")
+	}
+}

--- a/internal/pluginhost/auth_callbacks.go
+++ b/internal/pluginhost/auth_callbacks.go
@@ -351,6 +351,9 @@ func (h *Host) buildAuthFromFileData(path string, data []byte) (*coreauth.Auth, 
 			auth.Runtime = existing.Runtime
 		}
 	}
+	if errWeight := coreauth.ValidateAuthWeight(auth); errWeight != nil {
+		return nil, fmt.Errorf("invalid auth weight: %w", errWeight)
+	}
 	coreauth.ApplyCustomHeadersFromMetadata(auth)
 	return auth, nil
 }

--- a/internal/pluginhost/auth_callbacks_test.go
+++ b/internal/pluginhost/auth_callbacks_test.go
@@ -211,6 +211,34 @@ func TestHostAuthGetRuntimeCallbackReturnsRuntimeInfo(t *testing.T) {
 	}
 }
 
+func TestHostAuthSaveCallbackRejectsInvalidWeightBeforePersistence(t *testing.T) {
+	for _, rawWeight := range []string{`1.5`, `1000001`, `9223372036854775808`, `"invalid"`} {
+		t.Run(rawWeight, func(t *testing.T) {
+			authDir := t.TempDir()
+			host := New()
+			host.runtimeConfig = &config.Config{AuthDir: authDir}
+			host.SetAuthManager(coreauth.NewManager(nil, nil, nil))
+
+			req, errMarshal := json.Marshal(pluginapi.HostAuthSaveRequest{
+				Name: "invalid.json",
+				JSON: json.RawMessage(`{"type":"demo","weight":` + rawWeight + `}`),
+			})
+			if errMarshal != nil {
+				t.Fatalf("marshal request: %v", errMarshal)
+			}
+			if _, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAuthSave, req); errCall == nil {
+				t.Fatal("host.auth.save accepted an invalid weight")
+			}
+			if _, errStat := os.Stat(filepath.Join(authDir, "invalid.json")); !os.IsNotExist(errStat) {
+				t.Fatalf("invalid auth file was persisted: %v", errStat)
+			}
+			if auths := host.currentAuthManager().List(); len(auths) != 0 {
+				t.Fatalf("invalid auth was registered: %#v", auths)
+			}
+		})
+	}
+}
+
 func TestHostAuthSaveCallbackWritesPhysicalFile(t *testing.T) {
 	authDir := t.TempDir()
 	host := New()

--- a/internal/pluginhost/auth_callbacks_test.go
+++ b/internal/pluginhost/auth_callbacks_test.go
@@ -248,6 +248,34 @@ func TestHostAuthGetRuntimeCallbackReturnsRuntimeInfo(t *testing.T) {
 	}
 }
 
+func TestHostAuthSaveCallbackRejectsInvalidWeightBeforePersistence(t *testing.T) {
+	for _, rawWeight := range []string{`1.5`, `1000001`, `9223372036854775808`, `"invalid"`} {
+		t.Run(rawWeight, func(t *testing.T) {
+			authDir := t.TempDir()
+			host := New()
+			host.runtimeConfig = &config.Config{AuthDir: authDir}
+			host.SetAuthManager(coreauth.NewManager(nil, nil, nil))
+
+			req, errMarshal := json.Marshal(pluginapi.HostAuthSaveRequest{
+				Name: "invalid.json",
+				JSON: json.RawMessage(`{"type":"demo","weight":` + rawWeight + `}`),
+			})
+			if errMarshal != nil {
+				t.Fatalf("marshal request: %v", errMarshal)
+			}
+			if _, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAuthSave, req); errCall == nil {
+				t.Fatal("host.auth.save accepted an invalid weight")
+			}
+			if _, errStat := os.Stat(filepath.Join(authDir, "invalid.json")); !os.IsNotExist(errStat) {
+				t.Fatalf("invalid auth file was persisted: %v", errStat)
+			}
+			if auths := host.currentAuthManager().List(); len(auths) != 0 {
+				t.Fatalf("invalid auth was registered: %#v", auths)
+			}
+		})
+	}
+}
+
 func TestHostAuthSaveCallbackWritesPhysicalFile(t *testing.T) {
 	authDir := t.TempDir()
 	host := New()

--- a/internal/redisqueue/plugin.go
+++ b/internal/redisqueue/plugin.go
@@ -64,6 +64,7 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 		serviceTier = coreusage.ServiceTierFromContext(ctx)
 	}
 	responseServiceTier := strings.TrimSpace(record.ResponseServiceTier)
+	clientRequestMetadata := internallogging.GetClientRequestMetadata(ctx)
 
 	usageDetail := coreusage.EnsureTokenBreakdownForProvider(record.Detail, record.Provider, record.ExecutorType)
 	tokens := tokenStats{
@@ -89,6 +90,9 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 		TTFTMs:          record.TTFT.Milliseconds(),
 		Source:          record.Source,
 		AuthIndex:       record.AuthIndex,
+		ClientIP:        clientRequestMetadata.ClientIP,
+		XForwardedFor:   clientRequestMetadata.XForwardedFor,
+		UserAgent:       clientRequestMetadata.UserAgent,
 		Tokens:          tokens,
 		Failed:          failed,
 		Generate:        coreusage.GenerateEnabled(record.Generate),
@@ -141,6 +145,9 @@ type requestDetail struct {
 	TTFTMs          int64       `json:"ttft_ms"`
 	Source          string      `json:"source"`
 	AuthIndex       string      `json:"auth_index"`
+	ClientIP        string      `json:"client_ip"`
+	XForwardedFor   string      `json:"x_forwarded_for"`
+	UserAgent       string      `json:"user_agent"`
 	Tokens          tokenStats  `json:"tokens"`
 	Failed          bool        `json:"failed"`
 	Generate        bool        `json:"generate"`

--- a/internal/redisqueue/plugin.go
+++ b/internal/redisqueue/plugin.go
@@ -70,6 +70,7 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 	}
 	responseServiceTier := strings.TrimSpace(record.ResponseServiceTier)
 	effectiveServiceTier := coreusage.CanonicalEffectiveServiceTier(record.EffectiveServiceTier)
+	clientRequestMetadata := internallogging.GetClientRequestMetadata(ctx)
 
 	usageDetail := coreusage.EnsureTokenBreakdownForProvider(record.Detail, record.Provider, record.ExecutorType)
 	tokens := tokenStats{
@@ -101,6 +102,9 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 		TTFTMs:          record.TTFT.Milliseconds(),
 		Source:          record.Source,
 		AuthIndex:       record.AuthIndex,
+		ClientIP:        clientRequestMetadata.ClientIP,
+		XForwardedFor:   clientRequestMetadata.XForwardedFor,
+		UserAgent:       clientRequestMetadata.UserAgent,
 		Tokens:          tokens,
 		Failed:          failed,
 		Generate:        coreusage.GenerateEnabled(record.Generate),
@@ -157,6 +161,9 @@ type requestDetail struct {
 	TTFTMs          int64       `json:"ttft_ms"`
 	Source          string      `json:"source"`
 	AuthIndex       string      `json:"auth_index"`
+	ClientIP        string      `json:"client_ip"`
+	XForwardedFor   string      `json:"x_forwarded_for"`
+	UserAgent       string      `json:"user_agent"`
 	Tokens          tokenStats  `json:"tokens"`
 	Failed          bool        `json:"failed"`
 	Generate        bool        `json:"generate"`

--- a/internal/redisqueue/plugin_test.go
+++ b/internal/redisqueue/plugin_test.go
@@ -17,6 +17,11 @@ func TestUsageQueuePluginPayloadIncludesStableFieldsAndSuccess(t *testing.T) {
 	withEnabledQueue(t, func() {
 		ctx := internallogging.WithRequestID(context.Background(), "ctx-request-id")
 		ctx = internallogging.WithEndpoint(ctx, "POST /v1/chat/completions")
+		ctx = internallogging.WithClientRequestMetadata(ctx, internallogging.ClientRequestMetadata{
+			ClientIP:      "192.0.2.10",
+			XForwardedFor: "203.0.113.5, 198.51.100.8",
+			UserAgent:     "test-client/1.0",
+		})
 		ctx = internallogging.WithResponseStatusHolder(ctx)
 		internallogging.SetResponseStatus(ctx, http.StatusOK)
 		responseHeaders := http.Header{}
@@ -57,6 +62,9 @@ func TestUsageQueuePluginPayloadIncludesStableFieldsAndSuccess(t *testing.T) {
 		requireStringField(t, payload, "auth_type", "apikey")
 		requireMissingField(t, payload, "user_api_key")
 		requireStringField(t, payload, "request_id", "ctx-request-id")
+		requireStringField(t, payload, "client_ip", "192.0.2.10")
+		requireStringField(t, payload, "x_forwarded_for", "203.0.113.5, 198.51.100.8")
+		requireStringField(t, payload, "user_agent", "test-client/1.0")
 		requireStringField(t, payload, "reasoning_effort", "medium")
 		requireStringField(t, payload, "service_tier", "auto")
 		requireMissingField(t, payload, "request_service_tier")

--- a/internal/redisqueue/plugin_test.go
+++ b/internal/redisqueue/plugin_test.go
@@ -18,6 +18,11 @@ func TestUsageQueuePluginPayloadIncludesStableFieldsAndSuccess(t *testing.T) {
 	withEnabledQueue(t, func() {
 		ctx := internallogging.WithRequestID(context.Background(), "ctx-request-id")
 		ctx = internallogging.WithEndpoint(ctx, "POST /v1/chat/completions")
+		ctx = internallogging.WithClientRequestMetadata(ctx, internallogging.ClientRequestMetadata{
+			ClientIP:      "192.0.2.10",
+			XForwardedFor: "203.0.113.5, 198.51.100.8",
+			UserAgent:     "test-client/1.0",
+		})
 		ctx = internallogging.WithResponseStatusHolder(ctx)
 		internallogging.SetResponseStatus(ctx, http.StatusOK)
 		responseHeaders := http.Header{}
@@ -59,6 +64,9 @@ func TestUsageQueuePluginPayloadIncludesStableFieldsAndSuccess(t *testing.T) {
 		requireStringField(t, payload, "auth_type", "apikey")
 		requireMissingField(t, payload, "user_api_key")
 		requireStringField(t, payload, "request_id", "ctx-request-id")
+		requireStringField(t, payload, "client_ip", "192.0.2.10")
+		requireStringField(t, payload, "x_forwarded_for", "203.0.113.5, 198.51.100.8")
+		requireStringField(t, payload, "user_agent", "test-client/1.0")
 		requireStringField(t, payload, "reasoning_effort", "medium")
 		requireStringField(t, payload, "service_tier", "auto")
 		requireStringField(t, payload, "request_service_tier", "auto")

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -2618,29 +2618,6 @@
       }
     },
     {
-      "id": "gemini-3.5-flash-lite",
-      "object": "model",
-      "owned_by": "antigravity",
-      "type": "antigravity",
-      "display_name": "Gemini 3.5 Flash Lite",
-      "name": "gemini-3.5-flash-lite",
-      "description": "Gemini 3.5 Flash Lite",
-      "context_length": 1048576,
-      "max_completion_tokens": 65535,
-      "thinking": {
-        "min": 1,
-        "max": 65535,
-        "zero_allowed": true,
-        "dynamic_allowed": true,
-        "levels": [
-          "minimal",
-          "low",
-          "medium",
-          "high"
-        ]
-      }
-    },
-    {
       "id": "gemini-3.5-flash-low",
       "object": "model",
       "owned_by": "antigravity",

--- a/internal/runtime/executor/antigravity_executor_execute.go
+++ b/internal/runtime/executor/antigravity_executor_execute.go
@@ -217,8 +217,8 @@ attemptLoop:
 					}
 				}
 				if errClear := clearAntigravityReasoningReplayOnInvalidSignature(ctx, replayScope, httpResp.StatusCode, bodyBytes); errClear != nil {
-					err = errClear
-					return resp, err
+					// Report the upstream failure rather than the cleanup failure.
+					logAntigravityReasoningReplayDegraded(replayScope, "invalidate", errClear)
 				}
 				err = newAntigravityStatusErr(httpResp.StatusCode, bodyBytes)
 				return resp, err
@@ -452,8 +452,8 @@ attemptLoop:
 					}
 				}
 				if errClear := clearAntigravityReasoningReplayOnInvalidSignature(ctx, replayScope, httpResp.StatusCode, bodyBytes); errClear != nil {
-					err = errClear
-					return resp, err
+					// Report the upstream failure rather than the cleanup failure.
+					logAntigravityReasoningReplayDegraded(replayScope, "invalidate", errClear)
 				}
 				err = newAntigravityStatusErr(httpResp.StatusCode, bodyBytes)
 				return resp, err

--- a/internal/runtime/executor/antigravity_executor_request.go
+++ b/internal/runtime/executor/antigravity_executor_request.go
@@ -173,24 +173,33 @@ func sanitizeAntigravityRequestSchemas(payloadStr string, useAntigravitySchema b
 		payloadStr = renamed
 	}
 
-	clean := util.CleanJSONSchemaForGemini
+	toolSchemaCleaner := util.CleanJSONSchemaForGemini
 	if useAntigravitySchema {
-		clean = util.CleanJSONSchemaForAntigravity
+		toolSchemaCleaner = util.CleanJSONSchemaForAntigravity
 	}
+	responseSchemaCleaner := util.CleanJSONSchemaForAntigravityResponse
 
-	for _, schemaPath := range antigravitySchemaPaths(payloadStr) {
+	cleanNestedToolSchema := func(schemaRaw string) string {
+		return cleanNestedSchema(toolSchemaCleaner, schemaRaw)
+	}
+	payloadStr = cleanAntigravitySchemasAtPaths(payloadStr, antigravityDeclarationSchemaPaths(payloadStr), cleanNestedToolSchema)
+	payloadStr = cleanAntigravitySchemasAtPaths(payloadStr, antigravityGenerationSchemaPaths(payloadStr), responseSchemaCleaner)
+	return payloadStr
+}
+
+func cleanAntigravitySchemasAtPaths(payloadStr string, schemaPaths []string, clean func(string) string) string {
+	for _, schemaPath := range schemaPaths {
 		schema := gjson.Get(payloadStr, schemaPath)
 		if !schema.Exists() {
 			continue
 		}
-		updated, errSet := sjson.SetRawBytes([]byte(payloadStr), schemaPath, []byte(cleanNestedSchema(clean, schema.Raw)))
+		updated, errSet := sjson.SetRawBytes([]byte(payloadStr), schemaPath, []byte(clean(schema.Raw)))
 		if errSet != nil {
 			log.Debugf("antigravity: failed to write cleaned schema at %s: %v", schemaPath, errSet)
 			continue
 		}
 		payloadStr = string(updated)
 	}
-
 	return payloadStr
 }
 
@@ -241,7 +250,12 @@ func antigravityFunctionDeclarationPaths(payloadStr string) []string {
 // A function declaration may carry a schema for its parameters and for its result, so all of
 // them must be cleaned; anything omitted here reaches the upstream API uncleaned.
 func antigravitySchemaPaths(payloadStr string) []string {
-	paths := make([]string, 0, 12)
+	paths := antigravityDeclarationSchemaPaths(payloadStr)
+	return append(paths, antigravityGenerationSchemaPaths(payloadStr)...)
+}
+
+func antigravityDeclarationSchemaPaths(payloadStr string) []string {
+	paths := make([]string, 0, 8)
 	for _, base := range antigravityFunctionDeclarationPaths(payloadStr) {
 		for _, key := range antigravityDeclarationSchemaKeys {
 			if gjson.Get(payloadStr, base+"."+key).IsObject() {
@@ -249,11 +263,16 @@ func antigravitySchemaPaths(payloadStr string) []string {
 			}
 		}
 	}
+	return paths
+}
+
+func antigravityGenerationSchemaPaths(payloadStr string) []string {
+	paths := make([]string, 0, len(antigravityGenerationConfigContainers)*len(antigravityGenerationSchemaKeys))
 	for _, container := range antigravityGenerationConfigContainers {
 		for _, key := range antigravityGenerationSchemaKeys {
-			p := container + "." + key
-			if gjson.Get(payloadStr, p).IsObject() {
-				paths = append(paths, p)
+			path := container + "." + key
+			if gjson.Get(payloadStr, path).IsObject() {
+				paths = append(paths, path)
 			}
 		}
 	}

--- a/internal/runtime/executor/antigravity_executor_stream.go
+++ b/internal/runtime/executor/antigravity_executor_stream.go
@@ -225,8 +225,8 @@ attemptLoop:
 					}
 				}
 				if errClear := clearAntigravityReasoningReplayOnInvalidSignature(ctx, replayScope, httpResp.StatusCode, bodyBytes); errClear != nil {
-					err = errClear
-					return nil, err
+					// Report the upstream failure rather than the cleanup failure.
+					logAntigravityReasoningReplayDegraded(replayScope, "invalidate", errClear)
 				}
 				err = newAntigravityStatusErr(httpResp.StatusCode, bodyBytes)
 				return nil, err

--- a/internal/runtime/executor/antigravity_reasoning_replay.go
+++ b/internal/runtime/executor/antigravity_reasoning_replay.go
@@ -5,19 +5,53 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
 
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
+	homekv "github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	internalsignature "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
+
+// antigravityReplayLogKey returns a short, non-reversible tag for a replay
+// identifier. Session keys and tool call IDs are never logged verbatim.
+func antigravityReplayLogKey(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(value))
+	return fmt.Sprintf("%x", sum[:8])
+}
+
+// antigravityCountClaudeToolProvenanceIDs reports how many reserved
+// Claude-facing provenance IDs are still present in a Gemini-shaped payload.
+func antigravityCountClaudeToolProvenanceIDs(payload []byte) int {
+	count := 0
+	contents := gjson.GetBytes(payload, "request.contents")
+	if !contents.IsArray() {
+		return 0
+	}
+	for _, content := range contents.Array() {
+		for _, part := range content.Get("parts").Array() {
+			for _, path := range []string{"functionCall.id", "functionResponse.id"} {
+				if util.IsGeminiClaudeToolUseID(part.Get(path).String()) {
+					count++
+				}
+			}
+		}
+	}
+	return count
+}
 
 type antigravityReasoningReplayScope struct {
 	modelName     string
@@ -198,23 +232,57 @@ func antigravityReasoningReplayResolveContentIndex(payload []byte, cached int) i
 	return -1
 }
 
+// logAntigravityReasoningReplayDegraded reports that a replay-state operation
+// failed and the request continued without it. A Home that predates the CAS
+// command fails every call, and the Home client already warns once about that,
+// so those are logged at debug level to avoid one warning per request.
+func logAntigravityReasoningReplayDegraded(scope antigravityReasoningReplayScope, stage string, err error) {
+	if err == nil {
+		return
+	}
+	if errors.Is(err, homekv.ErrCompareAndSwapUnsupported) {
+		log.Debugf("antigravity executor: reasoning replay %s unavailable on this Home (session=%s): %v",
+			stage, antigravityReplayLogKey(scope.sessionKey), err)
+		return
+	}
+	log.Warnf("antigravity executor: reasoning replay %s failed; continuing without replay (session=%s): %v",
+		stage, antigravityReplayLogKey(scope.sessionKey), err)
+}
+
 func prepareAntigravityGeminiReasoningReplayPayload(ctx context.Context, modelName string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, payload []byte) ([]byte, antigravityReasoningReplayScope, error) {
 	if !antigravityUsesReasoningReplayCache(modelName) {
 		return payload, antigravityReasoningReplayScope{}, nil
 	}
 	updated, scope, replayApplied, errReplay := applyAntigravityReasoningReplayCache(ctx, modelName, req, opts, payload)
 	if errReplay != nil {
-		return payload, scope, errReplay
+		// Replay state is an optimization, not a correctness requirement: a ledger
+		// miss is already a tolerated outcome below. Failing the request here would
+		// surface as an untyped executor error, which MarkResult treats as a
+		// credential fault and uses to mark every candidate credential unavailable.
+		// Degrade to "no replay this turn" instead.
+		logAntigravityReasoningReplayDegraded(scope, "read", errReplay)
+		updated = payload
 	}
 	updated = normalizeAntigravityGeminiFunctionResponseRoles(updated)
 	if antigravityPayloadHasClaudeToolProvenanceID(updated) {
-		return payload, scope, statusErr{code: http.StatusBadRequest, msg: "antigravity executor: missing Claude tool provenance; start a new session or restore replay state"}
+		// The replay ledger could not resolve every tool ID — the session lane
+		// changed, the entry expired, the process restarted, or a turn never
+		// committed. Degrade those calls instead of killing the conversation.
+		degradedPayload, degradedCount := degradeAntigravityClaudeToolProvenanceIDs(updated)
+		log.Warnf("antigravity executor: replay state missing for %d tool ID(s); rewriting them to synthetic IDs and continuing without reasoning replay for those calls", degradedCount)
+		updated = degradedPayload
 	}
+	// An identity-only restore drops the cached signature, which can leave a model
+	// turn's first function call unsigned. Gemini rejects that, so re-assert the
+	// invariant the pre-replay sanitizer established.
+	updated = antigravityRepairUnsignedFirstFunctionCalls(updated)
 	if errPairing := internalsignature.ValidateGeminiFunctionCallPairing(updated); errPairing != nil {
 		originalPairingValid := internalsignature.ValidateGeminiFunctionCallPairing(payload) == nil
 		if replayApplied && originalPairingValid && scope.valid() {
 			if _, errDelete := internalcache.DeleteAntigravityReasoningReplayItemsIfUnchanged(ctx, scope.modelName, scope.sessionKey, scope.cacheSnapshot); errDelete != nil {
-				return payload, scope, errDelete
+				// Invalidation is best-effort cleanup. Returning it here would replace
+				// the pairing diagnosis below with an untyped error.
+				logAntigravityReasoningReplayDegraded(scope, "invalidate", errDelete)
 			}
 		}
 		return payload, scope, statusErr{code: http.StatusBadRequest, msg: fmt.Sprintf("antigravity executor: invalid Gemini function call history: %v", errPairing)}
@@ -244,7 +312,15 @@ func applyAntigravityReasoningReplayCache(ctx context.Context, modelName string,
 	}
 	items, snapshot, ok, err := internalcache.GetAntigravityReasoningReplayItemsWithSnapshotRequired(ctx, scope.modelName, scope.sessionKey)
 	scope.cacheSnapshot = snapshot
+	reservedBefore := antigravityCountClaudeToolProvenanceIDs(payload)
 	if err != nil || !ok || len(items) == 0 {
+		// A ledger miss on a payload that still carries reserved provenance IDs is
+		// the signature of a session/lane switch, cache expiry, or a turn that never
+		// committed. Log it so the two failure families stay distinguishable.
+		if reservedBefore > 0 {
+			log.Debugf("antigravity replay: ledger miss with %d reserved tool provenance ID(s) present (session=%s found=%t)",
+				reservedBefore, antigravityReplayLogKey(scope.sessionKey), ok)
+		}
 		return payload, scope, false, err
 	}
 	updated := payload
@@ -264,6 +340,11 @@ func applyAntigravityReasoningReplayCache(ctx context.Context, modelName string,
 		}
 		updated = next
 		changed = true
+	}
+	if reservedBefore > 0 {
+		log.Debugf("antigravity replay: ledger items=%d reserved before=%d after=%d applied=%t (session=%s)",
+			len(items), reservedBefore, antigravityCountClaudeToolProvenanceIDs(updated), changed,
+			antigravityReplayLogKey(scope.sessionKey))
 	}
 	if !changed {
 		return payload, scope, false, nil
@@ -290,6 +371,11 @@ func filterAntigravityReasoningReplayItemsForRequestWithSchemas(payload []byte, 
 				if !needsNativeRestore && (signature == "" || antigravityHasNativeThoughtSignature(part.Get("thoughtSignature").String())) {
 					continue
 				}
+				break
+			}
+			// Even without a context match, an exact opaque ID match can still
+			// restore the native call identity.
+			if _, _, foundProvenance := antigravityFunctionCallProvenanceLocation(payload, itemResult, toolSchemas); foundProvenance {
 				break
 			}
 			callID := strings.TrimSpace(itemResult.Get("call_id").String())
@@ -530,7 +616,15 @@ func antigravityFunctionCallPartLocationForReplayWithSchemas(payload []byte, ite
 			if antigravityFunctionCallMatchesReplayItem(fc, itemResult, toolSchemas) {
 				return ci, pi, true
 			}
+			log.Debugf("antigravity replay: located call %q at contents[%d].parts[%d] but name/args did not match ledger item (opaque_id=%t)",
+				name, ci, pi, util.IsGeminiClaudeToolUseID(candidateID))
+			return -1, -1, false
 		}
+		// The candidate ID matched exactly, so callID+name+args are already proven
+		// identical. Only the surrounding context drifted, which invalidates the
+		// cached signature but not the tool identity.
+		log.Debugf("antigravity replay: exact tool ID match for %q at contents[%d].parts[%d] rejected by context hash (opaque_id=%t)",
+			name, ci, pi, util.IsGeminiClaudeToolUseID(candidateID))
 		return -1, -1, false
 	}
 	contents := gjson.GetBytes(payload, "request.contents")
@@ -577,6 +671,37 @@ func antigravityFunctionCallPartLocationForReplayWithSchemas(payload []byte, ite
 		return matches[0][0], matches[0][1], true
 	}
 	return -1, -1, false
+}
+
+// antigravityFunctionCallProvenanceLocation locates the function call whose
+// Claude-facing opaque ID was derived from this exact ledger item.
+//
+// The opaque ID is sha256(call_id, name, args), so an exact match already proves
+// that the call ID, tool name and arguments are identical to the provider-native
+// call. The surrounding context hash adds nothing to that proof; it only decides
+// whether the cached thoughtSignature is still valid. Callers therefore use this
+// to recover tool identity after the context has drifted, without replaying any
+// signature.
+func antigravityFunctionCallProvenanceLocation(payload []byte, itemResult gjson.Result, toolSchemas map[string]any) (contentIndex int, partIndex int, ok bool) {
+	name := strings.TrimSpace(itemResult.Get("name").String())
+	args := itemResult.Get("args")
+	callID := strings.TrimSpace(itemResult.Get("call_id").String())
+	if name == "" || !args.Exists() || callID == "" {
+		return -1, -1, false
+	}
+	stableID := util.GeminiClaudeToolUseID(callID, name, args.Raw)
+	if stableID == "" || stableID == callID {
+		return -1, -1, false
+	}
+	ci, pi, found := antigravityFunctionCallPartLocation(payload, stableID)
+	if !found {
+		return -1, -1, false
+	}
+	fc := gjson.GetBytes(payload, fmt.Sprintf("request.contents.%d.parts.%d.functionCall", ci, pi))
+	if !antigravityFunctionCallMatchesReplayItem(fc, itemResult, toolSchemas) {
+		return -1, -1, false
+	}
+	return ci, pi, true
 }
 
 func insertAntigravityModelFunctionCallBeforeContent(payload []byte, beforeIndex int, name, callID, thoughtSig string, args gjson.Result) ([]byte, bool) {
@@ -887,6 +1012,102 @@ func antigravityPayloadHasClaudeToolProvenanceID(payload []byte) bool {
 	return false
 }
 
+// antigravitySyntheticToolCallID derives a deterministic neutral call ID for a
+// reserved Claude-facing provenance ID that could not be resolved back to its
+// provider-native call. It is stable across turns and never lands in the reserved
+// namespace, so call/response pairs stay consistent without impersonating a
+// provider-issued ID.
+func antigravitySyntheticToolCallID(reservedID string) string {
+	sum := sha256.Sum256([]byte("antigravity-degraded-tool-call\x00" + reservedID))
+	return fmt.Sprintf("call_%x", sum[:6])
+}
+
+// degradeAntigravityClaudeToolProvenanceIDs rewrites unresolved reserved tool
+// provenance IDs to neutral synthetic IDs so a conversation survives a replay
+// ledger miss instead of failing closed forever.
+//
+// The same reserved ID always maps to the same synthetic ID, so functionCall and
+// functionResponse stay paired. Whatever signature the client carried in-band is
+// kept: Gemini validates a thought signature's own integrity, not its binding to
+// the call ID or the surrounding history, so rewriting the ID does not invalidate
+// it. Calls left with no signature at all get the leading bypass sentinel from
+// antigravityRepairUnsignedFirstFunctionCalls. Every other part is left alone,
+// preserving the native "1 signed + N unsigned" parallel-call shape.
+func degradeAntigravityClaudeToolProvenanceIDs(payload []byte) ([]byte, int) {
+	contents := gjson.GetBytes(payload, "request.contents")
+	if !contents.IsArray() {
+		return payload, 0
+	}
+	out := payload
+	degraded := 0
+	for ci, content := range contents.Array() {
+		parts := content.Get("parts")
+		if !parts.IsArray() {
+			continue
+		}
+		for pi, part := range parts.Array() {
+			partPath := fmt.Sprintf("request.contents.%d.parts.%d", ci, pi)
+			if fc := part.Get("functionCall"); fc.Exists() {
+				id := strings.TrimSpace(fc.Get("id").String())
+				if !util.IsGeminiClaudeToolUseID(id) {
+					continue
+				}
+				out, _ = sjson.SetBytes(out, partPath+".functionCall.id", antigravitySyntheticToolCallID(id))
+				degraded++
+				continue
+			}
+			if fr := part.Get("functionResponse"); fr.Exists() {
+				id := strings.TrimSpace(fr.Get("id").String())
+				if !util.IsGeminiClaudeToolUseID(id) {
+					continue
+				}
+				out, _ = sjson.SetBytes(out, partPath+".functionResponse.id", antigravitySyntheticToolCallID(id))
+				degraded++
+			}
+		}
+	}
+	return out, degraded
+}
+
+// antigravityRepairUnsignedFirstFunctionCalls restores Gemini's bypass sentinel on
+// the first function call of any model turn that replay left completely unsigned.
+//
+// Gemini rejects a model turn whose leading functionCall carries no
+// thoughtSignature. The request-level sanitizer enforces that invariant, but it
+// runs before reasoning replay, and replay can legitimately drop a signature
+// afterwards: a degraded call loses one, and an identity-only restore on drifted
+// context deliberately declines to replay one. Only a missing signature is filled
+// in here, so native signatures are never touched.
+func antigravityRepairUnsignedFirstFunctionCalls(payload []byte) []byte {
+	contents := gjson.GetBytes(payload, "request.contents")
+	if !contents.IsArray() {
+		return payload
+	}
+	out := payload
+	for ci, content := range contents.Array() {
+		if !strings.EqualFold(strings.TrimSpace(content.Get("role").String()), "model") {
+			continue
+		}
+		parts := content.Get("parts")
+		if !parts.IsArray() {
+			continue
+		}
+		for pi, part := range parts.Array() {
+			if !part.Get("functionCall").Exists() {
+				continue
+			}
+			if antigravityNativePartThoughtSignature(part) == "" {
+				out, _ = sjson.SetBytes(out, fmt.Sprintf("request.contents.%d.parts.%d.thoughtSignature", ci, pi),
+					internalsignature.GeminiSkipThoughtSignatureValidator)
+			}
+			// Only the first function call of a turn needs a signature; siblings stay
+			// unsigned to preserve the native parallel-call shape.
+			break
+		}
+	}
+	return out
+}
+
 func antigravityCanonicalReplayJSON(raw []byte) []byte {
 	var value any
 	if json.Unmarshal(raw, &value) != nil {
@@ -921,9 +1142,6 @@ func antigravityThoughtSignatureReplayPartPath(payload []byte, itemResult gjson.
 	if ci < 0 || ci >= len(contentArr) || !strings.EqualFold(strings.TrimSpace(contentArr[ci].Get("role").String()), "model") {
 		return "", false
 	}
-	if !antigravityReplayItemContextMatches(payload, itemResult, ci) {
-		return "", false
-	}
 	parts := contentArr[ci].Get("parts")
 	if !parts.IsArray() {
 		return "", false
@@ -931,6 +1149,12 @@ func antigravityThoughtSignatureReplayPartPath(payload []byte, itemResult gjson.
 	partArr := parts.Array()
 	targetKind := strings.TrimSpace(itemResult.Get("targetKind").String())
 	targetHash := strings.TrimSpace(itemResult.Get("targetHash").String())
+	// A target hash pins the signature to a part whose own bytes are unchanged,
+	// which is all Gemini validates: the signature's own integrity, never its
+	// binding to the surrounding history. Drift elsewhere in the conversation
+	// therefore costs this signature nothing, so it is deliberately not gated on
+	// the context fingerprint. The fallback below has no such proof and stays
+	// gated.
 	if targetHash != "" {
 		if targetOccurrence := itemResult.Get("targetOccurrence"); targetOccurrence.Exists() {
 			wanted := int(targetOccurrence.Int())
@@ -963,6 +1187,11 @@ func antigravityThoughtSignatureReplayPartPath(payload []byte, itemResult gjson.
 		return "", false
 	}
 
+	// No target hash: nothing proves which part this signature belongs to, so
+	// only a matching context fingerprint makes the positional guess safe.
+	if !antigravityReplayItemContextMatches(payload, itemResult, ci) {
+		return "", false
+	}
 	pi := int(itemResult.Get("partIndex").Int())
 	if pi >= 0 && pi < len(partArr) && partArr[pi].Type != gjson.Null {
 		if kind, _ := antigravityReplayPartFingerprint(partArr[pi]); kind != "" {
@@ -1100,7 +1329,12 @@ func antigravityFunctionResponsesCanRestoreID(payload []byte, currentID, nativeN
 	return valid
 }
 
-func restoreAntigravityNativeFunctionCallReplay(payload []byte, contentIndex, partIndex int, itemResult gjson.Result, allowLegacyIDRestore bool) ([]byte, bool) {
+// restoreAntigravityNativeFunctionCallReplay rewrites one function call part back
+// to its provider-native identity. allowSignature reports whether the cached
+// thoughtSignature may be replayed as well; identity-only restores pass false
+// because the surrounding context no longer matches the one the signature was
+// issued for.
+func restoreAntigravityNativeFunctionCallReplay(payload []byte, contentIndex, partIndex int, itemResult gjson.Result, allowLegacyIDRestore, allowSignature bool) ([]byte, bool) {
 	partPath := fmt.Sprintf("request.contents.%d.parts.%d", contentIndex, partIndex)
 	currentCall := gjson.GetBytes(payload, partPath+".functionCall")
 	if !currentCall.Exists() {
@@ -1112,7 +1346,7 @@ func restoreAntigravityNativeFunctionCallReplay(payload []byte, contentIndex, pa
 	restoreIdentity := currentID == nativeID || util.IsGeminiClaudeToolUseID(currentID) || allowLegacyIDRestore
 	if !restoreIdentity {
 		signature := strings.TrimSpace(itemResult.Get("thoughtSignature").String())
-		if signature == "" || antigravityHasNativeThoughtSignature(gjson.GetBytes(payload, partPath+".thoughtSignature").String()) {
+		if !allowSignature || signature == "" || antigravityHasNativeThoughtSignature(gjson.GetBytes(payload, partPath+".thoughtSignature").String()) {
 			return payload, false
 		}
 		payload = antigravityRemoveThoughtSignatureFromOtherParts(payload, contentIndex, signature, partPath)
@@ -1133,7 +1367,7 @@ func restoreAntigravityNativeFunctionCallReplay(payload []byte, contentIndex, pa
 	for _, field := range []string{"thoughtSignature", "thought_signature", "extra_content.google.thought_signature"} {
 		out, _ = sjson.DeleteBytes(out, partPath+"."+field)
 	}
-	if signature := strings.TrimSpace(itemResult.Get("thoughtSignature").String()); signature != "" {
+	if signature := strings.TrimSpace(itemResult.Get("thoughtSignature").String()); allowSignature && signature != "" {
 		out = antigravityRemoveThoughtSignatureFromOtherParts(out, contentIndex, signature, partPath)
 		out, _ = sjson.SetBytes(out, partPath+".thoughtSignature", signature)
 	}
@@ -1170,12 +1404,22 @@ func mergeAntigravityFunctionCallPartReplayWithSchemas(payload []byte, itemResul
 	}
 	if ci, pi, exists := antigravityFunctionCallPartLocationForReplayWithSchemas(payload, itemResult, toolSchemas); exists {
 		_, allowLegacyIDRestore := toolSchemas[name]
-		return restoreAntigravityNativeFunctionCallReplay(payload, ci, pi, itemResult, allowLegacyIDRestore)
+		return restoreAntigravityNativeFunctionCallReplay(payload, ci, pi, itemResult, allowLegacyIDRestore, true)
+	}
+	// The context drifted, but an exact opaque ID match still proves this call's
+	// identity. Gemini validates a thought signature's own integrity and nothing
+	// about the history around it, so the drift costs the signature nothing: restore
+	// the native call and its signature rather than making the model re-reason.
+	if ci, pi, exists := antigravityFunctionCallProvenanceLocation(payload, itemResult, toolSchemas); exists {
+		return restoreAntigravityNativeFunctionCallReplay(payload, ci, pi, itemResult, false, true)
 	}
 	if callID != "" {
-		if antigravityPayloadHasFunctionCallID(payload, callID) {
-			// The ID is present but its semantic payload did not match above. Never
-			// replay or reinsert an opaque signature onto that changed call.
+		stableID := util.GeminiClaudeToolUseID(callID, name, args.Raw)
+		if antigravityPayloadHasFunctionCallID(payload, callID) || (stableID != "" && antigravityPayloadHasFunctionCallID(payload, stableID)) {
+			// The call is already in the history under its native or Claude-facing
+			// ID, and neither lookup above accepted it, so the client changed it.
+			// Never replay an opaque signature onto that changed call, and never
+			// insert a second copy of it further down.
 			return payload, false
 		}
 		if frIndex, currentResponseID, ok := antigravityFunctionResponseContentIndexForReplay(payload, itemResult); ok {
@@ -1700,7 +1944,14 @@ func (a *antigravityReasoningReplayAccumulator) appendPendingThoughtSignatures()
 }
 
 func (a *antigravityReasoningReplayAccumulator) Commit(ctx context.Context) {
-	if a == nil || !a.scope.valid() || !a.terminal {
+	if a == nil || !a.scope.valid() {
+		return
+	}
+	log.Debugf("antigravity replay: accumulator commit terminal=%t overflow=%t items=%d (session=%s)",
+		a.terminal, a.overflow, len(a.items), antigravityReplayLogKey(a.scope.sessionKey))
+	if !a.terminal {
+		// No terminal finishReason means the stream never completed, so this turn
+		// contributes nothing to the ledger and its tool IDs become unresolvable.
 		return
 	}
 	if a.overflow {

--- a/internal/runtime/executor/antigravity_reasoning_replay.go
+++ b/internal/runtime/executor/antigravity_reasoning_replay.go
@@ -5,12 +5,14 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
 
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
+	homekv "github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	internalsignature "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
@@ -230,13 +232,36 @@ func antigravityReasoningReplayResolveContentIndex(payload []byte, cached int) i
 	return -1
 }
 
+// logAntigravityReasoningReplayDegraded reports that a replay-state operation
+// failed and the request continued without it. A Home that predates the CAS
+// command fails every call, and the Home client already warns once about that,
+// so those are logged at debug level to avoid one warning per request.
+func logAntigravityReasoningReplayDegraded(scope antigravityReasoningReplayScope, stage string, err error) {
+	if err == nil {
+		return
+	}
+	if errors.Is(err, homekv.ErrCompareAndSwapUnsupported) {
+		log.Debugf("antigravity executor: reasoning replay %s unavailable on this Home (session=%s): %v",
+			stage, antigravityReplayLogKey(scope.sessionKey), err)
+		return
+	}
+	log.Warnf("antigravity executor: reasoning replay %s failed; continuing without replay (session=%s): %v",
+		stage, antigravityReplayLogKey(scope.sessionKey), err)
+}
+
 func prepareAntigravityGeminiReasoningReplayPayload(ctx context.Context, modelName string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, payload []byte) ([]byte, antigravityReasoningReplayScope, error) {
 	if !antigravityUsesReasoningReplayCache(modelName) {
 		return payload, antigravityReasoningReplayScope{}, nil
 	}
 	updated, scope, replayApplied, errReplay := applyAntigravityReasoningReplayCache(ctx, modelName, req, opts, payload)
 	if errReplay != nil {
-		return payload, scope, errReplay
+		// Replay state is an optimization, not a correctness requirement: a ledger
+		// miss is already a tolerated outcome below. Failing the request here would
+		// surface as an untyped executor error, which MarkResult treats as a
+		// credential fault and uses to mark every candidate credential unavailable.
+		// Degrade to "no replay this turn" instead.
+		logAntigravityReasoningReplayDegraded(scope, "read", errReplay)
+		updated = payload
 	}
 	updated = normalizeAntigravityGeminiFunctionResponseRoles(updated)
 	if antigravityPayloadHasClaudeToolProvenanceID(updated) {
@@ -255,7 +280,9 @@ func prepareAntigravityGeminiReasoningReplayPayload(ctx context.Context, modelNa
 		originalPairingValid := internalsignature.ValidateGeminiFunctionCallPairing(payload) == nil
 		if replayApplied && originalPairingValid && scope.valid() {
 			if _, errDelete := internalcache.DeleteAntigravityReasoningReplayItemsIfUnchanged(ctx, scope.modelName, scope.sessionKey, scope.cacheSnapshot); errDelete != nil {
-				return payload, scope, errDelete
+				// Invalidation is best-effort cleanup. Returning it here would replace
+				// the pairing diagnosis below with an untyped error.
+				logAntigravityReasoningReplayDegraded(scope, "invalidate", errDelete)
 			}
 		}
 		return payload, scope, statusErr{code: http.StatusBadRequest, msg: fmt.Sprintf("antigravity executor: invalid Gemini function call history: %v", errPairing)}

--- a/internal/runtime/executor/antigravity_reasoning_replay.go
+++ b/internal/runtime/executor/antigravity_reasoning_replay.go
@@ -15,9 +15,41 @@ import (
 	internalsignature "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
+
+// antigravityReplayLogKey returns a short, non-reversible tag for a replay
+// identifier. Session keys and tool call IDs are never logged verbatim.
+func antigravityReplayLogKey(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(value))
+	return fmt.Sprintf("%x", sum[:8])
+}
+
+// antigravityCountClaudeToolProvenanceIDs reports how many reserved
+// Claude-facing provenance IDs are still present in a Gemini-shaped payload.
+func antigravityCountClaudeToolProvenanceIDs(payload []byte) int {
+	count := 0
+	contents := gjson.GetBytes(payload, "request.contents")
+	if !contents.IsArray() {
+		return 0
+	}
+	for _, content := range contents.Array() {
+		for _, part := range content.Get("parts").Array() {
+			for _, path := range []string{"functionCall.id", "functionResponse.id"} {
+				if util.IsGeminiClaudeToolUseID(part.Get(path).String()) {
+					count++
+				}
+			}
+		}
+	}
+	return count
+}
 
 type antigravityReasoningReplayScope struct {
 	modelName     string
@@ -208,8 +240,17 @@ func prepareAntigravityGeminiReasoningReplayPayload(ctx context.Context, modelNa
 	}
 	updated = normalizeAntigravityGeminiFunctionResponseRoles(updated)
 	if antigravityPayloadHasClaudeToolProvenanceID(updated) {
-		return payload, scope, statusErr{code: http.StatusBadRequest, msg: "antigravity executor: missing Claude tool provenance; start a new session or restore replay state"}
+		// The replay ledger could not resolve every tool ID — the session lane
+		// changed, the entry expired, the process restarted, or a turn never
+		// committed. Degrade those calls instead of killing the conversation.
+		degradedPayload, degradedCount := degradeAntigravityClaudeToolProvenanceIDs(updated)
+		log.Warnf("antigravity executor: replay state missing for %d tool ID(s); rewriting them to synthetic IDs and continuing without reasoning replay for those calls", degradedCount)
+		updated = degradedPayload
 	}
+	// An identity-only restore drops the cached signature, which can leave a model
+	// turn's first function call unsigned. Gemini rejects that, so re-assert the
+	// invariant the pre-replay sanitizer established.
+	updated = antigravityRepairUnsignedFirstFunctionCalls(updated)
 	if errPairing := internalsignature.ValidateGeminiFunctionCallPairing(updated); errPairing != nil {
 		originalPairingValid := internalsignature.ValidateGeminiFunctionCallPairing(payload) == nil
 		if replayApplied && originalPairingValid && scope.valid() {
@@ -244,7 +285,15 @@ func applyAntigravityReasoningReplayCache(ctx context.Context, modelName string,
 	}
 	items, snapshot, ok, err := internalcache.GetAntigravityReasoningReplayItemsWithSnapshotRequired(ctx, scope.modelName, scope.sessionKey)
 	scope.cacheSnapshot = snapshot
+	reservedBefore := antigravityCountClaudeToolProvenanceIDs(payload)
 	if err != nil || !ok || len(items) == 0 {
+		// A ledger miss on a payload that still carries reserved provenance IDs is
+		// the signature of a session/lane switch, cache expiry, or a turn that never
+		// committed. Log it so the two failure families stay distinguishable.
+		if reservedBefore > 0 {
+			log.Debugf("antigravity replay: ledger miss with %d reserved tool provenance ID(s) present (session=%s found=%t)",
+				reservedBefore, antigravityReplayLogKey(scope.sessionKey), ok)
+		}
 		return payload, scope, false, err
 	}
 	updated := payload
@@ -264,6 +313,11 @@ func applyAntigravityReasoningReplayCache(ctx context.Context, modelName string,
 		}
 		updated = next
 		changed = true
+	}
+	if reservedBefore > 0 {
+		log.Debugf("antigravity replay: ledger items=%d reserved before=%d after=%d applied=%t (session=%s)",
+			len(items), reservedBefore, antigravityCountClaudeToolProvenanceIDs(updated), changed,
+			antigravityReplayLogKey(scope.sessionKey))
 	}
 	if !changed {
 		return payload, scope, false, nil
@@ -290,6 +344,11 @@ func filterAntigravityReasoningReplayItemsForRequestWithSchemas(payload []byte, 
 				if !needsNativeRestore && (signature == "" || antigravityHasNativeThoughtSignature(part.Get("thoughtSignature").String())) {
 					continue
 				}
+				break
+			}
+			// Even without a context match, an exact opaque ID match can still
+			// restore the native call identity.
+			if _, _, foundProvenance := antigravityFunctionCallProvenanceLocation(payload, itemResult, toolSchemas); foundProvenance {
 				break
 			}
 			callID := strings.TrimSpace(itemResult.Get("call_id").String())
@@ -530,7 +589,15 @@ func antigravityFunctionCallPartLocationForReplayWithSchemas(payload []byte, ite
 			if antigravityFunctionCallMatchesReplayItem(fc, itemResult, toolSchemas) {
 				return ci, pi, true
 			}
+			log.Debugf("antigravity replay: located call %q at contents[%d].parts[%d] but name/args did not match ledger item (opaque_id=%t)",
+				name, ci, pi, util.IsGeminiClaudeToolUseID(candidateID))
+			return -1, -1, false
 		}
+		// The candidate ID matched exactly, so callID+name+args are already proven
+		// identical. Only the surrounding context drifted, which invalidates the
+		// cached signature but not the tool identity.
+		log.Debugf("antigravity replay: exact tool ID match for %q at contents[%d].parts[%d] rejected by context hash (opaque_id=%t)",
+			name, ci, pi, util.IsGeminiClaudeToolUseID(candidateID))
 		return -1, -1, false
 	}
 	contents := gjson.GetBytes(payload, "request.contents")
@@ -577,6 +644,37 @@ func antigravityFunctionCallPartLocationForReplayWithSchemas(payload []byte, ite
 		return matches[0][0], matches[0][1], true
 	}
 	return -1, -1, false
+}
+
+// antigravityFunctionCallProvenanceLocation locates the function call whose
+// Claude-facing opaque ID was derived from this exact ledger item.
+//
+// The opaque ID is sha256(call_id, name, args), so an exact match already proves
+// that the call ID, tool name and arguments are identical to the provider-native
+// call. The surrounding context hash adds nothing to that proof; it only decides
+// whether the cached thoughtSignature is still valid. Callers therefore use this
+// to recover tool identity after the context has drifted, without replaying any
+// signature.
+func antigravityFunctionCallProvenanceLocation(payload []byte, itemResult gjson.Result, toolSchemas map[string]any) (contentIndex int, partIndex int, ok bool) {
+	name := strings.TrimSpace(itemResult.Get("name").String())
+	args := itemResult.Get("args")
+	callID := strings.TrimSpace(itemResult.Get("call_id").String())
+	if name == "" || !args.Exists() || callID == "" {
+		return -1, -1, false
+	}
+	stableID := util.GeminiClaudeToolUseID(callID, name, args.Raw)
+	if stableID == "" || stableID == callID {
+		return -1, -1, false
+	}
+	ci, pi, found := antigravityFunctionCallPartLocation(payload, stableID)
+	if !found {
+		return -1, -1, false
+	}
+	fc := gjson.GetBytes(payload, fmt.Sprintf("request.contents.%d.parts.%d.functionCall", ci, pi))
+	if !antigravityFunctionCallMatchesReplayItem(fc, itemResult, toolSchemas) {
+		return -1, -1, false
+	}
+	return ci, pi, true
 }
 
 func insertAntigravityModelFunctionCallBeforeContent(payload []byte, beforeIndex int, name, callID, thoughtSig string, args gjson.Result) ([]byte, bool) {
@@ -887,6 +985,103 @@ func antigravityPayloadHasClaudeToolProvenanceID(payload []byte) bool {
 	return false
 }
 
+// antigravitySyntheticToolCallID derives a deterministic neutral call ID for a
+// reserved Claude-facing provenance ID that could not be resolved back to its
+// provider-native call. It is stable across turns and never lands in the reserved
+// namespace, so call/response pairs stay consistent without impersonating a
+// provider-issued ID.
+func antigravitySyntheticToolCallID(reservedID string) string {
+	sum := sha256.Sum256([]byte("antigravity-degraded-tool-call\x00" + reservedID))
+	return fmt.Sprintf("call_%x", sum[:6])
+}
+
+// degradeAntigravityClaudeToolProvenanceIDs rewrites unresolved reserved tool
+// provenance IDs to neutral synthetic IDs so a conversation survives a replay
+// ledger miss instead of failing closed forever.
+//
+// The same reserved ID always maps to the same synthetic ID, so functionCall and
+// functionResponse stay paired. Signatures on a rewritten call are dropped because
+// they can no longer correspond to it; callers restore the leading call's bypass
+// sentinel via antigravityRepairUnsignedFirstFunctionCalls. Every other part is
+// left alone, preserving the native "1 signed + N unsigned" parallel-call shape.
+func degradeAntigravityClaudeToolProvenanceIDs(payload []byte) ([]byte, int) {
+	contents := gjson.GetBytes(payload, "request.contents")
+	if !contents.IsArray() {
+		return payload, 0
+	}
+	out := payload
+	degraded := 0
+	for ci, content := range contents.Array() {
+		parts := content.Get("parts")
+		if !parts.IsArray() {
+			continue
+		}
+		for pi, part := range parts.Array() {
+			partPath := fmt.Sprintf("request.contents.%d.parts.%d", ci, pi)
+			if fc := part.Get("functionCall"); fc.Exists() {
+				id := strings.TrimSpace(fc.Get("id").String())
+				if !util.IsGeminiClaudeToolUseID(id) {
+					continue
+				}
+				out, _ = sjson.SetBytes(out, partPath+".functionCall.id", antigravitySyntheticToolCallID(id))
+				for _, field := range []string{"thoughtSignature", "thought_signature", "extra_content.google.thought_signature"} {
+					out, _ = sjson.DeleteBytes(out, partPath+"."+field)
+				}
+				degraded++
+				continue
+			}
+			if fr := part.Get("functionResponse"); fr.Exists() {
+				id := strings.TrimSpace(fr.Get("id").String())
+				if !util.IsGeminiClaudeToolUseID(id) {
+					continue
+				}
+				out, _ = sjson.SetBytes(out, partPath+".functionResponse.id", antigravitySyntheticToolCallID(id))
+				degraded++
+			}
+		}
+	}
+	return out, degraded
+}
+
+// antigravityRepairUnsignedFirstFunctionCalls restores Gemini's bypass sentinel on
+// the first function call of any model turn that replay left completely unsigned.
+//
+// Gemini rejects a model turn whose leading functionCall carries no
+// thoughtSignature. The request-level sanitizer enforces that invariant, but it
+// runs before reasoning replay, and replay can legitimately drop a signature
+// afterwards: a degraded call loses one, and an identity-only restore on drifted
+// context deliberately declines to replay one. Only a missing signature is filled
+// in here, so native signatures are never touched.
+func antigravityRepairUnsignedFirstFunctionCalls(payload []byte) []byte {
+	contents := gjson.GetBytes(payload, "request.contents")
+	if !contents.IsArray() {
+		return payload
+	}
+	out := payload
+	for ci, content := range contents.Array() {
+		if !strings.EqualFold(strings.TrimSpace(content.Get("role").String()), "model") {
+			continue
+		}
+		parts := content.Get("parts")
+		if !parts.IsArray() {
+			continue
+		}
+		for pi, part := range parts.Array() {
+			if !part.Get("functionCall").Exists() {
+				continue
+			}
+			if antigravityNativePartThoughtSignature(part) == "" {
+				out, _ = sjson.SetBytes(out, fmt.Sprintf("request.contents.%d.parts.%d.thoughtSignature", ci, pi),
+					internalsignature.GeminiSkipThoughtSignatureValidator)
+			}
+			// Only the first function call of a turn needs a signature; siblings stay
+			// unsigned to preserve the native parallel-call shape.
+			break
+		}
+	}
+	return out
+}
+
 func antigravityCanonicalReplayJSON(raw []byte) []byte {
 	var value any
 	if json.Unmarshal(raw, &value) != nil {
@@ -1100,7 +1295,12 @@ func antigravityFunctionResponsesCanRestoreID(payload []byte, currentID, nativeN
 	return valid
 }
 
-func restoreAntigravityNativeFunctionCallReplay(payload []byte, contentIndex, partIndex int, itemResult gjson.Result, allowLegacyIDRestore bool) ([]byte, bool) {
+// restoreAntigravityNativeFunctionCallReplay rewrites one function call part back
+// to its provider-native identity. allowSignature reports whether the cached
+// thoughtSignature may be replayed as well; identity-only restores pass false
+// because the surrounding context no longer matches the one the signature was
+// issued for.
+func restoreAntigravityNativeFunctionCallReplay(payload []byte, contentIndex, partIndex int, itemResult gjson.Result, allowLegacyIDRestore, allowSignature bool) ([]byte, bool) {
 	partPath := fmt.Sprintf("request.contents.%d.parts.%d", contentIndex, partIndex)
 	currentCall := gjson.GetBytes(payload, partPath+".functionCall")
 	if !currentCall.Exists() {
@@ -1112,7 +1312,7 @@ func restoreAntigravityNativeFunctionCallReplay(payload []byte, contentIndex, pa
 	restoreIdentity := currentID == nativeID || util.IsGeminiClaudeToolUseID(currentID) || allowLegacyIDRestore
 	if !restoreIdentity {
 		signature := strings.TrimSpace(itemResult.Get("thoughtSignature").String())
-		if signature == "" || antigravityHasNativeThoughtSignature(gjson.GetBytes(payload, partPath+".thoughtSignature").String()) {
+		if !allowSignature || signature == "" || antigravityHasNativeThoughtSignature(gjson.GetBytes(payload, partPath+".thoughtSignature").String()) {
 			return payload, false
 		}
 		payload = antigravityRemoveThoughtSignatureFromOtherParts(payload, contentIndex, signature, partPath)
@@ -1133,7 +1333,7 @@ func restoreAntigravityNativeFunctionCallReplay(payload []byte, contentIndex, pa
 	for _, field := range []string{"thoughtSignature", "thought_signature", "extra_content.google.thought_signature"} {
 		out, _ = sjson.DeleteBytes(out, partPath+"."+field)
 	}
-	if signature := strings.TrimSpace(itemResult.Get("thoughtSignature").String()); signature != "" {
+	if signature := strings.TrimSpace(itemResult.Get("thoughtSignature").String()); allowSignature && signature != "" {
 		out = antigravityRemoveThoughtSignatureFromOtherParts(out, contentIndex, signature, partPath)
 		out, _ = sjson.SetBytes(out, partPath+".thoughtSignature", signature)
 	}
@@ -1170,12 +1370,21 @@ func mergeAntigravityFunctionCallPartReplayWithSchemas(payload []byte, itemResul
 	}
 	if ci, pi, exists := antigravityFunctionCallPartLocationForReplayWithSchemas(payload, itemResult, toolSchemas); exists {
 		_, allowLegacyIDRestore := toolSchemas[name]
-		return restoreAntigravityNativeFunctionCallReplay(payload, ci, pi, itemResult, allowLegacyIDRestore)
+		return restoreAntigravityNativeFunctionCallReplay(payload, ci, pi, itemResult, allowLegacyIDRestore, true)
+	}
+	// The context drifted, but an exact opaque ID match still proves this call's
+	// identity. Restore the native call so the request stays replayable, and leave
+	// it unsigned rather than replaying a signature issued for a different history.
+	if ci, pi, exists := antigravityFunctionCallProvenanceLocation(payload, itemResult, toolSchemas); exists {
+		return restoreAntigravityNativeFunctionCallReplay(payload, ci, pi, itemResult, false, false)
 	}
 	if callID != "" {
-		if antigravityPayloadHasFunctionCallID(payload, callID) {
-			// The ID is present but its semantic payload did not match above. Never
-			// replay or reinsert an opaque signature onto that changed call.
+		stableID := util.GeminiClaudeToolUseID(callID, name, args.Raw)
+		if antigravityPayloadHasFunctionCallID(payload, callID) || (stableID != "" && antigravityPayloadHasFunctionCallID(payload, stableID)) {
+			// The call is already in the history under its native or Claude-facing
+			// ID, and neither lookup above accepted it, so the client changed it.
+			// Never replay an opaque signature onto that changed call, and never
+			// insert a second copy of it further down.
 			return payload, false
 		}
 		if frIndex, currentResponseID, ok := antigravityFunctionResponseContentIndexForReplay(payload, itemResult); ok {
@@ -1700,7 +1909,14 @@ func (a *antigravityReasoningReplayAccumulator) appendPendingThoughtSignatures()
 }
 
 func (a *antigravityReasoningReplayAccumulator) Commit(ctx context.Context) {
-	if a == nil || !a.scope.valid() || !a.terminal {
+	if a == nil || !a.scope.valid() {
+		return
+	}
+	log.Debugf("antigravity replay: accumulator commit terminal=%t overflow=%t items=%d (session=%s)",
+		a.terminal, a.overflow, len(a.items), antigravityReplayLogKey(a.scope.sessionKey))
+	if !a.terminal {
+		// No terminal finishReason means the stream never completed, so this turn
+		// contributes nothing to the ledger and its tool IDs become unresolvable.
 		return
 	}
 	if a.overflow {

--- a/internal/runtime/executor/antigravity_reasoning_replay.go
+++ b/internal/runtime/executor/antigravity_reasoning_replay.go
@@ -15,9 +15,41 @@ import (
 	internalsignature "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
+
+// antigravityReplayLogKey returns a short, non-reversible tag for a replay
+// identifier. Session keys and tool call IDs are never logged verbatim.
+func antigravityReplayLogKey(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(value))
+	return fmt.Sprintf("%x", sum[:8])
+}
+
+// antigravityCountClaudeToolProvenanceIDs reports how many reserved
+// Claude-facing provenance IDs are still present in a Gemini-shaped payload.
+func antigravityCountClaudeToolProvenanceIDs(payload []byte) int {
+	count := 0
+	contents := gjson.GetBytes(payload, "request.contents")
+	if !contents.IsArray() {
+		return 0
+	}
+	for _, content := range contents.Array() {
+		for _, part := range content.Get("parts").Array() {
+			for _, path := range []string{"functionCall.id", "functionResponse.id"} {
+				if util.IsGeminiClaudeToolUseID(part.Get(path).String()) {
+					count++
+				}
+			}
+		}
+	}
+	return count
+}
 
 type antigravityReasoningReplayScope struct {
 	modelName     string
@@ -208,8 +240,17 @@ func prepareAntigravityGeminiReasoningReplayPayload(ctx context.Context, modelNa
 	}
 	updated = normalizeAntigravityGeminiFunctionResponseRoles(updated)
 	if antigravityPayloadHasClaudeToolProvenanceID(updated) {
-		return payload, scope, statusErr{code: http.StatusBadRequest, msg: "antigravity executor: missing Claude tool provenance; start a new session or restore replay state"}
+		// The replay ledger could not resolve every tool ID — the session lane
+		// changed, the entry expired, the process restarted, or a turn never
+		// committed. Degrade those calls instead of killing the conversation.
+		degradedPayload, degradedCount := degradeAntigravityClaudeToolProvenanceIDs(updated)
+		log.Warnf("antigravity executor: replay state missing for %d tool ID(s); rewriting them to synthetic IDs and continuing without reasoning replay for those calls", degradedCount)
+		updated = degradedPayload
 	}
+	// An identity-only restore drops the cached signature, which can leave a model
+	// turn's first function call unsigned. Gemini rejects that, so re-assert the
+	// invariant the pre-replay sanitizer established.
+	updated = antigravityRepairUnsignedFirstFunctionCalls(updated)
 	if errPairing := internalsignature.ValidateGeminiFunctionCallPairing(updated); errPairing != nil {
 		originalPairingValid := internalsignature.ValidateGeminiFunctionCallPairing(payload) == nil
 		if replayApplied && originalPairingValid && scope.valid() {
@@ -244,7 +285,15 @@ func applyAntigravityReasoningReplayCache(ctx context.Context, modelName string,
 	}
 	items, snapshot, ok, err := internalcache.GetAntigravityReasoningReplayItemsWithSnapshotRequired(ctx, scope.modelName, scope.sessionKey)
 	scope.cacheSnapshot = snapshot
+	reservedBefore := antigravityCountClaudeToolProvenanceIDs(payload)
 	if err != nil || !ok || len(items) == 0 {
+		// A ledger miss on a payload that still carries reserved provenance IDs is
+		// the signature of a session/lane switch, cache expiry, or a turn that never
+		// committed. Log it so the two failure families stay distinguishable.
+		if reservedBefore > 0 {
+			log.Debugf("antigravity replay: ledger miss with %d reserved tool provenance ID(s) present (session=%s found=%t)",
+				reservedBefore, antigravityReplayLogKey(scope.sessionKey), ok)
+		}
 		return payload, scope, false, err
 	}
 	updated := payload
@@ -264,6 +313,11 @@ func applyAntigravityReasoningReplayCache(ctx context.Context, modelName string,
 		}
 		updated = next
 		changed = true
+	}
+	if reservedBefore > 0 {
+		log.Debugf("antigravity replay: ledger items=%d reserved before=%d after=%d applied=%t (session=%s)",
+			len(items), reservedBefore, antigravityCountClaudeToolProvenanceIDs(updated), changed,
+			antigravityReplayLogKey(scope.sessionKey))
 	}
 	if !changed {
 		return payload, scope, false, nil
@@ -290,6 +344,11 @@ func filterAntigravityReasoningReplayItemsForRequestWithSchemas(payload []byte, 
 				if !needsNativeRestore && (signature == "" || antigravityHasNativeThoughtSignature(part.Get("thoughtSignature").String())) {
 					continue
 				}
+				break
+			}
+			// Even without a context match, an exact opaque ID match can still
+			// restore the native call identity.
+			if _, _, foundProvenance := antigravityFunctionCallProvenanceLocation(payload, itemResult, toolSchemas); foundProvenance {
 				break
 			}
 			callID := strings.TrimSpace(itemResult.Get("call_id").String())
@@ -530,7 +589,15 @@ func antigravityFunctionCallPartLocationForReplayWithSchemas(payload []byte, ite
 			if antigravityFunctionCallMatchesReplayItem(fc, itemResult, toolSchemas) {
 				return ci, pi, true
 			}
+			log.Debugf("antigravity replay: located call %q at contents[%d].parts[%d] but name/args did not match ledger item (opaque_id=%t)",
+				name, ci, pi, util.IsGeminiClaudeToolUseID(candidateID))
+			return -1, -1, false
 		}
+		// The candidate ID matched exactly, so callID+name+args are already proven
+		// identical. Only the surrounding context drifted, which invalidates the
+		// cached signature but not the tool identity.
+		log.Debugf("antigravity replay: exact tool ID match for %q at contents[%d].parts[%d] rejected by context hash (opaque_id=%t)",
+			name, ci, pi, util.IsGeminiClaudeToolUseID(candidateID))
 		return -1, -1, false
 	}
 	contents := gjson.GetBytes(payload, "request.contents")
@@ -577,6 +644,37 @@ func antigravityFunctionCallPartLocationForReplayWithSchemas(payload []byte, ite
 		return matches[0][0], matches[0][1], true
 	}
 	return -1, -1, false
+}
+
+// antigravityFunctionCallProvenanceLocation locates the function call whose
+// Claude-facing opaque ID was derived from this exact ledger item.
+//
+// The opaque ID is sha256(call_id, name, args), so an exact match already proves
+// that the call ID, tool name and arguments are identical to the provider-native
+// call. The surrounding context hash adds nothing to that proof; it only decides
+// whether the cached thoughtSignature is still valid. Callers therefore use this
+// to recover tool identity after the context has drifted, without replaying any
+// signature.
+func antigravityFunctionCallProvenanceLocation(payload []byte, itemResult gjson.Result, toolSchemas map[string]any) (contentIndex int, partIndex int, ok bool) {
+	name := strings.TrimSpace(itemResult.Get("name").String())
+	args := itemResult.Get("args")
+	callID := strings.TrimSpace(itemResult.Get("call_id").String())
+	if name == "" || !args.Exists() || callID == "" {
+		return -1, -1, false
+	}
+	stableID := util.GeminiClaudeToolUseID(callID, name, args.Raw)
+	if stableID == "" || stableID == callID {
+		return -1, -1, false
+	}
+	ci, pi, found := antigravityFunctionCallPartLocation(payload, stableID)
+	if !found {
+		return -1, -1, false
+	}
+	fc := gjson.GetBytes(payload, fmt.Sprintf("request.contents.%d.parts.%d.functionCall", ci, pi))
+	if !antigravityFunctionCallMatchesReplayItem(fc, itemResult, toolSchemas) {
+		return -1, -1, false
+	}
+	return ci, pi, true
 }
 
 func insertAntigravityModelFunctionCallBeforeContent(payload []byte, beforeIndex int, name, callID, thoughtSig string, args gjson.Result) ([]byte, bool) {
@@ -887,6 +985,102 @@ func antigravityPayloadHasClaudeToolProvenanceID(payload []byte) bool {
 	return false
 }
 
+// antigravitySyntheticToolCallID derives a deterministic neutral call ID for a
+// reserved Claude-facing provenance ID that could not be resolved back to its
+// provider-native call. It is stable across turns and never lands in the reserved
+// namespace, so call/response pairs stay consistent without impersonating a
+// provider-issued ID.
+func antigravitySyntheticToolCallID(reservedID string) string {
+	sum := sha256.Sum256([]byte("antigravity-degraded-tool-call\x00" + reservedID))
+	return fmt.Sprintf("call_%x", sum[:6])
+}
+
+// degradeAntigravityClaudeToolProvenanceIDs rewrites unresolved reserved tool
+// provenance IDs to neutral synthetic IDs so a conversation survives a replay
+// ledger miss instead of failing closed forever.
+//
+// The same reserved ID always maps to the same synthetic ID, so functionCall and
+// functionResponse stay paired. Whatever signature the client carried in-band is
+// kept: Gemini validates a thought signature's own integrity, not its binding to
+// the call ID or the surrounding history, so rewriting the ID does not invalidate
+// it. Calls left with no signature at all get the leading bypass sentinel from
+// antigravityRepairUnsignedFirstFunctionCalls. Every other part is left alone,
+// preserving the native "1 signed + N unsigned" parallel-call shape.
+func degradeAntigravityClaudeToolProvenanceIDs(payload []byte) ([]byte, int) {
+	contents := gjson.GetBytes(payload, "request.contents")
+	if !contents.IsArray() {
+		return payload, 0
+	}
+	out := payload
+	degraded := 0
+	for ci, content := range contents.Array() {
+		parts := content.Get("parts")
+		if !parts.IsArray() {
+			continue
+		}
+		for pi, part := range parts.Array() {
+			partPath := fmt.Sprintf("request.contents.%d.parts.%d", ci, pi)
+			if fc := part.Get("functionCall"); fc.Exists() {
+				id := strings.TrimSpace(fc.Get("id").String())
+				if !util.IsGeminiClaudeToolUseID(id) {
+					continue
+				}
+				out, _ = sjson.SetBytes(out, partPath+".functionCall.id", antigravitySyntheticToolCallID(id))
+				degraded++
+				continue
+			}
+			if fr := part.Get("functionResponse"); fr.Exists() {
+				id := strings.TrimSpace(fr.Get("id").String())
+				if !util.IsGeminiClaudeToolUseID(id) {
+					continue
+				}
+				out, _ = sjson.SetBytes(out, partPath+".functionResponse.id", antigravitySyntheticToolCallID(id))
+				degraded++
+			}
+		}
+	}
+	return out, degraded
+}
+
+// antigravityRepairUnsignedFirstFunctionCalls restores Gemini's bypass sentinel on
+// the first function call of any model turn that replay left completely unsigned.
+//
+// Gemini rejects a model turn whose leading functionCall carries no
+// thoughtSignature. The request-level sanitizer enforces that invariant, but it
+// runs before reasoning replay, and replay can legitimately drop a signature
+// afterwards: a degraded call loses one, and an identity-only restore on drifted
+// context deliberately declines to replay one. Only a missing signature is filled
+// in here, so native signatures are never touched.
+func antigravityRepairUnsignedFirstFunctionCalls(payload []byte) []byte {
+	contents := gjson.GetBytes(payload, "request.contents")
+	if !contents.IsArray() {
+		return payload
+	}
+	out := payload
+	for ci, content := range contents.Array() {
+		if !strings.EqualFold(strings.TrimSpace(content.Get("role").String()), "model") {
+			continue
+		}
+		parts := content.Get("parts")
+		if !parts.IsArray() {
+			continue
+		}
+		for pi, part := range parts.Array() {
+			if !part.Get("functionCall").Exists() {
+				continue
+			}
+			if antigravityNativePartThoughtSignature(part) == "" {
+				out, _ = sjson.SetBytes(out, fmt.Sprintf("request.contents.%d.parts.%d.thoughtSignature", ci, pi),
+					internalsignature.GeminiSkipThoughtSignatureValidator)
+			}
+			// Only the first function call of a turn needs a signature; siblings stay
+			// unsigned to preserve the native parallel-call shape.
+			break
+		}
+	}
+	return out
+}
+
 func antigravityCanonicalReplayJSON(raw []byte) []byte {
 	var value any
 	if json.Unmarshal(raw, &value) != nil {
@@ -921,9 +1115,6 @@ func antigravityThoughtSignatureReplayPartPath(payload []byte, itemResult gjson.
 	if ci < 0 || ci >= len(contentArr) || !strings.EqualFold(strings.TrimSpace(contentArr[ci].Get("role").String()), "model") {
 		return "", false
 	}
-	if !antigravityReplayItemContextMatches(payload, itemResult, ci) {
-		return "", false
-	}
 	parts := contentArr[ci].Get("parts")
 	if !parts.IsArray() {
 		return "", false
@@ -931,6 +1122,12 @@ func antigravityThoughtSignatureReplayPartPath(payload []byte, itemResult gjson.
 	partArr := parts.Array()
 	targetKind := strings.TrimSpace(itemResult.Get("targetKind").String())
 	targetHash := strings.TrimSpace(itemResult.Get("targetHash").String())
+	// A target hash pins the signature to a part whose own bytes are unchanged,
+	// which is all Gemini validates: the signature's own integrity, never its
+	// binding to the surrounding history. Drift elsewhere in the conversation
+	// therefore costs this signature nothing, so it is deliberately not gated on
+	// the context fingerprint. The fallback below has no such proof and stays
+	// gated.
 	if targetHash != "" {
 		if targetOccurrence := itemResult.Get("targetOccurrence"); targetOccurrence.Exists() {
 			wanted := int(targetOccurrence.Int())
@@ -963,6 +1160,11 @@ func antigravityThoughtSignatureReplayPartPath(payload []byte, itemResult gjson.
 		return "", false
 	}
 
+	// No target hash: nothing proves which part this signature belongs to, so
+	// only a matching context fingerprint makes the positional guess safe.
+	if !antigravityReplayItemContextMatches(payload, itemResult, ci) {
+		return "", false
+	}
 	pi := int(itemResult.Get("partIndex").Int())
 	if pi >= 0 && pi < len(partArr) && partArr[pi].Type != gjson.Null {
 		if kind, _ := antigravityReplayPartFingerprint(partArr[pi]); kind != "" {
@@ -1100,7 +1302,12 @@ func antigravityFunctionResponsesCanRestoreID(payload []byte, currentID, nativeN
 	return valid
 }
 
-func restoreAntigravityNativeFunctionCallReplay(payload []byte, contentIndex, partIndex int, itemResult gjson.Result, allowLegacyIDRestore bool) ([]byte, bool) {
+// restoreAntigravityNativeFunctionCallReplay rewrites one function call part back
+// to its provider-native identity. allowSignature reports whether the cached
+// thoughtSignature may be replayed as well; identity-only restores pass false
+// because the surrounding context no longer matches the one the signature was
+// issued for.
+func restoreAntigravityNativeFunctionCallReplay(payload []byte, contentIndex, partIndex int, itemResult gjson.Result, allowLegacyIDRestore, allowSignature bool) ([]byte, bool) {
 	partPath := fmt.Sprintf("request.contents.%d.parts.%d", contentIndex, partIndex)
 	currentCall := gjson.GetBytes(payload, partPath+".functionCall")
 	if !currentCall.Exists() {
@@ -1112,7 +1319,7 @@ func restoreAntigravityNativeFunctionCallReplay(payload []byte, contentIndex, pa
 	restoreIdentity := currentID == nativeID || util.IsGeminiClaudeToolUseID(currentID) || allowLegacyIDRestore
 	if !restoreIdentity {
 		signature := strings.TrimSpace(itemResult.Get("thoughtSignature").String())
-		if signature == "" || antigravityHasNativeThoughtSignature(gjson.GetBytes(payload, partPath+".thoughtSignature").String()) {
+		if !allowSignature || signature == "" || antigravityHasNativeThoughtSignature(gjson.GetBytes(payload, partPath+".thoughtSignature").String()) {
 			return payload, false
 		}
 		payload = antigravityRemoveThoughtSignatureFromOtherParts(payload, contentIndex, signature, partPath)
@@ -1133,7 +1340,7 @@ func restoreAntigravityNativeFunctionCallReplay(payload []byte, contentIndex, pa
 	for _, field := range []string{"thoughtSignature", "thought_signature", "extra_content.google.thought_signature"} {
 		out, _ = sjson.DeleteBytes(out, partPath+"."+field)
 	}
-	if signature := strings.TrimSpace(itemResult.Get("thoughtSignature").String()); signature != "" {
+	if signature := strings.TrimSpace(itemResult.Get("thoughtSignature").String()); allowSignature && signature != "" {
 		out = antigravityRemoveThoughtSignatureFromOtherParts(out, contentIndex, signature, partPath)
 		out, _ = sjson.SetBytes(out, partPath+".thoughtSignature", signature)
 	}
@@ -1170,12 +1377,22 @@ func mergeAntigravityFunctionCallPartReplayWithSchemas(payload []byte, itemResul
 	}
 	if ci, pi, exists := antigravityFunctionCallPartLocationForReplayWithSchemas(payload, itemResult, toolSchemas); exists {
 		_, allowLegacyIDRestore := toolSchemas[name]
-		return restoreAntigravityNativeFunctionCallReplay(payload, ci, pi, itemResult, allowLegacyIDRestore)
+		return restoreAntigravityNativeFunctionCallReplay(payload, ci, pi, itemResult, allowLegacyIDRestore, true)
+	}
+	// The context drifted, but an exact opaque ID match still proves this call's
+	// identity. Gemini validates a thought signature's own integrity and nothing
+	// about the history around it, so the drift costs the signature nothing: restore
+	// the native call and its signature rather than making the model re-reason.
+	if ci, pi, exists := antigravityFunctionCallProvenanceLocation(payload, itemResult, toolSchemas); exists {
+		return restoreAntigravityNativeFunctionCallReplay(payload, ci, pi, itemResult, false, true)
 	}
 	if callID != "" {
-		if antigravityPayloadHasFunctionCallID(payload, callID) {
-			// The ID is present but its semantic payload did not match above. Never
-			// replay or reinsert an opaque signature onto that changed call.
+		stableID := util.GeminiClaudeToolUseID(callID, name, args.Raw)
+		if antigravityPayloadHasFunctionCallID(payload, callID) || (stableID != "" && antigravityPayloadHasFunctionCallID(payload, stableID)) {
+			// The call is already in the history under its native or Claude-facing
+			// ID, and neither lookup above accepted it, so the client changed it.
+			// Never replay an opaque signature onto that changed call, and never
+			// insert a second copy of it further down.
 			return payload, false
 		}
 		if frIndex, currentResponseID, ok := antigravityFunctionResponseContentIndexForReplay(payload, itemResult); ok {
@@ -1700,7 +1917,14 @@ func (a *antigravityReasoningReplayAccumulator) appendPendingThoughtSignatures()
 }
 
 func (a *antigravityReasoningReplayAccumulator) Commit(ctx context.Context) {
-	if a == nil || !a.scope.valid() || !a.terminal {
+	if a == nil || !a.scope.valid() {
+		return
+	}
+	log.Debugf("antigravity replay: accumulator commit terminal=%t overflow=%t items=%d (session=%s)",
+		a.terminal, a.overflow, len(a.items), antigravityReplayLogKey(a.scope.sessionKey))
+	if !a.terminal {
+		// No terminal finishReason means the stream never completed, so this turn
+		// contributes nothing to the ledger and its tool IDs become unresolvable.
 		return
 	}
 	if a.overflow {

--- a/internal/runtime/executor/antigravity_reasoning_replay.go
+++ b/internal/runtime/executor/antigravity_reasoning_replay.go
@@ -1000,10 +1000,12 @@ func antigravitySyntheticToolCallID(reservedID string) string {
 // ledger miss instead of failing closed forever.
 //
 // The same reserved ID always maps to the same synthetic ID, so functionCall and
-// functionResponse stay paired. Signatures on a rewritten call are dropped because
-// they can no longer correspond to it; callers restore the leading call's bypass
-// sentinel via antigravityRepairUnsignedFirstFunctionCalls. Every other part is
-// left alone, preserving the native "1 signed + N unsigned" parallel-call shape.
+// functionResponse stay paired. Whatever signature the client carried in-band is
+// kept: Gemini validates a thought signature's own integrity, not its binding to
+// the call ID or the surrounding history, so rewriting the ID does not invalidate
+// it. Calls left with no signature at all get the leading bypass sentinel from
+// antigravityRepairUnsignedFirstFunctionCalls. Every other part is left alone,
+// preserving the native "1 signed + N unsigned" parallel-call shape.
 func degradeAntigravityClaudeToolProvenanceIDs(payload []byte) ([]byte, int) {
 	contents := gjson.GetBytes(payload, "request.contents")
 	if !contents.IsArray() {
@@ -1024,9 +1026,6 @@ func degradeAntigravityClaudeToolProvenanceIDs(payload []byte) ([]byte, int) {
 					continue
 				}
 				out, _ = sjson.SetBytes(out, partPath+".functionCall.id", antigravitySyntheticToolCallID(id))
-				for _, field := range []string{"thoughtSignature", "thought_signature", "extra_content.google.thought_signature"} {
-					out, _ = sjson.DeleteBytes(out, partPath+"."+field)
-				}
 				degraded++
 				continue
 			}
@@ -1373,10 +1372,11 @@ func mergeAntigravityFunctionCallPartReplayWithSchemas(payload []byte, itemResul
 		return restoreAntigravityNativeFunctionCallReplay(payload, ci, pi, itemResult, allowLegacyIDRestore, true)
 	}
 	// The context drifted, but an exact opaque ID match still proves this call's
-	// identity. Restore the native call so the request stays replayable, and leave
-	// it unsigned rather than replaying a signature issued for a different history.
+	// identity. Gemini validates a thought signature's own integrity and nothing
+	// about the history around it, so the drift costs the signature nothing: restore
+	// the native call and its signature rather than making the model re-reason.
 	if ci, pi, exists := antigravityFunctionCallProvenanceLocation(payload, itemResult, toolSchemas); exists {
-		return restoreAntigravityNativeFunctionCallReplay(payload, ci, pi, itemResult, false, false)
+		return restoreAntigravityNativeFunctionCallReplay(payload, ci, pi, itemResult, false, true)
 	}
 	if callID != "" {
 		stableID := util.GeminiClaudeToolUseID(callID, name, args.Raw)

--- a/internal/runtime/executor/antigravity_reasoning_replay.go
+++ b/internal/runtime/executor/antigravity_reasoning_replay.go
@@ -1115,9 +1115,6 @@ func antigravityThoughtSignatureReplayPartPath(payload []byte, itemResult gjson.
 	if ci < 0 || ci >= len(contentArr) || !strings.EqualFold(strings.TrimSpace(contentArr[ci].Get("role").String()), "model") {
 		return "", false
 	}
-	if !antigravityReplayItemContextMatches(payload, itemResult, ci) {
-		return "", false
-	}
 	parts := contentArr[ci].Get("parts")
 	if !parts.IsArray() {
 		return "", false
@@ -1125,6 +1122,12 @@ func antigravityThoughtSignatureReplayPartPath(payload []byte, itemResult gjson.
 	partArr := parts.Array()
 	targetKind := strings.TrimSpace(itemResult.Get("targetKind").String())
 	targetHash := strings.TrimSpace(itemResult.Get("targetHash").String())
+	// A target hash pins the signature to a part whose own bytes are unchanged,
+	// which is all Gemini validates: the signature's own integrity, never its
+	// binding to the surrounding history. Drift elsewhere in the conversation
+	// therefore costs this signature nothing, so it is deliberately not gated on
+	// the context fingerprint. The fallback below has no such proof and stays
+	// gated.
 	if targetHash != "" {
 		if targetOccurrence := itemResult.Get("targetOccurrence"); targetOccurrence.Exists() {
 			wanted := int(targetOccurrence.Int())
@@ -1157,6 +1160,11 @@ func antigravityThoughtSignatureReplayPartPath(payload []byte, itemResult gjson.
 		return "", false
 	}
 
+	// No target hash: nothing proves which part this signature belongs to, so
+	// only a matching context fingerprint makes the positional guess safe.
+	if !antigravityReplayItemContextMatches(payload, itemResult, ci) {
+		return "", false
+	}
 	pi := int(itemResult.Get("partIndex").Int())
 	if pi >= 0 && pi < len(partArr) && partArr[pi].Type != gjson.Null {
 		if kind, _ := antigravityReplayPartFingerprint(partArr[pi]); kind != "" {

--- a/internal/runtime/executor/antigravity_reasoning_replay_test.go
+++ b/internal/runtime/executor/antigravity_reasoning_replay_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	homekv "github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	internalsignature "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -46,6 +48,28 @@ func TestAntigravityReasoningReplayAccumulatorMultiToolSSEChunks(t *testing.T) {
 	}
 	if got := gjson.GetBytes(items[0], "thoughtSignature").String(); got != "sig-first" {
 		t.Fatalf("first sig = %q", got)
+	}
+}
+
+func TestPrepareAntigravityGeminiReasoningReplayPayloadToleratesHomeKVFailure(t *testing.T) {
+	// An enabled Home client with no heartbeat makes CurrentKVClient report home
+	// mode with an error, which is how every Home-side KV failure reaches the
+	// replay cache — including the "unknown command 'cas'" case from an older
+	// Home. The request must proceed without replay rather than fail, because a
+	// bare executor error would make MarkResult mark the credential unavailable.
+	homekv.SetCurrent(homekv.New(config.HomeConfig{Enabled: true}))
+	t.Cleanup(func() { homekv.SetCurrent(nil) })
+
+	payload := []byte(`{"sessionId":"kv-failure","request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`)
+	out, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), "gemini-3-flash-agent", cliproxyexecutor.Request{}, cliproxyexecutor.Options{}, payload)
+	if errPrepare != nil {
+		t.Fatalf("prepare error = %v, want nil so the request proceeds without replay", errPrepare)
+	}
+	if len(out) == 0 {
+		t.Fatal("prepare returned an empty payload")
+	}
+	if got := gjson.GetBytes(out, "sessionId").String(); got != "kv-failure" {
+		t.Fatalf("payload sessionId = %q, want kv-failure", got)
 	}
 }
 
@@ -759,8 +783,10 @@ func TestAntigravityReasoningReplayAccumulatorCountsExistingFunctionOccurrenceTh
 	if errPrepare != nil {
 		t.Fatal(errPrepare)
 	}
+	// The leading call gets Gemini's bypass sentinel (it carries no native
+	// signature); only the second occurrence may receive the replayed one.
 	parts := gjson.GetBytes(prepared, "request.contents.0.parts").Array()
-	if len(parts) != 2 || parts[0].Get("thoughtSignature").String() != "" || parts[1].Get("thoughtSignature").String() != signature {
+	if len(parts) != 2 || antigravityHasNativeThoughtSignature(parts[0].Get("thoughtSignature").String()) || parts[1].Get("thoughtSignature").String() != signature {
 		t.Fatalf("function occurrence replay targeted the wrong call: %s", prepared)
 	}
 }
@@ -843,7 +869,7 @@ func TestPrepareAntigravityGeminiReasoningReplayRejectsReusedIDWithChangedCall(t
 	if errPrepare != nil {
 		t.Fatal(errPrepare)
 	}
-	if got := gjson.GetBytes(out, "request.contents.1.parts.0.thoughtSignature").String(); got != "" {
+	if got := gjson.GetBytes(out, "request.contents.1.parts.0.thoughtSignature").String(); antigravityHasNativeThoughtSignature(got) {
 		t.Fatalf("changed call with reused ID received stale signature %q; body=%s", got, out)
 	}
 	if got := gjson.GetBytes(out, "request.contents.1.parts.1.thoughtSignature").String(); got != "" {
@@ -875,7 +901,7 @@ func TestPrepareAntigravityGeminiReasoningReplayRejectsChangedIDLessCallAtSamePo
 	if errPrepare != nil {
 		t.Fatal(errPrepare)
 	}
-	if got := gjson.GetBytes(out, "request.contents.1.parts.0.thoughtSignature").String(); got != "" {
+	if got := gjson.GetBytes(out, "request.contents.1.parts.0.thoughtSignature").String(); antigravityHasNativeThoughtSignature(got) {
 		t.Fatalf("changed ID-less call received stale signature %q; body=%s", got, out)
 	}
 }
@@ -1014,7 +1040,7 @@ func TestAntigravityReasoningReplayDoesNotCommitPartialResponse(t *testing.T) {
 	}
 }
 
-func TestPrepareAntigravityGeminiReasoningReplayRejectsFingerprintMismatch(t *testing.T) {
+func TestPrepareAntigravityGeminiReasoningReplayKeepsTextSignatureOnContextDrift(t *testing.T) {
 	internalcache.ClearAntigravityReasoningReplayCache()
 	t.Cleanup(internalcache.ClearAntigravityReasoningReplayCache)
 
@@ -1029,8 +1055,31 @@ func TestPrepareAntigravityGeminiReasoningReplayRejectsFingerprintMismatch(t *te
 	if errPrepare != nil {
 		t.Fatal(errPrepare)
 	}
+	// The signed part itself is byte-identical, so the signature still describes
+	// it exactly. Only the surrounding turns drifted, which Gemini does not bind
+	// signatures to, so dropping it here would only force needless re-reasoning.
+	if got := gjson.GetBytes(out, "request.contents.1.parts.0.thoughtSignature").String(); got != "fingerprinted-signature-123456" {
+		t.Fatalf("signature = %q, want the signature replayed even though the surrounding context drifted; body=%s", got, out)
+	}
+}
+
+func TestPrepareAntigravityGeminiReasoningReplayRejectsFingerprintMismatch(t *testing.T) {
+	internalcache.ClearAntigravityReasoningReplayCache()
+	t.Cleanup(internalcache.ClearAntigravityReasoningReplayCache)
+
+	kind, fingerprint := antigravityReplayPartFingerprint(gjson.Parse(`{"text":"original answer"}`))
+	item := buildAntigravityThoughtSignatureItem(1, 0, "fingerprinted-signature-123456", kind, fingerprint)
+	internalcache.CacheAntigravityReasoningReplayItems("gemini-3.6-flash-high", "session:edited", [][]byte{item})
+
+	// The client rewrote the signed part, so the cached signature describes text
+	// that is no longer in the request and must not be attached to the new text.
+	payload := []byte(`{"sessionId":"edited","request":{"contents":[{"role":"user","parts":[{"text":"turn"}]},{"role":"model","parts":[{"text":"edited answer"}]},{"role":"user","parts":[{"text":"next"}]}]}}`)
+	out, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), "gemini-3.6-flash-high", cliproxyexecutor.Request{}, cliproxyexecutor.Options{}, payload)
+	if errPrepare != nil {
+		t.Fatal(errPrepare)
+	}
 	if got := gjson.GetBytes(out, "request.contents.1.parts.0.thoughtSignature").String(); got != "" {
-		t.Fatalf("mismatched rebuilt context received stale signature %q; body=%s", got, out)
+		t.Fatalf("edited part received stale signature %q; body=%s", got, out)
 	}
 }
 
@@ -1469,7 +1518,7 @@ func TestPrepareAntigravityGeminiReasoningReplayRestoresLegacyClaudeToolIDWithSc
 	}
 }
 
-func TestPrepareAntigravityGeminiReasoningReplayFailsClosedWithoutClaudeToolProvenance(t *testing.T) {
+func TestPrepareAntigravityGeminiReasoningReplayDegradesWithoutClaudeToolProvenance(t *testing.T) {
 	internalcache.ClearAntigravityReasoningReplayCache()
 	t.Cleanup(internalcache.ClearAntigravityReasoningReplayCache)
 
@@ -1478,9 +1527,26 @@ func TestPrepareAntigravityGeminiReasoningReplayFailsClosedWithoutClaudeToolProv
 	payload := []byte(`{"sessionId":"sess-missing-provenance","request":{"contents":[{"role":"model","parts":[{"thoughtSignature":"skip_thought_signature_validator","functionCall":{"id":"` + clientID + `","name":"Read","args":{"file_path":"/tmp/a"}}}]},{"role":"user","parts":[{"functionResponse":{"id":"` + clientID + `","name":"Read","response":{"result":"ok"}}}]}]}}`)
 	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")}
 
-	_, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), model, cliproxyexecutor.Request{Model: model, Payload: payload}, opts, payload)
-	if errPrepare == nil || !strings.Contains(errPrepare.Error(), "missing Claude tool provenance") {
-		t.Fatalf("error = %v, want fail-closed missing provenance", errPrepare)
+	// An empty ledger must not kill the conversation: the reserved IDs are
+	// rewritten to neutral synthetic IDs and the request stays valid.
+	out, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), model, cliproxyexecutor.Request{Model: model, Payload: payload}, opts, payload)
+	if errPrepare != nil {
+		t.Fatalf("prepare failed: %v", errPrepare)
+	}
+	if antigravityPayloadHasClaudeToolProvenanceID(out) {
+		t.Fatalf("reserved provenance IDs leaked upstream: %s", out)
+	}
+	call := gjson.GetBytes(out, "request.contents.0.parts.0")
+	response := gjson.GetBytes(out, "request.contents.1.parts.0.functionResponse")
+	callID := call.Get("functionCall.id").String()
+	if callID == "" || callID != response.Get("id").String() {
+		t.Fatalf("degraded call/response pairing broken: call=%q response=%q", callID, response.Get("id").String())
+	}
+	if got := call.Get("thoughtSignature").String(); got != internalsignature.GeminiSkipThoughtSignatureValidator {
+		t.Fatalf("first degraded call thoughtSignature = %q, want bypass sentinel", got)
+	}
+	if errPairing := internalsignature.ValidateGeminiFunctionCallPairing(out); errPairing != nil {
+		t.Fatalf("degraded history is invalid: %v", errPairing)
 	}
 }
 
@@ -1539,9 +1605,28 @@ func TestPrepareAntigravityGeminiReasoningReplayRejectsChangedClaudeToolArgument
 	original := []byte(`{"tools":[{"name":"Edit","input_schema":{"type":"object","properties":{"replace_all":{"type":"boolean","default":false}}}}]}`)
 	opts := cliproxyexecutor.Options{OriginalRequest: original, SourceFormat: sdktranslator.FromString("claude")}
 
-	_, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), model, cliproxyexecutor.Request{Model: model, Payload: payload}, opts, payload)
-	if errPrepare == nil || !strings.Contains(errPrepare.Error(), "missing Claude tool provenance") {
-		t.Fatalf("error = %v, want fail-closed changed arguments", errPrepare)
+	// The client changed the arguments, so the native call must NOT be restored.
+	// The request still goes through, but only with a neutral synthetic ID and
+	// without the native identity or the cached signature.
+	out, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), model, cliproxyexecutor.Request{Model: model, Payload: payload}, opts, payload)
+	if errPrepare != nil {
+		t.Fatalf("prepare failed: %v", errPrepare)
+	}
+	if antigravityPayloadHasClaudeToolProvenanceID(out) {
+		t.Fatalf("reserved provenance IDs leaked upstream: %s", out)
+	}
+	call := gjson.GetBytes(out, "request.contents.0.parts.0")
+	if got := call.Get("functionCall.id").String(); got == "native-edit-changed" {
+		t.Fatalf("native call ID was restored onto changed arguments: %s", out)
+	}
+	if got := call.Get("thoughtSignature").String(); got != internalsignature.GeminiSkipThoughtSignatureValidator {
+		t.Fatalf("changed call thoughtSignature = %q, want bypass sentinel and no native signature", got)
+	}
+	if !call.Get("functionCall.args.replace_all").Bool() {
+		t.Fatalf("client arguments were rewritten by replay: %s", call.Raw)
+	}
+	if errPairing := internalsignature.ValidateGeminiFunctionCallPairing(out); errPairing != nil {
+		t.Fatalf("degraded history is invalid: %v", errPairing)
 	}
 }
 
@@ -1597,5 +1682,115 @@ func TestPrepareAntigravityGeminiReasoningReplayRejectsUnmatchedNonPlaceholderRe
 	}
 	if !strings.Contains(errPrepare.Error(), "invalid Gemini function call history") {
 		t.Fatalf("error = %v, want invalid Gemini function call history", errPrepare)
+	}
+}
+
+func TestPrepareAntigravityGeminiReasoningReplayRestoresIdentityOnContextDrift(t *testing.T) {
+	internalcache.ClearAntigravityReasoningReplayCache()
+	t.Cleanup(internalcache.ClearAntigravityReasoningReplayCache)
+
+	const model = "gemini-3.6-flash-high"
+	const args = `{"file_path":"/tmp/a"}`
+	clientID := util.GeminiClaudeToolUseID("native-drift", "Read", args)
+	payload := []byte(`{"sessionId":"sess-context-drift","request":{"contents":[{"role":"model","parts":[{"thoughtSignature":"skip_thought_signature_validator","functionCall":{"id":"` + clientID + `","name":"Read","args":` + args + `}}]},{"role":"user","parts":[{"functionResponse":{"id":"` + clientID + `","name":"Read","response":{"result":"ok"}}}]}]}}`)
+	// A stale contextHash stands in for compacted or rewritten history: the tool
+	// identity is still provable from the opaque ID, but the cached signature is
+	// no longer valid for this conversation.
+	item := []byte(`{"type":"function_call_part","contentIndex":0,"partIndex":0,"targetOccurrence":0,"name":"Read","call_id":"native-drift","args":` + args + `,"thoughtSignature":"EsMTCsATARFNMg/XNVix5lDpkKaHR7Xg","contextHash":"0000000000000000000000000000000000000000000000000000000000000000"}`)
+	sessionKey := antigravityReasoningReplayScopeFromPayload(model, payload).sessionKey
+	if !internalcache.CacheAntigravityReasoningReplayItems(model, sessionKey, [][]byte{item}) {
+		t.Fatal("failed to cache drifted provenance")
+	}
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")}
+
+	out, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), model, cliproxyexecutor.Request{Model: model, Payload: payload}, opts, payload)
+	if errPrepare != nil {
+		t.Fatalf("prepare failed: %v", errPrepare)
+	}
+	if antigravityPayloadHasClaudeToolProvenanceID(out) {
+		t.Fatalf("reserved provenance IDs leaked upstream: %s", out)
+	}
+	call := gjson.GetBytes(out, "request.contents.0.parts.0")
+	if got := call.Get("functionCall.id").String(); got != "native-drift" {
+		t.Fatalf("functionCall.id = %q, want native identity restored despite context drift", got)
+	}
+	if got := gjson.GetBytes(out, "request.contents.1.parts.0.functionResponse.id").String(); got != "native-drift" {
+		t.Fatalf("functionResponse.id = %q, want native identity restored", got)
+	}
+	if got := call.Get("thoughtSignature").String(); !antigravityHasNativeThoughtSignature(got) {
+		t.Fatalf("thoughtSignature = %q, want the native signature replayed even though the context drifted", got)
+	}
+	if errPairing := internalsignature.ValidateGeminiFunctionCallPairing(out); errPairing != nil {
+		t.Fatalf("restored history is invalid: %v", errPairing)
+	}
+}
+
+func TestDegradeAntigravityClaudeToolProvenanceIDsKeepsParallelShape(t *testing.T) {
+	ids := make([]string, 3)
+	for i := range ids {
+		ids[i] = util.GeminiClaudeToolUseID(fmt.Sprintf("native-%d", i), "Read", `{"file_path":"/tmp/a"}`)
+	}
+	payload := []byte(`{"request":{"contents":[{"role":"model","parts":[` +
+		`{"thoughtSignature":"EsMTCsATARFNMg/XNVix5lDpkKaHR7Xg","functionCall":{"id":"` + ids[0] + `","name":"Read","args":{"file_path":"/tmp/a"}}},` +
+		`{"functionCall":{"id":"` + ids[1] + `","name":"Read","args":{"file_path":"/tmp/b"}}},` +
+		`{"functionCall":{"id":"` + ids[2] + `","name":"Read","args":{"file_path":"/tmp/c"}}}` +
+		`]},{"role":"user","parts":[` +
+		`{"functionResponse":{"id":"` + ids[0] + `","name":"Read","response":{"result":"a"}}},` +
+		`{"functionResponse":{"id":"` + ids[1] + `","name":"Read","response":{"result":"b"}}},` +
+		`{"functionResponse":{"id":"` + ids[2] + `","name":"Read","response":{"result":"c"}}}` +
+		`]}]}}`)
+
+	out, degraded := degradeAntigravityClaudeToolProvenanceIDs(payload)
+	out = antigravityRepairUnsignedFirstFunctionCalls(out)
+	if degraded != 6 {
+		t.Fatalf("degraded = %d, want 6 (3 calls + 3 responses)", degraded)
+	}
+	if antigravityPayloadHasClaudeToolProvenanceID(out) {
+		t.Fatalf("reserved provenance IDs leaked upstream: %s", out)
+	}
+
+	calls := gjson.GetBytes(out, "request.contents.0.parts").Array()
+	responses := gjson.GetBytes(out, "request.contents.1.parts").Array()
+	if len(calls) != 3 || len(responses) != 3 {
+		t.Fatalf("part counts changed: %d calls, %d responses", len(calls), len(responses))
+	}
+	signed := 0
+	for i, call := range calls {
+		signature := call.Get("thoughtSignature").String()
+		if signature != "" {
+			signed++
+		}
+		if i == 0 && !antigravityHasNativeThoughtSignature(signature) {
+			t.Fatalf("first call thoughtSignature = %q, want the in-band signature kept through degradation", signature)
+		}
+		if i > 0 && signature != "" {
+			t.Fatalf("sibling call %d gained a signature %q, want unsigned", i, signature)
+		}
+		if got := call.Get("functionCall.id").String(); got != responses[i].Get("functionResponse.id").String() {
+			t.Fatalf("call/response pairing broken at %d: %q vs %q", i, got, responses[i].Get("functionResponse.id").String())
+		}
+	}
+	if signed != 1 {
+		t.Fatalf("signed calls = %d, want exactly 1 signed + 2 unsigned native parallel shape", signed)
+	}
+	if errPairing := internalsignature.ValidateGeminiFunctionCallPairing(out); errPairing != nil {
+		t.Fatalf("degraded history is invalid: %v", errPairing)
+	}
+}
+
+func TestPrepareAntigravityGeminiReasoningReplayStillRejectsBrokenPairing(t *testing.T) {
+	internalcache.ClearAntigravityReasoningReplayCache()
+	t.Cleanup(internalcache.ClearAntigravityReasoningReplayCache)
+
+	const model = "gemini-3.6-flash-high"
+	clientID := util.GeminiClaudeToolUseID("native-orphan", "Read", `{"file_path":"/tmp/a"}`)
+	// A functionResponse with no preceding functionCall is structurally invalid and
+	// must keep failing even though provenance degradation is now in play.
+	payload := []byte(`{"sessionId":"sess-orphan","request":{"contents":[{"role":"user","parts":[{"functionResponse":{"id":"` + clientID + `","name":"Read","response":{"result":"ok"}}}]}]}}`)
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")}
+
+	_, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), model, cliproxyexecutor.Request{Model: model, Payload: payload}, opts, payload)
+	if errPrepare == nil || !strings.Contains(errPrepare.Error(), "invalid Gemini function call history") {
+		t.Fatalf("error = %v, want structural pairing rejection", errPrepare)
 	}
 }

--- a/internal/runtime/executor/antigravity_reasoning_replay_test.go
+++ b/internal/runtime/executor/antigravity_reasoning_replay_test.go
@@ -1016,7 +1016,7 @@ func TestAntigravityReasoningReplayDoesNotCommitPartialResponse(t *testing.T) {
 	}
 }
 
-func TestPrepareAntigravityGeminiReasoningReplayRejectsFingerprintMismatch(t *testing.T) {
+func TestPrepareAntigravityGeminiReasoningReplayKeepsTextSignatureOnContextDrift(t *testing.T) {
 	internalcache.ClearAntigravityReasoningReplayCache()
 	t.Cleanup(internalcache.ClearAntigravityReasoningReplayCache)
 
@@ -1031,8 +1031,31 @@ func TestPrepareAntigravityGeminiReasoningReplayRejectsFingerprintMismatch(t *te
 	if errPrepare != nil {
 		t.Fatal(errPrepare)
 	}
+	// The signed part itself is byte-identical, so the signature still describes
+	// it exactly. Only the surrounding turns drifted, which Gemini does not bind
+	// signatures to, so dropping it here would only force needless re-reasoning.
+	if got := gjson.GetBytes(out, "request.contents.1.parts.0.thoughtSignature").String(); got != "fingerprinted-signature-123456" {
+		t.Fatalf("signature = %q, want the signature replayed even though the surrounding context drifted; body=%s", got, out)
+	}
+}
+
+func TestPrepareAntigravityGeminiReasoningReplayRejectsFingerprintMismatch(t *testing.T) {
+	internalcache.ClearAntigravityReasoningReplayCache()
+	t.Cleanup(internalcache.ClearAntigravityReasoningReplayCache)
+
+	kind, fingerprint := antigravityReplayPartFingerprint(gjson.Parse(`{"text":"original answer"}`))
+	item := buildAntigravityThoughtSignatureItem(1, 0, "fingerprinted-signature-123456", kind, fingerprint)
+	internalcache.CacheAntigravityReasoningReplayItems("gemini-3.6-flash-high", "session:edited", [][]byte{item})
+
+	// The client rewrote the signed part, so the cached signature describes text
+	// that is no longer in the request and must not be attached to the new text.
+	payload := []byte(`{"sessionId":"edited","request":{"contents":[{"role":"user","parts":[{"text":"turn"}]},{"role":"model","parts":[{"text":"edited answer"}]},{"role":"user","parts":[{"text":"next"}]}]}}`)
+	out, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), "gemini-3.6-flash-high", cliproxyexecutor.Request{}, cliproxyexecutor.Options{}, payload)
+	if errPrepare != nil {
+		t.Fatal(errPrepare)
+	}
 	if got := gjson.GetBytes(out, "request.contents.1.parts.0.thoughtSignature").String(); got != "" {
-		t.Fatalf("mismatched rebuilt context received stale signature %q; body=%s", got, out)
+		t.Fatalf("edited part received stale signature %q; body=%s", got, out)
 	}
 }
 

--- a/internal/runtime/executor/antigravity_reasoning_replay_test.go
+++ b/internal/runtime/executor/antigravity_reasoning_replay_test.go
@@ -759,8 +759,10 @@ func TestAntigravityReasoningReplayAccumulatorCountsExistingFunctionOccurrenceTh
 	if errPrepare != nil {
 		t.Fatal(errPrepare)
 	}
+	// The leading call gets Gemini's bypass sentinel (it carries no native
+	// signature); only the second occurrence may receive the replayed one.
 	parts := gjson.GetBytes(prepared, "request.contents.0.parts").Array()
-	if len(parts) != 2 || parts[0].Get("thoughtSignature").String() != "" || parts[1].Get("thoughtSignature").String() != signature {
+	if len(parts) != 2 || antigravityHasNativeThoughtSignature(parts[0].Get("thoughtSignature").String()) || parts[1].Get("thoughtSignature").String() != signature {
 		t.Fatalf("function occurrence replay targeted the wrong call: %s", prepared)
 	}
 }
@@ -843,7 +845,7 @@ func TestPrepareAntigravityGeminiReasoningReplayRejectsReusedIDWithChangedCall(t
 	if errPrepare != nil {
 		t.Fatal(errPrepare)
 	}
-	if got := gjson.GetBytes(out, "request.contents.1.parts.0.thoughtSignature").String(); got != "" {
+	if got := gjson.GetBytes(out, "request.contents.1.parts.0.thoughtSignature").String(); antigravityHasNativeThoughtSignature(got) {
 		t.Fatalf("changed call with reused ID received stale signature %q; body=%s", got, out)
 	}
 	if got := gjson.GetBytes(out, "request.contents.1.parts.1.thoughtSignature").String(); got != "" {
@@ -875,7 +877,7 @@ func TestPrepareAntigravityGeminiReasoningReplayRejectsChangedIDLessCallAtSamePo
 	if errPrepare != nil {
 		t.Fatal(errPrepare)
 	}
-	if got := gjson.GetBytes(out, "request.contents.1.parts.0.thoughtSignature").String(); got != "" {
+	if got := gjson.GetBytes(out, "request.contents.1.parts.0.thoughtSignature").String(); antigravityHasNativeThoughtSignature(got) {
 		t.Fatalf("changed ID-less call received stale signature %q; body=%s", got, out)
 	}
 }
@@ -1469,7 +1471,7 @@ func TestPrepareAntigravityGeminiReasoningReplayRestoresLegacyClaudeToolIDWithSc
 	}
 }
 
-func TestPrepareAntigravityGeminiReasoningReplayFailsClosedWithoutClaudeToolProvenance(t *testing.T) {
+func TestPrepareAntigravityGeminiReasoningReplayDegradesWithoutClaudeToolProvenance(t *testing.T) {
 	internalcache.ClearAntigravityReasoningReplayCache()
 	t.Cleanup(internalcache.ClearAntigravityReasoningReplayCache)
 
@@ -1478,9 +1480,26 @@ func TestPrepareAntigravityGeminiReasoningReplayFailsClosedWithoutClaudeToolProv
 	payload := []byte(`{"sessionId":"sess-missing-provenance","request":{"contents":[{"role":"model","parts":[{"thoughtSignature":"skip_thought_signature_validator","functionCall":{"id":"` + clientID + `","name":"Read","args":{"file_path":"/tmp/a"}}}]},{"role":"user","parts":[{"functionResponse":{"id":"` + clientID + `","name":"Read","response":{"result":"ok"}}}]}]}}`)
 	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")}
 
-	_, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), model, cliproxyexecutor.Request{Model: model, Payload: payload}, opts, payload)
-	if errPrepare == nil || !strings.Contains(errPrepare.Error(), "missing Claude tool provenance") {
-		t.Fatalf("error = %v, want fail-closed missing provenance", errPrepare)
+	// An empty ledger must not kill the conversation: the reserved IDs are
+	// rewritten to neutral synthetic IDs and the request stays valid.
+	out, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), model, cliproxyexecutor.Request{Model: model, Payload: payload}, opts, payload)
+	if errPrepare != nil {
+		t.Fatalf("prepare failed: %v", errPrepare)
+	}
+	if antigravityPayloadHasClaudeToolProvenanceID(out) {
+		t.Fatalf("reserved provenance IDs leaked upstream: %s", out)
+	}
+	call := gjson.GetBytes(out, "request.contents.0.parts.0")
+	response := gjson.GetBytes(out, "request.contents.1.parts.0.functionResponse")
+	callID := call.Get("functionCall.id").String()
+	if callID == "" || callID != response.Get("id").String() {
+		t.Fatalf("degraded call/response pairing broken: call=%q response=%q", callID, response.Get("id").String())
+	}
+	if got := call.Get("thoughtSignature").String(); got != internalsignature.GeminiSkipThoughtSignatureValidator {
+		t.Fatalf("first degraded call thoughtSignature = %q, want bypass sentinel", got)
+	}
+	if errPairing := internalsignature.ValidateGeminiFunctionCallPairing(out); errPairing != nil {
+		t.Fatalf("degraded history is invalid: %v", errPairing)
 	}
 }
 
@@ -1539,9 +1558,28 @@ func TestPrepareAntigravityGeminiReasoningReplayRejectsChangedClaudeToolArgument
 	original := []byte(`{"tools":[{"name":"Edit","input_schema":{"type":"object","properties":{"replace_all":{"type":"boolean","default":false}}}}]}`)
 	opts := cliproxyexecutor.Options{OriginalRequest: original, SourceFormat: sdktranslator.FromString("claude")}
 
-	_, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), model, cliproxyexecutor.Request{Model: model, Payload: payload}, opts, payload)
-	if errPrepare == nil || !strings.Contains(errPrepare.Error(), "missing Claude tool provenance") {
-		t.Fatalf("error = %v, want fail-closed changed arguments", errPrepare)
+	// The client changed the arguments, so the native call must NOT be restored.
+	// The request still goes through, but only with a neutral synthetic ID and
+	// without the native identity or the cached signature.
+	out, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), model, cliproxyexecutor.Request{Model: model, Payload: payload}, opts, payload)
+	if errPrepare != nil {
+		t.Fatalf("prepare failed: %v", errPrepare)
+	}
+	if antigravityPayloadHasClaudeToolProvenanceID(out) {
+		t.Fatalf("reserved provenance IDs leaked upstream: %s", out)
+	}
+	call := gjson.GetBytes(out, "request.contents.0.parts.0")
+	if got := call.Get("functionCall.id").String(); got == "native-edit-changed" {
+		t.Fatalf("native call ID was restored onto changed arguments: %s", out)
+	}
+	if got := call.Get("thoughtSignature").String(); got != internalsignature.GeminiSkipThoughtSignatureValidator {
+		t.Fatalf("changed call thoughtSignature = %q, want bypass sentinel and no native signature", got)
+	}
+	if !call.Get("functionCall.args.replace_all").Bool() {
+		t.Fatalf("client arguments were rewritten by replay: %s", call.Raw)
+	}
+	if errPairing := internalsignature.ValidateGeminiFunctionCallPairing(out); errPairing != nil {
+		t.Fatalf("degraded history is invalid: %v", errPairing)
 	}
 }
 
@@ -1597,5 +1635,118 @@ func TestPrepareAntigravityGeminiReasoningReplayRejectsUnmatchedNonPlaceholderRe
 	}
 	if !strings.Contains(errPrepare.Error(), "invalid Gemini function call history") {
 		t.Fatalf("error = %v, want invalid Gemini function call history", errPrepare)
+	}
+}
+
+func TestPrepareAntigravityGeminiReasoningReplayRestoresIdentityOnContextDrift(t *testing.T) {
+	internalcache.ClearAntigravityReasoningReplayCache()
+	t.Cleanup(internalcache.ClearAntigravityReasoningReplayCache)
+
+	const model = "gemini-3.6-flash-high"
+	const args = `{"file_path":"/tmp/a"}`
+	clientID := util.GeminiClaudeToolUseID("native-drift", "Read", args)
+	payload := []byte(`{"sessionId":"sess-context-drift","request":{"contents":[{"role":"model","parts":[{"thoughtSignature":"skip_thought_signature_validator","functionCall":{"id":"` + clientID + `","name":"Read","args":` + args + `}}]},{"role":"user","parts":[{"functionResponse":{"id":"` + clientID + `","name":"Read","response":{"result":"ok"}}}]}]}}`)
+	// A stale contextHash stands in for compacted or rewritten history: the tool
+	// identity is still provable from the opaque ID, but the cached signature is
+	// no longer valid for this conversation.
+	item := []byte(`{"type":"function_call_part","contentIndex":0,"partIndex":0,"targetOccurrence":0,"name":"Read","call_id":"native-drift","args":` + args + `,"thoughtSignature":"EsMTCsATARFNMg/XNVix5lDpkKaHR7Xg","contextHash":"0000000000000000000000000000000000000000000000000000000000000000"}`)
+	sessionKey := antigravityReasoningReplayScopeFromPayload(model, payload).sessionKey
+	if !internalcache.CacheAntigravityReasoningReplayItems(model, sessionKey, [][]byte{item}) {
+		t.Fatal("failed to cache drifted provenance")
+	}
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")}
+
+	out, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), model, cliproxyexecutor.Request{Model: model, Payload: payload}, opts, payload)
+	if errPrepare != nil {
+		t.Fatalf("prepare failed: %v", errPrepare)
+	}
+	if antigravityPayloadHasClaudeToolProvenanceID(out) {
+		t.Fatalf("reserved provenance IDs leaked upstream: %s", out)
+	}
+	call := gjson.GetBytes(out, "request.contents.0.parts.0")
+	if got := call.Get("functionCall.id").String(); got != "native-drift" {
+		t.Fatalf("functionCall.id = %q, want native identity restored despite context drift", got)
+	}
+	if got := gjson.GetBytes(out, "request.contents.1.parts.0.functionResponse.id").String(); got != "native-drift" {
+		t.Fatalf("functionResponse.id = %q, want native identity restored", got)
+	}
+	if got := call.Get("thoughtSignature").String(); antigravityHasNativeThoughtSignature(got) {
+		t.Fatalf("thoughtSignature = %q, want no native signature replayed on drifted context", got)
+	}
+	if errPairing := internalsignature.ValidateGeminiFunctionCallPairing(out); errPairing != nil {
+		t.Fatalf("restored history is invalid: %v", errPairing)
+	}
+}
+
+func TestDegradeAntigravityClaudeToolProvenanceIDsKeepsParallelShape(t *testing.T) {
+	ids := make([]string, 3)
+	for i := range ids {
+		ids[i] = util.GeminiClaudeToolUseID(fmt.Sprintf("native-%d", i), "Read", `{"file_path":"/tmp/a"}`)
+	}
+	payload := []byte(`{"request":{"contents":[{"role":"model","parts":[` +
+		`{"thoughtSignature":"EsMTCsATARFNMg/XNVix5lDpkKaHR7Xg","functionCall":{"id":"` + ids[0] + `","name":"Read","args":{"file_path":"/tmp/a"}}},` +
+		`{"functionCall":{"id":"` + ids[1] + `","name":"Read","args":{"file_path":"/tmp/b"}}},` +
+		`{"functionCall":{"id":"` + ids[2] + `","name":"Read","args":{"file_path":"/tmp/c"}}}` +
+		`]},{"role":"user","parts":[` +
+		`{"functionResponse":{"id":"` + ids[0] + `","name":"Read","response":{"result":"a"}}},` +
+		`{"functionResponse":{"id":"` + ids[1] + `","name":"Read","response":{"result":"b"}}},` +
+		`{"functionResponse":{"id":"` + ids[2] + `","name":"Read","response":{"result":"c"}}}` +
+		`]}]}}`)
+
+	out, degraded := degradeAntigravityClaudeToolProvenanceIDs(payload)
+	out = antigravityRepairUnsignedFirstFunctionCalls(out)
+	if degraded != 6 {
+		t.Fatalf("degraded = %d, want 6 (3 calls + 3 responses)", degraded)
+	}
+	if antigravityPayloadHasClaudeToolProvenanceID(out) {
+		t.Fatalf("reserved provenance IDs leaked upstream: %s", out)
+	}
+
+	calls := gjson.GetBytes(out, "request.contents.0.parts").Array()
+	responses := gjson.GetBytes(out, "request.contents.1.parts").Array()
+	if len(calls) != 3 || len(responses) != 3 {
+		t.Fatalf("part counts changed: %d calls, %d responses", len(calls), len(responses))
+	}
+	signed := 0
+	for i, call := range calls {
+		signature := call.Get("thoughtSignature").String()
+		if signature != "" {
+			signed++
+		}
+		if i == 0 && signature != internalsignature.GeminiSkipThoughtSignatureValidator {
+			t.Fatalf("first call thoughtSignature = %q, want bypass sentinel", signature)
+		}
+		if i > 0 && signature != "" {
+			t.Fatalf("sibling call %d gained a signature %q, want unsigned", i, signature)
+		}
+		if got := call.Get("functionCall.id").String(); got != responses[i].Get("functionResponse.id").String() {
+			t.Fatalf("call/response pairing broken at %d: %q vs %q", i, got, responses[i].Get("functionResponse.id").String())
+		}
+	}
+	if signed != 1 {
+		t.Fatalf("signed calls = %d, want exactly 1 signed + 2 unsigned native parallel shape", signed)
+	}
+	if strings.Contains(string(out), "EsMTCsATARFNMg/XNVix5lDpkKaHR7Xg") {
+		t.Fatalf("stale native signature leaked after degradation: %s", out)
+	}
+	if errPairing := internalsignature.ValidateGeminiFunctionCallPairing(out); errPairing != nil {
+		t.Fatalf("degraded history is invalid: %v", errPairing)
+	}
+}
+
+func TestPrepareAntigravityGeminiReasoningReplayStillRejectsBrokenPairing(t *testing.T) {
+	internalcache.ClearAntigravityReasoningReplayCache()
+	t.Cleanup(internalcache.ClearAntigravityReasoningReplayCache)
+
+	const model = "gemini-3.6-flash-high"
+	clientID := util.GeminiClaudeToolUseID("native-orphan", "Read", `{"file_path":"/tmp/a"}`)
+	// A functionResponse with no preceding functionCall is structurally invalid and
+	// must keep failing even though provenance degradation is now in play.
+	payload := []byte(`{"sessionId":"sess-orphan","request":{"contents":[{"role":"user","parts":[{"functionResponse":{"id":"` + clientID + `","name":"Read","response":{"result":"ok"}}}]}]}}`)
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")}
+
+	_, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), model, cliproxyexecutor.Request{Model: model, Payload: payload}, opts, payload)
+	if errPrepare == nil || !strings.Contains(errPrepare.Error(), "invalid Gemini function call history") {
+		t.Fatalf("error = %v, want structural pairing rejection", errPrepare)
 	}
 }

--- a/internal/runtime/executor/antigravity_reasoning_replay_test.go
+++ b/internal/runtime/executor/antigravity_reasoning_replay_test.go
@@ -1670,8 +1670,8 @@ func TestPrepareAntigravityGeminiReasoningReplayRestoresIdentityOnContextDrift(t
 	if got := gjson.GetBytes(out, "request.contents.1.parts.0.functionResponse.id").String(); got != "native-drift" {
 		t.Fatalf("functionResponse.id = %q, want native identity restored", got)
 	}
-	if got := call.Get("thoughtSignature").String(); antigravityHasNativeThoughtSignature(got) {
-		t.Fatalf("thoughtSignature = %q, want no native signature replayed on drifted context", got)
+	if got := call.Get("thoughtSignature").String(); !antigravityHasNativeThoughtSignature(got) {
+		t.Fatalf("thoughtSignature = %q, want the native signature replayed even though the context drifted", got)
 	}
 	if errPairing := internalsignature.ValidateGeminiFunctionCallPairing(out); errPairing != nil {
 		t.Fatalf("restored history is invalid: %v", errPairing)
@@ -1713,8 +1713,8 @@ func TestDegradeAntigravityClaudeToolProvenanceIDsKeepsParallelShape(t *testing.
 		if signature != "" {
 			signed++
 		}
-		if i == 0 && signature != internalsignature.GeminiSkipThoughtSignatureValidator {
-			t.Fatalf("first call thoughtSignature = %q, want bypass sentinel", signature)
+		if i == 0 && !antigravityHasNativeThoughtSignature(signature) {
+			t.Fatalf("first call thoughtSignature = %q, want the in-band signature kept through degradation", signature)
 		}
 		if i > 0 && signature != "" {
 			t.Fatalf("sibling call %d gained a signature %q, want unsigned", i, signature)
@@ -1725,9 +1725,6 @@ func TestDegradeAntigravityClaudeToolProvenanceIDsKeepsParallelShape(t *testing.
 	}
 	if signed != 1 {
 		t.Fatalf("signed calls = %d, want exactly 1 signed + 2 unsigned native parallel shape", signed)
-	}
-	if strings.Contains(string(out), "EsMTCsATARFNMg/XNVix5lDpkKaHR7Xg") {
-		t.Fatalf("stale native signature leaked after degradation: %s", out)
 	}
 	if errPairing := internalsignature.ValidateGeminiFunctionCallPairing(out); errPairing != nil {
 		t.Fatalf("degraded history is invalid: %v", errPairing)

--- a/internal/runtime/executor/antigravity_reasoning_replay_test.go
+++ b/internal/runtime/executor/antigravity_reasoning_replay_test.go
@@ -759,8 +759,10 @@ func TestAntigravityReasoningReplayAccumulatorCountsExistingFunctionOccurrenceTh
 	if errPrepare != nil {
 		t.Fatal(errPrepare)
 	}
+	// The leading call gets Gemini's bypass sentinel (it carries no native
+	// signature); only the second occurrence may receive the replayed one.
 	parts := gjson.GetBytes(prepared, "request.contents.0.parts").Array()
-	if len(parts) != 2 || parts[0].Get("thoughtSignature").String() != "" || parts[1].Get("thoughtSignature").String() != signature {
+	if len(parts) != 2 || antigravityHasNativeThoughtSignature(parts[0].Get("thoughtSignature").String()) || parts[1].Get("thoughtSignature").String() != signature {
 		t.Fatalf("function occurrence replay targeted the wrong call: %s", prepared)
 	}
 }
@@ -843,7 +845,7 @@ func TestPrepareAntigravityGeminiReasoningReplayRejectsReusedIDWithChangedCall(t
 	if errPrepare != nil {
 		t.Fatal(errPrepare)
 	}
-	if got := gjson.GetBytes(out, "request.contents.1.parts.0.thoughtSignature").String(); got != "" {
+	if got := gjson.GetBytes(out, "request.contents.1.parts.0.thoughtSignature").String(); antigravityHasNativeThoughtSignature(got) {
 		t.Fatalf("changed call with reused ID received stale signature %q; body=%s", got, out)
 	}
 	if got := gjson.GetBytes(out, "request.contents.1.parts.1.thoughtSignature").String(); got != "" {
@@ -875,7 +877,7 @@ func TestPrepareAntigravityGeminiReasoningReplayRejectsChangedIDLessCallAtSamePo
 	if errPrepare != nil {
 		t.Fatal(errPrepare)
 	}
-	if got := gjson.GetBytes(out, "request.contents.1.parts.0.thoughtSignature").String(); got != "" {
+	if got := gjson.GetBytes(out, "request.contents.1.parts.0.thoughtSignature").String(); antigravityHasNativeThoughtSignature(got) {
 		t.Fatalf("changed ID-less call received stale signature %q; body=%s", got, out)
 	}
 }
@@ -1014,7 +1016,7 @@ func TestAntigravityReasoningReplayDoesNotCommitPartialResponse(t *testing.T) {
 	}
 }
 
-func TestPrepareAntigravityGeminiReasoningReplayRejectsFingerprintMismatch(t *testing.T) {
+func TestPrepareAntigravityGeminiReasoningReplayKeepsTextSignatureOnContextDrift(t *testing.T) {
 	internalcache.ClearAntigravityReasoningReplayCache()
 	t.Cleanup(internalcache.ClearAntigravityReasoningReplayCache)
 
@@ -1029,8 +1031,31 @@ func TestPrepareAntigravityGeminiReasoningReplayRejectsFingerprintMismatch(t *te
 	if errPrepare != nil {
 		t.Fatal(errPrepare)
 	}
+	// The signed part itself is byte-identical, so the signature still describes
+	// it exactly. Only the surrounding turns drifted, which Gemini does not bind
+	// signatures to, so dropping it here would only force needless re-reasoning.
+	if got := gjson.GetBytes(out, "request.contents.1.parts.0.thoughtSignature").String(); got != "fingerprinted-signature-123456" {
+		t.Fatalf("signature = %q, want the signature replayed even though the surrounding context drifted; body=%s", got, out)
+	}
+}
+
+func TestPrepareAntigravityGeminiReasoningReplayRejectsFingerprintMismatch(t *testing.T) {
+	internalcache.ClearAntigravityReasoningReplayCache()
+	t.Cleanup(internalcache.ClearAntigravityReasoningReplayCache)
+
+	kind, fingerprint := antigravityReplayPartFingerprint(gjson.Parse(`{"text":"original answer"}`))
+	item := buildAntigravityThoughtSignatureItem(1, 0, "fingerprinted-signature-123456", kind, fingerprint)
+	internalcache.CacheAntigravityReasoningReplayItems("gemini-3.6-flash-high", "session:edited", [][]byte{item})
+
+	// The client rewrote the signed part, so the cached signature describes text
+	// that is no longer in the request and must not be attached to the new text.
+	payload := []byte(`{"sessionId":"edited","request":{"contents":[{"role":"user","parts":[{"text":"turn"}]},{"role":"model","parts":[{"text":"edited answer"}]},{"role":"user","parts":[{"text":"next"}]}]}}`)
+	out, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), "gemini-3.6-flash-high", cliproxyexecutor.Request{}, cliproxyexecutor.Options{}, payload)
+	if errPrepare != nil {
+		t.Fatal(errPrepare)
+	}
 	if got := gjson.GetBytes(out, "request.contents.1.parts.0.thoughtSignature").String(); got != "" {
-		t.Fatalf("mismatched rebuilt context received stale signature %q; body=%s", got, out)
+		t.Fatalf("edited part received stale signature %q; body=%s", got, out)
 	}
 }
 
@@ -1469,7 +1494,7 @@ func TestPrepareAntigravityGeminiReasoningReplayRestoresLegacyClaudeToolIDWithSc
 	}
 }
 
-func TestPrepareAntigravityGeminiReasoningReplayFailsClosedWithoutClaudeToolProvenance(t *testing.T) {
+func TestPrepareAntigravityGeminiReasoningReplayDegradesWithoutClaudeToolProvenance(t *testing.T) {
 	internalcache.ClearAntigravityReasoningReplayCache()
 	t.Cleanup(internalcache.ClearAntigravityReasoningReplayCache)
 
@@ -1478,9 +1503,26 @@ func TestPrepareAntigravityGeminiReasoningReplayFailsClosedWithoutClaudeToolProv
 	payload := []byte(`{"sessionId":"sess-missing-provenance","request":{"contents":[{"role":"model","parts":[{"thoughtSignature":"skip_thought_signature_validator","functionCall":{"id":"` + clientID + `","name":"Read","args":{"file_path":"/tmp/a"}}}]},{"role":"user","parts":[{"functionResponse":{"id":"` + clientID + `","name":"Read","response":{"result":"ok"}}}]}]}}`)
 	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")}
 
-	_, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), model, cliproxyexecutor.Request{Model: model, Payload: payload}, opts, payload)
-	if errPrepare == nil || !strings.Contains(errPrepare.Error(), "missing Claude tool provenance") {
-		t.Fatalf("error = %v, want fail-closed missing provenance", errPrepare)
+	// An empty ledger must not kill the conversation: the reserved IDs are
+	// rewritten to neutral synthetic IDs and the request stays valid.
+	out, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), model, cliproxyexecutor.Request{Model: model, Payload: payload}, opts, payload)
+	if errPrepare != nil {
+		t.Fatalf("prepare failed: %v", errPrepare)
+	}
+	if antigravityPayloadHasClaudeToolProvenanceID(out) {
+		t.Fatalf("reserved provenance IDs leaked upstream: %s", out)
+	}
+	call := gjson.GetBytes(out, "request.contents.0.parts.0")
+	response := gjson.GetBytes(out, "request.contents.1.parts.0.functionResponse")
+	callID := call.Get("functionCall.id").String()
+	if callID == "" || callID != response.Get("id").String() {
+		t.Fatalf("degraded call/response pairing broken: call=%q response=%q", callID, response.Get("id").String())
+	}
+	if got := call.Get("thoughtSignature").String(); got != internalsignature.GeminiSkipThoughtSignatureValidator {
+		t.Fatalf("first degraded call thoughtSignature = %q, want bypass sentinel", got)
+	}
+	if errPairing := internalsignature.ValidateGeminiFunctionCallPairing(out); errPairing != nil {
+		t.Fatalf("degraded history is invalid: %v", errPairing)
 	}
 }
 
@@ -1539,9 +1581,28 @@ func TestPrepareAntigravityGeminiReasoningReplayRejectsChangedClaudeToolArgument
 	original := []byte(`{"tools":[{"name":"Edit","input_schema":{"type":"object","properties":{"replace_all":{"type":"boolean","default":false}}}}]}`)
 	opts := cliproxyexecutor.Options{OriginalRequest: original, SourceFormat: sdktranslator.FromString("claude")}
 
-	_, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), model, cliproxyexecutor.Request{Model: model, Payload: payload}, opts, payload)
-	if errPrepare == nil || !strings.Contains(errPrepare.Error(), "missing Claude tool provenance") {
-		t.Fatalf("error = %v, want fail-closed changed arguments", errPrepare)
+	// The client changed the arguments, so the native call must NOT be restored.
+	// The request still goes through, but only with a neutral synthetic ID and
+	// without the native identity or the cached signature.
+	out, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), model, cliproxyexecutor.Request{Model: model, Payload: payload}, opts, payload)
+	if errPrepare != nil {
+		t.Fatalf("prepare failed: %v", errPrepare)
+	}
+	if antigravityPayloadHasClaudeToolProvenanceID(out) {
+		t.Fatalf("reserved provenance IDs leaked upstream: %s", out)
+	}
+	call := gjson.GetBytes(out, "request.contents.0.parts.0")
+	if got := call.Get("functionCall.id").String(); got == "native-edit-changed" {
+		t.Fatalf("native call ID was restored onto changed arguments: %s", out)
+	}
+	if got := call.Get("thoughtSignature").String(); got != internalsignature.GeminiSkipThoughtSignatureValidator {
+		t.Fatalf("changed call thoughtSignature = %q, want bypass sentinel and no native signature", got)
+	}
+	if !call.Get("functionCall.args.replace_all").Bool() {
+		t.Fatalf("client arguments were rewritten by replay: %s", call.Raw)
+	}
+	if errPairing := internalsignature.ValidateGeminiFunctionCallPairing(out); errPairing != nil {
+		t.Fatalf("degraded history is invalid: %v", errPairing)
 	}
 }
 
@@ -1597,5 +1658,115 @@ func TestPrepareAntigravityGeminiReasoningReplayRejectsUnmatchedNonPlaceholderRe
 	}
 	if !strings.Contains(errPrepare.Error(), "invalid Gemini function call history") {
 		t.Fatalf("error = %v, want invalid Gemini function call history", errPrepare)
+	}
+}
+
+func TestPrepareAntigravityGeminiReasoningReplayRestoresIdentityOnContextDrift(t *testing.T) {
+	internalcache.ClearAntigravityReasoningReplayCache()
+	t.Cleanup(internalcache.ClearAntigravityReasoningReplayCache)
+
+	const model = "gemini-3.6-flash-high"
+	const args = `{"file_path":"/tmp/a"}`
+	clientID := util.GeminiClaudeToolUseID("native-drift", "Read", args)
+	payload := []byte(`{"sessionId":"sess-context-drift","request":{"contents":[{"role":"model","parts":[{"thoughtSignature":"skip_thought_signature_validator","functionCall":{"id":"` + clientID + `","name":"Read","args":` + args + `}}]},{"role":"user","parts":[{"functionResponse":{"id":"` + clientID + `","name":"Read","response":{"result":"ok"}}}]}]}}`)
+	// A stale contextHash stands in for compacted or rewritten history: the tool
+	// identity is still provable from the opaque ID, but the cached signature is
+	// no longer valid for this conversation.
+	item := []byte(`{"type":"function_call_part","contentIndex":0,"partIndex":0,"targetOccurrence":0,"name":"Read","call_id":"native-drift","args":` + args + `,"thoughtSignature":"EsMTCsATARFNMg/XNVix5lDpkKaHR7Xg","contextHash":"0000000000000000000000000000000000000000000000000000000000000000"}`)
+	sessionKey := antigravityReasoningReplayScopeFromPayload(model, payload).sessionKey
+	if !internalcache.CacheAntigravityReasoningReplayItems(model, sessionKey, [][]byte{item}) {
+		t.Fatal("failed to cache drifted provenance")
+	}
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")}
+
+	out, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), model, cliproxyexecutor.Request{Model: model, Payload: payload}, opts, payload)
+	if errPrepare != nil {
+		t.Fatalf("prepare failed: %v", errPrepare)
+	}
+	if antigravityPayloadHasClaudeToolProvenanceID(out) {
+		t.Fatalf("reserved provenance IDs leaked upstream: %s", out)
+	}
+	call := gjson.GetBytes(out, "request.contents.0.parts.0")
+	if got := call.Get("functionCall.id").String(); got != "native-drift" {
+		t.Fatalf("functionCall.id = %q, want native identity restored despite context drift", got)
+	}
+	if got := gjson.GetBytes(out, "request.contents.1.parts.0.functionResponse.id").String(); got != "native-drift" {
+		t.Fatalf("functionResponse.id = %q, want native identity restored", got)
+	}
+	if got := call.Get("thoughtSignature").String(); !antigravityHasNativeThoughtSignature(got) {
+		t.Fatalf("thoughtSignature = %q, want the native signature replayed even though the context drifted", got)
+	}
+	if errPairing := internalsignature.ValidateGeminiFunctionCallPairing(out); errPairing != nil {
+		t.Fatalf("restored history is invalid: %v", errPairing)
+	}
+}
+
+func TestDegradeAntigravityClaudeToolProvenanceIDsKeepsParallelShape(t *testing.T) {
+	ids := make([]string, 3)
+	for i := range ids {
+		ids[i] = util.GeminiClaudeToolUseID(fmt.Sprintf("native-%d", i), "Read", `{"file_path":"/tmp/a"}`)
+	}
+	payload := []byte(`{"request":{"contents":[{"role":"model","parts":[` +
+		`{"thoughtSignature":"EsMTCsATARFNMg/XNVix5lDpkKaHR7Xg","functionCall":{"id":"` + ids[0] + `","name":"Read","args":{"file_path":"/tmp/a"}}},` +
+		`{"functionCall":{"id":"` + ids[1] + `","name":"Read","args":{"file_path":"/tmp/b"}}},` +
+		`{"functionCall":{"id":"` + ids[2] + `","name":"Read","args":{"file_path":"/tmp/c"}}}` +
+		`]},{"role":"user","parts":[` +
+		`{"functionResponse":{"id":"` + ids[0] + `","name":"Read","response":{"result":"a"}}},` +
+		`{"functionResponse":{"id":"` + ids[1] + `","name":"Read","response":{"result":"b"}}},` +
+		`{"functionResponse":{"id":"` + ids[2] + `","name":"Read","response":{"result":"c"}}}` +
+		`]}]}}`)
+
+	out, degraded := degradeAntigravityClaudeToolProvenanceIDs(payload)
+	out = antigravityRepairUnsignedFirstFunctionCalls(out)
+	if degraded != 6 {
+		t.Fatalf("degraded = %d, want 6 (3 calls + 3 responses)", degraded)
+	}
+	if antigravityPayloadHasClaudeToolProvenanceID(out) {
+		t.Fatalf("reserved provenance IDs leaked upstream: %s", out)
+	}
+
+	calls := gjson.GetBytes(out, "request.contents.0.parts").Array()
+	responses := gjson.GetBytes(out, "request.contents.1.parts").Array()
+	if len(calls) != 3 || len(responses) != 3 {
+		t.Fatalf("part counts changed: %d calls, %d responses", len(calls), len(responses))
+	}
+	signed := 0
+	for i, call := range calls {
+		signature := call.Get("thoughtSignature").String()
+		if signature != "" {
+			signed++
+		}
+		if i == 0 && !antigravityHasNativeThoughtSignature(signature) {
+			t.Fatalf("first call thoughtSignature = %q, want the in-band signature kept through degradation", signature)
+		}
+		if i > 0 && signature != "" {
+			t.Fatalf("sibling call %d gained a signature %q, want unsigned", i, signature)
+		}
+		if got := call.Get("functionCall.id").String(); got != responses[i].Get("functionResponse.id").String() {
+			t.Fatalf("call/response pairing broken at %d: %q vs %q", i, got, responses[i].Get("functionResponse.id").String())
+		}
+	}
+	if signed != 1 {
+		t.Fatalf("signed calls = %d, want exactly 1 signed + 2 unsigned native parallel shape", signed)
+	}
+	if errPairing := internalsignature.ValidateGeminiFunctionCallPairing(out); errPairing != nil {
+		t.Fatalf("degraded history is invalid: %v", errPairing)
+	}
+}
+
+func TestPrepareAntigravityGeminiReasoningReplayStillRejectsBrokenPairing(t *testing.T) {
+	internalcache.ClearAntigravityReasoningReplayCache()
+	t.Cleanup(internalcache.ClearAntigravityReasoningReplayCache)
+
+	const model = "gemini-3.6-flash-high"
+	clientID := util.GeminiClaudeToolUseID("native-orphan", "Read", `{"file_path":"/tmp/a"}`)
+	// A functionResponse with no preceding functionCall is structurally invalid and
+	// must keep failing even though provenance degradation is now in play.
+	payload := []byte(`{"sessionId":"sess-orphan","request":{"contents":[{"role":"user","parts":[{"functionResponse":{"id":"` + clientID + `","name":"Read","response":{"result":"ok"}}}]}]}}`)
+	opts := cliproxyexecutor.Options{SourceFormat: sdktranslator.FromString("claude")}
+
+	_, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), model, cliproxyexecutor.Request{Model: model, Payload: payload}, opts, payload)
+	if errPrepare == nil || !strings.Contains(errPrepare.Error(), "invalid Gemini function call history") {
+		t.Fatalf("error = %v, want structural pairing rejection", errPrepare)
 	}
 }

--- a/internal/runtime/executor/antigravity_reasoning_replay_test.go
+++ b/internal/runtime/executor/antigravity_reasoning_replay_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	internalcache "github.com/router-for-me/CLIProxyAPI/v7/internal/cache"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	homekv "github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	internalsignature "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -46,6 +48,28 @@ func TestAntigravityReasoningReplayAccumulatorMultiToolSSEChunks(t *testing.T) {
 	}
 	if got := gjson.GetBytes(items[0], "thoughtSignature").String(); got != "sig-first" {
 		t.Fatalf("first sig = %q", got)
+	}
+}
+
+func TestPrepareAntigravityGeminiReasoningReplayPayloadToleratesHomeKVFailure(t *testing.T) {
+	// An enabled Home client with no heartbeat makes CurrentKVClient report home
+	// mode with an error, which is how every Home-side KV failure reaches the
+	// replay cache — including the "unknown command 'cas'" case from an older
+	// Home. The request must proceed without replay rather than fail, because a
+	// bare executor error would make MarkResult mark the credential unavailable.
+	homekv.SetCurrent(homekv.New(config.HomeConfig{Enabled: true}))
+	t.Cleanup(func() { homekv.SetCurrent(nil) })
+
+	payload := []byte(`{"sessionId":"kv-failure","request":{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}}`)
+	out, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), "gemini-3-flash-agent", cliproxyexecutor.Request{}, cliproxyexecutor.Options{}, payload)
+	if errPrepare != nil {
+		t.Fatalf("prepare error = %v, want nil so the request proceeds without replay", errPrepare)
+	}
+	if len(out) == 0 {
+		t.Fatal("prepare returned an empty payload")
+	}
+	if got := gjson.GetBytes(out, "sessionId").String(); got != "kv-failure" {
+		t.Fatalf("payload sessionId = %q, want kv-failure", got)
 	}
 }
 

--- a/internal/runtime/executor/antigravity_schema_sanitize_test.go
+++ b/internal/runtime/executor/antigravity_schema_sanitize_test.go
@@ -243,6 +243,85 @@ func TestSanitizeAntigravityRequestSchemasMatchesWholePayloadCleaning(t *testing
 	}
 }
 
+func TestSanitizeAntigravityRequestSchemasKeepsResponseSchemasPlaceholderFree(t *testing.T) {
+	payload := `{"request":{
+		"tools":[{"functionDeclarations":[{"name":"tool","parameters":{"type":"object","properties":{"value":{"type":"string"}}}}]}],
+		"generationConfig":{"responseSchema":{"type":"object","properties":{
+			"empty":{"type":"object"},
+			"optional":{"type":"object","properties":{"value":{"type":"string"}}}
+		}}}
+	}}`
+
+	got := sanitizeAntigravityRequestSchemas(payload, true)
+	toolSchema := gjson.Get(got, "request.tools.0.functionDeclarations.0.parameters")
+	if required := toolSchema.Get("required.0").String(); required != "_" {
+		t.Fatalf("tool schema lost VALIDATED placeholder, required[0] = %q: %s", required, got)
+	}
+
+	responseSchema := gjson.Get(got, "request.generationConfig.responseSchema")
+	for _, path := range []string{
+		"required",
+		"properties._",
+		"properties.reason",
+		"properties.empty.required",
+		"properties.empty.properties.reason",
+		"properties.optional.required",
+		"properties.optional.properties._",
+	} {
+		if responseSchema.Get(path).Exists() {
+			t.Errorf("response schema gained tool-only field %s: %s", path, responseSchema.Raw)
+		}
+	}
+}
+
+func TestAntigravityBuildRequestKeepsJSONObjectSchemaPlaceholderFree(t *testing.T) {
+	input := []byte(`{"model":"gemini-3.1-pro-low","messages":[{"role":"user","content":"hi"}],"response_format":{"type":"json_object"}}`)
+	translated := antigravitychat.ConvertOpenAIRequestToAntigravity("gemini-3.1-pro-low", input, false)
+	body := buildRequestBodyFromRawPayload(t, "gemini-3.1-pro-low", translated)
+	encoded, errMarshal := json.Marshal(body)
+	if errMarshal != nil {
+		t.Fatal(errMarshal)
+	}
+
+	schema := gjson.GetBytes(encoded, "request.generationConfig.responseSchema")
+	if got := schema.Get("type").String(); got != "object" {
+		t.Fatalf("responseSchema.type = %q, want object: %s", got, encoded)
+	}
+	if schema.Get("properties.reason").Exists() || schema.Get("required").Exists() {
+		t.Fatalf("json_object schema gained tool placeholders: %s", schema.Raw)
+	}
+}
+
+func TestAntigravityBuildRequestPreservesGenerationResponseSchemaMetadata(t *testing.T) {
+	payload := []byte(`{"request":{"generationConfig":{"responseSchema":{
+		"type":"object",
+		"nullable":true,
+		"properties":{"_":{"type":"string","nullable":true}},
+		"required":["_"]
+	}}}}`)
+
+	for _, modelName := range []string{"gemini-3.6-flash-high", "gemini-3.1-pro-low"} {
+		t.Run(modelName, func(t *testing.T) {
+			body := buildRequestBodyFromRawPayload(t, modelName, payload)
+			encoded, errMarshal := json.Marshal(body)
+			if errMarshal != nil {
+				t.Fatal(errMarshal)
+			}
+
+			schema := gjson.GetBytes(encoded, "request.generationConfig.responseSchema")
+			if !schema.Get("nullable").Bool() || !schema.Get("properties._.nullable").Bool() {
+				t.Fatalf("response schema nullable metadata was removed: %s", schema.Raw)
+			}
+			if !schema.Get("properties._").Exists() {
+				t.Fatalf("legitimate underscore property was removed: %s", schema.Raw)
+			}
+			if required := schema.Get("required.0").String(); required != "_" {
+				t.Fatalf("required[0] = %q, want underscore: %s", required, schema.Raw)
+			}
+		})
+	}
+}
+
 func TestAntigravityBuildRequestSanitizesSnakeCaseGenerationResponseSchemas(t *testing.T) {
 	for _, testCase := range []struct {
 		alias     string

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -32,18 +32,19 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	to := sdktranslator.FromString("claude")
-	// Use streaming translation to preserve function calling, except for claude.
-	stream := from != to
+	// Use an upstream stream whenever the downstream response needs translation
+	// from Claude events. Native Claude responses use the JSON response path.
+	upstreamStream := responseFormat != to
 	originalPayloadSource := req.Payload
 	if len(opts.OriginalRequest) > 0 {
 		originalPayloadSource = opts.OriginalRequest
 	}
 	originalPayload := originalPayloadSource
-	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, stream)
-	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, stream)
+	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, upstreamStream)
+	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, upstreamStream)
 	body = helps.SetStringIfDifferent(body, "model", upstreamModel)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}
@@ -83,6 +84,9 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	// Normalize TTL values to prevent ordering violations under prompt-caching-scope-2026-01-05.
 	// A 1h-TTL block must not appear after a 5m-TTL block in evaluation order (tools→system→messages).
 	body = normalizeCacheControlTTL(body)
+	// Payload rules and other request processing may rewrite stream. Keep the
+	// upstream body, transport headers, and response parser on one authority.
+	body = helps.SetBoolIfDifferent(body, "stream", upstreamStream)
 
 	// Extract betas from body and convert to header
 	var extraBetas []string
@@ -107,7 +111,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	if err != nil {
 		return resp, err
 	}
-	if errHeaders := applyClaudeHeaders(httpReq, auth, apiKey, false, extraBetas, e.cfg, opts.Headers); errHeaders != nil {
+	if errHeaders := applyClaudeHeaders(httpReq, auth, apiKey, upstreamStream, extraBetas, e.cfg, opts.Headers); errHeaders != nil {
 		return resp, errHeaders
 	}
 	var authID, authLabel, authType, authValue string
@@ -181,7 +185,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		return resp, err
 	}
 	helps.AppendAPIResponseChunk(ctx, e.cfg, data)
-	if stream {
+	if upstreamStream {
 		if errValidate := validateClaudeStreamingResponse(data); errValidate != nil {
 			helps.RecordAPIResponseError(ctx, e.cfg, errValidate)
 			return resp, errValidate

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -32,15 +32,16 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	from := opts.SourceFormat
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 	to := sdktranslator.FromString("claude")
-	// Use streaming translation to preserve function calling, except for claude.
-	stream := from != to
+	// Use an upstream stream whenever the downstream response needs translation
+	// from Claude events. Native Claude responses use the JSON response path.
+	upstreamStream := responseFormat != to
 	originalPayloadSource := req.Payload
 	if len(opts.OriginalRequest) > 0 {
 		originalPayloadSource = opts.OriginalRequest
 	}
 	originalPayload := originalPayloadSource
-	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, stream)
-	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, stream)
+	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, upstreamStream)
+	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, upstreamStream)
 	body = helps.SetStringIfDifferent(body, "model", upstreamModel)
 
 	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
@@ -83,6 +84,9 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	// Normalize TTL values to prevent ordering violations under prompt-caching-scope-2026-01-05.
 	// A 1h-TTL block must not appear after a 5m-TTL block in evaluation order (tools→system→messages).
 	body = normalizeCacheControlTTL(body)
+	// Payload rules and other request processing may rewrite stream. Keep the
+	// upstream body, transport headers, and response parser on one authority.
+	body = helps.SetBoolIfDifferent(body, "stream", upstreamStream)
 
 	// Extract betas from body and convert to header
 	var extraBetas []string
@@ -107,7 +111,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	if err != nil {
 		return resp, err
 	}
-	if errHeaders := applyClaudeHeaders(httpReq, auth, apiKey, false, extraBetas, e.cfg, opts.Headers); errHeaders != nil {
+	if errHeaders := applyClaudeHeaders(httpReq, auth, apiKey, upstreamStream, extraBetas, e.cfg, opts.Headers); errHeaders != nil {
 		return resp, errHeaders
 	}
 	var authID, authLabel, authType, authValue string
@@ -181,7 +185,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 		return resp, err
 	}
 	helps.AppendAPIResponseChunk(ctx, e.cfg, data)
-	if stream {
+	if upstreamStream {
 		if errValidate := validateClaudeStreamingResponse(data); errValidate != nil {
 			helps.RecordAPIResponseError(ctx, e.cfg, errValidate)
 			return resp, errValidate

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -44,7 +44,7 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, upstreamStream)
 	body = helps.SetStringIfDifferent(body, "model", upstreamModel)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -344,10 +344,10 @@ func applyClaudeHeaders(r *http.Request, auth *cliproxyauth.Auth, apiKey string,
 		attrs = auth.Attributes
 	}
 	util.ApplyCustomHeadersFromAttrs(r, attrs)
-	// Re-enforce Accept-Encoding: identity after ApplyCustomHeadersFromAttrs, which
-	// may override it with a user-configured value.  Compressed SSE breaks the line
-	// scanner regardless of user preference, so this is non-negotiable for streams.
+	// Re-enforce the SSE transport contract after custom headers. A custom Accept
+	// value can disable event negotiation, while compressed SSE breaks line parsing.
 	if stream {
+		r.Header.Set("Accept", "text/event-stream")
 		r.Header.Set("Accept-Encoding", "identity")
 	}
 	return nil

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -44,7 +44,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, true)
 	body = helps.SetStringIfDifferent(body, "model", upstreamModel)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -1622,6 +1622,105 @@ func TestClaudeExecutor_ExecuteOpenAINonStreamConvertsValidClaudeStream(t *testi
 	}
 }
 
+func TestClaudeExecutor_ExecuteTransportMatchesResponseFormat(t *testing.T) {
+	const model = "claude-3-5-sonnet-20241022"
+	streamResponse := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_123","model":"claude-3-5-sonnet-20241022"}}`,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}`,
+		`event: message_delta`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":2,"output_tokens":1}}`,
+		`event: message_stop`,
+		`data: {"type":"message_stop"}`,
+		``,
+	}, "\n")
+	jsonResponse := `{"id":"msg_123","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":2,"output_tokens":1}}`
+
+	tests := []struct {
+		name           string
+		sourceFormat   sdktranslator.Format
+		responseFormat sdktranslator.Format
+		wantStream     bool
+	}{
+		{name: "OpenAI to OpenAI uses SSE", sourceFormat: sdktranslator.FormatOpenAI, responseFormat: sdktranslator.FormatOpenAI, wantStream: true},
+		{name: "OpenAI to Claude uses JSON", sourceFormat: sdktranslator.FormatOpenAI, responseFormat: sdktranslator.FormatClaude, wantStream: false},
+		{name: "Claude to OpenAI uses SSE", sourceFormat: sdktranslator.FormatClaude, responseFormat: sdktranslator.FormatOpenAI, wantStream: true},
+		{name: "Claude to Claude uses JSON", sourceFormat: sdktranslator.FormatClaude, responseFormat: sdktranslator.FormatClaude, wantStream: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var seenBody []byte
+			var seenHeaders http.Header
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				seenBody, _ = io.ReadAll(r.Body)
+				seenHeaders = r.Header.Clone()
+				if tt.wantStream {
+					w.Header().Set("Content-Type", "text/event-stream")
+					_, _ = w.Write([]byte(streamResponse))
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(jsonResponse))
+			}))
+			defer server.Close()
+
+			executor := NewClaudeExecutor(&config.Config{
+				Payload: config.PayloadConfig{
+					Override: []config.PayloadRule{{
+						Models: []config.PayloadModelRule{{Name: model, Protocol: "claude"}},
+						Params: map[string]any{"stream": !tt.wantStream},
+					}},
+				},
+			})
+			attributes := map[string]string{
+				"api_key":  "key-123",
+				"base_url": server.URL,
+			}
+			if tt.wantStream {
+				attributes["header:Accept"] = "application/json"
+				attributes["header:Accept-Encoding"] = "gzip, deflate, br, zstd"
+			}
+			auth := &cliproxyauth.Auth{Attributes: attributes}
+			payload := []byte(`{"model":"claude-3-5-sonnet-20241022","stream":false,"messages":[{"role":"user","content":"hi"}]}`)
+
+			_, err := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+				Model:   model,
+				Payload: payload,
+			}, cliproxyexecutor.Options{
+				SourceFormat:   tt.sourceFormat,
+				ResponseFormat: tt.responseFormat,
+				Headers: http.Header{
+					"Anthropic-Beta": []string{"client-beta"},
+				},
+			})
+			if err != nil {
+				t.Fatalf("Execute error: %v", err)
+			}
+			stream := gjson.GetBytes(seenBody, "stream")
+			if !stream.Exists() || stream.Bool() != tt.wantStream {
+				t.Fatalf("upstream stream = %s, want %t; body=%s", stream.Raw, tt.wantStream, string(seenBody))
+			}
+			wantAccept := "application/json"
+			wantEncoding := "gzip, deflate, br, zstd"
+			if tt.wantStream {
+				wantAccept = "text/event-stream"
+				wantEncoding = "identity"
+			}
+			if got := seenHeaders.Get("Accept"); got != wantAccept {
+				t.Fatalf("Accept = %q, want %q", got, wantAccept)
+			}
+			if got := seenHeaders.Get("Accept-Encoding"); got != wantEncoding {
+				t.Fatalf("Accept-Encoding = %q, want %q", got, wantEncoding)
+			}
+			if got := seenHeaders.Get("Anthropic-Beta"); !strings.Contains(got, "client-beta") {
+				t.Fatalf("Anthropic-Beta = %q, want client beta preserved", got)
+			}
+		})
+	}
+}
+
 func executeOpenAIChatCompletionThroughClaude(t *testing.T, upstreamBody string) (cliproxyexecutor.Response, error) {
 	t.Helper()
 

--- a/internal/runtime/executor/claude_executor_tokens.go
+++ b/internal/runtime/executor/claude_executor_tokens.go
@@ -26,6 +26,11 @@ func (e *ClaudeExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	// Use streaming translation to preserve function calling, except for claude.
 	stream := from != to
 	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, stream)
+	var errThinking error
+	body, errThinking = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
+	if errThinking != nil {
+		return cliproxyexecutor.Response{}, errThinking
+	}
 	if rebuildMidSystemMessageEnabled(e.cfg, auth) {
 		body = rebuildMidSystemMessagesToTopLevel(body)
 	}
@@ -113,6 +118,11 @@ func (e *ClaudeExecutor) countTokensUpstream(ctx context.Context, auth *cliproxy
 	stream := from != to
 	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, stream)
 	body = helps.SetStringIfDifferent(body, "model", upstreamModel)
+	var errThinking error
+	body, errThinking = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
+	if errThinking != nil {
+		return cliproxyexecutor.Response{}, errThinking
+	}
 	if rebuildMidSystemMessageEnabled(e.cfg, auth) {
 		body = rebuildMidSystemMessagesToTopLevel(body)
 	}

--- a/internal/runtime/executor/codex_executor_execute.go
+++ b/internal/runtime/executor/codex_executor_execute.go
@@ -45,7 +45,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	originalPayload := originalPayloadSource
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}
@@ -214,7 +214,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	originalPayload := originalPayloadSource
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}

--- a/internal/runtime/executor/codex_executor_execute.go
+++ b/internal/runtime/executor/codex_executor_execute.go
@@ -53,7 +53,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	originalPayload := originalPayloadSource
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}
@@ -275,7 +275,7 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	originalPayload := originalPayloadSource
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}

--- a/internal/runtime/executor/codex_executor_stream.go
+++ b/internal/runtime/executor/codex_executor_stream.go
@@ -46,7 +46,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	originalPayload := originalPayloadSource
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, true)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtime/executor/codex_executor_stream.go
+++ b/internal/runtime/executor/codex_executor_stream.go
@@ -54,7 +54,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	originalPayload := originalPayloadSource
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, true)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtime/executor/codex_executor_tokens.go
+++ b/internal/runtime/executor/codex_executor_tokens.go
@@ -23,7 +23,7 @@ func (e *CodexExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth
 	to := sdktranslator.FromString("codex")
 	body := sdktranslator.TranslateRequest(from, to, baseModel, req.Payload, false)
 
-	body, err := thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err := helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}

--- a/internal/runtime/executor/codex_websockets_execute.go
+++ b/internal/runtime/executor/codex_websockets_execute.go
@@ -46,7 +46,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	originalPayload := originalPayloadSource
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}

--- a/internal/runtime/executor/codex_websockets_execute.go
+++ b/internal/runtime/executor/codex_websockets_execute.go
@@ -53,7 +53,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	originalPayload := originalPayloadSource
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, false)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -46,7 +46,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	originalPayload := originalPayloadSource
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, true)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -53,7 +53,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	originalPayload := originalPayloadSource
 	originalTranslated, body := translateCodexRequestPair(from, to, baseModel, originalPayload, req.Payload, true)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -148,7 +148,7 @@ func (e *GeminiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, false)
 	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, false)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}
@@ -261,7 +261,7 @@ func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, true)
 	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, true)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}
@@ -391,7 +391,7 @@ func (e *GeminiExecutor) executeInteractions(ctx context.Context, auth *cliproxy
 	if gjson.GetBytes(body, "model").Exists() && targetName != "" {
 		body = helps.SetStringIfDifferent(body, "model", targetName)
 	}
-	body, err = applyGeminiInteractionsThinking(body, req.Model)
+	body, err = applyGeminiInteractionsThinking(body, req, opts)
 	if err != nil {
 		return resp, err
 	}
@@ -467,7 +467,7 @@ func (e *GeminiExecutor) executeInteractionsStream(ctx context.Context, auth *cl
 	if gjson.GetBytes(body, "model").Exists() && targetName != "" {
 		body = helps.SetStringIfDifferent(body, "model", targetName)
 	}
-	body, err = applyGeminiInteractionsThinking(body, req.Model)
+	body, err = applyGeminiInteractionsThinking(body, req, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -621,7 +621,7 @@ func (e *GeminiExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	to := sdktranslator.FromString("gemini")
 	translatedReq := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, false)
 
-	translatedReq, err := thinking.ApplyThinking(translatedReq, req.Model, from.String(), to.String(), e.Identifier())
+	translatedReq, err := helps.ApplyRequestThinking(translatedReq, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}
@@ -801,8 +801,12 @@ func isNativeInteractionsAuth(auth *cliproxyauth.Auth) bool {
 	return strings.EqualFold(strings.TrimSpace(auth.Provider), "gemini-interactions")
 }
 
-func applyGeminiInteractionsThinking(body []byte, model string) ([]byte, error) {
-	return thinking.ApplyThinking(body, model, sdktranslator.FormatInteractions.String(), sdktranslator.FormatInteractions.String(), "gemini")
+func applyGeminiInteractionsThinking(body []byte, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) ([]byte, error) {
+	fromFormat := opts.SourceFormat.String()
+	if strings.TrimSpace(fromFormat) == "" {
+		fromFormat = sdktranslator.FormatInteractions.String()
+	}
+	return helps.ApplyRequestThinking(body, req, opts, fromFormat, sdktranslator.FormatInteractions.String(), "gemini")
 }
 
 func applyGeminiInteractionsRevisionHeader(req *http.Request) {

--- a/internal/runtime/executor/gemini_vertex_executor.go
+++ b/internal/runtime/executor/gemini_vertex_executor.go
@@ -331,7 +331,7 @@ func (e *GeminiVertexExecutor) executeWithServiceAccount(ctx context.Context, au
 		originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, false)
 		body = helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, false)
 
-		body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+		body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 		if err != nil {
 			return resp, err
 		}
@@ -456,7 +456,7 @@ func (e *GeminiVertexExecutor) executeWithAPIKey(ctx context.Context, auth *clip
 	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, false)
 	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, false)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}
@@ -571,7 +571,7 @@ func (e *GeminiVertexExecutor) executeStreamWithServiceAccount(ctx context.Conte
 	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, true)
 	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, true)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}
@@ -717,7 +717,7 @@ func (e *GeminiVertexExecutor) executeStreamWithAPIKey(ctx context.Context, auth
 	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, true)
 	body := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, true)
 
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), to.String(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}
@@ -854,7 +854,7 @@ func (e *GeminiVertexExecutor) countTokensWithServiceAccount(ctx context.Context
 
 	translatedReq := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, false)
 
-	translatedReq, err := thinking.ApplyThinking(translatedReq, req.Model, from.String(), to.String(), e.Identifier())
+	translatedReq, err := helps.ApplyRequestThinking(translatedReq, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}
@@ -945,7 +945,7 @@ func (e *GeminiVertexExecutor) countTokensWithAPIKey(ctx context.Context, auth *
 
 	translatedReq := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, false)
 
-	translatedReq, err := thinking.ApplyThinking(translatedReq, req.Model, from.String(), to.String(), e.Identifier())
+	translatedReq, err := helps.ApplyRequestThinking(translatedReq, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}

--- a/internal/runtime/executor/helps/model_capabilities.go
+++ b/internal/runtime/executor/helps/model_capabilities.go
@@ -1,0 +1,20 @@
+package helps
+
+import (
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// ApplyRequestThinking preserves the registry lookup path unless the auth
+// manager bound an exact configured API-key model definition to this attempt.
+func ApplyRequestThinking(body []byte, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, fromFormat, toFormat, provider string) ([]byte, error) {
+	if modelInfo, ok := cliproxyauth.ResolvedAPIKeyModelInfo(req); ok {
+		sourceBody := opts.OriginalRequest
+		if len(sourceBody) == 0 {
+			sourceBody = req.Payload
+		}
+		return thinking.ApplyThinkingWithModelInfo(body, sourceBody, req.Model, fromFormat, toFormat, provider, modelInfo)
+	}
+	return thinking.ApplyThinking(body, req.Model, fromFormat, toFormat, provider)
+}

--- a/internal/runtime/executor/helps/model_capabilities_test.go
+++ b/internal/runtime/executor/helps/model_capabilities_test.go
@@ -1,0 +1,149 @@
+package helps_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	helps "github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/claude"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+type configuredThinkingExecutor struct {
+	seenModel string
+	resolved  bool
+}
+
+func (*configuredThinkingExecutor) Identifier() string { return "claude" }
+
+func (e *configuredThinkingExecutor) Execute(_ context.Context, _ *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.seenModel = req.Model
+	modelInfo, resolved := cliproxyauth.ResolvedAPIKeyModelInfo(req)
+	e.resolved = resolved && modelInfo != nil
+	body := []byte(`{"thinking":{"type":"adaptive"},"output_config":{"effort":"low"}}`)
+	out, err := helps.ApplyRequestThinking(body, req, opts, opts.SourceFormat.String(), "claude", "claude")
+	return cliproxyexecutor.Response{Payload: out}, err
+}
+
+func (e *configuredThinkingExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	response, err := e.Execute(ctx, auth, req, opts)
+	if err != nil {
+		return nil, err
+	}
+	chunks := make(chan cliproxyexecutor.StreamChunk, 1)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: response.Payload}
+	close(chunks)
+	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (*configuredThinkingExecutor) Refresh(_ context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *configuredThinkingExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return e.Execute(ctx, auth, req, opts)
+}
+
+func (*configuredThinkingExecutor) HttpRequest(context.Context, *cliproxyauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestApplyRequestThinkingUsesSelectedPrefixedAPIKeyModel(t *testing.T) {
+	manager := cliproxyauth.NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{
+		SDKConfig: internalconfig.SDKConfig{ForceModelPrefix: true},
+		ClaudeKey: []internalconfig.ClaudeKey{{
+			APIKey: "selected-key",
+			Prefix: "tenant",
+			Models: []internalconfig.ClaudeModel{{
+				Name: "shared-upstream", Alias: "public-model",
+				Thinking: &registry.ThinkingSupport{Levels: []string{"high"}},
+			}},
+		}},
+	})
+	executor := &configuredThinkingExecutor{}
+	manager.RegisterExecutor(executor)
+	auth := &cliproxyauth.Auth{
+		ID:       "selected-auth",
+		Provider: "claude",
+		Prefix:   "tenant",
+		Attributes: map[string]string{
+			cliproxyauth.AttributeAuthKind: cliproxyauth.AuthKindAPIKey,
+			cliproxyauth.AttributeAPIKey:   "selected-key",
+			cliproxyauth.AttributeSource:   "config:claude[0]",
+		},
+	}
+
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: "tenant/public-model", Type: "claude"}})
+	modelRegistry.RegisterClient("unrelated-auth", auth.Provider, []*registry.ModelInfo{{
+		ID: "shared-upstream", Type: "claude",
+		Thinking: &registry.ThinkingSupport{Levels: []string{"max"}},
+	}})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(auth.ID)
+		modelRegistry.UnregisterClient("unrelated-auth")
+	})
+	ctx := t.Context()
+	registered, errRegister := manager.Register(ctx, auth)
+	if errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+	if registered == nil {
+		t.Fatal("Register() returned nil auth")
+	}
+
+	original := []byte(`{"model":"tenant/public-model","reasoning_effort":"max","messages":[{"role":"user","content":"hello"}]}`)
+	req := cliproxyexecutor.Request{
+		Model:   "tenant/public-model",
+		Payload: original,
+		Format:  sdktranslator.FormatOpenAI,
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat:    sdktranslator.FormatOpenAI,
+		OriginalRequest: original,
+	}
+	assertResponse := func(path string, payload []byte) {
+		t.Helper()
+		if executor.seenModel != "shared-upstream" {
+			t.Fatalf("%s executor model = %q, want shared-upstream", path, executor.seenModel)
+		}
+		if !executor.resolved {
+			t.Fatalf("%s request did not receive selected model capabilities", path)
+		}
+		if got := gjson.GetBytes(payload, "output_config.effort").String(); got != "high" {
+			t.Fatalf("%s output effort = %q, want selected credential capability high; body=%s", path, got, payload)
+		}
+	}
+
+	response, errExecute := manager.Execute(ctx, []string{"claude"}, req, opts)
+	if errExecute != nil {
+		t.Fatalf("Execute() error = %v", errExecute)
+	}
+	assertResponse("execute", response.Payload)
+
+	countResponse, errCount := manager.ExecuteCount(ctx, []string{"claude"}, req, opts)
+	if errCount != nil {
+		t.Fatalf("ExecuteCount() error = %v", errCount)
+	}
+	assertResponse("count", countResponse.Payload)
+
+	streamResult, errStream := manager.ExecuteStream(ctx, []string{"claude"}, req, opts)
+	if errStream != nil {
+		t.Fatalf("ExecuteStream() error = %v", errStream)
+	}
+	var streamPayload []byte
+	for chunk := range streamResult.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("ExecuteStream() chunk error = %v", chunk.Err)
+		}
+		streamPayload = append(streamPayload, chunk.Payload...)
+	}
+	assertResponse("stream", streamPayload)
+}

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -114,7 +114,7 @@ func (e *OpenAICompatExecutor) Execute(ctx context.Context, auth *cliproxyauth.A
 	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, opts.Stream)
 	translated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, opts.Stream)
 
-	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	translated, err = helps.ApplyRequestThinking(translated, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return resp, err
 	}
@@ -315,7 +315,7 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 	originalTranslated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, originalPayload, true)
 	translated := helps.TranslateRequestWithCodexMultiAgentV2(ctx, opts.Headers, e.cfg, from, to, baseModel, req.Payload, true)
 
-	translated, err = thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	translated, err = helps.ApplyRequestThinking(translated, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}
@@ -587,7 +587,7 @@ func (e *OpenAICompatExecutor) CountTokens(ctx context.Context, auth *cliproxyau
 
 	modelForCounting := baseModel
 
-	translated, err := thinking.ApplyThinking(translated, req.Model, from.String(), to.String(), e.Identifier())
+	translated, err := helps.ApplyRequestThinking(translated, req, opts, from.String(), to.String(), e.Identifier())
 	if err != nil {
 		return cliproxyexecutor.Response{}, err
 	}

--- a/internal/runtime/executor/xai_executor_request.go
+++ b/internal/runtime/executor/xai_executor_request.go
@@ -73,7 +73,7 @@ func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliprox
 	body = preserveXAIResponsesOutputControls(body, req.Payload, from)
 
 	var err error
-	body, err = thinking.ApplyThinking(body, req.Model, from.String(), e.Identifier(), e.Identifier())
+	body, err = helps.ApplyRequestThinking(body, req, opts, from.String(), e.Identifier(), e.Identifier())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/signature/claude_messages_sanitize.go
+++ b/internal/signature/claude_messages_sanitize.go
@@ -37,9 +37,10 @@ func SanitizeClaudeMessagesSignaturesForModel(payload []byte, targetModel string
 }
 
 // SanitizeClaudeMessagesForClaudeUpstream prepares a Claude /v1/messages body
-// for native Claude upstreams. Invalid thinking blocks are dropped, valid
-// thinking signatures are normalized to Claude provider-native E-form, and
-// tool_use blocks keep only their tool-call payload.
+// for Claude-compatible upstreams. Valid Claude signatures are normalized to
+// provider-native E-form, valid Claude CAIS signatures are kept,
+// incompatible thinking blocks are dropped, and tool_use blocks keep only their
+// tool-call payload.
 func SanitizeClaudeMessagesForClaudeUpstream(payload []byte, targetModel string) ([]byte, SignatureSanitizeReport) {
 	return SanitizeClaudeMessagesSignaturesForTarget(payload, ClaudeMessagesSignatureSanitizeOptions{
 		TargetProvider:                SignatureProviderClaude,
@@ -94,7 +95,7 @@ func SanitizeClaudeMessagesSignaturesForTarget(payload []byte, opts ClaudeMessag
 					keptParts = append(keptParts, updatedPart)
 					continue
 				}
-				updatedPart, changed, decisions := sanitizeClaudeToolUseSignature(part, targetProvider, i, j)
+				updatedPart, changed, decisions := sanitizeClaudeToolUseSignature(part, targetProvider, opts.TargetModel, i, j)
 				report.Decisions = append(report.Decisions, decisions...)
 				if changed {
 					messageModified = true
@@ -124,7 +125,7 @@ func SanitizeClaudeMessagesSignaturesForTarget(payload []byte, opts ClaudeMessag
 			}
 
 			rawSignature := part.Get("signature").String()
-			decision := DecideSignatureCompatibility(targetProvider, rawSignature, SignatureBlockKindClaudeThinking)
+			decision := DecideSignatureCompatibilityForModel(targetProvider, opts.TargetModel, rawSignature, SignatureBlockKindClaudeThinking)
 			decision.Reason = fmt.Sprintf("messages[%d].content[%d]: %s", i, j, decision.Reason)
 			report.Decisions = append(report.Decisions, decision)
 
@@ -195,7 +196,7 @@ func stripClaudeToolUseSignatureFields(part gjson.Result) (string, bool) {
 	return updated, changed
 }
 
-func sanitizeClaudeToolUseSignature(part gjson.Result, targetProvider SignatureProvider, messageIdx, partIdx int) (string, bool, []SignatureCompatibilityDecision) {
+func sanitizeClaudeToolUseSignature(part gjson.Result, targetProvider SignatureProvider, targetModel string, messageIdx, partIdx int) (string, bool, []SignatureCompatibilityDecision) {
 	updated := part.Raw
 	changed := false
 	var decisions []SignatureCompatibilityDecision
@@ -212,7 +213,7 @@ func sanitizeClaudeToolUseSignature(part gjson.Result, targetProvider SignatureP
 		} else if targetProvider == SignatureProviderGPT {
 			blockKind = SignatureBlockKindGPTReasoning
 		}
-		decision := DecideSignatureCompatibility(targetProvider, sigResult.String(), blockKind)
+		decision := DecideSignatureCompatibilityForModel(targetProvider, targetModel, sigResult.String(), blockKind)
 		decision.Reason = fmt.Sprintf("messages[%d].content[%d].%s: %s", messageIdx, partIdx, sigPath, decision.Reason)
 		decisions = append(decisions, decision)
 

--- a/internal/signature/claude_test.go
+++ b/internal/signature/claude_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/tidwall/gjson"
+	"google.golang.org/protobuf/encoding/protowire"
 )
 
 func TestStripInvalidClaudeThinkingBlocks_RemovesGPTEncryptedContent(t *testing.T) {
@@ -157,5 +158,484 @@ func TestStripInvalidClaudeThinkingBlocks_KeepsClaudeSignaturePrefixes(t *testin
 	content := gjson.GetBytes(out, "messages.0.content").Array()
 	if len(content) != 2 {
 		t.Fatalf("content length = %d, want 2: %s", len(content), string(out))
+	}
+}
+
+const observedFable5Sample = "CAISqwIKiAEIEBgCKkBHRlRBsNiptQUWfPoOhuQKwi5LnncZVO9bB5jqOs76D7uBtgktML0zqJtNmLHXHHcgD6lk4MQu4QBXzFd1lbC3Mg5jbGF1ZGUtZmFibGUtNTgBQgh0aGlua2luZ1okZDk3NDM5NzUtNGJiMC00OTM2LTllMjgtZDViMGQyMWJkYzQ4EgxCGh+XVFFFeySAjtAaDL/A1LltGu6MMJ+eXSIwsN0oBpDrqLv22UBfkMnTotnIbkvkOyb9xZHgigG6OZVHaI3gThm+maLKmgO5PrFLKlDFYp+YZksy/wKwszJlnLTPzAK+NUlfzagOE1ymtZTXhAYK260XyFYmg/te/C231+Fr/hoX+EJoUBnrn0gD7hqMISOT+TaFEuOXYsN517GfaxgB"
+
+const observedContextID = "d9743975-4bb0-4936-9e28-d5b0d21bdc48"
+
+// claudeCAISParts builds Claude CAIS signatures field by field so tests can
+// assert both the observed layout and the upstream drift the validator must
+// tolerate or reject.
+type claudeCAISParts struct {
+	includeTopEnvelope   bool
+	topEnvelope          uint64
+	includeTopTrailer    bool
+	includeContainer     bool
+	includeChannelBlock  bool
+	includeChannelID     bool
+	channelID            uint64
+	channelIDAsBytes     bool
+	includeChannelVerion bool
+	includeSignature     bool
+	signatureLen         int
+	includeModelText     bool
+	modelText            []byte
+	includeField7        bool
+	blockKind            string
+	contextID            string
+}
+
+// defaultClaudeCAISParts mirrors the layout observed on claude-fable-5 and
+// claude-opus-5 responses.
+func defaultClaudeCAISParts(model string) claudeCAISParts {
+	return claudeCAISParts{
+		includeTopEnvelope:   true,
+		topEnvelope:          2,
+		includeTopTrailer:    true,
+		includeContainer:     true,
+		includeChannelBlock:  true,
+		includeChannelID:     true,
+		channelID:            16,
+		includeChannelVerion: true,
+		includeSignature:     true,
+		signatureLen:         64,
+		includeModelText:     true,
+		modelText:            []byte(model),
+		includeField7:        true,
+		blockKind:            "thinking",
+		contextID:            observedContextID,
+	}
+}
+
+func (p claudeCAISParts) encode() string {
+	var channelBlock []byte
+	if p.includeChannelID {
+		if p.channelIDAsBytes {
+			channelBlock = protowire.AppendTag(channelBlock, 1, protowire.BytesType)
+			channelBlock = protowire.AppendBytes(channelBlock, []byte{0x10})
+		} else {
+			channelBlock = protowire.AppendTag(channelBlock, 1, protowire.VarintType)
+			channelBlock = protowire.AppendVarint(channelBlock, p.channelID)
+		}
+	}
+	if p.includeChannelVerion {
+		channelBlock = protowire.AppendTag(channelBlock, 3, protowire.VarintType)
+		channelBlock = protowire.AppendVarint(channelBlock, 2)
+	}
+	if p.includeSignature {
+		channelBlock = protowire.AppendTag(channelBlock, 5, protowire.BytesType)
+		channelBlock = protowire.AppendBytes(channelBlock, make([]byte, p.signatureLen))
+	}
+	if p.includeModelText {
+		channelBlock = protowire.AppendTag(channelBlock, 6, protowire.BytesType)
+		channelBlock = protowire.AppendBytes(channelBlock, p.modelText)
+	}
+	if p.includeField7 {
+		channelBlock = protowire.AppendTag(channelBlock, 7, protowire.VarintType)
+		channelBlock = protowire.AppendVarint(channelBlock, 1)
+	}
+	if p.blockKind != "" {
+		channelBlock = protowire.AppendTag(channelBlock, 8, protowire.BytesType)
+		channelBlock = protowire.AppendString(channelBlock, p.blockKind)
+	}
+	if p.contextID != "" {
+		channelBlock = protowire.AppendTag(channelBlock, 11, protowire.BytesType)
+		channelBlock = protowire.AppendString(channelBlock, p.contextID)
+	}
+
+	var container []byte
+	if p.includeChannelBlock {
+		container = protowire.AppendTag(container, 1, protowire.BytesType)
+		container = protowire.AppendBytes(container, channelBlock)
+	}
+
+	var payload []byte
+	if p.includeTopEnvelope {
+		payload = protowire.AppendTag(payload, 1, protowire.VarintType)
+		payload = protowire.AppendVarint(payload, p.topEnvelope)
+	}
+	if p.includeContainer {
+		payload = protowire.AppendTag(payload, 2, protowire.BytesType)
+		payload = protowire.AppendBytes(payload, container)
+	}
+	if p.includeTopTrailer {
+		payload = protowire.AppendTag(payload, 3, protowire.VarintType)
+		payload = protowire.AppendVarint(payload, 1)
+	}
+	return base64.StdEncoding.EncodeToString(payload)
+}
+
+func testClaudeCAISSignature(model string) string {
+	return defaultClaudeCAISParts(model).encode()
+}
+
+func TestClaudeCAISSignature_ObservedFable5Sample(t *testing.T) {
+	if !IsValidClaudeCAISSignature(observedFable5Sample) {
+		t.Fatal("IsValidClaudeCAISSignature(observedFable5Sample) = false, want true")
+	}
+
+	info, err := InspectClaudeCAISSignature(observedFable5Sample)
+	if err != nil {
+		t.Fatalf("InspectClaudeCAISSignature failed: %v", err)
+	}
+
+	if info.ModelText != "claude-fable-5" {
+		t.Fatalf("ModelText = %q, want %q", info.ModelText, "claude-fable-5")
+	}
+	if info.BlockKind != "thinking" {
+		t.Fatalf("BlockKind = %q, want %q", info.BlockKind, "thinking")
+	}
+	expectedUUID := "d9743975-4bb0-4936-9e28-d5b0d21bdc48"
+	if info.ContextID != expectedUUID {
+		t.Fatalf("ContextID = %q, want %q", info.ContextID, expectedUUID)
+	}
+	if info.FirstByte != 0x08 {
+		t.Fatalf("FirstByte = 0x%02x, want 0x08", info.FirstByte)
+	}
+}
+
+func TestClaudeCAISSignature_DetectSignatureProvider(t *testing.T) {
+	prefixes := []string{
+		"",
+		"ccmax#",
+		"claude-code-max#",
+		"claude_code_max#",
+		"cais#",
+		"claude-cais#",
+		"claude_cais#",
+		"claude#",
+	}
+	for _, prefix := range prefixes {
+		sig := prefix + observedFable5Sample
+		got := DetectSignatureProvider(sig)
+		if got != SignatureProviderClaude {
+			t.Errorf("DetectSignatureProvider(%q) = %q, want %q", sig, got, SignatureProviderClaude)
+		}
+	}
+}
+
+func TestClaudeCAISSignature_ObservedOpus5Layout(t *testing.T) {
+	signature := testClaudeCAISSignature("claude-opus-5")
+	info, err := InspectClaudeCAISSignature(signature)
+	if err != nil {
+		t.Fatalf("InspectClaudeCAISSignature failed: %v", err)
+	}
+	if info.ModelText != "claude-opus-5" {
+		t.Fatalf("ModelText = %q, want claude-opus-5", info.ModelText)
+	}
+	decision := DecideSignatureCompatibilityForModel(SignatureProviderClaude, "claude-opus-5", signature, SignatureBlockKindClaudeThinking)
+	if !decision.Compatible || decision.NormalizedSignature != signature || decision.DetectedProvider != SignatureProviderClaude {
+		t.Fatalf("same-model opus-5 decision = %+v, want preserved with DetectedProvider=claude", decision)
+	}
+}
+
+func TestClaudeCAISSignature_NotCompatibleWithGemini(t *testing.T) {
+	if normalized, ok := CompatibleSignatureForProvider(SignatureProviderGemini, observedFable5Sample); ok || normalized != "" {
+		t.Fatalf("CompatibleSignatureForProvider(Gemini) = %q, %v; want empty and false", normalized, ok)
+	}
+	if IsSignatureCompatibleWithProvider(SignatureProviderGemini, observedFable5Sample) {
+		t.Fatal("IsSignatureCompatibleWithProvider(Gemini) = true, want false")
+	}
+	if isRecognizedGeminiProviderSignature(observedFable5Sample, SignatureBlockKindUnknown) {
+		t.Fatal("isRecognizedGeminiProviderSignature = true, want false")
+	}
+	if _, err := InspectGeminiThoughtSignature(observedFable5Sample); err == nil {
+		t.Fatal("InspectGeminiThoughtSignature should fail for Claude CAIS signature")
+	}
+}
+
+func TestClaudeCAISSignature_CompatibleWithAllClaudeTargets(t *testing.T) {
+	decision := DecideSignatureCompatibilityForModel(SignatureProviderClaude, "claude-fable-5", observedFable5Sample, SignatureBlockKindClaudeThinking)
+	if !decision.Compatible || decision.Action != SignatureActionPreserve || decision.NormalizedSignature != observedFable5Sample || decision.DetectedProvider != SignatureProviderClaude {
+		t.Fatalf("DecideSignatureCompatibilityForModel(Claude, claude-fable-5) = %+v, want compatible & preserved with DetectedProvider=claude", decision)
+	}
+
+	decisionCase := DecideSignatureCompatibilityForModel(SignatureProviderClaude, "CLAUDE-FABLE-5", observedFable5Sample, SignatureBlockKindClaudeThinking)
+	if !decisionCase.Compatible || decisionCase.Action != SignatureActionPreserve {
+		t.Fatalf("DecideSignatureCompatibilityForModel case-insensitive failed: %+v", decisionCase)
+	}
+
+	decisionDiff := DecideSignatureCompatibilityForModel(SignatureProviderClaude, "claude-opus-5", observedFable5Sample, SignatureBlockKindClaudeThinking)
+	if !decisionDiff.Compatible || decisionDiff.Action != SignatureActionPreserve || decisionDiff.NormalizedSignature != observedFable5Sample {
+		t.Fatalf("DecideSignatureCompatibilityForModel(Claude, claude-opus-5) = %+v, want compatible & preserved", decisionDiff)
+	}
+
+	opus5Sig := testClaudeCAISSignature("claude-opus-5")
+	decisionOpusToOpus48 := DecideSignatureCompatibilityForModel(SignatureProviderClaude, "claude-opus-4-8", opus5Sig, SignatureBlockKindClaudeThinking)
+	if !decisionOpusToOpus48.Compatible || decisionOpusToOpus48.Action != SignatureActionPreserve || decisionOpusToOpus48.NormalizedSignature != opus5Sig {
+		t.Fatalf("DecideSignatureCompatibilityForModel(Claude, claude-opus-4-8) with opus-5 signature = %+v, want compatible & preserved", decisionOpusToOpus48)
+	}
+
+	if normalized, ok := CompatibleSignatureForProvider(SignatureProviderClaude, observedFable5Sample); !ok || normalized != observedFable5Sample {
+		t.Fatalf("CompatibleSignatureForProvider(Claude, observedFable5Sample) = %q, %v; want %q, true", normalized, ok, observedFable5Sample)
+	}
+
+	decisionGemini := DecideSignatureCompatibilityForModel(SignatureProviderGemini, "claude-fable-5", observedFable5Sample, SignatureBlockKindClaudeThinking)
+	if decisionGemini.Compatible {
+		t.Fatalf("DecideSignatureCompatibilityForModel(Gemini, claude-fable-5) = %+v, want incompatible", decisionGemini)
+	}
+}
+
+func TestSanitizeClaudeMessagesForClaudeUpstream_ClaudeCAIS(t *testing.T) {
+	inputSame := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"keep","signature":"` + observedFable5Sample + `"},{"type":"text","text":"answer"}]}]}`)
+
+	outputSame, reportSame := SanitizeClaudeMessagesForClaudeUpstream(inputSame, "claude-fable-5")
+	if reportSame.Preserved != 1 || reportSame.DroppedBlocks != 0 {
+		t.Fatalf("unexpected report for same model: %+v", reportSame)
+	}
+	if got := gjson.GetBytes(outputSame, "messages.0.content.0.signature").String(); got != observedFable5Sample {
+		t.Fatalf("signature = %q, want preserved %q", got, observedFable5Sample)
+	}
+
+	inputTool := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"keep","signature":"` + observedFable5Sample + `"},{"type":"text","text":"answer"},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"pwd"},"signature":"` + observedFable5Sample + `"}]}]}`)
+	outputTool, reportTool := SanitizeClaudeMessagesForClaudeUpstream(inputTool, "claude-fable-5")
+	if reportTool.Preserved != 1 {
+		t.Fatalf("unexpected report for tool input: %+v", reportTool)
+	}
+	partsTool := gjson.GetBytes(outputTool, "messages.0.content").Array()
+	if len(partsTool) != 3 {
+		t.Fatalf("content len = %d, want 3", len(partsTool))
+	}
+	if partsTool[0].Get("signature").String() != observedFable5Sample {
+		t.Fatalf("thinking block signature lost: %s", partsTool[0].Raw)
+	}
+	if partsTool[2].Get("signature").Exists() {
+		t.Fatalf("tool_use signature should be stripped: %s", partsTool[2].Raw)
+	}
+
+	inputDiff := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"keep","signature":"` + observedFable5Sample + `"},{"type":"text","text":"answer"}]}]}`)
+	outputDiff, reportDiff := SanitizeClaudeMessagesForClaudeUpstream(inputDiff, "claude-opus-5")
+	if reportDiff.Preserved != 1 || reportDiff.DroppedBlocks != 0 {
+		t.Fatalf("unexpected report for cross model: %+v", reportDiff)
+	}
+	partsDiff := gjson.GetBytes(outputDiff, "messages.0.content").Array()
+	if len(partsDiff) != 2 {
+		t.Fatalf("content len = %d, want 2: %s", len(partsDiff), outputDiff)
+	}
+	if got := partsDiff[0].Get("signature").String(); got != observedFable5Sample {
+		t.Fatalf("thinking signature = %q, want %q", got, observedFable5Sample)
+	}
+}
+
+// TestClaudeCAISSignature_ToleratesUpstreamFieldDrift pins the deliberately
+// structural validation: rejecting a signature drops the whole thinking block,
+// so incidental values observed today must not become hard requirements.
+func TestClaudeCAISSignature_ToleratesUpstreamFieldDrift(t *testing.T) {
+	cases := []struct {
+		name  string
+		parts claudeCAISParts
+	}{
+		{"observed layout", defaultClaudeCAISParts("claude-opus-5")},
+		{"new channel id", func() claudeCAISParts {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.channelID = 17
+			return p
+		}()},
+		{"new envelope version", func() claudeCAISParts {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.topEnvelope = 3
+			return p
+		}()},
+		{"no top-level trailer", func() claudeCAISParts {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.includeTopTrailer = false
+			return p
+		}()},
+		{"no channel version", func() claudeCAISParts {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.includeChannelVerion = false
+			return p
+		}()},
+		{"longer signature bytes", func() claudeCAISParts {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.signatureLen = 96
+			return p
+		}()},
+		{"no field 7", func() claudeCAISParts {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.includeField7 = false
+			return p
+		}()},
+		{"other block kind", func() claudeCAISParts {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.blockKind = "redacted_thinking"
+			return p
+		}()},
+		{"no block kind", func() claudeCAISParts {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.blockKind = ""
+			return p
+		}()},
+		{"no context id", func() claudeCAISParts {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.contextID = ""
+			return p
+		}()},
+		{"unreleased model name", func() claudeCAISParts {
+			p := defaultClaudeCAISParts("claude-opus-6-preview")
+			return p
+		}()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sig := tc.parts.encode()
+			if _, err := InspectClaudeCAISSignature(sig); err != nil {
+				t.Fatalf("InspectClaudeCAISSignature failed: %v", err)
+			}
+			if got := DetectSignatureProviderForBlock(sig, SignatureBlockKindClaudeThinking); got != SignatureProviderClaude {
+				t.Fatalf("DetectSignatureProviderForBlock = %q, want %q", got, SignatureProviderClaude)
+			}
+
+			input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"keep","signature":"` + sig + `"}]}]}`)
+			output, report := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-opus-5")
+			if report.Preserved != 1 || report.DroppedBlocks != 0 {
+				t.Fatalf("report = %+v, want preserved thinking block", report)
+			}
+			if got := gjson.GetBytes(output, "messages.0.content.0.signature").String(); got != sig {
+				t.Fatalf("signature = %q, want preserved %q", got, sig)
+			}
+		})
+	}
+}
+
+func TestClaudeCAISSignature_RejectsMalformedPayloads(t *testing.T) {
+	truncated := func() string {
+		decoded, err := base64.StdEncoding.DecodeString(observedFable5Sample)
+		if err != nil {
+			t.Fatalf("decode observed sample: %v", err)
+		}
+		return base64.StdEncoding.EncodeToString(decoded[:len(decoded)/2])
+	}()
+
+	cases := []struct {
+		name      string
+		signature string
+	}{
+		{"empty", ""},
+		{"whitespace only", "   "},
+		{"not base64", "CAIS!!!not-base64"},
+		{"truncated payload", truncated},
+		// 'E' prefix is the classic Claude form and must not reach CAIS parsing.
+		{"classic claude prefix", base64.StdEncoding.EncodeToString([]byte{0x12, 0x00})},
+		// 'C' prefix but a non-0x08 marker byte, the only way to reach the marker
+		// check (a 'C' prefix constrains the first byte to 0x08-0x0b).
+		{"wrong marker byte", base64.StdEncoding.EncodeToString([]byte{0x0a, 0x00})},
+		{"no container", func() string {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.includeContainer = false
+			return p.encode()
+		}()},
+		{"no channel block", func() string {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.includeChannelBlock = false
+			return p.encode()
+		}()},
+		{"no channel id", func() string {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.includeChannelID = false
+			return p.encode()
+		}()},
+		{"channel id wrong wire type", func() string {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.channelIDAsBytes = true
+			return p.encode()
+		}()},
+		{"no signature bytes", func() string {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.includeSignature = false
+			return p.encode()
+		}()},
+		{"empty signature bytes", func() string {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.signatureLen = 0
+			return p.encode()
+		}()},
+		{"no model text", func() string {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.includeModelText = false
+			return p.encode()
+		}()},
+		{"foreign model text", func() string {
+			p := defaultClaudeCAISParts("gemini-3-pro")
+			return p.encode()
+		}()},
+		{"invalid utf-8 model text", func() string {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.modelText = []byte{'c', 'l', 'a', 'u', 'd', 'e', '-', 0xff, 0xfe}
+			return p.encode()
+		}()},
+		{"non-uuid context id", func() string {
+			p := defaultClaudeCAISParts("claude-opus-5")
+			p.contextID = "not-a-canonical-uuid-value-000000000"
+			return p.encode()
+		}()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if IsValidClaudeCAISSignature(tc.signature) {
+				t.Fatalf("IsValidClaudeCAISSignature(%q) = true, want false", tc.signature)
+			}
+		})
+	}
+}
+
+// TestClaudeCAISSignature_DoesNotShadowClassicClaudeSignature guards the
+// detection order: CAIS validation runs before classic Claude validation, so it
+// must not claim E/R signatures and change how they are normalized.
+func TestClaudeCAISSignature_DoesNotShadowClassicClaudeSignature(t *testing.T) {
+	classic := testClaudeThinkingSignature()
+	if IsValidClaudeCAISSignature(classic) {
+		t.Fatal("IsValidClaudeCAISSignature(classic Claude signature) = true, want false")
+	}
+	if got := DetectSignatureProviderForBlock(classic, SignatureBlockKindClaudeThinking); got != SignatureProviderClaude {
+		t.Fatalf("DetectSignatureProviderForBlock(classic) = %q, want %q", got, SignatureProviderClaude)
+	}
+
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"keep","signature":"` + classic + `"}]}]}`)
+	output, report := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-sonnet-4-6")
+	if report.Preserved != 1 || report.DroppedBlocks != 0 {
+		t.Fatalf("report = %+v, want preserved classic thinking block", report)
+	}
+	if got := gjson.GetBytes(output, "messages.0.content.0.signature").String(); got != classic {
+		t.Fatalf("signature = %q, want provider-native E-form %q", got, classic)
+	}
+}
+
+// TestClaudeCAISSignature_CachePrefixSurvivesClaudeUpstreamSanitize covers the
+// cached-signature path: cache.GetModelGroup collapses every Claude model to the
+// "claude" prefix, so a CAIS signature reaches the sanitizer as "claude#..." and
+// must be replayed with the prefix stripped instead of being dropped.
+func TestClaudeCAISSignature_CachePrefixSurvivesClaudeUpstreamSanitize(t *testing.T) {
+	for _, prefix := range []string{"claude#", "anthropic#", "cais#", "ccmax#"} {
+		t.Run(prefix, func(t *testing.T) {
+			prefixed := prefix + observedFable5Sample
+			input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"keep","signature":"` + prefixed + `"}]}]}`)
+			output, report := SanitizeClaudeMessagesForClaudeUpstream(input, "claude-fable-5")
+			if report.Preserved != 1 || report.DroppedBlocks != 0 {
+				t.Fatalf("report = %+v, want preserved thinking block", report)
+			}
+			if got := gjson.GetBytes(output, "messages.0.content.0.signature").String(); got != observedFable5Sample {
+				t.Fatalf("signature = %q, want unprefixed %q", got, observedFable5Sample)
+			}
+		})
+	}
+}
+
+func TestCompatibleAntigravityClaudeThinkingSignature_RejectsClaudeCAIS(t *testing.T) {
+	if normalized, ok := CompatibleAntigravityClaudeThinkingSignature(observedFable5Sample); ok || normalized != "" {
+		t.Fatalf("CompatibleAntigravityClaudeThinkingSignature(ClaudeCAIS) = %q, %v; want empty and false", normalized, ok)
+	}
+	if normalized, ok := CompatibleAntigravityClaudeThinkingSignature("ccmax#" + observedFable5Sample); ok || normalized != "" {
+		t.Fatalf("CompatibleAntigravityClaudeThinkingSignature(ccmax#ClaudeCAIS) = %q, %v; want empty and false", normalized, ok)
+	}
+	if normalized, ok := CompatibleAntigravityClaudeThinkingSignature("cais#" + observedFable5Sample); ok || normalized != "" {
+		t.Fatalf("CompatibleAntigravityClaudeThinkingSignature(cais#ClaudeCAIS) = %q, %v; want empty and false", normalized, ok)
+	}
+	if normalized, ok := CompatibleAntigravityClaudeThinkingSignature("claude-cais#" + observedFable5Sample); ok || normalized != "" {
+		t.Fatalf("CompatibleAntigravityClaudeThinkingSignature(claude-cais#ClaudeCAIS) = %q, %v; want empty and false", normalized, ok)
 	}
 }

--- a/internal/signature/claude_validation.go
+++ b/internal/signature/claude_validation.go
@@ -48,6 +48,65 @@
 // Vertex, Bedrock) and legacy ch=11 signatures. Both single-layer (E) and
 // double-layer (R) encodings are supported. Historical cache-mode modelGroup#
 // prefixes are stripped.
+//
+// # CAIS envelope (newest Claude Code models)
+//
+// Newer Claude Code models wrap the channel block in a CAIS envelope whose
+// decoded payload starts with 0x08 (top-level field 1 varint) instead of 0x12,
+// so the base64 string starts with 'C' instead of 'E'/'R'. The envelope version
+// varint in top-level field 1 is the ONLY structural difference from the layout
+// above; everything below it is unchanged.
+//
+// The channel block itself belongs to a newer schema generation that is shared
+// by both envelopes: channel_id 16, no infra field 2, plus a block kind (field
+// 8) and a context id (field 11). Observed traffic confirms this schema
+// appears under the classic 0x12 envelope too (opus-4-6/4-7/4-8, sonnet-5) and
+// under the CAIS envelope (opus-5, fable-5), so envelope form and channel schema
+// generation vary independently and must not be inferred from each other:
+//
+//	Top-level protobuf
+//	|- Field 1 (varint): envelope version [required marker, observed as 2]
+//	|- Field 2 (bytes): container [required]
+//	|  `- Field 1 (bytes): channel block [required]
+//	|     |- Field 1  (varint): channel_id [required, observed as 16]
+//	|     |- Field 3  (varint): version [optional, observed as 2]
+//	|     |- Field 5  (bytes):  ECDSA signature [required, observed as 64B]
+//	|     |- Field 6  (bytes):  model_text [required, "claude-" prefixed]
+//	|     |- Field 7  (varint): unknown [optional, observed as 1]
+//	|     |- Field 8  (bytes):  block kind [optional, observed as "thinking"]
+//	|     `- Field 11 (bytes):  context id [optional, canonical UUID]
+//	`- Field 3 (varint): trailer [optional, observed as 1]
+//
+// CAIS validation is structural rather than an exact replay of the observed
+// bytes. The payload is an opaque upstream-issued blob and rejecting it drops
+// the whole thinking block, so only the fields that actually identify the format
+// are required: the 0x08 marker, the nested container/channel block, the
+// signature bytes, and the "claude-" model text. Observed-but-incidental values
+// such as channel_id 16 or the "thinking" block kind are recorded for debugging
+// and checked only for wire type, so an upstream field bump cannot silently
+// erase conversation history.
+//
+// # Which provider emits which envelope
+//
+// Three providers serve Claude models, and the envelope depends on the model
+// generation rather than on the provider:
+//
+//   - Claude Code OAuth subscription (Claude Code Max): opus-4-5, sonnet-4-6 and
+//     every later model up to opus-5 and fable-5. Emits the CAIS envelope for
+//     the newest models (opus-5, fable-5) and the single-layer E envelope for the
+//     opus-4-6/4-7/4-8 and sonnet-5 generation — but both carry the same
+//     channel_id 16 channel schema, so only the envelope differs.
+//   - Claude Messages API: the full Claude model range, same envelopes as the
+//     Claude Code OAuth subscription.
+//   - Antigravity: only opus-4-6-think and sonnet-4-6, and always the
+//     double-layer R form on Google infrastructure (infra_google). Antigravity
+//     never issues a CAIS envelope or a single-layer E signature, and its replay
+//     path requires R form, so CompatibleAntigravityClaudeThinkingSignature
+//     rejects CAIS signatures.
+//
+// A single conversation therefore mixes envelopes whenever a user switches model
+// generations or providers, and every form must stay replayable toward the
+// provider that issued it.
 package signature
 
 import (
@@ -515,4 +574,228 @@ func decodeClaudeBytesField(raw []byte, label string) ([]byte, error) {
 		return nil, fmt.Errorf("invalid Claude signature: failed to decode %s: %w", label, protowire.ParseError(n))
 	}
 	return value, nil
+}
+
+// claudeCAISSignatureMarker is the decoded first byte identifying the CAIS
+// envelope (protobuf tag for top-level field 1, varint).
+const claudeCAISSignatureMarker = 0x08
+
+// claudeCAISModelTextPrefix is the model_text prefix that distinguishes a CAIS
+// channel block from an arbitrary protobuf payload.
+const claudeCAISModelTextPrefix = "claude-"
+
+// ClaudeCAISSignatureInfo describes the locally inspected structure of a Claude
+// CAIS thinking signature.
+type ClaudeCAISSignatureInfo struct {
+	FirstByte       byte
+	EnvelopeVersion uint64
+	ChannelID       uint64
+	ModelText       string
+	BlockKind       string
+	ContextID       string
+
+	SignatureLen int
+}
+
+// IsValidClaudeCAISSignature returns whether rawSignature is a valid Claude CAIS
+// thinking signature.
+func IsValidClaudeCAISSignature(rawSignature string) bool {
+	_, err := InspectClaudeCAISSignature(rawSignature)
+	return err == nil
+}
+
+// InspectClaudeCAISSignature decodes and validates a Claude CAIS thinking
+// signature. See the CAIS envelope section in this file's package comment for
+// the layout and for why validation is structural rather than exact.
+func InspectClaudeCAISSignature(rawSignature string) (*ClaudeCAISSignatureInfo, error) {
+	sig := stripClaudeSignaturePrefix(rawSignature)
+	if sig == "" {
+		return nil, fmt.Errorf("empty signature")
+	}
+	if len(sig) > MaxClaudeThinkingSignatureLen {
+		return nil, fmt.Errorf("signature exceeds maximum length (%d bytes)", MaxClaudeThinkingSignatureLen)
+	}
+	// A payload whose first byte is 0x08 always base64-encodes to a string
+	// starting with 'C' (0x08>>2 == 2). Checking that first keeps this validator
+	// cheap on the hot paths that probe every signature, since classic Claude
+	// (E/R) and Gemini envelopes are rejected without a base64 decode.
+	if sig[0] != 'C' {
+		return nil, fmt.Errorf("invalid Claude CAIS signature: expected 'C' prefix, got %q", string(sig[0]))
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(sig)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Claude CAIS signature: base64 decode failed: %w", err)
+	}
+	if len(decoded) == 0 {
+		return nil, fmt.Errorf("invalid Claude CAIS signature: empty after decode")
+	}
+	if decoded[0] != claudeCAISSignatureMarker {
+		return nil, fmt.Errorf("invalid Claude CAIS signature: expected first byte 0x%02x, got 0x%02x", claudeCAISSignatureMarker, decoded[0])
+	}
+
+	info := &ClaudeCAISSignatureInfo{FirstByte: decoded[0]}
+
+	var container []byte
+	err = walkClaudeProtobufFields(decoded, func(num protowire.Number, typ protowire.Type, raw []byte) error {
+		switch num {
+		case 1:
+			value, errField := decodeClaudeCAISVarint(raw, typ, "CAIS top-level field 1 envelope version")
+			if errField != nil {
+				return errField
+			}
+			info.EnvelopeVersion = value
+		case 2:
+			value, errField := decodeClaudeCAISBytes(raw, typ, "CAIS top-level field 2 container")
+			if errField != nil {
+				return errField
+			}
+			container = value
+		case 3:
+			if _, errField := decodeClaudeCAISVarint(raw, typ, "CAIS top-level field 3 trailer"); errField != nil {
+				return errField
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if container == nil {
+		return nil, fmt.Errorf("invalid Claude CAIS signature: missing top-level field 2 container")
+	}
+
+	var channelBlock []byte
+	err = walkClaudeProtobufFields(container, func(num protowire.Number, typ protowire.Type, raw []byte) error {
+		if num != 1 {
+			return nil
+		}
+		value, errField := decodeClaudeCAISBytes(raw, typ, "CAIS container field 1 channel block")
+		if errField != nil {
+			return errField
+		}
+		channelBlock = value
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if channelBlock == nil {
+		return nil, fmt.Errorf("invalid Claude CAIS signature: missing container field 1 channel block")
+	}
+
+	var haveChannelID, haveSignatureBytes, haveModelText bool
+	err = walkClaudeProtobufFields(channelBlock, func(num protowire.Number, typ protowire.Type, raw []byte) error {
+		switch num {
+		case 1:
+			value, errField := decodeClaudeCAISVarint(raw, typ, "CAIS channel field 1 channel_id")
+			if errField != nil {
+				return errField
+			}
+			info.ChannelID = value
+			haveChannelID = true
+		case 3:
+			if _, errField := decodeClaudeCAISVarint(raw, typ, "CAIS channel field 3 version"); errField != nil {
+				return errField
+			}
+		case 5:
+			value, errField := decodeClaudeCAISBytes(raw, typ, "CAIS channel field 5 signature bytes")
+			if errField != nil {
+				return errField
+			}
+			if len(value) == 0 {
+				return fmt.Errorf("invalid Claude CAIS signature: channel field 5 signature bytes must not be empty")
+			}
+			info.SignatureLen = len(value)
+			haveSignatureBytes = true
+		case 6:
+			value, errField := decodeClaudeCAISUTF8(raw, typ, "CAIS channel field 6 model_text")
+			if errField != nil {
+				return errField
+			}
+			if !strings.HasPrefix(value, claudeCAISModelTextPrefix) {
+				return fmt.Errorf("invalid Claude CAIS signature: channel field 6 model_text must start with %q, got %q", claudeCAISModelTextPrefix, value)
+			}
+			info.ModelText = value
+			haveModelText = true
+		case 7:
+			if _, errField := decodeClaudeCAISVarint(raw, typ, "CAIS channel field 7"); errField != nil {
+				return errField
+			}
+		case 8:
+			value, errField := decodeClaudeCAISUTF8(raw, typ, "CAIS channel field 8 block kind")
+			if errField != nil {
+				return errField
+			}
+			info.BlockKind = value
+		case 11:
+			value, errField := decodeClaudeCAISUTF8(raw, typ, "CAIS channel field 11 context id")
+			if errField != nil {
+				return errField
+			}
+			if !isCanonicalUUID(value) {
+				return fmt.Errorf("invalid Claude CAIS signature: channel field 11 context id must be a canonical UUID, got %q", value)
+			}
+			info.ContextID = value
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case !haveChannelID:
+		return nil, fmt.Errorf("invalid Claude CAIS signature: missing channel field 1 channel_id")
+	case !haveSignatureBytes:
+		return nil, fmt.Errorf("invalid Claude CAIS signature: missing channel field 5 signature bytes")
+	case !haveModelText:
+		return nil, fmt.Errorf("invalid Claude CAIS signature: missing channel field 6 model_text")
+	}
+
+	return info, nil
+}
+
+func decodeClaudeCAISVarint(raw []byte, typ protowire.Type, label string) (uint64, error) {
+	if typ != protowire.VarintType {
+		return 0, fmt.Errorf("invalid Claude CAIS signature: %s must be varint", label)
+	}
+	return decodeClaudeVarintField(raw, label)
+}
+
+func decodeClaudeCAISBytes(raw []byte, typ protowire.Type, label string) ([]byte, error) {
+	if typ != protowire.BytesType {
+		return nil, fmt.Errorf("invalid Claude CAIS signature: %s must be bytes", label)
+	}
+	return decodeClaudeBytesField(raw, label)
+}
+
+func decodeClaudeCAISUTF8(raw []byte, typ protowire.Type, label string) (string, error) {
+	value, err := decodeClaudeCAISBytes(raw, typ, label)
+	if err != nil {
+		return "", err
+	}
+	if !utf8.Valid(value) {
+		return "", fmt.Errorf("invalid Claude CAIS signature: %s must be valid UTF-8", label)
+	}
+	return string(value), nil
+}
+
+func isCanonicalUUID(s string) bool {
+	if len(s) != 36 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		b := s[i]
+		switch i {
+		case 8, 13, 18, 23:
+			if b != '-' {
+				return false
+			}
+		default:
+			if !((b >= '0' && b <= '9') || (b >= 'a' && b <= 'f') || (b >= 'A' && b <= 'F')) {
+				return false
+			}
+		}
+	}
+	return true
 }

--- a/internal/signature/gemini_validation.go
+++ b/internal/signature/gemini_validation.go
@@ -37,11 +37,13 @@
 //     traceable to a prior Gemini model response in the same conversation.
 //   - Opaque-shape tier: for real Gemini signatures, require a non-empty string,
 //     bounded length, successful standard base64 decoding, and a known protobuf
-//     envelope when the caller needs provider compatibility. Observed samples
-//     currently include Gemini 3.x field-2 -> field-1 payloads containing either
-//     versioned opaque state or a provider UUID, plus Gemini 2.5 repeated field-1
-//     payloads. Bare base64 UUID payloads are classified separately and should be
-//     replaced with the bypass sentinel rather than replayed.
+//     envelope when the caller needs provider compatibility. The only known
+//     envelope is the Gemini 3.x field-2 -> field-1 payload, whose body holds
+//     either versioned opaque state or a provider UUID. Gemini 2.5 emitted a
+//     repeated field-1 form; those models are out of scope and their signatures
+//     are no longer a known envelope. Bare base64 UUID payloads are classified
+//     separately and should be replaced with the bypass sentinel rather than
+//     replayed.
 //   - Replay tier: real validation means preserving the exact model part that
 //     came from Gemini, including its thoughtSignature, id/name/function args,
 //     part index, and ordering relative to sibling parallel function calls.
@@ -93,18 +95,22 @@ type GeminiThoughtSignatureValidationOptions struct {
 	// protobuf envelopes observed in Gemini samples. This rejects opaque base64
 	// values such as base64 UUIDs.
 	RequireKnownEnvelope bool
-	// RequireObservedMarker requires the decoded payload to start with 0x12.
-	// Current Gemini 3.x samples show this marker, but Gemini 2.5 samples use a
-	// different protobuf prefix, so this should be used only for narrow Gemini 3
-	// experiments.
+	// RequireObservedMarker requires the decoded payload to start with 0x12. Every
+	// observed Gemini 3.x sample carries this marker, but it is only the outer
+	// protobuf tag, so RequireKnownEnvelope is the stronger check and should be
+	// preferred. This option exists for narrow experiments that want the marker
+	// without the full envelope walk.
 	RequireObservedMarker bool
 }
 
 type GeminiThoughtSignatureEnvelope string
 
 const (
-	GeminiThoughtSignatureEnvelopeUnknown        GeminiThoughtSignatureEnvelope = "unknown"
-	GeminiThoughtSignatureEnvelopeProtobufField1 GeminiThoughtSignatureEnvelope = "protobuf_field_1"
+	GeminiThoughtSignatureEnvelopeUnknown GeminiThoughtSignatureEnvelope = "unknown"
+	// GeminiThoughtSignatureEnvelopeProtobufField2 is the only replay-safe Gemini
+	// envelope. The repeated field-1 form emitted by Gemini 2.5 is no longer
+	// recognized: those models are out of scope, and their signatures now fall
+	// through to the bypass sentinel like any other unknown envelope.
 	GeminiThoughtSignatureEnvelopeProtobufField2 GeminiThoughtSignatureEnvelope = "protobuf_field_2"
 	GeminiThoughtSignatureEnvelopeASCIIUUID      GeminiThoughtSignatureEnvelope = "ascii_uuid"
 )
@@ -168,6 +174,10 @@ func InspectGeminiThoughtSignature(rawSignature string, opts ...GeminiThoughtSig
 	sig := strings.TrimSpace(rawSignature)
 	if sig == "" {
 		return nil, fmt.Errorf("empty Gemini thought signature")
+	}
+
+	if IsValidClaudeCAISSignature(sig) {
+		return nil, fmt.Errorf("invalid Gemini thought signature: detected Claude CAIS signature")
 	}
 
 	if IsGeminiThoughtSignatureBypass(sig) {
@@ -388,19 +398,10 @@ func classifyGeminiThoughtSignatureEnvelope(decoded []byte) (GeminiThoughtSignat
 	if isASCIIUUIDBytes(decoded) {
 		return GeminiThoughtSignatureEnvelopeASCIIUUID, false
 	}
-	switch {
-	case isGeminiField1Envelope(decoded):
-		return GeminiThoughtSignatureEnvelopeProtobufField1, true
-	case isGeminiField2Envelope(decoded):
+	if isGeminiField2Envelope(decoded) {
 		return GeminiThoughtSignatureEnvelopeProtobufField2, true
-	default:
-		return GeminiThoughtSignatureEnvelopeUnknown, false
 	}
-}
-
-func isGeminiField1Envelope(decoded []byte) bool {
-	info, ok := inspectGeminiField1Envelope(decoded)
-	return ok && info.RecordCount > 0
+	return GeminiThoughtSignatureEnvelopeUnknown, false
 }
 
 func isGeminiField2Envelope(decoded []byte) bool {
@@ -409,12 +410,7 @@ func isGeminiField2Envelope(decoded []byte) bool {
 }
 
 func inspectGeminiEnvelope(decoded []byte, envelope GeminiThoughtSignatureEnvelope) (recordCount int, opaquePayloadLen int) {
-	switch envelope {
-	case GeminiThoughtSignatureEnvelopeProtobufField1:
-		if info, ok := inspectGeminiField1Envelope(decoded); ok {
-			return info.RecordCount, info.OpaquePayloadLen
-		}
-	case GeminiThoughtSignatureEnvelopeProtobufField2:
+	if envelope == GeminiThoughtSignatureEnvelopeProtobufField2 {
 		if info, ok := inspectGeminiField2Envelope(decoded); ok {
 			return info.RecordCount, info.OpaquePayloadLen
 		}
@@ -425,26 +421,6 @@ func inspectGeminiEnvelope(decoded []byte, envelope GeminiThoughtSignatureEnvelo
 type geminiEnvelopeInfo struct {
 	RecordCount      int
 	OpaquePayloadLen int
-}
-
-func inspectGeminiField1Envelope(decoded []byte) (geminiEnvelopeInfo, bool) {
-	var info geminiEnvelopeInfo
-	offset := 0
-	for offset < len(decoded) {
-		num, typ, n := protowire.ConsumeTag(decoded[offset:])
-		if n < 0 || num != 1 || typ != protowire.BytesType {
-			return geminiEnvelopeInfo{}, false
-		}
-		offset += n
-		value, n := protowire.ConsumeBytes(decoded[offset:])
-		if n < 0 || !isLikelyGeminiOpaquePayload(value) {
-			return geminiEnvelopeInfo{}, false
-		}
-		info.RecordCount++
-		info.OpaquePayloadLen += len(value)
-		offset += n
-	}
-	return info, offset == len(decoded) && info.RecordCount > 0
 }
 
 func inspectGeminiField2Envelope(decoded []byte) (geminiEnvelopeInfo, bool) {
@@ -490,9 +466,19 @@ func consumeGeminiField2Field1Value(decoded []byte) ([]byte, bool) {
 }
 
 func isLikelyGeminiOpaquePayload(value []byte) bool {
-	// Observed Gemini 2.5 and Gemini 3.x envelopes wrap provider-opaque
-	// payloads that start with an internal version byte 0x01. The bytes after
-	// that are high-entropy provider state and must remain opaque.
+	// The envelope body is a Google Tink primitive output: one prefix-type byte
+	// (0x01 selects the TINK prefix) followed by a four-byte big-endian key id and
+	// then the ciphertext. Only the prefix-type byte is checked here, because it is
+	// a format constant while the key id is key material that Google rotates.
+	// Pinning the key id would reduce false positives to nothing but would reject
+	// every signature the moment a rotation happens, which is the worse failure.
+	// That rotation is observed, not hypothetical: gemini-3.1-flash-lite carries key
+	// id 0x0c39d6c7 in the archived corpus and 0x114d320f in the 2026-07-27 capture,
+	// and the newer id is shared by every Gemini 3.x variant captured that day. The
+	// bytes after the prefix are high-entropy provider state and stay opaque, so this
+	// one format byte is the only anchor available. It leaves a 1/256 false-positive
+	// rate against a caller that reproduces the protobuf envelope but not the key
+	// material; provenance or target scoping, not more byte checks, closes that gap.
 	return len(value) > 0 && value[0] == 0x01
 }
 

--- a/internal/signature/gemini_validation_test.go
+++ b/internal/signature/gemini_validation_test.go
@@ -126,24 +126,35 @@ func TestInspectGeminiThoughtSignature_AcceptsGemini3WrappedUUIDEnvelope(t *test
 	}
 }
 
-func TestInspectGeminiThoughtSignature_AcceptsGemini25Field1Envelope(t *testing.T) {
+// TestInspectGeminiThoughtSignature_RejectsGemini25Field1Envelope pins the removal
+// of the repeated field-1 envelope. Gemini 2.5 is out of scope, so its signatures
+// are no longer a known envelope; they degrade to the bypass sentinel on Gemini
+// model parts instead of being replayed verbatim.
+func TestInspectGeminiThoughtSignature_RejectsGemini25Field1Envelope(t *testing.T) {
 	sig := testGemini25ThoughtSignature([]byte{0x01, 0x8f}, []byte{0x01, 0x90, 0x91})
 
-	info, err := InspectGeminiThoughtSignature(sig, GeminiThoughtSignatureValidationOptions{RequireKnownEnvelope: true})
+	if _, err := InspectGeminiThoughtSignature(sig, GeminiThoughtSignatureValidationOptions{RequireKnownEnvelope: true}); err == nil {
+		t.Fatal("Gemini 2.5 field-1 envelope should no longer be a known envelope")
+	}
+
+	info, err := InspectGeminiThoughtSignature(sig)
 	if err != nil {
-		t.Fatalf("Gemini 2.5 field-1 envelope should be known: %v", err)
+		t.Fatalf("inspection without RequireKnownEnvelope should still succeed: %v", err)
 	}
-	if info.Envelope != GeminiThoughtSignatureEnvelopeProtobufField1 {
-		t.Fatalf("Envelope = %q, want %q", info.Envelope, GeminiThoughtSignatureEnvelopeProtobufField1)
+	if info.Envelope != GeminiThoughtSignatureEnvelopeUnknown {
+		t.Fatalf("Envelope = %q, want %q", info.Envelope, GeminiThoughtSignatureEnvelopeUnknown)
 	}
-	if info.HasObservedMarker {
-		t.Fatal("Gemini 2.5 field-1 envelope should not be marked as 0x12")
+	if info.KnownEnvelope {
+		t.Fatal("KnownEnvelope should be false for the retired field-1 envelope")
 	}
-	if info.RecordCount != 2 {
-		t.Fatalf("RecordCount = %d, want 2", info.RecordCount)
+
+	// Gemini model parts still recover through the documented sentinel.
+	decision := DecideSignatureCompatibility(SignatureProviderGemini, sig, SignatureBlockKindGeminiModelPart)
+	if decision.Action != SignatureActionReplaceWithGeminiBypass {
+		t.Fatalf("action = %q, want %q", decision.Action, SignatureActionReplaceWithGeminiBypass)
 	}
-	if info.OpaquePayloadLen != 5 {
-		t.Fatalf("OpaquePayloadLen = %d, want 5", info.OpaquePayloadLen)
+	if decision.ReplacementSignature != GeminiSkipThoughtSignatureValidator {
+		t.Fatalf("replacement = %q, want %q", decision.ReplacementSignature, GeminiSkipThoughtSignatureValidator)
 	}
 }
 

--- a/internal/signature/gpt_validation.go
+++ b/internal/signature/gpt_validation.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 )
 
 const MaxGPTReasoningSignatureLen = 32 * 1024 * 1024
@@ -29,11 +30,16 @@ func InspectGPTReasoningSignature(rawSignature string) (*GPTReasoningSignatureIn
 	if len(sig) > MaxGPTReasoningSignatureLen {
 		return nil, fmt.Errorf("GPT reasoning signature exceeds maximum length (%d bytes)", MaxGPTReasoningSignatureLen)
 	}
-	if index, r, ok := firstInvalidGPTReasoningSignatureChar(sig); ok {
-		return nil, fmt.Errorf("invalid GPT reasoning signature: contains non-base64url character U+%04X at byte %d", r, index)
-	}
+	// The literal prefix is the cheapest discriminator and rejects every other
+	// provider's envelope outright, so it runs before the full charset scan.
+	// Probing this validator is on the hot path for signatures of every provider,
+	// and scanning a multi-kilobyte payload only to reject it on five bytes was
+	// pure waste.
 	if !strings.HasPrefix(sig, "gAAAA") {
 		return nil, fmt.Errorf("invalid GPT reasoning signature: expected gAAAA prefix")
+	}
+	if index, r, ok := firstInvalidGPTReasoningSignatureChar(sig); ok {
+		return nil, fmt.Errorf("invalid GPT reasoning signature: contains non-base64url character U+%04X at byte %d", r, index)
 	}
 
 	decoded, err := decodeGPTReasoningSignature(sig)
@@ -68,14 +74,17 @@ func decodeGPTReasoningSignature(sig string) ([]byte, error) {
 	return nil, fmt.Errorf("invalid GPT reasoning signature: base64url decode failed")
 }
 
+// gptReasoningSignatureCharSet is the base64url alphabet, padding included.
+var gptReasoningSignatureCharSet = base64AlphabetSet("-_=")
+
+// firstInvalidGPTReasoningSignatureChar scans bytes against a lookup table for the
+// same reason as its Grok counterpart: every legal character is ASCII, and a
+// comparison chain mispredicts on nearly every byte of a multi-kilobyte reasoning
+// blob. The offending rune is decoded only for the error message.
 func firstInvalidGPTReasoningSignatureChar(sig string) (int, rune, bool) {
-	for index, r := range sig {
-		switch {
-		case r >= 'A' && r <= 'Z':
-		case r >= 'a' && r <= 'z':
-		case r >= '0' && r <= '9':
-		case r == '-' || r == '_' || r == '=':
-		default:
+	for index := 0; index < len(sig); index++ {
+		if !gptReasoningSignatureCharSet[sig[index]] {
+			r, _ := utf8.DecodeRuneInString(sig[index:])
 			return index, r, true
 		}
 	}

--- a/internal/signature/grok_validation.go
+++ b/internal/signature/grok_validation.go
@@ -5,14 +5,19 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"unicode/utf8"
 )
 
 const (
 	// MaxGrokEncryptedContentLen is a transport safety cap for opaque replay blobs.
 	MaxGrokEncryptedContentLen = 8 * 1024 * 1024
-	// MinGrokEncryptedContentDecodedLen is derived from native Grok CLI captures;
-	// shorter decoded payloads are treated as invalid replay state for xAI upstream.
-	MinGrokEncryptedContentDecodedLen = 50
+	// MinGrokEncryptedContentDecodedLen is a deliberately loose floor. The
+	// shortest observed native payload is exactly 50 bytes (grok-composer-2.5-fast),
+	// and those samples share no structure, so 50 is a sampling artifact rather
+	// than a protocol minimum. Sitting on the observed floor would silently reject
+	// a future shorter payload and surface as lost reasoning context, so keep
+	// headroom here and let the entropy check do the real filtering.
+	MinGrokEncryptedContentDecodedLen = 32
 	// MinGrokEncryptedContentEntropyRatio rejects obvious non-ciphertext payloads.
 	// Native samples are >= 0.892 against the sample-size entropy ceiling.
 	MinGrokEncryptedContentEntropyRatio = 0.85
@@ -25,6 +30,15 @@ type GrokEncryptedContentInfo struct {
 
 // InspectGrokEncryptedContent validates the transport shape of xAI/Grok
 // reasoning or compaction encrypted_content. This does not prove decryptability.
+//
+// This is NOT a provider classifier and must not be used as one. Unlike Claude,
+// Gemini and GPT, xAI emits no self-describing envelope: observed payloads are
+// indistinguishable from uniform random bytes (no magic prefix, no version byte,
+// no fixed suffix, and decoded lengths spread evenly modulo the AES block size).
+// Every high-entropy unpadded standard-base64 blob therefore satisfies the checks
+// below. Callers must establish provenance before asking this question, either
+// from an explicit provider cache prefix or from a confirmed xAI target model,
+// and treat the result as a replay-safety check rather than an identification.
 func InspectGrokEncryptedContent(raw string) (*GrokEncryptedContentInfo, error) {
 	sig := strings.TrimSpace(raw)
 	if sig == "" {
@@ -36,20 +50,36 @@ func InspectGrokEncryptedContent(raw string) (*GrokEncryptedContentInfo, error) 
 	if sig != raw {
 		return nil, fmt.Errorf("Grok encrypted_content has leading or trailing whitespace")
 	}
-	if strings.HasPrefix(sig, "gAAAA") {
-		return nil, fmt.Errorf("Grok encrypted_content looks like GPT/Codex reasoning signature")
-	}
 	if strings.Contains(sig, "=") {
 		return nil, fmt.Errorf("invalid Grok encrypted_content: expected unpadded standard base64")
 	}
 	if index, r, ok := firstInvalidGrokEncryptedContentChar(sig); ok {
 		return nil, fmt.Errorf("invalid Grok encrypted_content: contains non-base64 character U+%04X at byte %d", r, index)
 	}
-	if IsValidClaudeThinkingSignature(sig, ClaudeSignatureValidationOptions{Strict: true}) {
-		return nil, fmt.Errorf("Grok encrypted_content looks like Claude thinking signature")
+	if _, _, ok := SplitSignatureProviderPrefix(sig); ok {
+		return nil, fmt.Errorf("invalid Grok encrypted_content: carries another provider's cache prefix")
 	}
-	if _, err := InspectGeminiThoughtSignature(sig, GeminiThoughtSignatureValidationOptions{RequireKnownEnvelope: true}); err == nil {
-		return nil, fmt.Errorf("Grok encrypted_content looks like Gemini thoughtSignature")
+	// Foreign-envelope rejection only has to run for the narrow set of base64
+	// first characters a self-describing envelope can produce. Native xAI
+	// ciphertext is uniformly distributed, so this skips the whole chain for
+	// roughly 92% of real traffic without decoding anything. Every branch below
+	// stays exhaustive for the candidates that do reach it: Claude CAIS in
+	// particular is high-entropy standard base64 that drops its padding whenever
+	// the decoded length is a multiple of 3, so the padding gate above does not
+	// exclude it on its own.
+	if maybeSelfDescribingSignatureEnvelope(sig) {
+		if strings.HasPrefix(sig, "gAAAA") {
+			return nil, fmt.Errorf("Grok encrypted_content looks like GPT/Codex reasoning signature")
+		}
+		if IsValidClaudeThinkingSignature(sig, ClaudeSignatureValidationOptions{Strict: true}) {
+			return nil, fmt.Errorf("Grok encrypted_content looks like Claude thinking signature")
+		}
+		if IsValidClaudeCAISSignature(sig) {
+			return nil, fmt.Errorf("Grok encrypted_content looks like Claude CAIS thinking signature")
+		}
+		if _, err := InspectGeminiThoughtSignature(sig, GeminiThoughtSignatureValidationOptions{RequireKnownEnvelope: true}); err == nil {
+			return nil, fmt.Errorf("Grok encrypted_content looks like Gemini thoughtSignature")
+		}
 	}
 
 	decoded, err := decodeGrokEncryptedContent(sig)
@@ -81,14 +111,18 @@ func decodeGrokEncryptedContent(sig string) ([]byte, error) {
 	return decoded, nil
 }
 
+// grokEncryptedContentCharSet is the unpadded standard base64 alphabet.
+var grokEncryptedContentCharSet = base64AlphabetSet("+/")
+
+// firstInvalidGrokEncryptedContentChar scans bytes against a lookup table rather
+// than ranging over runes. Every legal character is ASCII, so rune iteration only
+// adds cost, and the table removes the branch mispredictions that dominated this
+// scan on multi-kilobyte payloads. The offending rune is decoded once, for the
+// error message, so multi-byte input is still reported accurately.
 func firstInvalidGrokEncryptedContentChar(sig string) (int, rune, bool) {
-	for index, r := range sig {
-		switch {
-		case r >= 'A' && r <= 'Z':
-		case r >= 'a' && r <= 'z':
-		case r >= '0' && r <= '9':
-		case r == '+' || r == '/':
-		default:
+	for index := 0; index < len(sig); index++ {
+		if !grokEncryptedContentCharSet[sig[index]] {
+			r, _ := utf8.DecodeRuneInString(sig[index:])
 			return index, r, true
 		}
 	}

--- a/internal/signature/grok_validation_test.go
+++ b/internal/signature/grok_validation_test.go
@@ -90,18 +90,18 @@ func TestInspectGrokEncryptedContent_RejectsGeminiThoughtSignatureEnvelope(t *te
 	}
 }
 
-func TestInspectGrokEncryptedContent_RejectsGemini25Field1Envelope(t *testing.T) {
+// TestInspectGrokEncryptedContent_RetiredGemini25Field1Envelope covers the
+// retired Gemini 2.5 envelope. It is no longer a known Gemini envelope, so the
+// Gemini fast-reject no longer fires for it and it falls to the residual class
+// like any other opaque payload. Recorded here so the change is deliberate rather
+// than an accident of the Gemini validator being narrowed.
+func TestInspectGrokEncryptedContent_RetiredGemini25Field1Envelope(t *testing.T) {
 	sample := testGemini25Field1ThoughtSignatureEnvelope()
-	if !IsValidGeminiThoughtSignature(sample, GeminiThoughtSignatureValidationOptions{RequireKnownEnvelope: true}) {
-		t.Fatal("fixture should be a known Gemini field-1 thoughtSignature")
+	if IsValidGeminiThoughtSignature(sample, GeminiThoughtSignatureValidationOptions{RequireKnownEnvelope: true}) {
+		t.Fatal("fixture should no longer be a known Gemini thoughtSignature")
 	}
-
-	_, err := InspectGrokEncryptedContent(sample)
-	if err == nil {
-		t.Fatal("expected Gemini field-1 thoughtSignature envelope to be rejected")
-	}
-	if !strings.Contains(err.Error(), "Gemini") {
-		t.Fatalf("error = %q, want Gemini fast-reject detail", err.Error())
+	if _, err := InspectGrokEncryptedContent(sample); err != nil {
+		t.Fatalf("retired envelope should reach the residual transport check, got %v", err)
 	}
 }
 
@@ -135,6 +135,72 @@ func TestInspectGrokEncryptedContent_RejectsAntigravityClaudeThinkingSignature(t
 	}
 	if !strings.Contains(err.Error(), "Claude") {
 		t.Fatalf("error = %q, want Claude fast-reject detail", err.Error())
+	}
+}
+
+// TestInspectGrokEncryptedContent_RejectsClaudeCAISSignature covers the CAIS
+// envelope emitted by the newest Claude Code models. CAIS payloads are
+// high-entropy standard base64 and drop their padding whenever the decoded
+// length is a multiple of 3, so neither the padding gate nor the classic Claude
+// strict check excludes them on their own.
+func TestInspectGrokEncryptedContent_RejectsClaudeCAISSignature(t *testing.T) {
+	cases := []struct {
+		name   string
+		sample string
+	}{
+		{name: "synthetic unpadded", sample: testUnpaddedClaudeCAISSignature()},
+		{name: "observed fable-5", sample: observedFable5Sample},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if strings.Contains(tc.sample, "=") {
+				t.Fatal("fixture must be unpadded so it reaches the Claude CAIS check")
+			}
+			if !IsValidClaudeCAISSignature(tc.sample) {
+				t.Fatal("fixture should be a valid Claude CAIS signature")
+			}
+			if IsValidClaudeThinkingSignature(tc.sample, ClaudeSignatureValidationOptions{Strict: true}) {
+				t.Fatal("CAIS fixture must not also pass classic Claude validation")
+			}
+
+			_, err := InspectGrokEncryptedContent(tc.sample)
+			if err == nil {
+				t.Fatal("expected Claude CAIS signature to be rejected")
+			}
+			if !strings.Contains(err.Error(), "CAIS") {
+				t.Fatalf("error = %q, want Claude CAIS fast-reject detail", err.Error())
+			}
+		})
+	}
+}
+
+// TestInspectGrokEncryptedContent_RejectsProviderCachePrefix keeps provenance
+// envelopes out of the residual class. A prefixed value belongs to whichever
+// provider the prefix names, and must never be replayed to xAI verbatim.
+func TestInspectGrokEncryptedContent_RejectsProviderCachePrefix(t *testing.T) {
+	for _, prefix := range []string{"claude#", "anthropic#", "gemini#", "openai#", "codex#"} {
+		sample := prefix + testUnpaddedClaudeCAISSignature()
+		if _, err := InspectGrokEncryptedContent(sample); err == nil {
+			t.Fatalf("%s prefixed payload should be rejected", prefix)
+		}
+	}
+}
+
+// TestInspectGrokEncryptedContent_ThresholdMargins documents that neither
+// threshold sits on observed data. The shortest observed native payload is 50
+// decoded bytes and the lowest observed entropy ratio is 0.892, so both limits
+// keep headroom for future models rather than fitting the current corpus exactly.
+func TestInspectGrokEncryptedContent_ThresholdMargins(t *testing.T) {
+	const shortestObservedDecodedLen = 50
+	const lowestObservedEntropyRatio = 0.892
+
+	if MinGrokEncryptedContentDecodedLen >= shortestObservedDecodedLen {
+		t.Fatalf("MinGrokEncryptedContentDecodedLen = %d, want below the shortest observed payload (%d) so a shorter future payload is not silently dropped",
+			MinGrokEncryptedContentDecodedLen, shortestObservedDecodedLen)
+	}
+	if MinGrokEncryptedContentEntropyRatio >= lowestObservedEntropyRatio {
+		t.Fatalf("MinGrokEncryptedContentEntropyRatio = %.3f, want below the lowest observed ratio (%.3f)",
+			MinGrokEncryptedContentEntropyRatio, lowestObservedEntropyRatio)
 	}
 }
 
@@ -208,6 +274,20 @@ func testGemini25Field1ThoughtSignatureEnvelope() string {
 
 func testUnpaddedClaudeThinkingSignature() string {
 	return testClaudeThinkingSignatureWithOpaqueLen(35)
+}
+
+// testUnpaddedClaudeCAISSignature builds a CAIS signature whose base64 form
+// carries no "=" padding, which is the shape that used to slip past the Grok
+// unpadded-base64 gate. The model text length is varied because padding depends
+// on the encoded payload length.
+func testUnpaddedClaudeCAISSignature() string {
+	for suffix := 0; suffix < 8; suffix++ {
+		parts := defaultClaudeCAISParts("claude-opus-5" + strings.Repeat("x", suffix))
+		if sample := parts.encode(); !strings.Contains(sample, "=") {
+			return sample
+		}
+	}
+	panic("could not build an unpadded Claude CAIS fixture")
 }
 
 func testUnpaddedAntigravityClaudeThinkingSignature() string {

--- a/internal/signature/provider_compatibility.go
+++ b/internal/signature/provider_compatibility.go
@@ -64,6 +64,65 @@ func SignatureProviderFromModelName(modelName string) SignatureProvider {
 	}
 }
 
+// selfDescribingSignatureFirstChars are the base64 first characters that a
+// self-describing provider envelope can produce. A base64 first character is
+// exactly the first payload byte shifted right by two, so a single character
+// comparison rules out every known envelope without decoding anything:
+//
+//	'C' -> 0x08..0x0b : Claude CAIS (0x08)
+//	'E' -> 0x10..0x13 : Claude single-layer (0x12), Gemini protobuf_field_2 (0x12)
+//	'R' -> 0x44..0x47 : Claude double-layer R (0x45, inner 'E')
+//	'g' -> 0x80..0x83 : GPT Fernet reasoning (0x80)
+//
+// Gemini's ascii_uuid envelope is deliberately absent. Its first byte is the
+// first hex character of the UUID, which spreads over 'M', 'N', 'O', 'Y' and 'Z'
+// depending on the value, and it is never a replay-safe envelope: it resolves to
+// SignatureProviderUnknown whether or not it reaches the validators, and Gemini
+// model parts recover it through the bypass sentinel keyed on block kind. Listing
+// one of its five possible characters would only look like coverage.
+//
+// Any provider added here must also be validated in
+// DetectSignatureProviderForBlock, otherwise its signatures would fall through
+// to the residual class. TestSelfDescribingSignatureFirstChars_CoversEveryKnownEnvelope
+// fails when a replay-safe envelope is missing from this set.
+const selfDescribingSignatureFirstChars = "CERg"
+
+// base64AlphabetSet builds a byte lookup table for the alphanumeric base64 core
+// plus the alphabet-specific characters in extra. Signature charset validation
+// runs over multi-kilobyte payloads, and a comparison chain over base64 text
+// mispredicts on nearly every byte because the characters are effectively random;
+// a single table load is branch-free and measures about an order of magnitude
+// faster on the observed corpora.
+func base64AlphabetSet(extra string) [256]bool {
+	var set [256]bool
+	for c := byte('A'); c <= 'Z'; c++ {
+		set[c] = true
+	}
+	for c := byte('a'); c <= 'z'; c++ {
+		set[c] = true
+	}
+	for c := byte('0'); c <= '9'; c++ {
+		set[c] = true
+	}
+	for i := 0; i < len(extra); i++ {
+		set[extra[i]] = true
+	}
+	return set
+}
+
+// maybeSelfDescribingSignatureEnvelope reports whether rawSignature can possibly
+// be a self-describing provider envelope. It is a structural pre-filter, not a
+// classifier: a false result is conclusive, a true result only narrows the
+// candidate set. Opaque ciphertext that carries no envelope (xAI/Grok
+// encrypted_content) is uniformly distributed over the byte space, so this
+// rejects roughly 92% of it with one comparison and no allocation.
+func maybeSelfDescribingSignatureEnvelope(rawSignature string) bool {
+	if rawSignature == "" {
+		return false
+	}
+	return strings.IndexByte(selfDescribingSignatureFirstChars, rawSignature[0]) >= 0
+}
+
 // DetectSignatureProvider classifies the provider family that can replay
 // rawSignature. It intentionally uses Claude strict validation before Gemini
 // detection because Gemini 3 signatures also decode from an E-prefixed base64
@@ -92,7 +151,7 @@ func DetectSignatureProviderForBlock(rawSignature string, blockKind SignatureBlo
 				return SignatureProviderGemini
 			}
 		case SignatureProviderClaude:
-			if IsValidClaudeThinkingSignature(unprefixed, ClaudeSignatureValidationOptions{Strict: true}) {
+			if IsValidClaudeThinkingSignature(unprefixed, ClaudeSignatureValidationOptions{Strict: true}) || IsValidClaudeCAISSignature(unprefixed) {
 				return SignatureProviderClaude
 			}
 		case SignatureProviderGPT:
@@ -106,11 +165,34 @@ func DetectSignatureProviderForBlock(rawSignature string, blockKind SignatureBlo
 		return SignatureProviderUnknown
 	}
 
+	// The bypass sentinel is a plain literal rather than an envelope, so it must
+	// be matched before the structural pre-filter below rejects it.
 	if IsGeminiThoughtSignatureBypass(sig) {
 		return SignatureProviderGeminiBypass
 	}
+	if !maybeSelfDescribingSignatureEnvelope(sig) {
+		return SignatureProviderUnknown
+	}
+
+	// Probes run from the strongest marker to the weakest:
+	//   1. GPT carries the literal "gAAAA" prefix, which pins both the version
+	//      byte and the high timestamp bytes.
+	//   2. Claude CAIS carries marker 0x08 plus a literal "claude-" model text.
+	//   3. Claude single/double-layer carries marker 0x12 plus the same literal.
+	//   4. Gemini validates wire shape only and has no literal to anchor on, so
+	//      it is the weakest judge and goes last.
+	//
+	// This ordering is defense in depth rather than a correctness requirement:
+	// Claude envelopes carry extra top-level fields beyond the container, which
+	// fails the single-record shape Gemini requires, so the two families stay
+	// separable in either order. TestGeminiEnvelopeNeverClaimsClaudeSignatures
+	// pins that invariant so a looser Gemini envelope check cannot make the
+	// order silently start mattering.
 	if IsValidGPTReasoningSignature(sig) {
 		return SignatureProviderGPT
+	}
+	if IsValidClaudeCAISSignature(sig) {
+		return SignatureProviderClaude
 	}
 	if IsValidClaudeThinkingSignature(sig, ClaudeSignatureValidationOptions{Strict: true}) {
 		return SignatureProviderClaude
@@ -129,6 +211,12 @@ func IsSignatureCompatibleWithProvider(targetProvider SignatureProvider, rawSign
 // DecideSignatureCompatibility returns the safe handling policy for replaying a
 // signed block into targetProvider.
 func DecideSignatureCompatibility(targetProvider SignatureProvider, rawSignature string, blockKind SignatureBlockKind) SignatureCompatibilityDecision {
+	return DecideSignatureCompatibilityForModel(targetProvider, "", rawSignature, blockKind)
+}
+
+// DecideSignatureCompatibilityForModel returns the safe handling policy for replaying a
+// signed block into targetProvider for targetModel.
+func DecideSignatureCompatibilityForModel(targetProvider SignatureProvider, targetModel string, rawSignature string, blockKind SignatureBlockKind) SignatureCompatibilityDecision {
 	targetProvider = normalizeSignatureTargetProvider(targetProvider)
 	if blockKind == "" {
 		blockKind = SignatureBlockKindUnknown
@@ -145,7 +233,7 @@ func DecideSignatureCompatibility(targetProvider SignatureProvider, rawSignature
 		decision.Compatible = true
 		decision.Action = SignatureActionPreserve
 		decision.NormalizedSignature = normalizeCompatibleSignatureForProvider(targetProvider, rawSignature, blockKind)
-		decision.Reason = "signature provider matches target provider"
+		decision.Reason = claudeCompatibleSignatureReason(targetProvider, rawSignature, targetModel)
 		return decision
 	}
 
@@ -191,7 +279,7 @@ func SplitSignatureProviderPrefix(rawSignature string) (SignatureProvider, strin
 // "claude-cache#..." cannot be mistaken for trusted provider provenance.
 func SignatureProviderFromCachePrefix(prefix string) SignatureProvider {
 	switch strings.ToLower(strings.TrimSpace(prefix)) {
-	case "claude", "anthropic":
+	case "claude", "anthropic", "cais", "claude-cais", "claude_cais", "ccmax", "claude-code-max", "claude_code_max":
 		return SignatureProviderClaude
 	case "gemini", "google":
 		return SignatureProviderGemini
@@ -247,6 +335,26 @@ func CompatibleAntigravityClaudeThinkingSignature(rawSignature string) (string, 
 	return normalized, true
 }
 
+// claudeCompatibleSignatureReason explains why a matching signature is
+// replayable. Claude CAIS signatures carry the issuing model inside the payload,
+// so the embedded model and the target model are both reported to make signature
+// decisions traceable in debug logs.
+func claudeCompatibleSignatureReason(targetProvider SignatureProvider, rawSignature, targetModel string) string {
+	const genericReason = "signature provider matches target provider"
+	if targetProvider != SignatureProviderClaude {
+		return genericReason
+	}
+	info, err := InspectClaudeCAISSignature(SignaturePayloadWithoutProviderPrefix(rawSignature))
+	if err != nil {
+		return genericReason
+	}
+	reason := "valid Claude CAIS signature with embedded model " + info.ModelText + " is compatible with any Claude target"
+	if trimmedModel := strings.TrimSpace(targetModel); trimmedModel != "" {
+		reason += ", including target model " + trimmedModel
+	}
+	return reason
+}
+
 func normalizeSignatureTargetProvider(provider SignatureProvider) SignatureProvider {
 	switch provider {
 	case SignatureProviderGeminiBypass:
@@ -273,6 +381,9 @@ func normalizeCompatibleSignatureForProvider(targetProvider SignatureProvider, r
 	payload := SignaturePayloadWithoutProviderPrefix(rawSignature)
 	switch normalizeSignatureTargetProvider(targetProvider) {
 	case SignatureProviderClaude:
+		if IsValidClaudeCAISSignature(payload) {
+			return payload
+		}
 		normalized, err := NormalizeClaudeProviderNativeThinkingSignature(payload)
 		if err != nil {
 			return ""
@@ -294,6 +405,9 @@ func normalizeCompatibleSignatureForProvider(targetProvider SignatureProvider, r
 }
 
 func isRecognizedGeminiProviderSignature(rawSignature string, blockKind SignatureBlockKind) bool {
+	if IsValidClaudeCAISSignature(rawSignature) {
+		return false
+	}
 	if IsValidGeminiThoughtSignature(rawSignature, GeminiThoughtSignatureValidationOptions{RequireKnownEnvelope: true}) {
 		return true
 	}

--- a/internal/signature/provider_compatibility_test.go
+++ b/internal/signature/provider_compatibility_test.go
@@ -30,6 +30,143 @@ func testClaudeThinkingSignature() string {
 	return base64.StdEncoding.EncodeToString(payload)
 }
 
+// TestBase64AlphabetSet_MatchesEncoderAlphabets pins the charset lookup tables
+// against the encoders they stand in for. A wrong table would silently accept
+// bytes that are not valid base64, or reject a legal payload character.
+func TestBase64AlphabetSet_MatchesEncoderAlphabets(t *testing.T) {
+	cases := []struct {
+		name     string
+		set      [256]bool
+		alphabet string
+	}{
+		{"grok unpadded std", grokEncryptedContentCharSet, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"},
+		{"gpt base64url", gptReasoningSignatureCharSet, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_="},
+	}
+	for _, tc := range cases {
+		allowed := map[byte]bool{}
+		for i := 0; i < len(tc.alphabet); i++ {
+			allowed[tc.alphabet[i]] = true
+		}
+		for c := 0; c < 256; c++ {
+			want := allowed[byte(c)]
+			if got := tc.set[c]; got != want {
+				t.Errorf("%s: byte 0x%02x (%q) accepted=%v, want %v", tc.name, c, string(rune(c)), got, want)
+			}
+		}
+	}
+}
+
+// replaySafeEnvelopeFixtures returns one fixture per self-describing provider
+// envelope that carries replayable state. Every entry must survive the structural
+// pre-filter, because losing one would silently reclassify that provider.
+func replaySafeEnvelopeFixtures() map[string]struct {
+	sig  string
+	want SignatureProvider
+} {
+	return map[string]struct {
+		sig  string
+		want SignatureProvider
+	}{
+		"claude single-layer E":  {testClaudeThinkingSignature(), SignatureProviderClaude},
+		"claude double-layer R":  {testUnpaddedAntigravityClaudeThinkingSignature(), SignatureProviderClaude},
+		"claude CAIS":            {testClaudeCAISSignature("claude-fable-5"), SignatureProviderClaude},
+		"gemini protobuf field2": {testGeminiThoughtSignatureEnvelope(), SignatureProviderGemini},
+		"gpt fernet":             {testGPTReasoningSignature(), SignatureProviderGPT},
+	}
+}
+
+// TestSelfDescribingSignatureFirstChars_CoversEveryKnownEnvelope guards the
+// structural pre-filter. DetectSignatureProviderForBlock skips every provider
+// validator when maybeSelfDescribingSignatureEnvelope returns false, so an
+// envelope missing from selfDescribingSignatureFirstChars would silently fall
+// through to the residual class. Adding a provider envelope without registering
+// its base64 first character fails here.
+func TestSelfDescribingSignatureFirstChars_CoversEveryKnownEnvelope(t *testing.T) {
+	for name, fixture := range replaySafeEnvelopeFixtures() {
+		if !maybeSelfDescribingSignatureEnvelope(fixture.sig) {
+			t.Errorf("%s: first char %q is not in selfDescribingSignatureFirstChars %q; register it or detection will skip this envelope",
+				name, string(fixture.sig[0]), selfDescribingSignatureFirstChars)
+		}
+	}
+
+	// The pre-filter must not be so wide that it stops filtering. Opaque xAI
+	// ciphertext is the shape it exists to reject.
+	for _, sig := range []string{
+		"K1ZAIbzDbO",
+		"jQDLUr+fD8RFP8nbkkfI",
+		"qcgG7jzxH3D6mlVLBBaKXaG3",
+	} {
+		if maybeSelfDescribingSignatureEnvelope(sig) {
+			t.Errorf("opaque ciphertext %q must not look like a self-describing envelope", sig)
+		}
+	}
+}
+
+// TestGeminiASCIIUUIDIsGateIndependent documents why ascii_uuid is excluded from
+// selfDescribingSignatureFirstChars. Its first byte is the first hex character of
+// the UUID, so the base64 first character spreads over several values, and none of
+// them need to be registered: the envelope is never replay-safe, so it resolves to
+// SignatureProviderUnknown either way and Gemini model parts recover it through the
+// bypass sentinel keyed on block kind.
+func TestGeminiASCIIUUIDIsGateIndependent(t *testing.T) {
+	// First hex digit chosen to land on distinct base64 first characters.
+	for _, uuid := range []string{
+		"09743975-4bb0-4936-9e28-d5b0d21bdc48",
+		"49743975-4bb0-4936-9e28-d5b0d21bdc48",
+		"89743975-4bb0-4936-9e28-d5b0d21bdc48",
+		"a9743975-4bb0-4936-9e28-d5b0d21bdc48",
+		"e9743975-4bb0-4936-9e28-d5b0d21bdc48",
+	} {
+		sig := testGeminiThoughtSignature([]byte(uuid))
+		if got := DetectSignatureProvider(sig); got != SignatureProviderUnknown {
+			t.Errorf("uuid %q: DetectSignatureProvider = %q, want %q regardless of the pre-filter",
+				uuid[:8], got, SignatureProviderUnknown)
+		}
+		decision := DecideSignatureCompatibility(SignatureProviderGemini, sig, SignatureBlockKindGeminiFunctionCall)
+		if decision.Action != SignatureActionReplaceWithGeminiBypass {
+			t.Errorf("uuid %q: action = %q, want %q", uuid[:8], decision.Action, SignatureActionReplaceWithGeminiBypass)
+		}
+	}
+}
+
+// TestDetectSignatureProviderForBlock_ClassifiesEveryKnownEnvelope pins the
+// classification of each envelope so a reordering of the validator chain cannot
+// silently reassign one provider's signatures to another.
+func TestDetectSignatureProviderForBlock_ClassifiesEveryKnownEnvelope(t *testing.T) {
+	for name, fixture := range replaySafeEnvelopeFixtures() {
+		if got := DetectSignatureProvider(fixture.sig); got != fixture.want {
+			t.Errorf("%s: DetectSignatureProvider = %q, want %q", name, got, fixture.want)
+		}
+	}
+}
+
+// TestGeminiEnvelopeNeverClaimsClaudeSignatures pins the invariant that keeps
+// Claude and Gemini separable independently of probe order in
+// DetectSignatureProviderForBlock. Gemini validates wire shape only and has no
+// literal marker, so it is the weakest judge; Claude envelopes survive it solely
+// because they carry extra top-level fields beyond the container and therefore
+// fail Gemini's single-record shape. Loosening the Gemini envelope check would
+// make probe order start mattering, and fails here first.
+func TestGeminiEnvelopeNeverClaimsClaudeSignatures(t *testing.T) {
+	for name, sig := range map[string]string{
+		"single-layer E":        testClaudeThinkingSignature(),
+		"single-layer E opaque": testClaudeThinkingSignatureWithOpaqueLen(64),
+		"double-layer R":        testUnpaddedAntigravityClaudeThinkingSignature(),
+		"CAIS synthetic":        testClaudeCAISSignature("claude-opus-5"),
+		"CAIS observed":         observedFable5Sample,
+	} {
+		if isRecognizedGeminiProviderSignature(sig, SignatureBlockKindUnknown) {
+			t.Errorf("claude %s is claimed by the Gemini envelope check; probe order in DetectSignatureProviderForBlock is now load-bearing", name)
+		}
+		if got := DetectSignatureProvider(sig); got != SignatureProviderClaude {
+			t.Errorf("claude %s: DetectSignatureProvider = %q, want %q", name, got, SignatureProviderClaude)
+		}
+		if _, ok := CompatibleSignatureForProvider(SignatureProviderGemini, sig); ok {
+			t.Errorf("claude %s must not be replayable as a Gemini signature", name)
+		}
+	}
+}
+
 func TestDetectSignatureProvider_UsesProviderPrefix(t *testing.T) {
 	claudeSig := "claude#" + testClaudeThinkingSignature()
 	if got := DetectSignatureProvider(claudeSig); got != SignatureProviderClaude {

--- a/internal/store/gitstore.go
+++ b/internal/store/gitstore.go
@@ -265,6 +265,9 @@ func (s *GitTokenStore) Save(_ context.Context, auth *cliproxyauth.Auth) (string
 	if auth == nil {
 		return "", fmt.Errorf("auth filestore: auth is nil")
 	}
+	if errWeight := cliproxyauth.ValidateAuthWeight(auth); errWeight != nil {
+		return "", fmt.Errorf("auth filestore: %w", errWeight)
+	}
 
 	path, err := s.resolveAuthPath(auth)
 	if err != nil {
@@ -531,6 +534,9 @@ func (s *GitTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Auth, 
 	metadata := make(map[string]any)
 	if err = json.Unmarshal(data, &metadata); err != nil {
 		return nil, fmt.Errorf("unmarshal auth json: %w", err)
+	}
+	if errWeight := cliproxyauth.ValidateAuthWeight(&cliproxyauth.Auth{Metadata: metadata}); errWeight != nil {
+		return nil, errWeight
 	}
 	provider, _ := metadata["type"].(string)
 	if provider == "" {

--- a/internal/store/objectstore.go
+++ b/internal/store/objectstore.go
@@ -160,6 +160,9 @@ func (s *ObjectTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (s
 	if auth == nil {
 		return "", fmt.Errorf("object store: auth is nil")
 	}
+	if errWeight := cliproxyauth.ValidateAuthWeight(auth); errWeight != nil {
+		return "", fmt.Errorf("object store: %w", errWeight)
+	}
 
 	path, err := s.resolveAuthPath(auth)
 	if err != nil {
@@ -573,6 +576,9 @@ func (s *ObjectTokenStore) readAuthFile(path, baseDir string) (*cliproxyauth.Aut
 	metadata := make(map[string]any)
 	if err = json.Unmarshal(data, &metadata); err != nil {
 		return nil, fmt.Errorf("unmarshal auth json: %w", err)
+	}
+	if errWeight := cliproxyauth.ValidateAuthWeight(&cliproxyauth.Auth{Metadata: metadata}); errWeight != nil {
+		return nil, errWeight
 	}
 	provider := strings.TrimSpace(valueAsString(metadata["type"]))
 	if provider == "" {

--- a/internal/store/objectstore.go
+++ b/internal/store/objectstore.go
@@ -197,6 +197,9 @@ func (s *ObjectTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (s
 	if auth == nil {
 		return "", fmt.Errorf("object store: auth is nil")
 	}
+	if errWeight := cliproxyauth.ValidateAuthWeight(auth); errWeight != nil {
+		return "", fmt.Errorf("object store: %w", errWeight)
+	}
 
 	path, err := s.resolveAuthPath(auth)
 	if err != nil {
@@ -755,6 +758,9 @@ func (s *ObjectTokenStore) readAuthFile(path string) (*cliproxyauth.Auth, error)
 	metadata := make(map[string]any)
 	if err = json.Unmarshal(data, &metadata); err != nil {
 		return nil, fmt.Errorf("unmarshal auth json: %w", err)
+	}
+	if errWeight := cliproxyauth.ValidateAuthWeight(&cliproxyauth.Auth{Metadata: metadata}); errWeight != nil {
+		return nil, errWeight
 	}
 	provider := strings.TrimSpace(valueAsString(metadata["type"]))
 	if provider == "" {

--- a/internal/store/postgresstore.go
+++ b/internal/store/postgresstore.go
@@ -211,6 +211,9 @@ func (s *PostgresStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (stri
 	if auth == nil {
 		return "", fmt.Errorf("postgres store: auth is nil")
 	}
+	if errWeight := cliproxyauth.ValidateAuthWeight(auth); errWeight != nil {
+		return "", fmt.Errorf("postgres store: %w", errWeight)
+	}
 
 	path, err := s.resolveAuthPath(auth)
 	if err != nil {
@@ -317,6 +320,10 @@ func (s *PostgresStore) List(ctx context.Context) ([]*cliproxyauth.Auth, error) 
 		metadata := make(map[string]any)
 		if err = json.Unmarshal([]byte(payload), &metadata); err != nil {
 			log.WithError(err).Warnf("postgres store: skipping auth %s with invalid json", id)
+			continue
+		}
+		if errWeight := cliproxyauth.ValidateAuthWeight(&cliproxyauth.Auth{Metadata: metadata}); errWeight != nil {
+			log.WithError(errWeight).Warnf("postgres store: skipping auth %s with invalid weight", id)
 			continue
 		}
 		provider := strings.TrimSpace(valueAsString(metadata["type"]))

--- a/internal/thinking/apply.go
+++ b/internal/thinking/apply.go
@@ -162,7 +162,20 @@ func IsUserDefinedModel(modelInfo *registry.ModelInfo) bool {
 //	// Without suffix - uses body config
 //	result, err := thinking.ApplyThinking(body, "gemini-2.5-pro", "gemini", "gemini", "gemini")
 func ApplyThinking(body []byte, model string, fromFormat string, toFormat string, providerKey string) ([]byte, error) {
+	return applyThinking(body, nil, model, fromFormat, toFormat, providerKey, nil, false)
+}
+
+// ApplyThinkingWithModelInfo applies thinking with the exact configured model
+// definition selected for an API-key execution attempt.
+func ApplyThinkingWithModelInfo(body, sourceBody []byte, model string, fromFormat string, toFormat string, providerKey string, modelInfo *registry.ModelInfo) ([]byte, error) {
+	return applyThinking(body, sourceBody, model, fromFormat, toFormat, providerKey, modelInfo, true)
+}
+
+func applyThinking(body, sourceBody []byte, model string, fromFormat string, toFormat string, providerKey string, resolvedModelInfo *registry.ModelInfo, modelInfoResolved bool) ([]byte, error) {
 	providerFormat := strings.ToLower(strings.TrimSpace(toFormat))
+	if modelInfoResolved && providerFormat == "openai-response" {
+		providerFormat = "codex"
+	}
 	providerKey = strings.ToLower(strings.TrimSpace(providerKey))
 	if providerKey == "" {
 		providerKey = providerFormat
@@ -185,7 +198,10 @@ func ApplyThinking(body []byte, model string, fromFormat string, toFormat string
 	suffixResult := ParseSuffix(model)
 	baseModel := suffixResult.ModelName
 	// Use provider-specific lookup to handle capability differences across providers.
-	modelInfo := registry.LookupModelInfo(baseModel, providerKey)
+	modelInfo := resolvedModelInfo
+	if !modelInfoResolved {
+		modelInfo = registry.LookupModelInfo(baseModel, providerKey)
+	}
 
 	// 3. Model capability check
 	// Unknown models are treated as user-defined so thinking config can still be applied.
@@ -221,7 +237,12 @@ func ApplyThinking(body []byte, model string, fromFormat string, toFormat string
 			"level":    config.Level,
 		}).Debug("thinking: config from model suffix |")
 	} else {
-		config = extractThinkingConfig(body, providerFormat)
+		if modelInfoResolved && len(sourceBody) > 0 {
+			config = extractSourceThinkingConfig(sourceBody, fromFormat)
+		}
+		if !hasThinkingConfig(config) {
+			config = extractThinkingConfig(body, providerFormat)
+		}
 		if hasThinkingConfig(config) {
 			log.WithFields(log.Fields{
 				"provider": providerFormat,
@@ -239,6 +260,9 @@ func ApplyThinking(body []byte, model string, fromFormat string, toFormat string
 			"model":    modelInfo.ID,
 		}).Debug("thinking: no config found, passthrough |")
 		return body, nil
+	}
+	if modelInfoResolved && config.Mode == ModeLevel && modelInfo != nil && modelInfo.Thinking != nil && shouldMapConfiguredHighIntent(fromFormat, providerFormat, modelInfo) {
+		config.Level = mapConfiguredHighIntent(config.Level, modelInfo)
 	}
 
 	// 5. Validate and normalize configuration
@@ -274,6 +298,49 @@ func ApplyThinking(body []byte, model string, fromFormat string, toFormat string
 
 	// 6. Apply configuration using provider-specific applier
 	return applier.Apply(body, *validated, modelInfo)
+}
+
+func shouldMapConfiguredHighIntent(fromFormat, toFormat string, modelInfo *registry.ModelInfo) bool {
+	fromFormat = strings.ToLower(strings.TrimSpace(fromFormat))
+	toFormat = strings.ToLower(strings.TrimSpace(toFormat))
+	if fromFormat != toFormat {
+		return true
+	}
+	if modelInfo == nil {
+		return false
+	}
+	modelType := strings.ToLower(strings.TrimSpace(modelInfo.Type))
+	return modelType != "" && !isSameProviderFamily(toFormat, modelType)
+}
+
+func mapConfiguredHighIntent(level ThinkingLevel, modelInfo *registry.ModelInfo) ThinkingLevel {
+	if modelInfo == nil || modelInfo.Thinking == nil || len(modelInfo.Thinking.Levels) == 0 {
+		return level
+	}
+	level = ThinkingLevel(strings.ToLower(strings.TrimSpace(string(level))))
+	var candidates []ThinkingLevel
+	switch level {
+	case LevelXHigh:
+		candidates = []ThinkingLevel{LevelXHigh, LevelMax, LevelHigh}
+	case LevelMax:
+		candidates = []ThinkingLevel{LevelMax, LevelXHigh, LevelHigh}
+	default:
+		return level
+	}
+	for _, candidate := range candidates {
+		if isLevelSupported(string(candidate), modelInfo.Thinking.Levels) {
+			return candidate
+		}
+	}
+	return level
+}
+
+func extractSourceThinkingConfig(body []byte, provider string) ThinkingConfig {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "openai-response" {
+		return extractCodexConfig(body)
+	}
+	return extractThinkingConfig(body, provider)
 }
 
 // parseSuffixToConfig converts a raw suffix string to ThinkingConfig.

--- a/internal/thinking/apply_configured_api_key_test.go
+++ b/internal/thinking/apply_configured_api_key_test.go
@@ -1,0 +1,110 @@
+package thinking_test
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/claude"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/codex"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/thinking/provider/openai"
+	"github.com/tidwall/gjson"
+)
+
+func TestApplyThinkingWithModelInfoMapsCrossFamilyHighIntent(t *testing.T) {
+	tests := []struct {
+		name      string
+		source    string
+		supported []string
+		want      string
+	}{
+		{name: "xhigh stays xhigh", source: "xhigh", supported: []string{"high", "max", "xhigh"}, want: "xhigh"},
+		{name: "xhigh prefers max", source: "xhigh", supported: []string{"high", "max"}, want: "max"},
+		{name: "xhigh falls back to high", source: "xhigh", supported: []string{"high"}, want: "high"},
+		{name: "max stays max", source: "max", supported: []string{"high", "xhigh", "max"}, want: "max"},
+		{name: "max prefers xhigh", source: "max", supported: []string{"high", "xhigh"}, want: "xhigh"},
+		{name: "max falls back to high", source: "max", supported: []string{"high"}, want: "high"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			modelInfo := &registry.ModelInfo{
+				ID:       "claude-upstream",
+				Type:     "claude",
+				Thinking: &registry.ThinkingSupport{Levels: tc.supported},
+			}
+			body := []byte(`{"thinking":{"type":"adaptive"},"output_config":{"effort":"low"}}`)
+			source := []byte(`{"reasoning_effort":"` + tc.source + `"}`)
+			out, err := thinking.ApplyThinkingWithModelInfo(body, source, "claude-upstream", "openai", "claude", "claude", modelInfo)
+			if err != nil {
+				t.Fatalf("ApplyThinkingWithModelInfo() error = %v", err)
+			}
+			if got := gjson.GetBytes(out, "output_config.effort").String(); got != tc.want {
+				t.Fatalf("output effort = %q, want %q; body=%s", got, tc.want, out)
+			}
+		})
+	}
+}
+
+func TestApplyThinkingWithModelInfoMapsOpenAICompatibilityHighIntent(t *testing.T) {
+	modelInfo := &registry.ModelInfo{
+		ID:       "compat-upstream",
+		Type:     "openai-compatibility",
+		Thinking: &registry.ThinkingSupport{Levels: []string{"high", "max"}},
+	}
+	body := []byte(`{"reasoning_effort":"high"}`)
+	source := []byte(`{"reasoning_effort":"xhigh"}`)
+	out, err := thinking.ApplyThinkingWithModelInfo(body, source, "compat-upstream", "openai", "openai", "compat-provider", modelInfo)
+	if err != nil {
+		t.Fatalf("ApplyThinkingWithModelInfo() error = %v", err)
+	}
+	if got := gjson.GetBytes(out, "reasoning_effort").String(); got != "max" {
+		t.Fatalf("reasoning_effort = %q, want max; body=%s", got, out)
+	}
+}
+
+func TestApplyThinkingWithModelInfoMapsResponsesToCodexHighIntent(t *testing.T) {
+	modelInfo := &registry.ModelInfo{
+		ID:       "codex-upstream",
+		Type:     "codex",
+		Thinking: &registry.ThinkingSupport{Levels: []string{"high", "xhigh"}},
+	}
+	body := []byte(`{"reasoning":{"effort":"high"}}`)
+	source := []byte(`{"reasoning":{"effort":"max"}}`)
+	out, err := thinking.ApplyThinkingWithModelInfo(body, source, "codex-upstream", "openai-response", "codex", "codex", modelInfo)
+	if err != nil {
+		t.Fatalf("ApplyThinkingWithModelInfo() error = %v", err)
+	}
+	if got := gjson.GetBytes(out, "reasoning.effort").String(); got != "xhigh" {
+		t.Fatalf("reasoning.effort = %q, want xhigh; body=%s", got, out)
+	}
+}
+
+func TestApplyThinkingWithModelInfoKeepsSameFamilyValidationStrict(t *testing.T) {
+	modelInfo := &registry.ModelInfo{
+		ID:       "openai-upstream",
+		Type:     "openai",
+		Thinking: &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}},
+	}
+	body := []byte(`{"reasoning_effort":"xhigh"}`)
+	out, err := thinking.ApplyThinkingWithModelInfo(body, body, "openai-upstream", "openai", "openai", "openai", modelInfo)
+	if err == nil {
+		t.Fatalf("ApplyThinkingWithModelInfo() error = nil, want unsupported xhigh error; body=%s", out)
+	}
+}
+
+func TestApplyThinkingWithModelInfoUsesOriginalResponsesEffort(t *testing.T) {
+	modelInfo := &registry.ModelInfo{
+		ID:       "claude-upstream",
+		Type:     "claude",
+		Thinking: &registry.ThinkingSupport{Levels: []string{"high", "max"}},
+	}
+	body := []byte(`{"thinking":{"type":"adaptive"},"output_config":{"effort":"low"}}`)
+	source := []byte(`{"reasoning":{"effort":"xhigh"}}`)
+	out, err := thinking.ApplyThinkingWithModelInfo(body, source, "claude-upstream", "openai-response", "claude", "claude", modelInfo)
+	if err != nil {
+		t.Fatalf("ApplyThinkingWithModelInfo() error = %v", err)
+	}
+	if got := gjson.GetBytes(out, "output_config.effort").String(); got != "max" {
+		t.Fatalf("output effort = %q, want max; body=%s", got, out)
+	}
+}

--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
@@ -74,6 +74,22 @@ func ConvertOpenAIRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 		out, _ = sjson.SetBytes(out, "request.generationConfig.maxOutputTokens", maxTok.Num)
 	}
 
+	// Map OpenAI response_format to Antigravity structured output settings.
+	if responseFormat := gjson.GetBytes(rawJSON, "response_format"); responseFormat.Exists() {
+		switch responseFormatType := strings.ToLower(strings.TrimSpace(responseFormat.Get("type").String())); responseFormatType {
+		case "json_object", "json_schema":
+			for _, schemaKey := range []string{"responseSchema", "responseJsonSchema", "response_schema", "response_json_schema"} {
+				out, _ = sjson.DeleteBytes(out, "request.generationConfig."+schemaKey)
+			}
+			out, _ = sjson.SetBytes(out, "request.generationConfig.responseMimeType", "application/json")
+			if responseFormatType == "json_object" {
+				out, _ = sjson.SetRawBytes(out, "request.generationConfig.responseSchema", []byte(`{"type":"object"}`))
+			} else if schema := responseFormat.Get("json_schema.schema"); schema.Exists() {
+				out, _ = sjson.SetRawBytes(out, "request.generationConfig.responseSchema", []byte(schema.Raw))
+			}
+		}
+	}
+
 	// Candidate count (OpenAI 'n' parameter)
 	if n := gjson.GetBytes(rawJSON, "n"); n.Exists() && n.Type == gjson.Number {
 		if val := n.Int(); val > 1 {

--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request_test.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request_test.go
@@ -314,3 +314,79 @@ func TestConvertOpenAIRequestToAntigravityMapsToolChoiceModes(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertOpenAIRequestToAntigravityMapsResponseFormatJSONObject(t *testing.T) {
+	inputJSON := []byte(`{
+		"model":"gemini-3.6-flash-high",
+		"messages":[{"role":"user","content":"hi"}],
+		"generationConfig":{
+			"responseSchema":{"type":"string","description":"stale"},
+			"responseJsonSchema":{"type":"string"},
+			"response_schema":{"type":"string"},
+			"response_json_schema":{"type":"string"}
+		},
+		"response_format":{"type":"json_object"}
+	}`)
+
+	out := ConvertOpenAIRequestToAntigravity("gemini-3.6-flash-high", inputJSON, false)
+	if got := gjson.GetBytes(out, "request.generationConfig.responseMimeType").String(); got != "application/json" {
+		t.Fatalf("responseMimeType = %q, want application/json. Output: %s", got, out)
+	}
+	schema := gjson.GetBytes(out, "request.generationConfig.responseSchema")
+	if got := schema.Get("type").String(); got != "object" {
+		t.Fatalf("responseSchema.type = %q, want object. Output: %s", got, out)
+	}
+	if schema.Get("description").Exists() {
+		t.Fatalf("stale responseSchema survived. Output: %s", out)
+	}
+	assertNoResponseSchemaAliases(t, out)
+}
+
+func TestConvertOpenAIRequestToAntigravityMapsResponseFormatJSONSchema(t *testing.T) {
+	inputJSON := []byte(`{
+		"model":"gemini-3.6-flash-high",
+		"messages":[{"role":"user","content":"hi"}],
+		"generationConfig":{
+			"responseSchema":{"type":"string","description":"stale"},
+			"responseJsonSchema":{"type":"string"},
+			"response_schema":{"type":"string"},
+			"response_json_schema":{"type":"string"}
+		},
+		"response_format":{
+			"type":"json_schema",
+			"json_schema":{
+				"name":"verdict",
+				"schema":{
+					"type":"object",
+					"properties":{"score":{"type":"integer"}},
+					"required":["score"]
+				}
+			}
+		}
+	}`)
+
+	out := ConvertOpenAIRequestToAntigravity("gemini-3.6-flash-high", inputJSON, false)
+	if got := gjson.GetBytes(out, "request.generationConfig.responseMimeType").String(); got != "application/json" {
+		t.Fatalf("responseMimeType = %q, want application/json. Output: %s", got, out)
+	}
+	schema := gjson.GetBytes(out, "request.generationConfig.responseSchema")
+	if !schema.Exists() {
+		t.Fatalf("responseSchema missing. Output: %s", out)
+	}
+	if got := schema.Get("properties.score.type").String(); got != "integer" {
+		t.Fatalf("responseSchema.properties.score.type = %q, want integer. Output: %s", got, out)
+	}
+	if schema.Get("description").Exists() {
+		t.Fatalf("stale responseSchema survived. Output: %s", out)
+	}
+	assertNoResponseSchemaAliases(t, out)
+}
+
+func assertNoResponseSchemaAliases(t *testing.T, out []byte) {
+	t.Helper()
+	for _, schemaKey := range []string{"responseJsonSchema", "response_schema", "response_json_schema"} {
+		if gjson.GetBytes(out, "request.generationConfig."+schemaKey).Exists() {
+			t.Errorf("stale %s survived response_format mapping. Output: %s", schemaKey, out)
+		}
+	}
+}

--- a/internal/translator/claude/openai/chat-completions/claude_openai_request.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_request.go
@@ -165,6 +165,7 @@ func ConvertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream 
 	if messages := root.Get("messages"); messages.Exists() && messages.IsArray() {
 		systemBlocks := make([][]byte, 0)
 		messageBlocks := make([][]byte, 0)
+		previousRole := ""
 		messages.ForEach(func(_, message gjson.Result) bool {
 			role := message.Get("role").String()
 			contentResult := message.Get("content")
@@ -274,8 +275,15 @@ func ConvertOpenAIRequestToClaude(modelName string, inputRawJSON []byte, stream 
 					msg, _ = sjson.SetBytes(msg, "content.0.content", toolResultContent)
 				}
 				msg = common.AttachMessageCacheControl(msg, message)
-				messageBlocks = append(messageBlocks, msg)
+				if previousRole == "tool" && len(messageBlocks) > 0 {
+					toolResult := gjson.GetBytes(msg, "content.0")
+					lastIdx := len(messageBlocks) - 1
+					messageBlocks[lastIdx], _ = sjson.SetRawBytes(messageBlocks[lastIdx], "content.-1", []byte(toolResult.Raw))
+				} else {
+					messageBlocks = append(messageBlocks, msg)
+				}
 			}
+			previousRole = role
 			return true
 		})
 

--- a/internal/translator/claude/openai/chat-completions/claude_openai_request_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_request_test.go
@@ -44,6 +44,70 @@ func TestConvertOpenAIRequestToClaude_SanitizesToolCallIDsForClaude(t *testing.T
 	}
 }
 
+func TestConvertOpenAIRequestToClaude_GroupsConsecutiveParallelToolResults(t *testing.T) {
+	inputJSON := `{
+		"model": "gpt-4.1",
+		"messages": [
+			{"role": "user", "content": "Use both tools."},
+			{
+				"role": "assistant",
+				"content": "",
+				"tool_calls": [
+					{"id": "call_1", "type": "function", "function": {"name": "tool_a", "arguments": "{}"}},
+					{"id": "call_2", "type": "function", "function": {"name": "tool_b", "arguments": "{}"}}
+				]
+			},
+			{
+				"role": "tool",
+				"tool_call_id": "call_1",
+				"content": "one",
+				"cache_control": {"type": "ephemeral"}
+			},
+			{"role": "tool", "tool_call_id": "call_2", "content": "two"},
+			{"role": "assistant", "content": "Done."}
+		]
+	}`
+
+	result := ConvertOpenAIRequestToClaude("claude-sonnet-4-5", []byte(inputJSON), false)
+	resultJSON := gjson.ParseBytes(result)
+	messages := resultJSON.Get("messages").Array()
+
+	if len(messages) != 4 {
+		t.Fatalf("Expected 4 messages, got %d. Messages: %s", len(messages), resultJSON.Get("messages").Raw)
+	}
+	if got := messages[2].Get("role").String(); got != "user" {
+		t.Fatalf("Expected grouped tool result role %q, got %q", "user", got)
+	}
+	toolResults := messages[2].Get("content").Array()
+	if len(toolResults) != 2 {
+		t.Fatalf("Expected 2 grouped tool results, got %d. Content: %s", len(toolResults), messages[2].Get("content").Raw)
+	}
+	wants := []struct {
+		id      string
+		content string
+	}{
+		{id: "call_1", content: "one"},
+		{id: "call_2", content: "two"},
+	}
+	for i, want := range wants {
+		if got := toolResults[i].Get("type").String(); got != "tool_result" {
+			t.Fatalf("tool result %d type = %q, want tool_result", i, got)
+		}
+		if got := toolResults[i].Get("tool_use_id").String(); got != want.id {
+			t.Fatalf("tool result %d tool_use_id = %q, want %q", i, got, want.id)
+		}
+		if got := toolResults[i].Get("content").String(); got != want.content {
+			t.Fatalf("tool result %d content = %q, want %q", i, got, want.content)
+		}
+	}
+	if got := toolResults[0].Get("cache_control.type").String(); got != "ephemeral" {
+		t.Fatalf("first tool result cache_control.type = %q, want ephemeral", got)
+	}
+	if got := messages[3].Get("content.0.text").String(); got != "Done." {
+		t.Fatalf("following assistant message text = %q, want Done.", got)
+	}
+}
+
 func TestConvertOpenAIRequestToClaude_DropsTemperature(t *testing.T) {
 	inputJSON := `{
 		"model": "gpt-4.1",

--- a/internal/translator/claude/openai/chat-completions/claude_openai_response.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_response.go
@@ -64,12 +64,13 @@ func (u *claudeUsageTokens) Merge(usage gjson.Result) {
 	}
 }
 
-func (u claudeUsageTokens) OpenAIUsage() (promptTokens, completionTokens, totalTokens, cachedTokens int64) {
+func (u claudeUsageTokens) OpenAIUsage() (promptTokens, completionTokens, totalTokens, cachedTokens, cachedCreationTokens int64) {
 	cachedTokens = u.CacheReadInputTokens
-	promptTokens = u.InputTokens + u.CacheCreationInputTokens + cachedTokens
+	cachedCreationTokens = u.CacheCreationInputTokens
+	promptTokens = u.InputTokens + cachedCreationTokens + cachedTokens
 	completionTokens = u.OutputTokens
 	totalTokens = promptTokens + completionTokens
-	return promptTokens, completionTokens, totalTokens, cachedTokens
+	return promptTokens, completionTokens, totalTokens, cachedTokens, cachedCreationTokens
 }
 
 // ConvertClaudeResponseToOpenAI converts Claude Code streaming response format to OpenAI Chat Completions format.
@@ -241,11 +242,12 @@ func ConvertClaudeResponseToOpenAI(_ context.Context, modelName string, original
 		// Handle usage information for token counts
 		if usage := root.Get("usage"); usage.Exists() {
 			(*param).(*ConvertAnthropicResponseToOpenAIParams).Usage.Merge(usage)
-			promptTokens, completionTokens, totalTokens, cachedTokens := (*param).(*ConvertAnthropicResponseToOpenAIParams).Usage.OpenAIUsage()
+			promptTokens, completionTokens, totalTokens, cachedTokens, cachedCreationTokens := (*param).(*ConvertAnthropicResponseToOpenAIParams).Usage.OpenAIUsage()
 			template, _ = sjson.SetBytes(template, "usage.prompt_tokens", promptTokens)
 			template, _ = sjson.SetBytes(template, "usage.completion_tokens", completionTokens)
 			template, _ = sjson.SetBytes(template, "usage.total_tokens", totalTokens)
 			template, _ = sjson.SetBytes(template, "usage.prompt_tokens_details.cached_tokens", cachedTokens)
+			template, _ = sjson.SetBytes(template, "usage.prompt_tokens_details.cached_creation_tokens", cachedCreationTokens)
 		}
 		return [][]byte{template}
 
@@ -405,11 +407,12 @@ func ConvertClaudeResponseToOpenAINonStream(_ context.Context, _ string, origina
 	}
 
 	if usageTokens.HasUsage {
-		promptTokens, completionTokens, totalTokens, cachedTokens := usageTokens.OpenAIUsage()
+		promptTokens, completionTokens, totalTokens, cachedTokens, cachedCreationTokens := usageTokens.OpenAIUsage()
 		out, _ = sjson.SetBytes(out, "usage.prompt_tokens", promptTokens)
 		out, _ = sjson.SetBytes(out, "usage.completion_tokens", completionTokens)
 		out, _ = sjson.SetBytes(out, "usage.total_tokens", totalTokens)
 		out, _ = sjson.SetBytes(out, "usage.prompt_tokens_details.cached_tokens", cachedTokens)
+		out, _ = sjson.SetBytes(out, "usage.prompt_tokens_details.cached_creation_tokens", cachedCreationTokens)
 	}
 
 	// Set basic response fields including message ID, creation time, and model

--- a/internal/translator/claude/openai/chat-completions/claude_openai_response.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_response.go
@@ -65,22 +65,23 @@ func (u *claudeUsageTokens) Merge(usage gjson.Result) {
 	}
 }
 
-func (u claudeUsageTokens) OpenAIUsage() (promptTokens, completionTokens, totalTokens, cachedTokens int64) {
+func (u claudeUsageTokens) OpenAIUsage() (promptTokens, completionTokens, totalTokens, cachedTokens, cachedCreationTokens int64) {
 	inputTokens := translatorcommon.NonNegativeTokenCount(u.InputTokens)
-	cacheCreationTokens := translatorcommon.NonNegativeTokenCount(u.CacheCreationInputTokens)
+	cachedCreationTokens = translatorcommon.NonNegativeTokenCount(u.CacheCreationInputTokens)
 	cachedTokens = translatorcommon.NonNegativeTokenCount(u.CacheReadInputTokens)
 	completionTokens = translatorcommon.NonNegativeTokenCount(u.OutputTokens)
 
 	var ok bool
-	promptTokens, ok = translatorcommon.SumNonNegativeTokenCounts(inputTokens, cacheCreationTokens, cachedTokens)
+	promptTokens, ok = translatorcommon.SumNonNegativeTokenCounts(inputTokens, cachedCreationTokens, cachedTokens)
 	if !ok {
 		// Preserve Claude's raw prompt count, but clear the cache classification
 		// when the canonical total input cannot be represented.
 		promptTokens = inputTokens
 		cachedTokens = 0
+		cachedCreationTokens = 0
 	}
 	totalTokens, _ = translatorcommon.SumNonNegativeTokenCounts(promptTokens, completionTokens)
-	return promptTokens, completionTokens, totalTokens, cachedTokens
+	return promptTokens, completionTokens, totalTokens, cachedTokens, cachedCreationTokens
 }
 
 // ConvertClaudeResponseToOpenAI converts Claude Code streaming response format to OpenAI Chat Completions format.
@@ -252,11 +253,12 @@ func ConvertClaudeResponseToOpenAI(_ context.Context, modelName string, original
 		// Handle usage information for token counts
 		if usage := root.Get("usage"); usage.Exists() {
 			(*param).(*ConvertAnthropicResponseToOpenAIParams).Usage.Merge(usage)
-			promptTokens, completionTokens, totalTokens, cachedTokens := (*param).(*ConvertAnthropicResponseToOpenAIParams).Usage.OpenAIUsage()
+			promptTokens, completionTokens, totalTokens, cachedTokens, cachedCreationTokens := (*param).(*ConvertAnthropicResponseToOpenAIParams).Usage.OpenAIUsage()
 			template, _ = sjson.SetBytes(template, "usage.prompt_tokens", promptTokens)
 			template, _ = sjson.SetBytes(template, "usage.completion_tokens", completionTokens)
 			template, _ = sjson.SetBytes(template, "usage.total_tokens", totalTokens)
 			template, _ = sjson.SetBytes(template, "usage.prompt_tokens_details.cached_tokens", cachedTokens)
+			template, _ = sjson.SetBytes(template, "usage.prompt_tokens_details.cached_creation_tokens", cachedCreationTokens)
 		}
 		return [][]byte{template}
 
@@ -416,11 +418,12 @@ func ConvertClaudeResponseToOpenAINonStream(_ context.Context, _ string, origina
 	}
 
 	if usageTokens.HasUsage {
-		promptTokens, completionTokens, totalTokens, cachedTokens := usageTokens.OpenAIUsage()
+		promptTokens, completionTokens, totalTokens, cachedTokens, cachedCreationTokens := usageTokens.OpenAIUsage()
 		out, _ = sjson.SetBytes(out, "usage.prompt_tokens", promptTokens)
 		out, _ = sjson.SetBytes(out, "usage.completion_tokens", completionTokens)
 		out, _ = sjson.SetBytes(out, "usage.total_tokens", totalTokens)
 		out, _ = sjson.SetBytes(out, "usage.prompt_tokens_details.cached_tokens", cachedTokens)
+		out, _ = sjson.SetBytes(out, "usage.prompt_tokens_details.cached_creation_tokens", cachedCreationTokens)
 	}
 
 	// Set basic response fields including message ID, creation time, and model

--- a/internal/translator/claude/openai/chat-completions/claude_openai_response_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_response_test.go
@@ -7,6 +7,18 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+func assertCachedCreationTokens(t *testing.T, payload []byte, want int64) {
+	t.Helper()
+
+	got := gjson.GetBytes(payload, "usage.prompt_tokens_details.cached_creation_tokens")
+	if !got.Exists() {
+		t.Fatalf("expected cached_creation_tokens to exist, payload=%s", string(payload))
+	}
+	if got.Int() != want {
+		t.Fatalf("expected cached_creation_tokens %d, got %d", want, got.Int())
+	}
+}
+
 func TestConvertClaudeResponseToOpenAI_StreamUsageIncludesCachedTokens(t *testing.T) {
 	ctx := context.Background()
 	var param any
@@ -35,6 +47,7 @@ func TestConvertClaudeResponseToOpenAI_StreamUsageIncludesCachedTokens(t *testin
 	if gotCachedTokens := gjson.GetBytes(out[0], "usage.prompt_tokens_details.cached_tokens").Int(); gotCachedTokens != 22000 {
 		t.Fatalf("expected cached_tokens %d, got %d", 22000, gotCachedTokens)
 	}
+	assertCachedCreationTokens(t, out[0], 31)
 }
 
 func TestConvertClaudeResponseToOpenAI_StreamUsageMergesMessageStartUsage(t *testing.T) {
@@ -73,6 +86,7 @@ func TestConvertClaudeResponseToOpenAI_StreamUsageMergesMessageStartUsage(t *tes
 	if gotCachedTokens := gjson.GetBytes(out[0], "usage.prompt_tokens_details.cached_tokens").Int(); gotCachedTokens != 22000 {
 		t.Fatalf("expected cached_tokens %d, got %d", 22000, gotCachedTokens)
 	}
+	assertCachedCreationTokens(t, out[0], 31)
 }
 
 func TestConvertClaudeResponseToOpenAINonStream_UsageIncludesCachedTokens(t *testing.T) {
@@ -93,6 +107,7 @@ func TestConvertClaudeResponseToOpenAINonStream_UsageIncludesCachedTokens(t *tes
 	if gotCachedTokens := gjson.GetBytes(out, "usage.prompt_tokens_details.cached_tokens").Int(); gotCachedTokens != 22000 {
 		t.Fatalf("expected cached_tokens %d, got %d", 22000, gotCachedTokens)
 	}
+	assertCachedCreationTokens(t, out, 31)
 }
 
 func TestConvertClaudeResponseToOpenAINonStream_UsageMergesMessageStartUsage(t *testing.T) {
@@ -113,4 +128,5 @@ func TestConvertClaudeResponseToOpenAINonStream_UsageMergesMessageStartUsage(t *
 	if gotCachedTokens := gjson.GetBytes(out, "usage.prompt_tokens_details.cached_tokens").Int(); gotCachedTokens != 22000 {
 		t.Fatalf("expected cached_tokens %d, got %d", 22000, gotCachedTokens)
 	}
+	assertCachedCreationTokens(t, out, 31)
 }

--- a/internal/translator/claude/openai/chat-completions/claude_openai_response_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_response_test.go
@@ -9,22 +9,35 @@ import (
 )
 
 func TestClaudeUsageTokensOpenAIUsageFailsClosedOnOverflow(t *testing.T) {
-	prompt, completion, total, cached := (claudeUsageTokens{
+	prompt, completion, total, cached, cachedCreation := (claudeUsageTokens{
 		InputTokens:              math.MaxInt64,
 		OutputTokens:             1,
 		CacheCreationInputTokens: 1,
 		CacheReadInputTokens:     1,
 	}).OpenAIUsage()
 
-	if prompt != math.MaxInt64 || completion != 1 || total != 0 || cached != 0 {
+	if prompt != math.MaxInt64 || completion != 1 || total != 0 || cached != 0 || cachedCreation != 0 {
 		t.Fatalf(
-			"overflowed usage = prompt:%d completion:%d total:%d cached:%d, want %d/1/0/0",
+			"overflowed usage = prompt:%d completion:%d total:%d cached:%d cached_creation:%d, want %d/1/0/0/0",
 			prompt,
 			completion,
 			total,
 			cached,
+			cachedCreation,
 			int64(math.MaxInt64),
 		)
+	}
+}
+
+func assertCachedCreationTokens(t *testing.T, payload []byte, want int64) {
+	t.Helper()
+
+	got := gjson.GetBytes(payload, "usage.prompt_tokens_details.cached_creation_tokens")
+	if !got.Exists() {
+		t.Fatalf("expected cached_creation_tokens to exist, payload=%s", string(payload))
+	}
+	if got.Int() != want {
+		t.Fatalf("expected cached_creation_tokens %d, got %d", want, got.Int())
 	}
 }
 
@@ -56,6 +69,7 @@ func TestConvertClaudeResponseToOpenAI_StreamUsageIncludesCachedTokens(t *testin
 	if gotCachedTokens := gjson.GetBytes(out[0], "usage.prompt_tokens_details.cached_tokens").Int(); gotCachedTokens != 22000 {
 		t.Fatalf("expected cached_tokens %d, got %d", 22000, gotCachedTokens)
 	}
+	assertCachedCreationTokens(t, out[0], 31)
 }
 
 func TestConvertClaudeResponseToOpenAI_StreamUsageMergesMessageStartUsage(t *testing.T) {
@@ -94,6 +108,7 @@ func TestConvertClaudeResponseToOpenAI_StreamUsageMergesMessageStartUsage(t *tes
 	if gotCachedTokens := gjson.GetBytes(out[0], "usage.prompt_tokens_details.cached_tokens").Int(); gotCachedTokens != 22000 {
 		t.Fatalf("expected cached_tokens %d, got %d", 22000, gotCachedTokens)
 	}
+	assertCachedCreationTokens(t, out[0], 31)
 }
 
 func TestConvertClaudeResponseToOpenAINonStream_UsageIncludesCachedTokens(t *testing.T) {
@@ -114,6 +129,7 @@ func TestConvertClaudeResponseToOpenAINonStream_UsageIncludesCachedTokens(t *tes
 	if gotCachedTokens := gjson.GetBytes(out, "usage.prompt_tokens_details.cached_tokens").Int(); gotCachedTokens != 22000 {
 		t.Fatalf("expected cached_tokens %d, got %d", 22000, gotCachedTokens)
 	}
+	assertCachedCreationTokens(t, out, 31)
 }
 
 func TestConvertClaudeResponseToOpenAINonStream_UsageMergesMessageStartUsage(t *testing.T) {
@@ -134,4 +150,5 @@ func TestConvertClaudeResponseToOpenAINonStream_UsageMergesMessageStartUsage(t *
 	if gotCachedTokens := gjson.GetBytes(out, "usage.prompt_tokens_details.cached_tokens").Int(); gotCachedTokens != 22000 {
 		t.Fatalf("expected cached_tokens %d, got %d", 22000, gotCachedTokens)
 	}
+	assertCachedCreationTokens(t, out, 31)
 }

--- a/internal/translator/codex/claude/codex_claude_parallel_function_calls_test.go
+++ b/internal/translator/codex/claude/codex_claude_parallel_function_calls_test.go
@@ -1,0 +1,305 @@
+package claude
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+type codexClaudeContentBlock struct {
+	Index     int64
+	Type      string
+	ID        string
+	Name      string
+	Text      string
+	Arguments string
+}
+
+func translateCodexClaudeChunks(t *testing.T, chunks [][]byte) [][]byte {
+	t.Helper()
+
+	originalRequest := []byte(`{"stream":true,"tools":[{"name":"Read"}]}`)
+	var state any
+	var outputs [][]byte
+	for _, chunk := range chunks {
+		outputs = append(outputs, ConvertCodexResponseToClaude(context.Background(), "gpt-5", originalRequest, nil, chunk, &state)...)
+	}
+	return outputs
+}
+
+func assertCodexClaudeContentBlockLifecycle(t *testing.T, outputs [][]byte) []*codexClaudeContentBlock {
+	t.Helper()
+
+	open := make(map[int64]*codexClaudeContentBlock)
+	started := make(map[int64]struct{})
+	blocks := make([]*codexClaudeContentBlock, 0)
+	messageState := 0
+	for _, output := range outputs {
+		for _, line := range strings.Split(string(output), "\n") {
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			event := gjson.Parse(strings.TrimPrefix(line, "data: "))
+			if messageState == 2 {
+				t.Fatalf("event emitted after message_stop: %s", event.Raw)
+			}
+			index := event.Get("index").Int()
+			switch event.Get("type").String() {
+			case "content_block_start":
+				if messageState != 0 {
+					t.Fatalf("content block started after message terminal events: %s", event.Raw)
+				}
+				if len(open) != 0 {
+					t.Fatalf("content block start emitted while another block remains open: %v", open)
+				}
+				if _, exists := started[index]; exists {
+					t.Fatalf("content block index %d was reused", index)
+				}
+				block := &codexClaudeContentBlock{
+					Index: index,
+					Type:  event.Get("content_block.type").String(),
+					ID:    event.Get("content_block.id").String(),
+					Name:  event.Get("content_block.name").String(),
+				}
+				open[index] = block
+				started[index] = struct{}{}
+				blocks = append(blocks, block)
+			case "content_block_delta":
+				block := open[index]
+				if block == nil {
+					t.Fatalf("content block delta targets unopened index %d", index)
+				}
+				switch event.Get("delta.type").String() {
+				case "input_json_delta":
+					block.Arguments += event.Get("delta.partial_json").String()
+				case "text_delta":
+					block.Text += event.Get("delta.text").String()
+				}
+			case "content_block_stop":
+				if open[index] == nil {
+					t.Fatalf("content block stop targets unopened index %d", index)
+				}
+				delete(open, index)
+			case "message_delta":
+				if len(open) != 0 {
+					t.Fatalf("message_delta emitted while content blocks remain open: %v", open)
+				}
+				if messageState != 0 {
+					t.Fatalf("duplicate or out-of-order message_delta: %s", event.Raw)
+				}
+				messageState = 1
+			case "message_stop":
+				if len(open) != 0 {
+					t.Fatalf("message_stop emitted while content blocks remain open: %v", open)
+				}
+				if messageState != 1 {
+					t.Fatalf("message_stop emitted before message_delta: %s", event.Raw)
+				}
+				messageState = 2
+			}
+		}
+	}
+	if len(open) != 0 {
+		t.Fatalf("content blocks remain open: %v", open)
+	}
+	return blocks
+}
+
+func assertParallelCodexClaudeToolCalls(t *testing.T, blocks []*codexClaudeContentBlock) {
+	t.Helper()
+
+	if len(blocks) != 2 {
+		t.Fatalf("content block count = %d, want 2", len(blocks))
+	}
+	expectedIDs := []string{"call_a", "call_b"}
+	expectedArguments := []string{`{"file_path":"a"}`, `{"file_path":"b"}`}
+	for index, block := range blocks {
+		if block.Index != int64(index) {
+			t.Fatalf("block %d index = %d, want %d", index, block.Index, index)
+		}
+		if block.Type != "tool_use" || block.Name != "Read" {
+			t.Fatalf("block %d = %#v, want Read tool_use", index, block)
+		}
+		if block.ID != expectedIDs[index] {
+			t.Fatalf("block %d ID = %q, want %q", index, block.ID, expectedIDs[index])
+		}
+		if block.Arguments != expectedArguments[index] {
+			t.Fatalf("block %d arguments = %q, want %q", index, block.Arguments, expectedArguments[index])
+		}
+	}
+}
+
+func TestConvertCodexResponseToClaude_StreamSerializesInterleavedNamedFunctionCalls(t *testing.T) {
+	tests := []struct {
+		name   string
+		chunks [][]byte
+	}{
+		{
+			name: "first call finishes first",
+			chunks: [][]byte{
+				[]byte(`data: {"type":"response.created","response":{"id":"resp_parallel","model":"gpt-5"}}`),
+				[]byte(`data: {"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_a","name":"Read"},"output_index":1}`),
+				[]byte(`data: {"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_b","name":"Read"},"output_index":2}`),
+				[]byte(`data: {"type":"response.function_call_arguments.delta","delta":"{\"file_path\":\"a\"}","output_index":1}`),
+				[]byte(`data: {"type":"response.function_call_arguments.delta","delta":"{\"file_path\":\"b\"}","output_index":2}`),
+				[]byte(`data: {"type":"response.function_call_arguments.done","arguments":"{\"file_path\":\"a\"}","output_index":1}`),
+				[]byte(`data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_a","name":"Read","arguments":"{\"file_path\":\"a\"}"},"output_index":1}`),
+				[]byte(`data: {"type":"response.function_call_arguments.done","arguments":"{\"file_path\":\"b\"}","output_index":2}`),
+				[]byte(`data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_b","name":"Read","arguments":"{\"file_path\":\"b\"}"},"output_index":2}`),
+			},
+		},
+		{
+			name: "second call finishes first",
+			chunks: [][]byte{
+				[]byte(`data: {"type":"response.created","response":{"id":"resp_parallel","model":"gpt-5"}}`),
+				[]byte(`data: {"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_a","name":"Read"},"output_index":1}`),
+				[]byte(`data: {"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_b","name":"Read"},"output_index":2}`),
+				[]byte(`data: {"type":"response.function_call_arguments.delta","delta":"{\"file_path\":\"b\"}","output_index":2}`),
+				[]byte(`data: {"type":"response.function_call_arguments.done","arguments":"{\"file_path\":\"b\"}","output_index":2}`),
+				[]byte(`data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_b","name":"Read","arguments":"{\"file_path\":\"b\"}"},"output_index":2}`),
+				[]byte(`data: {"type":"response.function_call_arguments.delta","delta":"{\"file_path\":\"a\"}","output_index":1}`),
+				[]byte(`data: {"type":"response.function_call_arguments.done","arguments":"{\"file_path\":\"a\"}","output_index":1}`),
+				[]byte(`data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_a","name":"Read","arguments":"{\"file_path\":\"a\"}"},"output_index":1}`),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			blocks := assertCodexClaudeContentBlockLifecycle(t, translateCodexClaudeChunks(t, test.chunks))
+			assertParallelCodexClaudeToolCalls(t, blocks)
+		})
+	}
+}
+
+func TestConvertCodexResponseToClaude_StreamDefersOtherContentUntilFunctionCallsClose(t *testing.T) {
+	tests := []struct {
+		name         string
+		functionCall []byte
+		firstBlock   string
+		secondBlock  string
+	}{
+		{
+			name:         "named active call",
+			functionCall: []byte(`data: {"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_a","name":"Read"},"output_index":0}`),
+			firstBlock:   "tool_use",
+			secondBlock:  "text",
+		},
+		{
+			name:         "unnamed pending call",
+			functionCall: []byte(`data: {"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_a"},"output_index":0}`),
+			firstBlock:   "text",
+			secondBlock:  "tool_use",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			chunks := [][]byte{
+				[]byte(`data: {"type":"response.created","response":{"id":"resp_mixed","model":"gpt-5"}}`),
+				test.functionCall,
+				[]byte(`data: {"type":"response.output_item.added","item":{"type":"message","status":"in_progress"},"output_index":1}`),
+				[]byte(`data: {"type":"response.content_part.added","part":{"type":"output_text"},"content_index":0,"output_index":1}`),
+				[]byte(`data: {"type":"response.output_text.delta","delta":"done","output_index":1}`),
+				[]byte(`data: {"type":"response.content_part.done","part":{"type":"output_text"},"content_index":0,"output_index":1}`),
+				[]byte(`data: {"type":"response.output_item.done","item":{"type":"message","status":"completed"},"output_index":1}`),
+				[]byte(`data: {"type":"response.function_call_arguments.done","arguments":"{\"file_path\":\"a\"}","output_index":0}`),
+				[]byte(`data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_a","name":"Read","arguments":"{\"file_path\":\"a\"}"},"output_index":0}`),
+				[]byte(`data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1}}}`),
+			}
+
+			blocks := assertCodexClaudeContentBlockLifecycle(t, translateCodexClaudeChunks(t, chunks))
+			if len(blocks) != 2 {
+				t.Fatalf("content block count = %d, want 2", len(blocks))
+			}
+			if blocks[0].Index != 0 || blocks[0].Type != test.firstBlock {
+				t.Fatalf("unexpected first block: %#v", blocks[0])
+			}
+			if blocks[1].Index != 1 || blocks[1].Type != test.secondBlock {
+				t.Fatalf("unexpected second block: %#v", blocks[1])
+			}
+			for _, block := range blocks {
+				switch block.Type {
+				case "tool_use":
+					if block.Arguments != `{"file_path":"a"}` {
+						t.Fatalf("unexpected tool block: %#v", block)
+					}
+				case "text":
+					if block.Text != "done" {
+						t.Fatalf("unexpected text block: %#v", block)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestConvertCodexResponseToClaude_StreamDeferredTextClosesBeforeThinkingStarts(t *testing.T) {
+	chunks := [][]byte{
+		[]byte(`data: {"type":"response.created","response":{"id":"resp_mixed","model":"gpt-5"}}`),
+		[]byte(`data: {"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_a","name":"Read"},"output_index":0}`),
+		[]byte(`data: {"type":"response.content_part.added","part":{"type":"output_text"},"content_index":0,"output_index":1}`),
+		[]byte(`data: {"type":"response.output_text.delta","delta":"answer","output_index":1}`),
+		[]byte(`data: {"type":"response.output_item.added","item":{"type":"reasoning","encrypted_content":"enc_initial"},"output_index":2}`),
+		[]byte(`data: {"type":"response.reasoning_summary_part.added","output_index":2}`),
+		[]byte(`data: {"type":"response.reasoning_summary_text.delta","delta":"thought","output_index":2}`),
+		[]byte(`data: {"type":"response.output_item.done","item":{"type":"reasoning","encrypted_content":"enc_final"},"output_index":2}`),
+		[]byte(`data: {"type":"response.function_call_arguments.done","arguments":"{\"file_path\":\"a\"}","output_index":0}`),
+		[]byte(`data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_a","name":"Read","arguments":"{\"file_path\":\"a\"}"},"output_index":0}`),
+		[]byte(`data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1}}}`),
+	}
+
+	blocks := assertCodexClaudeContentBlockLifecycle(t, translateCodexClaudeChunks(t, chunks))
+	if len(blocks) != 3 {
+		t.Fatalf("content block count = %d, want 3", len(blocks))
+	}
+	if blocks[0].Index != 0 || blocks[0].Type != "tool_use" || blocks[0].Arguments != `{"file_path":"a"}` {
+		t.Fatalf("unexpected tool block: %#v", blocks[0])
+	}
+	if blocks[1].Index != 1 || blocks[1].Type != "text" || blocks[1].Text != "answer" {
+		t.Fatalf("unexpected text block: %#v", blocks[1])
+	}
+	if blocks[2].Index != 2 || blocks[2].Type != "thinking" {
+		t.Fatalf("unexpected thinking block: %#v", blocks[2])
+	}
+}
+
+func TestConvertCodexResponseToClaude_StreamTerminalMatchesFunctionCallsByOutputIndex(t *testing.T) {
+	chunks := [][]byte{
+		[]byte(`data: {"type":"response.created","response":{"id":"resp_parallel","model":"gpt-5"}}`),
+		[]byte(`data: {"type":"response.output_item.added","item":{"type":"function_call","name":"Read"},"output_index":0}`),
+		[]byte(`data: {"type":"response.output_item.added","item":{"type":"function_call","name":"Read"},"output_index":1}`),
+		[]byte(`data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1},"output":[{"type":"function_call","name":"Read","arguments":"{\"file_path\":\"a\"}"},{"type":"function_call","name":"Read","arguments":"{\"file_path\":\"b\"}"}]}}`),
+	}
+
+	blocks := assertCodexClaudeContentBlockLifecycle(t, translateCodexClaudeChunks(t, chunks))
+	if len(blocks) != 2 {
+		t.Fatalf("content block count = %d, want 2", len(blocks))
+	}
+	if blocks[0].Index != 0 || blocks[0].Arguments != `{"file_path":"a"}` {
+		t.Fatalf("unexpected first function call: %#v", blocks[0])
+	}
+	if blocks[1].Index != 1 || blocks[1].Arguments != `{"file_path":"b"}` {
+		t.Fatalf("unexpected second function call: %#v", blocks[1])
+	}
+}
+
+func TestConvertCodexResponseToClaude_StreamTerminalHydratesInterleavedFunctionCalls(t *testing.T) {
+	for _, terminalType := range []string{"response.completed", "response.incomplete"} {
+		t.Run(terminalType, func(t *testing.T) {
+			terminal := `data: {"type":"` + terminalType + `","response":{"usage":{"input_tokens":1,"output_tokens":1},"output":[{"type":"function_call","call_id":"call_a","name":"Read","arguments":"{\"file_path\":\"a\"}"},{"type":"function_call","call_id":"call_b","name":"Read","arguments":"{\"file_path\":\"b\"}"}]}}`
+			chunks := [][]byte{
+				[]byte(`data: {"type":"response.created","response":{"id":"resp_parallel","model":"gpt-5"}}`),
+				[]byte(`data: {"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_a","name":"Read"},"output_index":0}`),
+				[]byte(`data: {"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_b","name":"Read"},"output_index":1}`),
+				[]byte(`data: {"type":"response.function_call_arguments.delta","delta":"{\"file_path\":","output_index":0}`),
+				[]byte(terminal),
+			}
+
+			blocks := assertCodexClaudeContentBlockLifecycle(t, translateCodexClaudeChunks(t, chunks))
+			assertParallelCodexClaudeToolCalls(t, blocks)
+		})
+	}
+}

--- a/internal/translator/codex/claude/codex_claude_response.go
+++ b/internal/translator/codex/claude/codex_claude_response.go
@@ -27,29 +27,34 @@ const codexThinkingSummaryPartSeparator = "\n\n"
 
 // ConvertCodexResponseToClaudeParams holds parameters for response conversion.
 type ConvertCodexResponseToClaudeParams struct {
-	HasEmittedToolUse          bool
-	BlockIndex                 int
-	HasReceivedArgumentsDelta  bool
-	FunctionCallBlockOpen      bool
-	FunctionCallBlockCallID    string
-	FunctionCallBlockIndex     int
-	HasTextDelta               bool
-	TextBlockOpen              bool
-	ThinkingBlockOpen          bool
-	ThinkingSignature          string
-	ThinkingSummarySeen        bool
-	WebSearchToolUseIDs        map[string]struct{}
-	WebSearchToolResultIDs     map[string]struct{}
-	LastWebSearchToolUseID     string
-	PendingFunctionCalls       map[string]*pendingCodexFunctionCall
-	LastPendingFunctionCallKey string
+	HasEmittedToolUse      bool
+	BlockIndex             int
+	HasTextDelta           bool
+	TextBlockOpen          bool
+	ThinkingBlockOpen      bool
+	ThinkingSignature      string
+	ThinkingSummarySeen    bool
+	WebSearchToolUseIDs    map[string]struct{}
+	WebSearchToolResultIDs map[string]struct{}
+	LastWebSearchToolUseID string
+	FunctionCalls          map[string]*codexFunctionCallStream
+	FunctionCallQueue      []*codexFunctionCallStream
+	ActiveFunctionCall     *codexFunctionCallStream
+	LastFunctionCall       *codexFunctionCallStream
+	DeferredStreamEvents   [][]byte
 }
 
-type pendingCodexFunctionCall struct {
+type codexFunctionCallStream struct {
 	CallID                    string
+	Name                      string
+	BlockIndex                int
 	Arguments                 string
+	EmittedArgumentsLength    int
 	HasReceivedArgumentsDelta bool
-	StartEmitted              bool
+	EmitInitialEmptyDelta     bool
+	Started                   bool
+	Done                      bool
+	Closed                    bool
 }
 
 // ConvertCodexResponseToClaude performs sophisticated streaming response format conversion.
@@ -78,6 +83,7 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 	if !bytes.HasPrefix(rawJSON, dataTag) {
 		return [][]byte{}
 	}
+	streamEventRawJSON := bytes.Clone(rawJSON)
 	rawJSON = bytes.TrimSpace(rawJSON[5:])
 
 	output := make([]byte, 0, 512)
@@ -86,6 +92,10 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 
 	typeResult := rootResult.Get("type")
 	typeStr := typeResult.String()
+	if params.ActiveFunctionCall != nil && shouldDeferCodexStreamEvent(typeStr, rootResult) {
+		params.DeferredStreamEvents = append(params.DeferredStreamEvents, streamEventRawJSON)
+		return [][]byte{}
+	}
 	var template []byte
 
 	switch typeStr {
@@ -98,6 +108,7 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 
 		output = translatorcommon.AppendSSEEventBytes(output, "message_start", template, 2)
 	case "response.reasoning_summary_part.added":
+		output = append(output, stopCodexTextBlock(params)...)
 		// Codex splits a single reasoning item into several summary parts, but only
 		// output_item.done carries that item's final encrypted_content. Keep one
 		// thinking block open for the whole item and separate the parts with a blank
@@ -109,6 +120,7 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 		}
 		params.ThinkingSummarySeen = true
 	case "response.reasoning_summary_text.delta":
+		output = append(output, stopCodexTextBlock(params)...)
 		output = append(output, startCodexThinkingBlock(params)...)
 		output = append(output, appendCodexThinkingDelta(params, rootResult.Get("delta").String())...)
 	case "response.reasoning_summary_part.done":
@@ -137,9 +149,12 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 	case "response.completed", "response.incomplete":
 		template = []byte(`{"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":0,"output_tokens":0}}`)
 		responseData := rootResult.Get("response")
-		output = hydrateOpenCodexFunctionCallFromTerminal(output, params, responseData)
-		output = append(output, finalizeCodexOpenContentBlocks(params)...)
-		output = appendPendingCodexFunctionCallsFromTerminal(output, params, originalRequestRawJSON, responseData)
+		output = append(output, finalizeCodexThinkingBlock(params)...)
+		output = append(output, stopCodexTextBlock(params)...)
+		output = appendCodexFunctionCallsFromTerminal(output, params, originalRequestRawJSON, responseData)
+		output = appendDeferredCodexStreamEvents(output, originalRequestRawJSON, param)
+		output = append(output, finalizeCodexThinkingBlock(params)...)
+		output = append(output, stopCodexTextBlock(params)...)
 		template, _ = sjson.SetBytes(template, "delta.stop_reason", mapCodexStopReasonToClaude(codexStopReason(responseData), params.HasEmittedToolUse))
 		template = setClaudeStopSequence(template, "delta.stop_sequence", responseData)
 		inputTokens, outputTokens, cachedTokens := extractResponsesUsage(responseData.Get("usage"))
@@ -158,26 +173,15 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 		case "function_call":
 			output = append(output, finalizeCodexThinkingBlock(params)...)
 			output = append(output, stopCodexTextBlock(params)...)
-			params.HasReceivedArgumentsDelta = false
 
-			callID := codexFunctionCallID(itemResult)
-			name := itemResult.Get("name").String()
-			if name == "" {
-				recordPendingCodexFunctionCall(params, rootResult, itemResult)
-				break
+			call := recordCodexFunctionCall(params, rootResult, itemResult)
+			updateCodexFunctionCallIdentity(params, call, rootResult, itemResult)
+			if call.Name != "" {
+				call.EmitInitialEmptyDelta = true
 			}
-
-			if pending, pendingKeys := pendingCodexFunctionCallForDone(params, rootResult, itemResult); pending != nil {
-				deletePendingCodexFunctionCallAliases(params, pendingKeys)
-			}
-			blockIndex := params.BlockIndex
-			output = appendCodexFunctionCallStart(output, originalRequestRawJSON, callID, name, blockIndex)
-			params.HasEmittedToolUse = true
-			output = appendCodexFunctionCallArgumentDelta(output, "", blockIndex)
-			params.FunctionCallBlockOpen = true
-			params.FunctionCallBlockCallID = callID
-			params.FunctionCallBlockIndex = blockIndex
+			output = appendCodexFunctionCallQueue(output, params, originalRequestRawJSON)
 		case "reasoning":
+			output = append(output, stopCodexTextBlock(params)...)
 			// A previous reasoning item that never reported output_item.done must not
 			// leak its still-open block into this one.
 			output = append(output, finalizeCodexThinkingBlock(params)...)
@@ -226,41 +230,18 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 			output = append(output, stopCodexTextBlock(params)...)
 			params.HasTextDelta = true
 		case "function_call":
-			if pending, pendingKeys := pendingCodexFunctionCallForDone(params, rootResult, itemResult); pending != nil && !pending.StartEmitted {
-				name := itemResult.Get("name").String()
-				if name == "" {
-					return [][]byte{output}
-				}
-				callID := pending.CallID
-				if callID == "" {
-					callID = codexFunctionCallID(itemResult)
-				}
-				blockIndex := params.BlockIndex
-				output = appendCodexFunctionCallStart(output, originalRequestRawJSON, callID, name, blockIndex)
-				params.HasEmittedToolUse = true
-				pending.StartEmitted = true
-
-				args := pending.Arguments
-				if args == "" {
-					args = itemResult.Get("arguments").String()
-				}
-				if args != "" {
-					output = appendCodexFunctionCallArgumentDelta(output, args, blockIndex)
-				}
-				output = appendCodexFunctionCallStop(output, blockIndex)
-				params.BlockIndex++
-
-				deletePendingCodexFunctionCallAliases(params, pendingKeys)
-			} else if params.FunctionCallBlockOpen {
-				if !params.HasReceivedArgumentsDelta {
-					if args := itemResult.Get("arguments").String(); args != "" {
-						output = appendCodexFunctionCallArgumentDelta(output, args, params.FunctionCallBlockIndex)
-						params.HasReceivedArgumentsDelta = true
-					}
-				}
-				output = appendCodexOpenFunctionCallStop(output, params)
+			output = append(output, finalizeCodexThinkingBlock(params)...)
+			output = append(output, stopCodexTextBlock(params)...)
+			call := codexFunctionCallForEvent(params, rootResult, itemResult)
+			if call == nil {
+				call = recordCodexFunctionCall(params, rootResult, itemResult)
 			}
+			updateCodexFunctionCallIdentity(params, call, rootResult, itemResult)
+			updateCodexFunctionCallArguments(call, itemResult.Get("arguments").String(), false)
+			call.Done = true
+			output = appendCodexFunctionCallQueue(output, params, originalRequestRawJSON)
 		case "reasoning":
+			output = append(output, stopCodexTextBlock(params)...)
 			if signature := itemResult.Get("encrypted_content").String(); signature != "" {
 				params.ThinkingSignature = signature
 			}
@@ -275,34 +256,56 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 			output = appendCodexWebSearchToolResult(output, params, rootResult, itemResult)
 		}
 	case "response.function_call_arguments.delta":
-		delta := rootResult.Get("delta").String()
-		key := codexArgumentsFunctionCallKey(params, rootResult)
-		if pending, _ := pendingCodexFunctionCallForKey(params, key); pending != nil && !pending.StartEmitted {
-			pending.HasReceivedArgumentsDelta = true
-			pending.Arguments += delta
-			break
+		call := codexFunctionCallForEvent(params, rootResult, gjson.Result{})
+		if call == nil {
+			call = recordCodexFunctionCall(params, rootResult, gjson.Result{})
 		}
-
-		params.HasReceivedArgumentsDelta = true
-		output = appendCodexFunctionCallArgumentDelta(output, delta, params.BlockIndex)
+		updateCodexFunctionCallArguments(call, rootResult.Get("delta").String(), true)
+		output = appendCodexFunctionCallBufferedArguments(output, params, call)
 	case "response.function_call_arguments.done":
-		key := codexArgumentsFunctionCallKey(params, rootResult)
-		if pending, _ := pendingCodexFunctionCallForKey(params, key); pending != nil && !pending.StartEmitted {
-			if !pending.HasReceivedArgumentsDelta {
-				pending.Arguments = rootResult.Get("arguments").String()
-			}
-			break
+		call := codexFunctionCallForEvent(params, rootResult, gjson.Result{})
+		if call == nil {
+			call = recordCodexFunctionCall(params, rootResult, gjson.Result{})
 		}
-
-		if !params.HasReceivedArgumentsDelta {
-			if args := rootResult.Get("arguments").String(); args != "" {
-				output = appendCodexFunctionCallArgumentDelta(output, args, params.BlockIndex)
-				params.HasReceivedArgumentsDelta = true
-			}
-		}
+		updateCodexFunctionCallArguments(call, rootResult.Get("arguments").String(), false)
+		output = appendCodexFunctionCallBufferedArguments(output, params, call)
 	}
 
+	if len(params.FunctionCallQueue) == 0 {
+		output = appendDeferredCodexStreamEvents(output, originalRequestRawJSON, param)
+	}
 	return [][]byte{output}
+}
+
+func shouldDeferCodexStreamEvent(typeStr string, rootResult gjson.Result) bool {
+	switch typeStr {
+	case "error", "response.completed", "response.incomplete", "response.function_call_arguments.delta", "response.function_call_arguments.done":
+		return false
+	case "response.output_item.added", "response.output_item.done":
+		return rootResult.Get("item.type").String() != "function_call"
+	default:
+		return true
+	}
+}
+
+func appendDeferredCodexStreamEvents(output []byte, originalRequestRawJSON []byte, param *any) []byte {
+	if param == nil || *param == nil {
+		return output
+	}
+	params := (*param).(*ConvertCodexResponseToClaudeParams)
+	if len(params.DeferredStreamEvents) == 0 {
+		return output
+	}
+
+	events := params.DeferredStreamEvents
+	params.DeferredStreamEvents = nil
+	for _, event := range events {
+		translated := ConvertCodexResponseToClaude(context.Background(), "", originalRequestRawJSON, nil, event, param)
+		for _, chunk := range translated {
+			output = append(output, chunk...)
+		}
+	}
+	return output
 }
 
 func codexStreamErrorToClaudeError(rootResult gjson.Result) []byte {
@@ -515,78 +518,28 @@ func setClaudeStopSequence(out []byte, path string, responseData gjson.Result) [
 	return out
 }
 
-func codexFunctionCallKey(rootResult, itemResult gjson.Result) string {
-	if outputIndex := rootResult.Get("output_index"); outputIndex.Exists() {
-		return "output:" + outputIndex.Raw
-	}
-	if callID := codexFunctionCallID(itemResult); callID != "" {
-		return "call:" + callID
-	}
-	return "last"
-}
-
 func codexFunctionCallID(itemResult gjson.Result) string {
 	return itemResult.Get("call_id").String()
 }
 
-func codexFunctionCallIDKey(callID string) string {
-	if callID == "" {
-		return ""
-	}
-	return "call:" + callID
-}
-
-func codexArgumentsFunctionCallKey(params *ConvertCodexResponseToClaudeParams, rootResult gjson.Result) string {
+func codexFunctionCallKeys(rootResult, itemResult gjson.Result) []string {
+	keys := make([]string, 0, 5)
 	if outputIndex := rootResult.Get("output_index"); outputIndex.Exists() {
-		return "output:" + outputIndex.Raw
+		keys = appendUniqueCodexFunctionCallKey(keys, "output:"+outputIndex.Raw)
 	}
-	return params.LastPendingFunctionCallKey
-}
-
-func recordPendingCodexFunctionCall(params *ConvertCodexResponseToClaudeParams, rootResult, itemResult gjson.Result) {
-	if params.PendingFunctionCalls == nil {
-		params.PendingFunctionCalls = map[string]*pendingCodexFunctionCall{}
+	if callID := codexFunctionCallID(itemResult); callID != "" {
+		keys = appendUniqueCodexFunctionCallKey(keys, "call:"+callID)
 	}
-
-	pending := &pendingCodexFunctionCall{CallID: codexFunctionCallID(itemResult)}
-	key := codexFunctionCallKey(rootResult, itemResult)
-	params.PendingFunctionCalls[key] = pending
-	if callIDKey := codexFunctionCallIDKey(pending.CallID); callIDKey != "" {
-		params.PendingFunctionCalls[callIDKey] = pending
+	if callID := rootResult.Get("call_id").String(); callID != "" {
+		keys = appendUniqueCodexFunctionCallKey(keys, "call:"+callID)
 	}
-	params.LastPendingFunctionCallKey = key
-}
-
-func pendingCodexFunctionCallForKey(params *ConvertCodexResponseToClaudeParams, key string) (*pendingCodexFunctionCall, string) {
-	if params == nil || params.PendingFunctionCalls == nil || key == "" {
-		return nil, ""
+	if itemID := itemResult.Get("id").String(); itemID != "" {
+		keys = appendUniqueCodexFunctionCallKey(keys, "item:"+itemID)
 	}
-	pending, ok := params.PendingFunctionCalls[key]
-	if !ok {
-		return nil, ""
+	if itemID := rootResult.Get("item_id").String(); itemID != "" {
+		keys = appendUniqueCodexFunctionCallKey(keys, "item:"+itemID)
 	}
-	return pending, key
-}
-
-func pendingCodexFunctionCallForDone(params *ConvertCodexResponseToClaudeParams, rootResult, itemResult gjson.Result) (*pendingCodexFunctionCall, []string) {
-	if params == nil || params.PendingFunctionCalls == nil {
-		return nil, nil
-	}
-
-	keys := []string{codexFunctionCallKey(rootResult, itemResult)}
-	callID := codexFunctionCallID(itemResult)
-	if callID != "" {
-		keys = appendUniqueCodexFunctionCallKey(keys, codexFunctionCallIDKey(callID))
-	} else if !rootResult.Get("output_index").Exists() && params.LastPendingFunctionCallKey != "" {
-		keys = appendUniqueCodexFunctionCallKey(keys, params.LastPendingFunctionCallKey)
-	}
-
-	for _, key := range keys {
-		if pending, ok := params.PendingFunctionCalls[key]; ok {
-			return pending, keysForPendingCodexFunctionCall(params, pending)
-		}
-	}
-	return nil, nil
+	return keys
 }
 
 func appendUniqueCodexFunctionCallKey(keys []string, key string) []string {
@@ -601,29 +554,81 @@ func appendUniqueCodexFunctionCallKey(keys []string, key string) []string {
 	return append(keys, key)
 }
 
-func keysForPendingCodexFunctionCall(params *ConvertCodexResponseToClaudeParams, pending *pendingCodexFunctionCall) []string {
-	if params == nil || pending == nil || params.PendingFunctionCalls == nil {
+func codexFunctionCallForKeys(params *ConvertCodexResponseToClaudeParams, keys []string) *codexFunctionCallStream {
+	if params == nil || params.FunctionCalls == nil {
 		return nil
 	}
-
-	keys := make([]string, 0, 2)
-	for key, candidate := range params.PendingFunctionCalls {
-		if candidate == pending {
-			keys = append(keys, key)
+	for _, key := range keys {
+		if call := params.FunctionCalls[key]; call != nil {
+			return call
 		}
 	}
-	return keys
+	return nil
 }
 
-func deletePendingCodexFunctionCallAliases(params *ConvertCodexResponseToClaudeParams, keys []string) {
-	if params == nil || params.PendingFunctionCalls == nil {
+func codexFunctionCallForEvent(params *ConvertCodexResponseToClaudeParams, rootResult, itemResult gjson.Result) *codexFunctionCallStream {
+	keys := codexFunctionCallKeys(rootResult, itemResult)
+	if len(keys) > 0 {
+		return codexFunctionCallForKeys(params, keys)
+	}
+	if params == nil {
+		return nil
+	}
+	return params.LastFunctionCall
+}
+
+func recordCodexFunctionCall(params *ConvertCodexResponseToClaudeParams, rootResult, itemResult gjson.Result) *codexFunctionCallStream {
+	keys := codexFunctionCallKeys(rootResult, itemResult)
+	call := codexFunctionCallForKeys(params, keys)
+	if call == nil {
+		call = &codexFunctionCallStream{BlockIndex: -1}
+		params.FunctionCallQueue = append(params.FunctionCallQueue, call)
+	}
+	addCodexFunctionCallAliases(params, call, keys)
+	params.LastFunctionCall = call
+	return call
+}
+
+func addCodexFunctionCallAliases(params *ConvertCodexResponseToClaudeParams, call *codexFunctionCallStream, keys []string) {
+	if params == nil || call == nil {
 		return
 	}
+	if params.FunctionCalls == nil {
+		params.FunctionCalls = map[string]*codexFunctionCallStream{}
+	}
 	for _, key := range keys {
-		delete(params.PendingFunctionCalls, key)
-		if params.LastPendingFunctionCallKey == key {
-			params.LastPendingFunctionCallKey = ""
-		}
+		params.FunctionCalls[key] = call
+	}
+}
+
+func updateCodexFunctionCallIdentity(params *ConvertCodexResponseToClaudeParams, call *codexFunctionCallStream, rootResult, itemResult gjson.Result) {
+	if call == nil {
+		return
+	}
+	if callID := codexFunctionCallID(itemResult); callID != "" {
+		call.CallID = callID
+	}
+	if name := itemResult.Get("name").String(); name != "" {
+		call.Name = name
+	}
+	addCodexFunctionCallAliases(params, call, codexFunctionCallKeys(rootResult, itemResult))
+}
+
+func updateCodexFunctionCallArguments(call *codexFunctionCallStream, arguments string, delta bool) {
+	if call == nil || arguments == "" {
+		return
+	}
+	if delta {
+		call.Arguments += arguments
+		call.HasReceivedArgumentsDelta = true
+		return
+	}
+	if !call.HasReceivedArgumentsDelta {
+		call.Arguments = arguments
+		return
+	}
+	if strings.HasPrefix(arguments, call.Arguments) {
+		call.Arguments = arguments
 	}
 }
 
@@ -648,42 +653,78 @@ func appendCodexFunctionCallStop(output []byte, blockIndex int) []byte {
 	return translatorcommon.AppendSSEEventBytes(output, "content_block_stop", template, 2)
 }
 
-func appendCodexOpenFunctionCallStop(output []byte, params *ConvertCodexResponseToClaudeParams) []byte {
-	if params == nil || !params.FunctionCallBlockOpen {
+func appendCodexFunctionCallBufferedArguments(output []byte, params *ConvertCodexResponseToClaudeParams, call *codexFunctionCallStream) []byte {
+	if params == nil || call == nil || params.ActiveFunctionCall != call || !call.Started || call.Closed {
+		return output
+	}
+	if call.EmittedArgumentsLength >= len(call.Arguments) {
 		return output
 	}
 
-	blockIndex := params.FunctionCallBlockIndex
-	output = appendCodexFunctionCallStop(output, blockIndex)
-	if params.BlockIndex <= blockIndex {
-		params.BlockIndex = blockIndex + 1
-	}
-	params.FunctionCallBlockOpen = false
-	params.FunctionCallBlockCallID = ""
-	params.FunctionCallBlockIndex = 0
+	output = appendCodexFunctionCallArgumentDelta(output, call.Arguments[call.EmittedArgumentsLength:], call.BlockIndex)
+	call.EmittedArgumentsLength = len(call.Arguments)
 	return output
 }
 
-func hydrateOpenCodexFunctionCallFromTerminal(output []byte, params *ConvertCodexResponseToClaudeParams, responseData gjson.Result) []byte {
-	if params == nil || !params.FunctionCallBlockOpen || params.HasReceivedArgumentsDelta {
+func appendCodexFunctionCallQueue(output []byte, params *ConvertCodexResponseToClaudeParams, originalRequestRawJSON []byte) []byte {
+	if params == nil {
 		return output
 	}
 
-	responseData.Get("output").ForEach(func(_, item gjson.Result) bool {
-		if item.Get("type").String() != "function_call" || codexFunctionCallID(item) != params.FunctionCallBlockCallID {
-			return true
+	for {
+		if active := params.ActiveFunctionCall; active != nil {
+			output = appendCodexFunctionCallBufferedArguments(output, params, active)
+			if !active.Done {
+				return output
+			}
+			output = appendCodexFunctionCallStop(output, active.BlockIndex)
+			if params.BlockIndex <= active.BlockIndex {
+				params.BlockIndex = active.BlockIndex + 1
+			}
+			active.Closed = true
+			params.ActiveFunctionCall = nil
+			removeCodexFunctionCallFromQueue(params, active)
 		}
-		if args := item.Get("arguments").String(); args != "" {
-			output = appendCodexFunctionCallArgumentDelta(output, args, params.FunctionCallBlockIndex)
-			params.HasReceivedArgumentsDelta = true
+
+		for len(params.FunctionCallQueue) > 0 && params.FunctionCallQueue[0].Closed {
+			params.FunctionCallQueue = params.FunctionCallQueue[1:]
 		}
-		return false
-	})
-	return output
+		if len(params.FunctionCallQueue) == 0 {
+			return output
+		}
+
+		call := params.FunctionCallQueue[0]
+		if call.Name == "" {
+			return output
+		}
+
+		call.BlockIndex = params.BlockIndex
+		output = appendCodexFunctionCallStart(output, originalRequestRawJSON, call.CallID, call.Name, call.BlockIndex)
+		if call.EmitInitialEmptyDelta {
+			output = appendCodexFunctionCallArgumentDelta(output, "", call.BlockIndex)
+		}
+		call.Started = true
+		params.ActiveFunctionCall = call
+		params.HasEmittedToolUse = true
+		output = appendCodexFunctionCallBufferedArguments(output, params, call)
+	}
 }
 
-func appendPendingCodexFunctionCallsFromTerminal(output []byte, params *ConvertCodexResponseToClaudeParams, originalRequestRawJSON []byte, responseData gjson.Result) []byte {
-	if params == nil || len(params.PendingFunctionCalls) == 0 {
+func removeCodexFunctionCallFromQueue(params *ConvertCodexResponseToClaudeParams, call *codexFunctionCallStream) {
+	if params == nil || call == nil {
+		return
+	}
+	for index, queued := range params.FunctionCallQueue {
+		if queued != call {
+			continue
+		}
+		params.FunctionCallQueue = append(params.FunctionCallQueue[:index], params.FunctionCallQueue[index+1:]...)
+		return
+	}
+}
+
+func appendCodexFunctionCallsFromTerminal(output []byte, params *ConvertCodexResponseToClaudeParams, originalRequestRawJSON []byte, responseData gjson.Result) []byte {
+	if params == nil {
 		return output
 	}
 
@@ -692,88 +733,52 @@ func appendPendingCodexFunctionCallsFromTerminal(output []byte, params *ConvertC
 			return true
 		}
 
-		pending, pendingKeys := pendingCodexFunctionCallForTerminalItem(params, index, item)
-		if pending == nil {
-			return true
+		keys := codexFunctionCallKeys(gjson.Result{}, item)
+		if itemOutputIndex := item.Get("output_index"); itemOutputIndex.Exists() {
+			keys = appendUniqueCodexFunctionCallKey(keys, "output:"+itemOutputIndex.Raw)
 		}
-		if pending.StartEmitted {
-			deletePendingCodexFunctionCallAliases(params, pendingKeys)
-			return true
+		if index.Exists() {
+			keys = appendUniqueCodexFunctionCallKey(keys, "output:"+index.String())
 		}
-
-		name := item.Get("name").String()
-		if name == "" {
-			deletePendingCodexFunctionCallAliases(params, pendingKeys)
-			return true
+		call := codexFunctionCallForKeys(params, keys)
+		if call == nil {
+			call = &codexFunctionCallStream{BlockIndex: -1}
+			params.FunctionCallQueue = append(params.FunctionCallQueue, call)
 		}
-		callID := pending.CallID
-		if callID == "" {
-			callID = codexFunctionCallID(item)
-		}
-
-		blockIndex := params.BlockIndex
-		output = appendCodexFunctionCallStart(output, originalRequestRawJSON, callID, name, blockIndex)
-		params.HasEmittedToolUse = true
-		pending.StartEmitted = true
-
-		args := item.Get("arguments").String()
-		if args == "" {
-			args = pending.Arguments
-		}
-		if args != "" {
-			output = appendCodexFunctionCallArgumentDelta(output, args, blockIndex)
-		}
-		output = appendCodexFunctionCallStop(output, blockIndex)
-		params.BlockIndex++
-
-		deletePendingCodexFunctionCallAliases(params, pendingKeys)
+		addCodexFunctionCallAliases(params, call, keys)
+		updateCodexFunctionCallIdentity(params, call, gjson.Result{}, item)
+		updateCodexFunctionCallArguments(call, item.Get("arguments").String(), false)
+		call.Done = true
 		return true
 	})
 
-	clearPendingCodexFunctionCalls(params)
+	queuedCalls := params.FunctionCallQueue[:0]
+	for _, call := range params.FunctionCallQueue {
+		if call.Closed {
+			continue
+		}
+		if call.Name == "" {
+			call.Closed = true
+			continue
+		}
+		call.Done = true
+		queuedCalls = append(queuedCalls, call)
+	}
+	params.FunctionCallQueue = queuedCalls
+	output = appendCodexFunctionCallQueue(output, params, originalRequestRawJSON)
+
+	clearCodexFunctionCalls(params)
 	return output
 }
 
-func pendingCodexFunctionCallForTerminalItem(params *ConvertCodexResponseToClaudeParams, outputIndex, item gjson.Result) (*pendingCodexFunctionCall, []string) {
-	if params == nil || params.PendingFunctionCalls == nil {
-		return nil, nil
-	}
-
-	keys := make([]string, 0, 3)
-	if callID := codexFunctionCallID(item); callID != "" {
-		keys = appendUniqueCodexFunctionCallKey(keys, codexFunctionCallIDKey(callID))
-	}
-	if itemOutputIndex := item.Get("output_index"); itemOutputIndex.Exists() {
-		keys = appendUniqueCodexFunctionCallKey(keys, "output:"+itemOutputIndex.Raw)
-	}
-	if outputIndex.Exists() {
-		keys = appendUniqueCodexFunctionCallKey(keys, "output:"+outputIndex.Raw)
-	}
-
-	for _, key := range keys {
-		if pending, ok := params.PendingFunctionCalls[key]; ok {
-			return pending, keysForPendingCodexFunctionCall(params, pending)
-		}
-	}
-	return nil, nil
-}
-
-func clearPendingCodexFunctionCalls(params *ConvertCodexResponseToClaudeParams) {
-	if params == nil || params.PendingFunctionCalls == nil {
+func clearCodexFunctionCalls(params *ConvertCodexResponseToClaudeParams) {
+	if params == nil {
 		return
 	}
-	for key := range params.PendingFunctionCalls {
-		delete(params.PendingFunctionCalls, key)
-	}
-	params.LastPendingFunctionCallKey = ""
-}
-
-func finalizeCodexOpenContentBlocks(params *ConvertCodexResponseToClaudeParams) []byte {
-	output := make([]byte, 0, 256)
-	output = append(output, finalizeCodexThinkingBlock(params)...)
-	output = append(output, stopCodexTextBlock(params)...)
-	output = appendCodexOpenFunctionCallStop(output, params)
-	return output
+	clear(params.FunctionCalls)
+	params.FunctionCallQueue = nil
+	params.ActiveFunctionCall = nil
+	params.LastFunctionCall = nil
 }
 
 func resolveCodexClaudeToolUseName(originalRequestRawJSON []byte, name string) string {

--- a/internal/translator/codex/claude/codex_claude_response_test.go
+++ b/internal/translator/codex/claude/codex_claude_response_test.go
@@ -879,7 +879,7 @@ func TestConvertCodexResponseToClaude_StreamUnresolvedPendingFunctionCallDoesNot
 		t.Fatalf("stop_reason = %q, want end_turn. Outputs=%q", gotReason, outputs)
 	}
 	params, ok := param.(*ConvertCodexResponseToClaudeParams)
-	if !ok || len(params.PendingFunctionCalls) != 0 || params.LastPendingFunctionCallKey != "" {
+	if !ok || len(params.FunctionCalls) != 0 || len(params.FunctionCallQueue) != 0 || params.LastFunctionCall != nil {
 		t.Fatalf("pending function calls were not cleared: %#v", param)
 	}
 }

--- a/internal/translator/codex/claude/codex_claude_response_web_search.go
+++ b/internal/translator/codex/claude/codex_claude_response_web_search.go
@@ -28,6 +28,7 @@ func appendCodexWebSearchServerToolUse(output []byte, params *ConvertCodexRespon
 	}
 
 	if !alreadyStarted {
+		output = append(output, stopCodexTextBlock(params)...)
 		output = append(output, finalizeCodexThinkingBlock(params)...)
 		template := []byte(`{"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"","name":"web_search","input":{}}}`)
 		template, _ = sjson.SetBytes(template, "index", params.BlockIndex)

--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -24,21 +24,27 @@ const placeholderReasonDescription = "Brief explanation of why you are calling t
 // and replacements such as "enum" and "type" are fabricated. That regression reached production
 // once already; scope every call site to the schema itself.
 
-// CleanJSONSchemaForAntigravity transforms a JSON schema to be compatible with Antigravity API.
+// CleanJSONSchemaForAntigravity transforms a tool schema to be compatible with Antigravity API.
 // It handles unsupported keywords, type flattening, and schema simplification while preserving
-// semantic information as description hints.
+// semantic information as description hints and adding placeholders required by VALIDATED mode.
 func CleanJSONSchemaForAntigravity(jsonStr string) string {
-	return cleanJSONSchema(jsonStr, true)
+	return cleanJSONSchema(jsonStr, true, false)
+}
+
+// CleanJSONSchemaForAntigravityResponse transforms a response schema without adding tool-only
+// placeholders that would alter the client's structured output contract.
+func CleanJSONSchemaForAntigravityResponse(jsonStr string) string {
+	return cleanJSONSchema(jsonStr, false, false)
 }
 
 // CleanJSONSchemaForGemini transforms a JSON schema to be compatible with Gemini tool calling.
 // It removes unsupported keywords and simplifies schemas, without adding empty-schema placeholders.
 func CleanJSONSchemaForGemini(jsonStr string) string {
-	return cleanJSONSchema(jsonStr, false)
+	return cleanJSONSchema(jsonStr, false, true)
 }
 
 // cleanJSONSchema performs the core cleaning operations on the JSON schema.
-func cleanJSONSchema(jsonStr string, addPlaceholder bool) string {
+func cleanJSONSchema(jsonStr string, addPlaceholder, removeGeminiMetadata bool) string {
 	// Phase 1: Convert and add hints
 	jsonStr = convertRefsToHints(jsonStr)
 	jsonStr = convertConstToEnum(jsonStr)
@@ -54,7 +60,7 @@ func cleanJSONSchema(jsonStr string, addPlaceholder bool) string {
 
 	// Phase 3: Cleanup
 	jsonStr = removeUnsupportedKeywords(jsonStr)
-	if !addPlaceholder {
+	if removeGeminiMetadata {
 		// Gemini schema cleanup: remove nullable/title and placeholder-only fields.
 		jsonStr = removeKeywords(jsonStr, []string{"nullable", "title"})
 		jsonStr = removePlaceholderFields(jsonStr)

--- a/internal/util/gemini_schema_test.go
+++ b/internal/util/gemini_schema_test.go
@@ -733,6 +733,37 @@ func TestCleanJSONSchemaForAntigravity_EmptySchemaWithDescription(t *testing.T) 
 	}
 }
 
+func TestCleanJSONSchemaForAntigravityResponseDoesNotAddToolPlaceholders(t *testing.T) {
+	bare := gjson.Parse(CleanJSONSchemaForAntigravityResponse(`{"type":"object"}`))
+	if bare.Get("properties.reason").Exists() || bare.Get("required").Exists() {
+		t.Fatalf("bare response schema gained tool placeholders: %s", bare.Raw)
+	}
+
+	input := `{
+		"type":"object",
+		"title":"Response",
+		"nullable":true,
+		"properties":{
+			"empty":{"type":"object"},
+			"optional":{"type":"object","properties":{"value":{"type":"string"}}}
+		}
+	}`
+	result := gjson.Parse(CleanJSONSchemaForAntigravityResponse(input))
+	for _, path := range []string{
+		"properties.empty.properties.reason",
+		"properties.empty.required",
+		"properties.optional.properties._",
+		"properties.optional.required",
+	} {
+		if result.Get(path).Exists() {
+			t.Errorf("response schema gained tool-only field %s: %s", path, result.Raw)
+		}
+	}
+	if result.Get("title").String() != "Response" || !result.Get("nullable").Bool() {
+		t.Errorf("Antigravity response metadata was removed: %s", result.Raw)
+	}
+}
+
 // ============================================================================
 // Format field handling (ad-hoc patch removal)
 // ============================================================================

--- a/internal/watcher/clients.go
+++ b/internal/watcher/clients.go
@@ -119,7 +119,10 @@ func (w *Watcher) reloadClients(rescanAuth bool, affectedOAuthProviders []string
 							IDGenerator:      synthesizer.NewStableIDGenerator(),
 							PluginAuthParser: parser,
 						}
-						if generated := synthesizer.SynthesizeAuthFile(ctx, fullPath, data); len(generated) > 0 {
+						generated, errSynthesize := synthesizer.SynthesizeAuthFile(ctx, fullPath, data)
+						if errSynthesize != nil {
+							log.WithError(errSynthesize).Warnf("skipping auth file %s", name)
+						} else if len(generated) > 0 {
 							if pathAuths := authSliceToMap(generated); len(pathAuths) > 0 {
 								newFileAuthsByPath[normalizedPath] = authIDSet(pathAuths)
 							}
@@ -250,7 +253,10 @@ func (w *Watcher) addOrUpdateClientLocked(path string) {
 		IDGenerator:      synthesizer.NewStableIDGenerator(),
 		PluginAuthParser: parser,
 	}
-	generated := synthesizer.SynthesizeAuthFile(sctx, path, data)
+	generated, errSynthesize := synthesizer.SynthesizeAuthFile(sctx, path, data)
+	if errSynthesize != nil {
+		log.WithError(errSynthesize).Warnf("skipping auth file %s", filepath.Base(path))
+	}
 	newByID := authSliceToMap(generated)
 	w.clientsMutex.Lock()
 	if len(newByID) > 0 {
@@ -261,7 +267,9 @@ func (w *Watcher) addOrUpdateClientLocked(path string) {
 	updates := w.computePerPathUpdatesLocked(oldByID, newByID)
 	w.clientsMutex.Unlock()
 
-	w.persistAuthAsync(fmt.Sprintf("Sync auth %s", filepath.Base(path)), path)
+	if errSynthesize == nil {
+		w.persistAuthAsync(fmt.Sprintf("Sync auth %s", filepath.Base(path)), path)
+	}
 	w.dispatchAuthUpdates(updates)
 	redisqueue.NotifyUsageRefresh()
 }

--- a/internal/watcher/diff/model_hash.go
+++ b/internal/watcher/diff/model_hash.go
@@ -4,87 +4,38 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"sort"
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/modelconfig"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 )
 
 // ComputeOpenAICompatModelsHash returns a stable hash for OpenAI-compat models.
 // Used to detect model list changes during hot reload.
 func ComputeOpenAICompatModelsHash(models []config.OpenAICompatibilityModel) string {
-	keys := normalizeModelPairs(func(out func(key string)) {
-		for _, model := range models {
-			name := strings.TrimSpace(model.Name)
-			alias := strings.TrimSpace(model.Alias)
-			if name == "" && alias == "" {
-				continue
-			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("image=%t", model.Image))
-		}
-	})
-	return hashJoined(keys)
+	return modelconfig.ComputeOpenAICompatModelsHash(models)
 }
 
 // ComputeVertexCompatModelsHash returns a stable hash for Vertex-compatible models.
 func ComputeVertexCompatModelsHash(models []config.VertexCompatModel) string {
-	keys := normalizeModelPairs(func(out func(key string)) {
-		for _, model := range models {
-			name := strings.TrimSpace(model.Name)
-			alias := strings.TrimSpace(model.Alias)
-			if name == "" && alias == "" {
-				continue
-			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName))
-		}
-	})
-	return hashJoined(keys)
+	return modelconfig.ComputeVertexCompatModelsHash(models)
 }
 
 // ComputeClaudeModelsHash returns a stable hash for Claude model aliases.
 func ComputeClaudeModelsHash(models []config.ClaudeModel) string {
-	keys := normalizeModelPairs(func(out func(key string)) {
-		for _, model := range models {
-			name := strings.TrimSpace(model.Name)
-			alias := strings.TrimSpace(model.Alias)
-			if name == "" && alias == "" {
-				continue
-			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName))
-		}
-	})
-	return hashJoined(keys)
+	return modelconfig.ComputeClaudeModelsHash(models)
 }
 
 // ComputeCodexModelsHash returns a stable hash for Codex model aliases.
 func ComputeCodexModelsHash(models []config.CodexModel) string {
-	keys := normalizeModelPairs(func(out func(key string)) {
-		for _, model := range models {
-			name := strings.TrimSpace(model.Name)
-			alias := strings.TrimSpace(model.Alias)
-			if name == "" && alias == "" {
-				continue
-			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|" + fmt.Sprintf("force-mapping=%t", model.ForceMapping))
-		}
-	})
-	return hashJoined(keys)
+	return modelconfig.ComputeCodexModelsHash(models)
 }
 
 // ComputeGeminiModelsHash returns a stable hash for Gemini model aliases.
 func ComputeGeminiModelsHash(models []config.GeminiModel) string {
-	keys := normalizeModelPairs(func(out func(key string)) {
-		for _, model := range models {
-			name := strings.TrimSpace(model.Name)
-			alias := strings.TrimSpace(model.Alias)
-			if name == "" && alias == "" {
-				continue
-			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName))
-		}
-	})
-	return hashJoined(keys)
+	return modelconfig.ComputeGeminiModelsHash(models)
 }
 
 // ComputeExcludedModelsHash returns a normalized hash for excluded model lists.
@@ -105,6 +56,11 @@ func ComputeExcludedModelsHash(excluded []string) string {
 	data, _ := json.Marshal(normalized)
 	sum := sha256.Sum256(data)
 	return hex.EncodeToString(sum[:])
+}
+
+func thinkingHashSuffix(support *registry.ThinkingSupport) string {
+	data, _ := json.Marshal(support)
+	return "|thinking=" + string(data)
 }
 
 func normalizeModelPairs(collect func(out func(key string))) []string {

--- a/internal/watcher/diff/model_hash_test.go
+++ b/internal/watcher/diff/model_hash_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 )
 
 func TestComputeOpenAICompatModelsHash_Deterministic(t *testing.T) {
@@ -36,7 +37,20 @@ func TestComputeOpenAICompatModelsHash_IncludesImageFlag(t *testing.T) {
 	}
 }
 
-func TestComputeOpenAICompatModelsHash_NormalizesAndDedups(t *testing.T) {
+func TestComputeOpenAICompatModelsHashIncludesModalities(t *testing.T) {
+	base := []config.OpenAICompatibilityModel{{Name: "model", InputModalities: []string{"text"}, OutputModalities: []string{"text"}}}
+	inputChanged := []config.OpenAICompatibilityModel{{Name: "model", InputModalities: []string{"text", "image"}, OutputModalities: []string{"text"}}}
+	outputChanged := []config.OpenAICompatibilityModel{{Name: "model", InputModalities: []string{"text"}, OutputModalities: []string{"text", "image"}}}
+	baseHash := ComputeOpenAICompatModelsHash(base)
+	if baseHash == ComputeOpenAICompatModelsHash(inputChanged) {
+		t.Fatal("input modalities did not change model hash")
+	}
+	if baseHash == ComputeOpenAICompatModelsHash(outputChanged) {
+		t.Fatal("output modalities did not change model hash")
+	}
+}
+
+func TestComputeOpenAICompatModelsHashPreservesRoutingOrderAndDuplicates(t *testing.T) {
 	a := []config.OpenAICompatibilityModel{
 		{Name: "gpt-4", Alias: "gpt4"},
 		{Name: " "},
@@ -52,8 +66,8 @@ func TestComputeOpenAICompatModelsHash_NormalizesAndDedups(t *testing.T) {
 	if h1 == "" || h2 == "" {
 		t.Fatal("expected non-empty hashes for non-empty model sets")
 	}
-	if h1 != h2 {
-		t.Fatalf("expected normalized hashes to match, got %s / %s", h1, h2)
+	if h1 == h2 {
+		t.Fatalf("expected routing order and duplicates to change hashes, got %s", h1)
 	}
 }
 
@@ -69,7 +83,7 @@ func TestComputeVertexCompatModelsHash_DifferentInputs(t *testing.T) {
 	}
 }
 
-func TestComputeVertexCompatModelsHash_IgnoresBlankAndOrder(t *testing.T) {
+func TestComputeVertexCompatModelsHashPreservesDuplicates(t *testing.T) {
 	a := []config.VertexCompatModel{
 		{Name: "m1", Alias: "a1"},
 		{Name: " "},
@@ -78,8 +92,8 @@ func TestComputeVertexCompatModelsHash_IgnoresBlankAndOrder(t *testing.T) {
 	b := []config.VertexCompatModel{
 		{Name: "m1", Alias: "a1"},
 	}
-	if h1, h2 := ComputeVertexCompatModelsHash(a), ComputeVertexCompatModelsHash(b); h1 == "" || h1 != h2 {
-		t.Fatalf("expected same hash ignoring blanks/dupes, got %q / %q", h1, h2)
+	if h1, h2 := ComputeVertexCompatModelsHash(a), ComputeVertexCompatModelsHash(b); h1 == "" || h1 == h2 {
+		t.Fatalf("expected duplicate routing entries to change hash, got %q / %q", h1, h2)
 	}
 }
 
@@ -101,7 +115,7 @@ func TestComputeCodexModelsHash_Empty(t *testing.T) {
 	}
 }
 
-func TestComputeClaudeModelsHash_IgnoresBlankAndDedup(t *testing.T) {
+func TestComputeClaudeModelsHashPreservesDuplicates(t *testing.T) {
 	a := []config.ClaudeModel{
 		{Name: "m1", Alias: "a1"},
 		{Name: " "},
@@ -110,12 +124,12 @@ func TestComputeClaudeModelsHash_IgnoresBlankAndDedup(t *testing.T) {
 	b := []config.ClaudeModel{
 		{Name: "m1", Alias: "a1"},
 	}
-	if h1, h2 := ComputeClaudeModelsHash(a), ComputeClaudeModelsHash(b); h1 == "" || h1 != h2 {
-		t.Fatalf("expected same hash ignoring blanks/dupes, got %q / %q", h1, h2)
+	if h1, h2 := ComputeClaudeModelsHash(a), ComputeClaudeModelsHash(b); h1 == "" || h1 == h2 {
+		t.Fatalf("expected duplicate routing entries to change hash, got %q / %q", h1, h2)
 	}
 }
 
-func TestComputeCodexModelsHash_IgnoresBlankAndDedup(t *testing.T) {
+func TestComputeCodexModelsHashPreservesDuplicates(t *testing.T) {
 	a := []config.CodexModel{
 		{Name: "m1", Alias: "a1"},
 		{Name: " "},
@@ -124,8 +138,8 @@ func TestComputeCodexModelsHash_IgnoresBlankAndDedup(t *testing.T) {
 	b := []config.CodexModel{
 		{Name: "m1", Alias: "a1"},
 	}
-	if h1, h2 := ComputeCodexModelsHash(a), ComputeCodexModelsHash(b); h1 == "" || h1 != h2 {
-		t.Fatalf("expected same hash ignoring blanks/dupes, got %q / %q", h1, h2)
+	if h1, h2 := ComputeCodexModelsHash(a), ComputeCodexModelsHash(b); h1 == "" || h1 == h2 {
+		t.Fatalf("expected duplicate routing entries to change hash, got %q / %q", h1, h2)
 	}
 }
 
@@ -176,6 +190,21 @@ func TestComputeCodexModelsHashIncludesForceMapping(t *testing.T) {
 	withForceMapping := ComputeCodexModelsHash([]config.CodexModel{{Name: "m", Alias: "a", ForceMapping: true}})
 	if withoutForceMapping == "" || withoutForceMapping == withForceMapping {
 		t.Fatalf("force-mapping must change model hash: %q / %q", withoutForceMapping, withForceMapping)
+	}
+}
+
+func TestComputeOtherModelHashesIncludeForceMapping(t *testing.T) {
+	if ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{Name: "m"}}) == ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{Name: "m", ForceMapping: true}}) {
+		t.Fatal("OpenAI compatibility force-mapping did not change model hash")
+	}
+	if ComputeVertexCompatModelsHash([]config.VertexCompatModel{{Name: "m"}}) == ComputeVertexCompatModelsHash([]config.VertexCompatModel{{Name: "m", ForceMapping: true}}) {
+		t.Fatal("Vertex force-mapping did not change model hash")
+	}
+	if ComputeClaudeModelsHash([]config.ClaudeModel{{Name: "m"}}) == ComputeClaudeModelsHash([]config.ClaudeModel{{Name: "m", ForceMapping: true}}) {
+		t.Fatal("Claude force-mapping did not change model hash")
+	}
+	if ComputeGeminiModelsHash([]config.GeminiModel{{Name: "m"}}) == ComputeGeminiModelsHash([]config.GeminiModel{{Name: "m", ForceMapping: true}}) {
+		t.Fatal("Gemini force-mapping did not change model hash")
 	}
 }
 
@@ -251,5 +280,28 @@ func TestComputeCodexModelsHash_Deterministic(t *testing.T) {
 	}
 	if h3 := ComputeCodexModelsHash([]config.CodexModel{{Name: "a"}}); h3 == h1 {
 		t.Fatalf("expected different hash when models change, got %s", h3)
+	}
+}
+
+func TestComputeModelHashesIncludeThinking(t *testing.T) {
+	low := &registry.ThinkingSupport{Levels: []string{"low"}}
+	high := &registry.ThinkingSupport{Levels: []string{"high"}}
+	tests := []struct {
+		name string
+		low  string
+		high string
+	}{
+		{name: "openai compatibility", low: ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{Name: "m", Thinking: low}}), high: ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{Name: "m", Thinking: high}})},
+		{name: "vertex", low: ComputeVertexCompatModelsHash([]config.VertexCompatModel{{Name: "m", Thinking: low}}), high: ComputeVertexCompatModelsHash([]config.VertexCompatModel{{Name: "m", Thinking: high}})},
+		{name: "claude", low: ComputeClaudeModelsHash([]config.ClaudeModel{{Name: "m", Thinking: low}}), high: ComputeClaudeModelsHash([]config.ClaudeModel{{Name: "m", Thinking: high}})},
+		{name: "codex", low: ComputeCodexModelsHash([]config.CodexModel{{Name: "m", Thinking: low}}), high: ComputeCodexModelsHash([]config.CodexModel{{Name: "m", Thinking: high}})},
+		{name: "gemini", low: ComputeGeminiModelsHash([]config.GeminiModel{{Name: "m", Thinking: low}}), high: ComputeGeminiModelsHash([]config.GeminiModel{{Name: "m", Thinking: high}})},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.low == "" || tc.low == tc.high {
+				t.Fatalf("thinking capability must change model hash: %q / %q", tc.low, tc.high)
+			}
+		})
 	}
 }

--- a/internal/watcher/diff/model_hash_test.go
+++ b/internal/watcher/diff/model_hash_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 )
 
 func TestComputeOpenAICompatModelsHash_Deterministic(t *testing.T) {
@@ -36,7 +37,20 @@ func TestComputeOpenAICompatModelsHash_IncludesImageFlag(t *testing.T) {
 	}
 }
 
-func TestComputeOpenAICompatModelsHash_NormalizesAndDedups(t *testing.T) {
+func TestComputeOpenAICompatModelsHashIncludesModalities(t *testing.T) {
+	base := []config.OpenAICompatibilityModel{{Name: "model", InputModalities: []string{"text"}, OutputModalities: []string{"text"}}}
+	inputChanged := []config.OpenAICompatibilityModel{{Name: "model", InputModalities: []string{"text", "image"}, OutputModalities: []string{"text"}}}
+	outputChanged := []config.OpenAICompatibilityModel{{Name: "model", InputModalities: []string{"text"}, OutputModalities: []string{"text", "image"}}}
+	baseHash := ComputeOpenAICompatModelsHash(base)
+	if baseHash == ComputeOpenAICompatModelsHash(inputChanged) {
+		t.Fatal("input modalities did not change model hash")
+	}
+	if baseHash == ComputeOpenAICompatModelsHash(outputChanged) {
+		t.Fatal("output modalities did not change model hash")
+	}
+}
+
+func TestComputeOpenAICompatModelsHashPreservesRoutingOrderAndDuplicates(t *testing.T) {
 	a := []config.OpenAICompatibilityModel{
 		{Name: "gpt-4", Alias: "gpt4"},
 		{Name: " "},
@@ -52,8 +66,8 @@ func TestComputeOpenAICompatModelsHash_NormalizesAndDedups(t *testing.T) {
 	if h1 == "" || h2 == "" {
 		t.Fatal("expected non-empty hashes for non-empty model sets")
 	}
-	if h1 != h2 {
-		t.Fatalf("expected normalized hashes to match, got %s / %s", h1, h2)
+	if h1 == h2 {
+		t.Fatalf("expected routing order and duplicates to change hashes, got %s", h1)
 	}
 }
 
@@ -80,7 +94,7 @@ func TestComputeVertexCompatModelsHash_DifferentInputs(t *testing.T) {
 	}
 }
 
-func TestComputeVertexCompatModelsHash_IgnoresBlankAndOrder(t *testing.T) {
+func TestComputeVertexCompatModelsHashPreservesDuplicates(t *testing.T) {
 	a := []config.VertexCompatModel{
 		{Name: "m1", Alias: "a1"},
 		{Name: " "},
@@ -89,8 +103,8 @@ func TestComputeVertexCompatModelsHash_IgnoresBlankAndOrder(t *testing.T) {
 	b := []config.VertexCompatModel{
 		{Name: "m1", Alias: "a1"},
 	}
-	if h1, h2 := ComputeVertexCompatModelsHash(a), ComputeVertexCompatModelsHash(b); h1 == "" || h1 != h2 {
-		t.Fatalf("expected same hash ignoring blanks/dupes, got %q / %q", h1, h2)
+	if h1, h2 := ComputeVertexCompatModelsHash(a), ComputeVertexCompatModelsHash(b); h1 == "" || h1 == h2 {
+		t.Fatalf("expected duplicate routing entries to change hash, got %q / %q", h1, h2)
 	}
 }
 
@@ -112,7 +126,7 @@ func TestComputeCodexModelsHash_Empty(t *testing.T) {
 	}
 }
 
-func TestComputeClaudeModelsHash_IgnoresBlankAndDedup(t *testing.T) {
+func TestComputeClaudeModelsHashPreservesDuplicates(t *testing.T) {
 	a := []config.ClaudeModel{
 		{Name: "m1", Alias: "a1"},
 		{Name: " "},
@@ -121,12 +135,12 @@ func TestComputeClaudeModelsHash_IgnoresBlankAndDedup(t *testing.T) {
 	b := []config.ClaudeModel{
 		{Name: "m1", Alias: "a1"},
 	}
-	if h1, h2 := ComputeClaudeModelsHash(a), ComputeClaudeModelsHash(b); h1 == "" || h1 != h2 {
-		t.Fatalf("expected same hash ignoring blanks/dupes, got %q / %q", h1, h2)
+	if h1, h2 := ComputeClaudeModelsHash(a), ComputeClaudeModelsHash(b); h1 == "" || h1 == h2 {
+		t.Fatalf("expected duplicate routing entries to change hash, got %q / %q", h1, h2)
 	}
 }
 
-func TestComputeCodexModelsHash_IgnoresBlankAndDedup(t *testing.T) {
+func TestComputeCodexModelsHashPreservesDuplicates(t *testing.T) {
 	a := []config.CodexModel{
 		{Name: "m1", Alias: "a1"},
 		{Name: " "},
@@ -135,8 +149,8 @@ func TestComputeCodexModelsHash_IgnoresBlankAndDedup(t *testing.T) {
 	b := []config.CodexModel{
 		{Name: "m1", Alias: "a1"},
 	}
-	if h1, h2 := ComputeCodexModelsHash(a), ComputeCodexModelsHash(b); h1 == "" || h1 != h2 {
-		t.Fatalf("expected same hash ignoring blanks/dupes, got %q / %q", h1, h2)
+	if h1, h2 := ComputeCodexModelsHash(a), ComputeCodexModelsHash(b); h1 == "" || h1 == h2 {
+		t.Fatalf("expected duplicate routing entries to change hash, got %q / %q", h1, h2)
 	}
 }
 
@@ -187,6 +201,21 @@ func TestComputeCodexModelsHashIncludesForceMapping(t *testing.T) {
 	withForceMapping := ComputeCodexModelsHash([]config.CodexModel{{Name: "m", Alias: "a", ForceMapping: true}})
 	if withoutForceMapping == "" || withoutForceMapping == withForceMapping {
 		t.Fatalf("force-mapping must change model hash: %q / %q", withoutForceMapping, withForceMapping)
+	}
+}
+
+func TestComputeOtherModelHashesIncludeForceMapping(t *testing.T) {
+	if ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{Name: "m"}}) == ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{Name: "m", ForceMapping: true}}) {
+		t.Fatal("OpenAI compatibility force-mapping did not change model hash")
+	}
+	if ComputeVertexCompatModelsHash([]config.VertexCompatModel{{Name: "m"}}) == ComputeVertexCompatModelsHash([]config.VertexCompatModel{{Name: "m", ForceMapping: true}}) {
+		t.Fatal("Vertex force-mapping did not change model hash")
+	}
+	if ComputeClaudeModelsHash([]config.ClaudeModel{{Name: "m"}}) == ComputeClaudeModelsHash([]config.ClaudeModel{{Name: "m", ForceMapping: true}}) {
+		t.Fatal("Claude force-mapping did not change model hash")
+	}
+	if ComputeGeminiModelsHash([]config.GeminiModel{{Name: "m"}}) == ComputeGeminiModelsHash([]config.GeminiModel{{Name: "m", ForceMapping: true}}) {
+		t.Fatal("Gemini force-mapping did not change model hash")
 	}
 }
 
@@ -262,5 +291,28 @@ func TestComputeCodexModelsHash_Deterministic(t *testing.T) {
 	}
 	if h3 := ComputeCodexModelsHash([]config.CodexModel{{Name: "a"}}); h3 == h1 {
 		t.Fatalf("expected different hash when models change, got %s", h3)
+	}
+}
+
+func TestComputeModelHashesIncludeThinking(t *testing.T) {
+	low := &registry.ThinkingSupport{Levels: []string{"low"}}
+	high := &registry.ThinkingSupport{Levels: []string{"high"}}
+	tests := []struct {
+		name string
+		low  string
+		high string
+	}{
+		{name: "openai compatibility", low: ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{Name: "m", Thinking: low}}), high: ComputeOpenAICompatModelsHash([]config.OpenAICompatibilityModel{{Name: "m", Thinking: high}})},
+		{name: "vertex", low: ComputeVertexCompatModelsHash([]config.VertexCompatModel{{Name: "m", Thinking: low}}), high: ComputeVertexCompatModelsHash([]config.VertexCompatModel{{Name: "m", Thinking: high}})},
+		{name: "claude", low: ComputeClaudeModelsHash([]config.ClaudeModel{{Name: "m", Thinking: low}}), high: ComputeClaudeModelsHash([]config.ClaudeModel{{Name: "m", Thinking: high}})},
+		{name: "codex", low: ComputeCodexModelsHash([]config.CodexModel{{Name: "m", Thinking: low}}), high: ComputeCodexModelsHash([]config.CodexModel{{Name: "m", Thinking: high}})},
+		{name: "gemini", low: ComputeGeminiModelsHash([]config.GeminiModel{{Name: "m", Thinking: low}}), high: ComputeGeminiModelsHash([]config.GeminiModel{{Name: "m", Thinking: high}})},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.low == "" || tc.low == tc.high {
+				t.Fatalf("thinking capability must change model hash: %q / %q", tc.low, tc.high)
+			}
+		})
 	}
 }

--- a/internal/watcher/diff/models_summary.go
+++ b/internal/watcher/diff/models_summary.go
@@ -41,7 +41,7 @@ func SummarizeGeminiModels(models []config.GeminiModel) GeminiModelsSummary {
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + thinkingHashSuffix(model.Thinking))
 		}
 	})
 	return GeminiModelsSummary{
@@ -62,7 +62,7 @@ func SummarizeClaudeModels(models []config.ClaudeModel) ClaudeModelsSummary {
 			if name == "" && alias == "" {
 				continue
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName))
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + thinkingHashSuffix(model.Thinking))
 		}
 	})
 	return ClaudeModelsSummary{
@@ -87,7 +87,7 @@ func SummarizeCodexModels(models []config.CodexModel) CodexModelsSummary {
 			if model.ForceMapping {
 				forceMapping = "true"
 			}
-			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|force-mapping=" + forceMapping)
+			out(strings.ToLower(name) + "|" + strings.ToLower(alias) + "|" + strings.TrimSpace(model.DisplayName) + "|force-mapping=" + forceMapping + thinkingHashSuffix(model.Thinking))
 		}
 	})
 	return CodexModelsSummary{
@@ -111,7 +111,7 @@ func SummarizeVertexModels(models []config.VertexCompatModel) VertexModelsSummar
 		if alias != "" {
 			name = alias
 		}
-		names = append(names, name+"|"+strings.TrimSpace(model.DisplayName))
+		names = append(names, name+"|"+strings.TrimSpace(model.DisplayName)+thinkingHashSuffix(model.Thinking))
 	}
 	if len(names) == 0 {
 		return VertexModelsSummary{}

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -21,11 +21,25 @@ func NewConfigSynthesizer() *ConfigSynthesizer {
 	return &ConfigSynthesizer{}
 }
 
+func addWeightToAttrs(weight *int, attrs map[string]string) {
+	if weight == nil {
+		return
+	}
+	normalized := *weight
+	if normalized <= 0 {
+		normalized = 0
+	}
+	attrs[coreauth.AttributeWeight] = strconv.Itoa(normalized)
+}
+
 // Synthesize generates Auth entries from config API keys.
 func (s *ConfigSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth, error) {
 	out := make([]*coreauth.Auth, 0, 32)
 	if ctx == nil || ctx.Config == nil {
 		return out, nil
+	}
+	if errValidate := ctx.Config.ValidateCredentialWeights(); errValidate != nil {
+		return nil, fmt.Errorf("synthesize config API key auths: %w", errValidate)
 	}
 
 	// Gemini API Keys
@@ -73,8 +87,9 @@ func (s *ConfigSynthesizer) synthesizeGeminiKeyEntries(ctx *SynthesisContext, en
 		proxyURL := strings.TrimSpace(entry.ProxyURL)
 		id, token := idGen.Next(idKind, key, base)
 		attrs := map[string]string{
-			"source":  fmt.Sprintf("config:%s[%s]", sourceName, token),
-			"api_key": key,
+			"source":       fmt.Sprintf("config:%s[%s]", sourceName, token),
+			"api_key":      key,
+			"config_index": strconv.Itoa(i),
 		}
 		metadata := map[string]any{}
 		if entry.DisableCooling {
@@ -83,6 +98,7 @@ func (s *ConfigSynthesizer) synthesizeGeminiKeyEntries(ctx *SynthesisContext, en
 		if entry.Priority != 0 {
 			attrs["priority"] = strconv.Itoa(entry.Priority)
 		}
+		addWeightToAttrs(entry.Weight, attrs)
 		if base != "" {
 			attrs["base_url"] = base
 		}
@@ -128,8 +144,9 @@ func (s *ConfigSynthesizer) synthesizeClaudeKeys(ctx *SynthesisContext) []*corea
 		base := strings.TrimSpace(ck.BaseURL)
 		id, token := idGen.Next("claude:apikey", key, base)
 		attrs := map[string]string{
-			"source":  fmt.Sprintf("config:claude[%s]", token),
-			"api_key": key,
+			"source":       fmt.Sprintf("config:claude[%s]", token),
+			"api_key":      key,
+			"config_index": strconv.Itoa(i),
 		}
 		metadata := map[string]any{}
 		if ck.DisableCooling {
@@ -138,6 +155,7 @@ func (s *ConfigSynthesizer) synthesizeClaudeKeys(ctx *SynthesisContext) []*corea
 		if ck.Priority != 0 {
 			attrs["priority"] = strconv.Itoa(ck.Priority)
 		}
+		addWeightToAttrs(ck.Weight, attrs)
 		if base != "" {
 			attrs["base_url"] = base
 		}
@@ -196,8 +214,9 @@ func (s *ConfigSynthesizer) synthesizeCodexStyleKeys(ctx *SynthesisContext, entr
 		baseURL := strings.TrimSpace(entry.BaseURL)
 		id, token := idGen.Next(provider+":apikey", key, baseURL)
 		attrs := map[string]string{
-			"source":  fmt.Sprintf("config:%s[%s]", provider, token),
-			"api_key": key,
+			"source":       fmt.Sprintf("config:%s[%s]", provider, token),
+			"api_key":      key,
+			"config_index": strconv.Itoa(i),
 		}
 		metadata := map[string]any{}
 		if entry.DisableCooling {
@@ -206,6 +225,7 @@ func (s *ConfigSynthesizer) synthesizeCodexStyleKeys(ctx *SynthesisContext, entr
 		if entry.Priority != 0 {
 			attrs["priority"] = strconv.Itoa(entry.Priority)
 		}
+		addWeightToAttrs(entry.Weight, attrs)
 		if baseURL != "" {
 			attrs["base_url"] = baseURL
 		}
@@ -271,6 +291,7 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 				"base_url":     base,
 				"compat_name":  compat.Name,
 				"provider_key": internalProviderKey,
+				"config_index": strconv.Itoa(i),
 			}
 			metadata := map[string]any{}
 			if disableCooling {
@@ -279,6 +300,7 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 			if compat.Priority != 0 {
 				attrs["priority"] = strconv.Itoa(compat.Priority)
 			}
+			addWeightToAttrs(entry.Weight, attrs)
 			if key != "" {
 				attrs["api_key"] = key
 			}
@@ -313,6 +335,7 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 				"base_url":     base,
 				"compat_name":  compat.Name,
 				"provider_key": internalProviderKey,
+				"config_index": strconv.Itoa(i),
 			}
 			metadata := map[string]any{}
 			if disableCooling {
@@ -366,10 +389,12 @@ func (s *ConfigSynthesizer) synthesizeVertexCompat(ctx *SynthesisContext) []*cor
 			"source":       fmt.Sprintf("config:vertex-apikey[%s]", token),
 			"base_url":     base,
 			"provider_key": providerName,
+			"config_index": strconv.Itoa(i),
 		}
 		if compat.Priority != 0 {
 			attrs["priority"] = strconv.Itoa(compat.Priority)
 		}
+		addWeightToAttrs(compat.Weight, attrs)
 		if key != "" {
 			attrs["api_key"] = key
 		}

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -87,8 +87,9 @@ func (s *ConfigSynthesizer) synthesizeGeminiKeyEntries(ctx *SynthesisContext, en
 		proxyURL := strings.TrimSpace(entry.ProxyURL)
 		id, token := idGen.Next(idKind, key, base)
 		attrs := map[string]string{
-			"source":  fmt.Sprintf("config:%s[%s]", sourceName, token),
-			"api_key": key,
+			"source":       fmt.Sprintf("config:%s[%s]", sourceName, token),
+			"api_key":      key,
+			"config_index": strconv.Itoa(i),
 		}
 		metadata := map[string]any{}
 		if entry.DisableCooling {
@@ -143,8 +144,9 @@ func (s *ConfigSynthesizer) synthesizeClaudeKeys(ctx *SynthesisContext) []*corea
 		base := strings.TrimSpace(ck.BaseURL)
 		id, token := idGen.Next("claude:apikey", key, base)
 		attrs := map[string]string{
-			"source":  fmt.Sprintf("config:claude[%s]", token),
-			"api_key": key,
+			"source":       fmt.Sprintf("config:claude[%s]", token),
+			"api_key":      key,
+			"config_index": strconv.Itoa(i),
 		}
 		metadata := map[string]any{}
 		if ck.DisableCooling {
@@ -212,8 +214,9 @@ func (s *ConfigSynthesizer) synthesizeCodexStyleKeys(ctx *SynthesisContext, entr
 		baseURL := strings.TrimSpace(entry.BaseURL)
 		id, token := idGen.Next(provider+":apikey", key, baseURL)
 		attrs := map[string]string{
-			"source":  fmt.Sprintf("config:%s[%s]", provider, token),
-			"api_key": key,
+			"source":       fmt.Sprintf("config:%s[%s]", provider, token),
+			"api_key":      key,
+			"config_index": strconv.Itoa(i),
 		}
 		metadata := map[string]any{}
 		if entry.DisableCooling {
@@ -288,6 +291,7 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 				"base_url":     base,
 				"compat_name":  compat.Name,
 				"provider_key": internalProviderKey,
+				"config_index": strconv.Itoa(i),
 			}
 			metadata := map[string]any{}
 			if disableCooling {
@@ -331,6 +335,7 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 				"base_url":     base,
 				"compat_name":  compat.Name,
 				"provider_key": internalProviderKey,
+				"config_index": strconv.Itoa(i),
 			}
 			metadata := map[string]any{}
 			if disableCooling {
@@ -384,6 +389,7 @@ func (s *ConfigSynthesizer) synthesizeVertexCompat(ctx *SynthesisContext) []*cor
 			"source":       fmt.Sprintf("config:vertex-apikey[%s]", token),
 			"base_url":     base,
 			"provider_key": providerName,
+			"config_index": strconv.Itoa(i),
 		}
 		if compat.Priority != 0 {
 			attrs["priority"] = strconv.Itoa(compat.Priority)

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -21,11 +21,25 @@ func NewConfigSynthesizer() *ConfigSynthesizer {
 	return &ConfigSynthesizer{}
 }
 
+func addWeightToAttrs(weight *int, attrs map[string]string) {
+	if weight == nil {
+		return
+	}
+	normalized := *weight
+	if normalized <= 0 {
+		normalized = 0
+	}
+	attrs[coreauth.AttributeWeight] = strconv.Itoa(normalized)
+}
+
 // Synthesize generates Auth entries from config API keys.
 func (s *ConfigSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth, error) {
 	out := make([]*coreauth.Auth, 0, 32)
 	if ctx == nil || ctx.Config == nil {
 		return out, nil
+	}
+	if errValidate := ctx.Config.ValidateCredentialWeights(); errValidate != nil {
+		return nil, fmt.Errorf("synthesize config API key auths: %w", errValidate)
 	}
 
 	// Gemini API Keys
@@ -83,6 +97,7 @@ func (s *ConfigSynthesizer) synthesizeGeminiKeyEntries(ctx *SynthesisContext, en
 		if entry.Priority != 0 {
 			attrs["priority"] = strconv.Itoa(entry.Priority)
 		}
+		addWeightToAttrs(entry.Weight, attrs)
 		if base != "" {
 			attrs["base_url"] = base
 		}
@@ -138,6 +153,7 @@ func (s *ConfigSynthesizer) synthesizeClaudeKeys(ctx *SynthesisContext) []*corea
 		if ck.Priority != 0 {
 			attrs["priority"] = strconv.Itoa(ck.Priority)
 		}
+		addWeightToAttrs(ck.Weight, attrs)
 		if base != "" {
 			attrs["base_url"] = base
 		}
@@ -206,6 +222,7 @@ func (s *ConfigSynthesizer) synthesizeCodexStyleKeys(ctx *SynthesisContext, entr
 		if entry.Priority != 0 {
 			attrs["priority"] = strconv.Itoa(entry.Priority)
 		}
+		addWeightToAttrs(entry.Weight, attrs)
 		if baseURL != "" {
 			attrs["base_url"] = baseURL
 		}
@@ -279,6 +296,7 @@ func (s *ConfigSynthesizer) synthesizeOpenAICompat(ctx *SynthesisContext) []*cor
 			if compat.Priority != 0 {
 				attrs["priority"] = strconv.Itoa(compat.Priority)
 			}
+			addWeightToAttrs(entry.Weight, attrs)
 			if key != "" {
 				attrs["api_key"] = key
 			}
@@ -370,6 +388,7 @@ func (s *ConfigSynthesizer) synthesizeVertexCompat(ctx *SynthesisContext) []*cor
 		if compat.Priority != 0 {
 			attrs["priority"] = strconv.Itoa(compat.Priority)
 		}
+		addWeightToAttrs(compat.Weight, attrs)
 		if key != "" {
 			attrs["api_key"] = key
 		}

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -1,6 +1,8 @@
 package synthesizer
 
 import (
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -740,6 +742,146 @@ func TestConfigSynthesizer_IDStability(t *testing.T) {
 
 	if auths1[0].ID != auths2[0].ID {
 		t.Errorf("same config should produce same ID: got %q and %q", auths1[0].ID, auths2[0].ID)
+	}
+}
+
+func TestConfigSynthesizer_RejectsInvalidWeightsForAllAPIKeyTypes(t *testing.T) {
+	invalidWeight := config.MaxCredentialWeight + 1
+	tests := []struct {
+		name     string
+		cfg      *config.Config
+		wantPath string
+	}{
+		{
+			name:     "gemini",
+			cfg:      &config.Config{GeminiKey: []config.GeminiKey{{APIKey: "key", Weight: &invalidWeight}}},
+			wantPath: "gemini-api-key[0].weight",
+		},
+		{
+			name:     "interactions",
+			cfg:      &config.Config{InteractionsKey: []config.GeminiKey{{APIKey: "key", Weight: &invalidWeight}}},
+			wantPath: "interactions-api-key[0].weight",
+		},
+		{
+			name:     "claude",
+			cfg:      &config.Config{ClaudeKey: []config.ClaudeKey{{APIKey: "key", Weight: &invalidWeight}}},
+			wantPath: "claude-api-key[0].weight",
+		},
+		{
+			name:     "codex",
+			cfg:      &config.Config{CodexKey: []config.CodexKey{{APIKey: "key", Weight: &invalidWeight}}},
+			wantPath: "codex-api-key[0].weight",
+		},
+		{
+			name:     "xai",
+			cfg:      &config.Config{XAIKey: []config.XAIKey{{APIKey: "key", Weight: &invalidWeight}}},
+			wantPath: "xai-api-key[0].weight",
+		},
+		{
+			name: "openai compatibility",
+			cfg: &config.Config{OpenAICompatibility: []config.OpenAICompatibility{{
+				APIKeyEntries: []config.OpenAICompatibilityAPIKey{{APIKey: "key", Weight: &invalidWeight}},
+			}}},
+			wantPath: "openai-compatibility[0].api-key-entries[0].weight",
+		},
+		{
+			name:     "vertex",
+			cfg:      &config.Config{VertexCompatAPIKey: []config.VertexCompatKey{{APIKey: "key", Weight: &invalidWeight}}},
+			wantPath: "vertex-api-key[0].weight",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			auths, errSynthesize := NewConfigSynthesizer().Synthesize(&SynthesisContext{
+				Config:      testCase.cfg,
+				Now:         time.Now(),
+				IDGenerator: NewStableIDGenerator(),
+			})
+			if errSynthesize == nil {
+				t.Fatal("Synthesize() accepted an invalid credential weight")
+			}
+			if auths != nil {
+				t.Fatalf("Synthesize() auths = %#v, want nil", auths)
+			}
+			if !strings.Contains(errSynthesize.Error(), "synthesize config API key auths: "+testCase.wantPath) {
+				t.Fatalf("Synthesize() error = %q, want contextual path %q", errSynthesize, testCase.wantPath)
+			}
+		})
+	}
+}
+
+func TestConfigSynthesizer_OmittedWeightRemainsUnset(t *testing.T) {
+	auths, errSynthesize := NewConfigSynthesizer().Synthesize(&SynthesisContext{
+		Config:      &config.Config{GeminiKey: []config.GeminiKey{{APIKey: "key"}}},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	})
+	if errSynthesize != nil {
+		t.Fatalf("Synthesize() error = %v", errSynthesize)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("auth count = %d, want 1", len(auths))
+	}
+	if _, exists := auths[0].Attributes[coreauth.AttributeWeight]; exists {
+		t.Fatal("omitted weight was added to synthesized attributes")
+	}
+}
+
+func TestConfigSynthesizer_NormalizesNonPositiveWeightToZero(t *testing.T) {
+	weight := -5
+	auths, errSynthesize := NewConfigSynthesizer().Synthesize(&SynthesisContext{
+		Config:      &config.Config{GeminiKey: []config.GeminiKey{{APIKey: "key", Weight: &weight}}},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	})
+	if errSynthesize != nil {
+		t.Fatalf("Synthesize() error = %v", errSynthesize)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("auth count = %d, want 1", len(auths))
+	}
+	if gotWeight := auths[0].Attributes[coreauth.AttributeWeight]; gotWeight != "0" {
+		t.Fatalf("weight = %q, want 0", gotWeight)
+	}
+}
+
+func TestConfigSynthesizer_PropagatesWeightsForAllAPIKeyTypes(t *testing.T) {
+	weight := func(value int) *int { return &value }
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{
+			GeminiKey:       []config.GeminiKey{{APIKey: "gemini", Weight: weight(1)}},
+			InteractionsKey: []config.GeminiKey{{APIKey: "interactions", Weight: weight(2)}},
+			ClaudeKey:       []config.ClaudeKey{{APIKey: "claude", Weight: weight(3)}},
+			CodexKey:        []config.CodexKey{{APIKey: "codex", Weight: weight(4)}},
+			XAIKey:          []config.XAIKey{{APIKey: "xai", Weight: weight(5)}},
+			OpenAICompatibility: []config.OpenAICompatibility{{
+				Name:    "compat",
+				BaseURL: "https://compat.example.com",
+				APIKeyEntries: []config.OpenAICompatibilityAPIKey{{
+					APIKey: "compat",
+					Weight: weight(6),
+				}},
+			}},
+			VertexCompatAPIKey: []config.VertexCompatKey{{APIKey: "vertex", Weight: weight(7)}},
+		},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, errSynthesize := synth.Synthesize(ctx)
+	if errSynthesize != nil {
+		t.Fatalf("Synthesize() error = %v", errSynthesize)
+	}
+	if len(auths) != 7 {
+		t.Fatalf("auth count = %d, want 7", len(auths))
+	}
+	for index, auth := range auths {
+		wantWeight := strconv.Itoa(index + 1)
+		if gotWeight := auth.Attributes[coreauth.AttributeWeight]; gotWeight != wantWeight {
+			t.Fatalf("auth[%d] weight = %q, want %q", index, gotWeight, wantWeight)
+		}
 	}
 }
 

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -260,6 +260,9 @@ func TestConfigSynthesizer_ClaudeKeys(t *testing.T) {
 	if auths[0].Attributes["api_key"] != "sk-ant-api-xxx" {
 		t.Errorf("expected api_key sk-ant-api-xxx, got %s", auths[0].Attributes["api_key"])
 	}
+	if auths[0].Attributes["config_index"] != "0" {
+		t.Errorf("expected config_index 0, got %s", auths[0].Attributes["config_index"])
+	}
 	if _, ok := auths[0].Attributes["models_hash"]; !ok {
 		t.Error("expected models_hash in attributes")
 	}
@@ -540,6 +543,9 @@ func TestConfigSynthesizer_OpenAICompat_UsesNamespacedProviderKey(t *testing.T) 
 	}
 	if auth.Attributes["compat_name"] != "kimi" {
 		t.Fatalf("compat_name = %q, want kimi", auth.Attributes["compat_name"])
+	}
+	if auth.Attributes["config_index"] != "0" {
+		t.Fatalf("config_index = %q, want 0", auth.Attributes["config_index"])
 	}
 }
 

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -1,6 +1,8 @@
 package synthesizer
 
 import (
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -257,6 +259,9 @@ func TestConfigSynthesizer_ClaudeKeys(t *testing.T) {
 	}
 	if auths[0].Attributes["api_key"] != "sk-ant-api-xxx" {
 		t.Errorf("expected api_key sk-ant-api-xxx, got %s", auths[0].Attributes["api_key"])
+	}
+	if auths[0].Attributes["config_index"] != "0" {
+		t.Errorf("expected config_index 0, got %s", auths[0].Attributes["config_index"])
 	}
 	if _, ok := auths[0].Attributes["models_hash"]; !ok {
 		t.Error("expected models_hash in attributes")
@@ -606,6 +611,9 @@ func TestConfigSynthesizer_OpenAICompat_UsesNamespacedProviderKey(t *testing.T) 
 	if auth.Attributes["compat_name"] != "kimi" {
 		t.Fatalf("compat_name = %q, want kimi", auth.Attributes["compat_name"])
 	}
+	if auth.Attributes["config_index"] != "0" {
+		t.Fatalf("config_index = %q, want 0", auth.Attributes["config_index"])
+	}
 }
 
 func findSynthesizedAuthByProvider(auths []*coreauth.Auth, provider string) *coreauth.Auth {
@@ -816,6 +824,146 @@ func TestConfigSynthesizer_IDStability(t *testing.T) {
 
 	if auths1[0].ID != auths2[0].ID {
 		t.Errorf("same config should produce same ID: got %q and %q", auths1[0].ID, auths2[0].ID)
+	}
+}
+
+func TestConfigSynthesizer_RejectsInvalidWeightsForAllAPIKeyTypes(t *testing.T) {
+	invalidWeight := config.MaxCredentialWeight + 1
+	tests := []struct {
+		name     string
+		cfg      *config.Config
+		wantPath string
+	}{
+		{
+			name:     "gemini",
+			cfg:      &config.Config{GeminiKey: []config.GeminiKey{{APIKey: "key", Weight: &invalidWeight}}},
+			wantPath: "gemini-api-key[0].weight",
+		},
+		{
+			name:     "interactions",
+			cfg:      &config.Config{InteractionsKey: []config.GeminiKey{{APIKey: "key", Weight: &invalidWeight}}},
+			wantPath: "interactions-api-key[0].weight",
+		},
+		{
+			name:     "claude",
+			cfg:      &config.Config{ClaudeKey: []config.ClaudeKey{{APIKey: "key", Weight: &invalidWeight}}},
+			wantPath: "claude-api-key[0].weight",
+		},
+		{
+			name:     "codex",
+			cfg:      &config.Config{CodexKey: []config.CodexKey{{APIKey: "key", Weight: &invalidWeight}}},
+			wantPath: "codex-api-key[0].weight",
+		},
+		{
+			name:     "xai",
+			cfg:      &config.Config{XAIKey: []config.XAIKey{{APIKey: "key", Weight: &invalidWeight}}},
+			wantPath: "xai-api-key[0].weight",
+		},
+		{
+			name: "openai compatibility",
+			cfg: &config.Config{OpenAICompatibility: []config.OpenAICompatibility{{
+				APIKeyEntries: []config.OpenAICompatibilityAPIKey{{APIKey: "key", Weight: &invalidWeight}},
+			}}},
+			wantPath: "openai-compatibility[0].api-key-entries[0].weight",
+		},
+		{
+			name:     "vertex",
+			cfg:      &config.Config{VertexCompatAPIKey: []config.VertexCompatKey{{APIKey: "key", Weight: &invalidWeight}}},
+			wantPath: "vertex-api-key[0].weight",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			auths, errSynthesize := NewConfigSynthesizer().Synthesize(&SynthesisContext{
+				Config:      testCase.cfg,
+				Now:         time.Now(),
+				IDGenerator: NewStableIDGenerator(),
+			})
+			if errSynthesize == nil {
+				t.Fatal("Synthesize() accepted an invalid credential weight")
+			}
+			if auths != nil {
+				t.Fatalf("Synthesize() auths = %#v, want nil", auths)
+			}
+			if !strings.Contains(errSynthesize.Error(), "synthesize config API key auths: "+testCase.wantPath) {
+				t.Fatalf("Synthesize() error = %q, want contextual path %q", errSynthesize, testCase.wantPath)
+			}
+		})
+	}
+}
+
+func TestConfigSynthesizer_OmittedWeightRemainsUnset(t *testing.T) {
+	auths, errSynthesize := NewConfigSynthesizer().Synthesize(&SynthesisContext{
+		Config:      &config.Config{GeminiKey: []config.GeminiKey{{APIKey: "key"}}},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	})
+	if errSynthesize != nil {
+		t.Fatalf("Synthesize() error = %v", errSynthesize)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("auth count = %d, want 1", len(auths))
+	}
+	if _, exists := auths[0].Attributes[coreauth.AttributeWeight]; exists {
+		t.Fatal("omitted weight was added to synthesized attributes")
+	}
+}
+
+func TestConfigSynthesizer_NormalizesNonPositiveWeightToZero(t *testing.T) {
+	weight := -5
+	auths, errSynthesize := NewConfigSynthesizer().Synthesize(&SynthesisContext{
+		Config:      &config.Config{GeminiKey: []config.GeminiKey{{APIKey: "key", Weight: &weight}}},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	})
+	if errSynthesize != nil {
+		t.Fatalf("Synthesize() error = %v", errSynthesize)
+	}
+	if len(auths) != 1 {
+		t.Fatalf("auth count = %d, want 1", len(auths))
+	}
+	if gotWeight := auths[0].Attributes[coreauth.AttributeWeight]; gotWeight != "0" {
+		t.Fatalf("weight = %q, want 0", gotWeight)
+	}
+}
+
+func TestConfigSynthesizer_PropagatesWeightsForAllAPIKeyTypes(t *testing.T) {
+	weight := func(value int) *int { return &value }
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{
+			GeminiKey:       []config.GeminiKey{{APIKey: "gemini", Weight: weight(1)}},
+			InteractionsKey: []config.GeminiKey{{APIKey: "interactions", Weight: weight(2)}},
+			ClaudeKey:       []config.ClaudeKey{{APIKey: "claude", Weight: weight(3)}},
+			CodexKey:        []config.CodexKey{{APIKey: "codex", Weight: weight(4)}},
+			XAIKey:          []config.XAIKey{{APIKey: "xai", Weight: weight(5)}},
+			OpenAICompatibility: []config.OpenAICompatibility{{
+				Name:    "compat",
+				BaseURL: "https://compat.example.com",
+				APIKeyEntries: []config.OpenAICompatibilityAPIKey{{
+					APIKey: "compat",
+					Weight: weight(6),
+				}},
+			}},
+			VertexCompatAPIKey: []config.VertexCompatKey{{APIKey: "vertex", Weight: weight(7)}},
+		},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, errSynthesize := synth.Synthesize(ctx)
+	if errSynthesize != nil {
+		t.Fatalf("Synthesize() error = %v", errSynthesize)
+	}
+	if len(auths) != 7 {
+		t.Fatalf("auth count = %d, want 7", len(auths))
+	}
+	for index, auth := range auths {
+		wantWeight := strconv.Itoa(index + 1)
+		if gotWeight := auth.Attributes[coreauth.AttributeWeight]; gotWeight != wantWeight {
+			t.Fatalf("auth[%d] weight = %q, want %q", index, gotWeight, wantWeight)
+		}
 	}
 }
 

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -3,6 +3,7 @@ package synthesizer
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -13,6 +14,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+	log "github.com/sirupsen/logrus"
 )
 
 // FileSynthesizer generates Auth entries from OAuth JSON files.
@@ -50,7 +52,11 @@ func (s *FileSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth, e
 		if errRead != nil || len(data) == 0 {
 			continue
 		}
-		auths := synthesizeFileAuths(ctx, full, data)
+		auths, errSynthesize := synthesizeFileAuths(ctx, full, data)
+		if errSynthesize != nil {
+			log.WithError(errSynthesize).Warnf("skipping auth file %s", name)
+			continue
+		}
 		if len(auths) == 0 {
 			continue
 		}
@@ -61,19 +67,22 @@ func (s *FileSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth, e
 
 // SynthesizeAuthFile generates Auth entries for one auth JSON file payload.
 // It shares exactly the same mapping behavior as FileSynthesizer.Synthesize.
-func SynthesizeAuthFile(ctx *SynthesisContext, fullPath string, data []byte) []*coreauth.Auth {
+func SynthesizeAuthFile(ctx *SynthesisContext, fullPath string, data []byte) ([]*coreauth.Auth, error) {
 	return synthesizeFileAuths(ctx, fullPath, data)
 }
 
-func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []*coreauth.Auth {
+func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) ([]*coreauth.Auth, error) {
 	if ctx == nil || len(data) == 0 {
-		return nil
+		return nil, nil
 	}
 	now := ctx.Now
 	cfg := ctx.Config
 	var metadata map[string]any
 	if errUnmarshal := json.Unmarshal(data, &metadata); errUnmarshal != nil {
-		return nil
+		return nil, nil
+	}
+	if errWeight := coreauth.ValidateAuthWeight(&coreauth.Auth{Metadata: metadata}); errWeight != nil {
+		return nil, fmt.Errorf("invalid weight in %s: %w", filepath.Base(fullPath), errWeight)
 	}
 	t, _ := metadata["type"].(string)
 	provider := strings.ToLower(strings.TrimSpace(t))
@@ -90,7 +99,7 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 		if errParse == nil && handled {
 			auths = compactPluginAuths(auths)
 			if len(auths) == 0 {
-				return nil
+				return nil, nil
 			}
 			perAccountExcluded := extractExcludedModelsFromMetadata(metadata)
 			perAccountModelAliases := extractOAuthModelAliasesFromMetadata(metadata)
@@ -118,15 +127,18 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 					}
 					auth.Metadata["disabled"] = true
 				}
+				if errWeight := coreauth.ApplyAuthWeightMetadata(auth, metadata); errWeight != nil {
+					return nil, fmt.Errorf("invalid plugin auth weight in %s: %w", filepath.Base(fullPath), errWeight)
+				}
 				coreauth.SetOAuthModelAliasesAttribute(auth, perAccountModelAliases)
 				ApplyAuthExcludedModelsMeta(auth, cfg, perAccountExcluded, "oauth")
 				coreauth.ApplyCustomHeadersFromMetadata(auth)
 			}
-			return auths
+			return auths, nil
 		}
 	}
 	if provider == "" || provider == "gemini-cli" {
-		return nil
+		return nil, nil
 	}
 	label := provider
 	if email, _ := metadata["email"].(string); email != "" {
@@ -196,6 +208,9 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 			}
 		}
 	}
+	if errWeight := coreauth.ApplyAuthWeightMetadata(a, metadata); errWeight != nil {
+		return nil, fmt.Errorf("invalid auth weight in %s: %w", filepath.Base(fullPath), errWeight)
+	}
 	// Read note from auth file.
 	if rawNote, ok := metadata["note"]; ok {
 		if note, isStr := rawNote.(string); isStr {
@@ -217,7 +232,7 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 			}
 		}
 	}
-	return []*coreauth.Auth{a}
+	return []*coreauth.Auth{a}, nil
 }
 
 func parsePluginFileAuths(parser PluginAuthParser, req pluginapi.AuthParseRequest) ([]*coreauth.Auth, bool, error) {
@@ -241,6 +256,9 @@ func compactPluginAuths(auths []*coreauth.Auth) []*coreauth.Auth {
 	out := auths[:0]
 	for _, auth := range auths {
 		if auth == nil {
+			continue
+		}
+		if errWeight := coreauth.ValidateAuthWeight(auth); errWeight != nil {
 			continue
 		}
 		out = append(out, auth)

--- a/internal/watcher/synthesizer/file.go
+++ b/internal/watcher/synthesizer/file.go
@@ -3,6 +3,7 @@ package synthesizer
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -51,7 +52,11 @@ func (s *FileSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth, e
 		if errRead != nil || len(data) == 0 {
 			continue
 		}
-		auths := synthesizeFileAuths(ctx, full, data)
+		auths, errSynthesize := synthesizeFileAuths(ctx, full, data)
+		if errSynthesize != nil {
+			log.WithError(errSynthesize).Warnf("skipping auth file %s", name)
+			continue
+		}
 		if len(auths) == 0 {
 			continue
 		}
@@ -62,19 +67,22 @@ func (s *FileSynthesizer) Synthesize(ctx *SynthesisContext) ([]*coreauth.Auth, e
 
 // SynthesizeAuthFile generates Auth entries for one auth JSON file payload.
 // It shares exactly the same mapping behavior as FileSynthesizer.Synthesize.
-func SynthesizeAuthFile(ctx *SynthesisContext, fullPath string, data []byte) []*coreauth.Auth {
+func SynthesizeAuthFile(ctx *SynthesisContext, fullPath string, data []byte) ([]*coreauth.Auth, error) {
 	return synthesizeFileAuths(ctx, fullPath, data)
 }
 
-func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []*coreauth.Auth {
+func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) ([]*coreauth.Auth, error) {
 	if ctx == nil || len(data) == 0 {
-		return nil
+		return nil, nil
 	}
 	now := ctx.Now
 	cfg := ctx.Config
 	var metadata map[string]any
 	if errUnmarshal := json.Unmarshal(data, &metadata); errUnmarshal != nil {
-		return nil
+		return nil, nil
+	}
+	if errWeight := coreauth.ValidateAuthWeight(&coreauth.Auth{Metadata: metadata}); errWeight != nil {
+		return nil, fmt.Errorf("invalid weight in %s: %w", filepath.Base(fullPath), errWeight)
 	}
 	t, _ := metadata["type"].(string)
 	provider := strings.ToLower(strings.TrimSpace(t))
@@ -89,13 +97,12 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 			RawJSON:  data,
 		})
 		if errParse != nil {
-			log.WithField("file", filepath.Base(fullPath)).Warn("plugin auth parser failed; retaining no synthesized fallback")
-			return nil
+			return nil, fmt.Errorf("plugin auth parser failed for %s: %w", filepath.Base(fullPath), errParse)
 		}
 		if handled {
 			auths = compactPluginAuths(auths)
 			if len(auths) == 0 {
-				return nil
+				return nil, nil
 			}
 			perAccountExcluded := extractExcludedModelsFromMetadata(metadata)
 			perAccountModelAliases := extractOAuthModelAliasesFromMetadata(metadata)
@@ -123,15 +130,18 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 					}
 					auth.Metadata["disabled"] = true
 				}
+				if errWeight := coreauth.ApplyAuthWeightMetadata(auth, metadata); errWeight != nil {
+					return nil, fmt.Errorf("invalid plugin auth weight in %s: %w", filepath.Base(fullPath), errWeight)
+				}
 				coreauth.SetOAuthModelAliasesAttribute(auth, perAccountModelAliases)
 				ApplyAuthExcludedModelsMeta(auth, cfg, perAccountExcluded, "oauth")
 				coreauth.ApplyCustomHeadersFromMetadata(auth)
 			}
-			return auths
+			return auths, nil
 		}
 	}
 	if provider == "" || provider == "gemini-cli" {
-		return nil
+		return nil, nil
 	}
 	label := provider
 	if email, _ := metadata["email"].(string); email != "" {
@@ -201,6 +211,9 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 			}
 		}
 	}
+	if errWeight := coreauth.ApplyAuthWeightMetadata(a, metadata); errWeight != nil {
+		return nil, fmt.Errorf("invalid auth weight in %s: %w", filepath.Base(fullPath), errWeight)
+	}
 	// Read note from auth file.
 	if rawNote, ok := metadata["note"]; ok {
 		if note, isStr := rawNote.(string); isStr {
@@ -222,7 +235,7 @@ func synthesizeFileAuths(ctx *SynthesisContext, fullPath string, data []byte) []
 			}
 		}
 	}
-	return []*coreauth.Auth{a}
+	return []*coreauth.Auth{a}, nil
 }
 
 func parsePluginFileAuths(parser PluginAuthParser, req pluginapi.AuthParseRequest) ([]*coreauth.Auth, bool, error) {
@@ -246,6 +259,9 @@ func compactPluginAuths(auths []*coreauth.Auth) []*coreauth.Auth {
 	out := auths[:0]
 	for _, auth := range auths {
 		if auth == nil {
+			continue
+		}
+		if errWeight := coreauth.ValidateAuthWeight(auth); errWeight != nil {
 			continue
 		}
 		out = append(out, auth)

--- a/internal/watcher/synthesizer/file_test.go
+++ b/internal/watcher/synthesizer/file_test.go
@@ -202,7 +202,10 @@ func TestSynthesizeAuthFileExpandsPluginMultiAuths(t *testing.T) {
 		}),
 	}
 
-	auths := SynthesizeAuthFile(ctx, fullPath, raw)
+	auths, errSynthesize := SynthesizeAuthFile(ctx, fullPath, raw)
+	if errSynthesize != nil {
+		t.Fatalf("SynthesizeAuthFile() error = %v", errSynthesize)
+	}
 	if len(auths) != 2 {
 		t.Fatalf("SynthesizeAuthFile() len = %d, want two plugin auths", len(auths))
 	}
@@ -231,6 +234,30 @@ func TestSynthesizeAuthFileExpandsPluginMultiAuths(t *testing.T) {
 	}
 }
 
+func TestSynthesizeAuthFileSkipsInvalidPluginAuthWeight(t *testing.T) {
+	tempDir := t.TempDir()
+	fullPath := filepath.Join(tempDir, "plugin.json")
+	ctx := &SynthesisContext{
+		Config:  &config.Config{},
+		AuthDir: tempDir,
+		Now:     time.Date(2026, 6, 21, 0, 0, 0, 0, time.UTC),
+		PluginAuthParser: multiAuthParserFunc(func(context.Context, pluginapi.AuthParseRequest) ([]*coreauth.Auth, bool, error) {
+			return []*coreauth.Auth{
+				{ID: "invalid", Provider: "plugin", Attributes: map[string]string{coreauth.AttributeWeight: "1.5"}},
+				{ID: "valid", Provider: "plugin", Attributes: map[string]string{coreauth.AttributeWeight: "0"}},
+			}, true, nil
+		}),
+	}
+
+	auths, errSynthesize := SynthesizeAuthFile(ctx, fullPath, []byte(`{"type":"plugin"}`))
+	if errSynthesize != nil {
+		t.Fatalf("SynthesizeAuthFile() error = %v", errSynthesize)
+	}
+	if len(auths) != 1 || auths[0].ID != "valid" {
+		t.Fatalf("SynthesizeAuthFile() auths = %#v, want only valid zero-weight auth", auths)
+	}
+}
+
 func TestSynthesizeAuthFileAppliesSourceDisabledToPluginMultiAuths(t *testing.T) {
 	tempDir := t.TempDir()
 	fullPath := filepath.Join(tempDir, "geminicli.json")
@@ -248,7 +275,10 @@ func TestSynthesizeAuthFileAppliesSourceDisabledToPluginMultiAuths(t *testing.T)
 		}),
 	}
 
-	auths := SynthesizeAuthFile(ctx, fullPath, raw)
+	auths, errSynthesize := SynthesizeAuthFile(ctx, fullPath, raw)
+	if errSynthesize != nil {
+		t.Fatalf("SynthesizeAuthFile() error = %v", errSynthesize)
+	}
 	if len(auths) != 2 {
 		t.Fatalf("SynthesizeAuthFile() len = %d, want two plugin auths", len(auths))
 	}
@@ -276,7 +306,10 @@ func TestSynthesizeAuthFilePluginHandledEmptySuppressesBuiltin(t *testing.T) {
 		}),
 	}
 
-	auths := SynthesizeAuthFile(ctx, fullPath, raw)
+	auths, errSynthesize := SynthesizeAuthFile(ctx, fullPath, raw)
+	if errSynthesize != nil {
+		t.Fatalf("SynthesizeAuthFile() error = %v", errSynthesize)
+	}
 	if len(auths) != 0 {
 		t.Fatalf("SynthesizeAuthFile() len = %d, want plugin-handled empty result", len(auths))
 	}
@@ -500,6 +533,63 @@ func TestFileSynthesizer_Synthesize_PriorityParsing(t *testing.T) {
 			}
 			if ok {
 				t.Fatalf("expected priority attribute to be absent, got %q", value)
+			}
+		})
+	}
+}
+
+func TestFileSynthesizer_Synthesize_WeightParsing(t *testing.T) {
+	tests := []struct {
+		name   string
+		weight any
+		want   string
+		valid  bool
+	}{
+		{name: "number", weight: 5, want: "5", valid: true},
+		{name: "numeric string", weight: " 3 ", want: "3", valid: true},
+		{name: "zero excludes", weight: 0, want: "0", valid: true},
+		{name: "negative excludes", weight: -5, want: "0", valid: true},
+		{name: "maximum", weight: 1000000, want: "1000000", valid: true},
+		{name: "fraction rejected", weight: 1.5},
+		{name: "above maximum rejected", weight: 1000001},
+		{name: "overflow rejected", weight: "9223372036854775808"},
+		{name: "invalid string", weight: "heavy"},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			data, errMarshal := json.Marshal(map[string]any{"type": "claude", "weight": testCase.weight})
+			if errMarshal != nil {
+				t.Fatalf("json.Marshal() error = %v", errMarshal)
+			}
+			if errWrite := os.WriteFile(filepath.Join(tempDir, "auth.json"), data, 0644); errWrite != nil {
+				t.Fatalf("WriteFile() error = %v", errWrite)
+			}
+			ctx := &SynthesisContext{
+				Config:      &config.Config{},
+				AuthDir:     tempDir,
+				Now:         time.Now(),
+				IDGenerator: NewStableIDGenerator(),
+			}
+			auths, errSynthesize := NewFileSynthesizer().Synthesize(ctx)
+			if errSynthesize != nil {
+				t.Fatalf("Synthesize() error = %v", errSynthesize)
+			}
+			if !testCase.valid {
+				if len(auths) != 0 {
+					t.Fatalf("auth count = %d, want invalid credential skipped", len(auths))
+				}
+				if _, errDirect := SynthesizeAuthFile(ctx, filepath.Join(tempDir, "auth.json"), data); errDirect == nil {
+					t.Fatal("SynthesizeAuthFile() error = nil, want weight validation error")
+				}
+				return
+			}
+			if len(auths) != 1 {
+				t.Fatalf("auth count = %d, want 1", len(auths))
+			}
+			if gotWeight := auths[0].Attributes[coreauth.AttributeWeight]; gotWeight != testCase.want {
+				t.Fatalf("weight = %q, want %q", gotWeight, testCase.want)
 			}
 		})
 	}

--- a/internal/watcher/synthesizer/file_test.go
+++ b/internal/watcher/synthesizer/file_test.go
@@ -203,7 +203,10 @@ func TestSynthesizeAuthFileExpandsPluginMultiAuths(t *testing.T) {
 		}),
 	}
 
-	auths := SynthesizeAuthFile(ctx, fullPath, raw)
+	auths, errSynthesize := SynthesizeAuthFile(ctx, fullPath, raw)
+	if errSynthesize != nil {
+		t.Fatalf("SynthesizeAuthFile() error = %v", errSynthesize)
+	}
 	if len(auths) != 2 {
 		t.Fatalf("SynthesizeAuthFile() len = %d, want two plugin auths", len(auths))
 	}
@@ -232,6 +235,30 @@ func TestSynthesizeAuthFileExpandsPluginMultiAuths(t *testing.T) {
 	}
 }
 
+func TestSynthesizeAuthFileSkipsInvalidPluginAuthWeight(t *testing.T) {
+	tempDir := t.TempDir()
+	fullPath := filepath.Join(tempDir, "plugin.json")
+	ctx := &SynthesisContext{
+		Config:  &config.Config{},
+		AuthDir: tempDir,
+		Now:     time.Date(2026, 6, 21, 0, 0, 0, 0, time.UTC),
+		PluginAuthParser: multiAuthParserFunc(func(context.Context, pluginapi.AuthParseRequest) ([]*coreauth.Auth, bool, error) {
+			return []*coreauth.Auth{
+				{ID: "invalid", Provider: "plugin", Attributes: map[string]string{coreauth.AttributeWeight: "1.5"}},
+				{ID: "valid", Provider: "plugin", Attributes: map[string]string{coreauth.AttributeWeight: "0"}},
+			}, true, nil
+		}),
+	}
+
+	auths, errSynthesize := SynthesizeAuthFile(ctx, fullPath, []byte(`{"type":"plugin"}`))
+	if errSynthesize != nil {
+		t.Fatalf("SynthesizeAuthFile() error = %v", errSynthesize)
+	}
+	if len(auths) != 1 || auths[0].ID != "valid" {
+		t.Fatalf("SynthesizeAuthFile() auths = %#v, want only valid zero-weight auth", auths)
+	}
+}
+
 func TestSynthesizeAuthFileAppliesSourceDisabledToPluginMultiAuths(t *testing.T) {
 	tempDir := t.TempDir()
 	fullPath := filepath.Join(tempDir, "geminicli.json")
@@ -249,7 +276,10 @@ func TestSynthesizeAuthFileAppliesSourceDisabledToPluginMultiAuths(t *testing.T)
 		}),
 	}
 
-	auths := SynthesizeAuthFile(ctx, fullPath, raw)
+	auths, errSynthesize := SynthesizeAuthFile(ctx, fullPath, raw)
+	if errSynthesize != nil {
+		t.Fatalf("SynthesizeAuthFile() error = %v", errSynthesize)
+	}
 	if len(auths) != 2 {
 		t.Fatalf("SynthesizeAuthFile() len = %d, want two plugin auths", len(auths))
 	}
@@ -277,7 +307,10 @@ func TestSynthesizeAuthFilePluginHandledEmptySuppressesBuiltin(t *testing.T) {
 		}),
 	}
 
-	auths := SynthesizeAuthFile(ctx, fullPath, raw)
+	auths, errSynthesize := SynthesizeAuthFile(ctx, fullPath, raw)
+	if errSynthesize != nil {
+		t.Fatalf("SynthesizeAuthFile() error = %v", errSynthesize)
+	}
 	if len(auths) != 0 {
 		t.Fatalf("SynthesizeAuthFile() len = %d, want plugin-handled empty result", len(auths))
 	}
@@ -336,7 +369,10 @@ func TestSynthesizeAuthFilePluginParserErrorDoesNotFallback(t *testing.T) {
 			return nil, true, errors.New("plugin parse failed")
 		}),
 	}
-	auths := SynthesizeAuthFile(ctx, filepath.Join(ctx.AuthDir, "plugin.json"), []byte(`{"type":"plugin-provider"}`))
+	auths, errSynthesize := SynthesizeAuthFile(ctx, filepath.Join(ctx.AuthDir, "plugin.json"), []byte(`{"type":"plugin-provider"}`))
+	if errSynthesize == nil {
+		t.Fatal("SynthesizeAuthFile() error = nil, want plugin parser error")
+	}
 	if len(auths) != 0 {
 		t.Fatalf("SynthesizeAuthFile() = %#v, want no generic fallback", auths)
 	}
@@ -517,6 +553,63 @@ func TestFileSynthesizer_Synthesize_PriorityParsing(t *testing.T) {
 			}
 			if ok {
 				t.Fatalf("expected priority attribute to be absent, got %q", value)
+			}
+		})
+	}
+}
+
+func TestFileSynthesizer_Synthesize_WeightParsing(t *testing.T) {
+	tests := []struct {
+		name   string
+		weight any
+		want   string
+		valid  bool
+	}{
+		{name: "number", weight: 5, want: "5", valid: true},
+		{name: "numeric string", weight: " 3 ", want: "3", valid: true},
+		{name: "zero excludes", weight: 0, want: "0", valid: true},
+		{name: "negative excludes", weight: -5, want: "0", valid: true},
+		{name: "maximum", weight: 1000000, want: "1000000", valid: true},
+		{name: "fraction rejected", weight: 1.5},
+		{name: "above maximum rejected", weight: 1000001},
+		{name: "overflow rejected", weight: "9223372036854775808"},
+		{name: "invalid string", weight: "heavy"},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			data, errMarshal := json.Marshal(map[string]any{"type": "claude", "weight": testCase.weight})
+			if errMarshal != nil {
+				t.Fatalf("json.Marshal() error = %v", errMarshal)
+			}
+			if errWrite := os.WriteFile(filepath.Join(tempDir, "auth.json"), data, 0644); errWrite != nil {
+				t.Fatalf("WriteFile() error = %v", errWrite)
+			}
+			ctx := &SynthesisContext{
+				Config:      &config.Config{},
+				AuthDir:     tempDir,
+				Now:         time.Now(),
+				IDGenerator: NewStableIDGenerator(),
+			}
+			auths, errSynthesize := NewFileSynthesizer().Synthesize(ctx)
+			if errSynthesize != nil {
+				t.Fatalf("Synthesize() error = %v", errSynthesize)
+			}
+			if !testCase.valid {
+				if len(auths) != 0 {
+					t.Fatalf("auth count = %d, want invalid credential skipped", len(auths))
+				}
+				if _, errDirect := SynthesizeAuthFile(ctx, filepath.Join(tempDir, "auth.json"), data); errDirect == nil {
+					t.Fatal("SynthesizeAuthFile() error = nil, want weight validation error")
+				}
+				return
+			}
+			if len(auths) != 1 {
+				t.Fatalf("auth count = %d, want 1", len(auths))
+			}
+			if gotWeight := auths[0].Attributes[coreauth.AttributeWeight]; gotWeight != testCase.want {
+				t.Fatalf("weight = %q, want %q", gotWeight, testCase.want)
 			}
 		})
 	}

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"reflect"
 	"strings"
@@ -196,6 +197,17 @@ func requestExecutionMetadata(ctx context.Context) map[string]any {
 		meta[coreexecutor.DisallowFreeAuthMetadataKey] = true
 	}
 	return meta
+}
+
+func requestClientIP(request *http.Request) string {
+	if request == nil {
+		return ""
+	}
+	remoteAddr := strings.TrimSpace(request.RemoteAddr)
+	if host, _, errSplit := net.SplitHostPort(remoteAddr); errSplit == nil {
+		return strings.TrimSpace(host)
+	}
+	return remoteAddr
 }
 
 func requestCallerScope(ginCtx *gin.Context) string {
@@ -417,6 +429,13 @@ func (h *BaseAPIHandler) GetContextWithCancel(handler interfaces.APIHandler, c *
 	}
 	if endpoint != "" {
 		newCtx = logging.WithEndpoint(newCtx, endpoint)
+	}
+	if c != nil && c.Request != nil {
+		newCtx = logging.WithClientRequestMetadata(newCtx, logging.ClientRequestMetadata{
+			ClientIP:      requestClientIP(c.Request),
+			XForwardedFor: strings.TrimSpace(strings.Join(c.Request.Header.Values("X-Forwarded-For"), ", ")),
+			UserAgent:     strings.TrimSpace(c.Request.UserAgent()),
+		})
 	}
 	newCtx = logging.WithResponseStatusHolder(newCtx)
 	newCtx = logging.WithResponseHeadersHolder(newCtx)

--- a/sdk/api/handlers/handlers.go
+++ b/sdk/api/handlers/handlers.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"reflect"
 	"strings"
@@ -199,6 +200,17 @@ func requestExecutionMetadata(ctx context.Context) map[string]any {
 		meta[coreexecutor.DisallowFreeAuthMetadataKey] = true
 	}
 	return meta
+}
+
+func requestClientIP(request *http.Request) string {
+	if request == nil {
+		return ""
+	}
+	remoteAddr := strings.TrimSpace(request.RemoteAddr)
+	if host, _, errSplit := net.SplitHostPort(remoteAddr); errSplit == nil {
+		return strings.TrimSpace(host)
+	}
+	return remoteAddr
 }
 
 func requestCallerScope(ginCtx *gin.Context) string {
@@ -420,6 +432,13 @@ func (h *BaseAPIHandler) GetContextWithCancel(handler interfaces.APIHandler, c *
 	}
 	if endpoint != "" {
 		newCtx = logging.WithEndpoint(newCtx, endpoint)
+	}
+	if c != nil && c.Request != nil {
+		newCtx = logging.WithClientRequestMetadata(newCtx, logging.ClientRequestMetadata{
+			ClientIP:      requestClientIP(c.Request),
+			XForwardedFor: strings.TrimSpace(strings.Join(c.Request.Header.Values("X-Forwarded-For"), ", ")),
+			UserAgent:     strings.TrimSpace(c.Request.UserAgent()),
+		})
 	}
 	newCtx = logging.WithResponseStatusHolder(newCtx)
 	newCtx = logging.WithResponseHeadersHolder(newCtx)

--- a/sdk/api/handlers/handlers_errors.go
+++ b/sdk/api/handlers/handlers_errors.go
@@ -25,6 +25,15 @@ func statusFromError(err error) int {
 	return 0
 }
 
+func isAuthSelectionUnavailable(err error) bool {
+	var authErr *coreauth.Error
+	if !errors.As(err, &authErr) || authErr == nil {
+		return false
+	}
+	code := strings.TrimSpace(authErr.Code)
+	return code == "auth_not_found" || code == "auth_unavailable"
+}
+
 func enrichAuthSelectionError(err error, providers []string, model string) error {
 	if err == nil {
 		return nil

--- a/sdk/api/handlers/handlers_metadata_test.go
+++ b/sdk/api/handlers/handlers_metadata_test.go
@@ -9,8 +9,34 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	coresession "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/session"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 	"golang.org/x/net/context"
 )
+
+func TestGetContextWithCancelCapturesClientRequestMetadata(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	ginCtx.Request.RemoteAddr = "192.0.2.10:43123"
+	ginCtx.Request.Header.Add("X-Forwarded-For", "203.0.113.5")
+	ginCtx.Request.Header.Add("X-Forwarded-For", "198.51.100.8")
+	ginCtx.Request.Header.Set("User-Agent", "test-client/1.0")
+
+	handler := &BaseAPIHandler{Cfg: &config.SDKConfig{}}
+	ctx, cancel := handler.GetContextWithCancel(nil, ginCtx, context.Background())
+	defer cancel()
+
+	metadata := logging.GetClientRequestMetadata(ctx)
+	if metadata.ClientIP != "192.0.2.10" {
+		t.Fatalf("ClientIP = %q, want direct peer IP", metadata.ClientIP)
+	}
+	if metadata.XForwardedFor != "203.0.113.5, 198.51.100.8" {
+		t.Fatalf("XForwardedFor = %q", metadata.XForwardedFor)
+	}
+	if metadata.UserAgent != "test-client/1.0" {
+		t.Fatalf("UserAgent = %q", metadata.UserAgent)
+	}
+}
 
 func TestRequestExecutionMetadataIncludesExecutionSessionWithoutIdempotencyKey(t *testing.T) {
 	ctx := WithExecutionSessionID(context.Background(), "session-1")

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -461,7 +461,12 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 		bootstrapRetries++
 		retryResult, retryErr := h.AuthManager.ExecuteStream(ctx, providers, req, opts)
 		if retryErr != nil {
-			bootstrapErr = executionErrorMessage(enrichAuthSelectionError(retryErr, providers, normalizedModel))
+			originalBootstrapErr := executionErrorMessage(bootstrapStreamErr)
+			if isAuthSelectionUnavailable(retryErr) && originalBootstrapErr.StatusCode >= http.StatusInternalServerError {
+				bootstrapErr = originalBootstrapErr
+			} else {
+				bootstrapErr = executionErrorMessage(enrichAuthSelectionError(retryErr, providers, normalizedModel))
+			}
 			break
 		}
 		if retryResult == nil {

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -77,6 +77,9 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 	if auth == nil {
 		return "", fmt.Errorf("auth filestore: auth is nil")
 	}
+	if errWeight := cliproxyauth.ValidateAuthWeight(auth); errWeight != nil {
+		return "", fmt.Errorf("auth filestore: %w", errWeight)
+	}
 
 	path, err := s.resolveAuthPath(auth)
 	if err != nil {
@@ -233,6 +236,9 @@ func (s *FileTokenStore) readAuthFiles(path, baseDir string) ([]*cliproxyauth.Au
 	if err = json.Unmarshal(data, &metadata); err != nil {
 		return nil, fmt.Errorf("unmarshal auth json: %w", err)
 	}
+	if errWeight := cliproxyauth.ValidateAuthWeight(&cliproxyauth.Auth{Metadata: metadata}); errWeight != nil {
+		return nil, errWeight
+	}
 	provider, _ := metadata["type"].(string)
 	provider = strings.TrimSpace(provider)
 	if strings.EqualFold(provider, "gemini") {
@@ -277,6 +283,9 @@ func (s *FileTokenStore) readAuthFiles(path, baseDir string) ([]*cliproxyauth.Au
 						auth.Metadata = make(map[string]any)
 					}
 					auth.Metadata["disabled"] = true
+				}
+				if errWeight := cliproxyauth.ApplyAuthWeightMetadata(auth, metadata); errWeight != nil {
+					return nil, errWeight
 				}
 				cliproxyauth.ApplyCustomHeadersFromMetadata(auth)
 			}
@@ -371,6 +380,9 @@ func compactPluginAuths(auths []*cliproxyauth.Auth) []*cliproxyauth.Auth {
 	out := auths[:0]
 	for _, auth := range auths {
 		if auth == nil {
+			continue
+		}
+		if errWeight := cliproxyauth.ValidateAuthWeight(auth); errWeight != nil {
 			continue
 		}
 		out = append(out, auth)

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -77,6 +77,9 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 	if auth == nil {
 		return "", fmt.Errorf("auth filestore: auth is nil")
 	}
+	if errWeight := cliproxyauth.ValidateAuthWeight(auth); errWeight != nil {
+		return "", fmt.Errorf("auth filestore: %w", errWeight)
+	}
 
 	path, err := s.resolveAuthPath(auth)
 	if err != nil {
@@ -233,6 +236,9 @@ func (s *FileTokenStore) readAuthFiles(path, baseDir string) ([]*cliproxyauth.Au
 	if err = json.Unmarshal(data, &metadata); err != nil {
 		return nil, fmt.Errorf("unmarshal auth json: %w", err)
 	}
+	if errWeight := cliproxyauth.ValidateAuthWeight(&cliproxyauth.Auth{Metadata: metadata}); errWeight != nil {
+		return nil, errWeight
+	}
 	provider, _ := metadata["type"].(string)
 	provider = strings.TrimSpace(provider)
 	if strings.EqualFold(provider, "gemini") {
@@ -280,6 +286,9 @@ func (s *FileTokenStore) readAuthFiles(path, baseDir string) ([]*cliproxyauth.Au
 						auth.Metadata = make(map[string]any)
 					}
 					auth.Metadata["disabled"] = true
+				}
+				if errWeight := cliproxyauth.ApplyAuthWeightMetadata(auth, metadata); errWeight != nil {
+					return nil, errWeight
 				}
 				cliproxyauth.ApplyCustomHeadersFromMetadata(auth)
 			}
@@ -374,6 +383,9 @@ func compactPluginAuths(auths []*cliproxyauth.Auth) []*cliproxyauth.Auth {
 	out := auths[:0]
 	for _, auth := range auths {
 		if auth == nil {
+			continue
+		}
+		if errWeight := cliproxyauth.ValidateAuthWeight(auth); errWeight != nil {
 			continue
 		}
 		out = append(out, auth)

--- a/sdk/auth/filestore_test.go
+++ b/sdk/auth/filestore_test.go
@@ -146,10 +146,61 @@ func TestFileTokenStoreSaveExistingMetadataSetsFileAttributes(t *testing.T) {
 	}
 }
 
+func TestFileTokenStoreSaveRejectsInvalidWeight(t *testing.T) {
+	baseDir := t.TempDir()
+	store := NewFileTokenStore()
+	store.SetBaseDir(baseDir)
+	auth := &cliproxyauth.Auth{
+		ID:       "invalid.json",
+		FileName: "invalid.json",
+		Metadata: map[string]any{
+			"type":                       "test",
+			cliproxyauth.AttributeWeight: 1.5,
+		},
+	}
+
+	if _, errSave := store.Save(context.Background(), auth); errSave == nil {
+		t.Fatal("Save() accepted an invalid weight")
+	}
+	if _, errStat := os.Stat(filepath.Join(baseDir, auth.FileName)); !os.IsNotExist(errStat) {
+		t.Fatalf("invalid auth file was persisted: %v", errStat)
+	}
+}
+
+func TestFileTokenStoreListSkipsInvalidPluginSourceWeight(t *testing.T) {
+	baseDir := t.TempDir()
+	path := filepath.Join(baseDir, "plugin.json")
+	if errWrite := os.WriteFile(path, []byte(`{"type":"plugin","weight":"invalid"}`), 0o600); errWrite != nil {
+		t.Fatalf("write auth file: %v", errWrite)
+	}
+
+	parserCalled := false
+	RegisterPluginAuthParser(fileStoreMultiAuthParserFunc(func(context.Context, pluginapi.AuthParseRequest) ([]*cliproxyauth.Auth, bool, error) {
+		parserCalled = true
+		return []*cliproxyauth.Auth{{ID: "plugin.json", Provider: "plugin"}}, true, nil
+	}))
+	t.Cleanup(func() {
+		RegisterPluginAuthParser(nil)
+	})
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(baseDir)
+	auths, errList := store.List(context.Background())
+	if errList != nil {
+		t.Fatalf("List() error = %v", errList)
+	}
+	if parserCalled {
+		t.Fatal("plugin parser was called for an invalid persisted source")
+	}
+	if len(auths) != 0 {
+		t.Fatalf("List() returned invalid plugin auths: %#v", auths)
+	}
+}
+
 func TestFileTokenStoreListExpandsPluginMultiAuths(t *testing.T) {
 	baseDir := t.TempDir()
 	path := filepath.Join(baseDir, "geminicli.json")
-	if errWrite := os.WriteFile(path, []byte(`{"type":"gemini-cli","headers":{"X-Test":"value"}}`), 0o600); errWrite != nil {
+	if errWrite := os.WriteFile(path, []byte(`{"type":"gemini-cli","weight":3,"headers":{"X-Test":"value"}}`), 0o600); errWrite != nil {
 		t.Fatalf("write auth file: %v", errWrite)
 	}
 
@@ -210,6 +261,9 @@ func TestFileTokenStoreListExpandsPluginMultiAuths(t *testing.T) {
 		}
 		if gotHeader := auth.Attributes["header:X-Test"]; gotHeader != "value" {
 			t.Fatalf("header:X-Test = %q, want value", gotHeader)
+		}
+		if gotWeight := auth.Attributes[cliproxyauth.AttributeWeight]; gotWeight != "3" {
+			t.Fatalf("weight = %q, want 3", gotWeight)
 		}
 	}
 	if gotProject := auths[1].Metadata["project_id"]; gotProject != "project-a" {

--- a/sdk/auth/filestore_test.go
+++ b/sdk/auth/filestore_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -146,10 +147,64 @@ func TestFileTokenStoreSaveExistingMetadataSetsFileAttributes(t *testing.T) {
 	}
 }
 
+func TestFileTokenStoreSaveRejectsInvalidWeight(t *testing.T) {
+	baseDir := t.TempDir()
+	store := NewFileTokenStore()
+	store.SetBaseDir(baseDir)
+	auth := &cliproxyauth.Auth{
+		ID:       "invalid.json",
+		FileName: "invalid.json",
+		Metadata: map[string]any{
+			"type":                       "test",
+			cliproxyauth.AttributeWeight: 1.5,
+		},
+	}
+
+	if _, errSave := store.Save(context.Background(), auth); errSave == nil {
+		t.Fatal("Save() accepted an invalid weight")
+	}
+	if _, errStat := os.Stat(filepath.Join(baseDir, auth.FileName)); !os.IsNotExist(errStat) {
+		t.Fatalf("invalid auth file was persisted: %v", errStat)
+	}
+}
+
+func TestFileTokenStoreListReturnsInvalidPluginSourceWeight(t *testing.T) {
+	baseDir := t.TempDir()
+	path := filepath.Join(baseDir, "plugin.json")
+	if errWrite := os.WriteFile(path, []byte(`{"type":"plugin","weight":"invalid"}`), 0o600); errWrite != nil {
+		t.Fatalf("write auth file: %v", errWrite)
+	}
+
+	parserCalled := false
+	RegisterPluginAuthParser(fileStoreMultiAuthParserFunc(func(context.Context, pluginapi.AuthParseRequest) ([]*cliproxyauth.Auth, bool, error) {
+		parserCalled = true
+		return []*cliproxyauth.Auth{{ID: "plugin.json", Provider: "plugin"}}, true, nil
+	}))
+	t.Cleanup(func() {
+		RegisterPluginAuthParser(nil)
+	})
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(baseDir)
+	auths, errList := store.List(context.Background())
+	if errList == nil {
+		t.Fatal("List() error = nil, want invalid persisted weight error")
+	}
+	if parserCalled {
+		t.Fatal("plugin parser was called for an invalid persisted source")
+	}
+	if auths != nil {
+		t.Fatalf("List() auths = %#v, want nil on invalid persisted weight", auths)
+	}
+	if !strings.Contains(errList.Error(), path) || !strings.Contains(errList.Error(), "weight") {
+		t.Fatalf("List() error = %q, want source path and weight context", errList)
+	}
+}
+
 func TestFileTokenStoreListExpandsPluginMultiAuths(t *testing.T) {
 	baseDir := t.TempDir()
 	path := filepath.Join(baseDir, "geminicli.json")
-	if errWrite := os.WriteFile(path, []byte(`{"type":"gemini-cli","headers":{"X-Test":"value"}}`), 0o600); errWrite != nil {
+	if errWrite := os.WriteFile(path, []byte(`{"type":"gemini-cli","weight":3,"headers":{"X-Test":"value"}}`), 0o600); errWrite != nil {
 		t.Fatalf("write auth file: %v", errWrite)
 	}
 
@@ -210,6 +265,9 @@ func TestFileTokenStoreListExpandsPluginMultiAuths(t *testing.T) {
 		}
 		if gotHeader := auth.Attributes["header:X-Test"]; gotHeader != "value" {
 			t.Fatalf("header:X-Test = %q, want value", gotHeader)
+		}
+		if gotWeight := auth.Attributes[cliproxyauth.AttributeWeight]; gotWeight != "3" {
+			t.Fatalf("weight = %q, want 3", gotWeight)
 		}
 	}
 	if gotProject := auths[1].Metadata["project_id"]; gotProject != "project-a" {

--- a/sdk/cliproxy/auth/api_key_model_capabilities.go
+++ b/sdk/cliproxy/auth/api_key_model_capabilities.go
@@ -1,0 +1,217 @@
+package auth
+
+import (
+	"maps"
+	"strings"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/modelconfig"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+const resolvedAPIKeyModelInfoMetadataKey = "cliproxy.resolved_api_key_model_info"
+
+type apiKeyModelCapabilityRoute struct {
+	upstreamModel string
+	modelInfo     *registry.ModelInfo
+}
+
+type apiKeyModelCapabilityTable map[string]map[string][]apiKeyModelCapabilityRoute
+
+type apiKeyModelRoutingSnapshot struct {
+	config       *internalconfig.Config
+	aliases      apiKeyModelAliasTable
+	capabilities apiKeyModelCapabilityTable
+}
+
+func isConfiguredModelRoutingAuth(auth *Auth) bool {
+	if auth != nil && auth.AuthKind() == AuthKindAPIKey {
+		return true
+	}
+	if auth == nil || auth.AuthSourceKind() != AuthSourceConfig || auth.Attributes == nil {
+		return false
+	}
+	return strings.TrimSpace(auth.Attributes["compat_name"]) != ""
+}
+
+func (m *Manager) loadAPIKeyModelRouting() *apiKeyModelRoutingSnapshot {
+	if m == nil {
+		return &apiKeyModelRoutingSnapshot{config: &internalconfig.Config{}}
+	}
+	snapshot, _ := m.apiKeyModelRouting.Load().(*apiKeyModelRoutingSnapshot)
+	if snapshot == nil {
+		return &apiKeyModelRoutingSnapshot{config: &internalconfig.Config{}}
+	}
+	return snapshot
+}
+
+// ResolvedAPIKeyModelInfo returns the exact configured model definition bound to
+// this API-key execution attempt.
+func ResolvedAPIKeyModelInfo(req cliproxyexecutor.Request) (*registry.ModelInfo, bool) {
+	modelInfo, ok := req.Metadata[resolvedAPIKeyModelInfoMetadataKey].(*registry.ModelInfo)
+	if !ok || modelInfo == nil {
+		return nil, false
+	}
+	return modelInfo, true
+}
+
+func (m *Manager) attachResolvedAPIKeyModelInfo(req cliproxyexecutor.Request, auth *Auth, routeModel, upstreamModel string) cliproxyexecutor.Request {
+	return attachResolvedAPIKeyModelInfo(m.loadAPIKeyModelRouting(), req, auth, routeModel, upstreamModel)
+}
+
+func attachResolvedAPIKeyModelInfo(routing *apiKeyModelRoutingSnapshot, req cliproxyexecutor.Request, auth *Auth, routeModel, upstreamModel string) cliproxyexecutor.Request {
+	modelInfo, ok := lookupAPIKeyModelCapability(routing, auth, routeModel, upstreamModel)
+	if !ok {
+		return req
+	}
+	metadata := make(map[string]any, len(req.Metadata)+1)
+	maps.Copy(metadata, req.Metadata)
+	metadata[resolvedAPIKeyModelInfoMetadataKey] = modelInfo
+	req.Metadata = metadata
+	return req
+}
+
+func lookupAPIKeyModelCapability(routing *apiKeyModelRoutingSnapshot, auth *Auth, routeModel, upstreamModel string) (*registry.ModelInfo, bool) {
+	if !isConfiguredModelRoutingAuth(auth) || routing == nil {
+		return nil, false
+	}
+	byRoute := routing.capabilities[strings.TrimSpace(auth.ID)]
+	if len(byRoute) == 0 {
+		return nil, false
+	}
+	requestedModel := rewriteModelForAuth(strings.TrimSpace(routeModel), auth)
+	_, candidates := modelAliasLookupCandidates(requestedModel)
+	routes := make([]apiKeyModelCapabilityRoute, 0)
+	for _, candidate := range candidates {
+		routes = append(routes, byRoute[strings.ToLower(strings.TrimSpace(candidate))]...)
+	}
+	selected := strings.TrimSpace(upstreamModel)
+	for _, route := range routes {
+		if strings.EqualFold(strings.TrimSpace(route.upstreamModel), selected) {
+			return route.modelInfo, route.modelInfo != nil
+		}
+	}
+	for _, route := range routes {
+		if configuredUpstreamFallbackMatches(route.upstreamModel, selected) {
+			return route.modelInfo, route.modelInfo != nil
+		}
+	}
+	return nil, false
+}
+
+func configuredUpstreamFallbackMatches(configured, selected string) bool {
+	configuredResult := thinking.ParseSuffix(strings.TrimSpace(configured))
+	if configuredResult.HasSuffix {
+		return false
+	}
+	selectedResult := thinking.ParseSuffix(strings.TrimSpace(selected))
+	return strings.EqualFold(strings.TrimSpace(configuredResult.ModelName), strings.TrimSpace(selectedResult.ModelName))
+}
+
+func compileAPIKeyModelCapabilitiesForAuth(cfg *internalconfig.Config, auth *Auth) map[string][]apiKeyModelCapabilityRoute {
+	if cfg == nil || !isConfiguredModelRoutingAuth(auth) {
+		return nil
+	}
+	out := make(map[string][]apiKeyModelCapabilityRoute)
+	switch strings.ToLower(strings.TrimSpace(auth.Provider)) {
+	case "gemini":
+		if entry := resolveGeminiAPIKeyConfig(cfg, auth); entry != nil {
+			compileConfiguredModelCapabilities(out, entry.Models, "gemini")
+		}
+	case "gemini-interactions":
+		if entry := resolveInteractionsAPIKeyConfig(cfg, auth); entry != nil {
+			compileConfiguredModelCapabilities(out, entry.Models, "interactions")
+		}
+	case "claude":
+		if entry := resolveClaudeAPIKeyConfig(cfg, auth); entry != nil {
+			compileConfiguredModelCapabilities(out, entry.Models, "claude")
+		}
+	case "codex":
+		if entry := resolveCodexAPIKeyConfig(cfg, auth); entry != nil {
+			compileConfiguredModelCapabilities(out, entry.Models, "codex")
+		}
+	case "xai":
+		if entry := resolveXAIAPIKeyConfig(cfg, auth); entry != nil {
+			compileConfiguredModelCapabilities(out, entry.Models, "xai")
+		}
+	case "vertex":
+		if entry := resolveVertexAPIKeyConfig(cfg, auth); entry != nil {
+			compileConfiguredModelCapabilities(out, entry.Models, "gemini")
+		}
+	default:
+		providerKey, compatName := "", ""
+		if auth.Attributes != nil {
+			providerKey = strings.TrimSpace(auth.Attributes["provider_key"])
+			compatName = strings.TrimSpace(auth.Attributes["compat_name"])
+		}
+		if entry := resolveOpenAICompatConfigForAuth(cfg, auth, providerKey, compatName); entry != nil {
+			compileOpenAICompatibleModelCapabilities(out, entry.Models)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func compileConfiguredModelCapabilities[T interface {
+	GetName() string
+	GetAlias() string
+	GetThinking() *registry.ThinkingSupport
+}](out map[string][]apiKeyModelCapabilityRoute, models []T, modelType string) {
+	for i := range models {
+		addConfiguredModelCapability(out, models[i].GetName(), models[i].GetAlias(), modelType, models[i].GetThinking())
+	}
+}
+
+func compileOpenAICompatibleModelCapabilities(out map[string][]apiKeyModelCapabilityRoute, models []internalconfig.OpenAICompatibilityModel) {
+	for i := range models {
+		support := models[i].Thinking
+		if support == nil && !models[i].Image {
+			support = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
+		}
+		addConfiguredModelCapability(out, models[i].Name, models[i].Alias, "openai-compatibility", support)
+	}
+}
+
+func addConfiguredModelCapability(out map[string][]apiKeyModelCapabilityRoute, name, alias, modelType string, support *registry.ThinkingSupport) {
+	name = strings.TrimSpace(name)
+	alias = strings.TrimSpace(alias)
+	if name == "" {
+		name = alias
+	}
+	if alias == "" {
+		alias = name
+	}
+	if name == "" {
+		return
+	}
+	modelInfo := modelconfig.ResolveModelInfo(name, modelType, support)
+	route := apiKeyModelCapabilityRoute{upstreamModel: name, modelInfo: modelInfo}
+	seenKeys := make(map[string]struct{})
+	for _, routeModel := range []string{alias, name} {
+		_, candidates := modelAliasLookupCandidates(routeModel)
+		for _, candidate := range candidates {
+			key := strings.ToLower(strings.TrimSpace(candidate))
+			if key == "" {
+				continue
+			}
+			if _, exists := seenKeys[key]; exists {
+				continue
+			}
+			seenKeys[key] = struct{}{}
+			duplicate := false
+			for _, existing := range out[key] {
+				if strings.EqualFold(existing.upstreamModel, route.upstreamModel) {
+					duplicate = true
+					break
+				}
+			}
+			if !duplicate {
+				out[key] = append(out[key], route)
+			}
+		}
+	}
+}

--- a/sdk/cliproxy/auth/api_key_model_capabilities_test.go
+++ b/sdk/cliproxy/auth/api_key_model_capabilities_test.go
@@ -1,0 +1,253 @@
+package auth
+
+import (
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestAttachResolvedAPIKeyModelInfoUsesSelectedCredential(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{ClaudeKey: []internalconfig.ClaudeKey{
+		{
+			APIKey: "key-high",
+			Prefix: "tenant",
+			Models: []internalconfig.ClaudeModel{{
+				Name: "shared-upstream", Alias: "public-model",
+				Thinking: &registry.ThinkingSupport{Levels: []string{"high"}},
+			}},
+		},
+		{
+			APIKey: "key-max",
+			Prefix: "tenant",
+			Models: []internalconfig.ClaudeModel{{
+				Name: "shared-upstream", Alias: "public-model",
+				Thinking: &registry.ThinkingSupport{Levels: []string{"max"}},
+			}},
+		},
+	}})
+
+	authHigh := configuredCapabilityTestAuth("auth-high", "key-high")
+	authMax := configuredCapabilityTestAuth("auth-max", "key-max")
+	registerCapabilityTestAuth(t, manager, authHigh)
+	registerCapabilityTestAuth(t, manager, authMax)
+
+	assertResolvedThinkingLevels(t, manager.attachResolvedAPIKeyModelInfo(cliproxyexecutor.Request{}, authHigh, "tenant/public-model", "shared-upstream"), "high")
+	assertResolvedThinkingLevels(t, manager.attachResolvedAPIKeyModelInfo(cliproxyexecutor.Request{}, authMax, "tenant/public-model", "shared-upstream"), "max")
+}
+
+func TestAttachResolvedAPIKeyModelInfoUsesExactDuplicateCredentialConfig(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	highModels := []internalconfig.ClaudeModel{{
+		Name: "shared-upstream", Alias: "public-model",
+		Thinking: &registry.ThinkingSupport{Levels: []string{"high"}},
+	}}
+	maxModels := []internalconfig.ClaudeModel{{
+		Name: "shared-upstream", Alias: "public-model",
+		Thinking: &registry.ThinkingSupport{Levels: []string{"max"}},
+	}}
+	manager.SetConfig(&internalconfig.Config{ClaudeKey: []internalconfig.ClaudeKey{
+		{APIKey: "shared-key", Prefix: "tenant", Models: highModels},
+		{APIKey: "shared-key", Prefix: "tenant", Models: maxModels},
+	}})
+
+	authHigh := configuredCapabilityTestAuth("auth-duplicate-high", "shared-key")
+	authHigh.Attributes[AttributeConfigIndex] = "0"
+	authMax := configuredCapabilityTestAuth("auth-duplicate-max", "shared-key")
+	authMax.Attributes[AttributeConfigIndex] = "1"
+	registerCapabilityTestAuth(t, manager, authHigh)
+	registerCapabilityTestAuth(t, manager, authMax)
+
+	assertResolvedThinkingLevels(t, manager.attachResolvedAPIKeyModelInfo(cliproxyexecutor.Request{}, authHigh, "tenant/public-model", "shared-upstream"), "high")
+	assertResolvedThinkingLevels(t, manager.attachResolvedAPIKeyModelInfo(cliproxyexecutor.Request{}, authMax, "tenant/public-model", "shared-upstream"), "max")
+}
+
+func TestAttachResolvedAPIKeyModelInfoPrefersExactConfiguredSuffix(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	auth := configuredCapabilityTestAuth("auth-suffix", "key-suffix")
+	manager.SetConfig(&internalconfig.Config{ClaudeKey: []internalconfig.ClaudeKey{{
+		APIKey: "key-suffix",
+		Prefix: "tenant",
+		Models: []internalconfig.ClaudeModel{
+			{Name: "shared-upstream(high)", Alias: "public-high", Thinking: &registry.ThinkingSupport{Levels: []string{"high"}}},
+			{Name: "shared-upstream(low)", Alias: "public-low", Thinking: &registry.ThinkingSupport{Levels: []string{"low"}}},
+			{Name: "alias-upstream", Alias: "public(high)", Thinking: &registry.ThinkingSupport{Levels: []string{"high"}}},
+			{Name: "alias-upstream", Alias: "public(low)", Thinking: &registry.ThinkingSupport{Levels: []string{"low"}}},
+		},
+	}}})
+	registerCapabilityTestAuth(t, manager, auth)
+
+	req := manager.attachResolvedAPIKeyModelInfo(cliproxyexecutor.Request{}, auth, "tenant/public-low", "shared-upstream(low)")
+	assertResolvedThinkingLevels(t, req, "low")
+
+	models, _, _, routing := manager.executionModelCandidatesWithAlias(auth, "tenant/shared-upstream(low)")
+	if len(models) != 1 || models[0] != "shared-upstream(low)" {
+		t.Fatalf("direct suffixed models = %v, want [shared-upstream(low)]", models)
+	}
+	directReq := attachResolvedAPIKeyModelInfo(routing, cliproxyexecutor.Request{}, auth, "tenant/shared-upstream(low)", models[0])
+	assertResolvedThinkingLevels(t, directReq, "low")
+
+	aliasModels, _, _, aliasRouting := manager.executionModelCandidatesWithAlias(auth, "tenant/public(low)")
+	if len(aliasModels) != 1 || aliasModels[0] != "alias-upstream(low)" {
+		t.Fatalf("suffixed alias models = %v, want [alias-upstream(low)]", aliasModels)
+	}
+	aliasReq := attachResolvedAPIKeyModelInfo(aliasRouting, cliproxyexecutor.Request{}, auth, "tenant/public(low)", aliasModels[0])
+	assertResolvedThinkingLevels(t, aliasReq, "low")
+}
+
+func TestAPIKeyModelRoutingClonesPublishedConfig(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	cfg := &internalconfig.Config{ClaudeKey: []internalconfig.ClaudeKey{{
+		APIKey: "key-clone",
+		Prefix: "tenant",
+		Models: []internalconfig.ClaudeModel{{
+			Name: "shared-upstream", Alias: "public",
+			Thinking: &registry.ThinkingSupport{Levels: []string{"high"}},
+		}},
+	}}}
+	manager.SetConfig(cfg)
+	cfg.ClaudeKey[0].Models[0].Alias = "mutated"
+	cfg.ClaudeKey[0].Models[0].Thinking.Levels[0] = "max"
+
+	auth := configuredCapabilityTestAuth("auth-clone", "key-clone")
+	registerCapabilityTestAuth(t, manager, auth)
+	models, _, _, routing := manager.executionModelCandidatesWithAlias(auth, "tenant/public")
+	if len(models) != 1 || models[0] != "shared-upstream" {
+		t.Fatalf("cloned execution models = %v, want [shared-upstream]", models)
+	}
+	req := attachResolvedAPIKeyModelInfo(routing, cliproxyexecutor.Request{}, auth, "tenant/public", models[0])
+	assertResolvedThinkingLevels(t, req, "high")
+}
+
+func TestAPIKeyModelRoutingKeepsOneExecutionSnapshotAcrossReload(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	auth := configuredCapabilityTestAuth("auth-reload", "key-reload")
+	buildConfig := func(level string) *internalconfig.Config {
+		return &internalconfig.Config{ClaudeKey: []internalconfig.ClaudeKey{{
+			APIKey: "key-reload",
+			Prefix: "tenant",
+			Models: []internalconfig.ClaudeModel{{
+				Name: "shared-upstream", Alias: "public",
+				Thinking: &registry.ThinkingSupport{Levels: []string{level}},
+			}},
+		}}}
+	}
+	manager.SetConfig(buildConfig("high"))
+	registerCapabilityTestAuth(t, manager, auth)
+	models, _, _, oldRouting := manager.executionModelCandidatesWithAlias(auth, "tenant/public")
+	if len(models) != 1 || models[0] != "shared-upstream" {
+		t.Fatalf("execution models = %v, want [shared-upstream]", models)
+	}
+
+	manager.SetConfig(buildConfig("max"))
+	oldReq := attachResolvedAPIKeyModelInfo(oldRouting, cliproxyexecutor.Request{}, auth, "tenant/public", models[0])
+	assertResolvedThinkingLevels(t, oldReq, "high")
+	newReq := manager.attachResolvedAPIKeyModelInfo(cliproxyexecutor.Request{}, auth, "tenant/public", models[0])
+	assertResolvedThinkingLevels(t, newReq, "max")
+}
+
+func TestAttachResolvedAPIKeyModelInfoSupportsKeylessOpenAICompatibility(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{OpenAICompatibility: []internalconfig.OpenAICompatibility{{
+		Name:    "keyless",
+		Prefix:  "tenant",
+		BaseURL: "https://example.com/v1",
+		Models: []internalconfig.OpenAICompatibilityModel{
+			{
+				Name: "shared-upstream", Alias: "public-model", ForceMapping: true,
+				Thinking: &registry.ThinkingSupport{Levels: []string{"high"}},
+			},
+			{
+				Name: "fallback-upstream", Alias: "public-model",
+				Thinking: &registry.ThinkingSupport{Levels: []string{"high"}},
+			},
+		},
+	}}})
+	auth := &Auth{
+		ID:       "auth-keyless",
+		Provider: "openai-compatibility:keyless",
+		Prefix:   "tenant",
+		Attributes: map[string]string{
+			AttributeSource: "config:keyless[0]",
+			"compat_name":   "keyless",
+			"provider_key":  "openai-compatibility:keyless",
+		},
+	}
+	registerCapabilityTestAuth(t, manager, auth)
+	models, _, aliasResult, routing := manager.executionModelCandidatesWithAlias(auth, "tenant/public-model")
+	if len(models) != 2 || models[0] != "shared-upstream" || models[1] != "fallback-upstream" {
+		t.Fatalf("keyless execution models = %v, want [shared-upstream fallback-upstream]", models)
+	}
+	if !aliasResult.ForceMapping || aliasResult.UpstreamModel != "shared-upstream" {
+		t.Fatalf("keyless force mapping result = %+v, want shared-upstream force mapping", aliasResult)
+	}
+	fallbackAliasResult := resolveAttemptAliasResult(routing, auth, "tenant/public-model", "fallback-upstream", aliasResult)
+	if fallbackAliasResult.ForceMapping {
+		t.Fatalf("fallback alias result = %+v, want force mapping disabled", fallbackAliasResult)
+	}
+	req := attachResolvedAPIKeyModelInfo(routing, cliproxyexecutor.Request{}, auth, "tenant/public-model", models[0])
+	assertResolvedThinkingLevels(t, req, "high")
+}
+
+func TestAttachResolvedAPIKeyModelInfoBindsUnknownConfiguredCapability(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	auth := configuredCapabilityTestAuth("auth-fallback", "key-fallback")
+	manager.SetConfig(&internalconfig.Config{ClaudeKey: []internalconfig.ClaudeKey{{
+		APIKey: "key-fallback",
+		Prefix: "tenant",
+		Models: []internalconfig.ClaudeModel{{Name: "unknown-upstream", Alias: "unknown-public"}},
+	}}})
+	registerCapabilityTestAuth(t, manager, auth)
+
+	req := manager.attachResolvedAPIKeyModelInfo(cliproxyexecutor.Request{}, auth, "tenant/unknown-public", "unknown-upstream")
+	info, ok := ResolvedAPIKeyModelInfo(req)
+	if !ok || info == nil || info.UserDefined || info.Thinking != nil {
+		t.Fatalf("ResolvedAPIKeyModelInfo() = (%+v, %t), want authoritative empty capability", info, ok)
+	}
+	fallbackReq := manager.attachResolvedAPIKeyModelInfo(cliproxyexecutor.Request{}, auth, "tenant/not-configured", "not-configured")
+	if fallbackInfo, fallbackOK := ResolvedAPIKeyModelInfo(fallbackReq); fallbackOK || fallbackInfo != nil {
+		t.Fatalf("unconfigured model info = (%+v, %t), want registry fallback", fallbackInfo, fallbackOK)
+	}
+}
+
+func registerCapabilityTestAuth(t *testing.T, manager *Manager, auth *Auth) {
+	t.Helper()
+	registered, errRegister := manager.Register(t.Context(), auth)
+	if errRegister != nil {
+		t.Fatalf("Register() error = %v", errRegister)
+	}
+	if registered == nil {
+		t.Fatal("Register() returned nil auth")
+	}
+}
+
+func configuredCapabilityTestAuth(id, apiKey string) *Auth {
+	return &Auth{
+		ID:       id,
+		Provider: "claude",
+		Prefix:   "tenant",
+		Attributes: map[string]string{
+			AttributeAuthKind: AuthKindAPIKey,
+			AttributeAPIKey:   apiKey,
+			AttributeSource:   "config:claude[0]",
+		},
+	}
+}
+
+func assertResolvedThinkingLevels(t *testing.T, req cliproxyexecutor.Request, want ...string) {
+	t.Helper()
+	info, ok := ResolvedAPIKeyModelInfo(req)
+	if !ok || info == nil || info.Thinking == nil {
+		t.Fatalf("ResolvedAPIKeyModelInfo() = (%+v, %t), want thinking levels %v", info, ok, want)
+	}
+	if len(info.Thinking.Levels) != len(want) {
+		t.Fatalf("thinking levels = %v, want %v", info.Thinking.Levels, want)
+	}
+	for i := range want {
+		if info.Thinking.Levels[i] != want[i] {
+			t.Fatalf("thinking levels = %v, want %v", info.Thinking.Levels, want)
+		}
+	}
+}

--- a/sdk/cliproxy/auth/classification.go
+++ b/sdk/cliproxy/auth/classification.go
@@ -15,10 +15,12 @@ const (
 
 	AttributeAPIKey        = "api_key"
 	AttributeAuthKind      = "auth_kind"
+	AttributeConfigIndex   = "config_index"
 	AttributePath          = "path"
 	AttributeRuntimeOnly   = "runtime_only"
 	AttributeSource        = "source"
 	AttributeSourceBackend = "source_backend"
+	AttributeWeight        = "weight"
 )
 
 // AuthKind returns the credential kind using explicit metadata first and legacy

--- a/sdk/cliproxy/auth/classification.go
+++ b/sdk/cliproxy/auth/classification.go
@@ -19,6 +19,7 @@ const (
 	AttributeRuntimeOnly   = "runtime_only"
 	AttributeSource        = "source"
 	AttributeSourceBackend = "source_backend"
+	AttributeWeight        = "weight"
 )
 
 // AuthKind returns the credential kind using explicit metadata first and legacy

--- a/sdk/cliproxy/auth/classification.go
+++ b/sdk/cliproxy/auth/classification.go
@@ -15,6 +15,7 @@ const (
 
 	AttributeAPIKey        = "api_key"
 	AttributeAuthKind      = "auth_kind"
+	AttributeConfigIndex   = "config_index"
 	AttributePath          = "path"
 	AttributeRuntimeOnly   = "runtime_only"
 	AttributeSource        = "source"

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -135,9 +135,8 @@ type Manager struct {
 	// oauthModelAlias stores global OAuth model alias mappings (alias -> upstream name) keyed by channel.
 	oauthModelAlias atomic.Value
 
-	// apiKeyModelAlias caches resolved model alias mappings for API-key auths.
-	// Keyed by auth.ID, value is alias(lower) -> upstream model (including suffix).
-	apiKeyModelAlias atomic.Value
+	// apiKeyModelRouting atomically publishes per-auth aliases and configured capabilities.
+	apiKeyModelRouting atomic.Value
 
 	// modelPoolOffsets tracks per-auth alias pool rotation state.
 	modelPoolOffsets map[string]int
@@ -181,7 +180,7 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 	}
 	// atomic.Value requires non-nil initial value.
 	manager.runtimeConfig.Store(&internalconfig.Config{})
-	manager.apiKeyModelAlias.Store(apiKeyModelAliasTable(nil))
+	manager.apiKeyModelRouting.Store(&apiKeyModelRoutingSnapshot{config: &internalconfig.Config{}})
 	defaultInFlightConfig, errInFlightConfig := HomeInFlightPublisherConfigFromConfig(internalconfig.DefaultCredentialInFlightConfig())
 	if errInFlightConfig == nil {
 		manager.ApplyHomeInFlightPublisherConfig(defaultInFlightConfig)

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -138,9 +138,8 @@ type Manager struct {
 	// oauthModelAlias stores global OAuth model alias mappings (alias -> upstream name) keyed by channel.
 	oauthModelAlias atomic.Value
 
-	// apiKeyModelAlias caches resolved model alias mappings for API-key auths.
-	// Keyed by auth.ID, value is alias(lower) -> upstream model (including suffix).
-	apiKeyModelAlias atomic.Value
+	// apiKeyModelRouting atomically publishes per-auth aliases and configured capabilities.
+	apiKeyModelRouting atomic.Value
 
 	// modelPoolOffsets tracks per-auth alias pool rotation state.
 	modelPoolOffsets map[string]int
@@ -201,7 +200,7 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 	}
 	// atomic.Value requires non-nil initial value.
 	manager.runtimeConfig.Store(&internalconfig.Config{})
-	manager.apiKeyModelAlias.Store(apiKeyModelAliasTable(nil))
+	manager.apiKeyModelRouting.Store(&apiKeyModelRoutingSnapshot{config: &internalconfig.Config{}})
 	defaultInFlightConfig, errInFlightConfig := HomeInFlightPublisherConfigFromConfig(internalconfig.DefaultCredentialInFlightConfig())
 	if errInFlightConfig == nil {
 		manager.ApplyHomeInFlightPublisherConfig(defaultInFlightConfig)

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -120,6 +120,8 @@ func (m *Manager) SetConfigSnapshot(cfg *internalconfig.Config) bool {
 func (m *Manager) setConfigSnapshotLocked(cfg *internalconfig.Config) bool {
 	if cfg == nil {
 		cfg = &internalconfig.Config{}
+	} else {
+		cfg = cfg.CloneForRuntime()
 	}
 	m.mu.RLock()
 	oldCooldownStore := m.cooldownStore

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -86,6 +86,13 @@ func nextTransientErrorRetryAfter(now time.Time) time.Time {
 	return now.Add(time.Duration(seconds) * time.Second)
 }
 
+func recoverableFailureRetryAfter(now time.Time, disableCooling bool) time.Time {
+	if disableCooling {
+		return time.Time{}
+	}
+	return nextTransientErrorRetryAfter(now)
+}
+
 // SetConfig updates the runtime config snapshot used by request-time helpers.
 // Callers should provide the latest config on reload so per-credential alias mapping stays in sync.
 func (m *Manager) SetConfig(cfg *internalconfig.Config) {
@@ -820,16 +827,18 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								setModelQuota = true
 							}
 						case 408, 500, 502, 503, 504:
-							if disableCooling {
-								state.NextRetryAfter = time.Time{}
-							} else {
-								state.NextRetryAfter = nextTransientErrorRetryAfter(now)
-							}
+							state.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
+							state.Unavailable = !state.NextRetryAfter.IsZero()
 						default:
-							state.NextRetryAfter = time.Time{}
+							state.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
+							state.Unavailable = !state.NextRetryAfter.IsZero()
 						}
 					}
 
+					if disableCooling && state.NextRetryAfter.IsZero() && state.Quota.NextRecoverAt.IsZero() {
+						state.Unavailable = false
+						state.Quota.Exceeded = false
+					}
 					auth.Status = StatusError
 					auth.UpdatedAt = now
 					updateAggregatedAvailability(auth, now)
@@ -1571,6 +1580,12 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 	if isRequestScopedResultError(resultErr) {
 		return
 	}
+	defer func() {
+		if disableCooling && auth.NextRetryAfter.IsZero() && auth.Quota.NextRecoverAt.IsZero() {
+			auth.Unavailable = false
+			auth.Quota.Exceeded = false
+		}
+	}()
 	auth.Unavailable = true
 	auth.Status = StatusError
 	auth.UpdatedAt = now
@@ -1640,15 +1655,14 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		auth.NextRetryAfter = next
 	case 408, 500, 502, 503, 504:
 		auth.StatusMessage = "transient upstream error"
-		if disableCooling {
-			auth.NextRetryAfter = time.Time{}
-		} else {
-			auth.NextRetryAfter = nextTransientErrorRetryAfter(now)
-		}
+		auth.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
+		auth.Unavailable = !auth.NextRetryAfter.IsZero()
 	default:
 		if auth.StatusMessage == "" {
 			auth.StatusMessage = "request failed"
 		}
+		auth.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
+		auth.Unavailable = !auth.NextRetryAfter.IsZero()
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -86,6 +86,13 @@ func nextTransientErrorRetryAfter(now time.Time) time.Time {
 	return now.Add(time.Duration(seconds) * time.Second)
 }
 
+func recoverableFailureRetryAfter(now time.Time, disableCooling bool) time.Time {
+	if disableCooling {
+		return time.Time{}
+	}
+	return nextTransientErrorRetryAfter(now)
+}
+
 // SetConfig updates the runtime config snapshot used by request-time helpers.
 // Callers should provide the latest config on reload so per-credential alias mapping stays in sync.
 func (m *Manager) SetConfig(cfg *internalconfig.Config) {
@@ -130,6 +137,8 @@ func (m *Manager) SetConfigSnapshot(cfg *internalconfig.Config) bool {
 func (m *Manager) setConfigSnapshotLocked(cfg *internalconfig.Config) bool {
 	if cfg == nil {
 		cfg = &internalconfig.Config{}
+	} else {
+		cfg = cfg.CloneForRuntime()
 	}
 	// Publish policy and invalidate old absolute deadlines atomically with
 	// respect to begin/MarkResult, preserving manager -> continuity lock order.
@@ -861,16 +870,18 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								setModelQuota = true
 							}
 						case 408, 500, 502, 503, 504:
-							if disableCooling {
-								state.NextRetryAfter = time.Time{}
-							} else {
-								state.NextRetryAfter = nextTransientErrorRetryAfter(now)
-							}
+							state.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
+							state.Unavailable = !state.NextRetryAfter.IsZero()
 						default:
-							state.NextRetryAfter = time.Time{}
+							state.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
+							state.Unavailable = !state.NextRetryAfter.IsZero()
 						}
 					}
 
+					if disableCooling && state.NextRetryAfter.IsZero() && state.Quota.NextRecoverAt.IsZero() {
+						state.Unavailable = false
+						state.Quota.Exceeded = false
+					}
 					auth.Status = StatusError
 					auth.UpdatedAt = now
 					updateAggregatedAvailability(auth, now)
@@ -1607,6 +1618,12 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 	if isRequestScopedResultError(resultErr) {
 		return
 	}
+	defer func() {
+		if disableCooling && auth.NextRetryAfter.IsZero() && auth.Quota.NextRecoverAt.IsZero() {
+			auth.Unavailable = false
+			auth.Quota.Exceeded = false
+		}
+	}()
 	auth.Unavailable = true
 	auth.Status = StatusError
 	auth.UpdatedAt = now
@@ -1688,15 +1705,14 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		auth.NextRetryAfter = next
 	case 408, 500, 502, 503, 504:
 		auth.StatusMessage = "transient upstream error"
-		if disableCooling {
-			auth.NextRetryAfter = time.Time{}
-		} else {
-			auth.NextRetryAfter = nextTransientErrorRetryAfter(now)
-		}
+		auth.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
+		auth.Unavailable = !auth.NextRetryAfter.IsZero()
 	default:
 		if auth.StatusMessage == "" {
 			auth.StatusMessage = "request failed"
 		}
+		auth.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
+		auth.Unavailable = !auth.NextRetryAfter.IsZero()
 	}
 }
 

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -302,7 +302,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 		}
 		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
 
-		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(auth, routeModel)
+		models, pooled, aliasResult, routing := m.preparedExecutionModelsWithAlias(auth, routeModel)
 		if len(models) == 0 {
 			continue
 		}
@@ -329,6 +329,9 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			execReq, execOpts, errIntercept = applyRequestAfterAuthInterceptor(execCtx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
 			if errIntercept != nil {
 				return cliproxyexecutor.Response{}, errIntercept
+			}
+			if !restoreExecutionModel {
+				execReq = attachResolvedAPIKeyModelInfo(routing, execReq, auth, routeModel, upstreamModel)
 			}
 			resp, errExec := executor.Execute(execCtx, auth, execReq, execOpts)
 			if errExec != nil {
@@ -360,7 +363,8 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				continue
 			}
 			m.MarkResult(execCtx, result)
-			rewriteForceMappedResponse(&resp, aliasResult)
+			attemptAliasResult := resolveAttemptAliasResult(routing, auth, routeModel, upstreamModel, aliasResult)
+			rewriteForceMappedResponse(&resp, attemptAliasResult)
 			return resp, nil
 		}
 		if authErr != nil {
@@ -419,7 +423,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 		}
 		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
 
-		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(auth, routeModel)
+		models, pooled, aliasResult, routing := m.preparedExecutionModelsWithAlias(auth, routeModel)
 		if len(models) == 0 {
 			continue
 		}
@@ -446,6 +450,9 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			execReq, execOpts, errIntercept = applyRequestAfterAuthInterceptor(execCtx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
 			if errIntercept != nil {
 				return cliproxyexecutor.Response{}, errIntercept
+			}
+			if !restoreExecutionModel {
+				execReq = attachResolvedAPIKeyModelInfo(routing, execReq, auth, routeModel, upstreamModel)
 			}
 			resp, errExec := executor.CountTokens(execCtx, auth, execReq, execOpts)
 			if errExec != nil {
@@ -485,7 +492,8 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				continue
 			}
 			m.MarkResult(execCtx, result)
-			rewriteForceMappedResponse(&resp, aliasResult)
+			attemptAliasResult := resolveAttemptAliasResult(routing, auth, routeModel, upstreamModel, aliasResult)
+			rewriteForceMappedResponse(&resp, attemptAliasResult)
 			return resp, nil
 		}
 		if authErr != nil {
@@ -579,7 +587,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
 		}
-		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(auth, routeModel)
+		models, pooled, aliasResult, routing := m.preparedExecutionModelsWithAlias(auth, routeModel)
 		if selection != nil && aliasResult.ForceMapping && responseAlias != "" {
 			aliasResult.OriginalAlias = responseAlias
 		}
@@ -628,7 +636,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			models = models[:1]
 			pooled = false
 		}
-		streamResult, errStream := m.executeStreamWithModelPool(execCtx, executor, auth, provider, execReq, execOpts, routeModel, streamExecutionModel, models, pooled, aliasResult, !homeMode, selection != nil)
+		streamResult, errStream := m.executeStreamWithModelPool(execCtx, executor, auth, provider, execReq, execOpts, routeModel, streamExecutionModel, models, pooled, aliasResult, routing, !homeMode, selection != nil)
 		if errStream != nil {
 			if selection != nil {
 				releaseAttempt()

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -302,7 +302,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 		}
 		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
 
-		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(auth, routeModel)
+		models, pooled, aliasResult, routing := m.preparedExecutionModelsWithAlias(auth, routeModel)
 		if len(models) == 0 {
 			continue
 		}
@@ -343,6 +343,9 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				selectedPublished = true
 			}
 			markCodexModelFallbackDispatch(execOpts, auth.ID)
+			if !restoreExecutionModel {
+				execReq = attachResolvedAPIKeyModelInfo(routing, execReq, auth, routeModel, upstreamModel)
+			}
 			resp, errExec := executor.Execute(execCtx, auth, execReq, execOpts)
 			if errExec != nil {
 				if errCtx := execCtx.Err(); errCtx != nil {
@@ -387,7 +390,8 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				continue
 			}
 			m.MarkResult(execCtx, result)
-			rewriteForceMappedResponse(&resp, aliasResult)
+			attemptAliasResult := resolveAttemptAliasResult(routing, auth, routeModel, upstreamModel, aliasResult)
+			rewriteForceMappedResponse(&resp, attemptAliasResult)
 			return resp, nil
 		}
 		if authErr != nil {
@@ -447,7 +451,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 		}
 		execCtx = contextWithRequestedModelAlias(execCtx, opts, routeModel)
 
-		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(auth, routeModel)
+		models, pooled, aliasResult, routing := m.preparedExecutionModelsWithAlias(auth, routeModel)
 		if len(models) == 0 {
 			continue
 		}
@@ -482,6 +486,9 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			if !selectedPublished {
 				publishSelectedAuthMetadata(execOpts.Metadata, auth)
 				selectedPublished = true
+			}
+			if !restoreExecutionModel {
+				execReq = attachResolvedAPIKeyModelInfo(routing, execReq, auth, routeModel, upstreamModel)
 			}
 			resp, errExec := executor.CountTokens(execCtx, auth, execReq, execOpts)
 			if errExec != nil {
@@ -527,7 +534,8 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				continue
 			}
 			m.MarkResult(execCtx, result)
-			rewriteForceMappedResponse(&resp, aliasResult)
+			attemptAliasResult := resolveAttemptAliasResult(routing, auth, routeModel, upstreamModel, aliasResult)
+			rewriteForceMappedResponse(&resp, attemptAliasResult)
 			return resp, nil
 		}
 		if authErr != nil {
@@ -647,7 +655,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
 		}
-		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(auth, routeModel)
+		models, pooled, aliasResult, routing := m.preparedExecutionModelsWithAlias(auth, routeModel)
 		if selection != nil && aliasResult.ForceMapping && responseAlias != "" {
 			aliasResult.OriginalAlias = responseAlias
 		}
@@ -696,7 +704,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			models = models[:1]
 			pooled = false
 		}
-		streamResult, errStream := m.executeStreamWithModelPool(execCtx, executor, auth, provider, execReq, execOpts, routeModel, streamExecutionModel, models, pooled, aliasResult, !homeMode, selection != nil)
+		streamResult, errStream := m.executeStreamWithModelPool(execCtx, executor, auth, provider, execReq, execOpts, routeModel, streamExecutionModel, models, pooled, aliasResult, routing, !homeMode, selection != nil)
 		if errStream != nil {
 			if selection != nil {
 				releaseAttempt()

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -1045,7 +1045,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 		}
 		c.auth = preparedAuth
 		publishSelectedAuthMetadata(creditsOpts.Metadata, c.auth)
-		models, pooled, aliasResult := m.executionModelCandidatesWithAlias(c.auth, routeModel)
+		models, pooled, aliasResult, routing := m.executionModelCandidatesWithAlias(c.auth, routeModel)
 		if len(models) == 0 {
 			continue
 		}
@@ -1064,7 +1064,8 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 				continue
 			}
 			m.MarkResult(creditsCtx, result)
-			rewriteForceMappedResponse(&resp, aliasResult)
+			attemptAliasResult := resolveAttemptAliasResult(routing, c.auth, routeModel, upstreamModel, aliasResult)
+			rewriteForceMappedResponse(&resp, attemptAliasResult)
 			return resp, true, nil
 		}
 	}
@@ -1099,11 +1100,11 @@ func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cl
 		}
 		c.auth = preparedAuth
 		publishSelectedAuthMetadata(creditsOpts.Metadata, c.auth)
-		models, pooled, aliasResult := m.executionModelCandidatesWithAlias(c.auth, routeModel)
+		models, pooled, aliasResult, routing := m.executionModelCandidatesWithAlias(c.auth, routeModel)
 		if len(models) == 0 {
 			continue
 		}
-		result, errStream := m.executeStreamWithModelPool(creditsCtx, c.executor, c.auth, c.provider, req, creditsOpts, routeModel, "", models, pooled, aliasResult, true, false)
+		result, errStream := m.executeStreamWithModelPool(creditsCtx, c.executor, c.auth, c.provider, req, creditsOpts, routeModel, "", models, pooled, aliasResult, routing, true, false)
 		if errStream != nil {
 			continue
 		}

--- a/sdk/cliproxy/auth/conductor_home_execution.go
+++ b/sdk/cliproxy/auth/conductor_home_execution.go
@@ -55,7 +55,7 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
 		}
-		models, pooled, aliasResult := m.preparedExecutionModelsWithAlias(auth, routeModel)
+		models, pooled, aliasResult, routing := m.preparedExecutionModelsWithAlias(auth, routeModel)
 		if aliasResult.ForceMapping && responseAlias != "" {
 			aliasResult.OriginalAlias = responseAlias
 		}
@@ -97,6 +97,9 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 				selection.End("request_intercepted")
 				return cliproxyexecutor.Response{}, errIntercept
 			}
+			if !restoreExecutionModel {
+				execReq = attachResolvedAPIKeyModelInfo(routing, execReq, preparedAuth, routeModel, upstreamModel)
+			}
 			if errCtx := execCtx.Err(); errCtx != nil {
 				releaseAttempt()
 				selection.End("attempt_canceled")
@@ -113,7 +116,8 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 			if errExecute == nil {
 				m.reportHomeResult(execCtx, result, preparedAuth)
 				releaseAttempt()
-				rewriteForceMappedResponse(&response, aliasResult)
+				attemptAliasResult := resolveAttemptAliasResult(routing, preparedAuth, routeModel, upstreamModel, aliasResult)
+				rewriteForceMappedResponse(&response, attemptAliasResult)
 				if !m.retainHomeWebsocketSelection(ctx, opts, routeModel, selection) {
 					selection.End("completed")
 				}

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -68,6 +69,9 @@ func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 	if auth == nil {
 		return nil, nil
 	}
+	if errWeight := ValidateAuthWeight(auth); errWeight != nil {
+		return nil, fmt.Errorf("register auth: %w", errWeight)
+	}
 	if auth.ID == "" {
 		auth.ID = uuid.NewString()
 	}
@@ -100,6 +104,9 @@ func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 	if auth == nil || auth.ID == "" {
 		return nil, nil
+	}
+	if errWeight := ValidateAuthWeight(auth); errWeight != nil {
+		return nil, fmt.Errorf("update auth: %w", errWeight)
 	}
 	m.mu.Lock()
 	existing, ok := m.auths[auth.ID]
@@ -222,6 +229,9 @@ func (m *Manager) Load(ctx context.Context) error {
 		if auth == nil || auth.ID == "" {
 			continue
 		}
+		if errWeight := ValidateAuthWeight(auth); errWeight != nil {
+			continue
+		}
 		auth.EnsureIndex()
 		m.auths[auth.ID] = auth.Clone()
 	}
@@ -238,6 +248,9 @@ func (m *Manager) Load(ctx context.Context) error {
 func (m *Manager) persist(ctx context.Context, auth *Auth) error {
 	if m.store == nil || auth == nil {
 		return nil
+	}
+	if errWeight := ValidateAuthWeight(auth); errWeight != nil {
+		return fmt.Errorf("persist auth: %w", errWeight)
 	}
 	if shouldSkipPersist(ctx) {
 		return nil

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -68,6 +69,9 @@ func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 	if auth == nil {
 		return nil, nil
 	}
+	if errWeight := ValidateAuthWeight(auth); errWeight != nil {
+		return nil, fmt.Errorf("register auth: %w", errWeight)
+	}
 	if auth.ID == "" {
 		auth.ID = uuid.NewString()
 	}
@@ -100,6 +104,9 @@ func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 	if auth == nil || auth.ID == "" {
 		return nil, nil
+	}
+	if errWeight := ValidateAuthWeight(auth); errWeight != nil {
+		return nil, fmt.Errorf("update auth: %w", errWeight)
 	}
 	m.mu.Lock()
 	existing, ok := m.auths[auth.ID]
@@ -232,6 +239,9 @@ func (m *Manager) Load(ctx context.Context) error {
 		if auth == nil || auth.ID == "" {
 			continue
 		}
+		if errWeight := ValidateAuthWeight(auth); errWeight != nil {
+			continue
+		}
 		auth.EnsureIndex()
 		m.auths[auth.ID] = auth.Clone()
 	}
@@ -250,6 +260,9 @@ func (m *Manager) Load(ctx context.Context) error {
 func (m *Manager) persist(ctx context.Context, auth *Auth) error {
 	if m.store == nil || auth == nil {
 		return nil
+	}
+	if errWeight := ValidateAuthWeight(auth); errWeight != nil {
+		return fmt.Errorf("persist auth: %w", errWeight)
 	}
 	if shouldSkipPersist(ctx) {
 		return nil

--- a/sdk/cliproxy/auth/conductor_models.go
+++ b/sdk/cliproxy/auth/conductor_models.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"bytes"
+	"strconv"
 	"strings"
 	"time"
 
@@ -12,7 +13,11 @@ import (
 )
 
 func (m *Manager) lookupAPIKeyUpstreamModel(authID, requestedModel string) string {
-	if m == nil {
+	return lookupAPIKeyUpstreamModel(m.loadAPIKeyModelRouting(), authID, requestedModel)
+}
+
+func lookupAPIKeyUpstreamModel(routing *apiKeyModelRoutingSnapshot, authID, requestedModel string) string {
+	if routing == nil {
 		return ""
 	}
 	authID = strings.TrimSpace(authID)
@@ -23,23 +28,21 @@ func (m *Manager) lookupAPIKeyUpstreamModel(authID, requestedModel string) strin
 	if requestedModel == "" {
 		return ""
 	}
-	table, _ := m.apiKeyModelAlias.Load().(apiKeyModelAliasTable)
-	if table == nil {
-		return ""
-	}
-	byAlias := table[authID]
+	byAlias := routing.aliases[authID]
 	if len(byAlias) == 0 {
 		return ""
 	}
-	key := strings.ToLower(thinking.ParseSuffix(requestedModel).ModelName)
-	if key == "" {
-		key = strings.ToLower(requestedModel)
+	keys := []string{strings.ToLower(requestedModel)}
+	baseKey := strings.ToLower(strings.TrimSpace(thinking.ParseSuffix(requestedModel).ModelName))
+	if baseKey != "" && baseKey != keys[0] {
+		keys = append(keys, baseKey)
 	}
-	resolved := strings.TrimSpace(byAlias[key])
-	if resolved == "" {
-		return ""
+	for _, key := range keys {
+		if resolved := strings.TrimSpace(byAlias[key]); resolved != "" {
+			return preserveRequestedModelSuffix(requestedModel, resolved)
+		}
 	}
-	return preserveRequestedModelSuffix(requestedModel, resolved)
+	return ""
 }
 
 func isAPIKeyAuth(auth *Auth) bool {
@@ -49,8 +52,8 @@ func isAPIKeyAuth(auth *Auth) bool {
 	return auth.AuthKind() == AuthKindAPIKey
 }
 
-func isOpenAICompatAPIKeyAuth(auth *Auth) bool {
-	if !isAPIKeyAuth(auth) {
+func isConfiguredOpenAICompatAuth(auth *Auth) bool {
+	if !isConfiguredModelRoutingAuth(auth) {
 		return false
 	}
 	if strings.EqualFold(strings.TrimSpace(auth.Provider), "openai-compatibility") {
@@ -126,14 +129,17 @@ func rotateStrings(values []string, offset int) []string {
 }
 
 func (m *Manager) resolveOpenAICompatUpstreamModelPool(auth *Auth, requestedModel string) []string {
-	if m == nil || !isOpenAICompatAPIKeyAuth(auth) {
+	return resolveOpenAICompatUpstreamModelPool(m.loadAPIKeyModelRouting().config, auth, requestedModel)
+}
+
+func resolveOpenAICompatUpstreamModelPool(cfg *internalconfig.Config, auth *Auth, requestedModel string) []string {
+	if !isConfiguredOpenAICompatAuth(auth) {
 		return nil
 	}
 	requestedModel = strings.TrimSpace(requestedModel)
 	if requestedModel == "" {
 		return nil
 	}
-	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
 	if cfg == nil {
 		cfg = &internalconfig.Config{}
 	}
@@ -143,7 +149,7 @@ func (m *Manager) resolveOpenAICompatUpstreamModelPool(auth *Auth, requestedMode
 		providerKey = strings.TrimSpace(auth.Attributes["provider_key"])
 		compatName = strings.TrimSpace(auth.Attributes["compat_name"])
 	}
-	entry := resolveOpenAICompatConfig(cfg, providerKey, compatName, auth.Provider)
+	entry := resolveOpenAICompatConfigForAuth(cfg, auth, providerKey, compatName)
 	if entry == nil {
 		return nil
 	}
@@ -244,14 +250,15 @@ func (m *Manager) preparedExecutionModels(auth *Auth, routeModel string) ([]stri
 	return m.filterExecutionModels(auth, routeModel, candidates, pooled), pooled
 }
 
-func (m *Manager) preparedExecutionModelsWithAlias(auth *Auth, routeModel string) ([]string, bool, OAuthModelAliasResult) {
-	candidates, pooled, aliasResult := m.executionModelCandidatesWithAlias(auth, routeModel)
-	return m.filterExecutionModels(auth, routeModel, candidates, pooled), pooled, aliasResult
+func (m *Manager) preparedExecutionModelsWithAlias(auth *Auth, routeModel string) ([]string, bool, OAuthModelAliasResult, *apiKeyModelRoutingSnapshot) {
+	candidates, pooled, aliasResult, routing := m.executionModelCandidatesWithAlias(auth, routeModel)
+	return m.filterExecutionModels(auth, routeModel, candidates, pooled), pooled, aliasResult, routing
 }
 
-func (m *Manager) executionModelCandidatesWithAlias(auth *Auth, routeModel string) ([]string, bool, OAuthModelAliasResult) {
+func (m *Manager) executionModelCandidatesWithAlias(auth *Auth, routeModel string) ([]string, bool, OAuthModelAliasResult, *apiKeyModelRoutingSnapshot) {
+	routing := m.loadAPIKeyModelRouting()
 	requestedModel := rewriteModelForAuth(routeModel, auth)
-	aliasResult := m.resolveExecutionAliasResultForRequested(auth, requestedModel)
+	aliasResult := m.resolveExecutionAliasResultForRequestedWithRouting(routing, auth, requestedModel)
 	if aliasResult.ForceMapping && auth != nil && auth.Attributes != nil && strings.EqualFold(strings.TrimSpace(auth.Attributes[homeForceMappingAttributeKey]), "true") {
 		aliasResult.OriginalAlias = strings.TrimSpace(routeModel)
 	}
@@ -264,7 +271,7 @@ func (m *Manager) executionModelCandidatesWithAlias(auth *Auth, routeModel strin
 		}
 	}
 	if len(candidates) == 0 {
-		if pool := m.resolveOpenAICompatUpstreamModelPool(auth, upstreamModel); len(pool) > 0 {
+		if pool := resolveOpenAICompatUpstreamModelPool(routing.config, auth, upstreamModel); len(pool) > 0 {
 			if len(pool) == 1 {
 				candidates = pool
 			} else {
@@ -272,7 +279,7 @@ func (m *Manager) executionModelCandidatesWithAlias(auth *Auth, routeModel strin
 				candidates = rotateStrings(pool, offset)
 			}
 		} else {
-			resolved := m.applyAPIKeyModelAlias(auth, upstreamModel)
+			resolved := m.applyAPIKeyModelAliasWithRouting(routing, auth, upstreamModel)
 			if strings.TrimSpace(resolved) == "" {
 				resolved = upstreamModel
 			}
@@ -280,7 +287,7 @@ func (m *Manager) executionModelCandidatesWithAlias(auth *Auth, routeModel strin
 		}
 	}
 	pooled := len(candidates) > 1
-	return candidates, pooled, aliasResult
+	return candidates, pooled, aliasResult, routing
 }
 
 func (m *Manager) resolveExecutionAliasResult(auth *Auth, routeModel string) OAuthModelAliasResult {
@@ -289,11 +296,15 @@ func (m *Manager) resolveExecutionAliasResult(auth *Auth, routeModel string) OAu
 }
 
 func (m *Manager) resolveExecutionAliasResultForRequested(auth *Auth, requestedModel string) OAuthModelAliasResult {
+	return m.resolveExecutionAliasResultForRequestedWithRouting(m.loadAPIKeyModelRouting(), auth, requestedModel)
+}
+
+func (m *Manager) resolveExecutionAliasResultForRequestedWithRouting(routing *apiKeyModelRoutingSnapshot, auth *Auth, requestedModel string) OAuthModelAliasResult {
 	if result := homeForceMappingAliasResult(auth, requestedModel); result.ForceMapping {
 		return result
 	}
-	if auth != nil && auth.AuthKind() == AuthKindAPIKey {
-		return m.resolveAPIKeyModelAliasWithResult(auth, requestedModel)
+	if isConfiguredModelRoutingAuth(auth) {
+		return resolveAPIKeyModelAliasWithResult(routing.config, auth, requestedModel)
 	}
 	return m.applyOAuthModelAliasWithResult(auth, requestedModel)
 }
@@ -320,7 +331,7 @@ func homeForceMappingAliasResult(auth *Auth, requestedModel string) OAuthModelAl
 }
 
 func executionAliasPoolModel(auth *Auth, requestedModel string, aliasResult OAuthModelAliasResult) string {
-	if auth != nil && auth.AuthKind() == AuthKindAPIKey {
+	if isConfiguredModelRoutingAuth(auth) {
 		if strings.TrimSpace(requestedModel) != "" {
 			return requestedModel
 		}
@@ -332,16 +343,34 @@ func executionAliasPoolModel(auth *Auth, requestedModel string, aliasResult OAut
 }
 
 func (m *Manager) resolveAPIKeyModelAliasWithResult(auth *Auth, requestedModel string) OAuthModelAliasResult {
-	if m == nil || auth == nil {
+	return resolveAPIKeyModelAliasWithResult(m.loadAPIKeyModelRouting().config, auth, requestedModel)
+}
+
+func resolveAPIKeyModelAliasWithResult(cfg *internalconfig.Config, auth *Auth, requestedModel string) OAuthModelAliasResult {
+	if auth == nil {
 		return OAuthModelAliasResult{}
 	}
 	requestedModel = strings.TrimSpace(requestedModel)
 	if requestedModel == "" {
 		return OAuthModelAliasResult{}
 	}
-	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
 	if cfg == nil {
 		cfg = &internalconfig.Config{}
+	}
+	models := configuredModelAliasEntries(cfg, auth)
+	if len(models) == 0 {
+		return OAuthModelAliasResult{UpstreamModel: requestedModel}
+	}
+	result := resolveModelAliasResultFromConfigModels(requestedModel, models)
+	if strings.TrimSpace(result.UpstreamModel) == "" {
+		return OAuthModelAliasResult{UpstreamModel: requestedModel}
+	}
+	return result
+}
+
+func configuredModelAliasEntries(cfg *internalconfig.Config, auth *Auth) []modelAliasEntry {
+	if cfg == nil || auth == nil {
+		return nil
 	}
 	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
 	var models []modelAliasEntry
@@ -378,17 +407,46 @@ func (m *Manager) resolveAPIKeyModelAliasWithResult(auth *Auth, requestedModel s
 			compatName = strings.TrimSpace(auth.Attributes["compat_name"])
 		}
 		if compatName != "" || strings.EqualFold(strings.TrimSpace(auth.Provider), "openai-compatibility") {
-			if entry := resolveOpenAICompatConfig(cfg, providerKey, compatName, auth.Provider); entry != nil {
+			if entry := resolveOpenAICompatConfigForAuth(cfg, auth, providerKey, compatName); entry != nil {
 				models = asModelAliasEntries(entry.Models)
 			}
 		}
 	}
-	if len(models) == 0 {
-		return OAuthModelAliasResult{UpstreamModel: requestedModel}
+	return models
+}
+
+func resolveModelAliasResultForUpstream(cfg *internalconfig.Config, auth *Auth, requestedModel, upstreamModel string) OAuthModelAliasResult {
+	requestedModel = strings.TrimSpace(requestedModel)
+	upstreamModel = strings.TrimSpace(upstreamModel)
+	if requestedModel == "" || upstreamModel == "" {
+		return OAuthModelAliasResult{}
 	}
-	result := resolveModelAliasResultFromConfigModels(requestedModel, models)
+	requestResult := thinking.ParseSuffix(requestedModel)
+	models := configuredModelAliasEntries(cfg, auth)
+	filtered := make([]modelAliasEntry, 0, 1)
+	for _, model := range models {
+		name := strings.TrimSpace(model.GetName())
+		if name != "" && strings.EqualFold(preserveResolvedModelSuffix(name, requestResult), upstreamModel) {
+			filtered = append(filtered, model)
+		}
+	}
+	if len(filtered) == 0 {
+		return OAuthModelAliasResult{}
+	}
+	return resolveModelAliasResultFromConfigModels(requestedModel, filtered)
+}
+
+func resolveAttemptAliasResult(routing *apiKeyModelRoutingSnapshot, auth *Auth, routeModel, upstreamModel string, fallback OAuthModelAliasResult) OAuthModelAliasResult {
+	if routing == nil || !isConfiguredModelRoutingAuth(auth) {
+		return fallback
+	}
+	requestedModel := rewriteModelForAuth(routeModel, auth)
+	result := resolveModelAliasResultForUpstream(routing.config, auth, requestedModel, upstreamModel)
 	if strings.TrimSpace(result.UpstreamModel) == "" {
-		return OAuthModelAliasResult{UpstreamModel: requestedModel}
+		return fallback
+	}
+	if result.ForceMapping && fallback.ForceMapping && strings.TrimSpace(fallback.OriginalAlias) != "" {
+		result.OriginalAlias = fallback.OriginalAlias
 	}
 	return result
 }
@@ -435,12 +493,12 @@ func (m *Manager) rebuildAPIKeyModelAliasFromRuntimeConfig() {
 	if m == nil {
 		return
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
 	if cfg == nil {
 		cfg = &internalconfig.Config{}
 	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.rebuildAPIKeyModelAliasLocked(cfg)
 }
 
@@ -458,6 +516,7 @@ func (m *Manager) rebuildAPIKeyModelAliasLocked(cfg *internalconfig.Config) {
 	}
 
 	out := make(apiKeyModelAliasTable)
+	capabilities := make(apiKeyModelCapabilityTable)
 	for _, auth := range m.auths {
 		if auth == nil {
 			continue
@@ -465,7 +524,7 @@ func (m *Manager) rebuildAPIKeyModelAliasLocked(cfg *internalconfig.Config) {
 		if strings.TrimSpace(auth.ID) == "" {
 			continue
 		}
-		if auth.AuthKind() != AuthKindAPIKey {
+		if !isConfiguredModelRoutingAuth(auth) {
 			continue
 		}
 
@@ -505,7 +564,7 @@ func (m *Manager) rebuildAPIKeyModelAliasLocked(cfg *internalconfig.Config) {
 				compatName = strings.TrimSpace(auth.Attributes["compat_name"])
 			}
 			if compatName != "" || strings.EqualFold(strings.TrimSpace(auth.Provider), "openai-compatibility") {
-				if entry := resolveOpenAICompatConfig(cfg, providerKey, compatName, auth.Provider); entry != nil {
+				if entry := resolveOpenAICompatConfigForAuth(cfg, auth, providerKey, compatName); entry != nil {
 					compileAPIKeyModelAliasForModels(byAlias, entry.Models)
 				}
 			}
@@ -514,9 +573,16 @@ func (m *Manager) rebuildAPIKeyModelAliasLocked(cfg *internalconfig.Config) {
 		if len(byAlias) > 0 {
 			out[auth.ID] = byAlias
 		}
+		if byCapability := compileAPIKeyModelCapabilitiesForAuth(cfg, auth); len(byCapability) > 0 {
+			capabilities[auth.ID] = byCapability
+		}
 	}
 
-	m.apiKeyModelAlias.Store(out)
+	m.apiKeyModelRouting.Store(&apiKeyModelRoutingSnapshot{
+		config:       cfg,
+		aliases:      out,
+		capabilities: capabilities,
+	})
 }
 
 func compileAPIKeyModelAliasForModels[T interface {
@@ -526,42 +592,27 @@ func compileAPIKeyModelAliasForModels[T interface {
 	if out == nil {
 		return
 	}
+	add := func(key, name string) {
+		key = strings.ToLower(strings.TrimSpace(key))
+		if key == "" {
+			return
+		}
+		if _, exists := out[key]; !exists {
+			out[key] = name
+		}
+	}
 	for i := range models {
 		alias := strings.TrimSpace(models[i].GetAlias())
 		name := strings.TrimSpace(models[i].GetName())
 		if alias == "" || name == "" {
 			continue
 		}
-		aliasKey := strings.ToLower(thinking.ParseSuffix(alias).ModelName)
-		if aliasKey == "" {
-			aliasKey = strings.ToLower(alias)
-		}
-		// Config priority: first alias wins.
-		if _, exists := out[aliasKey]; exists {
-			continue
-		}
-		out[aliasKey] = name
-		// Also allow direct lookup by upstream name (case-insensitive), so lookups on already-upstream
-		// models remain a cheap no-op.
-		nameKey := strings.ToLower(thinking.ParseSuffix(name).ModelName)
-		if nameKey == "" {
-			nameKey = strings.ToLower(name)
-		}
-		if nameKey != "" {
-			if _, exists := out[nameKey]; !exists {
-				out[nameKey] = name
-			}
-		}
-		// Preserve config suffix priority by seeding a base-name lookup when name already has suffix.
-		nameResult := thinking.ParseSuffix(name)
-		if nameResult.HasSuffix {
-			baseKey := strings.ToLower(strings.TrimSpace(nameResult.ModelName))
-			if baseKey != "" {
-				if _, exists := out[baseKey]; !exists {
-					out[baseKey] = name
-				}
-			}
-		}
+		// Exact suffix routes are retained alongside first-entry base fallbacks.
+		add(alias, name)
+		add(thinking.ParseSuffix(alias).ModelName, name)
+		// Direct upstream requests use the same exact-first lookup behavior.
+		add(name, name)
+		add(thinking.ParseSuffix(name).ModelName, name)
 	}
 }
 
@@ -581,7 +632,11 @@ func rewriteModelForAuth(model string, auth *Auth) string {
 }
 
 func (m *Manager) applyAPIKeyModelAlias(auth *Auth, requestedModel string) string {
-	if m == nil || auth == nil {
+	return m.applyAPIKeyModelAliasWithRouting(m.loadAPIKeyModelRouting(), auth, requestedModel)
+}
+
+func (m *Manager) applyAPIKeyModelAliasWithRouting(routing *apiKeyModelRoutingSnapshot, auth *Auth, requestedModel string) string {
+	if auth == nil {
 		return requestedModel
 	}
 
@@ -595,13 +650,12 @@ func (m *Manager) applyAPIKeyModelAlias(auth *Auth, requestedModel string) strin
 	}
 
 	// Fast path: lookup per-auth mapping table (keyed by auth.ID).
-	if resolved := m.lookupAPIKeyUpstreamModel(auth.ID, requestedModel); resolved != "" {
+	if resolved := lookupAPIKeyUpstreamModel(routing, auth.ID, requestedModel); resolved != "" {
 		return resolved
 	}
 
-	// Slow path: scan config for the matching credential entry and resolve alias.
-	// This acts as a safety net if mappings are stale or auth.ID is missing.
-	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)
+	// Slow path: scan the same config snapshot used to compile the alias table.
+	cfg := routing.config
 	if cfg == nil {
 		cfg = &internalconfig.Config{}
 	}
@@ -636,6 +690,8 @@ func (m *Manager) applyAPIKeyModelAlias(auth *Auth, requestedModel string) strin
 type APIKeyConfigEntry interface {
 	GetAPIKey() string
 	GetBaseURL() string
+	GetPrefix() string
+	GetProxyURL() string
 }
 
 func resolveAPIKeyConfig[T APIKeyConfigEntry](entries []T, auth *Auth) *T {
@@ -644,33 +700,40 @@ func resolveAPIKeyConfig[T APIKeyConfigEntry](entries []T, auth *Auth) *T {
 	}
 	attrKey, attrBase := "", ""
 	if auth.Attributes != nil {
-		attrKey = strings.TrimSpace(auth.Attributes["api_key"])
+		attrKey = strings.TrimSpace(auth.Attributes[AttributeAPIKey])
 		attrBase = strings.TrimSpace(auth.Attributes["base_url"])
 	}
-	for i := range entries {
-		entry := &entries[i]
-		cfgKey := strings.TrimSpace((*entry).GetAPIKey())
-		cfgBase := strings.TrimSpace((*entry).GetBaseURL())
+	matchesCredentials := func(entry T) bool {
+		cfgKey := strings.TrimSpace(entry.GetAPIKey())
+		cfgBase := strings.TrimSpace(entry.GetBaseURL())
 		if attrKey != "" && attrBase != "" {
-			if strings.EqualFold(cfgKey, attrKey) && strings.EqualFold(cfgBase, attrBase) {
-				return entry
-			}
-			continue
+			return strings.EqualFold(cfgKey, attrKey) && strings.EqualFold(cfgBase, attrBase)
 		}
-		if attrKey != "" && strings.EqualFold(cfgKey, attrKey) {
-			if cfgBase == "" || strings.EqualFold(cfgBase, attrBase) {
-				return entry
-			}
+		if attrKey != "" {
+			return strings.EqualFold(cfgKey, attrKey) && (cfgBase == "" || strings.EqualFold(cfgBase, attrBase))
 		}
-		if attrKey == "" && attrBase != "" && strings.EqualFold(cfgBase, attrBase) {
-			return entry
+		return attrBase != "" && strings.EqualFold(cfgBase, attrBase)
+	}
+	if auth.AuthSourceKind() == AuthSourceConfig && auth.Attributes != nil {
+		if index, errIndex := strconv.Atoi(strings.TrimSpace(auth.Attributes[AttributeConfigIndex])); errIndex == nil && index >= 0 && index < len(entries) && matchesCredentials(entries[index]) {
+			return &entries[index]
+		}
+	}
+	for i := range entries {
+		entry := entries[i]
+		if matchesCredentials(entry) && strings.EqualFold(strings.TrimSpace(entry.GetPrefix()), strings.TrimSpace(auth.Prefix)) && strings.EqualFold(strings.TrimSpace(entry.GetProxyURL()), strings.TrimSpace(auth.ProxyURL)) {
+			return &entries[i]
+		}
+	}
+	for i := range entries {
+		if matchesCredentials(entries[i]) {
+			return &entries[i]
 		}
 	}
 	if attrKey != "" {
 		for i := range entries {
-			entry := &entries[i]
-			if strings.EqualFold(strings.TrimSpace((*entry).GetAPIKey()), attrKey) {
-				return entry
+			if strings.EqualFold(strings.TrimSpace(entries[i].GetAPIKey()), attrKey) {
+				return &entries[i]
 			}
 		}
 	}
@@ -777,7 +840,7 @@ func resolveUpstreamModelForOpenAICompatAPIKey(cfg *internalconfig.Config, auth 
 	if compatName == "" && !strings.EqualFold(strings.TrimSpace(auth.Provider), "openai-compatibility") {
 		return ""
 	}
-	entry := resolveOpenAICompatConfig(cfg, providerKey, compatName, auth.Provider)
+	entry := resolveOpenAICompatConfigForAuth(cfg, auth, providerKey, compatName)
 	if entry == nil {
 		return ""
 	}
@@ -785,6 +848,22 @@ func resolveUpstreamModelForOpenAICompatAPIKey(cfg *internalconfig.Config, auth 
 }
 
 type apiKeyModelAliasTable map[string]map[string]string
+
+func resolveOpenAICompatConfigForAuth(cfg *internalconfig.Config, auth *Auth, providerKey, compatName string) *internalconfig.OpenAICompatibility {
+	if cfg == nil {
+		return nil
+	}
+	if auth != nil && auth.AuthSourceKind() == AuthSourceConfig && auth.Attributes != nil {
+		if index, errIndex := strconv.Atoi(strings.TrimSpace(auth.Attributes[AttributeConfigIndex])); errIndex == nil && index >= 0 && index < len(cfg.OpenAICompatibility) && !cfg.OpenAICompatibility[index].Disabled {
+			return &cfg.OpenAICompatibility[index]
+		}
+	}
+	authProvider := ""
+	if auth != nil {
+		authProvider = auth.Provider
+	}
+	return resolveOpenAICompatConfig(cfg, providerKey, compatName, authProvider)
+}
 
 func resolveOpenAICompatConfig(cfg *internalconfig.Config, providerKey, compatName, authProvider string) *internalconfig.OpenAICompatibility {
 	if cfg == nil {

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -42,11 +42,40 @@ func (m *Manager) hasPluginScheduler() bool {
 
 func isBuiltInSelector(selector Selector) bool {
 	switch selector.(type) {
-	case *RoundRobinSelector, *FillFirstSelector:
+	case *RoundRobinSelector, *WeightedRoundRobinSelector, *FillFirstSelector:
 		return true
 	default:
 		return false
 	}
+}
+
+type requiredAuthKindContextKey struct{}
+
+type authSelectionEligibility struct {
+	requiredKind     string
+	disallowFreeAuth bool
+}
+
+func withRequiredAuthKind(ctx context.Context, requiredKind string) context.Context {
+	return context.WithValue(ctx, requiredAuthKindContextKey{}, requiredKind)
+}
+
+func authSelectionEligibilityForRequest(ctx context.Context, opts cliproxyexecutor.Options) authSelectionEligibility {
+	eligibility := authSelectionEligibility{disallowFreeAuth: disallowFreeAuthFromMetadata(opts.Metadata)}
+	if ctx != nil {
+		eligibility.requiredKind, _ = ctx.Value(requiredAuthKindContextKey{}).(string)
+	}
+	return eligibility
+}
+
+func (e authSelectionEligibility) allows(auth *Auth) bool {
+	if auth == nil {
+		return false
+	}
+	if e.requiredKind != "" && auth.AuthKind() != e.requiredKind {
+		return false
+	}
+	return !e.disallowFreeAuth || !isFreeCodexAuth(auth)
 }
 
 func (m *Manager) syncSchedulerFromSnapshot(auths []*Auth) {
@@ -444,38 +473,28 @@ func (m *Manager) pickViaBuiltinScheduler(ctx context.Context, strategy schedule
 		return nil, false, nil
 	}
 	providerKey := strings.ToLower(strings.TrimSpace(provider))
-	disallowFreeAuth := disallowFreeAuthFromMetadata(opts.Metadata)
-	for {
-		var selected *Auth
-		var errPick error
-		if providerKey == "mixed" {
+	var selected *Auth
+	var errPick error
+	if providerKey == "mixed" {
+		selected, _, errPick = m.scheduler.pickMixedWithStrategy(ctx, providers, model, opts, tried, strategy)
+		if errPick != nil && model != "" && shouldRetrySchedulerPick(errPick) {
+			m.syncScheduler()
 			selected, _, errPick = m.scheduler.pickMixedWithStrategy(ctx, providers, model, opts, tried, strategy)
-			if errPick != nil && model != "" && shouldRetrySchedulerPick(errPick) {
-				m.syncScheduler()
-				selected, _, errPick = m.scheduler.pickMixedWithStrategy(ctx, providers, model, opts, tried, strategy)
-			}
-		} else {
+		}
+	} else {
+		selected, errPick = m.scheduler.pickSingleWithStrategy(ctx, providerKey, model, opts, tried, strategy)
+		if errPick != nil && model != "" && shouldRetrySchedulerPick(errPick) {
+			m.syncScheduler()
 			selected, errPick = m.scheduler.pickSingleWithStrategy(ctx, providerKey, model, opts, tried, strategy)
-			if errPick != nil && model != "" && shouldRetrySchedulerPick(errPick) {
-				m.syncScheduler()
-				selected, errPick = m.scheduler.pickSingleWithStrategy(ctx, providerKey, model, opts, tried, strategy)
-			}
 		}
-		if errPick != nil {
-			return nil, true, errPick
-		}
-		if selected == nil {
-			return nil, true, &Error{Code: "auth_not_found", Message: "selector returned no auth"}
-		}
-		if disallowFreeAuth && isFreeCodexAuth(selected) {
-			if tried == nil {
-				tried = make(map[string]struct{})
-			}
-			tried[selected.ID] = struct{}{}
-			continue
-		}
-		return selected, true, nil
 	}
+	if errPick != nil {
+		return nil, true, errPick
+	}
+	if selected == nil {
+		return nil, true, &Error{Code: "auth_not_found", Message: "selector returned no auth"}
+	}
+	return selected, true, nil
 }
 
 func (m *Manager) pickViaPluginScheduler(ctx context.Context, scheduler PluginScheduler, provider string, providers []string, model string, opts cliproxyexecutor.Options, tried map[string]struct{}, candidates []*Auth) (*Auth, bool, error) {
@@ -932,7 +951,7 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 	}
 
 	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
-	disallowFreeAuth := disallowFreeAuthFromMetadata(opts.Metadata)
+	eligibility := authSelectionEligibilityForRequest(ctx, opts)
 
 	m.mu.RLock()
 	selector := m.selector
@@ -959,7 +978,7 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 		if pinnedAuthID != "" && candidate.ID != pinnedAuthID {
 			continue
 		}
-		if disallowFreeAuth && isFreeCodexAuth(candidate) {
+		if !eligibility.allows(candidate) {
 			continue
 		}
 		if _, used := tried[candidate.ID]; used {
@@ -987,7 +1006,8 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 		return nil, nil, errPick
 	}
 	if !handled {
-		selected, errPick = selector.Pick(ctx, provider, selectionArgForSelector(selector, model), opts, available)
+		selectorCtx := withWeightedSelectorStateModel(ctx, selector, model)
+		selected, errPick = selector.Pick(selectorCtx, provider, selectionArgForSelector(selector, model), opts, available)
 		if errPick != nil {
 			return nil, nil, errPick
 		}
@@ -1034,30 +1054,18 @@ func (m *Manager) SelectAuthByKind(ctx context.Context, provider, model, require
 		return nil, &Error{Code: "invalid_auth_kind", Message: "required auth kind is invalid", HTTPStatus: http.StatusBadRequest}
 	}
 
-	tried := make(map[string]struct{})
-	for {
-		selected, _, errPick := m.pickNextLegacy(ctx, provider, model, opts, tried)
-		if errPick != nil {
-			return nil, errPick
-		}
-		if selected == nil {
-			return nil, &Error{Code: "auth_not_found", Message: "selector returned no auth"}
-		}
-		if selected.AuthKind() == requiredKind {
-			if m.HomeEnabled() {
-				return nil, &Error{Code: "home_unavailable", Message: "legacy auth selection is unavailable while Home is enabled", HTTPStatus: http.StatusServiceUnavailable}
-			}
-			return selected, nil
-		}
-		authID := strings.TrimSpace(selected.ID)
-		if authID == "" {
-			return nil, &Error{Code: "auth_not_found", Message: "selected auth has no ID"}
-		}
-		if _, alreadyTried := tried[authID]; alreadyTried {
-			return nil, &Error{Code: "auth_not_found", Message: "selector repeatedly returned an ineligible auth"}
-		}
-		tried[authID] = struct{}{}
+	selectionCtx := withRequiredAuthKind(ctx, requiredKind)
+	selected, _, errPick := m.pickNextLegacy(selectionCtx, provider, model, opts, nil)
+	if errPick != nil {
+		return nil, errPick
 	}
+	if selected == nil {
+		return nil, &Error{Code: "auth_not_found", Message: "selector returned no auth"}
+	}
+	if m.HomeEnabled() {
+		return nil, &Error{Code: "home_unavailable", Message: "legacy auth selection is unavailable while Home is enabled", HTTPStatus: http.StatusServiceUnavailable}
+	}
+	return selected, nil
 }
 
 // SelectHomeAuthByKind selects a Home dispatch while retaining its execution scope.
@@ -1115,10 +1123,14 @@ func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cli
 	if m.hasPluginScheduler() || !m.useSchedulerFastPath() {
 		return m.pickNextLegacy(ctx, provider, model, opts, tried)
 	}
+	eligibility := authSelectionEligibilityForRequest(ctx, opts)
 	if strings.TrimSpace(model) != "" {
 		m.mu.RLock()
 		for _, candidate := range m.auths {
 			if candidate == nil || executorKeyFromAuth(candidate) != provider || candidate.Disabled {
+				continue
+			}
+			if !eligibility.allows(candidate) {
 				continue
 			}
 			if _, used := tried[candidate.ID]; used {
@@ -1135,37 +1147,27 @@ func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cli
 	if !okExecutor {
 		return nil, nil, &Error{Code: "executor_not_found", Message: "executor not registered"}
 	}
-	disallowFreeAuth := disallowFreeAuthFromMetadata(opts.Metadata)
-	for {
-		selected, errPick := m.scheduler.pickSingle(ctx, provider, model, opts, tried)
-		if errPick != nil && model != "" && shouldRetrySchedulerPick(errPick) {
-			m.syncScheduler()
-			selected, errPick = m.scheduler.pickSingle(ctx, provider, model, opts, tried)
-		}
-		if errPick != nil {
-			return nil, nil, errPick
-		}
-		if selected == nil {
-			return nil, nil, &Error{Code: "auth_not_found", Message: "selector returned no auth"}
-		}
-		if disallowFreeAuth && isFreeCodexAuth(selected) {
-			if tried == nil {
-				tried = make(map[string]struct{})
-			}
-			tried[selected.ID] = struct{}{}
-			continue
-		}
-		authCopy := selected.Clone()
-		if !selected.indexAssigned {
-			m.mu.Lock()
-			if current := m.auths[authCopy.ID]; current != nil && !current.indexAssigned {
-				current.EnsureIndex()
-				authCopy = current.Clone()
-			}
-			m.mu.Unlock()
-		}
-		return authCopy, executor, nil
+	selected, errPick := m.scheduler.pickSingle(ctx, provider, model, opts, tried)
+	if errPick != nil && model != "" && shouldRetrySchedulerPick(errPick) {
+		m.syncScheduler()
+		selected, errPick = m.scheduler.pickSingle(ctx, provider, model, opts, tried)
 	}
+	if errPick != nil {
+		return nil, nil, errPick
+	}
+	if selected == nil {
+		return nil, nil, &Error{Code: "auth_not_found", Message: "selector returned no auth"}
+	}
+	authCopy := selected.Clone()
+	if !selected.indexAssigned {
+		m.mu.Lock()
+		if current := m.auths[authCopy.ID]; current != nil && !current.indexAssigned {
+			current.EnsureIndex()
+			authCopy = current.Clone()
+		}
+		m.mu.Unlock()
+	}
+	return authCopy, executor, nil
 }
 
 func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, string, error) {
@@ -1174,7 +1176,7 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 	}
 
 	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
-	disallowFreeAuth := disallowFreeAuthFromMetadata(opts.Metadata)
+	eligibility := authSelectionEligibilityForRequest(ctx, opts)
 
 	providerSet := make(map[string]struct{}, len(providers))
 	for _, provider := range providers {
@@ -1208,7 +1210,7 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 		if pinnedAuthID != "" && candidate.ID != pinnedAuthID {
 			continue
 		}
-		if disallowFreeAuth && isFreeCodexAuth(candidate) {
+		if !eligibility.allows(candidate) {
 			continue
 		}
 		providerKey := executorKeyFromAuth(candidate)
@@ -1246,7 +1248,8 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 		return nil, nil, "", errPick
 	}
 	if !handled {
-		selected, errPick = selector.Pick(ctx, "mixed", selectionArgForSelector(selector, model), opts, available)
+		selectorCtx := withWeightedSelectorStateModel(ctx, selector, model)
+		selected, errPick = selector.Pick(selectorCtx, "mixed", selectionArgForSelector(selector, model), opts, available)
 		if errPick != nil {
 			return nil, nil, "", errPick
 		}
@@ -1299,6 +1302,7 @@ func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model s
 	if len(eligibleProviders) == 0 {
 		return nil, nil, "", &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
+	eligibility := authSelectionEligibilityForRequest(ctx, opts)
 	if strings.TrimSpace(model) != "" {
 		providerSet := make(map[string]struct{}, len(eligibleProviders))
 		for _, providerKey := range eligibleProviders {
@@ -1312,6 +1316,9 @@ func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model s
 			if _, ok := providerSet[executorKeyFromAuth(candidate)]; !ok {
 				continue
 			}
+			if !eligibility.allows(candidate) {
+				continue
+			}
 			if _, used := tried[candidate.ID]; used {
 				continue
 			}
@@ -1323,39 +1330,29 @@ func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model s
 		m.mu.RUnlock()
 	}
 
-	disallowFreeAuth := disallowFreeAuthFromMetadata(opts.Metadata)
-	for {
-		selected, providerKey, errPick := m.scheduler.pickMixed(ctx, eligibleProviders, model, opts, tried)
-		if errPick != nil && model != "" && shouldRetrySchedulerPick(errPick) {
-			m.syncScheduler()
-			selected, providerKey, errPick = m.scheduler.pickMixed(ctx, eligibleProviders, model, opts, tried)
-		}
-		if errPick != nil {
-			return nil, nil, "", errPick
-		}
-		if selected == nil {
-			return nil, nil, "", &Error{Code: "auth_not_found", Message: "selector returned no auth"}
-		}
-		if disallowFreeAuth && isFreeCodexAuth(selected) {
-			if tried == nil {
-				tried = make(map[string]struct{})
-			}
-			tried[selected.ID] = struct{}{}
-			continue
-		}
-		executor, okExecutor := m.Executor(providerKey)
-		if !okExecutor {
-			return nil, nil, "", &Error{Code: "executor_not_found", Message: "executor not registered"}
-		}
-		authCopy := selected.Clone()
-		if !selected.indexAssigned {
-			m.mu.Lock()
-			if current := m.auths[authCopy.ID]; current != nil && !current.indexAssigned {
-				current.EnsureIndex()
-				authCopy = current.Clone()
-			}
-			m.mu.Unlock()
-		}
-		return authCopy, executor, providerKey, nil
+	selected, providerKey, errPick := m.scheduler.pickMixed(ctx, eligibleProviders, model, opts, tried)
+	if errPick != nil && model != "" && shouldRetrySchedulerPick(errPick) {
+		m.syncScheduler()
+		selected, providerKey, errPick = m.scheduler.pickMixed(ctx, eligibleProviders, model, opts, tried)
 	}
+	if errPick != nil {
+		return nil, nil, "", errPick
+	}
+	if selected == nil {
+		return nil, nil, "", &Error{Code: "auth_not_found", Message: "selector returned no auth"}
+	}
+	executor, okExecutor := m.Executor(providerKey)
+	if !okExecutor {
+		return nil, nil, "", &Error{Code: "executor_not_found", Message: "executor not registered"}
+	}
+	authCopy := selected.Clone()
+	if !selected.indexAssigned {
+		m.mu.Lock()
+		if current := m.auths[authCopy.ID]; current != nil && !current.indexAssigned {
+			current.EnsureIndex()
+			authCopy = current.Clone()
+		}
+		m.mu.Unlock()
+	}
+	return authCopy, executor, providerKey, nil
 }

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -42,11 +42,40 @@ func (m *Manager) hasPluginScheduler() bool {
 
 func isBuiltInSelector(selector Selector) bool {
 	switch selector.(type) {
-	case *RoundRobinSelector, *FillFirstSelector:
+	case *RoundRobinSelector, *WeightedRoundRobinSelector, *FillFirstSelector:
 		return true
 	default:
 		return false
 	}
+}
+
+type requiredAuthKindContextKey struct{}
+
+type authSelectionEligibility struct {
+	requiredKind     string
+	disallowFreeAuth bool
+}
+
+func withRequiredAuthKind(ctx context.Context, requiredKind string) context.Context {
+	return context.WithValue(ctx, requiredAuthKindContextKey{}, requiredKind)
+}
+
+func authSelectionEligibilityForRequest(ctx context.Context, opts cliproxyexecutor.Options) authSelectionEligibility {
+	eligibility := authSelectionEligibility{disallowFreeAuth: disallowFreeAuthFromMetadata(opts.Metadata)}
+	if ctx != nil {
+		eligibility.requiredKind, _ = ctx.Value(requiredAuthKindContextKey{}).(string)
+	}
+	return eligibility
+}
+
+func (e authSelectionEligibility) allows(auth *Auth) bool {
+	if auth == nil {
+		return false
+	}
+	if e.requiredKind != "" && auth.AuthKind() != e.requiredKind {
+		return false
+	}
+	return !e.disallowFreeAuth || !isFreeCodexAuth(auth)
 }
 
 func (m *Manager) syncSchedulerFromSnapshot(auths []*Auth) {
@@ -534,38 +563,28 @@ func (m *Manager) pickViaBuiltinScheduler(ctx context.Context, strategy schedule
 		return nil, false, nil
 	}
 	providerKey := strings.ToLower(strings.TrimSpace(provider))
-	disallowFreeAuth := disallowFreeAuthFromMetadata(opts.Metadata)
-	for {
-		var selected *Auth
-		var errPick error
-		if providerKey == "mixed" {
+	var selected *Auth
+	var errPick error
+	if providerKey == "mixed" {
+		selected, _, errPick = m.scheduler.pickMixedWithStrategy(ctx, providers, model, opts, tried, strategy)
+		if errPick != nil && model != "" && shouldRetrySchedulerPick(errPick) {
+			m.syncScheduler()
 			selected, _, errPick = m.scheduler.pickMixedWithStrategy(ctx, providers, model, opts, tried, strategy)
-			if errPick != nil && model != "" && shouldRetrySchedulerPick(errPick) {
-				m.syncScheduler()
-				selected, _, errPick = m.scheduler.pickMixedWithStrategy(ctx, providers, model, opts, tried, strategy)
-			}
-		} else {
+		}
+	} else {
+		selected, errPick = m.scheduler.pickSingleWithStrategy(ctx, providerKey, model, opts, tried, strategy)
+		if errPick != nil && model != "" && shouldRetrySchedulerPick(errPick) {
+			m.syncScheduler()
 			selected, errPick = m.scheduler.pickSingleWithStrategy(ctx, providerKey, model, opts, tried, strategy)
-			if errPick != nil && model != "" && shouldRetrySchedulerPick(errPick) {
-				m.syncScheduler()
-				selected, errPick = m.scheduler.pickSingleWithStrategy(ctx, providerKey, model, opts, tried, strategy)
-			}
 		}
-		if errPick != nil {
-			return nil, true, errPick
-		}
-		if selected == nil {
-			return nil, true, &Error{Code: "auth_not_found", Message: "selector returned no auth"}
-		}
-		if disallowFreeAuth && isFreeCodexAuth(selected) {
-			if tried == nil {
-				tried = make(map[string]struct{})
-			}
-			tried[selected.ID] = struct{}{}
-			continue
-		}
-		return selected, true, nil
 	}
+	if errPick != nil {
+		return nil, true, errPick
+	}
+	if selected == nil {
+		return nil, true, &Error{Code: "auth_not_found", Message: "selector returned no auth"}
+	}
+	return selected, true, nil
 }
 
 func (m *Manager) pickViaPluginScheduler(ctx context.Context, scheduler PluginScheduler, provider string, providers []string, model string, opts cliproxyexecutor.Options, tried map[string]struct{}, candidates []*Auth) (*Auth, bool, error) {
@@ -991,7 +1010,7 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 	}
 
 	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
-	disallowFreeAuth := disallowFreeAuthFromMetadata(opts.Metadata)
+	eligibility := authSelectionEligibilityForRequest(ctx, opts)
 
 	m.mu.RLock()
 	selector := m.selector
@@ -1018,7 +1037,7 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 		if pinnedAuthID != "" && candidate.ID != pinnedAuthID {
 			continue
 		}
-		if disallowFreeAuth && isFreeCodexAuth(candidate) {
+		if !eligibility.allows(candidate) {
 			continue
 		}
 		if _, used := tried[candidate.ID]; used {
@@ -1046,7 +1065,8 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 		return nil, nil, errPick
 	}
 	if !handled {
-		selected, errPick = selector.Pick(ctx, provider, selectionArgForSelector(selector, model), opts, available)
+		selectorCtx := withWeightedSelectorStateModel(ctx, selector, model)
+		selected, errPick = selector.Pick(selectorCtx, provider, selectionArgForSelector(selector, model), opts, available)
 		if errPick != nil {
 			return nil, nil, errPick
 		}
@@ -1093,30 +1113,18 @@ func (m *Manager) SelectAuthByKind(ctx context.Context, provider, model, require
 		return nil, &Error{Code: "invalid_auth_kind", Message: "required auth kind is invalid", HTTPStatus: http.StatusBadRequest}
 	}
 
-	tried := make(map[string]struct{})
-	for {
-		selected, _, errPick := m.pickNextLegacy(ctx, provider, model, opts, tried)
-		if errPick != nil {
-			return nil, errPick
-		}
-		if selected == nil {
-			return nil, &Error{Code: "auth_not_found", Message: "selector returned no auth"}
-		}
-		if selected.AuthKind() == requiredKind {
-			if m.HomeEnabled() {
-				return nil, &Error{Code: "home_unavailable", Message: "legacy auth selection is unavailable while Home is enabled", HTTPStatus: http.StatusServiceUnavailable}
-			}
-			return selected, nil
-		}
-		authID := strings.TrimSpace(selected.ID)
-		if authID == "" {
-			return nil, &Error{Code: "auth_not_found", Message: "selected auth has no ID"}
-		}
-		if _, alreadyTried := tried[authID]; alreadyTried {
-			return nil, &Error{Code: "auth_not_found", Message: "selector repeatedly returned an ineligible auth"}
-		}
-		tried[authID] = struct{}{}
+	selectionCtx := withRequiredAuthKind(ctx, requiredKind)
+	selected, _, errPick := m.pickNextLegacy(selectionCtx, provider, model, opts, nil)
+	if errPick != nil {
+		return nil, errPick
 	}
+	if selected == nil {
+		return nil, &Error{Code: "auth_not_found", Message: "selector returned no auth"}
+	}
+	if m.HomeEnabled() {
+		return nil, &Error{Code: "home_unavailable", Message: "legacy auth selection is unavailable while Home is enabled", HTTPStatus: http.StatusServiceUnavailable}
+	}
+	return selected, nil
 }
 
 // SelectHomeAuthByKind selects a Home dispatch while retaining its execution scope.
@@ -1174,10 +1182,14 @@ func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cli
 	if m.hasPluginScheduler() || !m.useSchedulerFastPath() {
 		return m.pickNextLegacy(ctx, provider, model, opts, tried)
 	}
+	eligibility := authSelectionEligibilityForRequest(ctx, opts)
 	if strings.TrimSpace(model) != "" {
 		m.mu.RLock()
 		for _, candidate := range m.auths {
 			if candidate == nil || executorKeyFromAuth(candidate) != provider || candidate.Disabled {
+				continue
+			}
+			if !eligibility.allows(candidate) {
 				continue
 			}
 			if _, used := tried[candidate.ID]; used {
@@ -1194,37 +1206,27 @@ func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cli
 	if !okExecutor {
 		return nil, nil, &Error{Code: "executor_not_found", Message: "executor not registered"}
 	}
-	disallowFreeAuth := disallowFreeAuthFromMetadata(opts.Metadata)
-	for {
-		selected, errPick := m.scheduler.pickSingle(ctx, provider, model, opts, tried)
-		if errPick != nil && model != "" && shouldRetrySchedulerPick(errPick) {
-			m.syncScheduler()
-			selected, errPick = m.scheduler.pickSingle(ctx, provider, model, opts, tried)
-		}
-		if errPick != nil {
-			return nil, nil, errPick
-		}
-		if selected == nil {
-			return nil, nil, &Error{Code: "auth_not_found", Message: "selector returned no auth"}
-		}
-		if disallowFreeAuth && isFreeCodexAuth(selected) {
-			if tried == nil {
-				tried = make(map[string]struct{})
-			}
-			tried[selected.ID] = struct{}{}
-			continue
-		}
-		authCopy := selected.Clone()
-		if !selected.indexAssigned {
-			m.mu.Lock()
-			if current := m.auths[authCopy.ID]; current != nil && !current.indexAssigned {
-				current.EnsureIndex()
-				authCopy = current.Clone()
-			}
-			m.mu.Unlock()
-		}
-		return authCopy, executor, nil
+	selected, errPick := m.scheduler.pickSingle(ctx, provider, model, opts, tried)
+	if errPick != nil && model != "" && shouldRetrySchedulerPick(errPick) {
+		m.syncScheduler()
+		selected, errPick = m.scheduler.pickSingle(ctx, provider, model, opts, tried)
 	}
+	if errPick != nil {
+		return nil, nil, errPick
+	}
+	if selected == nil {
+		return nil, nil, &Error{Code: "auth_not_found", Message: "selector returned no auth"}
+	}
+	authCopy := selected.Clone()
+	if !selected.indexAssigned {
+		m.mu.Lock()
+		if current := m.auths[authCopy.ID]; current != nil && !current.indexAssigned {
+			current.EnsureIndex()
+			authCopy = current.Clone()
+		}
+		m.mu.Unlock()
+	}
+	return authCopy, executor, nil
 }
 func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, model string, opts cliproxyexecutor.Options, tried map[string]struct{}) (*Auth, ProviderExecutor, string, error) {
 	if m.HomeEnabled() {
@@ -1232,7 +1234,7 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 	}
 
 	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
-	disallowFreeAuth := disallowFreeAuthFromMetadata(opts.Metadata)
+	eligibility := authSelectionEligibilityForRequest(ctx, opts)
 
 	providerSet := make(map[string]struct{}, len(providers))
 	for _, provider := range providers {
@@ -1266,7 +1268,7 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 		if pinnedAuthID != "" && candidate.ID != pinnedAuthID {
 			continue
 		}
-		if disallowFreeAuth && isFreeCodexAuth(candidate) {
+		if !eligibility.allows(candidate) {
 			continue
 		}
 		providerKey := executorKeyFromAuth(candidate)
@@ -1307,7 +1309,8 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 		return nil, nil, "", errPick
 	}
 	if !handled {
-		selected, errPick = selector.Pick(ctx, "mixed", selectionArgForSelector(selector, model), opts, available)
+		selectorCtx := withWeightedSelectorStateModel(ctx, selector, model)
+		selected, errPick = selector.Pick(selectorCtx, "mixed", selectionArgForSelector(selector, model), opts, available)
 		if errPick != nil {
 			return nil, nil, "", errPick
 		}
@@ -1362,6 +1365,7 @@ func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model s
 	if len(eligibleProviders) == 0 {
 		return nil, nil, "", &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
+	eligibility := authSelectionEligibilityForRequest(ctx, opts)
 	if strings.TrimSpace(model) != "" {
 		providerSet := make(map[string]struct{}, len(eligibleProviders))
 		for _, providerKey := range eligibleProviders {
@@ -1375,6 +1379,9 @@ func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model s
 			if _, ok := providerSet[executorKeyFromAuth(candidate)]; !ok {
 				continue
 			}
+			if !eligibility.allows(candidate) {
+				continue
+			}
 			if _, used := tried[candidate.ID]; used {
 				continue
 			}
@@ -1386,39 +1393,29 @@ func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model s
 		m.mu.RUnlock()
 	}
 
-	disallowFreeAuth := disallowFreeAuthFromMetadata(opts.Metadata)
-	for {
-		selected, providerKey, errPick := m.scheduler.pickMixed(ctx, eligibleProviders, model, opts, tried)
-		if errPick != nil && model != "" && shouldRetrySchedulerPick(errPick) {
-			m.syncScheduler()
-			selected, providerKey, errPick = m.scheduler.pickMixed(ctx, eligibleProviders, model, opts, tried)
-		}
-		if errPick != nil {
-			return nil, nil, "", errPick
-		}
-		if selected == nil {
-			return nil, nil, "", &Error{Code: "auth_not_found", Message: "selector returned no auth"}
-		}
-		if disallowFreeAuth && isFreeCodexAuth(selected) {
-			if tried == nil {
-				tried = make(map[string]struct{})
-			}
-			tried[selected.ID] = struct{}{}
-			continue
-		}
-		executor, okExecutor := m.Executor(providerKey)
-		if !okExecutor {
-			return nil, nil, "", &Error{Code: "executor_not_found", Message: "executor not registered"}
-		}
-		authCopy := selected.Clone()
-		if !selected.indexAssigned {
-			m.mu.Lock()
-			if current := m.auths[authCopy.ID]; current != nil && !current.indexAssigned {
-				current.EnsureIndex()
-				authCopy = current.Clone()
-			}
-			m.mu.Unlock()
-		}
-		return authCopy, executor, providerKey, nil
+	selected, providerKey, errPick := m.scheduler.pickMixed(ctx, eligibleProviders, model, opts, tried)
+	if errPick != nil && model != "" && shouldRetrySchedulerPick(errPick) {
+		m.syncScheduler()
+		selected, providerKey, errPick = m.scheduler.pickMixed(ctx, eligibleProviders, model, opts, tried)
 	}
+	if errPick != nil {
+		return nil, nil, "", errPick
+	}
+	if selected == nil {
+		return nil, nil, "", &Error{Code: "auth_not_found", Message: "selector returned no auth"}
+	}
+	executor, okExecutor := m.Executor(providerKey)
+	if !okExecutor {
+		return nil, nil, "", &Error{Code: "executor_not_found", Message: "executor not registered"}
+	}
+	authCopy := selected.Clone()
+	if !selected.indexAssigned {
+		m.mu.Lock()
+		if current := m.auths[authCopy.ID]; current != nil && !current.indexAssigned {
+			current.EnsureIndex()
+			authCopy = current.Clone()
+		}
+		m.mu.Unlock()
+	}
+	return authCopy, executor, providerKey, nil
 }

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -180,7 +180,7 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 	return &cliproxyexecutor.StreamResult{Headers: headers, Chunks: out}
 }
 
-func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor ProviderExecutor, auth *Auth, provider string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, routeModel, executionModel string, execModels []string, pooled bool, aliasResult OAuthModelAliasResult, allowRetry bool, ephemeralResult bool) (*cliproxyexecutor.StreamResult, error) {
+func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor ProviderExecutor, auth *Auth, provider string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, routeModel, executionModel string, execModels []string, pooled bool, aliasResult OAuthModelAliasResult, routing *apiKeyModelRoutingSnapshot, allowRetry bool, ephemeralResult bool) (*cliproxyexecutor.StreamResult, error) {
 	if executor == nil {
 		return nil, &Error{Code: "executor_not_found", Message: "executor not registered"}
 	}
@@ -199,6 +199,9 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		execReq, execOpts, errIntercept = applyRequestAfterAuthInterceptor(ctx, executor, provider, execReq, execOpts, requestedModelAliasFromOptions(execOpts, routeModel))
 		if errIntercept != nil {
 			return nil, errIntercept
+		}
+		if executionModel == "" {
+			execReq = attachResolvedAPIKeyModelInfo(routing, execReq, auth, routeModel, execModel)
 		}
 		if errCtx := ctx.Err(); errCtx != nil {
 			return nil, errCtx
@@ -304,7 +307,8 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			close(closedCh)
 			remaining = closedCh
 		}
-		return m.wrapStreamResult(ctx, auth.Clone(), provider, resultModel, streamResult.Headers, buffered, remaining, aliasResult, ephemeralResult), nil
+		attemptAliasResult := resolveAttemptAliasResult(routing, auth, routeModel, execModel, aliasResult)
+		return m.wrapStreamResult(ctx, auth.Clone(), provider, resultModel, streamResult.Headers, buffered, remaining, attemptAliasResult, ephemeralResult), nil
 	}
 	if lastErr == nil {
 		lastErr = &Error{Code: "auth_not_found", Message: "no upstream model available"}

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -189,7 +189,8 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: headers, Chunks: out, Metadata: cloneSchedulerAnyMap(metadata)}
 }
-func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor ProviderExecutor, auth *Auth, provider string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, routeModel, executionModel string, execModels []string, pooled bool, aliasResult OAuthModelAliasResult, allowRetry bool, ephemeralResult bool) (*cliproxyexecutor.StreamResult, error) {
+
+func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor ProviderExecutor, auth *Auth, provider string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, routeModel, executionModel string, execModels []string, pooled bool, aliasResult OAuthModelAliasResult, routing *apiKeyModelRoutingSnapshot, allowRetry bool, ephemeralResult bool) (*cliproxyexecutor.StreamResult, error) {
 	if executor == nil {
 		return nil, &Error{Code: "executor_not_found", Message: "executor not registered"}
 	}
@@ -213,6 +214,9 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		if allowed, confirmed := m.codexRateLimitContinuityDispatchDisposition(ctx); !allowed {
 			m.abandonCodexRateLimitContinuityAttempt(ctx)
 			return nil, codexRateLimitObservationPendingError{confirmed: confirmed}
+		}
+		if executionModel == "" {
+			execReq = attachResolvedAPIKeyModelInfo(routing, execReq, auth, routeModel, execModel)
 		}
 		if errCtx := ctx.Err(); errCtx != nil {
 			return nil, errCtx
@@ -349,7 +353,8 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			close(closedCh)
 			remaining = closedCh
 		}
-		return m.wrapStreamResult(ctx, auth.Clone(), provider, resultModel, streamResult.Headers, streamResult.Metadata, buffered, remaining, aliasResult, ephemeralResult), nil
+		attemptAliasResult := resolveAttemptAliasResult(routing, auth, routeModel, execModel, aliasResult)
+		return m.wrapStreamResult(ctx, auth.Clone(), provider, resultModel, streamResult.Headers, streamResult.Metadata, buffered, remaining, attemptAliasResult, ephemeralResult), nil
 	}
 	if lastErr == nil {
 		lastErr = &Error{Code: "auth_not_found", Message: "no upstream model available"}

--- a/sdk/cliproxy/auth/conductor_weight_validation_test.go
+++ b/sdk/cliproxy/auth/conductor_weight_validation_test.go
@@ -1,0 +1,93 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+type weightValidationStore struct {
+	auths     []*Auth
+	saveCount int
+}
+
+func (s *weightValidationStore) List(context.Context) ([]*Auth, error) {
+	return s.auths, nil
+}
+
+func (s *weightValidationStore) Save(context.Context, *Auth) (string, error) {
+	s.saveCount++
+	return "", nil
+}
+
+func (s *weightValidationStore) Delete(context.Context, string) error {
+	return nil
+}
+
+func TestManagerLoadSkipsInvalidExplicitWeights(t *testing.T) {
+	store := &weightValidationStore{auths: []*Auth{
+		{ID: "omitted", Provider: "test"},
+		{ID: "zero", Provider: "test", Metadata: map[string]any{AttributeWeight: json.Number("0")}},
+		{ID: "fraction", Provider: "test", Metadata: map[string]any{AttributeWeight: json.Number("1.5")}},
+		{ID: "overflow", Provider: "test", Attributes: map[string]string{AttributeWeight: "9223372036854775808"}},
+	}}
+	manager := NewManager(store, nil, nil)
+
+	if errLoad := manager.Load(context.Background()); errLoad != nil {
+		t.Fatalf("Load() error = %v", errLoad)
+	}
+	if _, ok := manager.GetByID("omitted"); !ok {
+		t.Fatal("omitted weight auth was not loaded")
+	}
+	if _, ok := manager.GetByID("zero"); !ok {
+		t.Fatal("zero weight auth was not loaded")
+	}
+	for _, id := range []string{"fraction", "overflow"} {
+		if _, ok := manager.GetByID(id); ok {
+			t.Fatalf("invalid auth %q remained active after Load()", id)
+		}
+	}
+}
+
+func TestManagerRegisterAndUpdateRejectInvalidExplicitWeights(t *testing.T) {
+	store := &weightValidationStore{}
+	manager := NewManager(store, nil, nil)
+	ctx := context.Background()
+
+	invalid := &Auth{
+		ID:       "invalid",
+		Provider: "test",
+		Metadata: map[string]any{AttributeWeight: "nonnumeric"},
+	}
+	if _, errRegister := manager.Register(ctx, invalid); errRegister == nil {
+		t.Fatal("Register() accepted an invalid weight")
+	}
+	if _, ok := manager.GetByID(invalid.ID); ok {
+		t.Fatal("invalid registered auth became active")
+	}
+	if store.saveCount != 0 {
+		t.Fatalf("invalid Register() save count = %d, want 0", store.saveCount)
+	}
+
+	valid := &Auth{
+		ID:         "valid",
+		Provider:   "test",
+		Attributes: map[string]string{AttributeWeight: "2"},
+		Metadata:   map[string]any{"type": "test"},
+	}
+	if _, errRegister := manager.Register(ctx, valid); errRegister != nil {
+		t.Fatalf("Register(valid) error = %v", errRegister)
+	}
+	invalidUpdate := valid.Clone()
+	invalidUpdate.Attributes[AttributeWeight] = "1000001"
+	if _, errUpdate := manager.Update(ctx, invalidUpdate); errUpdate == nil {
+		t.Fatal("Update() accepted an invalid weight")
+	}
+	current, ok := manager.GetByID(valid.ID)
+	if !ok || current.Attributes[AttributeWeight] != "2" {
+		t.Fatalf("invalid Update() changed active auth: %#v", current)
+	}
+	if store.saveCount != 1 {
+		t.Fatalf("save count = %d, want only the valid Register() save", store.saveCount)
+	}
+}

--- a/sdk/cliproxy/auth/cooldown_backoff_test.go
+++ b/sdk/cliproxy/auth/cooldown_backoff_test.go
@@ -5,6 +5,9 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
 
 func withQuotaCooldownEnabled(t *testing.T) {
@@ -149,6 +152,118 @@ func TestApplyAuthFailureStateQuotaBackoffOncePerWindow(t *testing.T) {
 	}
 	if !auth.Quota.NextRecoverAt.Equal(now.Add(13 * time.Second)) {
 		t.Fatalf("expected retry hint window to close at %v, got %v", now.Add(13*time.Second), auth.Quota.NextRecoverAt)
+	}
+}
+
+func TestRecoverableUnknownFailuresHaveFiniteCooldown(t *testing.T) {
+	withQuotaCooldownEnabled(t)
+	previousTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(0)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(previousTransient) })
+
+	testCases := []struct {
+		name      string
+		model     string
+		resultErr *Error
+	}{
+		{name: "model failure without error details", model: "gpt-5"},
+		{name: "auth transport failure without status", resultErr: &Error{Message: "connection reset"}},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			manager := NewManager(nil, nil, nil)
+			auth := &Auth{ID: "auth-unknown-" + testCase.name, Provider: "codex"}
+			if _, errRegister := manager.Register(WithSkipPersist(context.Background()), auth); errRegister != nil {
+				t.Fatalf("Register returned error: %v", errRegister)
+			}
+
+			manager.MarkResult(context.Background(), Result{
+				AuthID:   auth.ID,
+				Provider: auth.Provider,
+				Model:    testCase.model,
+				Success:  false,
+				Error:    testCase.resultErr,
+			})
+
+			updated, ok := manager.GetByID(auth.ID)
+			if !ok || updated == nil {
+				t.Fatal("expected auth after failure")
+			}
+			var nextRetryAfter time.Time
+			if testCase.model == "" {
+				nextRetryAfter = updated.NextRetryAfter
+			} else {
+				state := updated.ModelStates[testCase.model]
+				if state == nil {
+					t.Fatalf("expected model state for %q", testCase.model)
+				}
+				nextRetryAfter = state.NextRetryAfter
+			}
+			if nextRetryAfter.IsZero() {
+				t.Fatal("recoverable failure has no retry deadline")
+			}
+			if blocked, _, _ := isAuthBlockedForModel(updated, testCase.model, time.Now()); !blocked {
+				t.Fatal("auth was not blocked during recoverable failure cooldown")
+			}
+			if blocked, _, _ := isAuthBlockedForModel(updated, testCase.model, nextRetryAfter.Add(time.Nanosecond)); blocked {
+				t.Fatal("auth did not automatically recover after retry deadline")
+			}
+		})
+	}
+}
+
+func TestSchedulerPromotesUnknownFailureAfterRetryDeadline(t *testing.T) {
+	withQuotaCooldownEnabled(t)
+	previousTransient := transientErrorCooldownSeconds.Load()
+	SetTransientErrorCooldownSeconds(0)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(previousTransient) })
+
+	const (
+		provider = "gemini"
+		model    = "scheduler-unknown-recovery-model"
+		authID   = "scheduler-unknown-recovery-auth"
+	)
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.RegisterClient(authID, provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { modelRegistry.UnregisterClient(authID) })
+
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), &Auth{ID: authID, Provider: provider}); errRegister != nil {
+		t.Fatalf("Register returned error: %v", errRegister)
+	}
+	if _, errPick := manager.scheduler.pickSingle(context.Background(), provider, model, cliproxyexecutor.Options{}, nil); errPick != nil {
+		t.Fatalf("initial scheduler pick returned error: %v", errPick)
+	}
+
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   authID,
+		Provider: provider,
+		Model:    model,
+		Success:  false,
+		Error:    &Error{Message: "transport closed"},
+	})
+
+	manager.scheduler.mu.Lock()
+	defer manager.scheduler.mu.Unlock()
+	providerScheduler := manager.scheduler.providers[provider]
+	if providerScheduler == nil {
+		t.Fatalf("scheduler provider %q is missing", provider)
+	}
+	shard := providerScheduler.modelShards[model]
+	if shard == nil {
+		t.Fatalf("scheduler model shard %q is missing", model)
+	}
+	entry := shard.entries[authID]
+	if entry == nil {
+		t.Fatalf("scheduler auth %q is missing", authID)
+	}
+	if entry.state != scheduledStateBlocked || entry.nextRetryAt.IsZero() {
+		t.Fatalf("scheduler entry state = %v, retry = %v; want finite blocked state", entry.state, entry.nextRetryAt)
+	}
+
+	shard.promoteExpiredLocked(entry.nextRetryAt.Add(time.Nanosecond))
+	if entry.state != scheduledStateReady {
+		t.Fatalf("scheduler entry state after deadline = %v, want ready", entry.state)
 	}
 }
 

--- a/sdk/cliproxy/auth/oauth_model_alias.go
+++ b/sdk/cliproxy/auth/oauth_model_alias.go
@@ -112,9 +112,9 @@ func modelAliasLookupCandidates(requestedModel string) (thinking.SuffixResult, [
 	if base == "" {
 		base = requestedModel
 	}
-	candidates := []string{base}
+	candidates := []string{requestedModel}
 	if base != requestedModel {
-		candidates = append(candidates, requestedModel)
+		candidates = append(candidates, base)
 	}
 	return requestResult, candidates
 }
@@ -151,12 +151,12 @@ func resolveModelAliasPoolFromConfigModels(requestedModel string, models []model
 		return nil
 	}
 
-	out := make([]string, 0)
-	seen := make(map[string]struct{})
-	for i := range models {
-		name := strings.TrimSpace(models[i].GetName())
-		alias := strings.TrimSpace(models[i].GetAlias())
-		for _, candidate := range candidates {
+	for _, candidate := range candidates {
+		out := make([]string, 0)
+		seen := make(map[string]struct{})
+		for i := range models {
+			name := strings.TrimSpace(models[i].GetName())
+			alias := strings.TrimSpace(models[i].GetAlias())
 			if candidate == "" || alias == "" || !strings.EqualFold(alias, candidate) {
 				continue
 			}
@@ -167,23 +167,22 @@ func resolveModelAliasPoolFromConfigModels(requestedModel string, models []model
 			resolved = preserveResolvedModelSuffix(resolved, requestResult)
 			key := strings.ToLower(strings.TrimSpace(resolved))
 			if key == "" {
-				break
+				continue
 			}
 			if _, exists := seen[key]; exists {
-				break
+				continue
 			}
 			seen[key] = struct{}{}
 			out = append(out, resolved)
-			break
+		}
+		if len(out) > 0 {
+			return out
 		}
 	}
-	if len(out) > 0 {
-		return out
-	}
 
-	for i := range models {
-		name := strings.TrimSpace(models[i].GetName())
-		for _, candidate := range candidates {
+	for _, candidate := range candidates {
+		for i := range models {
+			name := strings.TrimSpace(models[i].GetName())
 			if candidate == "" || name == "" || !strings.EqualFold(name, candidate) {
 				continue
 			}
@@ -214,15 +213,15 @@ func resolveModelAliasResultFromConfigModels(requestedModel string, models []mod
 	if baseModel == "" {
 		baseModel = requestedModel
 	}
-	for i := range models {
-		original := strings.TrimSpace(models[i].GetName())
-		alias := strings.TrimSpace(models[i].GetAlias())
-		if original == "" || alias == "" {
+	for _, candidate := range candidates {
+		key := strings.TrimSpace(candidate)
+		if key == "" {
 			continue
 		}
-		for _, candidate := range candidates {
-			key := strings.TrimSpace(candidate)
-			if key == "" || !strings.EqualFold(alias, key) {
+		for i := range models {
+			original := strings.TrimSpace(models[i].GetName())
+			alias := strings.TrimSpace(models[i].GetAlias())
+			if original == "" || alias == "" || !strings.EqualFold(alias, key) {
 				continue
 			}
 			if strings.EqualFold(original, baseModel) {
@@ -343,15 +342,15 @@ func resolveUpstreamModelFromAliases(aliases []internalconfig.OAuthModelAlias, r
 	if baseModel == "" {
 		baseModel = strings.TrimSpace(requestedModel)
 	}
-	for _, entry := range aliases {
-		original := strings.TrimSpace(entry.Name)
-		alias := strings.TrimSpace(entry.Alias)
-		if original == "" || alias == "" {
+	for _, candidate := range candidates {
+		key := strings.TrimSpace(candidate)
+		if key == "" {
 			continue
 		}
-		for _, candidate := range candidates {
-			key := strings.TrimSpace(candidate)
-			if key == "" || !strings.EqualFold(alias, key) {
+		for _, entry := range aliases {
+			original := strings.TrimSpace(entry.Name)
+			alias := strings.TrimSpace(entry.Alias)
+			if original == "" || alias == "" || !strings.EqualFold(alias, key) {
 				continue
 			}
 			if strings.EqualFold(original, baseModel) {
@@ -394,13 +393,8 @@ func resolveUpstreamModelFromAliasTable(m *Manager, auth *Auth, requestedModel, 
 		return OAuthModelAliasResult{}
 	}
 
-	requestResult := thinking.ParseSuffix(requestedModel)
+	requestResult, candidates := modelAliasLookupCandidates(requestedModel)
 	baseModel := requestResult.ModelName
-
-	candidates := []string{baseModel}
-	if baseModel != requestedModel {
-		candidates = append(candidates, requestedModel)
-	}
 
 	raw := m.oauthModelAlias.Load()
 	table, _ := raw.(*oauthModelAliasTable)

--- a/sdk/cliproxy/auth/oauth_model_alias_test.go
+++ b/sdk/cliproxy/auth/oauth_model_alias_test.go
@@ -352,6 +352,22 @@ func TestApplyOAuthModelAliasWithResult_ForceMappingUsesConfigAliasNotRequestSuf
 		t.Fatalf("OriginalAlias = %q want gpt-5.4-fast", res.OriginalAlias)
 	}
 }
+func TestApplyOAuthModelAliasWithResultPrefersExactSuffixedAlias(t *testing.T) {
+	t.Parallel()
+	manager := NewManager(nil, nil, nil)
+	manager.SetOAuthModelAlias(map[string][]internalconfig.OAuthModelAlias{
+		"codex": {
+			{Name: "base-upstream", Alias: "public", Fork: true},
+			{Name: "low-upstream", Alias: "public(low)", Fork: true, ForceMapping: true},
+		},
+	})
+	auth := &Auth{ID: "exact-suffix", Provider: "codex"}
+	result := manager.applyOAuthModelAliasWithResult(auth, "public(low)")
+	if result.UpstreamModel != "low-upstream(low)" || !result.ForceMapping {
+		t.Fatalf("exact suffixed alias result = %+v, want low-upstream(low) with force mapping", result)
+	}
+}
+
 func TestApplyOAuthModelAliasWithResult_NoForceMappingPreservesRequestedModelInOriginalAlias(t *testing.T) {
 	t.Parallel()
 	mgr := NewManager(nil, nil, nil)

--- a/sdk/cliproxy/auth/openai_compat_pool_test.go
+++ b/sdk/cliproxy/auth/openai_compat_pool_test.go
@@ -256,6 +256,21 @@ func TestResolveModelAliasPoolFromConfigModels(t *testing.T) {
 	}
 }
 
+func TestResolveModelAliasPoolPrefersExactSuffixedAlias(t *testing.T) {
+	models := []modelAliasEntry{
+		internalconfig.OpenAICompatibilityModel{Name: "base-model", Alias: "public"},
+		internalconfig.OpenAICompatibilityModel{Name: "low-model", Alias: "public(low)", ForceMapping: true},
+	}
+	got := resolveModelAliasPoolFromConfigModels("public(low)", models)
+	if len(got) != 1 || got[0] != "low-model(low)" {
+		t.Fatalf("exact suffixed pool = %v, want [low-model(low)]", got)
+	}
+	result := resolveModelAliasResultFromConfigModels("public(low)", models)
+	if result.UpstreamModel != "low-model(low)" || !result.ForceMapping {
+		t.Fatalf("exact suffixed alias result = %+v, want low-model(low) with force mapping", result)
+	}
+}
+
 func TestManagerExecute_OpenAICompatAliasPoolRotatesWithinAuth(t *testing.T) {
 	alias := "claude-opus-4.66"
 	executor := &openAICompatPoolExecutor{id: openAICompatPoolProviderKey}
@@ -450,6 +465,27 @@ func TestManagerExecute_OpenAICompatAliasPoolFallsBackWithinSameAuth(t *testing.
 		if got[i] != want[i] {
 			t.Fatalf("execute call %d model = %q, want %q", i, got[i], want[i])
 		}
+	}
+}
+
+func TestManagerExecute_OpenAICompatAliasPoolUsesSelectedModelForceMapping(t *testing.T) {
+	alias := "public-model"
+	executor := &openAICompatPoolExecutor{
+		id:              openAICompatPoolProviderKey,
+		executeErrors:   map[string]error{"first-upstream": &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota"}},
+		executePayloads: map[string][]byte{"second-upstream": []byte(`{"model":"second-upstream"}`)},
+	}
+	manager := newOpenAICompatPoolTestManager(t, alias, []internalconfig.OpenAICompatibilityModel{
+		{Name: "first-upstream", Alias: alias, ForceMapping: true},
+		{Name: "second-upstream", Alias: alias},
+	}, executor)
+
+	response, errExecute := manager.Execute(context.Background(), []string{openAICompatPoolProviderKey}, cliproxyexecutor.Request{Model: alias}, cliproxyexecutor.Options{})
+	if errExecute != nil {
+		t.Fatalf("Execute() error = %v", errExecute)
+	}
+	if got := string(response.Payload); got != `{"model":"second-upstream"}` {
+		t.Fatalf("payload = %s, want selected model without force mapping", got)
 	}
 }
 

--- a/sdk/cliproxy/auth/openai_compat_pool_test.go
+++ b/sdk/cliproxy/auth/openai_compat_pool_test.go
@@ -280,6 +280,21 @@ func TestResolveModelAliasPoolFromConfigModels(t *testing.T) {
 	}
 }
 
+func TestResolveModelAliasPoolPrefersExactSuffixedAlias(t *testing.T) {
+	models := []modelAliasEntry{
+		internalconfig.OpenAICompatibilityModel{Name: "base-model", Alias: "public"},
+		internalconfig.OpenAICompatibilityModel{Name: "low-model", Alias: "public(low)", ForceMapping: true},
+	}
+	got := resolveModelAliasPoolFromConfigModels("public(low)", models)
+	if len(got) != 1 || got[0] != "low-model(low)" {
+		t.Fatalf("exact suffixed pool = %v, want [low-model(low)]", got)
+	}
+	result := resolveModelAliasResultFromConfigModels("public(low)", models)
+	if result.UpstreamModel != "low-model(low)" || !result.ForceMapping {
+		t.Fatalf("exact suffixed alias result = %+v, want low-model(low) with force mapping", result)
+	}
+}
+
 func TestManagerExecute_OpenAICompatAliasPoolRotatesWithinAuth(t *testing.T) {
 	alias := "claude-opus-4.66"
 	executor := &openAICompatPoolExecutor{id: openAICompatPoolProviderKey}
@@ -519,6 +534,27 @@ func TestManagerExecute_OpenAICompatAliasPoolPublishesSelectedAuthOnceAcrossMode
 	}
 	if selected := executor.ExecuteSelectedAuths(); len(selected) != 2 || selected[0] != callbacks[0] || selected[1] != callbacks[0] {
 		t.Fatalf("executor selected auth metadata = %#v, want callback auth on both model attempts", selected)
+	}
+}
+
+func TestManagerExecute_OpenAICompatAliasPoolUsesSelectedModelForceMapping(t *testing.T) {
+	alias := "public-model"
+	executor := &openAICompatPoolExecutor{
+		id:              openAICompatPoolProviderKey,
+		executeErrors:   map[string]error{"first-upstream": &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota"}},
+		executePayloads: map[string][]byte{"second-upstream": []byte(`{"model":"second-upstream"}`)},
+	}
+	manager := newOpenAICompatPoolTestManager(t, alias, []internalconfig.OpenAICompatibilityModel{
+		{Name: "first-upstream", Alias: alias, ForceMapping: true},
+		{Name: "second-upstream", Alias: alias},
+	}, executor)
+
+	response, errExecute := manager.Execute(context.Background(), []string{openAICompatPoolProviderKey}, cliproxyexecutor.Request{Model: alias}, cliproxyexecutor.Options{})
+	if errExecute != nil {
+		t.Fatalf("Execute() error = %v", errExecute)
+	}
+	if got := string(response.Payload); got != `{"model":"second-upstream"}` {
+		t.Fatalf("payload = %s, want selected model without force mapping", got)
 	}
 }
 

--- a/sdk/cliproxy/auth/scheduler.go
+++ b/sdk/cliproxy/auth/scheduler.go
@@ -15,10 +15,11 @@ import (
 type schedulerStrategy int
 
 const (
-	schedulerStrategyCurrent    schedulerStrategy = -1
-	schedulerStrategyCustom     schedulerStrategy = 0
-	schedulerStrategyRoundRobin schedulerStrategy = 1
-	schedulerStrategyFillFirst  schedulerStrategy = 2
+	schedulerStrategyCurrent            schedulerStrategy = -1
+	schedulerStrategyCustom             schedulerStrategy = 0
+	schedulerStrategyRoundRobin         schedulerStrategy = 1
+	schedulerStrategyFillFirst          schedulerStrategy = 2
+	schedulerStrategyWeightedRoundRobin schedulerStrategy = 3
 )
 
 // scheduledState describes how an auth currently participates in a model shard.
@@ -33,11 +34,12 @@ const (
 
 // authScheduler keeps the incremental provider/model scheduling state used by Manager.
 type authScheduler struct {
-	mu            sync.Mutex
-	strategy      schedulerStrategy
-	providers     map[string]*providerScheduler
-	authProviders map[string]string
-	mixedCursors  map[string]int
+	mu                  sync.Mutex
+	strategy            schedulerStrategy
+	providers           map[string]*providerScheduler
+	authProviders       map[string]string
+	mixedCursors        map[string]int
+	mixedWeightedStates map[string]*smoothWeightedState
 }
 
 // providerScheduler stores auth metadata and model shards for a single provider.
@@ -52,6 +54,7 @@ type scheduledAuthMeta struct {
 	auth              *Auth
 	providerKey       string
 	priority          int
+	weight            int64
 	websocketEnabled  bool
 	supportedModelSet map[string]struct{}
 }
@@ -81,15 +84,17 @@ type readyBucket struct {
 
 // readyView holds the selection order for flat round-robin traversal.
 type readyView struct {
-	flat   []*scheduledAuth
-	cursor int
+	flat          []*scheduledAuth
+	cursor        int
+	weightedState smoothWeightedState
 }
 
 // cooldownQueue is the blocked auth collection ordered by next retry time during rebuilds.
 type cooldownQueue []*scheduledAuth
 
 type readyViewCursorState struct {
-	cursor int
+	cursor        int
+	weightedState smoothWeightedState
 }
 
 type readyBucketCursorState struct {
@@ -98,7 +103,20 @@ type readyBucketCursorState struct {
 }
 
 func snapshotReadyViewCursors(view readyView) readyViewCursorState {
-	return readyViewCursorState{cursor: view.cursor}
+	state := readyViewCursorState{cursor: view.cursor}
+	if len(view.weightedState.current) > 0 {
+		state.weightedState.current = make(map[string]int64, len(view.weightedState.current))
+		for authID, current := range view.weightedState.current {
+			state.weightedState.current[authID] = current
+		}
+	}
+	if len(view.weightedState.weights) > 0 {
+		state.weightedState.weights = make(map[string]int64, len(view.weightedState.weights))
+		for authID, weight := range view.weightedState.weights {
+			state.weightedState.weights[authID] = weight
+		}
+	}
+	return state
 }
 
 func restoreReadyViewCursors(view *readyView, state readyViewCursorState) {
@@ -108,6 +126,12 @@ func restoreReadyViewCursors(view *readyView, state readyViewCursorState) {
 	if len(view.flat) > 0 {
 		view.cursor = normalizeCursor(state.cursor, len(view.flat))
 	}
+	weights := scheduledWeightVector(view.flat)
+	if len(state.weightedState.current) == 0 || !weightVectorsEqual(state.weightedState.weights, weights) {
+		return
+	}
+	view.weightedState.current = state.weightedState.current
+	view.weightedState.weights = weights
 }
 
 func normalizeCursor(cursor, size int) int {
@@ -124,10 +148,11 @@ func normalizeCursor(cursor, size int) int {
 // newAuthScheduler constructs an empty scheduler configured for the supplied selector strategy.
 func newAuthScheduler(selector Selector) *authScheduler {
 	return &authScheduler{
-		strategy:      selectorStrategy(selector),
-		providers:     make(map[string]*providerScheduler),
-		authProviders: make(map[string]string),
-		mixedCursors:  make(map[string]int),
+		strategy:            selectorStrategy(selector),
+		providers:           make(map[string]*providerScheduler),
+		authProviders:       make(map[string]string),
+		mixedCursors:        make(map[string]int),
+		mixedWeightedStates: make(map[string]*smoothWeightedState),
 	}
 }
 
@@ -136,6 +161,8 @@ func selectorStrategy(selector Selector) schedulerStrategy {
 	switch selector.(type) {
 	case *FillFirstSelector:
 		return schedulerStrategyFillFirst
+	case *WeightedRoundRobinSelector:
+		return schedulerStrategyWeightedRoundRobin
 	case nil, *RoundRobinSelector:
 		return schedulerStrategyRoundRobin
 	default:
@@ -152,6 +179,7 @@ func (s *authScheduler) setSelector(selector Selector) {
 	defer s.mu.Unlock()
 	s.strategy = selectorStrategy(selector)
 	clear(s.mixedCursors)
+	clear(s.mixedWeightedStates)
 }
 
 // rebuild recreates the complete scheduler state from an auth snapshot.
@@ -164,6 +192,7 @@ func (s *authScheduler) rebuild(auths []*Auth) {
 	s.providers = make(map[string]*providerScheduler)
 	s.authProviders = make(map[string]string)
 	s.mixedCursors = make(map[string]int)
+	s.mixedWeightedStates = make(map[string]*smoothWeightedState)
 	now := time.Now()
 	for _, auth := range auths {
 		s.upsertAuthLocked(auth, now)
@@ -206,6 +235,7 @@ func (s *authScheduler) pickSingleWithStrategy(ctx context.Context, provider, mo
 	providerKey := strings.ToLower(strings.TrimSpace(provider))
 	modelKey := canonicalModelKey(model)
 	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
+	eligibility := authSelectionEligibilityForRequest(ctx, opts)
 	preferWebsocket := cliproxyexecutor.DownstreamWebsocket(ctx) && providerPrefersWebsocketTransport(providerKey) && pinnedAuthID == ""
 
 	s.mu.Lock()
@@ -221,20 +251,7 @@ func (s *authScheduler) pickSingleWithStrategy(ctx context.Context, provider, mo
 	if shard == nil {
 		return nil, &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
-	predicate := func(entry *scheduledAuth) bool {
-		if entry == nil || entry.auth == nil {
-			return false
-		}
-		if pinnedAuthID != "" && entry.auth.ID != pinnedAuthID {
-			return false
-		}
-		if len(tried) > 0 {
-			if _, ok := tried[entry.auth.ID]; ok {
-				return false
-			}
-		}
-		return true
-	}
+	predicate := scheduledAuthPredicate(eligibility, tried, pinnedAuthID, strategy == schedulerStrategyWeightedRoundRobin)
 	if picked := shard.pickReadyLocked(preferWebsocket, strategy, predicate); picked != nil {
 		return picked, nil
 	}
@@ -277,6 +294,7 @@ func (s *authScheduler) pickMixedWithStrategy(ctx context.Context, providers []s
 		return picked, providerKey, nil
 	}
 	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
+	eligibility := authSelectionEligibilityForRequest(ctx, opts)
 	modelKey := canonicalModelKey(model)
 
 	s.mu.Lock()
@@ -294,23 +312,14 @@ func (s *authScheduler) pickMixedWithStrategy(ctx context.Context, providers []s
 			return nil, "", &Error{Code: "auth_not_found", Message: "no auth available"}
 		}
 		shard := providerState.ensureModelLocked(modelKey, time.Now())
-		predicate := func(entry *scheduledAuth) bool {
-			if entry == nil || entry.auth == nil || entry.auth.ID != pinnedAuthID {
-				return false
-			}
-			if len(tried) == 0 {
-				return true
-			}
-			_, ok := tried[pinnedAuthID]
-			return !ok
-		}
+		predicate := scheduledAuthPredicate(eligibility, tried, pinnedAuthID, strategy == schedulerStrategyWeightedRoundRobin)
 		if picked := shard.pickReadyLocked(false, strategy, predicate); picked != nil {
 			return picked, providerKey, nil
 		}
 		return nil, "", shard.unavailableErrorLocked("mixed", model, predicate)
 	}
 
-	predicate := triedPredicate(tried)
+	predicate := scheduledAuthPredicate(eligibility, tried, "", strategy == schedulerStrategyWeightedRoundRobin)
 	candidateShards := make([]*modelScheduler, len(normalized))
 	bestPriority := 0
 	hasCandidate := false
@@ -335,7 +344,7 @@ func (s *authScheduler) pickMixedWithStrategy(ctx context.Context, providers []s
 		}
 	}
 	if !hasCandidate {
-		return nil, "", s.mixedUnavailableErrorLocked(normalized, model, tried)
+		return nil, "", s.mixedUnavailableErrorLocked(normalized, model, predicate)
 	}
 
 	if strategy == schedulerStrategyFillFirst {
@@ -349,10 +358,46 @@ func (s *authScheduler) pickMixedWithStrategy(ctx context.Context, providers []s
 				return picked, providerKey, nil
 			}
 		}
-		return nil, "", s.mixedUnavailableErrorLocked(normalized, model, tried)
+		return nil, "", s.mixedUnavailableErrorLocked(normalized, model, predicate)
 	}
 
 	cursorKey := strings.Join(normalized, ",") + ":" + modelKey
+	if strategy == schedulerStrategyWeightedRoundRobin {
+		entries := make([]*scheduledAuth, 0)
+		for _, shard := range candidateShards {
+			if shard == nil {
+				continue
+			}
+			bucket := shard.readyByPriority[bestPriority]
+			if bucket != nil {
+				entries = append(entries, bucket.all.flat...)
+			}
+		}
+		sort.Slice(entries, func(i, j int) bool {
+			if entries[i] == nil || entries[i].auth == nil {
+				return false
+			}
+			if entries[j] == nil || entries[j].auth == nil {
+				return true
+			}
+			return entries[i].auth.ID < entries[j].auth.ID
+		})
+		if s.mixedWeightedStates == nil {
+			s.mixedWeightedStates = make(map[string]*smoothWeightedState)
+		}
+		state := s.mixedWeightedStates[cursorKey]
+		if state == nil {
+			state = &smoothWeightedState{}
+			s.mixedWeightedStates[cursorKey] = state
+		}
+		state.prepare(scheduledWeightVectorMatching(entries, predicate))
+		picked := pickSmoothWeightedScheduled(entries, state.current, predicate)
+		if picked != nil && picked.meta != nil {
+			return picked.auth, picked.meta.providerKey, nil
+		}
+		return nil, "", s.mixedUnavailableErrorLocked(normalized, model, predicate)
+	}
+
 	weights := make([]int, len(normalized))
 	segmentStarts := make([]int, len(normalized))
 	segmentEnds := make([]int, len(normalized))
@@ -360,13 +405,13 @@ func (s *authScheduler) pickMixedWithStrategy(ctx context.Context, providers []s
 	for providerIndex, shard := range candidateShards {
 		segmentStarts[providerIndex] = totalWeight
 		if shard != nil {
-			weights[providerIndex] = shard.readyCountAtPriorityLocked(false, bestPriority)
+			weights[providerIndex] = shard.readyCountAtPriorityLocked(false, bestPriority, predicate)
 		}
 		totalWeight += weights[providerIndex]
 		segmentEnds[providerIndex] = totalWeight
 	}
 	if totalWeight == 0 {
-		return nil, "", s.mixedUnavailableErrorLocked(normalized, model, tried)
+		return nil, "", s.mixedUnavailableErrorLocked(normalized, model, predicate)
 	}
 
 	startSlot := s.mixedCursors[cursorKey] % totalWeight
@@ -381,7 +426,7 @@ func (s *authScheduler) pickMixedWithStrategy(ctx context.Context, providers []s
 		}
 	}
 	if startProviderIndex < 0 {
-		return nil, "", s.mixedUnavailableErrorLocked(normalized, model, tried)
+		return nil, "", s.mixedUnavailableErrorLocked(normalized, model, predicate)
 	}
 
 	slot := startSlot
@@ -405,11 +450,11 @@ func (s *authScheduler) pickMixedWithStrategy(ctx context.Context, providers []s
 		s.mixedCursors[cursorKey] = slot + 1
 		return picked, providerKey, nil
 	}
-	return nil, "", s.mixedUnavailableErrorLocked(normalized, model, tried)
+	return nil, "", s.mixedUnavailableErrorLocked(normalized, model, predicate)
 }
 
 // mixedUnavailableErrorLocked synthesizes the mixed-provider cooldown or unavailable error.
-func (s *authScheduler) mixedUnavailableErrorLocked(providers []string, model string, tried map[string]struct{}) error {
+func (s *authScheduler) mixedUnavailableErrorLocked(providers []string, model string, predicate func(*scheduledAuth) bool) error {
 	now := time.Now()
 	total := 0
 	cooldownCount := 0
@@ -423,7 +468,7 @@ func (s *authScheduler) mixedUnavailableErrorLocked(providers []string, model st
 		if shard == nil {
 			continue
 		}
-		localTotal, localCooldownCount, localEarliest := shard.availabilitySummaryLocked(triedPredicate(tried))
+		localTotal, localCooldownCount, localEarliest := shard.availabilitySummaryLocked(predicate)
 		total += localTotal
 		cooldownCount += localCooldownCount
 		if !localEarliest.IsZero() && (earliest.IsZero() || localEarliest.Before(earliest)) {
@@ -443,17 +488,24 @@ func (s *authScheduler) mixedUnavailableErrorLocked(providers []string, model st
 	return &Error{Code: "auth_unavailable", Message: "no auth available"}
 }
 
-// triedPredicate builds a filter that excludes auths already attempted for the current request.
-func triedPredicate(tried map[string]struct{}) func(*scheduledAuth) bool {
-	if len(tried) == 0 {
-		return func(entry *scheduledAuth) bool { return entry != nil && entry.auth != nil }
-	}
+// scheduledAuthPredicate filters request-ineligible auths before scheduler state advances.
+func scheduledAuthPredicate(eligibility authSelectionEligibility, tried map[string]struct{}, pinnedAuthID string, requirePositiveWeight bool) func(*scheduledAuth) bool {
 	return func(entry *scheduledAuth) bool {
-		if entry == nil || entry.auth == nil {
+		if entry == nil || entry.auth == nil || !eligibility.allows(entry.auth) {
 			return false
 		}
-		_, ok := tried[entry.auth.ID]
-		return !ok
+		if requirePositiveWeight && (entry.meta == nil || entry.meta.weight <= 0) {
+			return false
+		}
+		if pinnedAuthID != "" && entry.auth.ID != pinnedAuthID {
+			return false
+		}
+		if len(tried) > 0 {
+			if _, ok := tried[entry.auth.ID]; ok {
+				return false
+			}
+		}
+		return true
 	}
 }
 
@@ -543,6 +595,7 @@ func buildScheduledAuthMeta(auth *Auth) *scheduledAuthMeta {
 		auth:              auth,
 		providerKey:       providerKey,
 		priority:          authPriority(auth),
+		weight:            authWeight(auth),
 		websocketEnabled:  authWebsocketsEnabled(auth),
 		supportedModelSet: supportedModelSetForAuth(auth.ID),
 	}
@@ -789,9 +842,12 @@ func (m *modelScheduler) pickReadyAtPriorityLocked(preferWebsocket bool, priorit
 		view = &bucket.ws
 	}
 	var picked *scheduledAuth
-	if strategy == schedulerStrategyFillFirst {
+	switch strategy {
+	case schedulerStrategyFillFirst:
 		picked = view.pickFirst(predicate)
-	} else {
+	case schedulerStrategyWeightedRoundRobin:
+		picked = view.pickWeighted(predicate)
+	default:
 		picked = view.pickRoundRobin(predicate)
 	}
 	if picked == nil || picked.auth == nil {
@@ -800,7 +856,7 @@ func (m *modelScheduler) pickReadyAtPriorityLocked(preferWebsocket bool, priorit
 	return picked.auth
 }
 
-func (m *modelScheduler) readyCountAtPriorityLocked(preferWebsocket bool, priority int) int {
+func (m *modelScheduler) readyCountAtPriorityLocked(preferWebsocket bool, priority int, predicate func(*scheduledAuth) bool) int {
 	if m == nil {
 		return 0
 	}
@@ -808,10 +864,17 @@ func (m *modelScheduler) readyCountAtPriorityLocked(preferWebsocket bool, priori
 	if bucket == nil {
 		return 0
 	}
-	if preferWebsocket && len(bucket.ws.flat) > 0 {
-		return len(bucket.ws.flat)
+	view := &bucket.all
+	if preferWebsocket && bucket.ws.pickFirst(predicate) != nil {
+		view = &bucket.ws
 	}
-	return len(bucket.all.flat)
+	count := 0
+	for _, entry := range view.flat {
+		if predicate == nil || predicate(entry) {
+			count++
+		}
+	}
+	return count
 }
 
 // unavailableErrorLocked returns the correct unavailable or cooldown error for the shard.
@@ -973,4 +1036,72 @@ func (v *readyView) pickRoundRobin(predicate func(*scheduledAuth) bool) *schedul
 		return entry
 	}
 	return nil
+}
+
+// pickWeighted returns the next ready entry using smooth weighted round-robin.
+func (v *readyView) pickWeighted(predicate func(*scheduledAuth) bool) *scheduledAuth {
+	if v == nil || len(v.flat) == 0 {
+		return nil
+	}
+	v.weightedState.prepare(scheduledWeightVectorMatching(v.flat, predicate))
+	return pickSmoothWeightedScheduled(v.flat, v.weightedState.current, predicate)
+}
+
+func scheduledWeightVector(entries []*scheduledAuth) map[string]int64 {
+	return scheduledWeightVectorMatching(entries, nil)
+}
+
+func scheduledWeightVectorMatching(entries []*scheduledAuth, predicate func(*scheduledAuth) bool) map[string]int64 {
+	weights := make(map[string]int64, len(entries))
+	for _, entry := range entries {
+		if entry == nil || entry.auth == nil || entry.meta == nil || entry.meta.weight <= 0 {
+			continue
+		}
+		if predicate != nil && !predicate(entry) {
+			continue
+		}
+		weights[entry.auth.ID] = entry.meta.weight
+	}
+	return weights
+}
+
+func pickSmoothWeightedScheduled(entries []*scheduledAuth, current map[string]int64, predicate func(*scheduledAuth) bool) *scheduledAuth {
+	active := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		if entry == nil || entry.auth == nil || entry.meta == nil || entry.meta.weight <= 0 {
+			continue
+		}
+		if predicate != nil && !predicate(entry) {
+			continue
+		}
+		active[entry.auth.ID] = struct{}{}
+	}
+	for authID := range current {
+		if _, ok := active[authID]; !ok {
+			delete(current, authID)
+		}
+	}
+
+	var picked *scheduledAuth
+	var pickedCurrent int64
+	var totalWeight int64
+	for _, entry := range entries {
+		if entry == nil || entry.auth == nil || entry.meta == nil || entry.meta.weight <= 0 {
+			continue
+		}
+		if predicate != nil && !predicate(entry) {
+			continue
+		}
+		current[entry.auth.ID] = saturatingAddInt64(current[entry.auth.ID], entry.meta.weight)
+		totalWeight = saturatingAddInt64(totalWeight, entry.meta.weight)
+		if picked == nil || current[entry.auth.ID] > pickedCurrent {
+			picked = entry
+			pickedCurrent = current[entry.auth.ID]
+		}
+	}
+	if picked == nil {
+		return nil
+	}
+	current[picked.auth.ID] = saturatingAddInt64(current[picked.auth.ID], -totalWeight)
+	return picked
 }

--- a/sdk/cliproxy/auth/scheduler.go
+++ b/sdk/cliproxy/auth/scheduler.go
@@ -15,10 +15,11 @@ import (
 type schedulerStrategy int
 
 const (
-	schedulerStrategyCurrent    schedulerStrategy = -1
-	schedulerStrategyCustom     schedulerStrategy = 0
-	schedulerStrategyRoundRobin schedulerStrategy = 1
-	schedulerStrategyFillFirst  schedulerStrategy = 2
+	schedulerStrategyCurrent            schedulerStrategy = -1
+	schedulerStrategyCustom             schedulerStrategy = 0
+	schedulerStrategyRoundRobin         schedulerStrategy = 1
+	schedulerStrategyFillFirst          schedulerStrategy = 2
+	schedulerStrategyWeightedRoundRobin schedulerStrategy = 3
 )
 
 // scheduledState describes how an auth currently participates in a model shard.
@@ -33,11 +34,12 @@ const (
 
 // authScheduler keeps the incremental provider/model scheduling state used by Manager.
 type authScheduler struct {
-	mu            sync.Mutex
-	strategy      schedulerStrategy
-	providers     map[string]*providerScheduler
-	authProviders map[string]string
-	mixedCursors  map[string]int
+	mu                  sync.Mutex
+	strategy            schedulerStrategy
+	providers           map[string]*providerScheduler
+	authProviders       map[string]string
+	mixedCursors        map[string]int
+	mixedWeightedStates map[string]*smoothWeightedState
 }
 
 // providerScheduler stores auth metadata and model shards for a single provider.
@@ -52,6 +54,7 @@ type scheduledAuthMeta struct {
 	auth              *Auth
 	providerKey       string
 	priority          int
+	weight            int64
 	websocketEnabled  bool
 	supportedModelSet map[string]struct{}
 }
@@ -81,15 +84,17 @@ type readyBucket struct {
 
 // readyView holds the selection order for flat round-robin traversal.
 type readyView struct {
-	flat   []*scheduledAuth
-	cursor int
+	flat          []*scheduledAuth
+	cursor        int
+	weightedState smoothWeightedState
 }
 
 // cooldownQueue is the blocked auth collection ordered by next retry time during rebuilds.
 type cooldownQueue []*scheduledAuth
 
 type readyViewCursorState struct {
-	cursor int
+	cursor        int
+	weightedState smoothWeightedState
 }
 
 type readyBucketCursorState struct {
@@ -98,7 +103,20 @@ type readyBucketCursorState struct {
 }
 
 func snapshotReadyViewCursors(view readyView) readyViewCursorState {
-	return readyViewCursorState{cursor: view.cursor}
+	state := readyViewCursorState{cursor: view.cursor}
+	if len(view.weightedState.current) > 0 {
+		state.weightedState.current = make(map[string]int64, len(view.weightedState.current))
+		for authID, current := range view.weightedState.current {
+			state.weightedState.current[authID] = current
+		}
+	}
+	if len(view.weightedState.weights) > 0 {
+		state.weightedState.weights = make(map[string]int64, len(view.weightedState.weights))
+		for authID, weight := range view.weightedState.weights {
+			state.weightedState.weights[authID] = weight
+		}
+	}
+	return state
 }
 
 func restoreReadyViewCursors(view *readyView, state readyViewCursorState) {
@@ -108,6 +126,12 @@ func restoreReadyViewCursors(view *readyView, state readyViewCursorState) {
 	if len(view.flat) > 0 {
 		view.cursor = normalizeCursor(state.cursor, len(view.flat))
 	}
+	weights := scheduledWeightVector(view.flat)
+	if len(state.weightedState.current) == 0 || !weightVectorsEqual(state.weightedState.weights, weights) {
+		return
+	}
+	view.weightedState.current = state.weightedState.current
+	view.weightedState.weights = weights
 }
 
 func normalizeCursor(cursor, size int) int {
@@ -124,10 +148,11 @@ func normalizeCursor(cursor, size int) int {
 // newAuthScheduler constructs an empty scheduler configured for the supplied selector strategy.
 func newAuthScheduler(selector Selector) *authScheduler {
 	return &authScheduler{
-		strategy:      selectorStrategy(selector),
-		providers:     make(map[string]*providerScheduler),
-		authProviders: make(map[string]string),
-		mixedCursors:  make(map[string]int),
+		strategy:            selectorStrategy(selector),
+		providers:           make(map[string]*providerScheduler),
+		authProviders:       make(map[string]string),
+		mixedCursors:        make(map[string]int),
+		mixedWeightedStates: make(map[string]*smoothWeightedState),
 	}
 }
 
@@ -136,6 +161,8 @@ func selectorStrategy(selector Selector) schedulerStrategy {
 	switch selector.(type) {
 	case *FillFirstSelector:
 		return schedulerStrategyFillFirst
+	case *WeightedRoundRobinSelector:
+		return schedulerStrategyWeightedRoundRobin
 	case nil, *RoundRobinSelector:
 		return schedulerStrategyRoundRobin
 	default:
@@ -152,6 +179,7 @@ func (s *authScheduler) setSelector(selector Selector) {
 	defer s.mu.Unlock()
 	s.strategy = selectorStrategy(selector)
 	clear(s.mixedCursors)
+	clear(s.mixedWeightedStates)
 }
 
 // rebuild recreates the complete scheduler state from an auth snapshot.
@@ -164,6 +192,7 @@ func (s *authScheduler) rebuild(auths []*Auth) {
 	s.providers = make(map[string]*providerScheduler)
 	s.authProviders = make(map[string]string)
 	s.mixedCursors = make(map[string]int)
+	s.mixedWeightedStates = make(map[string]*smoothWeightedState)
 	now := time.Now()
 	for _, auth := range auths {
 		s.upsertAuthLocked(auth, now)
@@ -206,6 +235,7 @@ func (s *authScheduler) pickSingleWithStrategy(ctx context.Context, provider, mo
 	providerKey := strings.ToLower(strings.TrimSpace(provider))
 	modelKey := canonicalModelKey(model)
 	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
+	eligibility := authSelectionEligibilityForRequest(ctx, opts)
 	preferWebsocket := cliproxyexecutor.DownstreamWebsocket(ctx) && providerPrefersWebsocketTransport(providerKey) && pinnedAuthID == ""
 
 	s.mu.Lock()
@@ -221,20 +251,7 @@ func (s *authScheduler) pickSingleWithStrategy(ctx context.Context, provider, mo
 	if shard == nil {
 		return nil, &Error{Code: "auth_not_found", Message: "no auth available"}
 	}
-	predicate := func(entry *scheduledAuth) bool {
-		if entry == nil || entry.auth == nil {
-			return false
-		}
-		if pinnedAuthID != "" && entry.auth.ID != pinnedAuthID {
-			return false
-		}
-		if len(tried) > 0 {
-			if _, ok := tried[entry.auth.ID]; ok {
-				return false
-			}
-		}
-		return true
-	}
+	predicate := scheduledAuthPredicate(eligibility, tried, pinnedAuthID, strategy == schedulerStrategyWeightedRoundRobin)
 	if picked := shard.pickReadyLocked(preferWebsocket, strategy, predicate); picked != nil {
 		return picked, nil
 	}
@@ -277,6 +294,7 @@ func (s *authScheduler) pickMixedWithStrategy(ctx context.Context, providers []s
 		return picked, providerKey, nil
 	}
 	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
+	eligibility := authSelectionEligibilityForRequest(ctx, opts)
 	modelKey := canonicalModelKey(model)
 
 	s.mu.Lock()
@@ -294,23 +312,14 @@ func (s *authScheduler) pickMixedWithStrategy(ctx context.Context, providers []s
 			return nil, "", &Error{Code: "auth_not_found", Message: "no auth available"}
 		}
 		shard := providerState.ensureModelLocked(modelKey, time.Now())
-		predicate := func(entry *scheduledAuth) bool {
-			if entry == nil || entry.auth == nil || entry.auth.ID != pinnedAuthID {
-				return false
-			}
-			if len(tried) == 0 {
-				return true
-			}
-			_, ok := tried[pinnedAuthID]
-			return !ok
-		}
+		predicate := scheduledAuthPredicate(eligibility, tried, pinnedAuthID, strategy == schedulerStrategyWeightedRoundRobin)
 		if picked := shard.pickReadyLocked(false, strategy, predicate); picked != nil {
 			return picked, providerKey, nil
 		}
 		return nil, "", shard.unavailableErrorLocked("mixed", model, predicate)
 	}
 
-	predicate := triedPredicate(tried)
+	predicate := scheduledAuthPredicate(eligibility, tried, "", strategy == schedulerStrategyWeightedRoundRobin)
 	candidateShards := make([]*modelScheduler, len(normalized))
 	bestPriority := 0
 	hasCandidate := false
@@ -335,7 +344,7 @@ func (s *authScheduler) pickMixedWithStrategy(ctx context.Context, providers []s
 		}
 	}
 	if !hasCandidate {
-		return nil, "", s.mixedUnavailableErrorLocked(normalized, model, tried)
+		return nil, "", s.mixedUnavailableErrorLocked(normalized, model, predicate)
 	}
 
 	if strategy == schedulerStrategyFillFirst {
@@ -349,10 +358,46 @@ func (s *authScheduler) pickMixedWithStrategy(ctx context.Context, providers []s
 				return picked, providerKey, nil
 			}
 		}
-		return nil, "", s.mixedUnavailableErrorLocked(normalized, model, tried)
+		return nil, "", s.mixedUnavailableErrorLocked(normalized, model, predicate)
 	}
 
 	cursorKey := strings.Join(normalized, ",") + ":" + modelKey
+	if strategy == schedulerStrategyWeightedRoundRobin {
+		entries := make([]*scheduledAuth, 0)
+		for _, shard := range candidateShards {
+			if shard == nil {
+				continue
+			}
+			bucket := shard.readyByPriority[bestPriority]
+			if bucket != nil {
+				entries = append(entries, bucket.all.flat...)
+			}
+		}
+		sort.Slice(entries, func(i, j int) bool {
+			if entries[i] == nil || entries[i].auth == nil {
+				return false
+			}
+			if entries[j] == nil || entries[j].auth == nil {
+				return true
+			}
+			return entries[i].auth.ID < entries[j].auth.ID
+		})
+		if s.mixedWeightedStates == nil {
+			s.mixedWeightedStates = make(map[string]*smoothWeightedState)
+		}
+		state := s.mixedWeightedStates[cursorKey]
+		if state == nil {
+			state = &smoothWeightedState{}
+			s.mixedWeightedStates[cursorKey] = state
+		}
+		state.prepare(scheduledWeightVectorMatching(entries, predicate))
+		picked := pickSmoothWeightedScheduled(entries, state.current, predicate)
+		if picked != nil && picked.meta != nil {
+			return picked.auth, picked.meta.providerKey, nil
+		}
+		return nil, "", s.mixedUnavailableErrorLocked(normalized, model, predicate)
+	}
+
 	weights := make([]int, len(normalized))
 	segmentStarts := make([]int, len(normalized))
 	segmentEnds := make([]int, len(normalized))
@@ -360,13 +405,13 @@ func (s *authScheduler) pickMixedWithStrategy(ctx context.Context, providers []s
 	for providerIndex, shard := range candidateShards {
 		segmentStarts[providerIndex] = totalWeight
 		if shard != nil {
-			weights[providerIndex] = shard.readyCountAtPriorityLocked(false, bestPriority)
+			weights[providerIndex] = shard.readyCountAtPriorityLocked(false, bestPriority, predicate)
 		}
 		totalWeight += weights[providerIndex]
 		segmentEnds[providerIndex] = totalWeight
 	}
 	if totalWeight == 0 {
-		return nil, "", s.mixedUnavailableErrorLocked(normalized, model, tried)
+		return nil, "", s.mixedUnavailableErrorLocked(normalized, model, predicate)
 	}
 
 	startSlot := s.mixedCursors[cursorKey] % totalWeight
@@ -381,7 +426,7 @@ func (s *authScheduler) pickMixedWithStrategy(ctx context.Context, providers []s
 		}
 	}
 	if startProviderIndex < 0 {
-		return nil, "", s.mixedUnavailableErrorLocked(normalized, model, tried)
+		return nil, "", s.mixedUnavailableErrorLocked(normalized, model, predicate)
 	}
 
 	slot := startSlot
@@ -405,11 +450,11 @@ func (s *authScheduler) pickMixedWithStrategy(ctx context.Context, providers []s
 		s.mixedCursors[cursorKey] = slot + 1
 		return picked, providerKey, nil
 	}
-	return nil, "", s.mixedUnavailableErrorLocked(normalized, model, tried)
+	return nil, "", s.mixedUnavailableErrorLocked(normalized, model, predicate)
 }
 
 // mixedUnavailableErrorLocked synthesizes the mixed-provider cooldown or unavailable error.
-func (s *authScheduler) mixedUnavailableErrorLocked(providers []string, model string, tried map[string]struct{}) error {
+func (s *authScheduler) mixedUnavailableErrorLocked(providers []string, model string, predicate func(*scheduledAuth) bool) error {
 	now := time.Now()
 	total := 0
 	cooldownCount := 0
@@ -423,7 +468,7 @@ func (s *authScheduler) mixedUnavailableErrorLocked(providers []string, model st
 		if shard == nil {
 			continue
 		}
-		localTotal, localCooldownCount, localEarliest := shard.availabilitySummaryLocked(triedPredicate(tried))
+		localTotal, localCooldownCount, localEarliest := shard.availabilitySummaryLocked(predicate)
 		total += localTotal
 		cooldownCount += localCooldownCount
 		if !localEarliest.IsZero() && (earliest.IsZero() || localEarliest.Before(earliest)) {
@@ -443,17 +488,24 @@ func (s *authScheduler) mixedUnavailableErrorLocked(providers []string, model st
 	return &Error{Code: "auth_unavailable", Message: "no auth available"}
 }
 
-// triedPredicate builds a filter that excludes auths already attempted for the current request.
-func triedPredicate(tried map[string]struct{}) func(*scheduledAuth) bool {
-	if len(tried) == 0 {
-		return func(entry *scheduledAuth) bool { return entry != nil && entry.auth != nil }
-	}
+// scheduledAuthPredicate filters request-ineligible auths before scheduler state advances.
+func scheduledAuthPredicate(eligibility authSelectionEligibility, tried map[string]struct{}, pinnedAuthID string, requirePositiveWeight bool) func(*scheduledAuth) bool {
 	return func(entry *scheduledAuth) bool {
-		if entry == nil || entry.auth == nil {
+		if entry == nil || entry.auth == nil || !eligibility.allows(entry.auth) {
 			return false
 		}
-		_, ok := tried[entry.auth.ID]
-		return !ok
+		if requirePositiveWeight && (entry.meta == nil || entry.meta.weight <= 0) {
+			return false
+		}
+		if pinnedAuthID != "" && entry.auth.ID != pinnedAuthID {
+			return false
+		}
+		if len(tried) > 0 {
+			if _, ok := tried[entry.auth.ID]; ok {
+				return false
+			}
+		}
+		return true
 	}
 }
 
@@ -544,6 +596,7 @@ func buildScheduledAuthMeta(auth *Auth) *scheduledAuthMeta {
 		auth:              auth,
 		providerKey:       providerKey,
 		priority:          authPriority(auth),
+		weight:            authWeight(auth),
 		websocketEnabled:  authWebsocketsEnabled(auth),
 		supportedModelSet: supportedModelSetForAuth(auth.ID),
 	}
@@ -790,9 +843,12 @@ func (m *modelScheduler) pickReadyAtPriorityLocked(preferWebsocket bool, priorit
 		view = &bucket.ws
 	}
 	var picked *scheduledAuth
-	if strategy == schedulerStrategyFillFirst {
+	switch strategy {
+	case schedulerStrategyFillFirst:
 		picked = view.pickFirst(predicate)
-	} else {
+	case schedulerStrategyWeightedRoundRobin:
+		picked = view.pickWeighted(predicate)
+	default:
 		picked = view.pickRoundRobin(predicate)
 	}
 	if picked == nil || picked.auth == nil {
@@ -801,7 +857,7 @@ func (m *modelScheduler) pickReadyAtPriorityLocked(preferWebsocket bool, priorit
 	return picked.auth.Clone()
 }
 
-func (m *modelScheduler) readyCountAtPriorityLocked(preferWebsocket bool, priority int) int {
+func (m *modelScheduler) readyCountAtPriorityLocked(preferWebsocket bool, priority int, predicate func(*scheduledAuth) bool) int {
 	if m == nil {
 		return 0
 	}
@@ -809,10 +865,17 @@ func (m *modelScheduler) readyCountAtPriorityLocked(preferWebsocket bool, priori
 	if bucket == nil {
 		return 0
 	}
-	if preferWebsocket && len(bucket.ws.flat) > 0 {
-		return len(bucket.ws.flat)
+	view := &bucket.all
+	if preferWebsocket && bucket.ws.pickFirst(predicate) != nil {
+		view = &bucket.ws
 	}
-	return len(bucket.all.flat)
+	count := 0
+	for _, entry := range view.flat {
+		if predicate == nil || predicate(entry) {
+			count++
+		}
+	}
+	return count
 }
 
 // unavailableErrorLocked returns the correct unavailable or cooldown error for the shard.
@@ -974,4 +1037,72 @@ func (v *readyView) pickRoundRobin(predicate func(*scheduledAuth) bool) *schedul
 		return entry
 	}
 	return nil
+}
+
+// pickWeighted returns the next ready entry using smooth weighted round-robin.
+func (v *readyView) pickWeighted(predicate func(*scheduledAuth) bool) *scheduledAuth {
+	if v == nil || len(v.flat) == 0 {
+		return nil
+	}
+	v.weightedState.prepare(scheduledWeightVectorMatching(v.flat, predicate))
+	return pickSmoothWeightedScheduled(v.flat, v.weightedState.current, predicate)
+}
+
+func scheduledWeightVector(entries []*scheduledAuth) map[string]int64 {
+	return scheduledWeightVectorMatching(entries, nil)
+}
+
+func scheduledWeightVectorMatching(entries []*scheduledAuth, predicate func(*scheduledAuth) bool) map[string]int64 {
+	weights := make(map[string]int64, len(entries))
+	for _, entry := range entries {
+		if entry == nil || entry.auth == nil || entry.meta == nil || entry.meta.weight <= 0 {
+			continue
+		}
+		if predicate != nil && !predicate(entry) {
+			continue
+		}
+		weights[entry.auth.ID] = entry.meta.weight
+	}
+	return weights
+}
+
+func pickSmoothWeightedScheduled(entries []*scheduledAuth, current map[string]int64, predicate func(*scheduledAuth) bool) *scheduledAuth {
+	active := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		if entry == nil || entry.auth == nil || entry.meta == nil || entry.meta.weight <= 0 {
+			continue
+		}
+		if predicate != nil && !predicate(entry) {
+			continue
+		}
+		active[entry.auth.ID] = struct{}{}
+	}
+	for authID := range current {
+		if _, ok := active[authID]; !ok {
+			delete(current, authID)
+		}
+	}
+
+	var picked *scheduledAuth
+	var pickedCurrent int64
+	var totalWeight int64
+	for _, entry := range entries {
+		if entry == nil || entry.auth == nil || entry.meta == nil || entry.meta.weight <= 0 {
+			continue
+		}
+		if predicate != nil && !predicate(entry) {
+			continue
+		}
+		current[entry.auth.ID] = saturatingAddInt64(current[entry.auth.ID], entry.meta.weight)
+		totalWeight = saturatingAddInt64(totalWeight, entry.meta.weight)
+		if picked == nil || current[entry.auth.ID] > pickedCurrent {
+			picked = entry
+			pickedCurrent = current[entry.auth.ID]
+		}
+	}
+	if picked == nil {
+		return nil
+	}
+	current[picked.auth.ID] = saturatingAddInt64(current[picked.auth.ID], -totalWeight)
+	return picked
 }

--- a/sdk/cliproxy/auth/scheduler_test.go
+++ b/sdk/cliproxy/auth/scheduler_test.go
@@ -20,6 +20,22 @@ type schedulerTestExecutor struct {
 	provider string
 }
 
+type schedulerLoadStore struct {
+	auths []*Auth
+}
+
+func (s *schedulerLoadStore) List(context.Context) ([]*Auth, error) {
+	return s.auths, nil
+}
+
+func (s *schedulerLoadStore) Save(context.Context, *Auth) (string, error) {
+	return "", nil
+}
+
+func (s *schedulerLoadStore) Delete(context.Context, string) error {
+	return nil
+}
+
 func (e schedulerTestExecutor) Identifier() string {
 	if e.provider != "" {
 		return e.provider
@@ -150,6 +166,165 @@ func TestSchedulerPick_RoundRobinHighestPriority(t *testing.T) {
 		if got.ID != wantID {
 			t.Fatalf("pickSingle() #%d auth.ID = %q, want %q", index, got.ID, wantID)
 		}
+	}
+}
+
+func TestSchedulerPick_WeightedRoundRobin(t *testing.T) {
+	t.Parallel()
+
+	scheduler := newSchedulerForTest(
+		&WeightedRoundRobinSelector{},
+		&Auth{ID: "a", Provider: "gemini", Attributes: map[string]string{AttributeWeight: "5"}},
+		&Auth{ID: "b", Provider: "gemini", Attributes: map[string]string{AttributeWeight: "3"}},
+		&Auth{ID: "c", Provider: "gemini", Attributes: map[string]string{AttributeWeight: "2"}},
+	)
+
+	counts := make(map[string]int)
+	for index := 0; index < 100; index++ {
+		got, errPick := scheduler.pickSingle(context.Background(), "gemini", "", cliproxyexecutor.Options{}, nil)
+		if errPick != nil {
+			t.Fatalf("pickSingle() #%d error = %v", index, errPick)
+		}
+		counts[got.ID]++
+	}
+	want := map[string]int{"a": 50, "b": 30, "c": 20}
+	for authID, wantCount := range want {
+		if counts[authID] != wantCount {
+			t.Fatalf("auth %q picks = %d, want %d", authID, counts[authID], wantCount)
+		}
+	}
+}
+
+func TestManagerLoad_WeightedRoundRobinUsesPersistedMetadataWeight(t *testing.T) {
+	t.Parallel()
+
+	manager := NewManager(&schedulerLoadStore{auths: []*Auth{
+		{ID: "a", Provider: "gemini", Metadata: map[string]any{AttributeWeight: float64(5)}},
+		{ID: "b", Provider: "gemini", Metadata: map[string]any{AttributeWeight: float64(1)}},
+	}}, &WeightedRoundRobinSelector{}, nil)
+	if errLoad := manager.Load(context.Background()); errLoad != nil {
+		t.Fatalf("Load() error = %v", errLoad)
+	}
+
+	counts := make(map[string]int)
+	for index := 0; index < 60; index++ {
+		got, errPick := manager.scheduler.pickSingle(context.Background(), "gemini", "", cliproxyexecutor.Options{}, nil)
+		if errPick != nil {
+			t.Fatalf("pickSingle() #%d error = %v", index, errPick)
+		}
+		counts[got.ID]++
+	}
+	if counts["a"] != 50 || counts["b"] != 10 {
+		t.Fatalf("metadata-weighted picks = %#v, want a:b=50:10", counts)
+	}
+}
+
+func TestSchedulerPick_WeightedRoundRobinResetsCreditsWhenWeightsChange(t *testing.T) {
+	t.Parallel()
+
+	authA := &Auth{ID: "a", Provider: "gemini", Attributes: map[string]string{AttributeWeight: "1000000"}}
+	authB := &Auth{ID: "b", Provider: "gemini", Attributes: map[string]string{AttributeWeight: "1"}}
+	scheduler := newSchedulerForTest(&WeightedRoundRobinSelector{}, authA, authB)
+	for index := 0; index < 1000; index++ {
+		if _, errPick := scheduler.pickSingle(context.Background(), "gemini", "", cliproxyexecutor.Options{}, nil); errPick != nil {
+			t.Fatalf("warmup pickSingle() #%d error = %v", index, errPick)
+		}
+	}
+
+	authA.Attributes[AttributeWeight] = "1"
+	scheduler.upsertAuth(authA)
+	counts := make(map[string]int)
+	for index := 0; index < 20; index++ {
+		got, errPick := scheduler.pickSingle(context.Background(), "gemini", "", cliproxyexecutor.Options{}, nil)
+		if errPick != nil {
+			t.Fatalf("pickSingle() after weight change #%d error = %v", index, errPick)
+		}
+		counts[got.ID]++
+	}
+	if counts["a"] != 10 || counts["b"] != 10 {
+		t.Fatalf("picks after weight change = %#v, want a:b=10:10", counts)
+	}
+}
+
+func TestSchedulerPick_WeightedWebsocketResetsCreditsWhenWeightsChange(t *testing.T) {
+	t.Parallel()
+
+	authA := &Auth{ID: "a", Provider: "codex", Attributes: map[string]string{AttributeWeight: "1000000", "websockets": "true"}}
+	authB := &Auth{ID: "b", Provider: "codex", Attributes: map[string]string{AttributeWeight: "1", "websockets": "true"}}
+	scheduler := newSchedulerForTest(&WeightedRoundRobinSelector{}, authA, authB)
+	ctx := cliproxyexecutor.WithDownstreamWebsocket(context.Background())
+	for index := 0; index < 1000; index++ {
+		if _, errPick := scheduler.pickSingle(ctx, "codex", "", cliproxyexecutor.Options{}, nil); errPick != nil {
+			t.Fatalf("warmup websocket pickSingle() #%d error = %v", index, errPick)
+		}
+	}
+
+	authA.Attributes[AttributeWeight] = "1"
+	scheduler.upsertAuth(authA)
+	counts := make(map[string]int)
+	for index := 0; index < 20; index++ {
+		got, errPick := scheduler.pickSingle(ctx, "codex", "", cliproxyexecutor.Options{}, nil)
+		if errPick != nil {
+			t.Fatalf("websocket pickSingle() after weight change #%d error = %v", index, errPick)
+		}
+		counts[got.ID]++
+	}
+	if counts["a"] != 10 || counts["b"] != 10 {
+		t.Fatalf("websocket picks after weight change = %#v, want a:b=10:10", counts)
+	}
+}
+
+func TestManagerLegacyWeightedRoundRobinKeepsIndependentAliasPrefixedModelState(t *testing.T) {
+	manager := NewManager(nil, &WeightedRoundRobinSelector{}, nil)
+	manager.executors["gemini"] = schedulerTestExecutor{}
+	manager.SetPluginScheduler(&fakePluginScheduler{})
+
+	auths := []*Auth{
+		{ID: "a-heavy", Provider: "gemini", Attributes: map[string]string{AttributeWeight: "3"}},
+		{ID: "a-light", Provider: "gemini", Attributes: map[string]string{AttributeWeight: "1"}},
+		{ID: "b-light", Provider: "gemini", Attributes: map[string]string{AttributeWeight: "1"}},
+		{ID: "b-heavy", Provider: "gemini", Attributes: map[string]string{AttributeWeight: "3"}},
+	}
+	for _, auth := range auths {
+		if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+			t.Fatalf("Register(%s) error = %v", auth.ID, errRegister)
+		}
+	}
+	registerSchedulerModels(t, "gemini", "team-a/shared", "a-heavy", "a-light")
+	registerSchedulerModels(t, "gemini", "team-b/shared", "b-light", "b-heavy")
+
+	counts := make(map[string]int)
+	for index := 0; index < 40; index++ {
+		for _, model := range []string{"team-a/shared", "team-b/shared"} {
+			got, _, errPick := manager.pickNext(context.Background(), "gemini", model, cliproxyexecutor.Options{}, nil)
+			if errPick != nil {
+				t.Fatalf("pickNext(%q) #%d error = %v", model, index, errPick)
+			}
+			counts[got.ID]++
+		}
+	}
+	want := map[string]int{"a-heavy": 30, "a-light": 10, "b-light": 10, "b-heavy": 30}
+	for authID, wantCount := range want {
+		if counts[authID] != wantCount {
+			t.Fatalf("auth %q picks = %d, want %d; all=%#v", authID, counts[authID], wantCount, counts)
+		}
+	}
+}
+
+func TestSchedulerPick_WeightedRoundRobinSkipsNonPositiveWeightPriorityTier(t *testing.T) {
+	t.Parallel()
+
+	scheduler := newSchedulerForTest(
+		&WeightedRoundRobinSelector{},
+		&Auth{ID: "excluded", Provider: "gemini", Attributes: map[string]string{"priority": "10", AttributeWeight: "0"}},
+		&Auth{ID: "available", Provider: "gemini", Attributes: map[string]string{"priority": "0", AttributeWeight: "1"}},
+	)
+	got, errPick := scheduler.pickSingle(context.Background(), "gemini", "", cliproxyexecutor.Options{}, nil)
+	if errPick != nil {
+		t.Fatalf("pickSingle() error = %v", errPick)
+	}
+	if got == nil || got.ID != "available" {
+		t.Fatalf("pickSingle() auth = %#v, want available", got)
 	}
 }
 
@@ -313,6 +488,63 @@ func TestSchedulerPick_MixedProvidersUsesWeightedProviderRotationOverReadyCandid
 		if got.ID != wantIDs[index] {
 			t.Fatalf("pickMixed() #%d auth.ID = %q, want %q", index, got.ID, wantIDs[index])
 		}
+	}
+}
+
+func TestSchedulerPick_MixedProvidersWeightedRoundRobin(t *testing.T) {
+	t.Parallel()
+
+	scheduler := newSchedulerForTest(
+		&WeightedRoundRobinSelector{},
+		&Auth{ID: "gemini-a", Provider: "gemini", Attributes: map[string]string{AttributeWeight: "5"}},
+		&Auth{ID: "claude-b", Provider: "claude", Attributes: map[string]string{AttributeWeight: "3"}},
+		&Auth{ID: "claude-c", Provider: "claude", Attributes: map[string]string{AttributeWeight: "2"}},
+	)
+
+	counts := make(map[string]int)
+	for index := 0; index < 100; index++ {
+		got, provider, errPick := scheduler.pickMixed(context.Background(), []string{"gemini", "claude"}, "", cliproxyexecutor.Options{}, nil)
+		if errPick != nil {
+			t.Fatalf("pickMixed() #%d error = %v", index, errPick)
+		}
+		if got == nil || provider == "" {
+			t.Fatalf("pickMixed() #%d returned auth=%v provider=%q", index, got, provider)
+		}
+		counts[got.ID]++
+	}
+	want := map[string]int{"gemini-a": 50, "claude-b": 30, "claude-c": 20}
+	for authID, wantCount := range want {
+		if counts[authID] != wantCount {
+			t.Fatalf("auth %q picks = %d, want %d", authID, counts[authID], wantCount)
+		}
+	}
+}
+
+func TestSchedulerPick_MixedProvidersResetsCreditsWhenWeightsChange(t *testing.T) {
+	t.Parallel()
+
+	authA := &Auth{ID: "gemini-a", Provider: "gemini", Attributes: map[string]string{AttributeWeight: "1000000"}}
+	authB := &Auth{ID: "claude-b", Provider: "claude", Attributes: map[string]string{AttributeWeight: "1"}}
+	scheduler := newSchedulerForTest(&WeightedRoundRobinSelector{}, authA, authB)
+	providers := []string{"gemini", "claude"}
+	for index := 0; index < 1000; index++ {
+		if _, _, errPick := scheduler.pickMixed(context.Background(), providers, "", cliproxyexecutor.Options{}, nil); errPick != nil {
+			t.Fatalf("warmup pickMixed() #%d error = %v", index, errPick)
+		}
+	}
+
+	authA.Attributes[AttributeWeight] = "1"
+	scheduler.upsertAuth(authA)
+	counts := make(map[string]int)
+	for index := 0; index < 20; index++ {
+		got, _, errPick := scheduler.pickMixed(context.Background(), providers, "", cliproxyexecutor.Options{}, nil)
+		if errPick != nil {
+			t.Fatalf("pickMixed() after weight change #%d error = %v", index, errPick)
+		}
+		counts[got.ID]++
+	}
+	if counts[authA.ID] != 10 || counts[authB.ID] != 10 {
+		t.Fatalf("mixed picks after weight change = %#v, want 10 each", counts)
 	}
 }
 
@@ -481,8 +713,113 @@ func TestManagerSelectAuthByKindSkipsAPIKey(t *testing.T) {
 	if selected == nil || selected.ID != "codex-oauth" {
 		t.Fatalf("SelectAuthByKind() auth = %#v, want codex-oauth", selected)
 	}
-	if scheduler.calls != 2 {
-		t.Fatalf("scheduler.calls = %d, want 2", scheduler.calls)
+	if scheduler.calls != 1 {
+		t.Fatalf("scheduler.calls = %d, want 1", scheduler.calls)
+	}
+	if len(scheduler.requests) != 1 || len(scheduler.requests[0].Candidates) != 1 || scheduler.requests[0].Candidates[0].ID != "codex-oauth" {
+		t.Fatalf("scheduler candidates = %#v, want only codex-oauth", scheduler.requests)
+	}
+}
+
+func TestManagerSelectAuthByKindWeightedRoundRobinIgnoresIneligibleAPIKeyWeight(t *testing.T) {
+	manager := NewManager(nil, &WeightedRoundRobinSelector{}, nil)
+	manager.executors["codex"] = schedulerTestExecutor{}
+	for _, candidate := range []*Auth{
+		{ID: "api-high", Provider: "codex", Attributes: map[string]string{AttributeAPIKey: "test-key", AttributeWeight: "100"}},
+		{ID: "oauth-heavy", Provider: "codex", Attributes: map[string]string{AttributeWeight: "5"}, Metadata: map[string]any{"access_token": "heavy-token"}},
+		{ID: "oauth-light", Provider: "codex", Attributes: map[string]string{AttributeWeight: "1"}, Metadata: map[string]any{"access_token": "light-token"}},
+	} {
+		if _, errRegister := manager.Register(context.Background(), candidate); errRegister != nil {
+			t.Fatalf("Register(%s) error = %v", candidate.ID, errRegister)
+		}
+	}
+
+	counts := make(map[string]int)
+	for index := 0; index < 600; index++ {
+		selected, errSelect := manager.SelectAuthByKind(context.Background(), "codex", "", AuthKindOAuth, cliproxyexecutor.Options{})
+		if errSelect != nil {
+			t.Fatalf("SelectAuthByKind() #%d error = %v", index, errSelect)
+		}
+		counts[selected.ID]++
+	}
+	if counts["oauth-heavy"] != 500 || counts["oauth-light"] != 100 || counts["api-high"] != 0 {
+		t.Fatalf("weighted OAuth picks = %#v, want oauth-heavy:oauth-light=500:100 and no API key", counts)
+	}
+}
+
+func TestManagerWeightedRoundRobinDisallowFreeAuthIgnoresFreeWeight(t *testing.T) {
+	tests := []struct {
+		name  string
+		mixed bool
+	}{
+		{name: "single provider"},
+		{name: "mixed providers", mixed: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := NewManager(nil, &WeightedRoundRobinSelector{}, nil)
+			manager.executors["codex"] = schedulerTestExecutor{}
+			lightProvider := "codex"
+			if tt.mixed {
+				lightProvider = "gemini"
+				manager.executors["gemini"] = schedulerTestExecutor{provider: "gemini"}
+			}
+			for _, candidate := range []*Auth{
+				{ID: "free-high", Provider: "codex", Attributes: map[string]string{"plan_type": "free", AttributeWeight: "100"}, Metadata: map[string]any{"access_token": "free-token"}},
+				{ID: "paid-heavy", Provider: "codex", Attributes: map[string]string{"plan_type": "plus", AttributeWeight: "5"}, Metadata: map[string]any{"access_token": "heavy-token"}},
+				{ID: "paid-light", Provider: lightProvider, Attributes: map[string]string{"plan_type": "plus", AttributeWeight: "1"}, Metadata: map[string]any{"access_token": "light-token"}},
+			} {
+				if _, errRegister := manager.Register(context.Background(), candidate); errRegister != nil {
+					t.Fatalf("Register(%s) error = %v", candidate.ID, errRegister)
+				}
+			}
+
+			opts := cliproxyexecutor.Options{Metadata: map[string]any{cliproxyexecutor.DisallowFreeAuthMetadataKey: true}}
+			counts := make(map[string]int)
+			for index := 0; index < 600; index++ {
+				var selected *Auth
+				var errPick error
+				if tt.mixed {
+					selected, _, _, errPick = manager.pickNextMixed(context.Background(), []string{"codex", "gemini"}, "", opts, nil)
+				} else {
+					selected, _, errPick = manager.pickNext(context.Background(), "codex", "", opts, nil)
+				}
+				if errPick != nil {
+					t.Fatalf("weighted pick #%d error = %v", index, errPick)
+				}
+				counts[selected.ID]++
+			}
+			if counts["paid-heavy"] != 500 || counts["paid-light"] != 100 || counts["free-high"] != 0 {
+				t.Fatalf("weighted non-free picks = %#v, want paid-heavy:paid-light=500:100 and no free auth", counts)
+			}
+		})
+	}
+}
+
+func TestManagerSelectAuthByKindRoundRobinKeepsEligibleRotation(t *testing.T) {
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.executors["codex"] = schedulerTestExecutor{}
+	for _, candidate := range []*Auth{
+		{ID: "api-key", Provider: "codex", Attributes: map[string]string{AttributeAPIKey: "test-key"}},
+		{ID: "oauth-a", Provider: "codex", Metadata: map[string]any{"access_token": "token-a"}},
+		{ID: "oauth-b", Provider: "codex", Metadata: map[string]any{"access_token": "token-b"}},
+	} {
+		if _, errRegister := manager.Register(context.Background(), candidate); errRegister != nil {
+			t.Fatalf("Register(%s) error = %v", candidate.ID, errRegister)
+		}
+	}
+
+	counts := make(map[string]int)
+	for index := 0; index < 6; index++ {
+		selected, errSelect := manager.SelectAuthByKind(context.Background(), "codex", "", AuthKindOAuth, cliproxyexecutor.Options{})
+		if errSelect != nil {
+			t.Fatalf("SelectAuthByKind() #%d error = %v", index, errSelect)
+		}
+		counts[selected.ID]++
+	}
+	if counts["oauth-a"] != 3 || counts["oauth-b"] != 3 || counts["api-key"] != 0 {
+		t.Fatalf("round-robin OAuth picks = %#v, want three picks per OAuth auth and no API key", counts)
 	}
 }
 

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -16,6 +16,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/credentialweight"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -27,6 +28,36 @@ type RoundRobinSelector struct {
 	mu      sync.Mutex
 	cursors map[string]int
 	maxKeys int
+}
+
+// WeightedRoundRobinSelector provides smooth weighted round-robin selection.
+type WeightedRoundRobinSelector struct {
+	mu      sync.Mutex
+	states  map[string]*smoothWeightedState
+	maxKeys int
+}
+
+type smoothWeightedState struct {
+	current map[string]int64
+	weights map[string]int64
+}
+
+type weightedSelectorStateModelKey struct{}
+
+func withWeightedSelectorStateModel(ctx context.Context, selector Selector, routeModel string) context.Context {
+	if _, ok := selector.(*WeightedRoundRobinSelector); !ok || strings.TrimSpace(routeModel) == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, weightedSelectorStateModelKey{}, routeModel)
+}
+
+func weightedSelectorStateModel(ctx context.Context, availabilityModel string) string {
+	if ctx != nil {
+		if routeModel, ok := ctx.Value(weightedSelectorStateModelKey{}).(string); ok && strings.TrimSpace(routeModel) != "" {
+			return routeModel
+		}
+	}
+	return availabilityModel
 }
 
 // FillFirstSelector selects the first available credential (deterministic ordering).
@@ -125,6 +156,27 @@ func authPriority(auth *Auth) int {
 		return 0
 	}
 	return parsed
+}
+
+func authWeight(auth *Auth) int64 {
+	if auth == nil {
+		return credentialweight.Default
+	}
+	if rawWeight, ok := auth.Attributes[AttributeWeight]; ok && strings.TrimSpace(rawWeight) != "" {
+		weight, errParse := credentialweight.ParseString(rawWeight)
+		if errParse != nil {
+			return 0
+		}
+		return weight
+	}
+	if rawWeight, ok := auth.Metadata[AttributeWeight]; ok {
+		weight, errParse := credentialweight.ParseValue(rawWeight)
+		if errParse != nil {
+			return 0
+		}
+		return weight
+	}
+	return credentialweight.Default
 }
 
 func canonicalModelKey(model string) string {
@@ -290,6 +342,125 @@ func (s *RoundRobinSelector) ensureCursorKey(key string, limit int) {
 	}
 }
 
+func positiveWeightAuths(auths []*Auth) []*Auth {
+	weightedCandidates := make([]*Auth, 0, len(auths))
+	for _, auth := range auths {
+		if authWeight(auth) > 0 {
+			weightedCandidates = append(weightedCandidates, auth)
+		}
+	}
+	return weightedCandidates
+}
+
+// Pick selects the next available auth using smooth weighted round-robin.
+func (s *WeightedRoundRobinSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	_ = opts
+	available, errAvailable := getAvailableAuths(positiveWeightAuths(auths), provider, model, time.Now())
+	if errAvailable != nil {
+		return nil, errAvailable
+	}
+	available = preferCodexWebsocketAuths(ctx, provider, available)
+	stateModel := weightedSelectorStateModel(ctx, model)
+	key := provider + ":" + canonicalModelKey(stateModel)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.states == nil {
+		s.states = make(map[string]*smoothWeightedState)
+	}
+	limit := s.maxKeys
+	if limit <= 0 {
+		limit = 4096
+	}
+	if _, ok := s.states[key]; !ok && len(s.states) >= limit {
+		s.states = make(map[string]*smoothWeightedState)
+	}
+	state := s.states[key]
+	if state == nil {
+		state = &smoothWeightedState{}
+		s.states[key] = state
+	}
+	weights := authWeightVector(available)
+	state.prepare(weights)
+	picked := pickSmoothWeightedAuth(available, state.current)
+	if picked == nil {
+		return nil, &Error{Code: "auth_unavailable", Message: "no auth available with positive weight"}
+	}
+	return picked, nil
+}
+
+func (s *smoothWeightedState) prepare(weights map[string]int64) {
+	if s.current == nil || !weightVectorsEqual(s.weights, weights) {
+		s.current = make(map[string]int64)
+	}
+	s.weights = weights
+}
+
+func weightVectorsEqual(left, right map[string]int64) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for authID, weight := range left {
+		if right[authID] != weight {
+			return false
+		}
+	}
+	return true
+}
+
+func authWeightVector(auths []*Auth) map[string]int64 {
+	weights := make(map[string]int64, len(auths))
+	for _, auth := range auths {
+		if auth == nil {
+			continue
+		}
+		if weight := authWeight(auth); weight > 0 {
+			weights[auth.ID] = weight
+		}
+	}
+	return weights
+}
+
+func pickSmoothWeightedAuth(auths []*Auth, current map[string]int64) *Auth {
+	active := make(map[string]struct{}, len(auths))
+	var picked *Auth
+	var pickedCurrent int64
+	var totalWeight int64
+	for _, auth := range auths {
+		weight := authWeight(auth)
+		if auth == nil || weight <= 0 {
+			continue
+		}
+		active[auth.ID] = struct{}{}
+		current[auth.ID] = saturatingAddInt64(current[auth.ID], weight)
+		totalWeight = saturatingAddInt64(totalWeight, weight)
+		if picked == nil || current[auth.ID] > pickedCurrent {
+			picked = auth
+			pickedCurrent = current[auth.ID]
+		}
+	}
+	for authID := range current {
+		if _, ok := active[authID]; !ok {
+			delete(current, authID)
+		}
+	}
+	if picked == nil {
+		return nil
+	}
+	current[picked.ID] = saturatingAddInt64(current[picked.ID], -totalWeight)
+	return picked
+}
+
+func saturatingAddInt64(value, delta int64) int64 {
+	if delta > 0 && value > math.MaxInt64-delta {
+		return math.MaxInt64
+	}
+	if delta < 0 && value < math.MinInt64-delta {
+		return math.MinInt64
+	}
+	return value + delta
+}
+
 // Pick selects the first available auth for the provider in a deterministic manner.
 func (s *FillFirstSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
 	_ = opts
@@ -322,43 +493,38 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 				if state.Status == StatusDisabled {
 					return true, blockReasonDisabled, time.Time{}
 				}
-				if state.Unavailable {
-					if state.NextRetryAfter.IsZero() {
-						return false, blockReasonNone, time.Time{}
-					}
-					if state.NextRetryAfter.After(now) {
-						next := state.NextRetryAfter
-						if !state.Quota.NextRecoverAt.IsZero() && state.Quota.NextRecoverAt.After(now) {
-							next = state.Quota.NextRecoverAt
-						}
-						if next.Before(now) {
-							next = now
-						}
-						if state.Quota.Exceeded {
-							return true, blockReasonCooldown, next
-						}
-						return true, blockReasonOther, next
-					}
-				}
-				return false, blockReasonNone, time.Time{}
+				return availabilityBlock(state.Unavailable, state.Quota.Exceeded, state.NextRetryAfter, state.Quota.NextRecoverAt, now)
 			}
+			// Auth-level availability can aggregate failures from other models.
+			return false, blockReasonNone, time.Time{}
 		}
+		return availabilityBlock(auth.Unavailable, auth.Quota.Exceeded, auth.NextRetryAfter, auth.Quota.NextRecoverAt, now)
+	}
+	return availabilityBlock(auth.Unavailable, auth.Quota.Exceeded, auth.NextRetryAfter, auth.Quota.NextRecoverAt, now)
+}
+
+func availabilityBlock(unavailable, quotaExceeded bool, nextRetryAfter, nextRecoverAt, now time.Time) (bool, blockReason, time.Time) {
+	if !unavailable && !quotaExceeded {
 		return false, blockReasonNone, time.Time{}
 	}
-	if auth.Unavailable && auth.NextRetryAfter.After(now) {
-		next := auth.NextRetryAfter
-		if !auth.Quota.NextRecoverAt.IsZero() && auth.Quota.NextRecoverAt.After(now) {
-			next = auth.Quota.NextRecoverAt
+
+	hasRecoveryTime := !nextRetryAfter.IsZero() || !nextRecoverAt.IsZero()
+	var next time.Time
+	for _, candidate := range []time.Time{nextRetryAfter, nextRecoverAt} {
+		if candidate.After(now) && (next.IsZero() || candidate.After(next)) {
+			next = candidate
 		}
-		if next.Before(now) {
-			next = now
-		}
-		if auth.Quota.Exceeded {
+	}
+	if !next.IsZero() {
+		if quotaExceeded {
 			return true, blockReasonCooldown, next
 		}
 		return true, blockReasonOther, next
 	}
-	return false, blockReasonNone, time.Time{}
+	if hasRecoveryTime {
+		return false, blockReasonNone, time.Time{}
+	}
+	return true, blockReasonOther, time.Time{}
 }
 
 // SessionAffinitySelector wraps another selector with session-sticky behavior.
@@ -413,7 +579,11 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 	}
 
 	now := time.Now()
-	available, err := getAvailableAuths(auths, provider, model, now)
+	availabilityCandidates := auths
+	if _, weighted := s.fallback.(*WeightedRoundRobinSelector); weighted {
+		availabilityCandidates = positiveWeightAuths(auths)
+	}
+	available, err := getAvailableAuths(availabilityCandidates, provider, model, now)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -16,6 +16,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/credentialweight"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -27,6 +28,36 @@ type RoundRobinSelector struct {
 	mu      sync.Mutex
 	cursors map[string]int
 	maxKeys int
+}
+
+// WeightedRoundRobinSelector provides smooth weighted round-robin selection.
+type WeightedRoundRobinSelector struct {
+	mu      sync.Mutex
+	states  map[string]*smoothWeightedState
+	maxKeys int
+}
+
+type smoothWeightedState struct {
+	current map[string]int64
+	weights map[string]int64
+}
+
+type weightedSelectorStateModelKey struct{}
+
+func withWeightedSelectorStateModel(ctx context.Context, selector Selector, routeModel string) context.Context {
+	if _, ok := selector.(*WeightedRoundRobinSelector); !ok || strings.TrimSpace(routeModel) == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, weightedSelectorStateModelKey{}, routeModel)
+}
+
+func weightedSelectorStateModel(ctx context.Context, availabilityModel string) string {
+	if ctx != nil {
+		if routeModel, ok := ctx.Value(weightedSelectorStateModelKey{}).(string); ok && strings.TrimSpace(routeModel) != "" {
+			return routeModel
+		}
+	}
+	return availabilityModel
 }
 
 // FillFirstSelector selects the first available credential (deterministic ordering).
@@ -125,6 +156,27 @@ func authPriority(auth *Auth) int {
 		return 0
 	}
 	return parsed
+}
+
+func authWeight(auth *Auth) int64 {
+	if auth == nil {
+		return credentialweight.Default
+	}
+	if rawWeight, ok := auth.Attributes[AttributeWeight]; ok && strings.TrimSpace(rawWeight) != "" {
+		weight, errParse := credentialweight.ParseString(rawWeight)
+		if errParse != nil {
+			return 0
+		}
+		return weight
+	}
+	if rawWeight, ok := auth.Metadata[AttributeWeight]; ok {
+		weight, errParse := credentialweight.ParseValue(rawWeight)
+		if errParse != nil {
+			return 0
+		}
+		return weight
+	}
+	return credentialweight.Default
 }
 
 func canonicalModelKey(model string) string {
@@ -290,6 +342,125 @@ func (s *RoundRobinSelector) ensureCursorKey(key string, limit int) {
 	}
 }
 
+func positiveWeightAuths(auths []*Auth) []*Auth {
+	weightedCandidates := make([]*Auth, 0, len(auths))
+	for _, auth := range auths {
+		if authWeight(auth) > 0 {
+			weightedCandidates = append(weightedCandidates, auth)
+		}
+	}
+	return weightedCandidates
+}
+
+// Pick selects the next available auth using smooth weighted round-robin.
+func (s *WeightedRoundRobinSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
+	_ = opts
+	available, errAvailable := getAvailableAuths(positiveWeightAuths(auths), provider, model, time.Now())
+	if errAvailable != nil {
+		return nil, errAvailable
+	}
+	available = preferCodexWebsocketAuths(ctx, provider, available)
+	stateModel := weightedSelectorStateModel(ctx, model)
+	key := provider + ":" + canonicalModelKey(stateModel)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.states == nil {
+		s.states = make(map[string]*smoothWeightedState)
+	}
+	limit := s.maxKeys
+	if limit <= 0 {
+		limit = 4096
+	}
+	if _, ok := s.states[key]; !ok && len(s.states) >= limit {
+		s.states = make(map[string]*smoothWeightedState)
+	}
+	state := s.states[key]
+	if state == nil {
+		state = &smoothWeightedState{}
+		s.states[key] = state
+	}
+	weights := authWeightVector(available)
+	state.prepare(weights)
+	picked := pickSmoothWeightedAuth(available, state.current)
+	if picked == nil {
+		return nil, &Error{Code: "auth_unavailable", Message: "no auth available with positive weight"}
+	}
+	return picked, nil
+}
+
+func (s *smoothWeightedState) prepare(weights map[string]int64) {
+	if s.current == nil || !weightVectorsEqual(s.weights, weights) {
+		s.current = make(map[string]int64)
+	}
+	s.weights = weights
+}
+
+func weightVectorsEqual(left, right map[string]int64) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for authID, weight := range left {
+		if right[authID] != weight {
+			return false
+		}
+	}
+	return true
+}
+
+func authWeightVector(auths []*Auth) map[string]int64 {
+	weights := make(map[string]int64, len(auths))
+	for _, auth := range auths {
+		if auth == nil {
+			continue
+		}
+		if weight := authWeight(auth); weight > 0 {
+			weights[auth.ID] = weight
+		}
+	}
+	return weights
+}
+
+func pickSmoothWeightedAuth(auths []*Auth, current map[string]int64) *Auth {
+	active := make(map[string]struct{}, len(auths))
+	var picked *Auth
+	var pickedCurrent int64
+	var totalWeight int64
+	for _, auth := range auths {
+		weight := authWeight(auth)
+		if auth == nil || weight <= 0 {
+			continue
+		}
+		active[auth.ID] = struct{}{}
+		current[auth.ID] = saturatingAddInt64(current[auth.ID], weight)
+		totalWeight = saturatingAddInt64(totalWeight, weight)
+		if picked == nil || current[auth.ID] > pickedCurrent {
+			picked = auth
+			pickedCurrent = current[auth.ID]
+		}
+	}
+	for authID := range current {
+		if _, ok := active[authID]; !ok {
+			delete(current, authID)
+		}
+	}
+	if picked == nil {
+		return nil
+	}
+	current[picked.ID] = saturatingAddInt64(current[picked.ID], -totalWeight)
+	return picked
+}
+
+func saturatingAddInt64(value, delta int64) int64 {
+	if delta > 0 && value > math.MaxInt64-delta {
+		return math.MaxInt64
+	}
+	if delta < 0 && value < math.MinInt64-delta {
+		return math.MinInt64
+	}
+	return value + delta
+}
+
 // Pick selects the first available auth for the provider in a deterministic manner.
 func (s *FillFirstSelector) Pick(ctx context.Context, provider, model string, opts cliproxyexecutor.Options, auths []*Auth) (*Auth, error) {
 	_ = opts
@@ -322,43 +493,38 @@ func isAuthBlockedForModel(auth *Auth, model string, now time.Time) (bool, block
 				if state.Status == StatusDisabled {
 					return true, blockReasonDisabled, time.Time{}
 				}
-				if state.Unavailable {
-					if state.NextRetryAfter.IsZero() {
-						return false, blockReasonNone, time.Time{}
-					}
-					if state.NextRetryAfter.After(now) {
-						next := state.NextRetryAfter
-						if !state.Quota.NextRecoverAt.IsZero() && state.Quota.NextRecoverAt.After(now) {
-							next = state.Quota.NextRecoverAt
-						}
-						if next.Before(now) {
-							next = now
-						}
-						if state.Quota.Exceeded {
-							return true, blockReasonCooldown, next
-						}
-						return true, blockReasonOther, next
-					}
-				}
-				return false, blockReasonNone, time.Time{}
+				return availabilityBlock(state.Unavailable, state.Quota.Exceeded, state.NextRetryAfter, state.Quota.NextRecoverAt, now)
 			}
+			// Auth-level availability can aggregate failures from other models.
+			return false, blockReasonNone, time.Time{}
 		}
+		return availabilityBlock(auth.Unavailable, auth.Quota.Exceeded, auth.NextRetryAfter, auth.Quota.NextRecoverAt, now)
+	}
+	return availabilityBlock(auth.Unavailable, auth.Quota.Exceeded, auth.NextRetryAfter, auth.Quota.NextRecoverAt, now)
+}
+
+func availabilityBlock(unavailable, quotaExceeded bool, nextRetryAfter, nextRecoverAt, now time.Time) (bool, blockReason, time.Time) {
+	if !unavailable && !quotaExceeded {
 		return false, blockReasonNone, time.Time{}
 	}
-	if auth.Unavailable && auth.NextRetryAfter.After(now) {
-		next := auth.NextRetryAfter
-		if !auth.Quota.NextRecoverAt.IsZero() && auth.Quota.NextRecoverAt.After(now) {
-			next = auth.Quota.NextRecoverAt
+
+	hasRecoveryTime := !nextRetryAfter.IsZero() || !nextRecoverAt.IsZero()
+	var next time.Time
+	for _, candidate := range []time.Time{nextRetryAfter, nextRecoverAt} {
+		if candidate.After(now) && (next.IsZero() || candidate.After(next)) {
+			next = candidate
 		}
-		if next.Before(now) {
-			next = now
-		}
-		if auth.Quota.Exceeded {
+	}
+	if !next.IsZero() {
+		if quotaExceeded {
 			return true, blockReasonCooldown, next
 		}
 		return true, blockReasonOther, next
 	}
-	return false, blockReasonNone, time.Time{}
+	if hasRecoveryTime {
+		return false, blockReasonNone, time.Time{}
+	}
+	return true, blockReasonOther, time.Time{}
 }
 
 // SessionAffinitySelector wraps another selector with session-sticky behavior.
@@ -414,7 +580,11 @@ func (s *SessionAffinitySelector) Pick(ctx context.Context, provider, model stri
 	}
 
 	now := time.Now()
-	available, err := getAvailableAuths(auths, provider, model, now)
+	availabilityCandidates := auths
+	if _, weighted := s.fallback.(*WeightedRoundRobinSelector); weighted {
+		availabilityCandidates = positiveWeightAuths(auths)
+	}
+	available, err := getAvailableAuths(availabilityCandidates, provider, model, now)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"strings"
 	"sync"
@@ -59,6 +60,217 @@ func TestRoundRobinSelectorPick_CyclesDeterministic(t *testing.T) {
 		}
 		if got.ID != id {
 			t.Fatalf("Pick() #%d auth.ID = %q, want %q", i, got.ID, id)
+		}
+	}
+}
+
+func TestWeightedRoundRobinSelectorPick_DistributesAndSkipsNonPositiveWeights(t *testing.T) {
+	t.Parallel()
+
+	selector := &WeightedRoundRobinSelector{}
+	auths := []*Auth{
+		{ID: "a", Attributes: map[string]string{AttributeWeight: "5"}},
+		{ID: "b", Attributes: map[string]string{AttributeWeight: "3"}},
+		{ID: "c", Attributes: map[string]string{AttributeWeight: "2"}},
+		{ID: "disabled-by-weight", Attributes: map[string]string{AttributeWeight: "0"}},
+	}
+
+	counts := make(map[string]int)
+	for index := 0; index < 100; index++ {
+		got, errPick := selector.Pick(context.Background(), "gemini", "model", cliproxyexecutor.Options{}, auths)
+		if errPick != nil {
+			t.Fatalf("Pick() #%d error = %v", index, errPick)
+		}
+		counts[got.ID]++
+	}
+	want := map[string]int{"a": 50, "b": 30, "c": 20}
+	for authID, wantCount := range want {
+		if counts[authID] != wantCount {
+			t.Fatalf("auth %q picks = %d, want %d", authID, counts[authID], wantCount)
+		}
+	}
+	if counts["disabled-by-weight"] != 0 {
+		t.Fatalf("non-positive weight auth picks = %d, want 0", counts["disabled-by-weight"])
+	}
+}
+
+func TestWeightedRoundRobinSelectorPick_ResetsCreditsWhenWeightsChange(t *testing.T) {
+	t.Parallel()
+
+	selector := &WeightedRoundRobinSelector{}
+	authA := &Auth{ID: "a", Attributes: map[string]string{AttributeWeight: "1000000"}}
+	authB := &Auth{ID: "b", Attributes: map[string]string{AttributeWeight: "1"}}
+	auths := []*Auth{authA, authB}
+	for index := 0; index < 1000; index++ {
+		if _, errPick := selector.Pick(context.Background(), "gemini", "model", cliproxyexecutor.Options{}, auths); errPick != nil {
+			t.Fatalf("warmup Pick() #%d error = %v", index, errPick)
+		}
+	}
+
+	authA.Attributes[AttributeWeight] = "1"
+	counts := make(map[string]int)
+	for index := 0; index < 20; index++ {
+		got, errPick := selector.Pick(context.Background(), "gemini", "model", cliproxyexecutor.Options{}, auths)
+		if errPick != nil {
+			t.Fatalf("Pick() after weight change #%d error = %v", index, errPick)
+		}
+		counts[got.ID]++
+	}
+	if counts["a"] != 10 || counts["b"] != 10 {
+		t.Fatalf("picks after weight change = %#v, want a:b=10:10", counts)
+	}
+}
+
+func TestWeightedRoundRobinSelectorPick_RebalancesWhenHighestWeightUnavailable(t *testing.T) {
+	t.Parallel()
+
+	selector := &WeightedRoundRobinSelector{}
+	auths := []*Auth{
+		{ID: "a", Disabled: true, Attributes: map[string]string{AttributeWeight: "5"}},
+		{ID: "b", Attributes: map[string]string{AttributeWeight: "3"}},
+		{ID: "c", Attributes: map[string]string{AttributeWeight: "2"}},
+	}
+	counts := make(map[string]int)
+	for index := 0; index < 100; index++ {
+		got, errPick := selector.Pick(context.Background(), "gemini", "model", cliproxyexecutor.Options{}, auths)
+		if errPick != nil {
+			t.Fatalf("Pick() #%d error = %v", index, errPick)
+		}
+		counts[got.ID]++
+	}
+	if counts["a"] != 0 || counts["b"] != 60 || counts["c"] != 40 {
+		t.Fatalf("weighted failover counts = %#v, want b:c=60:40 with a skipped", counts)
+	}
+}
+
+func TestWeightedRoundRobinSelectorPick_SkipsUnavailableAndQuotaExceededWithoutRecovery(t *testing.T) {
+	t.Parallel()
+
+	model := "test-model"
+	selector := &WeightedRoundRobinSelector{}
+	auths := []*Auth{
+		{
+			ID: "model-unavailable",
+			ModelStates: map[string]*ModelState{
+				model: {Unavailable: true},
+			},
+		},
+		{ID: "quota-exceeded", Quota: QuotaState{Exceeded: true}},
+		{ID: "available"},
+	}
+
+	gotModel, errModel := selector.Pick(context.Background(), "gemini", model, cliproxyexecutor.Options{}, auths)
+	if errModel != nil || gotModel == nil || gotModel.ID != "available" {
+		t.Fatalf("model Pick() = %#v, %v; want available", gotModel, errModel)
+	}
+	for index := 0; index < 4; index++ {
+		gotAuth, errAuth := selector.Pick(context.Background(), "gemini", "", cliproxyexecutor.Options{}, auths)
+		if errAuth != nil || gotAuth == nil {
+			t.Fatalf("auth Pick() #%d = %#v, %v; want available auth", index, gotAuth, errAuth)
+		}
+		if gotAuth.ID == "quota-exceeded" {
+			t.Fatalf("auth Pick() #%d selected quota-exceeded credential", index)
+		}
+	}
+}
+
+func TestAuthWeight_MetadataFallbackAndAttributePrecedence(t *testing.T) {
+	t.Parallel()
+
+	if got := authWeight(&Auth{Metadata: map[string]any{AttributeWeight: float64(7)}}); got != 7 {
+		t.Fatalf("authWeight(metadata) = %d, want 7", got)
+	}
+	if got := authWeight(&Auth{
+		Attributes: map[string]string{AttributeWeight: "3"},
+		Metadata:   map[string]any{AttributeWeight: float64(7)},
+	}); got != 3 {
+		t.Fatalf("authWeight(attribute and metadata) = %d, want attribute weight 3", got)
+	}
+}
+
+func TestAuthWeight_InvalidAndOverflowValuesAreExcluded(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{"1.5", "1000001", "9223372036854775807", "9223372036854775808"} {
+		auth := &Auth{Attributes: map[string]string{AttributeWeight: raw}}
+		if got := authWeight(auth); got != 0 {
+			t.Fatalf("authWeight(%q) = %d, want 0", raw, got)
+		}
+	}
+	if got := authWeight(&Auth{Metadata: map[string]any{AttributeWeight: 1.5}}); got != 0 {
+		t.Fatalf("authWeight(invalid metadata) = %d, want 0", got)
+	}
+	if got := authWeight(&Auth{Attributes: map[string]string{AttributeWeight: "-1"}}); got != 0 {
+		t.Fatalf("authWeight(-1) = %d, want 0", got)
+	}
+}
+
+func TestPickSmoothWeightedAuth_SaturatesCorruptState(t *testing.T) {
+	t.Parallel()
+
+	current := map[string]int64{"a": math.MaxInt64, "b": math.MinInt64}
+	picked := pickSmoothWeightedAuth([]*Auth{{ID: "a"}, {ID: "b"}}, current)
+	if picked == nil {
+		t.Fatal("pickSmoothWeightedAuth() returned nil")
+	}
+	if current["a"] != math.MaxInt64-2 || current["b"] != math.MinInt64+1 {
+		t.Fatalf("current state = %#v, want saturated arithmetic", current)
+	}
+}
+
+func TestWeightedRoundRobinSelectorPick_RecoveredAuthReturnsWithoutAccumulatedCredit(t *testing.T) {
+	t.Parallel()
+
+	selector := &WeightedRoundRobinSelector{}
+	authA := &Auth{ID: "a", Attributes: map[string]string{AttributeWeight: "5"}}
+	authB := &Auth{ID: "b", Attributes: map[string]string{AttributeWeight: "1"}}
+	auths := []*Auth{authA, authB}
+
+	for index := 0; index < 6; index++ {
+		if _, errPick := selector.Pick(context.Background(), "gemini", "model", cliproxyexecutor.Options{}, auths); errPick != nil {
+			t.Fatalf("warmup Pick() #%d error = %v", index, errPick)
+		}
+	}
+	authA.Unavailable = true
+	authA.NextRetryAfter = time.Now().Add(time.Hour)
+	for index := 0; index < 6; index++ {
+		got, errPick := selector.Pick(context.Background(), "gemini", "model", cliproxyexecutor.Options{}, auths)
+		if errPick != nil || got == nil || got.ID != "b" {
+			t.Fatalf("unavailable Pick() #%d = %#v, %v; want b", index, got, errPick)
+		}
+	}
+	authA.Unavailable = false
+	authA.NextRetryAfter = time.Time{}
+
+	counts := make(map[string]int)
+	for index := 0; index < 6; index++ {
+		got, errPick := selector.Pick(context.Background(), "gemini", "model", cliproxyexecutor.Options{}, auths)
+		if errPick != nil {
+			t.Fatalf("recovered Pick() #%d error = %v", index, errPick)
+		}
+		counts[got.ID]++
+	}
+	if counts["a"] != 5 || counts["b"] != 1 {
+		t.Fatalf("recovered picks = %#v, want a:b=5:1", counts)
+	}
+}
+
+func TestWeightedRoundRobinSelectorPick_DefaultWeightIsOne(t *testing.T) {
+	t.Parallel()
+
+	selector := &WeightedRoundRobinSelector{}
+	auths := []*Auth{{ID: "a"}, {ID: "b"}, {ID: "c"}}
+	counts := make(map[string]int)
+	for index := 0; index < 30; index++ {
+		got, errPick := selector.Pick(context.Background(), "gemini", "model", cliproxyexecutor.Options{}, auths)
+		if errPick != nil {
+			t.Fatalf("Pick() #%d error = %v", index, errPick)
+		}
+		counts[got.ID]++
+	}
+	for _, authID := range []string{"a", "b", "c"} {
+		if counts[authID] != 10 {
+			t.Fatalf("auth %q picks = %d, want 10", authID, counts[authID])
 		}
 	}
 }
@@ -285,7 +497,7 @@ func TestSelectorPick_AllCooldownReturnsModelCooldownError(t *testing.T) {
 	})
 }
 
-func TestIsAuthBlockedForModel_UnavailableWithoutNextRetryIsNotBlocked(t *testing.T) {
+func TestIsAuthBlockedForModel_UnavailableWithoutNextRetryIsBlocked(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now()
@@ -304,14 +516,45 @@ func TestIsAuthBlockedForModel_UnavailableWithoutNextRetryIsNotBlocked(t *testin
 	}
 
 	blocked, reason, next := isAuthBlockedForModel(auth, model, now)
-	if blocked {
-		t.Fatalf("blocked = true, want false")
+	if !blocked {
+		t.Fatalf("blocked = false, want true")
 	}
-	if reason != blockReasonNone {
-		t.Fatalf("reason = %v, want %v", reason, blockReasonNone)
+	if reason != blockReasonOther {
+		t.Fatalf("reason = %v, want %v", reason, blockReasonOther)
 	}
 	if !next.IsZero() {
 		t.Fatalf("next = %v, want zero", next)
+	}
+}
+
+func TestIsAuthBlockedForModel_AuthQuotaExceededWithoutRecoveryIsBlocked(t *testing.T) {
+	t.Parallel()
+
+	auth := &Auth{ID: "a", Quota: QuotaState{Exceeded: true}}
+	for _, model := range []string{"", "test-model"} {
+		blocked, reason, next := isAuthBlockedForModel(auth, model, time.Now())
+		if !blocked || reason != blockReasonOther || !next.IsZero() {
+			t.Fatalf("isAuthBlockedForModel(%q) = %v, %v, %v; want true, other, zero", model, blocked, reason, next)
+		}
+	}
+}
+
+func TestIsAuthBlockedForModel_ExpiredRecoveryIsAvailable(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	auth := &Auth{
+		ID:             "a",
+		Unavailable:    true,
+		NextRetryAfter: now.Add(-time.Minute),
+		Quota: QuotaState{
+			Exceeded:      true,
+			NextRecoverAt: now.Add(-time.Second),
+		},
+	}
+	blocked, reason, next := isAuthBlockedForModel(auth, "", now)
+	if blocked || reason != blockReasonNone || !next.IsZero() {
+		t.Fatalf("isAuthBlockedForModel() = %v, %v, %v; want false, none, zero", blocked, reason, next)
 	}
 }
 
@@ -496,6 +739,75 @@ func TestSessionAffinitySelector_SameSessionSameAuth(t *testing.T) {
 		if got.ID != first.ID {
 			t.Fatalf("Pick() #%d auth.ID = %q, want %q (same session should pick same auth)", i, got.ID, first.ID)
 		}
+	}
+}
+
+func TestSessionAffinitySelector_WeightedBindingRebindsAfterWeightBecomesZero(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelector(&WeightedRoundRobinSelector{})
+	defer selector.Stop()
+
+	authA := &Auth{ID: "auth-a", Attributes: map[string]string{AttributeWeight: "1"}}
+	authB := &Auth{ID: "auth-b", Attributes: map[string]string{AttributeWeight: "1"}}
+	auths := []*Auth{authA, authB}
+	opts := cliproxyexecutor.Options{OriginalRequest: []byte(`{"metadata":{"user_id":"user_xxx_account__session_weight-change"}}`)}
+
+	first, errFirst := selector.Pick(context.Background(), "claude", "claude-3", opts, auths)
+	if errFirst != nil {
+		t.Fatalf("first Pick() error = %v", errFirst)
+	}
+	if first.ID != authA.ID {
+		t.Fatalf("first Pick() auth.ID = %q, want %q", first.ID, authA.ID)
+	}
+
+	authA.Attributes[AttributeWeight] = "0"
+	second, errSecond := selector.Pick(context.Background(), "claude", "claude-3", opts, auths)
+	if errSecond != nil {
+		t.Fatalf("Pick() after weight update error = %v", errSecond)
+	}
+	if second.ID != authB.ID {
+		t.Fatalf("Pick() after weight update auth.ID = %q, want %q", second.ID, authB.ID)
+	}
+
+	authA.Attributes[AttributeWeight] = "10"
+	third, errThird := selector.Pick(context.Background(), "claude", "claude-3", opts, auths)
+	if errThird != nil {
+		t.Fatalf("Pick() after rebind error = %v", errThird)
+	}
+	if third.ID != authB.ID {
+		t.Fatalf("Pick() after rebind auth.ID = %q, want sticky auth %q", third.ID, authB.ID)
+	}
+}
+
+func TestSessionAffinitySelector_WeightedNewSessionsResetAfterWeightChange(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelector(&WeightedRoundRobinSelector{})
+	defer selector.Stop()
+	authA := &Auth{ID: "auth-a", Attributes: map[string]string{AttributeWeight: "1000000"}}
+	authB := &Auth{ID: "auth-b", Attributes: map[string]string{AttributeWeight: "1"}}
+	auths := []*Auth{authA, authB}
+	pickSession := func(index int) *Auth {
+		t.Helper()
+		opts := cliproxyexecutor.Options{OriginalRequest: []byte(fmt.Sprintf(`{"session_id":"session-%d"}`, index))}
+		picked, errPick := selector.Pick(context.Background(), "claude", "claude-3", opts, auths)
+		if errPick != nil {
+			t.Fatalf("Pick(session-%d) error = %v", index, errPick)
+		}
+		return picked
+	}
+	for index := 0; index < 1000; index++ {
+		pickSession(index)
+	}
+
+	authA.Attributes[AttributeWeight] = "1"
+	counts := make(map[string]int)
+	for index := 1000; index < 1020; index++ {
+		counts[pickSession(index).ID]++
+	}
+	if counts[authA.ID] != 10 || counts[authB.ID] != 10 {
+		t.Fatalf("new session picks after weight change = %#v, want 10 each", counts)
 	}
 }
 

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"strings"
 	"sync"
@@ -59,6 +60,217 @@ func TestRoundRobinSelectorPick_CyclesDeterministic(t *testing.T) {
 		}
 		if got.ID != id {
 			t.Fatalf("Pick() #%d auth.ID = %q, want %q", i, got.ID, id)
+		}
+	}
+}
+
+func TestWeightedRoundRobinSelectorPick_DistributesAndSkipsNonPositiveWeights(t *testing.T) {
+	t.Parallel()
+
+	selector := &WeightedRoundRobinSelector{}
+	auths := []*Auth{
+		{ID: "a", Attributes: map[string]string{AttributeWeight: "5"}},
+		{ID: "b", Attributes: map[string]string{AttributeWeight: "3"}},
+		{ID: "c", Attributes: map[string]string{AttributeWeight: "2"}},
+		{ID: "disabled-by-weight", Attributes: map[string]string{AttributeWeight: "0"}},
+	}
+
+	counts := make(map[string]int)
+	for index := 0; index < 100; index++ {
+		got, errPick := selector.Pick(context.Background(), "gemini", "model", cliproxyexecutor.Options{}, auths)
+		if errPick != nil {
+			t.Fatalf("Pick() #%d error = %v", index, errPick)
+		}
+		counts[got.ID]++
+	}
+	want := map[string]int{"a": 50, "b": 30, "c": 20}
+	for authID, wantCount := range want {
+		if counts[authID] != wantCount {
+			t.Fatalf("auth %q picks = %d, want %d", authID, counts[authID], wantCount)
+		}
+	}
+	if counts["disabled-by-weight"] != 0 {
+		t.Fatalf("non-positive weight auth picks = %d, want 0", counts["disabled-by-weight"])
+	}
+}
+
+func TestWeightedRoundRobinSelectorPick_ResetsCreditsWhenWeightsChange(t *testing.T) {
+	t.Parallel()
+
+	selector := &WeightedRoundRobinSelector{}
+	authA := &Auth{ID: "a", Attributes: map[string]string{AttributeWeight: "1000000"}}
+	authB := &Auth{ID: "b", Attributes: map[string]string{AttributeWeight: "1"}}
+	auths := []*Auth{authA, authB}
+	for index := 0; index < 1000; index++ {
+		if _, errPick := selector.Pick(context.Background(), "gemini", "model", cliproxyexecutor.Options{}, auths); errPick != nil {
+			t.Fatalf("warmup Pick() #%d error = %v", index, errPick)
+		}
+	}
+
+	authA.Attributes[AttributeWeight] = "1"
+	counts := make(map[string]int)
+	for index := 0; index < 20; index++ {
+		got, errPick := selector.Pick(context.Background(), "gemini", "model", cliproxyexecutor.Options{}, auths)
+		if errPick != nil {
+			t.Fatalf("Pick() after weight change #%d error = %v", index, errPick)
+		}
+		counts[got.ID]++
+	}
+	if counts["a"] != 10 || counts["b"] != 10 {
+		t.Fatalf("picks after weight change = %#v, want a:b=10:10", counts)
+	}
+}
+
+func TestWeightedRoundRobinSelectorPick_RebalancesWhenHighestWeightUnavailable(t *testing.T) {
+	t.Parallel()
+
+	selector := &WeightedRoundRobinSelector{}
+	auths := []*Auth{
+		{ID: "a", Disabled: true, Attributes: map[string]string{AttributeWeight: "5"}},
+		{ID: "b", Attributes: map[string]string{AttributeWeight: "3"}},
+		{ID: "c", Attributes: map[string]string{AttributeWeight: "2"}},
+	}
+	counts := make(map[string]int)
+	for index := 0; index < 100; index++ {
+		got, errPick := selector.Pick(context.Background(), "gemini", "model", cliproxyexecutor.Options{}, auths)
+		if errPick != nil {
+			t.Fatalf("Pick() #%d error = %v", index, errPick)
+		}
+		counts[got.ID]++
+	}
+	if counts["a"] != 0 || counts["b"] != 60 || counts["c"] != 40 {
+		t.Fatalf("weighted failover counts = %#v, want b:c=60:40 with a skipped", counts)
+	}
+}
+
+func TestWeightedRoundRobinSelectorPick_SkipsUnavailableAndQuotaExceededWithoutRecovery(t *testing.T) {
+	t.Parallel()
+
+	model := "test-model"
+	selector := &WeightedRoundRobinSelector{}
+	auths := []*Auth{
+		{
+			ID: "model-unavailable",
+			ModelStates: map[string]*ModelState{
+				model: {Unavailable: true},
+			},
+		},
+		{ID: "quota-exceeded", Quota: QuotaState{Exceeded: true}},
+		{ID: "available"},
+	}
+
+	gotModel, errModel := selector.Pick(context.Background(), "gemini", model, cliproxyexecutor.Options{}, auths)
+	if errModel != nil || gotModel == nil || gotModel.ID != "available" {
+		t.Fatalf("model Pick() = %#v, %v; want available", gotModel, errModel)
+	}
+	for index := 0; index < 4; index++ {
+		gotAuth, errAuth := selector.Pick(context.Background(), "gemini", "", cliproxyexecutor.Options{}, auths)
+		if errAuth != nil || gotAuth == nil {
+			t.Fatalf("auth Pick() #%d = %#v, %v; want available auth", index, gotAuth, errAuth)
+		}
+		if gotAuth.ID == "quota-exceeded" {
+			t.Fatalf("auth Pick() #%d selected quota-exceeded credential", index)
+		}
+	}
+}
+
+func TestAuthWeight_MetadataFallbackAndAttributePrecedence(t *testing.T) {
+	t.Parallel()
+
+	if got := authWeight(&Auth{Metadata: map[string]any{AttributeWeight: float64(7)}}); got != 7 {
+		t.Fatalf("authWeight(metadata) = %d, want 7", got)
+	}
+	if got := authWeight(&Auth{
+		Attributes: map[string]string{AttributeWeight: "3"},
+		Metadata:   map[string]any{AttributeWeight: float64(7)},
+	}); got != 3 {
+		t.Fatalf("authWeight(attribute and metadata) = %d, want attribute weight 3", got)
+	}
+}
+
+func TestAuthWeight_InvalidAndOverflowValuesAreExcluded(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{"1.5", "1000001", "9223372036854775807", "9223372036854775808"} {
+		auth := &Auth{Attributes: map[string]string{AttributeWeight: raw}}
+		if got := authWeight(auth); got != 0 {
+			t.Fatalf("authWeight(%q) = %d, want 0", raw, got)
+		}
+	}
+	if got := authWeight(&Auth{Metadata: map[string]any{AttributeWeight: 1.5}}); got != 0 {
+		t.Fatalf("authWeight(invalid metadata) = %d, want 0", got)
+	}
+	if got := authWeight(&Auth{Attributes: map[string]string{AttributeWeight: "-1"}}); got != 0 {
+		t.Fatalf("authWeight(-1) = %d, want 0", got)
+	}
+}
+
+func TestPickSmoothWeightedAuth_SaturatesCorruptState(t *testing.T) {
+	t.Parallel()
+
+	current := map[string]int64{"a": math.MaxInt64, "b": math.MinInt64}
+	picked := pickSmoothWeightedAuth([]*Auth{{ID: "a"}, {ID: "b"}}, current)
+	if picked == nil {
+		t.Fatal("pickSmoothWeightedAuth() returned nil")
+	}
+	if current["a"] != math.MaxInt64-2 || current["b"] != math.MinInt64+1 {
+		t.Fatalf("current state = %#v, want saturated arithmetic", current)
+	}
+}
+
+func TestWeightedRoundRobinSelectorPick_RecoveredAuthReturnsWithoutAccumulatedCredit(t *testing.T) {
+	t.Parallel()
+
+	selector := &WeightedRoundRobinSelector{}
+	authA := &Auth{ID: "a", Attributes: map[string]string{AttributeWeight: "5"}}
+	authB := &Auth{ID: "b", Attributes: map[string]string{AttributeWeight: "1"}}
+	auths := []*Auth{authA, authB}
+
+	for index := 0; index < 6; index++ {
+		if _, errPick := selector.Pick(context.Background(), "gemini", "model", cliproxyexecutor.Options{}, auths); errPick != nil {
+			t.Fatalf("warmup Pick() #%d error = %v", index, errPick)
+		}
+	}
+	authA.Unavailable = true
+	authA.NextRetryAfter = time.Now().Add(time.Hour)
+	for index := 0; index < 6; index++ {
+		got, errPick := selector.Pick(context.Background(), "gemini", "model", cliproxyexecutor.Options{}, auths)
+		if errPick != nil || got == nil || got.ID != "b" {
+			t.Fatalf("unavailable Pick() #%d = %#v, %v; want b", index, got, errPick)
+		}
+	}
+	authA.Unavailable = false
+	authA.NextRetryAfter = time.Time{}
+
+	counts := make(map[string]int)
+	for index := 0; index < 6; index++ {
+		got, errPick := selector.Pick(context.Background(), "gemini", "model", cliproxyexecutor.Options{}, auths)
+		if errPick != nil {
+			t.Fatalf("recovered Pick() #%d error = %v", index, errPick)
+		}
+		counts[got.ID]++
+	}
+	if counts["a"] != 5 || counts["b"] != 1 {
+		t.Fatalf("recovered picks = %#v, want a:b=5:1", counts)
+	}
+}
+
+func TestWeightedRoundRobinSelectorPick_DefaultWeightIsOne(t *testing.T) {
+	t.Parallel()
+
+	selector := &WeightedRoundRobinSelector{}
+	auths := []*Auth{{ID: "a"}, {ID: "b"}, {ID: "c"}}
+	counts := make(map[string]int)
+	for index := 0; index < 30; index++ {
+		got, errPick := selector.Pick(context.Background(), "gemini", "model", cliproxyexecutor.Options{}, auths)
+		if errPick != nil {
+			t.Fatalf("Pick() #%d error = %v", index, errPick)
+		}
+		counts[got.ID]++
+	}
+	for _, authID := range []string{"a", "b", "c"} {
+		if counts[authID] != 10 {
+			t.Fatalf("auth %q picks = %d, want 10", authID, counts[authID])
 		}
 	}
 }
@@ -285,7 +497,7 @@ func TestSelectorPick_AllCooldownReturnsModelCooldownError(t *testing.T) {
 	})
 }
 
-func TestIsAuthBlockedForModel_UnavailableWithoutNextRetryIsNotBlocked(t *testing.T) {
+func TestIsAuthBlockedForModel_UnavailableWithoutNextRetryIsBlocked(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now()
@@ -304,14 +516,45 @@ func TestIsAuthBlockedForModel_UnavailableWithoutNextRetryIsNotBlocked(t *testin
 	}
 
 	blocked, reason, next := isAuthBlockedForModel(auth, model, now)
-	if blocked {
-		t.Fatalf("blocked = true, want false")
+	if !blocked {
+		t.Fatalf("blocked = false, want true")
 	}
-	if reason != blockReasonNone {
-		t.Fatalf("reason = %v, want %v", reason, blockReasonNone)
+	if reason != blockReasonOther {
+		t.Fatalf("reason = %v, want %v", reason, blockReasonOther)
 	}
 	if !next.IsZero() {
 		t.Fatalf("next = %v, want zero", next)
+	}
+}
+
+func TestIsAuthBlockedForModel_AuthQuotaExceededWithoutRecoveryIsBlocked(t *testing.T) {
+	t.Parallel()
+
+	auth := &Auth{ID: "a", Quota: QuotaState{Exceeded: true}}
+	for _, model := range []string{"", "test-model"} {
+		blocked, reason, next := isAuthBlockedForModel(auth, model, time.Now())
+		if !blocked || reason != blockReasonOther || !next.IsZero() {
+			t.Fatalf("isAuthBlockedForModel(%q) = %v, %v, %v; want true, other, zero", model, blocked, reason, next)
+		}
+	}
+}
+
+func TestIsAuthBlockedForModel_ExpiredRecoveryIsAvailable(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	auth := &Auth{
+		ID:             "a",
+		Unavailable:    true,
+		NextRetryAfter: now.Add(-time.Minute),
+		Quota: QuotaState{
+			Exceeded:      true,
+			NextRecoverAt: now.Add(-time.Second),
+		},
+	}
+	blocked, reason, next := isAuthBlockedForModel(auth, "", now)
+	if blocked || reason != blockReasonNone || !next.IsZero() {
+		t.Fatalf("isAuthBlockedForModel() = %v, %v, %v; want false, none, zero", blocked, reason, next)
 	}
 }
 
@@ -520,6 +763,75 @@ func TestSessionAffinitySelector_ExplicitExecutionSessionMetadata(t *testing.T) 
 	}
 	if first.ID != second.ID {
 		t.Fatalf("auth IDs = %q/%q, want sticky", first.ID, second.ID)
+	}
+}
+
+func TestSessionAffinitySelector_WeightedBindingRebindsAfterWeightBecomesZero(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelector(&WeightedRoundRobinSelector{})
+	defer selector.Stop()
+
+	authA := &Auth{ID: "auth-a", Attributes: map[string]string{AttributeWeight: "1"}}
+	authB := &Auth{ID: "auth-b", Attributes: map[string]string{AttributeWeight: "1"}}
+	auths := []*Auth{authA, authB}
+	opts := cliproxyexecutor.Options{OriginalRequest: []byte(`{"metadata":{"user_id":"user_xxx_account__session_weight-change"}}`)}
+
+	first, errFirst := selector.Pick(context.Background(), "claude", "claude-3", opts, auths)
+	if errFirst != nil {
+		t.Fatalf("first Pick() error = %v", errFirst)
+	}
+	if first.ID != authA.ID {
+		t.Fatalf("first Pick() auth.ID = %q, want %q", first.ID, authA.ID)
+	}
+
+	authA.Attributes[AttributeWeight] = "0"
+	second, errSecond := selector.Pick(context.Background(), "claude", "claude-3", opts, auths)
+	if errSecond != nil {
+		t.Fatalf("Pick() after weight update error = %v", errSecond)
+	}
+	if second.ID != authB.ID {
+		t.Fatalf("Pick() after weight update auth.ID = %q, want %q", second.ID, authB.ID)
+	}
+
+	authA.Attributes[AttributeWeight] = "10"
+	third, errThird := selector.Pick(context.Background(), "claude", "claude-3", opts, auths)
+	if errThird != nil {
+		t.Fatalf("Pick() after rebind error = %v", errThird)
+	}
+	if third.ID != authB.ID {
+		t.Fatalf("Pick() after rebind auth.ID = %q, want sticky auth %q", third.ID, authB.ID)
+	}
+}
+
+func TestSessionAffinitySelector_WeightedNewSessionsResetAfterWeightChange(t *testing.T) {
+	t.Parallel()
+
+	selector := NewSessionAffinitySelector(&WeightedRoundRobinSelector{})
+	defer selector.Stop()
+	authA := &Auth{ID: "auth-a", Attributes: map[string]string{AttributeWeight: "1000000"}}
+	authB := &Auth{ID: "auth-b", Attributes: map[string]string{AttributeWeight: "1"}}
+	auths := []*Auth{authA, authB}
+	pickSession := func(index int) *Auth {
+		t.Helper()
+		opts := cliproxyexecutor.Options{OriginalRequest: []byte(fmt.Sprintf(`{"session_id":"session-%d"}`, index))}
+		picked, errPick := selector.Pick(context.Background(), "claude", "claude-3", opts, auths)
+		if errPick != nil {
+			t.Fatalf("Pick(session-%d) error = %v", index, errPick)
+		}
+		return picked
+	}
+	for index := 0; index < 1000; index++ {
+		pickSession(index)
+	}
+
+	authA.Attributes[AttributeWeight] = "1"
+	counts := make(map[string]int)
+	for index := 1000; index < 1020; index++ {
+		counts[pickSession(index).ID]++
+	}
+	if counts[authA.ID] != 10 || counts[authB.ID] != 10 {
+		t.Fatalf("new session picks after weight change = %#v, want 10 each", counts)
 	}
 }
 

--- a/sdk/cliproxy/auth/weight.go
+++ b/sdk/cliproxy/auth/weight.go
@@ -1,0 +1,49 @@
+package auth
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/credentialweight"
+)
+
+// ValidateAuthWeight validates every explicit credential weight source.
+func ValidateAuthWeight(auth *Auth) error {
+	if auth == nil {
+		return nil
+	}
+	if rawWeight, ok := auth.Attributes[AttributeWeight]; ok {
+		if _, errParse := credentialweight.ParseString(rawWeight); errParse != nil {
+			return fmt.Errorf("invalid attributes weight: %w", errParse)
+		}
+	}
+	if rawWeight, ok := auth.Metadata[AttributeWeight]; ok {
+		if _, errParse := credentialweight.ParseValue(rawWeight); errParse != nil {
+			return fmt.Errorf("invalid metadata weight: %w", errParse)
+		}
+	}
+	return nil
+}
+
+// ApplyAuthWeightMetadata validates the auth and applies a source metadata weight.
+func ApplyAuthWeightMetadata(auth *Auth, metadata map[string]any) error {
+	if errWeight := ValidateAuthWeight(auth); errWeight != nil {
+		return errWeight
+	}
+	if auth == nil || metadata == nil {
+		return nil
+	}
+	rawWeight, ok := metadata[AttributeWeight]
+	if !ok {
+		return nil
+	}
+	weight, errParse := credentialweight.ParseValue(rawWeight)
+	if errParse != nil {
+		return fmt.Errorf("invalid metadata weight: %w", errParse)
+	}
+	if auth.Attributes == nil {
+		auth.Attributes = make(map[string]string)
+	}
+	auth.Attributes[AttributeWeight] = strconv.FormatInt(weight, 10)
+	return nil
+}

--- a/sdk/cliproxy/auth/weight_test.go
+++ b/sdk/cliproxy/auth/weight_test.go
@@ -1,0 +1,43 @@
+package auth
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestValidateAuthWeight(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		auth    *Auth
+		wantErr bool
+	}{
+		{name: "omitted", auth: &Auth{}},
+		{name: "positive attribute", auth: &Auth{Attributes: map[string]string{AttributeWeight: "7"}}},
+		{name: "zero metadata", auth: &Auth{Metadata: map[string]any{AttributeWeight: json.Number("0")}}},
+		{name: "negative attribute", auth: &Auth{Attributes: map[string]string{AttributeWeight: "-2"}}},
+		{name: "fraction metadata", auth: &Auth{Metadata: map[string]any{AttributeWeight: json.Number("1.5")}}, wantErr: true},
+		{name: "above maximum attribute", auth: &Auth{Attributes: map[string]string{AttributeWeight: "1000001"}}, wantErr: true},
+		{name: "overflow metadata", auth: &Auth{Metadata: map[string]any{AttributeWeight: json.Number("9223372036854775808")}}, wantErr: true},
+		{name: "nonnumeric attribute", auth: &Auth{Attributes: map[string]string{AttributeWeight: "invalid"}}, wantErr: true},
+		{
+			name: "valid attribute does not hide invalid metadata",
+			auth: &Auth{
+				Attributes: map[string]string{AttributeWeight: "2"},
+				Metadata:   map[string]any{AttributeWeight: 1.5},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			errValidate := ValidateAuthWeight(test.auth)
+			if (errValidate != nil) != test.wantErr {
+				t.Fatalf("ValidateAuthWeight() error = %v, wantErr = %v", errValidate, test.wantErr)
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -194,6 +194,9 @@ func (b *Builder) Build() (*Service, error) {
 	if b.configPath == "" {
 		return nil, fmt.Errorf("cliproxy: configuration path is required")
 	}
+	if errValidate := b.cfg.ValidateCredentialWeights(); errValidate != nil {
+		return nil, fmt.Errorf("cliproxy: validate credential weights: %w", errValidate)
+	}
 	b.cfg.NormalizePluginsConfig()
 	if errResolvePluginsDir := b.cfg.ResolvePluginsDir(); errResolvePluginsDir != nil && b.cfg.Plugins.Enabled {
 		return nil, fmt.Errorf("cliproxy: %w", errResolvePluginsDir)

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -197,6 +197,9 @@ func (b *Builder) Build() (*Service, error) {
 	if err := b.cfg.Codex.ClientMetadata.Validate(); err != nil {
 		return nil, fmt.Errorf("cliproxy: %w", err)
 	}
+	if errValidate := b.cfg.ValidateCredentialWeights(); errValidate != nil {
+		return nil, fmt.Errorf("cliproxy: validate credential weights: %w", errValidate)
+	}
 	b.cfg.NormalizePluginsConfig()
 	if errResolvePluginsDir := b.cfg.ResolvePluginsDir(); errResolvePluginsDir != nil && b.cfg.Plugins.Enabled {
 		return nil, fmt.Errorf("cliproxy: %w", errResolvePluginsDir)

--- a/sdk/cliproxy/builder_weight_validation_test.go
+++ b/sdk/cliproxy/builder_weight_validation_test.go
@@ -1,0 +1,32 @@
+package cliproxy
+
+import (
+	"strings"
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestBuilderBuildRejectsInvalidWithConfigCredentialWeight(t *testing.T) {
+	invalidWeight := internalconfig.MaxCredentialWeight + 1
+	cfg := &internalconfig.Config{
+		ClaudeKey: []internalconfig.ClaudeKey{{
+			APIKey: "claude-key",
+			Weight: &invalidWeight,
+		}},
+	}
+
+	service, errBuild := NewBuilder().
+		WithConfig(cfg).
+		WithConfigPath(t.TempDir() + "/config.yaml").
+		Build()
+	if errBuild == nil {
+		t.Fatal("Build() accepted an invalid credential weight")
+	}
+	if service != nil {
+		t.Fatal("Build() returned a service for an invalid credential weight")
+	}
+	if !strings.Contains(errBuild.Error(), "cliproxy: validate credential weights: claude-api-key[0].weight") {
+		t.Fatalf("Build() error = %q, want contextual credential weight path", errBuild)
+	}
+}

--- a/sdk/cliproxy/executionregistry/registry.go
+++ b/sdk/cliproxy/executionregistry/registry.go
@@ -154,6 +154,30 @@ func (r *Registry) BeginDispatch() (*PendingDispatch, error) {
 	return pending, nil
 }
 
+// WaitPending waits until every dispatch with an unresolved Home response has ended or been installed.
+func (r *Registry) WaitPending(ctx context.Context) error {
+	if r == nil {
+		return ErrRegistryClosed
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	r.mu.Lock()
+	for len(r.pending) != 0 {
+		changed := r.changed
+		r.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-changed:
+		}
+		r.mu.Lock()
+	}
+	r.mu.Unlock()
+	return nil
+}
+
 // End releases a dispatch token that was not installed.
 func (p *PendingDispatch) End() {
 	if p == nil || p.registry == nil {

--- a/sdk/cliproxy/executionregistry/registry_test.go
+++ b/sdk/cliproxy/executionregistry/registry_test.go
@@ -91,6 +91,42 @@ func TestDrainWaitsForPendingDispatch(t *testing.T) {
 	}
 }
 
+func TestWaitPendingDoesNotDrainActiveScope(t *testing.T) {
+	registry := New()
+	activePending, errBegin := registry.BeginDispatch()
+	if errBegin != nil {
+		t.Fatal(errBegin)
+	}
+	scope, errInstall := registry.Install(activePending, ScopeSpec{})
+	if errInstall != nil {
+		t.Fatal(errInstall)
+	}
+	defer scope.End("test cleanup")
+	pending, errBegin := registry.BeginDispatch()
+	if errBegin != nil {
+		t.Fatal(errBegin)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- registry.WaitPending(ctx) }()
+	select {
+	case errWait := <-done:
+		t.Fatalf("WaitPending() returned before pending dispatch ended: %v", errWait)
+	case <-time.After(20 * time.Millisecond):
+	}
+	pending.End()
+	if errWait := <-done; errWait != nil {
+		t.Fatalf("WaitPending() error = %v", errWait)
+	}
+	nextPending, errNext := registry.BeginDispatch()
+	if errNext != nil {
+		t.Fatalf("WaitPending() stopped registry acceptance: %v", errNext)
+	}
+	nextPending.End()
+}
+
 func TestDrainReturnsWhenBlockingResourceCloseExceedsContext(t *testing.T) {
 	registry := New()
 	pending, errBegin := registry.BeginDispatch()

--- a/sdk/cliproxy/service_config.go
+++ b/sdk/cliproxy/service_config.go
@@ -40,6 +40,8 @@ func normalizedRoutingRuntimeState(cfg *config.Config) routingRuntimeState {
 	}
 
 	switch strings.ToLower(strings.TrimSpace(cfg.Routing.Strategy)) {
+	case "weighted-round-robin", "weightedroundrobin", "wrr":
+		state.strategy = "weighted-round-robin"
 	case "fill-first", "fillfirst", "ff":
 		state.strategy = "fill-first"
 	}
@@ -54,9 +56,12 @@ func normalizedRoutingRuntimeState(cfg *config.Config) routingRuntimeState {
 
 func newRoutingSelector(state routingRuntimeState) coreauth.Selector {
 	var selector coreauth.Selector
-	if state.strategy == "fill-first" {
+	switch state.strategy {
+	case "weighted-round-robin":
+		selector = &coreauth.WeightedRoundRobinSelector{}
+	case "fill-first":
 		selector = &coreauth.FillFirstSelector{}
-	} else {
+	default:
 		selector = &coreauth.RoundRobinSelector{}
 	}
 	if state.sessionAffinity {
@@ -92,6 +97,10 @@ func (s *Service) commitConfigUpdate(newCfg *config.Config) configCommit {
 		s.cfgMu.RUnlock()
 	}
 	if newCfg == nil {
+		return configCommit{}
+	}
+	if errValidate := newCfg.ValidateCredentialWeights(); errValidate != nil {
+		log.WithError(errValidate).Warn("rejected config update with invalid credential weights")
 		return configCommit{}
 	}
 

--- a/sdk/cliproxy/service_config_weight_test.go
+++ b/sdk/cliproxy/service_config_weight_test.go
@@ -1,0 +1,42 @@
+package cliproxy
+
+import (
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestWeightedRoundRobinRoutingSelector(t *testing.T) {
+	state := normalizedRoutingRuntimeState(&internalconfig.Config{
+		Routing: internalconfig.RoutingConfig{Strategy: "wrr"},
+	})
+	if state.strategy != "weighted-round-robin" {
+		t.Fatalf("strategy = %q, want weighted-round-robin", state.strategy)
+	}
+	if _, ok := newRoutingSelector(state).(*coreauth.WeightedRoundRobinSelector); !ok {
+		t.Fatalf("selector type = %T, want *auth.WeightedRoundRobinSelector", newRoutingSelector(state))
+	}
+}
+
+func TestServiceRejectsInvalidCredentialWeightConfigCommit(t *testing.T) {
+	originalCfg := &internalconfig.Config{}
+	service := &Service{cfg: originalCfg}
+	invalidWeight := internalconfig.MaxCredentialWeight + 1
+	newCfg := &internalconfig.Config{
+		VertexCompatAPIKey: []internalconfig.VertexCompatKey{{
+			APIKey: "vertex-key",
+			Weight: &invalidWeight,
+		}},
+	}
+
+	if service.applyConfigUpdateWithAuthSynthesis(nil, newCfg, true) {
+		t.Fatal("hot config application accepted an invalid credential weight")
+	}
+	if service.cfg != originalCfg {
+		t.Fatal("invalid hot config replaced the active config")
+	}
+	if service.configSequence != 0 {
+		t.Fatalf("config sequence = %d, want 0", service.configSequence)
+	}
+}

--- a/sdk/cliproxy/service_executionregistry_test.go
+++ b/sdk/cliproxy/service_executionregistry_test.go
@@ -1250,7 +1250,7 @@ func TestServiceExplicitReplacementCancelsRunWhenDrainTimesOut(t *testing.T) {
 	scope.End("test cleanup")
 }
 
-func TestServiceReplacesRegistryOnlyAfterNewSubscriptionAck(t *testing.T) {
+func TestServiceKeepsRegistryAcrossHeartbeatFailoverAndExposesOnlyAfterNewACK(t *testing.T) {
 	listener, errListen := net.Listen("tcp", "127.0.0.1:0")
 	if errListen != nil {
 		t.Fatalf("listen: %v", errListen)
@@ -1325,15 +1325,15 @@ func TestServiceReplacesRegistryOnlyAfterNewSubscriptionAck(t *testing.T) {
 
 	close(allowSecondAck)
 	secondRegistry := waitForServiceRegistry(t, service, time.Second)
-	if secondRegistry == firstRegistry {
-		t.Fatal("replacement subscription reused the old registry")
+	if secondRegistry != firstRegistry {
+		t.Fatal("heartbeat failover replaced the execution registry")
 	}
 	if home.Current() == nil {
 		t.Fatal("replacement client was not exposed after the replacement ACK")
 	}
 }
 
-func TestServiceDrainsBeforePreAckRetriesAndExposesOnlyAfterNewAck(t *testing.T) {
+func TestServicePreservesActiveScopeDuringPreACKFailoverRetries(t *testing.T) {
 	listener, errListen := net.Listen("tcp", "127.0.0.1:0")
 	if errListen != nil {
 		t.Fatalf("listen: %v", errListen)
@@ -1393,16 +1393,9 @@ func TestServiceDrainsBeforePreAckRetriesAndExposesOnlyAfterNewAck(t *testing.T)
 	close(loseFirst)
 	select {
 	case <-resourceClosed:
-	case <-time.After(time.Second):
-		t.Fatal("heartbeat loss did not close the active scope resource")
-	}
-	select {
-	case <-preAckAttempts:
-		t.Fatal("pre-ACK retry started before the active scope owner ended")
+		t.Fatal("heartbeat failover drained the active scope")
 	case <-time.After(50 * time.Millisecond):
 	}
-	scope.End("canceled")
-
 	firstPreAck := <-preAckAttempts
 	secondPreAck := <-preAckAttempts
 	if retryDelay := secondPreAck.Sub(firstPreAck); retryDelay < 75*time.Millisecond {
@@ -1423,12 +1416,13 @@ func TestServiceDrainsBeforePreAckRetriesAndExposesOnlyAfterNewAck(t *testing.T)
 
 	close(allowFinalAck)
 	secondRegistry := waitForServiceRegistry(t, service, time.Second)
-	if secondRegistry == firstRegistry || home.Current() == nil {
+	if secondRegistry != firstRegistry || home.Current() == nil {
 		t.Fatal("new Home lifetime was not exposed only after its subscription ACK")
 	}
+	scope.End("completed")
 }
 
-func TestServiceCancelsRunWhenBlockingScopeExceedsDrainBound(t *testing.T) {
+func TestServiceHeartbeatFailoverDoesNotDrainBlockingScope(t *testing.T) {
 	listener, errListen := net.Listen("tcp", "127.0.0.1:0")
 	if errListen != nil {
 		t.Fatalf("listen: %v", errListen)
@@ -1507,28 +1501,241 @@ func TestServiceCancelsRunWhenBlockingScopeExceedsDrainBound(t *testing.T) {
 	close(loseFirst)
 	select {
 	case <-started:
-	case <-time.After(time.Second):
-		t.Fatal("drain did not start closing the blocking scope")
+		t.Fatal("heartbeat failover started draining the blocking scope")
+	case <-time.After(50 * time.Millisecond):
 	}
 	select {
 	case <-secondSubscribe:
-		t.Fatal("new subscription started before the old registry drained")
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(time.Second):
+		t.Fatal("new subscription did not start while the old scope remained active")
 	}
 	service.homeMu.Lock()
 	exposedRegistry := service.homeRegistry
 	service.homeMu.Unlock()
 	if exposedRegistry != nil {
-		t.Fatal("new registry was exposed before the old registry drained")
+		t.Fatal("registry was exposed before the replacement ACK")
+	}
+	close(allowSecondAck)
+	if nextRegistry := waitForServiceRegistry(t, service, time.Second); nextRegistry != registry {
+		t.Fatal("heartbeat failover replaced the registry containing the active scope")
 	}
 	select {
 	case <-serviceCtx.Done():
-	case <-time.After(time.Second):
-		t.Fatal("service run was not canceled after drain timeout")
+		t.Fatal("heartbeat failover canceled the service run")
+	case <-time.After(50 * time.Millisecond):
 	}
 
 	close(release)
 	scope.End("test cleanup")
+}
+
+func TestServiceShutdownDrainsDetachedRegistryDuringRetry(t *testing.T) {
+	listener, errListen := net.Listen("tcp", "127.0.0.1:0")
+	if errListen != nil {
+		t.Fatalf("listen: %v", errListen)
+	}
+	firstAck := make(chan struct{})
+	loseFirst := make(chan struct{})
+	secondSubscribe := make(chan struct{})
+	var secondSubscribeOnce sync.Once
+	allowSecondAck := make(chan struct{})
+	stop := make(chan struct{})
+	var subscriptionMu sync.Mutex
+	subscriptions := 0
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		for {
+			conn, errAccept := listener.Accept()
+			if errAccept != nil {
+				return
+			}
+			go serveRegistryTestHomeConnection(conn, &subscriptionMu, &subscriptions, firstAck, loseFirst, secondSubscribe, &secondSubscribeOnce, allowSecondAck, stop)
+		}
+	}()
+	t.Cleanup(func() {
+		close(stop)
+		_ = listener.Close()
+		<-serverDone
+		home.ClearCurrent()
+	})
+
+	service := newRegistryTestService(t, listener)
+	serviceCtx, cancelService := context.WithCancel(context.Background())
+	t.Cleanup(cancelService)
+	service.homeMu.Lock()
+	service.runCancel = cancelService
+	service.homeMu.Unlock()
+	service.startHomeSubscriber(serviceCtx)
+
+	select {
+	case <-firstAck:
+	case <-time.After(time.Second):
+		t.Fatal("first subscription was not acknowledged")
+	}
+	registry := waitForServiceRegistry(t, service, time.Second)
+	pendingRetry, errBegin := registry.BeginDispatch()
+	if errBegin != nil {
+		t.Fatal(errBegin)
+	}
+	pendingScope, errBegin := registry.BeginDispatch()
+	if errBegin != nil {
+		t.Fatal(errBegin)
+	}
+	scope, errInstall := registry.Install(pendingScope, executionregistry.ScopeSpec{})
+	if errInstall != nil {
+		t.Fatal(errInstall)
+	}
+	resourceClosed := make(chan struct{})
+	if errBind := scope.Bind(func() error {
+		close(resourceClosed)
+		go scope.End("shutdown")
+		return nil
+	}); errBind != nil {
+		t.Fatal(errBind)
+	}
+	t.Cleanup(func() {
+		pendingRetry.End()
+		scope.End("test cleanup")
+	})
+
+	service.homeMu.Lock()
+	client := service.homeClient
+	service.homeMu.Unlock()
+	if client == nil {
+		t.Fatal("ready Home client is unavailable")
+	}
+	close(loseFirst)
+	deadline := time.After(time.Second)
+	for {
+		errRelease := client.PushConcurrencyRelease(context.Background(), home.ConcurrencyReleaseFrame{CredentialID: "cred-a", Model: "model-a", ReleaseSeq: 1})
+		if errors.Is(errRelease, home.ErrDispatchFenced) {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("subscriber retry did not close the previous Home client")
+		case <-time.After(time.Millisecond):
+		}
+	}
+
+	shutdownDone := make(chan error, 1)
+	go func() {
+		shutdownDone <- service.Shutdown(context.Background())
+	}()
+	pendingRetry.End()
+
+	select {
+	case <-resourceClosed:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown did not drain the detached execution registry")
+	}
+	select {
+	case errShutdown := <-shutdownDone:
+		if errShutdown != nil {
+			t.Fatalf("Shutdown() error = %v", errShutdown)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Shutdown() did not complete after draining the detached registry")
+	}
+}
+
+func TestServiceAmbiguousDispatchDrainsRegistryBeforeRetry(t *testing.T) {
+	listener, errListen := net.Listen("tcp", "127.0.0.1:0")
+	if errListen != nil {
+		t.Fatalf("listen: %v", errListen)
+	}
+	firstAck := make(chan struct{})
+	loseFirst := make(chan struct{})
+	secondSubscribe := make(chan struct{})
+	var secondSubscribeOnce sync.Once
+	allowSecondAck := make(chan struct{})
+	stop := make(chan struct{})
+	var subscriptionMu sync.Mutex
+	subscriptions := 0
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		for {
+			conn, errAccept := listener.Accept()
+			if errAccept != nil {
+				return
+			}
+			go serveRegistryTestHomeConnection(conn, &subscriptionMu, &subscriptions, firstAck, loseFirst, secondSubscribe, &secondSubscribeOnce, allowSecondAck, stop)
+		}
+	}()
+	t.Cleanup(func() {
+		close(stop)
+		_ = listener.Close()
+		<-serverDone
+		home.ClearCurrent()
+	})
+
+	service := newRegistryTestService(t, listener)
+	serviceCtx, cancelService := context.WithCancel(context.Background())
+	t.Cleanup(cancelService)
+	service.homeMu.Lock()
+	service.runCancel = cancelService
+	service.homeMu.Unlock()
+	service.startHomeSubscriber(serviceCtx)
+
+	select {
+	case <-firstAck:
+	case <-time.After(time.Second):
+		t.Fatal("first subscription was not acknowledged")
+	}
+	registry := waitForServiceRegistry(t, service, time.Second)
+	pending, errBegin := registry.BeginDispatch()
+	if errBegin != nil {
+		t.Fatal(errBegin)
+	}
+	scope, errInstall := registry.Install(pending, executionregistry.ScopeSpec{})
+	if errInstall != nil {
+		t.Fatal(errInstall)
+	}
+	resourceClosed := make(chan struct{})
+	if errBind := scope.Bind(func() error {
+		close(resourceClosed)
+		go scope.End("ambiguous dispatch")
+		return nil
+	}); errBind != nil {
+		t.Fatal(errBind)
+	}
+
+	service.homeMu.Lock()
+	client := service.homeClient
+	service.homeMu.Unlock()
+	if client == nil {
+		t.Fatal("ready Home client is unavailable")
+	}
+	client.AbortAmbiguousDispatch()
+	select {
+	case <-resourceClosed:
+	case <-time.After(time.Second):
+		t.Fatal("ambiguous dispatch did not drain the active registry")
+	}
+	select {
+	case <-secondSubscribe:
+	case <-time.After(time.Second):
+		t.Fatal("subscriber did not retry after ambiguous dispatch drain")
+	}
+	service.homeMu.Lock()
+	exposedRegistry := service.homeRegistry
+	service.homeMu.Unlock()
+	if exposedRegistry != nil {
+		t.Fatal("replacement registry was exposed before its subscription ACK")
+	}
+
+	close(allowSecondAck)
+	nextRegistry := waitForServiceRegistry(t, service, time.Second)
+	if nextRegistry == registry {
+		t.Fatal("ambiguous dispatch reused the drained execution registry")
+	}
+	select {
+	case <-serviceCtx.Done():
+		t.Fatal("successful ambiguous dispatch recovery canceled the service run")
+	case <-time.After(50 * time.Millisecond):
+	}
 }
 
 func TestServiceBacksOffAfterRepeatedPreAckFailures(t *testing.T) {
@@ -1585,7 +1792,7 @@ func TestServiceBacksOffAfterRepeatedPreAckFailures(t *testing.T) {
 	}
 }
 
-func TestServiceHeartbeatLossCancelsBlockedConfigFinalizationBeforeDrain(t *testing.T) {
+func TestServiceHeartbeatLossCancelsBlockedConfigFinalizationWithoutDrainingRegistry(t *testing.T) {
 	listener, errListen := net.Listen("tcp", "127.0.0.1:0")
 	if errListen != nil {
 		t.Fatalf("listen: %v", errListen)
@@ -1648,8 +1855,8 @@ func TestServiceHeartbeatLossCancelsBlockedConfigFinalizationBeforeDrain(t *test
 	}
 	select {
 	case <-resourceClosed:
-	case <-time.After(500 * time.Millisecond):
-		t.Fatal("heartbeat loss did not cancel the worker and drain the active execution")
+		t.Fatal("heartbeat loss drained the active execution")
+	case <-time.After(200 * time.Millisecond):
 	}
 	select {
 	case <-secondConfig:
@@ -1663,6 +1870,7 @@ func TestServiceHeartbeatLossCancelsBlockedConfigFinalizationBeforeDrain(t *test
 	if currentRegistry != nil || currentClient != nil || home.Current() != nil {
 		t.Fatal("heartbeat-lost lifetime left a published Home client or registry")
 	}
+	scope.End("completed")
 }
 
 func TestServiceConfigWorkerFinalizesRapidUpdatesInOrder(t *testing.T) {

--- a/sdk/cliproxy/service_executors.go
+++ b/sdk/cliproxy/service_executors.go
@@ -2,6 +2,7 @@ package cliproxy
 
 import (
 	"context"
+	"strconv"
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/constant"
@@ -12,7 +13,8 @@ import (
 )
 
 type openAICompatibilityRegistrationCache struct {
-	byName map[string]*openAICompatibilityRegistrationEntry
+	byName  map[string]*openAICompatibilityRegistrationEntry
+	byIndex map[int]*openAICompatibilityRegistrationEntry
 }
 
 type openAICompatibilityRegistrationEntry struct {
@@ -32,7 +34,8 @@ func (s *Service) newOpenAICompatibilityRegistrationCache() *openAICompatibility
 	}
 
 	cache := &openAICompatibilityRegistrationCache{
-		byName: make(map[string]*openAICompatibilityRegistrationEntry, len(cfg.OpenAICompatibility)),
+		byName:  make(map[string]*openAICompatibilityRegistrationEntry, len(cfg.OpenAICompatibility)),
+		byIndex: make(map[int]*openAICompatibilityRegistrationEntry, len(cfg.OpenAICompatibility)),
 	}
 	for i := range cfg.OpenAICompatibility {
 		compat := &cfg.OpenAICompatibility[i]
@@ -41,16 +44,17 @@ func (s *Service) newOpenAICompatibilityRegistrationCache() *openAICompatibility
 		}
 		compatName := strings.TrimSpace(compat.Name)
 		key := strings.ToLower(compatName)
-		if _, exists := cache.byName[key]; exists {
-			continue
-		}
 		providerName := strings.ToLower(compatName)
 		if providerName == "" {
 			providerName = "openai-compatibility"
 		}
-		cache.byName[key] = &openAICompatibilityRegistrationEntry{
+		entry := &openAICompatibilityRegistrationEntry{
 			providerKey: util.OpenAICompatibleProviderKey(providerName),
 			models:      buildOpenAICompatibilityConfigModels(compat),
+		}
+		cache.byIndex[i] = entry
+		if _, exists := cache.byName[key]; !exists {
+			cache.byName[key] = entry
 		}
 	}
 	if len(cache.byName) == 0 {
@@ -59,9 +63,15 @@ func (s *Service) newOpenAICompatibilityRegistrationCache() *openAICompatibility
 	return cache
 }
 
-func (c *openAICompatibilityRegistrationCache) lookup(compatName string) (*openAICompatibilityRegistrationEntry, bool) {
-	if c == nil || len(c.byName) == 0 {
+func (c *openAICompatibilityRegistrationCache) lookup(auth *coreauth.Auth, compatName string) (*openAICompatibilityRegistrationEntry, bool) {
+	if c == nil {
 		return nil, false
+	}
+	if auth != nil && auth.AuthSourceKind() == coreauth.AuthSourceConfig && auth.Attributes != nil {
+		if index, errIndex := strconv.Atoi(strings.TrimSpace(auth.Attributes[coreauth.AttributeConfigIndex])); errIndex == nil {
+			entry, ok := c.byIndex[index]
+			return entry, ok
+		}
 	}
 	entry, ok := c.byName[strings.ToLower(strings.TrimSpace(compatName))]
 	return entry, ok

--- a/sdk/cliproxy/service_home.go
+++ b/sdk/cliproxy/service_home.go
@@ -492,6 +492,25 @@ func (s *Service) runHomeSubscriber(homeCtx context.Context, parentCtx context.C
 	}()
 
 	var previousClient *home.Client
+	registry := executionregistry.New()
+	cancelBound := atomic.Int64{}
+	cancelBound.Store(int64(internalconfig.CredentialConcurrencyConfig{}.WithDefaults().CPACancelBound))
+	releaseFlusher := home.NewReleaseFlusher(nil, nil)
+	registry.SetReleaseSink(releaseFlusher.MarkDirty)
+	defer func() {
+		registry.SetReleaseSink(nil)
+		drainBound := time.Duration(cancelBound.Load())
+		if drainBound <= 0 {
+			drainBound = internalconfig.CredentialConcurrencyConfig{}.WithDefaults().CPACancelBound
+		}
+		drainCtx, cancelDrain := context.WithTimeout(context.WithoutCancel(parentCtx), drainBound)
+		errDrain := registry.Drain(drainCtx)
+		cancelDrain()
+		if errDrain != nil && !errors.Is(errDrain, executionregistry.ErrRegistryClosed) && parentCtx.Err() == nil {
+			log.WithError(errDrain).Error("failed to drain detached Home execution registry")
+			s.cancelServiceRun()
+		}
+	}()
 	for homeCtx.Err() == nil {
 		supervisor.setPublisherCompletion(nil)
 		client := previousClient
@@ -501,18 +520,15 @@ func (s *Service) runHomeSubscriber(homeCtx context.Context, parentCtx context.C
 			client = client.NewLifetime()
 		}
 		client.SetManagedLifetime(true)
-		registry := executionregistry.New()
 		releaseCtx, releaseCancel := context.WithCancel(context.WithoutCancel(homeCtx))
-		releaseFlusher := home.NewReleaseFlusher(client.LimiterConfig, client.PushConcurrencyRelease)
-		registry.SetReleaseSink(releaseFlusher.MarkDirty)
+		releaseFlusher.SetConfigProvider(client.LimiterConfig)
+		releaseFlusher.SetSender(client.PushConcurrencyRelease)
 		releaseDone := make(chan struct{})
 		go func() {
 			defer close(releaseDone)
 			releaseFlusher.Run(releaseCtx)
 		}()
 		lifetimeCtx, lifetimeCancel := context.WithCancel(homeCtx)
-		cancelBound := atomic.Int64{}
-		cancelBound.Store(int64(internalconfig.CredentialConcurrencyConfig{}.WithDefaults().CPACancelBound))
 		queue := newHomeConfigWorkQueue()
 		ready := make(chan struct{})
 		var readyOnce sync.Once
@@ -552,6 +568,48 @@ func (s *Service) runHomeSubscriber(homeCtx context.Context, parentCtx context.C
 		}
 
 		s.detachHomeSubscriberLifetime(client, registry)
+		retry := errRun != nil && homeCtx.Err() == nil
+		if retry {
+			releaseCancel()
+			<-releaseDone
+			client.Close()
+
+			settleBound := time.Duration(cancelBound.Load())
+			settleCtx, cancelSettle := context.WithTimeout(context.WithoutCancel(parentCtx), settleBound)
+			errPending := registry.WaitPending(settleCtx)
+			cancelSettle()
+			if errPending != nil {
+				log.WithError(errPending).Error("failed to settle pending Home dispatches before subscriber replacement")
+				s.cancelServiceRun()
+				return
+			}
+			legacyProtocol := home.IsLegacyMembershipProtocolError(errRun)
+			if legacyProtocol {
+				client.EnableLegacyMembership()
+			}
+			if client.AmbiguousDispatch() || home.IsMembershipTakeoverUnavailableError(errRun) || legacyProtocol || client.LegacyMembership() {
+				registry.SetReleaseSink(nil)
+				drainCtx, cancelDrain := context.WithTimeout(context.WithoutCancel(parentCtx), settleBound)
+				errDrain := registry.Drain(drainCtx)
+				cancelDrain()
+				if errDrain != nil {
+					log.WithError(errDrain).Error("failed to drain Home executions after unsafe subscriber replacement")
+					s.cancelServiceRun()
+					return
+				}
+				client.SuppressTakeover()
+				registry = executionregistry.New()
+				releaseFlusher = home.NewReleaseFlusher(nil, nil)
+				registry.SetReleaseSink(releaseFlusher.MarkDirty)
+			}
+			log.WithError(errRun).Warn("home config subscription lifetime ended")
+			if !published.Load() && !waitForHomeSubscriberRetry(homeCtx, homeSubscriberPreAckRetryBackoff) {
+				return
+			}
+			previousClient = client
+			continue
+		}
+
 		drainBound := time.Duration(cancelBound.Load())
 		drainCtx, cancelDrain := context.WithTimeout(context.WithoutCancel(parentCtx), drainBound)
 		errDrain := registry.Drain(drainCtx)
@@ -577,13 +635,7 @@ func (s *Service) runHomeSubscriber(homeCtx context.Context, parentCtx context.C
 			}
 			return
 		}
-		if errRun != nil && homeCtx.Err() == nil {
-			log.WithError(errRun).Warn("home config subscription lifetime ended")
-		}
-		if !published.Load() && errRun != nil && !waitForHomeSubscriberRetry(homeCtx, homeSubscriberPreAckRetryBackoff) {
-			return
-		}
-		previousClient = client
+		return
 	}
 }
 

--- a/sdk/cliproxy/service_home.go
+++ b/sdk/cliproxy/service_home.go
@@ -583,7 +583,11 @@ func (s *Service) runHomeSubscriber(homeCtx context.Context, parentCtx context.C
 				s.cancelServiceRun()
 				return
 			}
-			if client.AmbiguousDispatch() || home.IsMembershipTakeoverUnavailableError(errRun) {
+			legacyProtocol := home.IsLegacyMembershipProtocolError(errRun)
+			if legacyProtocol {
+				client.EnableLegacyMembership()
+			}
+			if client.AmbiguousDispatch() || home.IsMembershipTakeoverUnavailableError(errRun) || legacyProtocol || client.LegacyMembership() {
 				registry.SetReleaseSink(nil)
 				drainCtx, cancelDrain := context.WithTimeout(context.WithoutCancel(parentCtx), settleBound)
 				errDrain := registry.Drain(drainCtx)

--- a/sdk/cliproxy/service_home.go
+++ b/sdk/cliproxy/service_home.go
@@ -492,6 +492,25 @@ func (s *Service) runHomeSubscriber(homeCtx context.Context, parentCtx context.C
 	}()
 
 	var previousClient *home.Client
+	registry := executionregistry.New()
+	cancelBound := atomic.Int64{}
+	cancelBound.Store(int64(internalconfig.CredentialConcurrencyConfig{}.WithDefaults().CPACancelBound))
+	releaseFlusher := home.NewReleaseFlusher(nil, nil)
+	registry.SetReleaseSink(releaseFlusher.MarkDirty)
+	defer func() {
+		registry.SetReleaseSink(nil)
+		drainBound := time.Duration(cancelBound.Load())
+		if drainBound <= 0 {
+			drainBound = internalconfig.CredentialConcurrencyConfig{}.WithDefaults().CPACancelBound
+		}
+		drainCtx, cancelDrain := context.WithTimeout(context.WithoutCancel(parentCtx), drainBound)
+		errDrain := registry.Drain(drainCtx)
+		cancelDrain()
+		if errDrain != nil && !errors.Is(errDrain, executionregistry.ErrRegistryClosed) && parentCtx.Err() == nil {
+			log.WithError(errDrain).Error("failed to drain detached Home execution registry")
+			s.cancelServiceRun()
+		}
+	}()
 	for homeCtx.Err() == nil {
 		supervisor.setPublisherCompletion(nil)
 		client := previousClient
@@ -501,18 +520,15 @@ func (s *Service) runHomeSubscriber(homeCtx context.Context, parentCtx context.C
 			client = client.NewLifetime()
 		}
 		client.SetManagedLifetime(true)
-		registry := executionregistry.New()
 		releaseCtx, releaseCancel := context.WithCancel(context.WithoutCancel(homeCtx))
-		releaseFlusher := home.NewReleaseFlusher(client.LimiterConfig, client.PushConcurrencyRelease)
-		registry.SetReleaseSink(releaseFlusher.MarkDirty)
+		releaseFlusher.SetConfigProvider(client.LimiterConfig)
+		releaseFlusher.SetSender(client.PushConcurrencyRelease)
 		releaseDone := make(chan struct{})
 		go func() {
 			defer close(releaseDone)
 			releaseFlusher.Run(releaseCtx)
 		}()
 		lifetimeCtx, lifetimeCancel := context.WithCancel(homeCtx)
-		cancelBound := atomic.Int64{}
-		cancelBound.Store(int64(internalconfig.CredentialConcurrencyConfig{}.WithDefaults().CPACancelBound))
 		queue := newHomeConfigWorkQueue()
 		ready := make(chan struct{})
 		var readyOnce sync.Once
@@ -552,6 +568,44 @@ func (s *Service) runHomeSubscriber(homeCtx context.Context, parentCtx context.C
 		}
 
 		s.detachHomeSubscriberLifetime(client, registry)
+		retry := errRun != nil && homeCtx.Err() == nil
+		if retry {
+			releaseCancel()
+			<-releaseDone
+			client.Close()
+
+			settleBound := time.Duration(cancelBound.Load())
+			settleCtx, cancelSettle := context.WithTimeout(context.WithoutCancel(parentCtx), settleBound)
+			errPending := registry.WaitPending(settleCtx)
+			cancelSettle()
+			if errPending != nil {
+				log.WithError(errPending).Error("failed to settle pending Home dispatches before subscriber replacement")
+				s.cancelServiceRun()
+				return
+			}
+			if client.AmbiguousDispatch() || home.IsMembershipTakeoverUnavailableError(errRun) {
+				registry.SetReleaseSink(nil)
+				drainCtx, cancelDrain := context.WithTimeout(context.WithoutCancel(parentCtx), settleBound)
+				errDrain := registry.Drain(drainCtx)
+				cancelDrain()
+				if errDrain != nil {
+					log.WithError(errDrain).Error("failed to drain Home executions after unsafe subscriber replacement")
+					s.cancelServiceRun()
+					return
+				}
+				client.SuppressTakeover()
+				registry = executionregistry.New()
+				releaseFlusher = home.NewReleaseFlusher(nil, nil)
+				registry.SetReleaseSink(releaseFlusher.MarkDirty)
+			}
+			log.WithError(errRun).Warn("home config subscription lifetime ended")
+			if !published.Load() && !waitForHomeSubscriberRetry(homeCtx, homeSubscriberPreAckRetryBackoff) {
+				return
+			}
+			previousClient = client
+			continue
+		}
+
 		drainBound := time.Duration(cancelBound.Load())
 		drainCtx, cancelDrain := context.WithTimeout(context.WithoutCancel(parentCtx), drainBound)
 		errDrain := registry.Drain(drainCtx)
@@ -577,13 +631,7 @@ func (s *Service) runHomeSubscriber(homeCtx context.Context, parentCtx context.C
 			}
 			return
 		}
-		if errRun != nil && homeCtx.Err() == nil {
-			log.WithError(errRun).Warn("home config subscription lifetime ended")
-		}
-		if !published.Load() && errRun != nil && !waitForHomeSubscriberRetry(homeCtx, homeSubscriberPreAckRetryBackoff) {
-			return
-		}
-		previousClient = client
+		return
 	}
 }
 

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -2,10 +2,12 @@ package cliproxy
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/constant"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/modelconfig"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
@@ -191,7 +193,29 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 					isCompatAuth = true
 				}
 			}
-			if cached, ok := compatCache.lookup(compatName); ok {
+			registerCompat := func(compat *config.OpenAICompatibility) bool {
+				if compat == nil || compat.Disabled {
+					return false
+				}
+				isCompatAuth = true
+				ms := buildOpenAICompatibilityConfigModels(compat)
+				if providerKey == "" {
+					providerKey = "openai-compatibility"
+				}
+				if len(ms) > 0 {
+					ms = s.appendPluginModels(providerKey, ms)
+					s.registerResolvedModelsForAuth(a, providerKey, applyModelPrefixes(ms, a.Prefix, s.cfg.ForceModelPrefix))
+				} else {
+					ms = s.appendPluginModels(providerKey, nil)
+					if len(ms) > 0 {
+						s.registerResolvedModelsForAuth(a, providerKey, applyModelPrefixes(ms, a.Prefix, s.cfg.ForceModelPrefix))
+					} else {
+						GlobalModelRegistry().UnregisterClient(a.ID)
+					}
+				}
+				return true
+			}
+			if cached, ok := compatCache.lookup(a, compatName); ok {
 				isCompatAuth = true
 				if providerKey == "" {
 					providerKey = cached.providerKey
@@ -213,30 +237,12 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 				}
 				return
 			}
+			if indexed := configEntryForAuthIndex(a, s.cfg.OpenAICompatibility); indexed != nil && registerCompat(indexed) {
+				return
+			}
 			for i := range s.cfg.OpenAICompatibility {
 				compat := &s.cfg.OpenAICompatibility[i]
-				if compat.Disabled {
-					continue
-				}
-				if strings.EqualFold(compat.Name, compatName) {
-					isCompatAuth = true
-					ms := buildOpenAICompatibilityConfigModels(compat)
-					// Register and return
-					if len(ms) > 0 {
-						if providerKey == "" {
-							providerKey = "openai-compatibility"
-						}
-						ms = s.appendPluginModels(providerKey, ms)
-						s.registerResolvedModelsForAuth(a, providerKey, applyModelPrefixes(ms, a.Prefix, s.cfg.ForceModelPrefix))
-					} else {
-						// Ensure stale registrations are cleared when model list becomes empty.
-						ms = s.appendPluginModels(providerKey, nil)
-						if len(ms) > 0 {
-							s.registerResolvedModelsForAuth(a, providerKey, applyModelPrefixes(ms, a.Prefix, s.cfg.ForceModelPrefix))
-						} else {
-							GlobalModelRegistry().UnregisterClient(a.ID)
-						}
-					}
+				if strings.EqualFold(compat.Name, compatName) && registerCompat(compat) {
 					return
 				}
 			}
@@ -340,9 +346,23 @@ func (s *Service) latestAuthForModelRegistration(authID string) (*coreauth.Auth,
 	return auth, true
 }
 
+func configEntryForAuthIndex[T any](auth *coreauth.Auth, entries []T) *T {
+	if auth == nil || auth.AuthSourceKind() != coreauth.AuthSourceConfig || auth.Attributes == nil {
+		return nil
+	}
+	index, errIndex := strconv.Atoi(strings.TrimSpace(auth.Attributes[coreauth.AttributeConfigIndex]))
+	if errIndex != nil || index < 0 || index >= len(entries) {
+		return nil
+	}
+	return &entries[index]
+}
+
 func (s *Service) resolveConfigClaudeKey(auth *coreauth.Auth) *config.ClaudeKey {
 	if auth == nil || s.cfg == nil {
 		return nil
+	}
+	if entry := configEntryForAuthIndex(auth, s.cfg.ClaudeKey); entry != nil {
+		return entry
 	}
 	var attrKey, attrBase string
 	if auth.Attributes != nil {
@@ -397,6 +417,9 @@ func (s *Service) resolveConfigGeminiKeyEntry(auth *coreauth.Auth, entries []con
 	if auth == nil || s.cfg == nil {
 		return nil
 	}
+	if entry := configEntryForAuthIndex(auth, entries); entry != nil {
+		return entry
+	}
 	var attrKey, attrBase string
 	if auth.Attributes != nil {
 		attrKey = strings.TrimSpace(auth.Attributes["api_key"])
@@ -422,6 +445,9 @@ func (s *Service) resolveConfigGeminiKeyEntry(auth *coreauth.Auth, entries []con
 func (s *Service) resolveConfigVertexCompatKey(auth *coreauth.Auth) *config.VertexCompatKey {
 	if auth == nil || s.cfg == nil {
 		return nil
+	}
+	if entry := configEntryForAuthIndex(auth, s.cfg.VertexCompatAPIKey); entry != nil {
+		return entry
 	}
 	var attrKey, attrBase string
 	if auth.Attributes != nil {
@@ -470,6 +496,9 @@ func (s *Service) resolveConfigXAIKey(auth *coreauth.Auth) *config.XAIKey {
 func resolveConfigCodexStyleKey(auth *coreauth.Auth, entries []config.CodexKey) *config.CodexKey {
 	if auth == nil {
 		return nil
+	}
+	if entry := configEntryForAuthIndex(auth, entries); entry != nil {
+		return entry
 	}
 	var attrKey, attrBase string
 	if auth.Attributes != nil {
@@ -631,6 +660,7 @@ type modelEntry interface {
 	GetName() string
 	GetAlias() string
 	GetDisplayName() string
+	GetThinking() *registry.ThinkingSupport
 }
 
 func buildConfiguredModelInfo(model modelEntry, ownedBy, modelType string, created int64, fallbackDisplayName string, userDefined bool) *ModelInfo {
@@ -676,11 +706,11 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 		if info == nil {
 			continue
 		}
-		thinking := model.Thinking
-		if thinking == nil && !model.Image {
-			thinking = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
+		thinkingSupport := model.Thinking
+		if thinkingSupport == nil && !model.Image {
+			thinkingSupport = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
 		}
-		info.Thinking = thinking
+		info.Thinking = modelconfig.NormalizeThinkingSupport(thinkingSupport)
 		info.SupportedInputModalities = normalizeCompatConfigModalities(model.InputModalities)
 		info.SupportedOutputModalities = normalizeCompatConfigModalities(model.OutputModalities)
 		models = append(models, info)
@@ -731,10 +761,8 @@ func buildConfigModels[T modelEntry](models []T, ownedBy, modelType string) []*M
 			continue
 		}
 		seen[key] = struct{}{}
-		if name != "" {
-			if upstream := registry.LookupStaticModelInfo(name); upstream != nil && upstream.Thinking != nil {
-				info.Thinking = upstream.Thinking
-			}
+		if resolved := modelconfig.ResolveModelInfo(name, modelType, model.GetThinking()); resolved.Thinking != nil {
+			info.Thinking = resolved.Thinking
 		}
 		out = append(out, info)
 	}

--- a/sdk/cliproxy/service_models_config_index_test.go
+++ b/sdk/cliproxy/service_models_config_index_test.go
@@ -1,0 +1,41 @@
+package cliproxy
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestOpenAICompatibilityRegistrationCacheUsesConfigIndex(t *testing.T) {
+	service := &Service{cfg: &config.Config{OpenAICompatibility: []config.OpenAICompatibility{
+		{Name: "shared", Models: []config.OpenAICompatibilityModel{{Name: "first"}}},
+		{Name: "shared", Models: []config.OpenAICompatibilityModel{{Name: "second"}}},
+	}}}
+	cache := service.newOpenAICompatibilityRegistrationCache()
+	auth := &coreauth.Auth{Attributes: map[string]string{
+		coreauth.AttributeSource:      "config:shared[token-1]",
+		coreauth.AttributeConfigIndex: "1",
+	}}
+	entry, ok := cache.lookup(auth, "shared")
+	if !ok || entry == nil || len(entry.models) != 1 || entry.models[0].ID != "second" {
+		t.Fatalf("cached config entry = %+v, want second model", entry)
+	}
+}
+
+func TestResolveConfigClaudeKeyUsesConfigIndex(t *testing.T) {
+	service := &Service{cfg: &config.Config{ClaudeKey: []config.ClaudeKey{
+		{APIKey: "shared-key", Models: []config.ClaudeModel{{Name: "first"}}},
+		{APIKey: "shared-key", Models: []config.ClaudeModel{{Name: "second"}}},
+	}}}
+	auth := &coreauth.Auth{Attributes: map[string]string{
+		coreauth.AttributeAPIKey:      "shared-key",
+		coreauth.AttributeSource:      "config:claude[token-1]",
+		coreauth.AttributeConfigIndex: "1",
+	}}
+
+	entry := service.resolveConfigClaudeKey(auth)
+	if entry == nil || len(entry.Models) != 1 || entry.Models[0].Name != "second" {
+		t.Fatalf("resolved config entry = %+v, want second entry", entry)
+	}
+}

--- a/test/codex_claude_parallel_function_calls_test.go
+++ b/test/codex_claude_parallel_function_calls_test.go
@@ -1,0 +1,125 @@
+package test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+)
+
+func TestCodexToClaudeParallelFunctionCallsHaveValidLifecycle(t *testing.T) {
+	chunks := [][]byte{
+		[]byte(`data: {"type":"response.created","response":{"id":"resp_parallel","model":"gpt-5"}}`),
+		[]byte(`data: {"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_a","name":"Read"},"output_index":1}`),
+		[]byte(`data: {"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_b","name":"Read"},"output_index":2}`),
+		[]byte(`data: {"type":"response.function_call_arguments.delta","delta":"{\"file_path\":\"a\"}","output_index":1}`),
+		[]byte(`data: {"type":"response.function_call_arguments.done","arguments":"{\"file_path\":\"a\"}","output_index":1}`),
+		[]byte(`data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_a","name":"Read","arguments":"{\"file_path\":\"a\"}"},"output_index":1}`),
+		[]byte(`data: {"type":"response.function_call_arguments.delta","delta":"{\"file_path\":\"b\"}","output_index":2}`),
+		[]byte(`data: {"type":"response.function_call_arguments.done","arguments":"{\"file_path\":\"b\"}","output_index":2}`),
+		[]byte(`data: {"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_b","name":"Read","arguments":"{\"file_path\":\"b\"}"},"output_index":2}`),
+		[]byte(`data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1},"output":[{"type":"function_call","call_id":"call_a","name":"Read","arguments":"{\"file_path\":\"a\"}"},{"type":"function_call","call_id":"call_b","name":"Read","arguments":"{\"file_path\":\"b\"}"}]}}`),
+	}
+
+	originalRequest := []byte(`{"stream":true,"tools":[{"name":"Read"}]}`)
+	var state any
+	open := make(map[int64]struct{})
+	started := make(map[int64]struct{})
+	toolIDs := make(map[int64]string)
+	arguments := make(map[int64]string)
+	var startIndices []int64
+	var stopIndices []int64
+	messageState := 0
+
+	for _, chunk := range chunks {
+		outputs := sdktranslator.TranslateStream(
+			context.Background(),
+			sdktranslator.FormatCodex,
+			sdktranslator.FormatClaude,
+			"gpt-5",
+			originalRequest,
+			nil,
+			chunk,
+			&state,
+		)
+		for _, output := range outputs {
+			for _, line := range strings.Split(string(output), "\n") {
+				if !strings.HasPrefix(line, "data: ") {
+					continue
+				}
+				event := gjson.Parse(strings.TrimPrefix(line, "data: "))
+				if messageState == 2 {
+					t.Fatalf("event emitted after message_stop: %s", event.Raw)
+				}
+				index := event.Get("index").Int()
+				switch event.Get("type").String() {
+				case "content_block_start":
+					if messageState != 0 {
+						t.Fatalf("content block started after message terminal events: %s", event.Raw)
+					}
+					if len(open) != 0 {
+						t.Fatalf("content block start emitted while another block remains open: %v", open)
+					}
+					if _, exists := started[index]; exists {
+						t.Fatalf("content block index %d was reused", index)
+					}
+					open[index] = struct{}{}
+					started[index] = struct{}{}
+					startIndices = append(startIndices, index)
+					toolIDs[index] = event.Get("content_block.id").String()
+				case "content_block_delta":
+					if _, exists := open[index]; !exists {
+						t.Fatalf("content block delta targets unopened index %d", index)
+					}
+					if event.Get("delta.type").String() == "input_json_delta" {
+						arguments[index] += event.Get("delta.partial_json").String()
+					}
+				case "content_block_stop":
+					if _, exists := open[index]; !exists {
+						t.Fatalf("content block stop targets unopened index %d", index)
+					}
+					delete(open, index)
+					stopIndices = append(stopIndices, index)
+				case "message_delta":
+					if len(open) != 0 {
+						t.Fatalf("message_delta emitted while content blocks remain open: %v", open)
+					}
+					if messageState != 0 {
+						t.Fatalf("duplicate or out-of-order message_delta: %s", event.Raw)
+					}
+					messageState = 1
+				case "message_stop":
+					if len(open) != 0 {
+						t.Fatalf("message_stop emitted while content blocks remain open: %v", open)
+					}
+					if messageState != 1 {
+						t.Fatalf("message_stop emitted before message_delta: %s", event.Raw)
+					}
+					messageState = 2
+				}
+			}
+		}
+	}
+
+	if len(open) != 0 {
+		t.Fatalf("content blocks remain open: %v", open)
+	}
+	if messageState != 2 {
+		t.Fatalf("terminal message event state = %d, want message_delta followed by message_stop", messageState)
+	}
+	if len(startIndices) != 2 || startIndices[0] != 0 || startIndices[1] != 1 {
+		t.Fatalf("start indices = %v, want [0 1]", startIndices)
+	}
+	if len(stopIndices) != 2 || stopIndices[0] != 0 || stopIndices[1] != 1 {
+		t.Fatalf("stop indices = %v, want [0 1]", stopIndices)
+	}
+	if toolIDs[0] != "call_a" || toolIDs[1] != "call_b" {
+		t.Fatalf("tool IDs = %v, want call_a and call_b", toolIDs)
+	}
+	if arguments[0] != `{"file_path":"a"}` || arguments[1] != `{"file_path":"b"}` {
+		t.Fatalf("tool arguments = %v", arguments)
+	}
+}


### PR DESCRIPTION
## 结果与合并约束

本 PR 是 2026-07-30 protected full-sync 的第 3/3 段，将 CPA-Core-LTS 从 upstream `cade44b9cdee6b9328ea2648fd119129fdf11e2d`（v7.2.103）推进到 `4a2eb54dc6bf943196be4fb515e6a9407a4db143`（v7.2.105）。它吸收 weighted round-robin、credential weight validation、configured API-key model capability、Home CAS/recovery、Claude CAIS signature、Antigravity tool provenance/schema、client request metadata、Claude cache creation usage 与 Codex→Claude function-call 修复，同时保留 LTS 的 usage、Management API、Panel source、Codex continuity/fallback/selected-auth、WebSocket metadata、cache overflow fail-closed 和 auth store error propagation。

本 PR 必须使用 **Create a merge commit**，禁止 squash 或 rebase。当前仅为已推送 PR；尚未合入 `main`，未 tag、未 release、未 deploy。

## Type

- [x] Protected upstream full-sync
- [x] Staged upstream full-sync
- [ ] LTS protected-delta patch
- [ ] LTS feature / downstream patch maintenance
- [ ] Maintenance docs / CI
- [ ] Emergency hotfix

## Upstream sync info

- Upstream repo / branch: `router-for-me/CLIProxyAPI` / `main`
- Upstream from SHA: `cade44b9cdee6b9328ea2648fd119129fdf11e2d`
- Upstream to SHA: `4a2eb54dc6bf943196be4fb515e6a9407a4db143`
- Upstream tag: `v7.2.105`
- Sync branch: `codex/sync-upstream-v7.2.105-20260730`
- Stage: 3 / 3
- Range: 14 个 first-parent commits、19 个 non-merge commits。

## 主要吸收与适配

- 吸收 weighted round-robin scheduler、config/auth-file/API-key credential weight validation，以及按 auth/model 解析 configured API-key capability 的执行路径。
- 将新 scheduler/model capability 与 LTS Codex rate-limit continuity、fallback dispatch、context cancellation、selected-auth publication、session metadata 和 stream metadata 合并，不替换既有语义。
- 吸收 Home CAS/membership/recovery、Claude CAIS signature validation、Antigravity tool provenance/context-drift replay/schema/structured output、Claude stream `Accept` 修复与 shared `ApplyRequestThinking` 重构。
- Redis usage queue 增加 `client_ip`、`x_forwarded_for`、`user_agent`，并继续保留 `effective_service_tier` 与完整 LTS usage attribution。
- Claude→OpenAI usage 增加 `cached_creation_tokens`；继续使用 LTS 非负计数和 overflow fail-closed 算术，overflow 时同时清零 cache read/creation 分类。
- 吸收 Codex→Claude parallel function-call/grouping 修复，并从 embedded catalog 删除 Gemini 3.5 Flash Lite。
- 保留 File token store 的 fail-closed 契约：无效 persisted plugin `weight` 返回带 source path/weight 上下文的错误，不静默跳过 credential。

## Protected delta checklist

- [x] `usage-statistics-enabled` still exists
- [x] `internal/usage/` still exists
- [x] `/v0/management/usage` still exists
- [x] `/v0/management/usage/export` still exists
- [x] `/v0/management/usage/import` still exists
- [x] `docs/lts/core-feature-contracts.yaml` reviewed for touched protected or protected-adjacent features
- [x] `docs/lts/downstream-patches.yaml` reviewed for active patch retirement or reapplication
- [x] Usage record creation/schema reviewed or tested: API key, auth source, model, token breakdown, latency, success/failure
- [x] Management usage response shape reviewed or tested: `usage`, `failed_requests`, `apis`, `models`, `details`
- [x] Export/import roundtrip reviewed or tested when usage data shape is touched
- [x] CPA-Panel-LTS response shape reviewed
- [x] Local auth/config/panel/release/source customizations reviewed

Protected delta review:

- retained capabilities: **adapted**；usage、Management usage/export/import、usage queue、auth attribution 与 Panel response shape 均保留。
- LTS-owned features: **adapted**；Codex continuity/fallback/selected-auth、WebSocket metadata、xAI explicit tool authority 与 Panel source 均保留。
- shared review seams: **adapted**；request metadata、auth/model selection、token accounting、config/hot reload、Home lifecycle、plugin parser、stream handling 已逐项复核。
- downstream patches: **patch-still-required**；除既已退休条目外，没有发现满足 ledger retirement 条件的完整 upstream 等价实现。
- validation profiles: contract、registry、usage、targeted、race、build 与两种 repo-wide test 均在 PR head 通过；HF Space smoke 未运行，因为本任务未授权部署。
- upstream ordinary changes: **absorbed**；无文件级覆盖。

## Conflict resolution notes

8 个文本冲突已人工合并：

- `internal/redisqueue/plugin.go`
- `internal/translator/claude/openai/chat-completions/claude_openai_response.go`
- `internal/translator/claude/openai/chat-completions/claude_openai_response_test.go`
- `sdk/cliproxy/auth/conductor_execution.go`
- `sdk/cliproxy/auth/conductor_stream.go`
- `sdk/cliproxy/auth/openai_compat_pool_test.go`
- `sdk/cliproxy/auth/selector_test.go`
- `sdk/cliproxy/builder.go`

关键取舍：

- scheduler/capability wiring 与 continuity、fallback、selected-auth、per-attempt alias/force-mapping、stream metadata 共存。
- `cached_creation_tokens` 作为 additive usage detail；LTS overflow/nonnegative 规则保持不变。
- Redis client metadata 作为 additive wire fields；不替换 built-in full usage。
- upstream 期望无效 persisted plugin weight 被跳过，LTS 继续按 `auth-store-list-error-propagation` fail closed。
- `internal/watcher/synthesizer/file.go` 已修复 upstream 签名迁移后的旧式 `return nil` 遗漏，plugin parser error 现在显式返回带文件名上下文的 error，且不会 fallback 到 generic auth。

## LTS classification review

当前 baseline 为 `4a2eb54dc6bf943196be4fb515e6a9407a4db143`（v7.2.105）。所有 non-retired ledger 项均按 upstream diff、当前实现和 registry regression tests 复核：

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| full-usage-statistics-core / management-usage-api / panel-release-asset | retained capability | adapted | contract guard、usage/API tests、Panel source sentinel |
| auth-identity-attribution / config-compatibility-and-hot-reload | retained capability | adapted | weight/config/auth/watcher tests、full tests |
| codex-model-fallback | downstream patch | patch-still-required | fallback/context-reset regressions 继续通过 |
| codex-rate-limit-continuity | downstream patch | patch-still-required | continuity、selected-auth、session metadata 与 race tests 继续通过 |
| codex-interactions-service-tier-response | downstream patch | patch-still-required | usage/translator regressions 继续通过 |
| plugin-configured-enable-default | downstream patch | patch-still-required | plugin config regressions 继续通过 |
| home-plugin-sync-cancellation | downstream patch | patch-still-required | Home/plugin cancellation regressions 继续通过 |
| codex-gpt56-ultra-level | downstream patch | patch-still-required | configured model capability 仅覆盖部分配置能力，未替代 overlay/custom-model/canonicalization/HTTP+WS enforcement |
| codex-model-header-provider-snapshot | downstream patch | patch-still-required | header/provider snapshot regressions 继续通过 |
| codex-oauth-client-identity-finalization | downstream patch | patch-still-required | HTTP/WS/image identity regressions 继续通过 |
| codex-client-metadata-privacy | downstream patch | patch-still-required | canonical metadata、workspace redaction、HTTP/WS regressions 继续通过 |
| codex-model-not-found-request-scope | downstream patch | patch-still-required | typed 404/request-scoped cooldown regressions 继续通过 |
| codex-websocket-reader-generation | downstream patch | patch-still-required | generation/stale-reader/session-close regressions 继续通过 |
| codex-spark-reasoning-summary-compat | downstream patch | patch-still-required | HTTP/stream/WS summary sanitizer regressions 继续通过 |
| xai-explicit-tool-choice-none | downstream patch | patch-still-required | explicit none/allowlist/orphan fail-closed regressions 继续通过 |
| kimi-claude-delegated-auth-immutability | downstream patch | patch-still-required | delegated auth immutability regressions 继续通过 |
| request-body-panic-tempfile-cleanup | downstream patch | patch-still-required | request body cleanup regressions 继续通过 |
| api-request-body-size-limit | downstream patch | patch-still-required | encoded/decoded body bound regressions 继续通过 |
| object-store-auth-path-containment | downstream patch | patch-still-required | containment/no-follow regressions 继续通过 |
| auth-token-private-file-permissions | downstream patch | patch-still-required | private permission regressions 继续通过 |
| auth-store-list-error-propagation | downstream patch | patch-still-required | baseline 更新为 v7.2.105；invalid weight/parser/read errors 保持 fail closed |
| auth-store-metadata-hydration | downstream patch | patch-still-required | prefix/disabled/fields hydration regressions 继续通过 |
| panel-release-token-isolation | downstream patch | patch-still-required | dedicated/legacy token isolation regressions 继续通过 |
| gemini-unknown-method-not-found | downstream patch | patch-still-required | unknown method 404 regression 继续通过 |
| count-tokens-not-found-no-cooldown | downstream patch | patch-still-required | request-scoped count fallback regressions 继续通过 |
| management-logs-bounded-response | downstream patch | patch-still-required | bounded default/cursor regressions 继续通过 |
| transient-eof-cooldown | downstream patch | patch-still-required | upstream generic unknown cooldown 未提供 EOF/UnexpectedEOF 502 分类、status/cancellation precedence 与 post-delivery 保障 |
| expired-availability-pruning | downstream patch | patch-still-required | auth/model expiry pruning regressions 继续通过 |

`codex-image-generation-tool-dedup` 已在 ledger 中标记 `retired`；本段不重新引入 downstream 实现。

- [x] 本 PR 的 protected merge commit 必须通过 **Create a merge commit** 保持双亲历史可达；squash/rebase 禁止。

## Exact-head 验证

以下命令均在 `beb238089616eec24b8f5d7dca9f91b867e86d7d` 通过：

- [x] `scripts/check-lts-contract.sh`
- [x] `go run ./scripts/ltsregistry --root .`
- [x] `go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage' -count=1`
- [x] `go test ./sdk/api/handlers/... ./sdk/auth ./sdk/cliproxy ./sdk/cliproxy/executionregistry ./sdk/pluginabi ./sdk/pluginapi -count=1`
- [x] `go test -race ./sdk/cliproxy/auth -run 'CodexRateLimitContinuity|SessionAffinitySelector_ExplicitExecutionSessionMetadata|Weighted|OpenAICompatAliasPoolPublishesSelectedAuth|SelectedAuth' -count=1`
- [x] `go build -o /tmp/cpa-core-stage3-test-output ./cmd/server`
- [x] `go test ./... -count=1`
- [x] `go list ./... | rg -v '/tmp$' | xargs go test -count=1`
- [x] `git diff --check`

## Review focus 与边界

1. weighted scheduler/model capability wiring 是否与 continuity、fallback、selected-auth、stream metadata 和 per-attempt force mapping 正确共存。
2. Claude cache read/creation 的分类值是否在 normal/overflow 情况下都与 canonical prompt total 一致。
3. persisted invalid weight 的 fail-closed 行为，以及 watcher/plugin parser error 是否仍能阻止 credential 静默消失。
4. Redis client metadata、usage attribution 和 Panel source 是否保持 additive/compatible。

- [x] HF Space smoke 明确跳过：尚未合入且未授权部署。
- 未执行 tag、release、artifact 发布、部署或 runtime acceptance。
