### PR TITLE
fix(xai): 恢复 Multi-Agent plaintext provenance

### DIFF
--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -884,3 +884,27 @@ patches:
     upstream_issue_or_pr: router-for-me/CLIProxyAPI#4748
     state: required
     retire_when: Upstream converts only fully proven plaintext agent_message content, preserves opaque, encrypted, mixed, empty, and malformed history, limits spawn/message rewrites to equivalent positively identified Multi-Agent namespaces, removes only boolean-true message.encrypted markers without changing ordinary, MCP, custom, top-level, or incomplete agents tools, preserves native Codex HTTP and WebSocket history, and all listed regressions pass after removing the downstream implementation.
+
+  - id: xai-multi-agent-plaintext-provenance
+    reason: xAI requires namespace tools to be flattened and cannot consume the Codex message.encrypted schema marker, while the returning Codex client needs encrypted_function_args to distinguish a plaintext Multi-Agent call. LTS therefore records the exact root or additional_tools function declarations whose boolean-true marker was removed, restores namespace and short name first, then adds encrypted_function_args as an empty array only for response calls matching that request provenance across HTTP non-stream, SSE, and WebSocket.
+    introduced_in: 23caefe8b2495856c2c8df50b63823846ad6b910
+    affected_upstream_range: through ffdb9c9fbc78a6235d59c9ccbdc4243ba35ecdcd (v7.2.115, 2026-08-03); upstream xAI handling flattens and restores namespace tools and filters internal X Search traces, but does not derive before/after plaintext provenance from the Multi-Agent schema rewrite or restore encrypted_function_args on HTTP, SSE, and WebSocket responses.
+    files:
+      - docs/lts/downstream-patches.yaml
+      - internal/runtime/executor/xai_executor_execute.go
+      - internal/runtime/executor/xai_executor_request.go
+      - internal/runtime/executor/xai_executor_response.go
+      - internal/runtime/executor/xai_executor_stream.go
+      - internal/runtime/executor/xai_executor_test.go
+      - internal/runtime/executor/xai_websockets_executor.go
+      - internal/runtime/executor/xai_websockets_executor_test.go
+    regression_tests:
+      - TestXAIExecutorPrepareResponsesRequestRecordsPlaintextMultiAgentProvenance
+      - TestXAIExecutorPrepareResponsesRequestDoesNotRecordPlaintextProvenanceWhenDisabled
+      - TestRestoreXAIPlaintextMultiAgentFunctionArgsUsesRequestProvenance
+      - TestXAIExecutorExecuteRestoresPlaintextMultiAgentMarker
+      - TestXAIExecutorExecuteStreamRestoresPlaintextMultiAgentMarker
+      - TestXAIWebsocketsExecuteStreamRestoresPlaintextMultiAgentMarker
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: Upstream records provenance only for Multi-Agent function schemas whose JSON boolean-true message.encrypted marker was actually removed, covers both root tools and input additional_tools, restores namespace before adding an empty encrypted_function_args without overwriting an existing field or changing arguments and call IDs, leaves ordinary, custom, disabled, and unproven calls untouched across HTTP non-stream, SSE, and WebSocket, and all listed regressions pass after removing the downstream implementation.

--- a/internal/runtime/executor/xai_executor_execute.go
+++ b/internal/runtime/executor/xai_executor_execute.go
@@ -90,6 +90,7 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 		}
 		eventData := xaiNormalizeReasoningSummaryData(bytes.TrimSpace(line[len(xaiDataTag):]))
 		eventData = restoreXAINamespaceToolCalls(eventData, prepared.namespaceTools)
