### PR TITLE
fix(codex): 收紧 Multi-Agent plaintext 与工具 namespace 契约

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -232,9 +232,9 @@ codex:
   # Disable forcing the official Codex User-Agent and Originator headers on HTTP/SSE and WebSocket requests.
   disable-codex-cloaking: false
   # When true, optimize Codex Desktop and codex-tui requests for multi-agent v2.
-  # This refreshes Codex spawn_agent model details, removes message parameter encryption,
-  # normalizes encrypted agent_message content for Codex, and converts agent_message input
-  # into standard user messages for non-Codex upstream protocols.
+  # This refreshes Codex spawn_agent model details, requests plaintext message arguments,
+  # and converts only fully plaintext agent_message input. Opaque encrypted or mixed
+  # content is preserved.
   optimize-multi-agent-v2: false
   # Project selected Codex Desktop codex_app tools into eligible non-GPT root
   # requests after credential selection. Disabled by default; Desktop GPT/Code

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -850,3 +850,37 @@ patches:
     upstream_issue_or_pr: not-filed
     state: required
     retire_when: Upstream or the official client path gives non-GPT Direct models an equivalent explicitly bounded codex_app child surface, preserves byte-for-byte no-op behavior for GPT, Code Mode, subagents, malformed or ambiguous metadata, and forbidden tool surfaces, retains provider request and response namespace round trips, and all listed regressions pass after removing the downstream overlay.
+
+  - id: codex-multi-agent-plaintext-contract
+    reason: Codex Multi-Agent history and message-tool schemas carry plaintext provenance that must not be inferred from an encrypted_content string or an unqualified short tool name. LTS therefore converts agent_message only when every content part is a non-empty string input_text, preserves opaque or mixed history on native Codex and provider paths, and removes only a JSON boolean-true message.encrypted marker from positively identified collaboration, collaboration-optimize, or complete agents namespaces.
+    introduced_in: 798ad1854064361461225fe766db9b2f54a7653d
+    affected_upstream_range: through ffdb9c9fbc78a6235d59c9ccbdc4243ba35ecdcd (v7.2.115, 2026-08-03); upstream PR #4748 rewrites string encrypted_content parts without plaintext provenance, discovers message tools by recursive short-name matching across unrelated tool surfaces, and deletes message.encrypted without requiring JSON boolean true.
+    files:
+      - config.example.yaml
+      - docs/lts/downstream-patches.yaml
+      - internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2.go
+      - internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2_test.go
+      - internal/runtime/executor/codex_executor_spawn_agent_test.go
+      - internal/runtime/executor/codex_websockets_spawn_agent_test.go
+      - internal/runtime/executor/helps/codex_multi_agent_v2.go
+      - internal/runtime/executor/xai_executor_test.go
+    regression_tests:
+      - TestRewriteCodexMultiAgentV2MessageEncryptionNamespacesAndToolNames
+      - TestRewriteCodexMultiAgentV2MessageEncryptionAdditionalToolsAndGates
+      - TestRewriteCodexSpawnAgentDescriptionIgnoresTopLevelSameNameTool
+      - TestOptimizeCodexMultiAgentV2RequestPreservesNativeAgentMessage
+      - TestRewriteCodexMultiAgentV2InputRewritesAgentMessage
+      - TestRewriteCodexMultiAgentV2InputFailsClosedForOpaqueOrInvalidContent
+      - TestTranslateRequestWithCodexMultiAgentV2Conditions
+      - TestCodexMultiAgentMessageToolPathsRequireConfirmedNamespaces
+      - TestRewriteCodexMultiAgentMessageEncryptionDeletesOnlyBooleanTrue
+      - TestOptimizeCodexMultiAgentV2RequestRemovesEncryptionWithoutSpawnAgent
+      - TestOptimizeCodexMultiAgentV2RequestRemovesEncryptionInAdditionalTools
+      - TestOptimizeCodexMultiAgentV2RequestIgnoresUnconfirmedSameNameTools
+      - TestCodexExecutorOptimizeMultiAgentV2
+      - TestCodexWebsocketsExecutorOptimizeMultiAgentV2
+      - TestXAIExecutorPrepareResponsesRequestRewritesPlaintextCodexAgentMessage
+      - TestXAIExecutorPrepareResponsesRequestPreservesOpaqueCodexAgentMessage
+    upstream_issue_or_pr: router-for-me/CLIProxyAPI#4748
+    state: required
+    retire_when: Upstream converts only fully proven plaintext agent_message content, preserves opaque, encrypted, mixed, empty, and malformed history, limits spawn/message rewrites to equivalent positively identified Multi-Agent namespaces, removes only boolean-true message.encrypted markers without changing ordinary, MCP, custom, top-level, or incomplete agents tools, preserves native Codex HTTP and WebSocket history, and all listed regressions pass after removing the downstream implementation.

