### PR TITLE
sync(lts): 补充吸收 upstream v7.2.106 schema 与 model 修复

### DIFF
--- a/internal/runtime/executor/antigravity_schema_sanitize_test.go
+++ b/internal/runtime/executor/antigravity_schema_sanitize_test.go
@@ -274,6 +274,46 @@ func TestSanitizeAntigravityRequestSchemasKeepsResponseSchemasPlaceholderFree(t 
 	}
 }
 
+func TestSanitizeAntigravityRequestSchemasPreservesResponseUnionAndEnumType(t *testing.T) {
+	payload := `{"request":{
+		"tools":[{"functionDeclarations":[{"name":"tool","parameters":{"type":"object","properties":{
+			"choice":{"anyOf":[{"type":"string"},{"type":"null"}]},
+			"level":{"type":"number","enum":[1,2]}
+		}}}]}],
+		"generationConfig":{"responseSchema":{"type":"object","properties":{
+			"action":{"anyOf":[
+				{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]},
+				{"type":"null"}
+			]},
+			"conviction":{"type":"number","enum":[0.25,0.5,1]}
+		}}}
+	}}`
+
+	got := sanitizeAntigravityRequestSchemas(payload, true)
+	responseSchema := gjson.Get(got, "request.generationConfig.responseSchema")
+	union := responseSchema.Get("properties.action.anyOf")
+	if !union.IsArray() || len(union.Array()) != 2 || union.Get("1.type").String() != "null" {
+		t.Errorf("response anyOf union was flattened: %s", responseSchema.Raw)
+	}
+	conviction := responseSchema.Get("properties.conviction")
+	if gotType := conviction.Get("type").String(); gotType != "number" {
+		t.Errorf("response enum type = %q, want number: %s", gotType, responseSchema.Raw)
+	}
+	for _, enumValue := range conviction.Get("enum").Array() {
+		if enumValue.Type != gjson.String {
+			t.Errorf("response enum value is not a string: %s", conviction.Raw)
+		}
+	}
+
+	toolSchema := gjson.Get(got, "request.tools.0.functionDeclarations.0.parameters")
+	if toolSchema.Get("properties.choice.anyOf").Exists() {
+		t.Errorf("tool anyOf union was not flattened: %s", toolSchema.Raw)
+	}
+	if gotType := toolSchema.Get("properties.level.type").String(); gotType != "string" {
+		t.Errorf("tool enum type = %q, want string: %s", gotType, toolSchema.Raw)
+	}
+}
+
 func TestAntigravityBuildRequestKeepsJSONObjectSchemaPlaceholderFree(t *testing.T) {
 	input := []byte(`{"model":"gemini-3.1-pro-low","messages":[{"role":"user","content":"hi"}],"response_format":{"type":"json_object"}}`)
 	translated := antigravitychat.ConvertOpenAIRequestToAntigravity("gemini-3.1-pro-low", input, false)

--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -24,50 +24,67 @@ const placeholderReasonDescription = "Brief explanation of why you are calling t
 // and replacements such as "enum" and "type" are fabricated. That regression reached production
 // once already; scope every call site to the schema itself.
 
+type jsonSchemaCleanOptions struct {
+	addPlaceholder       bool
+	removeGeminiMetadata bool
+	flattenUnions        bool
+	forceEnumStringType  bool
+}
+
 // CleanJSONSchemaForAntigravity transforms a tool schema to be compatible with Antigravity API.
 // It handles unsupported keywords, type flattening, and schema simplification while preserving
 // semantic information as description hints and adding placeholders required by VALIDATED mode.
 func CleanJSONSchemaForAntigravity(jsonStr string) string {
-	return cleanJSONSchema(jsonStr, true, false)
+	return cleanJSONSchema(jsonStr, jsonSchemaCleanOptions{
+		addPlaceholder:      true,
+		flattenUnions:       true,
+		forceEnumStringType: true,
+	})
 }
 
-// CleanJSONSchemaForAntigravityResponse transforms a response schema without adding tool-only
-// placeholders that would alter the client's structured output contract.
+// CleanJSONSchemaForAntigravityResponse transforms a response schema without applying tool-only
+// compatibility rewrites that would alter the client's structured output contract.
 func CleanJSONSchemaForAntigravityResponse(jsonStr string) string {
-	return cleanJSONSchema(jsonStr, false, false)
+	return cleanJSONSchema(jsonStr, jsonSchemaCleanOptions{})
 }
 
 // CleanJSONSchemaForGemini transforms a JSON schema to be compatible with Gemini tool calling.
 // It removes unsupported keywords and simplifies schemas, without adding empty-schema placeholders.
 func CleanJSONSchemaForGemini(jsonStr string) string {
-	return cleanJSONSchema(jsonStr, false, true)
+	return cleanJSONSchema(jsonStr, jsonSchemaCleanOptions{
+		removeGeminiMetadata: true,
+		flattenUnions:        true,
+		forceEnumStringType:  true,
+	})
 }
 
 // cleanJSONSchema performs the core cleaning operations on the JSON schema.
-func cleanJSONSchema(jsonStr string, addPlaceholder, removeGeminiMetadata bool) string {
+func cleanJSONSchema(jsonStr string, options jsonSchemaCleanOptions) string {
 	// Phase 1: Convert and add hints
 	jsonStr = convertRefsToHints(jsonStr)
 	jsonStr = convertConstToEnum(jsonStr)
-	jsonStr = convertEnumValuesToStrings(jsonStr)
+	jsonStr = convertEnumValuesToStrings(jsonStr, options.forceEnumStringType)
 	jsonStr = addEnumHints(jsonStr)
 	jsonStr = addAdditionalPropertiesHints(jsonStr)
 	jsonStr = moveConstraintsToDescription(jsonStr)
 
 	// Phase 2: Flatten complex structures
 	jsonStr = mergeAllOf(jsonStr)
-	jsonStr = flattenAnyOfOneOf(jsonStr)
+	if options.flattenUnions {
+		jsonStr = flattenAnyOfOneOf(jsonStr)
+	}
 	jsonStr = flattenTypeArrays(jsonStr)
 
 	// Phase 3: Cleanup
 	jsonStr = removeUnsupportedKeywords(jsonStr)
-	if removeGeminiMetadata {
+	if options.removeGeminiMetadata {
 		// Gemini schema cleanup: remove nullable/title and placeholder-only fields.
 		jsonStr = removeKeywords(jsonStr, []string{"nullable", "title"})
 		jsonStr = removePlaceholderFields(jsonStr)
 	}
 	jsonStr = cleanupRequiredFields(jsonStr)
 	// Phase 4: Add placeholder for empty object schemas (Claude VALIDATED mode requirement)
-	if addPlaceholder {
+	if options.addPlaceholder {
 		jsonStr = addEmptySchemaPlaceholder(jsonStr)
 	}
 
@@ -201,9 +218,10 @@ func convertConstToEnum(jsonStr string) string {
 	return jsonStr
 }
 
-// convertEnumValuesToStrings ensures all enum values are strings and the schema type is set to string.
-// Gemini API requires enum values to be of type string, not numbers or booleans.
-func convertEnumValuesToStrings(jsonStr string) string {
+// convertEnumValuesToStrings ensures all enum values use the string representation required by
+// Gemini's proto schema. Tool schemas also require a string type, while response schemas preserve
+// their declared type because the upstream decoder uses it to select the emitted JSON value type.
+func convertEnumValuesToStrings(jsonStr string, forceStringType bool) string {
 	for _, p := range findPaths(jsonStr, "enum") {
 		arr := gjson.Get(jsonStr, p)
 		if !arr.IsArray() {
@@ -215,13 +233,13 @@ func convertEnumValuesToStrings(jsonStr string) string {
 			stringVals = append(stringVals, item.String())
 		}
 
-		// Always update enum values to strings and set type to "string"
-		// This ensures compatibility with Antigravity Gemini which only allows enum for STRING type
 		updated, _ := sjson.SetBytes([]byte(jsonStr), p, stringVals)
 		jsonStr = string(updated)
-		parentPath := trimSuffix(p, ".enum")
-		updated, _ = sjson.SetBytes([]byte(jsonStr), joinPath(parentPath, "type"), "string")
-		jsonStr = string(updated)
+		if forceStringType {
+			parentPath := trimSuffix(p, ".enum")
+			updated, _ = sjson.SetBytes([]byte(jsonStr), joinPath(parentPath, "type"), "string")
+			jsonStr = string(updated)
+		}
 	}
 	return jsonStr
 }

--- a/internal/util/gemini_schema_test.go
+++ b/internal/util/gemini_schema_test.go
@@ -764,6 +764,76 @@ func TestCleanJSONSchemaForAntigravityResponseDoesNotAddToolPlaceholders(t *test
 	}
 }
 
+func TestCleanJSONSchemaForAntigravityResponsePreservesUnions(t *testing.T) {
+	input := `{
+		"type":"object",
+		"properties":{
+			"action":{"anyOf":[
+				{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]},
+				{"type":"null"}
+			]},
+			"label":{"oneOf":[{"type":"string"},{"type":"null"}]}
+		}
+	}`
+
+	result := gjson.Parse(CleanJSONSchemaForAntigravityResponse(input))
+	for _, testCase := range []struct {
+		path      string
+		wantTypes []string
+	}{
+		{path: "properties.action.anyOf", wantTypes: []string{"object", "null"}},
+		{path: "properties.label.oneOf", wantTypes: []string{"string", "null"}},
+	} {
+		union := result.Get(testCase.path)
+		if !union.IsArray() {
+			t.Errorf("response union %s was flattened: %s", testCase.path, result.Raw)
+			continue
+		}
+		var gotTypes []string
+		for _, branch := range union.Array() {
+			gotTypes = append(gotTypes, branch.Get("type").String())
+		}
+		if !reflect.DeepEqual(gotTypes, testCase.wantTypes) {
+			t.Errorf("response union %s types = %v, want %v: %s", testCase.path, gotTypes, testCase.wantTypes, result.Raw)
+		}
+	}
+}
+
+func TestCleanJSONSchemaForAntigravityResponsePreservesEnumType(t *testing.T) {
+	input := `{
+		"type":"object",
+		"properties":{
+			"conviction":{"type":"number","enum":[0.25,0.5,1]},
+			"count":{"type":"integer","enum":[1,2]}
+		}
+	}`
+
+	result := gjson.Parse(CleanJSONSchemaForAntigravityResponse(input))
+	for _, testCase := range []struct {
+		path       string
+		wantType   string
+		wantValues []string
+	}{
+		{path: "properties.conviction", wantType: "number", wantValues: []string{"0.25", "0.5", "1"}},
+		{path: "properties.count", wantType: "integer", wantValues: []string{"1", "2"}},
+	} {
+		schema := result.Get(testCase.path)
+		if gotType := schema.Get("type").String(); gotType != testCase.wantType {
+			t.Errorf("%s type = %q, want %q: %s", testCase.path, gotType, testCase.wantType, result.Raw)
+		}
+		var gotValues []string
+		for _, enumValue := range schema.Get("enum").Array() {
+			if enumValue.Type != gjson.String {
+				t.Errorf("%s enum value is not a string: %s", testCase.path, enumValue.Raw)
+			}
+			gotValues = append(gotValues, enumValue.String())
+		}
+		if !reflect.DeepEqual(gotValues, testCase.wantValues) {
+			t.Errorf("%s enum values = %v, want %v: %s", testCase.path, gotValues, testCase.wantValues, result.Raw)
+		}
+	}
+}
+
 // ============================================================================
 // Format field handling (ad-hoc patch removal)
 // ============================================================================
@@ -862,6 +932,14 @@ func TestCleanJSONSchemaForAntigravity_NumericEnumToString(t *testing.T) {
 	}`
 
 	result := CleanJSONSchemaForAntigravity(input)
+	parsed := gjson.Parse(result)
+
+	// Tool enum schemas require both string values and a string type.
+	for _, path := range []string{"properties.priority", "properties.level"} {
+		if gotType := parsed.Get(path + ".type").String(); gotType != "string" {
+			t.Errorf("Tool enum type at %s = %q, want string: %s", path, gotType, result)
+		}
+	}
 
 	// Numeric enum values should be converted to strings
 	if strings.Contains(result, `"enum":[0,1,2]`) {

--- a/sdk/cliproxy/config_model_display_name_test.go
+++ b/sdk/cliproxy/config_model_display_name_test.go
@@ -68,31 +68,20 @@ func TestBuildConfigModelsDisplayName(t *testing.T) {
 	}
 }
 
-func TestBuildCodexConfigModelsPreservesBuiltinDisplayNames(t *testing.T) {
-	models := buildCodexConfigModels(&config.CodexKey{Models: []config.CodexModel{
-		{Name: "gpt-image-1.5", DisplayName: "Configured Image 1.5"},
-		{Name: "gpt-image-2", DisplayName: "Configured Image 2"},
-	}})
+func TestBuildCodexConfigModelsOnlyIncludesConfiguredModels(t *testing.T) {
+	models := buildCodexConfigModels(&config.CodexKey{Models: []config.CodexModel{{
+		Name: "upstream-codex", Alias: "configured-codex",
+	}}})
 
-	wantDisplayNames := map[string]string{
-		"gpt-image-1.5": "Configured Image 1.5",
-		"gpt-image-2":   "Configured Image 2",
+	if len(models) != 1 {
+		t.Fatalf("model count = %d, want 1", len(models))
 	}
-	for _, model := range models {
-		wantDisplayName, ok := wantDisplayNames[model.ID]
-		if !ok {
-			continue
-		}
-		if model.DisplayName != wantDisplayName {
-			t.Errorf("%s DisplayName = %q, want %q", model.ID, model.DisplayName, wantDisplayName)
-		}
-		if model.Object != "model" || model.OwnedBy != "openai" || model.Type != "openai" || model.Created != 1704067200 || model.Version != model.ID || model.UserDefined {
-			t.Errorf("%s builtin metadata was not preserved: %#v", model.ID, model)
-		}
-		delete(wantDisplayNames, model.ID)
+	if models[0].ID != "configured-codex" {
+		t.Fatalf("model ID = %q, want configured-codex", models[0].ID)
 	}
-	for modelID := range wantDisplayNames {
-		t.Errorf("missing builtin model %s", modelID)
+
+	if models := buildCodexConfigModels(&config.CodexKey{}); len(models) != 0 {
+		t.Fatalf("model count without configuration = %d, want 0", len(models))
 	}
 }
 

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -113,6 +113,17 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 		}
 		models = applyExcludedModels(models, excluded)
 	case "codex":
+		if authKind == "apikey" {
+			if entry := s.resolveConfigCodexKey(a); entry != nil {
+				models = buildCodexConfigModels(entry)
+				excluded = entry.ExcludedModels
+			} else {
+				models = nil
+			}
+			models = applyExcludedModels(models, excluded)
+			break
+		}
+
 		codexPlanType := ""
 		if a.Attributes != nil {
 			codexPlanType = strings.TrimSpace(a.Attributes["plan_type"])
@@ -128,14 +139,6 @@ func (s *Service) registerModelsForAuthWithCache(ctx context.Context, a *coreaut
 			models = registry.GetCodexFreeModels()
 		default:
 			models = registry.GetCodexProModels()
-		}
-		if entry := s.resolveConfigCodexKey(a); entry != nil {
-			if len(entry.Models) > 0 {
-				models = buildCodexConfigModels(entry)
-			}
-			if authKind == "apikey" {
-				excluded = entry.ExcludedModels
-			}
 		}
 		models = applyExcludedModels(models, excluded)
 	case "kimi":
@@ -774,7 +777,7 @@ func buildCodexConfigModels(entry *config.CodexKey) []*ModelInfo {
 		return nil
 	}
 
-	models := registry.WithCodexBuiltins(buildConfigModels(entry.Models, "openai", "openai"))
+	models := buildConfigModels(entry.Models, "openai", "openai")
 	configuredDisplayNames := make(map[string]string, len(entry.Models))
 	seenConfiguredModels := make(map[string]struct{}, len(entry.Models))
 	for i := range entry.Models {


### PR DESCRIPTION
## 结果与合并约束

本 PR 是 2026-07-30 protected full-sync 在最终复查时发现 upstream 漂移后的补充第 4/4 段，将 CPA-Core-LTS 从 upstream `4a2eb54dc6bf943196be4fb515e6a9407a4db143`（v7.2.105）推进到 `2b63d6bcda136af1d3638be8e0038658911fb217`（v7.2.106）。本段吸收 Codex API-key credential 仅暴露显式配置模型的修复，以及 Antigravity response schema union / enum type 保真修复。

本 PR 必须使用 **Create a merge commit**，禁止 squash 或 rebase。当前仅为已推送 PR；尚未合入 `main`，未 tag、未 release、未 deploy。

## Type

- [x] Protected upstream full-sync
- [x] Staged upstream full-sync
- [ ] LTS protected-delta patch
- [ ] LTS feature / downstream patch maintenance
- [ ] Maintenance docs / CI
- [ ] Emergency hotfix

## Upstream sync info

- Upstream repo / branch: `router-for-me/CLIProxyAPI` / `main`
- Upstream from SHA: `4a2eb54dc6bf943196be4fb515e6a9407a4db143`
- Upstream to SHA: `2b63d6bcda136af1d3638be8e0038658911fb217`
- Upstream tag: `v7.2.106`
- Sync branch: `codex/sync-upstream-stage-4-v7.2.106`
- Stage: 4 / 4（最终 fetch 发现的新漂移补充段）
- Range: 2 个 first-parent commits、2 个 non-merge commits。

## Diff 分类与取舍

| Upstream item | LTS class | Decision | Reason |
|---|---|---|---|
| `8cdd3f1d` / PR #4659：Codex API-key configured models only | ordinary upstream fix + model-resolution review seam | absorbed | API-key endpoint 只注册显式配置的模型，避免把不受该 endpoint 支持的 built-in IDs 误暴露；OAuth/plan catalog 逻辑保持不变，符合 LTS fail-closed 与真实 capability 原则。 |
| `2b63d6bc`：structured JSON schema cleaning options | ordinary upstream runtime fix | absorbed | tool schema 继续执行 union flatten / enum string coercion；response schema 不再套用 tool-only rewrite，保留 client structured-output union 和声明类型。 |

没有采用不同 downstream 解法需要覆盖的部分，也没有 sponsor/affiliate、usage 外置化、Management API 降级或 Panel source 变化。

## Protected delta review

- retained capabilities: **preserved**；完整 usage statistics、Management usage/export/import、auth attribution、Panel response shape 和 Panel source 均未被触碰。
- LTS-owned features: **preserved**；Codex fallback、rate-limit continuity、abnormal reasoning retry、selected-auth、WebSocket metadata 等实现未被修改。
- shared review seams: **reviewed**；`sdk/cliproxy/service_models.go` 的 API-key model registration 属于 model resolution seam；配置匹配仍复用 `resolveConfigCodexKey`，OAuth/plan catalog 保持原逻辑。
- downstream patches: **patch-still-required**；本段没有提供任何 active ledger patch 的完整 upstream 等价实现，`codex-gpt56-ultra-level`、`codex-model-fallback`、`codex-rate-limit-continuity` 等均不满足退休条件。
- validation profiles: contract、registry、usage/Management、targeted、race、build 与两种 repo-wide test 均在 exact head 通过；HF Space smoke 未运行，因为本任务未授权部署。
- upstream ordinary changes: **absorbed**；无文件级覆盖、无 cherry-pick、无文本冲突。

## Conflict resolution notes

- 文本冲突：无。
- merge 方式：`git merge --no-ff --log 2b63d6bcda136af1d3638be8e0038658911fb217`，保留 upstream ancestry。
- 变更文件：5 个；仅涉及 Antigravity schema sanitizer tests/util 与 SDK Codex model registration/tests。

## Exact-head 验证

以下命令均在 `766be99d5800221368e5e61ee0ddb1b117b6e02a` 通过：

- [x] `scripts/check-lts-contract.sh`
- [x] `go run ./scripts/ltsregistry --root .`
- [x] `go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'`
- [x] `go test ./internal/util ./internal/runtime/executor ./sdk/cliproxy/...`
- [x] `go test -race ./internal/runtime/executor ./sdk/cliproxy -count=1`
- [x] `go test ./...`
- [x] `go list ./... | rg -v '/tmp$' | xargs go test -count=1`
- [x] `go build -o test-output ./cmd/server`（验证后已清理产物）
- [x] `git diff --check origin/main...HEAD`

## Merge 与交付边界

- [x] 必须使用 **Create a merge commit**。
- [x] `upstream/main` / v7.2.106 已作为 merge parent 可达。
- [x] HF Space smoke 明确跳过：未授权部署。
- 未执行 tag、release、artifact 发布、部署或 runtime acceptance。