+		eventData = restoreXAIPlaintextMultiAgentFunctionArgs(eventData, prepared.plaintextMultiAgentTools)
 		eventData = responseFilter.apply(eventData)
 		if len(eventData) == 0 {
 			continue

--- a/internal/runtime/executor/xai_executor_request.go
+++ b/internal/runtime/executor/xai_executor_request.go
@@ -23,17 +23,18 @@ import (
 )
 
 type xaiPreparedRequest struct {
-	baseModel             string
-	from                  sdktranslator.Format
-	responseFormat        sdktranslator.Format
-	to                    sdktranslator.Format
-	originalPayload       []byte
-	body                  []byte
-	namespaceTools        map[string]xaiNamespaceToolRef
-	clientDeclaredTools   map[xaiClientToolKey]struct{}
-	sessionID             string
-	replayScope           xaiReasoningReplayScope
-	filterInternalXSearch bool
+	baseModel                string
+	from                     sdktranslator.Format
+	responseFormat           sdktranslator.Format
+	to                       sdktranslator.Format
+	originalPayload          []byte
+	body                     []byte
+	namespaceTools           map[string]xaiNamespaceToolRef
+	plaintextMultiAgentTools map[xaiClientToolKey]struct{}
+	clientDeclaredTools      map[xaiClientToolKey]struct{}
+	sessionID                string
+	replayScope              xaiReasoningReplayScope
+	filterInternalXSearch    bool
 }
 
 type xaiNamespaceToolRef struct {
@@ -88,6 +89,9 @@ func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliprox
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
 	body, _ = sjson.DeleteBytes(body, "stream_options")
 	body = helps.RewriteCodexMultiAgentV2Input(ctx, opts.Headers, body, e.cfg)
+	beforeMultiAgentEncryption := bytes.Clone(body)
+	body = helps.RewriteCodexMultiAgentV2MessageEncryption(ctx, opts.Headers, body, e.cfg)
+	plaintextMultiAgentTools := collectXAIPlaintextMultiAgentTools(beforeMultiAgentEncryption, body)
 	namespaceTools := collectXAINamespaceToolRefs(body)
 	// Collect before normalizeXAITools flattens namespace wrappers so keys match
 	// the post-restore (namespace, short-name) shape used by the response filter.
@@ -124,17 +128,18 @@ func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliprox
 	}
 
 	return &xaiPreparedRequest{
-		baseModel:             baseModel,
-		from:                  from,
-		responseFormat:        responseFormat,
-		to:                    to,
-		originalPayload:       originalPayload,
-		body:                  body,
-		namespaceTools:        namespaceTools,
-		clientDeclaredTools:   clientDeclaredTools,
-		sessionID:             sessionID,
-		replayScope:           replayScope,
-		filterInternalXSearch: xaiRequestHasNativeXSearch(body),
+		baseModel:                baseModel,
+		from:                     from,
+		responseFormat:           responseFormat,
+		to:                       to,
+		originalPayload:          originalPayload,
+		body:                     body,
+		namespaceTools:           namespaceTools,
+		plaintextMultiAgentTools: plaintextMultiAgentTools,
+		clientDeclaredTools:      clientDeclaredTools,
+		sessionID:                sessionID,
+		replayScope:              replayScope,
+		filterInternalXSearch:    xaiRequestHasNativeXSearch(body),
 	}, nil
 }
 