--- a/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2.go
+++ b/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2.go
@@ -22,15 +22,13 @@ import (
 const (
 	codexSpawnAgentDescriptionMarker      = "Spawns an agent"
 	codexSpawnAgentModelsHeading          = "Available model overrides (optional; inherited parent model is preferred):"
+	codexAgentsNamespace                  = "agents"
 	codexCollaborationNamespace           = "collaboration"
 	codexOptimizedCollaborationNamespace  = "collaboration-optimize"
 	codexOptimizedCollaborationNamePrefix = codexOptimizedCollaborationNamespace + "__"
 )
 
-// codexCollaborationMessageTools are the collaboration tool names whose
-// parameters.properties.message.encrypted field must be stripped so that
-// message content remains readable by the proxy.
-var codexCollaborationMessageTools = map[string]struct{}{
+var codexMultiAgentMessageToolNames = map[string]struct{}{
 	"spawn_agent":   {},
 	"send_message":  {},
 	"followup_task": {},
@@ -63,14 +61,27 @@ func RewriteCodexMultiAgentV2Input(ctx context.Context, headers http.Header, pay
 	if !codexMultiAgentV2Enabled(ctx, headers, cfg) {
 		return payload
 	}
-	return rewriteCodexAgentMessageInput(payload)
+	return rewriteCodexAgentMessageInput(payload, "assistant", "output_text")
+}
+
+// RewriteCodexMultiAgentV2MessageEncryption removes a Codex-only marker from
+// positively identified Multi-Agent message schemas for eligible clients.
+func RewriteCodexMultiAgentV2MessageEncryption(ctx context.Context, headers http.Header, payload []byte, cfg *config.Config) []byte {
+	if !codexMultiAgentV2Enabled(ctx, headers, cfg) {
+		return payload
+	}
+	return rewriteCodexMultiAgentMessageEncryption(payload)
 }
 
 // TranslateRequestWithCodexMultiAgentV2 normalizes official Codex multi-agent
 // input before translating it to a non-Codex target protocol.
 func TranslateRequestWithCodexMultiAgentV2(ctx context.Context, headers http.Header, cfg *config.Config, from, to sdktranslator.Format, model string, payload []byte, stream bool) []byte {
 	if from == sdktranslator.FormatOpenAIResponse && to != sdktranslator.FormatCodex && to != sdktranslator.FormatOpenAIResponse {
-		payload = RewriteCodexMultiAgentV2Input(ctx, headers, payload, cfg)
+		if codexMultiAgentV2Enabled(ctx, headers, cfg) {
+			// Non-Responses targets need a request-turn boundary. Only proven
+			// plaintext is converted; opaque or mixed content remains untouched.
+			payload = rewriteCodexAgentMessageInput(payload, "user", "input_text")
+		}
 	}
 	return sdktranslator.TranslateRequest(from, to, model, payload, stream)
 }
@@ -81,8 +92,9 @@ func OptimizeCodexMultiAgentV2Request(ctx context.Context, headers http.Header, 
 	if !codexMultiAgentV2Enabled(ctx, headers, cfg) {
 		return payload, false
 	}
-	updated := rewriteCodexAgentMessageContent(payload)
-	updated = removeCodexCollaborationMessageEncryption(updated, codexCollaborationMessageToolPaths(updated))
+	// Keep native Codex agent_message history intact. Provider-specific
+	// boundaries perform any proven-plaintext conversion explicitly.
+	updated := rewriteCodexMultiAgentMessageEncryption(payload)
 	toolPaths := codexSpawnAgentToolPaths(updated)
 	if len(toolPaths) == 0 || hasCodexOptimizedCollaborationConflict(updated) {
 		return updated, false
@@ -401,7 +413,8 @@ func mapInt(values map[string]any, key string) int {
 }
 
 func rewriteCodexSpawnAgentDescription(payload []byte, models []codexSpawnAgentModel) []byte {
-	return rewriteCodexSpawnAgentTools(payload, codexSpawnAgentToolPaths(payload), models)
+	updated := rewriteCodexMultiAgentMessageEncryption(payload)
+	return rewriteCodexSpawnAgentTools(updated, codexSpawnAgentToolPaths(updated), models)
 }
 
 func rewriteCodexSpawnAgentTools(payload []byte, toolPaths []string, models []codexSpawnAgentModel) []byte {
@@ -422,12 +435,6 @@ func rewriteCodexSpawnAgentTools(payload []byte, toolPaths []string, models []co
 					return payload
 				}
 			}
-		}
-
-		var errDelete error
-		updated, errDelete = sjson.DeleteBytes(updated, toolPath+".parameters.properties.message.encrypted")
-		if errDelete != nil {
-			return payload
 		}
 	}
 	return updated
@@ -551,20 +558,23 @@ func restoreCodexCollaborationValue(value any) bool {
 	return changed
 }
 
-func rewriteCodexAgentMessageInput(payload []byte) []byte {
+func rewriteCodexAgentMessageInput(payload []byte, role, contentType string) []byte {
 	input := gjson.GetBytes(payload, "input")
 	if !input.IsArray() {
 		return payload
 	}
 
-	updated := rewriteCodexAgentMessageContent(payload)
+	updated := rewriteCodexAgentMessageContent(payload, contentType)
 	for itemIndex, item := range input.Array() {
 		if strings.TrimSpace(item.Get("type").String()) != "agent_message" {
 			continue
 		}
+		if _, ok := codexPlaintextAgentMessageText(item); !ok {
+			continue
+		}
 		itemPath := fmt.Sprintf("input.%d", itemIndex)
 		var errSet error
-		updated, errSet = sjson.SetBytes(updated, itemPath+".role", "user")
+		updated, errSet = sjson.SetBytes(updated, itemPath+".role", role)
 		if errSet != nil {
 			return payload
 		}
@@ -572,11 +582,17 @@ func rewriteCodexAgentMessageInput(payload []byte) []byte {
 		if errSet != nil {
 			return payload
 		}
+		for _, field := range []string{"author", "recipient", "id", "internal_chat_message_metadata_passthrough"} {
+			updated, errSet = sjson.DeleteBytes(updated, itemPath+"."+field)
+			if errSet != nil {
+				return payload
+			}
+		}
 	}
 	return updated
 }
 
-func rewriteCodexAgentMessageContent(payload []byte) []byte {
+func rewriteCodexAgentMessageContent(payload []byte, contentType string) []byte {
 	input := gjson.GetBytes(payload, "input")
 	if !input.IsArray() {
 		return payload
@@ -587,51 +603,65 @@ func rewriteCodexAgentMessageContent(payload []byte) []byte {
 		if strings.TrimSpace(item.Get("type").String()) != "agent_message" {
 			continue
 		}
-		content := item.Get("content")
-		if !content.IsArray() {
+		text, ok := codexPlaintextAgentMessageText(item)
+		if !ok {
 			continue
 		}
-		for partIndex, part := range content.Array() {
-			if strings.TrimSpace(part.Get("type").String()) != "encrypted_content" {
-				continue
-			}
-			encryptedContent := part.Get("encrypted_content")
-			if encryptedContent.Type != gjson.String {
-				continue
-			}
-			partPath := fmt.Sprintf("input.%d.content.%d", itemIndex, partIndex)
-			var errSet error
-			updated, errSet = sjson.SetBytes(updated, partPath+".type", "input_text")
-			if errSet != nil {
-				return payload
-			}
-			updated, errSet = sjson.SetBytes(updated, partPath+".text", encryptedContent.String())
-			if errSet != nil {
-				return payload
-			}
-			updated, errSet = sjson.DeleteBytes(updated, partPath+".encrypted_content")
-			if errSet != nil {
-				return payload
-			}
+		content, errMarshal := json.Marshal([]map[string]string{{
+			"type": contentType,
+			"text": text,
+		}})
+		if errMarshal != nil {
+			return payload
+		}
+		var errSet error
+		updated, errSet = sjson.SetRawBytes(updated, fmt.Sprintf("input.%d.content", itemIndex), content)
+		if errSet != nil {
+			return payload
 		}
 	}
 	return updated
 }
 
+func codexPlaintextAgentMessageText(item gjson.Result) (string, bool) {
+	content := item.Get("content")
+	if !content.IsArray() {
+		return "", false
+	}
+	parts := content.Array()
+	if len(parts) == 0 {
+		return "", false
+	}
+
+	var text strings.Builder
+	for index, part := range parts {
+		partText := part.Get("text")
+		if strings.TrimSpace(part.Get("type").String()) != "input_text" ||
+			partText.Type != gjson.String || strings.TrimSpace(partText.String()) == "" {
+			return "", false
+		}
+		if index > 0 {
+			text.WriteByte('\n')
+		}
+		text.WriteString(partText.String())
+	}
+	return text.String(), true
+}
+
 func codexSpawnAgentToolPaths(payload []byte) []string {
-	return codexToolPathsByNames(payload, map[string]struct{}{"spawn_agent": {}})
+	return codexMultiAgentToolPaths(payload, map[string]struct{}{"spawn_agent": {}})
 }
 
-// codexCollaborationMessageToolPaths discovers function tools named
-// spawn_agent, send_message, or followup_task inside top-level tools arrays and
-// input[].additional_tools arrays, including nested namespace tools.
-func codexCollaborationMessageToolPaths(payload []byte) []string {
-	return codexToolPathsByNames(payload, codexCollaborationMessageTools)
+func codexMultiAgentMessageToolPaths(payload []byte) []string {
+	return codexMultiAgentToolPaths(payload, codexMultiAgentMessageToolNames)
 }
 
-func codexToolPathsByNames(payload []byte, names map[string]struct{}) []string {
+func codexMultiAgentToolPaths(payload []byte, names map[string]struct{}) []string {
+	if !gjson.ValidBytes(payload) {
+		return nil
+	}
 	paths := make([]string, 0, len(names))
-	collectCodexToolPathsByNames(gjson.GetBytes(payload, "tools"), "tools", &paths, names)
+	collectCodexMultiAgentToolPaths(gjson.GetBytes(payload, "tools"), "tools", &paths, names)
 
 	input := gjson.GetBytes(payload, "input")
 	if input.IsArray() {
@@ -639,38 +669,74 @@ func codexToolPathsByNames(payload []byte, names map[string]struct{}) []string {
 			if strings.TrimSpace(item.Get("type").String()) != "additional_tools" {
 				continue
 			}
-			collectCodexToolPathsByNames(item.Get("tools"), fmt.Sprintf("input.%d.tools", index), &paths, names)
+			collectCodexMultiAgentToolPaths(item.Get("tools"), fmt.Sprintf("input.%d.tools", index), &paths, names)
 		}
 	}
 	return paths
 }
 
-func collectCodexToolPathsByNames(tools gjson.Result, path string, paths *[]string, names map[string]struct{}) {
+func collectCodexMultiAgentToolPaths(tools gjson.Result, path string, paths *[]string, names map[string]struct{}) {
 	if !tools.IsArray() {
 		return
 	}
 	for index, tool := range tools.Array() {
 		toolPath := fmt.Sprintf("%s.%d", path, index)
-		toolType := strings.TrimSpace(tool.Get("type").String())
-		if toolType == "function" {
-			if _, ok := names[strings.TrimSpace(tool.Get("name").String())]; ok {
-				*paths = append(*paths, toolPath)
+		if strings.TrimSpace(tool.Get("type").String()) != "namespace" {
+			continue
+		}
+		childTools := tool.Get("tools")
+		if isCodexMultiAgentNamespace(tool.Get("name").String(), childTools) {
+			for childIndex, child := range childTools.Array() {
+				if strings.TrimSpace(child.Get("type").String()) != "function" {
+					continue
+				}
+				if _, ok := names[strings.TrimSpace(child.Get("name").String())]; ok {
+					*paths = append(*paths, fmt.Sprintf("%s.tools.%d", toolPath, childIndex))
+				}
 			}
 		}
-		if toolType == "namespace" {
-			collectCodexToolPathsByNames(tool.Get("tools"), toolPath+".tools", paths, names)
-		}
+		// Nested namespaces are evaluated independently; eligibility never
+		// inherits from an outer namespace.
+		collectCodexMultiAgentToolPaths(childTools, toolPath+".tools", paths, names)
 	}
 }
 
-// removeCodexCollaborationMessageEncryption deletes the
-// parameters.properties.message.encrypted field from each discovered
-// collaboration message tool so the proxy can read the plaintext message.
-func removeCodexCollaborationMessageEncryption(payload []byte, toolPaths []string) []byte {
+func isCodexMultiAgentNamespace(name string, tools gjson.Result) bool {
+	name = strings.TrimSpace(name)
+	if name == codexCollaborationNamespace || name == codexOptimizedCollaborationNamespace {
+		return true
+	}
+	if name != codexAgentsNamespace || !tools.IsArray() {
+		return false
+	}
+
+	seen := make(map[string]struct{}, len(codexMultiAgentMessageToolNames))
+	for _, tool := range tools.Array() {
+		if strings.TrimSpace(tool.Get("type").String()) != "function" {
+			continue
+		}
+		toolName := strings.TrimSpace(tool.Get("name").String())
+		if _, ok := codexMultiAgentMessageToolNames[toolName]; ok {
+			seen[toolName] = struct{}{}
+		}
+	}
+	for toolName := range codexMultiAgentMessageToolNames {
+		if _, ok := seen[toolName]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func rewriteCodexMultiAgentMessageEncryption(payload []byte) []byte {
 	updated := payload
-	for _, toolPath := range toolPaths {
+	for _, toolPath := range codexMultiAgentMessageToolPaths(payload) {
+		markerPath := toolPath + ".parameters.properties.message.encrypted"
+		if gjson.GetBytes(updated, markerPath).Type != gjson.True {
+			continue
+		}
 		var errDelete error
-		updated, errDelete = sjson.DeleteBytes(updated, toolPath+".parameters.properties.message.encrypted")
+		updated, errDelete = sjson.DeleteBytes(updated, markerPath)
 		if errDelete != nil {
 			return payload
 		}

--- a/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2_test.go
+++ b/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2_test.go
@@ -2,6 +2,7 @@ package multiagentv2
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -207,6 +208,103 @@ func TestRewriteCodexSpawnAgentDescriptionTopLevelWithoutMarker(t *testing.T) {
 	}
 }
 
+func TestRewriteCodexMultiAgentV2MessageEncryptionNamespacesAndToolNames(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`{"tools":[
+		{"type":"namespace","name":"agents","tools":[
+			{"type":"function","name":"spawn_agent","parameters":{"properties":{"message":{"encrypted":true}}}},
+			{"type":"function","name":"send_message","parameters":{"properties":{"message":{"encrypted":true}}}},
+			{"type":"function","name":"followup_task","parameters":{"properties":{"message":{"encrypted":true}}}}
+		]},
+		{"type":"namespace","name":"collaboration","tools":[
+			{"type":"function","name":"send_message","parameters":{"properties":{"message":{"encrypted":true}}}},
+			{"type":"function","name":"followup_task","parameters":{"properties":{"message":{"encrypted":true}}}}
+		]},
+		{"type":"namespace","name":"collaboration-optimize","tools":[
+			{"type":"function","name":"spawn_agent","parameters":{"properties":{"message":{"encrypted":true}}}}
+		]},
+		{"type":"namespace","name":"custom-agents","tools":[
+			{"type":"function","name":"spawn_agent","parameters":{"properties":{"message":{"encrypted":true}}}},
+			{"type":"function","name":"send_message","parameters":{"properties":{"message":{"encrypted":true}}}},
+			{"type":"function","name":"followup_task","parameters":{"properties":{"message":{"encrypted":true}}}}
+		]},
+		{"type":"namespace","name":"agents","tools":[
+			{"type":"function","name":"spawn_agent","parameters":{"properties":{"message":{"encrypted":true}}}}
+		]},
+		{"type":"namespace","name":"ordinary","tools":[
+			{"type":"function","name":"send_message","parameters":{"properties":{"message":{"encrypted":true}}}}
+		]},
+		{"type":"namespace","name":"mcp__test","tools":[
+			{"type":"function","name":"followup_task","parameters":{"properties":{"message":{"encrypted":true}}}}
+		]},
+		{"type":"namespace","name":"COLLABORATION","tools":[
+			{"type":"function","name":"spawn_agent","parameters":{"properties":{"message":{"encrypted":true}}}}
+		]},
+		{"type":"function","name":"spawn_agent","parameters":{"properties":{"message":{"encrypted":true}}}}
+	]}`)
+	headers := http.Header{"User-Agent": []string{"Codex Desktop/0.146.0-alpha.3"}}
+	cfg := &config.Config{Codex: config.CodexConfig{OptimizeMultiAgentV2: true}}
+	got := RewriteCodexMultiAgentV2MessageEncryption(context.Background(), headers, payload, cfg)
+
+	for _, path := range []string{
+		"tools.0.tools.0", "tools.0.tools.1", "tools.0.tools.2",
+		"tools.1.tools.0", "tools.1.tools.1", "tools.2.tools.0",
+	} {
+		if marker := gjson.GetBytes(got, path+".parameters.properties.message.encrypted"); marker.Exists() {
+			t.Fatalf("eligible marker at %s was preserved: %s", path, got)
+		}
+	}
+	for _, path := range []string{
+		"tools.3.tools.0", "tools.3.tools.1", "tools.3.tools.2",
+		"tools.4.tools.0", "tools.5.tools.0", "tools.6.tools.0",
+		"tools.7.tools.0", "tools.8",
+	} {
+		if marker := gjson.GetBytes(got, path+".parameters.properties.message.encrypted"); marker.Type != gjson.True {
+			t.Fatalf("unrelated marker at %s changed: %s", path, got)
+		}
+	}
+	if repeated := RewriteCodexMultiAgentV2MessageEncryption(context.Background(), headers, got, cfg); string(repeated) != string(got) {
+		t.Fatalf("second rewrite was not idempotent: %s", repeated)
+	}
+}
+
+func TestRewriteCodexMultiAgentV2MessageEncryptionAdditionalToolsAndGates(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`{"input":[{"type":"additional_tools","tools":[{"type":"namespace","name":"collaboration","tools":[{"type":"function","name":"send_message","parameters":{"properties":{"message":{"encrypted":true},"data":{"encrypted":"keep"}}}}]}]}]}`)
+	headers := http.Header{"User-Agent": []string{"codex-tui/0.145.0"}}
+	cfg := &config.Config{Codex: config.CodexConfig{OptimizeMultiAgentV2: true}}
+	got := RewriteCodexMultiAgentV2MessageEncryption(context.Background(), headers, payload, cfg)
+	if marker := gjson.GetBytes(got, "input.0.tools.0.tools.0.parameters.properties.message.encrypted"); marker.Exists() {
+		t.Fatalf("additional_tools marker was preserved: %s", got)
+	}
+	if other := gjson.GetBytes(got, "input.0.tools.0.tools.0.parameters.properties.data.encrypted").String(); other != "keep" {
+		t.Fatalf("unrelated encrypted field changed: %q", other)
+	}
+
+	for _, tt := range []struct {
+		name    string
+		headers http.Header
+		cfg     *config.Config
+	}{
+		{name: "disabled", headers: headers, cfg: &config.Config{}},
+		{name: "unrelated client", headers: http.Header{"User-Agent": []string{"curl/8.7.1"}}, cfg: cfg},
+		{name: "nil config", headers: headers},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			unchanged := RewriteCodexMultiAgentV2MessageEncryption(context.Background(), tt.headers, payload, tt.cfg)
+			if string(unchanged) != string(payload) {
+				t.Fatalf("ineligible request changed: %s", unchanged)
+			}
+		})
+	}
+	malformed := []byte(`{"tools":[`)
+	if gotMalformed := RewriteCodexMultiAgentV2MessageEncryption(context.Background(), headers, malformed, cfg); string(gotMalformed) != string(malformed) {
+		t.Fatalf("malformed payload changed: %s", gotMalformed)
+	}
+}
+
 func TestCodexSpawnAgentToolPathsIgnoreInvalidContainers(t *testing.T) {
 	t.Parallel()
 
@@ -252,7 +350,7 @@ func TestOptimizeCodexCollaborationNamespaceWithoutModels(t *testing.T) {
 	}
 }
 
-func TestRewriteCodexSpawnAgentDescriptionWithoutModelsStillRemovesEncrypted(t *testing.T) {
+func TestRewriteCodexSpawnAgentDescriptionIgnoresTopLevelSameNameTool(t *testing.T) {
 	t.Parallel()
 
 	payload := []byte(`{"tools":[{"type":"function","name":"spawn_agent","description":"unchanged","parameters":{"properties":{"message":{"encrypted":true}}}}]}`)
@@ -260,8 +358,8 @@ func TestRewriteCodexSpawnAgentDescriptionWithoutModelsStillRemovesEncrypted(t *
 	if description := gjson.GetBytes(got, "tools.0.description").String(); description != "unchanged" {
 		t.Fatalf("description = %q, want unchanged", description)
 	}
-	if encrypted := gjson.GetBytes(got, "tools.0.parameters.properties.message.encrypted"); encrypted.Exists() {
-		t.Fatalf("message encrypted was not removed: %s", encrypted.Raw)
+	if encrypted := gjson.GetBytes(got, "tools.0.parameters.properties.message.encrypted"); encrypted.Type != gjson.True {
+		t.Fatalf("top-level same-name marker changed: %s", got)
 	}
 }
 
@@ -309,7 +407,7 @@ func TestRewriteCodexSpawnAgentDescriptionEnabledOptimizesTool(t *testing.T) {
 	}
 }
 
-func TestOptimizeCodexMultiAgentV2RequestNormalizesAgentMessageContentOnly(t *testing.T) {
+func TestOptimizeCodexMultiAgentV2RequestPreservesNativeAgentMessage(t *testing.T) {
 	t.Parallel()
 
 	payload := []byte(`{"input":[{"type":"agent_message","id":"amsg_1","author":"/root","recipient":"/root/worker","content":[{"type":"input_text","text":"Payload:\n"},{"type":"encrypted_content","encrypted_content":"delegated task"}],"internal_chat_message_metadata_passthrough":{"turn_id":"turn_1"}}]}`)
@@ -323,11 +421,8 @@ func TestOptimizeCodexMultiAgentV2RequestNormalizesAgentMessageContentOnly(t *te
 	if message.Get("type").String() != "agent_message" || message.Get("role").Exists() {
 		t.Fatalf("outer agent message changed: %s", got)
 	}
-	if message.Get("content.1.type").String() != "input_text" || message.Get("content.1.text").String() != "delegated task" {
-		t.Fatalf("encrypted content was not normalized: %s", got)
-	}
-	if message.Get("content.1.encrypted_content").Exists() {
-		t.Fatalf("encrypted_content was preserved: %s", got)
+	if message.Get("content.1.type").String() != "encrypted_content" || message.Get("content.1.encrypted_content").String() != "delegated task" {
+		t.Fatalf("native opaque content changed: %s", got)
 	}
 	if message.Get("author").String() != "/root" || message.Get("recipient").String() != "/root/worker" || message.Get("internal_chat_message_metadata_passthrough.turn_id").String() != "turn_1" {
 		t.Fatalf("agent message metadata changed: %s", got)
@@ -393,14 +488,14 @@ func TestRewriteCodexMultiAgentV2InputRewritesAgentMessage(t *testing.T) {
 
 	payload := []byte(`{"model":"gpt-5.4","input":[{
 		"type":"agent_message",
-		"id":"amsg_019f92ae-84fd-76f0-aa66-5a722dee382e",
+		"id":"amsg_1",
 		"author":"/root",
 		"recipient":"/root/arithmetic_problem",
 		"content":[
 			{"type":"input_text","text":"Message Type: NEW_TASK\nTask name: /root/arithmetic_problem\nSender: /root\nPayload:\n"},
-			{"type":"encrypted_content","encrypted_content":"请出一道四则运算题，并给出答案。全程使用简体中文，题目简洁。"}
+			{"type":"input_text","text":"请出一道四则运算题，并给出答案。全程使用简体中文，题目简洁。"}
 		],
-		"internal_chat_message_metadata_passthrough":{"turn_id":"019f92ae-7eae-7371-957e-8f6f734edddc"}
+		"internal_chat_message_metadata_passthrough":{"turn_id":"turn_1"}
 	}]}`)
 	headers := http.Header{"User-Agent": []string{"Codex Desktop/0.146.0-alpha.3"}}
 	cfg := &config.Config{Codex: config.CodexConfig{OptimizeMultiAgentV2: true}}
@@ -409,30 +504,29 @@ func TestRewriteCodexMultiAgentV2InputRewritesAgentMessage(t *testing.T) {
 	if messageType := gjson.GetBytes(got, "input.0.type").String(); messageType != "message" {
 		t.Fatalf("type = %q, want message; payload=%s", messageType, got)
 	}
-	if role := gjson.GetBytes(got, "input.0.role").String(); role != "user" {
-		t.Fatalf("role = %q, want user; payload=%s", role, got)
+	if role := gjson.GetBytes(got, "input.0.role").String(); role != "assistant" {
+		t.Fatalf("role = %q, want assistant; payload=%s", role, got)
 	}
-	if partType := gjson.GetBytes(got, "input.0.content.1.type").String(); partType != "input_text" {
-		t.Fatalf("content[1].type = %q, want input_text; payload=%s", partType, got)
+	if partType := gjson.GetBytes(got, "input.0.content.0.type").String(); partType != "output_text" {
+		t.Fatalf("content[0].type = %q, want output_text; payload=%s", partType, got)
 	}
-	if text := gjson.GetBytes(got, "input.0.content.1.text").String(); text != "请出一道四则运算题，并给出答案。全程使用简体中文，题目简洁。" {
-		t.Fatalf("content[1].text = %q; payload=%s", text, got)
+	if text := gjson.GetBytes(got, "input.0.content.0.text").String(); text != "Message Type: NEW_TASK\nTask name: /root/arithmetic_problem\nSender: /root\nPayload:\n\n请出一道四则运算题，并给出答案。全程使用简体中文，题目简洁。" {
+		t.Fatalf("content[0].text = %q; payload=%s", text, got)
 	}
-	if encrypted := gjson.GetBytes(got, "input.0.content.1.encrypted_content"); encrypted.Exists() {
-		t.Fatalf("content[1].encrypted_content was preserved: %s", got)
+	if parts := gjson.GetBytes(got, "input.0.content.#").Int(); parts != 1 {
+		t.Fatalf("content parts = %d, want 1; payload=%s", parts, got)
 	}
-	if author := gjson.GetBytes(got, "input.0.author").String(); author != "/root" {
-		t.Fatalf("author = %q, want /root", author)
-	}
-	if turnID := gjson.GetBytes(got, "input.0.internal_chat_message_metadata_passthrough.turn_id").String(); turnID != "019f92ae-7eae-7371-957e-8f6f734edddc" {
-		t.Fatalf("turn_id = %q", turnID)
+	for _, field := range []string{"id", "author", "recipient", "internal_chat_message_metadata_passthrough"} {
+		if gjson.GetBytes(got, "input.0."+field).Exists() {
+			t.Fatalf("routing envelope field %s was preserved: %s", field, got)
+		}
 	}
 }
 
 func TestRewriteCodexMultiAgentV2InputConditions(t *testing.T) {
 	t.Parallel()
 
-	payload := []byte(`{"input":[{"type":"agent_message","content":[{"type":"encrypted_content","encrypted_content":"task"}]}]}`)
+	payload := []byte(`{"input":[{"type":"agent_message","content":[{"type":"input_text","text":"task"}]}]}`)
 	tests := []struct {
 		name      string
 		cfg       *config.Config
@@ -479,23 +573,44 @@ func TestRewriteCodexMultiAgentV2InputConditions(t *testing.T) {
 	}
 }
 
+func TestRewriteCodexMultiAgentV2InputFailsClosedForOpaqueOrInvalidContent(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte(`{"input":[
+		{"type":"agent_message","content":[{"type":"encrypted_content","encrypted_content":"gAAAAABciphertext-looking"}]},
+		{"type":"agent_message","content":[{"type":"input_text","text":"envelope"},{"type":"encrypted_content","encrypted_content":"mixed"}]},
+		{"type":"agent_message","content":[]},
+		{"type":"agent_message","content":[{"type":"input_text","text":"   "}]},
+		{"type":"agent_message","content":[{"type":"input_text","text":42}]},
+		{"type":"agent_message","content":[{"type":"output_text","text":"wrong union"}]}
+	]}`)
+	headers := http.Header{"User-Agent": []string{"Codex Desktop/0.146.0-alpha.3"}}
+	cfg := &config.Config{Codex: config.CodexConfig{OptimizeMultiAgentV2: true}}
+	got := RewriteCodexMultiAgentV2Input(context.Background(), headers, payload, cfg)
+	if string(got) != string(payload) {
+		t.Fatalf("opaque or invalid agent_message was rewritten: %s", got)
+	}
+}
+
 func TestTranslateRequestWithCodexMultiAgentV2Conditions(t *testing.T) {
-	payload := []byte(`{"model":"test-model","input":[{"type":"agent_message","content":[{"type":"encrypted_content","encrypted_content":"task"}]}]}`)
+	payload := []byte(`{"model":"test-model","input":[{"type":"agent_message","content":[{"type":"input_text","text":"task"}]}]}`)
 	enabledCfg := &config.Config{Codex: config.CodexConfig{OptimizeMultiAgentV2: true}}
 	eligibleHeaders := http.Header{"User-Agent": []string{"Codex Desktop/0.146.0-alpha.3"}}
 
 	translations := []struct {
-		name  string
-		to    sdktranslator.Format
-		path  string
-		want  string
-		model string
+		name         string
+		to           sdktranslator.Format
+		path         string
+		want         string
+		boundaryPath string
+		wantBoundary string
+		model        string
 	}{
-		{name: "Claude", to: sdktranslator.FormatClaude, path: "messages.0.content", want: "task", model: "claude-sonnet-4-5"},
-		{name: "Gemini", to: sdktranslator.FormatGemini, path: "contents.0.parts.0.text", want: "task", model: "gemini-2.5-pro"},
-		{name: "Antigravity", to: sdktranslator.FormatAntigravity, path: "request.contents.0.parts.0.text", want: "task", model: "gemini-2.5-pro"},
-		{name: "OpenAI", to: sdktranslator.FormatOpenAI, path: "messages.0.content.0.text", want: "task", model: "chat-model"},
-		{name: "Interactions", to: sdktranslator.FormatInteractions, path: "input.0.content.0.text", want: "task", model: "interaction-model"},
+		{name: "Claude", to: sdktranslator.FormatClaude, path: "messages.0.content", want: "task", boundaryPath: "messages.0.role", wantBoundary: "user", model: "claude-sonnet-4-5"},
+		{name: "Gemini", to: sdktranslator.FormatGemini, path: "contents.0.parts.0.text", want: "task", boundaryPath: "contents.0.role", wantBoundary: "user", model: "gemini-2.5-pro"},
+		{name: "Antigravity", to: sdktranslator.FormatAntigravity, path: "request.contents.0.parts.0.text", want: "task", boundaryPath: "request.contents.0.role", wantBoundary: "user", model: "gemini-2.5-pro"},
+		{name: "OpenAI", to: sdktranslator.FormatOpenAI, path: "messages.0.content.0.text", want: "task", boundaryPath: "messages.0.role", wantBoundary: "user", model: "chat-model"},
+		{name: "Interactions", to: sdktranslator.FormatInteractions, path: "input.0.content.0.text", want: "task", boundaryPath: "input.0.type", wantBoundary: "user_input", model: "interaction-model"},
 	}
 	for _, tt := range translations {
 		t.Run(tt.name, func(t *testing.T) {
@@ -503,8 +618,19 @@ func TestTranslateRequestWithCodexMultiAgentV2Conditions(t *testing.T) {
 			if value := gjson.GetBytes(got, tt.path).String(); value != tt.want {
 				t.Fatalf("%s = %q, want %q; output=%s", tt.path, value, tt.want, got)
 			}
+			if boundary := gjson.GetBytes(got, tt.boundaryPath).String(); boundary != tt.wantBoundary {
+				t.Fatalf("%s = %q, want %q; output=%s", tt.boundaryPath, boundary, tt.wantBoundary, got)
+			}
 		})
 	}
+
+	t.Run("opaque content stays fail closed", func(t *testing.T) {
+		opaque := []byte(`{"model":"chat-model","input":[{"type":"agent_message","content":[{"type":"encrypted_content","encrypted_content":"gAAAAABopaque"}]}]}`)
+		got := TranslateRequestWithCodexMultiAgentV2(context.Background(), eligibleHeaders, enabledCfg, sdktranslator.FormatOpenAIResponse, sdktranslator.FormatOpenAI, "chat-model", opaque, false)
+		if count := gjson.GetBytes(got, "messages.#").Int(); count != 0 {
+			t.Fatalf("opaque agent_message was translated: %s", got)
+		}
+	})
 
 	t.Run("disabled optimization", func(t *testing.T) {
 		got := TranslateRequestWithCodexMultiAgentV2(context.Background(), eligibleHeaders, &config.Config{}, sdktranslator.FormatOpenAIResponse, sdktranslator.FormatOpenAI, "chat-model", payload, false)
@@ -588,94 +714,69 @@ func TestCodexClientUserAgentPrefersGinRequest(t *testing.T) {
 	}
 }
 
-func TestCodexCollaborationMessageToolPathsFindsAllThreeTools(t *testing.T) {
+func TestCodexMultiAgentMessageToolPathsRequireConfirmedNamespaces(t *testing.T) {
 	t.Parallel()
 
 	payload := []byte(`{
 		"tools":[
 			{"type":"namespace","name":"collaboration","tools":[
-				{"type":"function","name":"spawn_agent","parameters":{"properties":{"message":{"encrypted":true}}}},
-				{"type":"function","name":"send_message","parameters":{"properties":{"message":{"encrypted":true}}}},
-				{"type":"function","name":"followup_task","parameters":{"properties":{"message":{"encrypted":true}}}},
-				{"type":"function","name":"unrelated_tool","parameters":{"properties":{"message":{"encrypted":true}}}}
+				{"type":"function","name":"spawn_agent"},
+				{"type":"function","name":"send_message"},
+				{"type":"function","name":"followup_task"},
+				{"type":"function","name":"unrelated_tool"}
+			]},
+			{"type":"namespace","name":"custom","tools":[
+				{"type":"namespace","name":"collaboration","tools":[{"type":"function","name":"send_message"}]},
+				{"type":"function","name":"followup_task"}
+			]},
+			{"type":"namespace","name":"agents","tools":[
+				{"type":"function","name":"spawn_agent"},
+				{"type":"function","name":"send_message"},
+				{"type":"function","name":"followup_task"},
+				{"type":"function","name":"extra"}
 			]}
-		]
+		],
+		"input":[{"type":"additional_tools","tools":[
+			{"type":"namespace","name":"collaboration-optimize","tools":[
+				{"type":"function","name":"send_message"},
+				{"type":"function","name":"followup_task"}
+			]}
+		]}]
 	}`)
-	paths := codexCollaborationMessageToolPaths(payload)
-	wantCount := 3
-	if len(paths) != wantCount {
-		t.Fatalf("path count = %d, want %d; paths=%v", len(paths), wantCount, paths)
+	got := codexMultiAgentMessageToolPaths(payload)
+	want := []string{
+		"tools.0.tools.0", "tools.0.tools.1", "tools.0.tools.2",
+		"tools.1.tools.0.tools.0",
+		"tools.2.tools.0", "tools.2.tools.1", "tools.2.tools.2",
+		"input.0.tools.0.tools.0", "input.0.tools.0.tools.1",
+	}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("paths = %v, want %v", got, want)
 	}
 }
 
-func TestCodexCollaborationMessageToolPathsAdditionalTools(t *testing.T) {
+func TestRewriteCodexMultiAgentMessageEncryptionDeletesOnlyBooleanTrue(t *testing.T) {
 	t.Parallel()
 
-	payload := []byte(`{
-		"input":[
-			{"type":"additional_tools","role":"developer","tools":[
-				{"type":"namespace","name":"collaboration","tools":[
-					{"type":"function","name":"send_message","parameters":{"properties":{"message":{"encrypted":true}}}},
-					{"type":"function","name":"followup_task","parameters":{"properties":{"message":{"encrypted":true}}}}
-				]}
-			]}
-		]
-	}`)
-	paths := codexCollaborationMessageToolPaths(payload)
-	if len(paths) != 2 {
-		t.Fatalf("path count = %d, want 2; paths=%v", len(paths), paths)
+	payload := []byte(`{"tools":[{"type":"namespace","name":"collaboration","tools":[
+		{"type":"function","name":"spawn_agent","parameters":{"properties":{"message":{"type":"string","encrypted":true},"data":{"encrypted":"keep"}}}},
+		{"type":"function","name":"send_message","parameters":{"properties":{"message":{"encrypted":false}}}},
+		{"type":"function","name":"followup_task","parameters":{"properties":{"message":{"encrypted":"true"}}}},
+		{"type":"function","name":"send_message","parameters":{"properties":{"message":{"encrypted":null}}}},
+		{"type":"function","name":"followup_task","parameters":{"properties":{"message":{"encrypted":1}}}}
+	]}]}`)
+	got := rewriteCodexMultiAgentMessageEncryption(payload)
+	if marker := gjson.GetBytes(got, "tools.0.tools.0.parameters.properties.message.encrypted"); marker.Exists() {
+		t.Fatalf("boolean true marker was preserved: %s", got)
 	}
-}
-
-func TestRemoveCodexCollaborationMessageEncryptionAllTools(t *testing.T) {
-	t.Parallel()
-
-	payload := []byte(`{
-		"tools":[
-			{"type":"namespace","name":"collaboration","tools":[
-				{"type":"function","name":"spawn_agent","parameters":{"type":"object","properties":{"message":{"type":"string","encrypted":true}}}},
-				{"type":"function","name":"send_message","parameters":{"type":"object","properties":{"message":{"type":"string","encrypted":true}}}},
-				{"type":"function","name":"followup_task","parameters":{"type":"object","properties":{"message":{"type":"string","encrypted":true}}}}
-			]}
-		]
-	}`)
-	paths := codexCollaborationMessageToolPaths(payload)
-	got := removeCodexCollaborationMessageEncryption(payload, paths)
-
-	for _, toolPath := range []string{
-		"tools.0.tools.0",
-		"tools.0.tools.1",
-		"tools.0.tools.2",
-	} {
-		if encrypted := gjson.GetBytes(got, toolPath+".parameters.properties.message.encrypted"); encrypted.Exists() {
-			t.Fatalf("%s.parameters.properties.message.encrypted was not removed: %s", toolPath, encrypted.Raw)
-		}
-		if msgType := gjson.GetBytes(got, toolPath+".parameters.properties.message.type").String(); msgType != "string" {
-			t.Fatalf("%s.parameters.properties.message.type changed: %q", toolPath, msgType)
+	for index, wantRaw := range []string{"false", `"true"`, "null", "1"} {
+		path := fmt.Sprintf("tools.0.tools.%d.parameters.properties.message.encrypted", index+1)
+		if marker := gjson.GetBytes(got, path); marker.Raw != wantRaw {
+			t.Fatalf("%s = %q, want %q; payload=%s", path, marker.Raw, wantRaw, got)
 		}
 	}
-}
-
-func TestRemoveCodexCollaborationMessageEncryptionPreservesUnrelatedEncryptedFields(t *testing.T) {
-	t.Parallel()
-
-	payload := []byte(`{
-		"tools":[
-			{"type":"function","name":"send_message","parameters":{"properties":{"message":{"type":"string","encrypted":true},"data":{"encrypted":"keep-me"}}}},
-			{"type":"function","name":"unrelated_tool","parameters":{"properties":{"message":{"encrypted":true}}}}
-		]
-	}`)
-	paths := codexCollaborationMessageToolPaths(payload)
-	got := removeCodexCollaborationMessageEncryption(payload, paths)
-
-	if encrypted := gjson.GetBytes(got, "tools.0.parameters.properties.message.encrypted"); encrypted.Exists() {
-		t.Fatalf("send_message message.encrypted was not removed: %s", encrypted.Raw)
-	}
-	if dataEncrypted := gjson.GetBytes(got, "tools.0.parameters.properties.data.encrypted").String(); dataEncrypted != "keep-me" {
-		t.Fatalf("unrelated data.encrypted was changed: %q", dataEncrypted)
-	}
-	if unrelatedEncrypted := gjson.GetBytes(got, "tools.1.parameters.properties.message.encrypted"); !unrelatedEncrypted.Exists() {
-		t.Fatalf("unrelated tool message.encrypted was removed: %s", got)
+	if encrypted := gjson.GetBytes(got, "tools.0.tools.0.parameters.properties.data.encrypted").String(); encrypted != "keep" {
+		t.Fatalf("unrelated encrypted field changed: %q", encrypted)
 	}
 }
 
@@ -757,17 +858,27 @@ func TestOptimizeCodexMultiAgentV2RequestRemovesEncryptionFromAllThreeToolsWithS
 	}
 }
 
-func TestRemoveCodexCollaborationMessageEncryptionNoOpWithoutEncrypted(t *testing.T) {
+func TestOptimizeCodexMultiAgentV2RequestIgnoresUnconfirmedSameNameTools(t *testing.T) {
 	t.Parallel()
 
-	payload := []byte(`{
-		"tools":[
-			{"type":"function","name":"send_message","parameters":{"type":"object","properties":{"message":{"type":"string"}}}}
-		]
-	}`)
-	paths := codexCollaborationMessageToolPaths(payload)
-	got := removeCodexCollaborationMessageEncryption(payload, paths)
+	payload := []byte(`{"tools":[
+		{"type":"function","name":"spawn_agent","description":"Spawns an agent.","parameters":{"properties":{"message":{"encrypted":true}}}},
+		{"type":"namespace","name":"ordinary","tools":[{"type":"function","name":"spawn_agent","description":"Spawns an agent.","parameters":{"properties":{"message":{"encrypted":true}}}}]},
+		{"type":"namespace","name":"agents","tools":[{"type":"function","name":"spawn_agent","description":"Spawns an agent.","parameters":{"properties":{"message":{"encrypted":true}}}}]},
+		{"type":"namespace","name":"mcp__agents","tools":[{"type":"function","name":"send_message","parameters":{"properties":{"message":{"encrypted":true}}}}]},
+		{"type":"namespace","name":"custom-agents","tools":[
+			{"type":"function","name":"spawn_agent","description":"Spawns an agent.","parameters":{"properties":{"message":{"encrypted":true}}}},
+			{"type":"function","name":"send_message","parameters":{"properties":{"message":{"encrypted":true}}}},
+			{"type":"function","name":"followup_task","parameters":{"properties":{"message":{"encrypted":true}}}}
+		]}
+	]}`)
+	headers := http.Header{"User-Agent": []string{"Codex Desktop/0.146.0-alpha.3"}}
+	cfg := &config.Config{Codex: config.CodexConfig{OptimizeMultiAgentV2: true}}
+	got, optimized := OptimizeCodexMultiAgentV2Request(context.Background(), headers, payload, cfg)
+	if optimized {
+		t.Fatal("unconfirmed same-name tools unexpectedly optimized a namespace")
+	}
 	if string(got) != string(payload) {
-		t.Fatalf("payload changed when no encrypted field existed: %s", got)
+		t.Fatalf("unconfirmed same-name tools changed: %s", got)
 	}
 }

--- a/internal/runtime/executor/codex_executor_spawn_agent_test.go
+++ b/internal/runtime/executor/codex_executor_spawn_agent_test.go
@@ -101,7 +101,7 @@ func TestCodexExecutorOptimizeMultiAgentV2(t *testing.T) {
 			}
 
 			assertCodexSpawnAgentOptimization(t, upstreamBody, modelID, tt.enabled)
-			assertCodexSpawnAgentRequestMessage(t, upstreamBody, tt.enabled)
+			assertCodexSpawnAgentRequestMessage(t, upstreamBody)
 			assertCodexSpawnAgentClientNamespace(t, clientPayload)
 		})
 	}
@@ -130,7 +130,7 @@ func codexSpawnAgentTestPayload() []byte {
 			"recipient":"/root/worker",
 			"content":[
 				{"type":"input_text","text":"Payload:\n"},
-				{"type":"encrypted_content","encrypted_content":"delegated task"}
+				{"type":"encrypted_content","encrypted_content":"gAAAAABopaque-delegated-task"}
 			],
 			"internal_chat_message_metadata_passthrough":{"turn_id":"turn_1"}
 		}]
@@ -155,7 +155,7 @@ func assertCodexSpawnAgentClientNamespace(t *testing.T, payload []byte) {
 	}
 }
 
-func assertCodexSpawnAgentRequestMessage(t *testing.T, payload []byte, enabled bool) {
+func assertCodexSpawnAgentRequestMessage(t *testing.T, payload []byte) {
 	t.Helper()
 	message := gjson.GetBytes(payload, "input.1")
 	if message.Get("type").String() != "agent_message" || message.Get("role").Exists() {
@@ -164,17 +164,8 @@ func assertCodexSpawnAgentRequestMessage(t *testing.T, payload []byte, enabled b
 	if message.Get("author").String() != "/root" || message.Get("recipient").String() != "/root/worker" || message.Get("internal_chat_message_metadata_passthrough.turn_id").String() != "turn_1" {
 		t.Fatalf("Codex executor changed agent message metadata: %s", payload)
 	}
-	if enabled {
-		if message.Get("content.1.type").String() != "input_text" || message.Get("content.1.text").String() != "delegated task" {
-			t.Fatalf("Codex executor did not normalize agent message content: %s", payload)
-		}
-		if message.Get("content.1.encrypted_content").Exists() {
-			t.Fatalf("Codex executor preserved encrypted_content: %s", payload)
-		}
-		return
-	}
-	if message.Get("content.1.type").String() != "encrypted_content" || message.Get("content.1.encrypted_content").String() != "delegated task" {
-		t.Fatalf("disabled optimization changed agent message content: %s", payload)
+	if message.Get("content.1.type").String() != "encrypted_content" || message.Get("content.1.encrypted_content").String() != "gAAAAABopaque-delegated-task" {
+		t.Fatalf("Codex executor changed opaque agent message content: %s", payload)
 	}
 }
 

--- a/internal/runtime/executor/codex_websockets_spawn_agent_test.go
+++ b/internal/runtime/executor/codex_websockets_spawn_agent_test.go
@@ -91,7 +91,7 @@ func TestCodexWebsocketsExecutorOptimizeMultiAgentV2(t *testing.T) {
 			}
 			upstreamPayload := <-capturedPayload
 			assertCodexSpawnAgentOptimization(t, upstreamPayload, modelID, tt.enabled)
-			assertCodexSpawnAgentRequestMessage(t, upstreamPayload, tt.enabled)
+			assertCodexSpawnAgentRequestMessage(t, upstreamPayload)
 			assertCodexSpawnAgentClientNamespace(t, clientPayload)
 		})
 	}

--- a/internal/runtime/executor/helps/codex_multi_agent_v2.go
+++ b/internal/runtime/executor/helps/codex_multi_agent_v2.go
@@ -21,6 +21,12 @@ func RewriteCodexMultiAgentV2Input(ctx context.Context, headers http.Header, pay
 	return multiagentv2.RewriteCodexMultiAgentV2Input(ctx, headers, payload, cfg)
 }
 
+// RewriteCodexMultiAgentV2MessageEncryption removes boolean-true encrypted
+// markers from positively identified Multi-Agent message schemas.
+func RewriteCodexMultiAgentV2MessageEncryption(ctx context.Context, headers http.Header, payload []byte, cfg *config.Config) []byte {
+	return multiagentv2.RewriteCodexMultiAgentV2MessageEncryption(ctx, headers, payload, cfg)
+}
+
 // TranslateRequestWithCodexMultiAgentV2 normalizes official Codex multi-agent
 // input before translating it to a non-Codex target protocol.
 func TranslateRequestWithCodexMultiAgentV2(ctx context.Context, headers http.Header, cfg *config.Config, from, to sdktranslator.Format, model string, payload []byte, stream bool) []byte {

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -329,7 +329,7 @@ func TestXAIExecutorExecuteShapesResponsesRequest(t *testing.T) {
 	}
 }
 
-func TestXAIExecutorPrepareResponsesRequestRewritesCodexAgentMessage(t *testing.T) {
+func TestXAIExecutorPrepareResponsesRequestRewritesPlaintextCodexAgentMessage(t *testing.T) {
 	t.Parallel()
 
 	exec := NewXAIExecutor(&config.Config{Codex: config.CodexConfig{OptimizeMultiAgentV2: true}})
@@ -342,7 +342,7 @@ func TestXAIExecutorPrepareResponsesRequestRewritesCodexAgentMessage(t *testing.
 			"recipient":"/root/arithmetic_question",
 			"content":[
 				{"type":"input_text","text":"Message Type: NEW_TASK\nTask name: /root/arithmetic_question\nSender: /root\nPayload:\n"},
-				{"type":"encrypted_content","encrypted_content":"请出一道四则运算题。只回复题目本身，不要解答；使用中文。"}
+				{"type":"input_text","text":"请出一道四则运算题。只回复题目本身，不要解答；使用中文。"}
 			],
 			"internal_chat_message_metadata_passthrough":{"turn_id":"019f92c3-6772-7213-8aac-8bd154d528f1"}
 		}]
@@ -359,22 +359,57 @@ func TestXAIExecutorPrepareResponsesRequestRewritesCodexAgentMessage(t *testing.
 	}
 
 	message := gjson.GetBytes(prepared.body, "input.0")
-	if message.Get("type").String() != "message" || message.Get("role").String() != "user" {
+	if message.Get("type").String() != "message" || message.Get("role").String() != "assistant" {
 		t.Fatalf("agent message was not rewritten: %s", prepared.body)
 	}
-	if message.Get("content.1.type").String() != "input_text" {
-		t.Fatalf("content[1].type = %q, want input_text; body=%s", message.Get("content.1.type").String(), prepared.body)
+	if message.Get("content.0.type").String() != "output_text" {
+		t.Fatalf("content[0].type = %q, want output_text; body=%s", message.Get("content.0.type").String(), prepared.body)
 	}
-	if text := message.Get("content.1.text").String(); text != "请出一道四则运算题。只回复题目本身，不要解答；使用中文。" {
-		t.Fatalf("content[1].text = %q; body=%s", text, prepared.body)
+	wantText := "Message Type: NEW_TASK\nTask name: /root/arithmetic_question\nSender: /root\nPayload:\n\n请出一道四则运算题。只回复题目本身，不要解答；使用中文。"
+	if text := message.Get("content.0.text").String(); text != wantText {
+		t.Fatalf("content[0].text = %q, want %q; body=%s", text, wantText, prepared.body)
 	}
-	if message.Get("content.1.encrypted_content").Exists() {
-		t.Fatalf("encrypted_content was preserved: %s", prepared.body)
+	if count := message.Get("content.#").Int(); count != 1 {
+		t.Fatalf("content parts = %d, want 1; body=%s", count, prepared.body)
 	}
-	if message.Get("id").String() != "amsg_019f92c3-6d77-7880-a6e4-f920867dc6a0" || message.Get("author").String() != "/root" || message.Get("recipient").String() != "/root/arithmetic_question" {
-		t.Fatalf("agent message identity fields changed: %s", prepared.body)
+	for _, field := range []string{"id", "author", "recipient", "internal_chat_message_metadata_passthrough"} {
+		if message.Get(field).Exists() {
+			t.Fatalf("routing envelope field %s was preserved: %s", field, prepared.body)
+		}
 	}
-	if turnID := message.Get("internal_chat_message_metadata_passthrough.turn_id").String(); turnID != "019f92c3-6772-7213-8aac-8bd154d528f1" {
+}
+
+func TestXAIExecutorPrepareResponsesRequestPreservesOpaqueCodexAgentMessage(t *testing.T) {
+	t.Parallel()
+
+	exec := NewXAIExecutor(&config.Config{Codex: config.CodexConfig{OptimizeMultiAgentV2: true}})
+	payload := []byte(`{"model":"grok-4.5","input":[{
+		"type":"agent_message","id":"amsg_opaque","author":"/root","recipient":"/root/worker",
+		"content":[{"type":"input_text","text":"Payload:\n"},{"type":"encrypted_content","encrypted_content":"gAAAAABopaque"}],
+		"internal_chat_message_metadata_passthrough":{"turn_id":"turn_opaque"}
+	}]}`)
+	prepared, errPrepare := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+		Model:   "grok-4.5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Headers:      http.Header{"User-Agent": []string{"Codex Desktop/0.146.0-alpha.3.1"}},
+	}, true)
+	if errPrepare != nil {
+		t.Fatalf("prepareResponsesRequest() error = %v", errPrepare)
+	}
+
+	message := gjson.GetBytes(prepared.body, "input.0")
+	if message.Get("type").String() != "agent_message" || message.Get("role").Exists() {
+		t.Fatalf("opaque agent message boundary changed: %s", prepared.body)
+	}
+	if message.Get("content.1.type").String() != "encrypted_content" || message.Get("content.1.encrypted_content").String() != "gAAAAABopaque" {
+		t.Fatalf("opaque agent message content changed: %s", prepared.body)
+	}
+	if message.Get("id").String() != "amsg_opaque" || message.Get("author").String() != "/root" || message.Get("recipient").String() != "/root/worker" {
+		t.Fatalf("opaque agent message identity changed: %s", prepared.body)
+	}
+	if turnID := message.Get("internal_chat_message_metadata_passthrough.turn_id").String(); turnID != "turn_opaque" {
 		t.Fatalf("turn_id = %q; body=%s", turnID, prepared.body)
 	}
 }


### PR DESCRIPTION
## 结果与边界

在已吸收 upstream PR #4748 的 `v7.2.115` 基线上收紧 Multi-Agent v2 契约：CPA 只转换可证明为 plaintext 的 `agent_message`，只在确认的 Multi-Agent namespace 中处理消息工具，并且只删除 JSON boolean `true` 的 `message.encrypted` marker。

本 PR 不修改 Codex Desktop、Codex Rust 源码、模型 catalog、`tool_mode`、`supports_search_tool` 或当前 `tool_namespace = "agents"`，不启用或改写线上配置，也不部署。由于 ledger 的 `introduced_in` 指向实现提交 `798ad1854064361461225fe766db9b2f54a7653d`，本 PR 必须使用 **Create a merge commit**，禁止 squash/rebase。

## Type

- [ ] Protected upstream full-sync
- [ ] Staged upstream full-sync
- [ ] LTS protected-delta patch
- [x] LTS feature / downstream patch maintenance
- [ ] Maintenance docs / CI
- [ ] Emergency hotfix

## 主要变更

- `agent_message.content` 只有在非空且每一项都是非空字符串 `input_text` 时才转换；多段文本以换行合并。`encrypted_content`、mixed、empty、空白和非字符串内容全部 fail-closed。
- Responses/xAI 边界把 proven plaintext 转为 `assistant/output_text`；翻译到非 Responses provider 时使用 `user/input_text` 请求边界；Codex native HTTP/WebSocket path 不再改写 opaque history。
- 只确认 `collaboration`、`collaboration-optimize`，以及直接声明完整 `spawn_agent`、`send_message`、`followup_task` function 集合的 `agents` namespace。嵌套 namespace 独立判定，不继承外层资格。
- top-level、ordinary、MCP、custom 和 incomplete `agents` 中的同名工具不变；没有 `spawn_agent` 时，确认 namespace 中的 `send_message`/`followup_task` 仍按契约处理。
- 仅删除值为 JSON boolean `true` 的 `parameters.properties.message.encrypted`；`false`、string、null、number 和其他 malformed 值保留。
- 导出 `RewriteCodexMultiAgentV2MessageEncryption` 及 executor wrapper，作为后续 xAI provenance PR 的唯一 request rewrite 边界。
- 新增 downstream patch `codex-multi-agent-plaintext-contract`。

## Protected delta review

- Request lifecycle：仅收紧现有 Codex Multi-Agent request normalization；provider selection、auth identity、retry 与 usage accounting 未改变。
- Config：`optimize-multi-agent-v2` key、默认值与运行时配置不变，只更新示例注释。
- Translator：未修改 `internal/translator/**`；非 Responses translation 继续通过现有 SDK translator，新增边界断言。
- Usage、Management usage response、Panel release source：行为和 schema 未改变；专用 usage contract tests 与全仓测试通过。

## LTS classification review

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| `codex-multi-agent-plaintext-contract` | downstream patch | `newly-added` | 实现提交 `798ad185`；strict plaintext、namespace、boolean marker、Codex HTTP/WS 与 xAI prepare 回归通过 |

- [x] `introduced_in` 指向本 PR 内实现提交；合并必须使用 **Create a merge commit**。

## Validation

- [x] `go test ./internal/config -count=1`
- [x] `go test ./sdk/cliproxy/... -count=1`
- [x] `go test ./internal/runtime/executor -count=1`
- [x] `go test ./internal/translator/openai/openai/responses -count=1`
- [x] `go test ./internal/usage ./internal/api/handlers/management ./test -run "Usage|usage" -count=1`
- [x] `scripts/check-lts-contract.sh`
- [x] `go run ./scripts/ltsregistry --root .`
- [x] `go build -o test-output ./cmd/server`（构建产物已清理）
- [x] `go test ./... -count=1`
- [x] `go list ./... | rg -v "/tmp$" | xargs go test -count=1`
- [x] `git diff --check`

## 未执行的动态验收

- [ ] 生产/HF runtime 部署：未授权，未执行。
- [ ] 当前 `agents` namespace 的真实 `DirectPlaintextMessage` 闭环：本 PR 只证明 CPA 组件契约，不修改 Desktop 配置或客户端。
- [ ] 真实 Grok/xAI canary：留到 MA-B 合并及后续显式部署授权后执行。

## Review focus

1. `codexPlaintextAgentMessageText` 是否严格拒绝 encrypted/mixed/empty/non-string content。
2. `isCodexMultiAgentNamespace` 与 nested namespace 独立判定是否避免普通同名工具误改。
3. boolean-true marker 删除与 Codex native history no-op 是否覆盖 HTTP/WebSocket。