@@ -1061,6 +1066,69 @@ func collectXAINamespaceToolRefs(body []byte) map[string]xaiNamespaceToolRef {
 		for _, item := range input.Array() {
 			if item.Get("type").String() == "additional_tools" {
 				collect(item.Get("tools"))
+			}
+		}
+	}
+	return refs
+}
+
+// collectXAIPlaintextMultiAgentTools records only function schemas whose
+// boolean-true encrypted marker was actually removed at the xAI boundary.
+// Comparing the adjacent before/after bodies keeps provenance tied to the
+// exported Multi-Agent rewrite instead of duplicating its namespace rules.
+func collectXAIPlaintextMultiAgentTools(beforeBody, afterBody []byte) map[xaiClientToolKey]struct{} {
+	refs := make(map[xaiClientToolKey]struct{})
+	if !gjson.ValidBytes(beforeBody) || !gjson.ValidBytes(afterBody) {
+		return refs
+	}
+
+	var collect func(gjson.Result, gjson.Result, string)
+	collect = func(beforeTools, afterTools gjson.Result, namespace string) {
+		if !beforeTools.IsArray() || !afterTools.IsArray() {
+			return
+		}
+		afterItems := afterTools.Array()
+		for index, beforeTool := range beforeTools.Array() {
+			if index >= len(afterItems) {
+				return
+			}
+			afterTool := afterItems[index]
+			beforeType := strings.TrimSpace(beforeTool.Get("type").String())
+			if beforeType != strings.TrimSpace(afterTool.Get("type").String()) ||
+				strings.TrimSpace(beforeTool.Get("name").String()) != strings.TrimSpace(afterTool.Get("name").String()) {
+				continue
+			}
+
+			switch beforeType {
+			case xaiNamespaceToolType:
+				collect(beforeTool.Get("tools"), afterTool.Get("tools"), strings.TrimSpace(beforeTool.Get("name").String()))
+			case xaiFunctionToolType:
+				if namespace == "" ||
+					beforeTool.Get("parameters.properties.message.encrypted").Type != gjson.True ||
+					afterTool.Get("parameters.properties.message.encrypted").Exists() {
+					continue
+				}
+				refs[xaiClientToolKey{
+					namespace: namespace,
+					name:      strings.TrimSpace(beforeTool.Get("name").String()),
+					toolType:  xaiFunctionToolType,
+				}] = struct{}{}
+			}
+		}
+	}
+
+	collect(gjson.GetBytes(beforeBody, "tools"), gjson.GetBytes(afterBody, "tools"), "")
+	beforeInput := gjson.GetBytes(beforeBody, "input")
+	afterInput := gjson.GetBytes(afterBody, "input")
+	if beforeInput.IsArray() && afterInput.IsArray() {
+		afterItems := afterInput.Array()
+		for index, beforeItem := range beforeInput.Array() {
+			if index >= len(afterItems) {
+				break
+			}
+			if strings.TrimSpace(beforeItem.Get("type").String()) == "additional_tools" &&
+				strings.TrimSpace(afterItems[index].Get("type").String()) == "additional_tools" {
+				collect(beforeItem.Get("tools"), afterItems[index].Get("tools"), "")
 			}
 		}
 	}

--- a/internal/runtime/executor/xai_executor_response.go
+++ b/internal/runtime/executor/xai_executor_response.go
@@ -346,6 +346,41 @@ func restoreXAINamespaceToolCallAtPath(data []byte, path string, refs map[string
 	return updated
 }
 
+// restoreXAIPlaintextMultiAgentFunctionArgs marks only calls whose request
+// declaration was actually rewritten from a boolean-true encrypted marker.
+func restoreXAIPlaintextMultiAgentFunctionArgs(data []byte, refs map[xaiClientToolKey]struct{}) []byte {
+	if len(refs) == 0 || len(data) == 0 || !gjson.ValidBytes(data) {
+		return data
+	}
+	data = restoreXAIPlaintextMultiAgentFunctionArgsAtPath(data, "item", refs)
+	output := gjson.GetBytes(data, "response.output")
+	if output.IsArray() {
+		for index := range output.Array() {
+			data = restoreXAIPlaintextMultiAgentFunctionArgsAtPath(data, fmt.Sprintf("response.output.%d", index), refs)
+		}
+	}
+	return data
+}
+
+func restoreXAIPlaintextMultiAgentFunctionArgsAtPath(data []byte, path string, refs map[xaiClientToolKey]struct{}) []byte {
+	if gjson.GetBytes(data, path+".type").String() != "function_call" {
+		return data
+	}
+	key := xaiClientToolKey{
+		namespace: strings.TrimSpace(gjson.GetBytes(data, path+".namespace").String()),
+		name:      strings.TrimSpace(gjson.GetBytes(data, path+".name").String()),
+		toolType:  xaiFunctionToolType,
+	}
+	if _, ok := refs[key]; !ok || gjson.GetBytes(data, path+".encrypted_function_args").Exists() {
+		return data
+	}
+	updated, errSet := sjson.SetRawBytes(data, path+".encrypted_function_args", []byte(`[]`))
+	if errSet != nil {
+		return data
+	}
+	return updated
+}
+
 // normalizeXAIObjectRootUnionBranchTypes makes untyped root union branches
 // explicitly object-only when the parameter root already permits only objects.
 // This preserves the original schema semantics while satisfying xAI validation.

--- a/internal/runtime/executor/xai_executor_stream.go
+++ b/internal/runtime/executor/xai_executor_stream.go
@@ -110,6 +110,7 @@ func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth
 				hasPendingEventLine := pendingEventLine != nil
 				for i, eventData := range eventDataList {
 					eventData = restoreXAINamespaceToolCalls(eventData, prepared.namespaceTools)
+					eventData = restoreXAIPlaintextMultiAgentFunctionArgs(eventData, prepared.plaintextMultiAgentTools)
 					eventData = responseFilter.apply(eventData)
 					if len(eventData) == 0 {
 						if hasPendingEventLine && i == 0 {

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -414,6 +414,244 @@ func TestXAIExecutorPrepareResponsesRequestPreservesOpaqueCodexAgentMessage(t *t
 	}
 }
 
+func TestXAIExecutorPrepareResponsesRequestRecordsPlaintextMultiAgentProvenance(t *testing.T) {
+	t.Parallel()
+
+	exec := NewXAIExecutor(&config.Config{Codex: config.CodexConfig{OptimizeMultiAgentV2: true}})
+	payload := []byte(`{"model":"grok-4.5","tools":[
+		{"type":"namespace","name":"collaboration","tools":[
+			{"type":"function","name":"spawn_agent","parameters":{"type":"object","properties":{"message":{"type":"string","encrypted":true}}}},
+			{"type":"function","name":"send_message","parameters":{"type":"object","properties":{"message":{"type":"string","encrypted":false}}}},
+			{"type":"function","name":"followup_task","parameters":{"type":"object","properties":{"message":{"type":"string","encrypted":"true"}}}}
+		]},
+		{"type":"namespace","name":"ordinary","tools":[
+			{"type":"function","name":"spawn_agent","parameters":{"type":"object","properties":{"message":{"type":"string","encrypted":true}}}}
+		]}
+	],"input":[
+		{"type":"additional_tools","tools":[{"type":"namespace","name":"collaboration-optimize","tools":[
+			{"type":"function","name":"send_message","parameters":{"type":"object","properties":{"message":{"type":"string","encrypted":true}}}}
+		]}]},
+		{"type":"additional_tools","tools":[{"type":"namespace","name":"agents","tools":[
+			{"type":"function","name":"spawn_agent","parameters":{"type":"object","properties":{"message":{"type":"string","encrypted":true}}}},
+			{"type":"function","name":"send_message","parameters":{"type":"object","properties":{"message":{"type":"string","encrypted":true}}}},
+			{"type":"function","name":"followup_task","parameters":{"type":"object","properties":{"message":{"type":"string","encrypted":true}}}}
+		]}]},
+		{"type":"message","role":"user","content":[{"type":"input_text","text":"delegate"}]}
+	]}`)
+	prepared, errPrepare := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+		Model:   "grok-4.5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Headers:      http.Header{"User-Agent": []string{"Codex Desktop/0.146.0-alpha.3"}},
+	}, true)
+	if errPrepare != nil {
+		t.Fatalf("prepareResponsesRequest() error = %v", errPrepare)
+	}
+
+	wantRefs := []xaiClientToolKey{
+		{namespace: "collaboration", name: "spawn_agent", toolType: xaiFunctionToolType},
+		{namespace: "collaboration-optimize", name: "send_message", toolType: xaiFunctionToolType},
+		{namespace: "agents", name: "spawn_agent", toolType: xaiFunctionToolType},
+		{namespace: "agents", name: "send_message", toolType: xaiFunctionToolType},
+		{namespace: "agents", name: "followup_task", toolType: xaiFunctionToolType},
+	}
+	if len(prepared.plaintextMultiAgentTools) != len(wantRefs) {
+		t.Fatalf("plaintext provenance count = %d, want %d: %#v", len(prepared.plaintextMultiAgentTools), len(wantRefs), prepared.plaintextMultiAgentTools)
+	}
+	for _, key := range wantRefs {
+		if _, ok := prepared.plaintextMultiAgentTools[key]; !ok {
+			t.Fatalf("plaintext provenance missing for %#v", key)
+		}
+		qualifiedName := qualifyXAINamespaceToolName(key.namespace, key.name)
+		path := `tools.#(name=="` + qualifiedName + `").parameters.properties.message.encrypted`
+		if marker := gjson.GetBytes(prepared.body, path); marker.Exists() {
+			t.Fatalf("%s marker remained: %s", qualifiedName, prepared.body)
+		}
+	}
+
+	for qualifiedName, wantRaw := range map[string]string{
+		"collaboration__send_message":  "false",
+		"collaboration__followup_task": `"true"`,
+		"ordinary__spawn_agent":        "true",
+	} {
+		path := `tools.#(name=="` + qualifiedName + `").parameters.properties.message.encrypted`
+		if marker := gjson.GetBytes(prepared.body, path); marker.Raw != wantRaw {
+			t.Fatalf("%s marker = %q, want %q; body=%s", qualifiedName, marker.Raw, wantRaw, prepared.body)
+		}
+	}
+}
+
+func TestXAIExecutorPrepareResponsesRequestDoesNotRecordPlaintextProvenanceWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	exec := NewXAIExecutor(&config.Config{})
+	prepared, errPrepare := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+		Model:   "grok-4.5",
+		Payload: xaiMultiAgentV2TestPayload(),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Headers:      http.Header{"User-Agent": []string{"Codex Desktop/0.146.0-alpha.3"}},
+	}, true)
+	if errPrepare != nil {
+		t.Fatalf("prepareResponsesRequest() error = %v", errPrepare)
+	}
+	if len(prepared.plaintextMultiAgentTools) != 0 {
+		t.Fatalf("disabled optimization recorded plaintext provenance: %#v", prepared.plaintextMultiAgentTools)
+	}
+	for _, name := range []string{"spawn_agent", "send_message", "followup_task"} {
+		path := `tools.#(name=="collaboration__` + name + `").parameters.properties.message.encrypted`
+		if marker := gjson.GetBytes(prepared.body, path); marker.Type != gjson.True {
+			t.Fatalf("disabled optimization changed collaboration.%s marker: %s", name, prepared.body)
+		}
+	}
+}
+
+func TestRestoreXAIPlaintextMultiAgentFunctionArgsUsesRequestProvenance(t *testing.T) {
+	t.Parallel()
+
+	refs := map[xaiClientToolKey]struct{}{
+		{namespace: "collaboration", name: "spawn_agent", toolType: xaiFunctionToolType}:   {},
+		{namespace: "collaboration", name: "send_message", toolType: xaiFunctionToolType}:  {},
+		{namespace: "collaboration", name: "followup_task", toolType: xaiFunctionToolType}: {},
+	}
+	payload := []byte(`{"type":"response.completed","response":{"output":[
+		{"id":"fc_0","type":"function_call","call_id":"call_0","name":"spawn_agent","namespace":"collaboration","arguments":"{\"task\":\"demo\"}"},
+		{"id":"fc_1","type":"function_call","call_id":"call_1","name":"send_message","namespace":"collaboration","arguments":"{}","encrypted_function_args":["existing"]},
+		{"id":"fc_2","type":"function_call","call_id":"call_2","name":"followup_task","namespace":"collaboration","arguments":"{}","encrypted_function_args":null},
+		{"id":"fc_3","type":"function_call","call_id":"call_3","name":"spawn_agent","namespace":"ordinary","arguments":"{}"},
+		{"id":"fc_4","type":"custom_tool_call","call_id":"call_4","name":"spawn_agent","namespace":"collaboration","input":"{}"},
+		{"id":"fc_5","type":"function_call","call_id":"call_5","name":"unknown","namespace":"collaboration","arguments":"{}"}
+	]}}`)
+	got := restoreXAIPlaintextMultiAgentFunctionArgs(payload, refs)
+	marker := gjson.GetBytes(got, "response.output.0.encrypted_function_args")
+	if !marker.IsArray() || marker.Get("#").Int() != 0 {
+		t.Fatalf("proven plaintext call missing encrypted_function_args=[]: %s", got)
+	}
+	if arguments := gjson.GetBytes(got, "response.output.0.arguments").String(); arguments != `{"task":"demo"}` {
+		t.Fatalf("arguments changed: %q", arguments)
+	}
+	if callID := gjson.GetBytes(got, "response.output.0.call_id").String(); callID != "call_0" {
+		t.Fatalf("call_id changed: %q", callID)
+	}
+	if existing := gjson.GetBytes(got, "response.output.1.encrypted_function_args.0").String(); existing != "existing" {
+		t.Fatalf("existing encrypted_function_args changed: %s", got)
+	}
+	if nullMarker := gjson.GetBytes(got, "response.output.2.encrypted_function_args"); nullMarker.Raw != "null" {
+		t.Fatalf("existing null encrypted_function_args changed: %s", got)
+	}
+	for _, index := range []int{3, 4, 5} {
+		if unexpected := gjson.GetBytes(got, fmt.Sprintf("response.output.%d.encrypted_function_args", index)); unexpected.Exists() {
+			t.Fatalf("unproven output.%d was marked: %s", index, got)
+		}
+	}
+
+	event := []byte(`{"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_event","name":"followup_task","namespace":"collaboration","arguments":"{}"}}`)
+	restoredEvent := restoreXAIPlaintextMultiAgentFunctionArgs(event, refs)
+	if eventMarker := gjson.GetBytes(restoredEvent, "item.encrypted_function_args"); !eventMarker.IsArray() || eventMarker.Get("#").Int() != 0 {
+		t.Fatalf("event item missing encrypted_function_args=[]: %s", restoredEvent)
+	}
+	malformed := []byte(`{"item":`)
+	if unchanged := restoreXAIPlaintextMultiAgentFunctionArgs(malformed, refs); !bytes.Equal(unchanged, malformed) {
+		t.Fatalf("malformed response changed: %s", unchanged)
+	}
+}
+
+func TestXAIExecutorExecuteRestoresPlaintextMultiAgentMarker(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var errRead error
+		gotBody, errRead = io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read body: %v", errRead)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"fc_1\",\"type\":\"function_call\",\"name\":\"collaboration__spawn_agent\",\"call_id\":\"call_1\",\"arguments\":\"{\\\"task\\\":\\\"demo\\\"}\"}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"status\":\"completed\",\"model\":\"grok-4.5\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}\n\n"))
+	}))
+	defer server.Close()
+
+	exec := NewXAIExecutor(&config.Config{Codex: config.CodexConfig{OptimizeMultiAgentV2: true}})
+	auth := &cliproxyauth.Auth{Provider: "xai", Attributes: map[string]string{"base_url": server.URL}, Metadata: map[string]any{"access_token": "xai-token"}}
+	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{Model: "grok-4.5", Payload: xaiMultiAgentV2TestPayload()}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse, ResponseFormat: sdktranslator.FormatOpenAIResponse, Headers: http.Header{"User-Agent": []string{"Codex Desktop/0.146.0-alpha.3"}},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	assertXAIPlaintextMultiAgentSchemas(t, gotBody)
+	assertXAIPlaintextMultiAgentCall(t, gjson.GetBytes(resp.Payload, "output.0"))
+}
+
+func TestXAIExecutorExecuteStreamRestoresPlaintextMultiAgentMarker(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"fc_1\",\"type\":\"function_call\",\"name\":\"collaboration__spawn_agent\",\"call_id\":\"call_1\",\"arguments\":\"{\\\"task\\\":\\\"demo\\\"}\"}}\n\n"))
+		_, _ = w.Write([]byte("event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"status\":\"completed\",\"model\":\"grok-4.5\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}\n\n"))
+	}))
+	defer server.Close()
+
+	exec := NewXAIExecutor(&config.Config{Codex: config.CodexConfig{OptimizeMultiAgentV2: true}})
+	auth := &cliproxyauth.Auth{Provider: "xai", Attributes: map[string]string{"base_url": server.URL}, Metadata: map[string]any{"access_token": "xai-token"}}
+	result, err := exec.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{Model: "grok-4.5", Payload: xaiMultiAgentV2TestPayload()}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse, ResponseFormat: sdktranslator.FormatOpenAIResponse, Stream: true, Headers: http.Header{"User-Agent": []string{"Codex Desktop/0.146.0-alpha.3"}},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+
+	var outputItemDone gjson.Result
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v", chunk.Err)
+		}
+		line := strings.TrimSpace(strings.TrimPrefix(string(chunk.Payload), "data:"))
+		if !gjson.Valid(line) {
+			continue
+		}
+		event := gjson.Parse(line)
+		if event.Get("type").String() == "response.output_item.done" {
+			outputItemDone = event.Get("item")
+		}
+	}
+	assertXAIPlaintextMultiAgentCall(t, outputItemDone)
+}
+
+func xaiMultiAgentV2TestPayload() []byte {
+	return []byte(`{"model":"grok-4.5","input":"delegate","tools":[{"type":"namespace","name":"collaboration","tools":[
+		{"type":"function","name":"spawn_agent","parameters":{"type":"object","properties":{"message":{"type":"string","encrypted":true}}}},
+		{"type":"function","name":"send_message","parameters":{"type":"object","properties":{"message":{"type":"string","encrypted":true}}}},
+		{"type":"function","name":"followup_task","parameters":{"type":"object","properties":{"message":{"type":"string","encrypted":true}}}}
+	]}]}`)
+}
+
+func assertXAIPlaintextMultiAgentSchemas(t *testing.T, body []byte) {
+	t.Helper()
+	for _, name := range []string{"spawn_agent", "send_message", "followup_task"} {
+		toolPath := `tools.#(name=="collaboration__` + name + `")`
+		if tool := gjson.GetBytes(body, toolPath); !tool.Exists() {
+			t.Fatalf("qualified collaboration.%s schema missing: %s", name, body)
+		}
+		if marker := gjson.GetBytes(body, toolPath+".parameters.properties.message.encrypted"); marker.Exists() {
+			t.Fatalf("collaboration.%s marker remained: %s", name, body)
+		}
+	}
+}
+
+func assertXAIPlaintextMultiAgentCall(t *testing.T, call gjson.Result) {
+	t.Helper()
+	if call.Get("type").String() != "function_call" || call.Get("name").String() != "spawn_agent" || call.Get("namespace").String() != "collaboration" {
+		t.Fatalf("unexpected restored Multi-Agent call: %s", call.Raw)
+	}
+	marker := call.Get("encrypted_function_args")
+	if !marker.IsArray() || marker.Get("#").Int() != 0 {
+		t.Fatalf("plaintext Multi-Agent call missing encrypted_function_args=[]: %s", call.Raw)
+	}
+	if call.Get("call_id").String() != "call_1" || call.Get("arguments").String() != `{"task":"demo"}` {
+		t.Fatalf("call identity or arguments changed: %s", call.Raw)
+	}
+}
+
 func TestXAIExecutorExecuteRestoresAdditionalToolsNamespaceCalls(t *testing.T) {
 	var gotBody []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/runtime/executor/xai_websockets_executor.go
+++ b/internal/runtime/executor/xai_websockets_executor.go
@@ -760,6 +760,7 @@ func (e *XAIWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *cliprox
 
 			for _, payload := range xaiNormalizeReasoningSummaryDataEvents(payload) {
 				payload = restoreXAINamespaceToolCalls(payload, prepared.namespaceTools)
+				payload = restoreXAIPlaintextMultiAgentFunctionArgs(payload, prepared.plaintextMultiAgentTools)
 				payload = responseFilter.apply(payload)
 				if len(payload) == 0 {
 					continue

--- a/internal/runtime/executor/xai_websockets_executor_test.go
+++ b/internal/runtime/executor/xai_websockets_executor_test.go
@@ -422,6 +422,86 @@ func TestXAIWebsocketsExecuteStreamRestoresNamespaceToolCalls(t *testing.T) {
 	}
 }
 
+func TestXAIWebsocketsExecuteStreamRestoresPlaintextMultiAgentMarker(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	capturedPayload := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		_, payload, errRead := conn.ReadMessage()
+		if errRead != nil {
+			t.Errorf("read upstream websocket message: %v", errRead)
+			return
+		}
+		capturedPayload <- bytes.Clone(payload)
+
+		events := [][]byte{
+			[]byte(`{"type":"response.output_item.done","output_index":0,"item":{"id":"fc_1","type":"function_call","name":"collaboration__spawn_agent","call_id":"call_1","arguments":"{\"task\":\"demo\"}"}}`),
+			[]byte(`{"type":"response.completed","response":{"id":"resp_1","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`),
+		}
+		for _, event := range events {
+			if errWrite := conn.WriteMessage(websocket.TextMessage, event); errWrite != nil {
+				t.Errorf("write websocket event: %v", errWrite)
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	exec := NewXAIWebsocketsExecutor(&config.Config{Codex: config.CodexConfig{OptimizeMultiAgentV2: true}})
+	auth := &cliproxyauth.Auth{
+		Provider: "xai",
+		Attributes: map[string]string{
+			"base_url":   server.URL,
+			"websockets": "true",
+		},
+		Metadata: map[string]any{"access_token": "xai-token"},
+	}
+	result, err := exec.ExecuteStream(
+		cliproxyexecutor.WithDownstreamWebsocket(context.Background()),
+		auth,
+		cliproxyexecutor.Request{Model: "grok-4.5", Payload: xaiMultiAgentV2TestPayload()},
+		cliproxyexecutor.Options{
+			SourceFormat:   sdktranslator.FormatOpenAIResponse,
+			ResponseFormat: sdktranslator.FormatOpenAIResponse,
+			Stream:         true,
+			Headers:        http.Header{"User-Agent": []string{"Codex Desktop/0.146.0-alpha.3"}},
+		},
+	)
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+
+	select {
+	case payload := <-capturedPayload:
+		assertXAIPlaintextMultiAgentSchemas(t, payload)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for upstream websocket payload")
+	}
+
+	var outputItemDone, completed gjson.Result
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v", chunk.Err)
+		}
+		payload := gjson.ParseBytes(bytes.TrimSpace(chunk.Payload))
+		switch payload.Get("type").String() {
+		case "response.output_item.done":
+			outputItemDone = payload.Get("item")
+		case "response.completed":
+			completed = payload.Get("response.output.0")
+		}
+	}
+
+	assertXAIPlaintextMultiAgentCall(t, outputItemDone)
+	assertXAIPlaintextMultiAgentCall(t, completed)
+}
+
 func TestXAIWebsocketsExecuteStreamPreservesClientSameNameToolsWithXSearch(t *testing.T) {
 	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## 结果与边界

基于已合入的 MA-A（PR #204 / merge `9f833c70`），为 xAI Responses 补齐 request provenance 和回程 plaintext marker：只有请求阶段确实删除了 JSON boolean `true` 的 Multi-Agent schema marker，返回的同一 namespace/function call 才会获得 `encrypted_function_args: []`。

本 PR 不复制 MA-A 的 namespace 判断，不修改 Codex Desktop、Codex Rust、模型 catalog 或当前配置，不部署、不启用线上功能。由于 ledger 的 `introduced_in` 指向实现提交 `23caefe8b2495856c2c8df50b63823846ad6b910`，本 PR 必须使用 **Create a merge commit**，禁止 squash/rebase。

## Type

- [ ] Protected upstream full-sync
- [ ] Staged upstream full-sync
- [ ] LTS protected-delta patch
- [x] LTS feature / downstream patch maintenance
- [ ] Maintenance docs / CI
- [ ] Emergency hotfix

## 主要变更

- xAI provider normalization 前保存 request body，并调用 MA-A 导出的 `RewriteCodexMultiAgentV2MessageEncryption`；通过相邻 before/after 树比较记录实际被删除 marker 的 function key。
- provenance 同时覆盖 top-level `tools` 与 `input[].additional_tools`；`false`、string、null、ordinary namespace、disabled gate 和未实际改写的 schema 不进入集合。
- `xaiPreparedRequest` 携带 `(namespace, short name, function)` provenance；不根据响应短名猜测，也不重新实现 namespace heuristic。
- HTTP non-stream、SSE、WebSocket 统一执行：restore namespace/short name → restore `encrypted_function_args: []` → existing X Search response filter。
- 已有 `encrypted_function_args`（包括非空数组或 null）不覆盖；ordinary、custom、unknown 或未命中 provenance 的调用不处理；`arguments`、`call_id` 和 item identity 保持不变。
- 新增 downstream patch `xai-multi-agent-plaintext-provenance`。

## Protected delta review

- Request lifecycle：只在 xAI provider translation/normalization seam 增加 provenance capture；auth、model selection、retry、usage accounting 与 request logging 未改变。
- Response lifecycle：复用现有 namespace restore 与 X Search filter，中间插入 provenance restore；HTTP、SSE、WebSocket 顺序一致。
- Config：不新增 key，不改变 `optimize-multi-agent-v2` 默认值或当前线上配置。
- Usage、Management usage response、Panel release source：行为和 schema 未改变；专用 usage tests 与全仓测试通过。

## LTS classification review

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| `xai-multi-agent-plaintext-provenance` | downstream patch | `newly-added` | 实现提交 `23caefe8`；root/additional provenance、marker 类型边界与 HTTP/SSE/WS round-trip 回归通过 |
| `codex-multi-agent-plaintext-contract` | downstream patch dependency | `preserved` | 只调用 MA-A exported helper；namespace 与 boolean marker 判断未复制或放宽 |

- [x] `introduced_in` 指向本 PR 内实现提交；合并必须使用 **Create a merge commit**。

## Validation

- [x] `go test ./internal/config -count=1`
- [x] `go test ./sdk/cliproxy/... -count=1`
- [x] `go test ./internal/runtime/executor -count=1`
- [x] `go test ./internal/translator/openai/openai/responses -count=1`
- [x] `go test ./internal/usage ./internal/api/handlers/management ./test -run "Usage|usage" -count=1`
- [x] `scripts/check-lts-contract.sh`
- [x] `go run ./scripts/ltsregistry --root .`
- [x] `go build -o test-output ./cmd/server`（构建产物已清理）
- [x] `go test ./... -count=1`
- [x] `go list ./... | rg -v "/tmp$" | xargs go test -count=1`
- [x] `git diff --check`

## 未执行的动态验收

- [ ] 生产/HF runtime 部署：未授权，未执行。
- [ ] 真实 Grok/xAI Desktop canary：需要后续部署授权；本 PR 当前只完成 CPA 组件级静态闭环。
- [ ] 当前 `tool_namespace = "agents"` 的官方 Desktop `DirectPlaintextMessage` 识别：本 PR 不修改客户端或配置，不能把静态测试表述成该端到端闭环已完成。

## Review focus

1. `collectXAIPlaintextMultiAgentTools` 是否只从实际 before/after marker 删除生成 provenance。
2. 三条回程是否都严格遵循 namespace restore → marker restore → response filter。
3. 现有 marker、不匹配 namespace/type/name、arguments 与 call ID 是否保持原样。