### PR TITLE
fix(runtime): isolate provider state and Codex rate limits

### DIFF
--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -908,3 +908,47 @@ patches:
     upstream_issue_or_pr: not-filed
     state: required
     retire_when: Upstream records provenance only for Multi-Agent function schemas whose JSON boolean-true message.encrypted marker was actually removed, covers both root tools and input additional_tools, restores namespace before adding an empty encrypted_function_args without overwriting an existing field or changing arguments and call IDs, leaves ordinary, custom, disabled, and unproven calls untouched across HTTP non-stream, SSE, and WebSocket, and all listed regressions pass after removing the downstream implementation.
+
+  - id: provider-runtime-state-isolation
+    reason: Runtime state belongs to one concrete auth provider generation and must not leak across same-ID provider replacement. Codex transient rate limits must remain distinct from quota exhaustion, non-buffering streams must not fail after delivering visible deltas merely because optional completion reconstruction exceeds its cap, and thinking-suffix cooldown reconciliation must restore only the intended concrete registry IDs without racing a newer success.
+    introduced_in: e97ccfb8b41e0874745d807d6c1434bcf572840f
+    affected_upstream_range: through a88197f845c979132c8978ea223c6af05cc81536 (v7.2.116, 2026-08-03); upstream still applies the abnormal-reasoning reconstruction cap to non-buffering streams, treats raw Codex rate_limit_error/rate_limit_exceeded 429s as quota, restores canonicalized cooldowns to the wrong thinking-suffix registry ID, and inherits health, model, refresh, runtime, and persisted cooldown state across same-ID provider replacement. This adapts the still-unique behavior recovered from closed CPA-Core-LTS PR #192 commits 4c8250c5 and a39fb5ee to the post-v7.2.116 split executor/conductor files; integration merge artifacts 502c3af2 and 201a5ed8 were not replayed.
+    files:
+      - docs/lts/downstream-patches.yaml
+      - internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
+      - internal/runtime/executor/codex_executor_retry_test.go
+      - internal/runtime/executor/codex_executor_stream.go
+      - internal/runtime/executor/codex_executor_terminal.go
+      - internal/runtime/executor/openai_compat_executor.go
+      - sdk/cliproxy/auth/codex_transient_rate_limit_test.go
+      - sdk/cliproxy/auth/conductor.go
+      - sdk/cliproxy/auth/conductor_cooldown.go
+      - sdk/cliproxy/auth/conductor_lifecycle.go
+      - sdk/cliproxy/auth/conductor_lts.go
+      - sdk/cliproxy/auth/conductor_reconcile_cooldown_test.go
+      - sdk/cliproxy/auth/conductor_selection.go
+      - sdk/cliproxy/auth/conductor_update_test.go
+      - sdk/cliproxy/service_auth.go
+      - sdk/cliproxy/service_stale_state_test.go
+    regression_tests:
+      - TestCodexExecutorAbnormalReasoningRetry_NonBufferingStreamOverReconstructionCapDoesNotFailAfterDelta
+      - TestNewCodexStatusErrTreatsUsageLimitAsRetryableRateLimit
+      - TestNewCodexStatusErrDoesNotClassifyTransientRateLimitForModelFallback
+      - TestResultErrorFromErrorPreservesCodexRateLimitClass
+      - TestManagerMarkResultCodexTransientRateLimitDoesNotSetQuota
+      - TestManagerMarkResultCodexRawTransientRateLimitDoesNotSetQuota
+      - TestManagerMarkResultCodexTransientRateLimitWithoutModelDoesNotSetQuota
+      - TestManagerMarkResultCodexTransientRateLimitDoesNotEraseActiveQuota
+      - TestManagerMarkResultCodexRawTransientRateLimitDoesNotEraseActiveQuota
+      - TestManagerMarkResultCodexRawTransientRateLimitWithoutModelPreservesActiveQuota
+      - TestManagerMarkResultNonCodexRawRateLimitRemainsQuota
+      - TestManager_ReconcileRegistryModelStatesRestoresCooldownForRegisteredThinkingSuffix
+      - TestManager_ReconcileRegistryModelStatesCanonicalStateAppliesToEntireRegisteredFamily
+      - TestManager_ReconcileRegistryModelStatesMissingSuffixFallsBackToRegisteredCanonicalModel
+      - TestManager_ReconcileRegistryModelStatesDoesNotRestoreCooldownAfterRacedSuccess
+      - TestManager_Update_ProviderChangeDoesNotInheritRuntimeState
+      - TestManager_Update_ProviderChangePersistsCooldownClear
+      - TestServiceApplyCoreAuthAddOrUpdate_ProviderChangeDoesNotInheritRuntimeState
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: Upstream separates Codex transient rate limits from usage quota at executor and auth-state boundaries, preserves active confirmed quota against older transient results, keeps non-buffering delivered streams independent from reconstruction memory caps, restores exact/canonical thinking-family cooldowns without stale races, clears all provider-owned runtime and persisted cooldown state on same-ID provider replacement, and every listed regression passes after removing the downstream implementation.

--- a/internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
+++ b/internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
@@ -1707,6 +1707,64 @@ func TestCodexExecutorAbnormalReasoningRetry_ObserveOnlyStreamingDoesNotBufferUn
 	}
 }
 
+func TestCodexExecutorAbnormalReasoningRetry_NonBufferingStreamOverReconstructionCapDoesNotFailAfterDelta(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  *config.Config
+	}{
+		{
+			name: "observe only",
+			cfg:  codexAbnormalReasoningRetryTestConfigWithAction(config.CodexAbnormalReasoningRetryActionObserveOnly),
+		},
+		{
+			name: "stream buffer disabled",
+			cfg: func() *config.Config {
+				streamBuffer := false
+				return codexAbnormalReasoningRetryTestConfig(nil, &streamBuffer)
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			streamBufferMaxBytes := int64(1)
+			tt.cfg.Codex.AbnormalReasoningRetry.StreamBufferMaxBytes = &streamBufferMaxBytes
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = w.Write([]byte(`data: {"type":"response.output_text.delta","delta":"visible"}` + "\n\n"))
+				_, _ = w.Write([]byte(`data: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"visible"}]}}` + "\n\n"))
+				_, _ = w.Write([]byte(codexCompletedSSE("gpt-5.5", 100)))
+			}))
+			defer server.Close()
+
+			executor := NewCodexExecutor(tt.cfg)
+			result, err := executor.ExecuteStream(context.Background(), codexAbnormalReasoningRetryTestAuth(server.URL), cliproxyexecutor.Request{
+				Model:   "gpt-5.5",
+				Payload: []byte(`{"model":"gpt-5.5","input":"hello"}`),
+			}, cliproxyexecutor.Options{
+				SourceFormat: sdktranslator.FromString("openai-response"),
+				Stream:       true,
+			})
+			if err != nil {
+				t.Fatalf("ExecuteStream error = %v", err)
+			}
+
+			var payload []byte
+			for chunk := range result.Chunks {
+				if chunk.Err != nil {
+					t.Fatalf("stream emitted an error after visible delta: %v", chunk.Err)
+				}
+				payload = append(payload, chunk.Payload...)
+			}
+			if !bytes.Contains(payload, []byte("visible")) {
+				t.Fatalf("stream payload = %s, want visible delta", payload)
+			}
+		})
+	}
+}
+
 func TestCodexExecutorAbnormalReasoningRetry_StreamingBufferMaxBytesAbnormalStillRetriesWithoutFallback(t *testing.T) {
 	streamBufferMaxBytes := int64(1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/runtime/executor/codex_executor_retry_test.go
+++ b/internal/runtime/executor/codex_executor_retry_test.go
@@ -95,12 +95,28 @@ func TestNewCodexStatusErrTreatsUsageLimitAsRetryableRateLimit(t *testing.T) {
 	if got := err.ModelFallbackReason(); got != "usage-limit" {
 		t.Fatalf("ModelFallbackReason() = %q, want usage-limit", got)
 	}
+	if got := err.CodexRateLimitClass(); got != CodexRateLimitClassUsageLimit {
+		t.Fatalf("CodexRateLimitClass() = %q, want %q", got, CodexRateLimitClassUsageLimit)
+	}
 }
 
 func TestNewCodexStatusErrDoesNotClassifyTransientRateLimitForModelFallback(t *testing.T) {
 	err := newCodexStatusErr(http.StatusTooManyRequests, []byte(`{"error":{"type":"rate_limit_error","code":"rate_limit_exceeded"}}`))
 	if got := err.ModelFallbackReason(); got != "" {
 		t.Fatalf("ModelFallbackReason() = %q, want empty", got)
+	}
+	if got := err.CodexRateLimitClass(); got != CodexRateLimitClassTransient {
+		t.Fatalf("CodexRateLimitClass() = %q, want %q", got, CodexRateLimitClassTransient)
+	}
+}
+
+func TestGenericStatusErrDoesNotClassifyCodexRateLimit(t *testing.T) {
+	err := statusErr{
+		code: http.StatusTooManyRequests,
+		msg:  `{"error":{"type":"rate_limit_error","code":"rate_limit_exceeded"}}`,
+	}
+	if got := err.CodexRateLimitClass(); got != "" {
+		t.Fatalf("CodexRateLimitClass() = %q, want empty for non-Codex status error", got)
 	}
 }
 

--- a/internal/runtime/executor/codex_executor_stream.go
+++ b/internal/runtime/executor/codex_executor_stream.go
@@ -171,7 +171,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		buffering := abnormalRetry.StreamBuffer()
 		bufferMaxBytes := abnormalRetry.StreamBufferMaxBytes()
 		scannerMaxTokenBytes := int64(52_428_800) // 50 MiB compatibility ceiling.
-		if bufferMaxBytes > 0 && bufferMaxBytes < scannerMaxTokenBytes {
+		if buffering && bufferMaxBytes > 0 && bufferMaxBytes < scannerMaxTokenBytes {
 			scannerMaxTokenBytes = bufferMaxBytes + 1
 			if scannerMaxTokenBytes < 64<<10 {
 				scannerMaxTokenBytes = 64 << 10
@@ -188,6 +188,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		var bufferedChunks []cliproxyexecutor.StreamChunk
 		var bufferLimitErr error
 		bufferLimitExceeded := false
+		reconstructionCapExceeded := false
 		var flushBuffered func() bool
 		exceedBufferLimit := func() {
 			if bufferLimitExceeded {
@@ -279,9 +280,23 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 				}
 				switch eventType {
 				case "response.output_item.done":
-					if !bufferLimitExceeded {
-						if bufferMaxBytes > 0 && bufferedBytes+outputItemsBytes+int64(len(data)) > bufferMaxBytes {
-							exceedBufferLimit()
+					if !bufferLimitExceeded && !reconstructionCapExceeded {
+						candidateBytes := outputItemsBytes + int64(len(data))
+						if buffering {
+							candidateBytes += bufferedBytes
+						}
+						if bufferMaxBytes > 0 && candidateBytes > bufferMaxBytes {
+							if buffering {
+								exceedBufferLimit()
+							} else {
+								// Deltas have already reached the client. Drop only optional
+								// completion reconstruction state instead of turning the
+								// delivered response into a terminal buffer-limit error.
+								reconstructionCapExceeded = true
+								outputItemsByIndex = nil
+								outputItemsFallback = nil
+								outputItemsBytes = 0
+							}
 						} else {
 							collectCodexOutputItemDone(data, outputItemsByIndex, &outputItemsFallback)
 							outputItemsBytes += int64(len(data))
@@ -374,7 +389,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 			if ctx.Err() != nil {
 				return
 			}
-			if bufferMaxBytes > 0 && strings.Contains(errScan.Error(), "token too long") {
+			if buffering && bufferMaxBytes > 0 && strings.Contains(errScan.Error(), "token too long") {
 				exceedBufferLimit()
 				helps.RecordAPIResponseError(ctx, e.cfg, bufferLimitErr)
 				reporter.PublishFailure(ctx, bufferLimitErr)

--- a/internal/runtime/executor/codex_executor_terminal.go
+++ b/internal/runtime/executor/codex_executor_terminal.go
@@ -288,8 +288,32 @@ func newCodexStatusErr(statusCode int, body []byte) statusErr {
 		msg:                 string(body),
 		modelFallbackReason: classification.ModelFallbackReason,
 		retryAfter:          classification.RetryAfter,
+		codexRateLimitClass: codexRateLimitClass(body),
 	}
 	return err
+}
+
+const (
+	CodexRateLimitClassUsageLimit = "usage-limit"
+	CodexRateLimitClassTransient  = "transient-rate-limit"
+)
+
+func codexRateLimitClass(body []byte) string {
+	if isCodexUsageLimitError(body) {
+		return CodexRateLimitClassUsageLimit
+	}
+	for _, candidate := range []string{
+		gjson.GetBytes(body, "error.type").String(),
+		gjson.GetBytes(body, "error.code").String(),
+		gjson.GetBytes(body, "type").String(),
+		gjson.GetBytes(body, "code").String(),
+	} {
+		switch strings.ToLower(strings.TrimSpace(candidate)) {
+		case "rate_limit_error", "rate_limit_exceeded":
+			return CodexRateLimitClassTransient
+		}
+	}
+	return ""
 }
 
 func classifyCodexStatusError(statusCode int, body []byte) []byte {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -864,6 +864,7 @@ type statusErr struct {
 	msg                 string
 	retryAfter          *time.Duration
 	modelFallbackReason string
+	codexRateLimitClass string
 }
 
 func (e statusErr) Error() string {
@@ -875,3 +876,4 @@ func (e statusErr) Error() string {
 func (e statusErr) StatusCode() int             { return e.code }
 func (e statusErr) RetryAfter() *time.Duration  { return e.retryAfter }
 func (e statusErr) ModelFallbackReason() string { return e.modelFallbackReason }
+func (e statusErr) CodexRateLimitClass() string { return e.codexRateLimitClass }

--- a/sdk/cliproxy/auth/codex_transient_rate_limit_test.go
+++ b/sdk/cliproxy/auth/codex_transient_rate_limit_test.go
@@ -1,0 +1,308 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+)
+
+type classifiedCodexRateLimitError struct {
+	class string
+}
+
+func (e classifiedCodexRateLimitError) Error() string               { return "codex rate limit" }
+func (e classifiedCodexRateLimitError) StatusCode() int             { return http.StatusTooManyRequests }
+func (e classifiedCodexRateLimitError) CodexRateLimitClass() string { return e.class }
+
+func TestResultErrorFromErrorPreservesCodexRateLimitClass(t *testing.T) {
+	const transientClass = "transient-rate-limit"
+	resultErr := resultErrorFromError(classifiedCodexRateLimitError{class: transientClass})
+	if resultErr == nil || resultErr.Code != transientClass {
+		t.Fatalf("result error = %+v, want code %q", resultErr, transientClass)
+	}
+	if resultErr.HTTPStatus != http.StatusTooManyRequests {
+		t.Fatalf("HTTP status = %d, want 429", resultErr.HTTPStatus)
+	}
+}
+
+func TestManagerMarkResultCodexTransientRateLimitDoesNotSetQuota(t *testing.T) {
+	prev := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(prev) })
+
+	const (
+		authID         = "codex-transient-rate-limit-auth"
+		model          = "codex-transient-rate-limit-model"
+		transientClass = "transient-rate-limit"
+	)
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	m := NewManager(nil, nil, nil)
+	if _, err := m.Register(context.Background(), &Auth{ID: authID, Provider: "codex", Status: StatusActive}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	m.MarkResult(context.Background(), Result{
+		AuthID: authID, Provider: "codex", Model: model,
+		Error: &Error{HTTPStatus: http.StatusTooManyRequests, Code: transientClass, Message: "rate_limit_error"},
+	})
+
+	updated, ok := m.GetByID(authID)
+	if !ok || updated == nil || updated.ModelStates[model] == nil {
+		t.Fatalf("missing updated model state: %+v", updated)
+	}
+	state := updated.ModelStates[model]
+	if state.Quota.Exceeded || state.Quota.Reason != "" {
+		t.Fatalf("transient rate limit was recorded as quota: %+v", state.Quota)
+	}
+	if !state.Unavailable || !state.NextRetryAfter.After(time.Now()) {
+		t.Fatalf("transient cooldown was not recorded: %+v", state)
+	}
+	if count := reg.GetModelCount(model); count != 1 {
+		t.Fatalf("registry model count = %d, want transient error not to suspend it", count)
+	}
+}
+
+func TestManagerMarkResultCodexRawTransientRateLimitDoesNotSetQuota(t *testing.T) {
+	prev := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(prev) })
+
+	for _, tt := range []struct {
+		name string
+		code string
+	}{
+		{name: "rate-limit-error", code: "rate_limit_error"},
+		{name: "rate-limit-exceeded", code: "rate_limit_exceeded"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			authID := "codex-raw-transient-" + tt.name
+			model := "codex-raw-transient-model-" + tt.name
+			reg := registry.GetGlobalRegistry()
+			reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+			t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+			m := NewManager(nil, nil, nil)
+			if _, err := m.Register(context.Background(), &Auth{ID: authID, Provider: "codex", Status: StatusActive}); err != nil {
+				t.Fatalf("register auth: %v", err)
+			}
+			m.MarkResult(context.Background(), Result{
+				AuthID: authID, Provider: "codex", Model: model,
+				Error: &Error{HTTPStatus: http.StatusTooManyRequests, Code: tt.code, Message: tt.code},
+			})
+
+			updated, ok := m.GetByID(authID)
+			if !ok || updated == nil || updated.ModelStates[model] == nil {
+				t.Fatalf("missing updated model state: %+v", updated)
+			}
+			state := updated.ModelStates[model]
+			if state.Quota.Exceeded || state.Quota.Reason != "" {
+				t.Fatalf("raw transient rate limit was recorded as quota: %+v", state.Quota)
+			}
+			if !state.Unavailable || !state.NextRetryAfter.After(time.Now()) {
+				t.Fatalf("raw transient cooldown was not recorded: %+v", state)
+			}
+			if count := reg.GetModelCount(model); count != 1 {
+				t.Fatalf("registry model count = %d, want transient error not to suspend it", count)
+			}
+		})
+	}
+}
+
+func TestManagerMarkResultCodexTransientRateLimitWithoutModelDoesNotSetQuota(t *testing.T) {
+	prev := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(prev) })
+
+	for _, tt := range []struct {
+		name string
+		code string
+	}{
+		{name: "synthetic", code: "transient-rate-limit"},
+		{name: "rate-limit-error", code: "rate_limit_error"},
+		{name: "rate-limit-exceeded", code: "rate_limit_exceeded"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			authID := "codex-auth-level-transient-" + tt.name
+			m := NewManager(nil, nil, nil)
+			if _, err := m.Register(context.Background(), &Auth{ID: authID, Provider: "codex", Status: StatusActive}); err != nil {
+				t.Fatalf("register auth: %v", err)
+			}
+			m.MarkResult(context.Background(), Result{
+				AuthID: authID, Provider: "codex",
+				Error: &Error{HTTPStatus: http.StatusTooManyRequests, Code: tt.code, Message: tt.code},
+			})
+
+			updated, ok := m.GetByID(authID)
+			if !ok || updated == nil {
+				t.Fatalf("missing updated auth: %+v", updated)
+			}
+			if updated.Quota.Exceeded || updated.Quota.Reason != "" {
+				t.Fatalf("auth-level transient rate limit was recorded as quota: %+v", updated.Quota)
+			}
+			if !updated.Unavailable || !updated.NextRetryAfter.After(time.Now()) {
+				t.Fatalf("auth-level transient cooldown was not recorded: %+v", updated)
+			}
+		})
+	}
+}
+
+func TestManagerMarkResultCodexTransientRateLimitDoesNotEraseActiveQuota(t *testing.T) {
+	prev := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(prev) })
+
+	const (
+		authID = "codex-transient-after-quota-auth"
+		model  = "codex-transient-after-quota-model"
+	)
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	m := NewManager(nil, nil, nil)
+	if _, err := m.Register(context.Background(), &Auth{ID: authID, Provider: "codex", Status: StatusActive}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	m.MarkResult(context.Background(), Result{
+		AuthID: authID, Model: model,
+		Error: &Error{HTTPStatus: http.StatusTooManyRequests, Code: "usage-limit", Message: "usage_limit_reached"},
+	})
+	if count := reg.GetModelCount(model); count != 0 {
+		t.Fatalf("registry model count after quota = %d, want 0", count)
+	}
+
+	m.MarkResult(context.Background(), Result{
+		AuthID: authID, Model: model,
+		Error: &Error{HTTPStatus: http.StatusTooManyRequests, Code: "transient-rate-limit", Message: "rate_limit_error"},
+	})
+
+	updated, ok := m.GetByID(authID)
+	if !ok || updated == nil || updated.ModelStates[model] == nil {
+		t.Fatalf("missing updated model state: %+v", updated)
+	}
+	state := updated.ModelStates[model]
+	if !state.Quota.Exceeded || state.Quota.Reason != "quota" || !state.NextRetryAfter.After(time.Now()) {
+		t.Fatalf("active quota was erased by an older transient result: %+v", state)
+	}
+	if state.LastError == nil || state.LastError.Code != "usage-limit" {
+		t.Fatalf("active quota error was replaced by transient state: %+v", state.LastError)
+	}
+	if count := reg.GetModelCount(model); count != 0 {
+		t.Fatalf("registry model count = %d, want manager and registry to retain active quota", count)
+	}
+}
+
+func TestManagerMarkResultCodexRawTransientRateLimitDoesNotEraseActiveQuota(t *testing.T) {
+	prev := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(prev) })
+
+	const (
+		authID = "codex-raw-transient-after-quota-auth"
+		model  = "codex-raw-transient-after-quota-model"
+	)
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	m := NewManager(nil, nil, nil)
+	if _, err := m.Register(context.Background(), &Auth{ID: authID, Provider: "codex", Status: StatusActive}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	m.MarkResult(context.Background(), Result{
+		AuthID: authID, Provider: "codex", Model: model,
+		Error: &Error{HTTPStatus: http.StatusTooManyRequests, Code: "usage-limit", Message: "usage_limit_reached"},
+	})
+	m.MarkResult(context.Background(), Result{
+		AuthID: authID, Provider: "codex", Model: model,
+		Error: &Error{HTTPStatus: http.StatusTooManyRequests, Code: "rate_limit_exceeded", Message: "rate_limit_exceeded"},
+	})
+
+	updated, ok := m.GetByID(authID)
+	if !ok || updated == nil || updated.ModelStates[model] == nil {
+		t.Fatalf("missing updated model state: %+v", updated)
+	}
+	state := updated.ModelStates[model]
+	if !state.Quota.Exceeded || state.Quota.Reason != "quota" || !state.NextRetryAfter.After(time.Now()) {
+		t.Fatalf("active quota was erased by raw transient result: %+v", state)
+	}
+	if state.LastError == nil || state.LastError.Code != "usage-limit" {
+		t.Fatalf("active quota error was replaced by raw transient state: %+v", state.LastError)
+	}
+	if count := reg.GetModelCount(model); count != 0 {
+		t.Fatalf("registry model count = %d, want active quota retained", count)
+	}
+}
+
+func TestManagerMarkResultCodexRawTransientRateLimitWithoutModelPreservesActiveQuota(t *testing.T) {
+	prev := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(prev) })
+
+	const authID = "codex-auth-level-raw-transient-after-quota"
+	retryAfter := 30 * time.Minute
+	m := NewManager(nil, nil, nil)
+	if _, err := m.Register(context.Background(), &Auth{ID: authID, Provider: "codex", Status: StatusActive}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	m.MarkResult(context.Background(), Result{
+		AuthID: authID, Provider: "codex",
+		Error:      &Error{HTTPStatus: http.StatusTooManyRequests, Code: "usage-limit", Message: "usage_limit_reached"},
+		RetryAfter: &retryAfter,
+	})
+	before, _ := m.GetByID(authID)
+	m.MarkResult(context.Background(), Result{
+		AuthID: authID, Provider: "codex",
+		Error: &Error{HTTPStatus: http.StatusTooManyRequests, Code: "rate_limit_error", Message: "rate_limit_error"},
+	})
+
+	updated, ok := m.GetByID(authID)
+	if !ok || updated == nil {
+		t.Fatalf("missing updated auth: %+v", updated)
+	}
+	if !updated.Quota.Exceeded || updated.Quota.Reason != "quota" || !updated.NextRetryAfter.Equal(before.NextRetryAfter) {
+		t.Fatalf("active auth-level quota was erased by raw transient result: before=%+v after=%+v", before, updated)
+	}
+	if updated.LastError == nil || updated.LastError.Code != "usage-limit" {
+		t.Fatalf("active auth-level quota error was replaced: %+v", updated.LastError)
+	}
+}
+
+func TestManagerMarkResultNonCodexRawRateLimitRemainsQuota(t *testing.T) {
+	prev := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(prev) })
+
+	const (
+		authID = "xai-raw-rate-limit-auth"
+		model  = "xai-raw-rate-limit-model"
+	)
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "xai", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	m := NewManager(nil, nil, nil)
+	if _, err := m.Register(context.Background(), &Auth{ID: authID, Provider: "xai", Status: StatusActive}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	m.MarkResult(context.Background(), Result{
+		AuthID: authID, Provider: "xai", Model: model,
+		Error: &Error{HTTPStatus: http.StatusTooManyRequests, Code: "rate_limit_error", Message: "rate_limit_error"},
+	})
+
+	updated, ok := m.GetByID(authID)
+	if !ok || updated == nil || updated.ModelStates[model] == nil {
+		t.Fatalf("missing updated model state: %+v", updated)
+	}
+	if !updated.ModelStates[model].Quota.Exceeded || updated.ModelStates[model].Quota.Reason != "quota" {
+		t.Fatalf("non-Codex raw rate limit did not remain quota: %+v", updated.ModelStates[model])
+	}
+	if count := reg.GetModelCount(model); count != 0 {
+		t.Fatalf("registry model count = %d, want non-Codex quota suspension", count)
+	}
+}

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -163,6 +163,9 @@ type Manager struct {
 	// continuityBeforeDispatchHook is an internal test seam invoked after
 	// continuity admission and before the final dispatch recheck.
 	continuityBeforeDispatchHook func()
+	// reconcileBeforeRegistryRestoreHook is an internal test seam invoked after
+	// model cooldowns are snapshotted and before registry restoration.
+	reconcileBeforeRegistryRestoreHook func()
 
 	// Optional HTTP RoundTripper provider injected by host.
 	rtProvider RoundTripperProvider

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -21,6 +21,8 @@ var quotaCooldownDisabled atomic.Bool
 
 var transientErrorCooldownSeconds atomic.Int64
 
+const codexTransientRateLimitClass = "transient-rate-limit"
+
 // SetQuotaCooldownDisabled toggles quota cooldown scheduling globally.
 func SetQuotaCooldownDisabled(disable bool) {
 	quotaCooldownDisabled.Store(disable)
@@ -416,6 +418,31 @@ func clearCooldownStateForAuth(auth *Auth, now time.Time) bool {
 	}
 	return changed
 }
+
+func clearProviderRuntimeState(auth *Auth, now time.Time) {
+	if auth == nil {
+		return
+	}
+	auth.Success = 0
+	auth.Failed = 0
+	auth.recentRequests = recentRequestRing{}
+	auth.Unavailable = false
+	auth.Quota = QuotaState{}
+	auth.LastError = nil
+	auth.StatusMessage = ""
+	auth.LastRefreshedAt = time.Time{}
+	auth.NextRefreshAfter = time.Time{}
+	auth.NextRetryAfter = time.Time{}
+	auth.ModelStates = nil
+	auth.Runtime = nil
+	if auth.Disabled || auth.Status == StatusDisabled {
+		auth.Status = StatusDisabled
+	} else {
+		auth.Status = StatusActive
+	}
+	auth.UpdatedAt = now
+}
+
 func dedupeStrings(values []string) []string {
 	if len(values) < 2 {
 		return values
@@ -768,11 +795,13 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				if !isRequestScopedResultError(result.Error) {
 					disableCooling := m.cooldownDisabledForAuth(auth)
 					state := ensureModelState(auth, result.Model)
+					transientRateLimit := isCodexTransientRateLimitResultError(auth.Provider, result.Error)
+					preserveActiveQuota := transientRateLimit && activeQuotaCooldown(state.Quota, state.NextRetryAfter, now)
 					state.modelFallbackReason = strings.ToLower(strings.TrimSpace(result.ModelFallbackReason))
 					state.Unavailable = true
 					state.Status = StatusError
 					state.UpdatedAt = now
-					if result.Error != nil {
+					if result.Error != nil && !preserveActiveQuota {
 						state.LastError = cloneError(result.Error)
 						state.StatusMessage = result.Error.Message
 						auth.LastError = cloneError(result.Error)
@@ -817,6 +846,23 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 							state.NextRetryAfter = next
 							suspendReason = "unauthorized"
 							shouldSuspendModel = true
+						}
+					} else if transientRateLimit {
+						if preserveActiveQuota {
+							setModelQuota = true
+							shouldSuspendModel = true
+							suspendReason = "quota"
+						} else {
+							if state.Quota.Exceeded && strings.EqualFold(strings.TrimSpace(state.Quota.Reason), "quota") {
+								clearModelQuota = true
+								shouldResumeModel = true
+							}
+							state.Quota = QuotaState{}
+							if disableCooling {
+								state.NextRetryAfter = time.Time{}
+							} else {
+								state.NextRetryAfter = nextTransientErrorRetryAfter(now)
+							}
 						}
 					} else {
 						switch statusCode {
@@ -888,7 +934,11 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 				}
 			} else {
 				disableCooling := m.cooldownDisabledForAuth(auth)
-				applyAuthFailureState(auth, result.Error, result.RetryAfter, now, disableCooling)
+				if isCodexTransientRateLimitResultError(auth.Provider, result.Error) {
+					applyTransientRateLimitAuthFailureState(auth, result.Error, now, disableCooling)
+				} else {
+					applyAuthFailureState(auth, result.Error, result.RetryAfter, now, disableCooling)
+				}
 			}
 		}
 
@@ -1184,10 +1234,27 @@ func resultErrorFromError(err error) *Error {
 			resultErr.HTTPStatus = http.StatusBadGateway
 		}
 	}
+	if class := codexRateLimitClassFromError(err); class != "" {
+		resultErr.Code = class
+	}
 	if isRequestScopedError(err) || isRequestInvalidError(err) {
 		resultErr.Code = requestScopedErrorCode
 	}
 	return resultErr
+}
+
+func codexRateLimitClassFromError(err error) string {
+	if err == nil {
+		return ""
+	}
+	type rateLimitClassifier interface {
+		CodexRateLimitClass() string
+	}
+	var classifier rateLimitClassifier
+	if !errors.As(err, &classifier) || classifier == nil {
+		return ""
+	}
+	return strings.TrimSpace(classifier.CodexRateLimitClass())
 }
 
 func isUnauthorizedError(err error) bool {
@@ -1714,6 +1781,35 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 		auth.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
 		auth.Unavailable = !auth.NextRetryAfter.IsZero()
 	}
+}
+
+func applyTransientRateLimitAuthFailureState(auth *Auth, resultErr *Error, now time.Time, disableCooling bool) {
+	if auth == nil {
+		return
+	}
+	preserveActiveQuota := activeQuotaCooldown(auth.Quota, auth.NextRetryAfter, now)
+	auth.Unavailable = true
+	auth.Status = StatusError
+	auth.UpdatedAt = now
+	if preserveActiveQuota {
+		return
+	}
+	auth.Quota = QuotaState{}
+	auth.LastError = cloneError(resultErr)
+	if resultErr != nil {
+		auth.StatusMessage = resultErr.Message
+	}
+	if disableCooling {
+		auth.NextRetryAfter = time.Time{}
+	} else {
+		auth.NextRetryAfter = nextTransientErrorRetryAfter(now)
+	}
+}
+
+func activeQuotaCooldown(quota QuotaState, nextRetryAfter, now time.Time) bool {
+	return quota.Exceeded &&
+		strings.EqualFold(strings.TrimSpace(quota.Reason), "quota") &&
+		nextRetryAfter.After(now)
 }
 
 // quotaCooldownAfterFailure returns the recovery deadline and backoff level for

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -118,15 +118,20 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 		auth.Index = existing.Index
 		auth.indexAssigned = existing.indexAssigned
 	}
-	auth.Success = existing.Success
-	auth.Failed = existing.Failed
-	auth.recentRequests = existing.recentRequests
-	if !existing.Disabled && existing.Status != StatusDisabled && !auth.Disabled && auth.Status != StatusDisabled {
-		if len(auth.ModelStates) == 0 && len(existing.ModelStates) > 0 {
-			auth.ModelStates = existing.ModelStates
-		}
-	}
 	now := time.Now()
+	sameProvider := strings.EqualFold(strings.TrimSpace(existing.Provider), strings.TrimSpace(auth.Provider))
+	if sameProvider {
+		auth.Success = existing.Success
+		auth.Failed = existing.Failed
+		auth.recentRequests = existing.recentRequests
+		if !existing.Disabled && existing.Status != StatusDisabled && !auth.Disabled && auth.Status != StatusDisabled {
+			if len(auth.ModelStates) == 0 && len(existing.ModelStates) > 0 {
+				auth.ModelStates = existing.ModelStates
+			}
+		}
+	} else {
+		clearProviderRuntimeState(auth, now)
+	}
 	clearedCooldown := false
 	if m.cooldownDisabledForAuth(auth) || auth.Disabled || auth.Status == StatusDisabled {
 		clearedCooldown = clearCooldownStateForAuth(auth, now)
@@ -144,7 +149,7 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 	m.queueRefreshReschedule(auth.ID)
 	_ = m.persist(ctx, auth)
 	m.hook.OnAuthUpdated(ctx, auth.Clone())
-	if clearedCooldown {
+	if clearedCooldown || !sameProvider {
 		m.persistCooldownStates(ctx)
 	}
 	return auth.Clone(), nil

--- a/sdk/cliproxy/auth/conductor_lts.go
+++ b/sdk/cliproxy/auth/conductor_lts.go
@@ -938,6 +938,18 @@ func isXaiBadCredentialsResultError(provider string, err *Error) bool {
 	return isXaiBadCredentialsMessage(err.Code) || isXaiBadCredentialsMessage(err.Message)
 }
 
+func isCodexTransientRateLimitResultError(provider string, err *Error) bool {
+	if err == nil || !strings.EqualFold(strings.TrimSpace(provider), "codex") {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(err.Code)) {
+	case codexTransientRateLimitClass, "rate_limit_error", "rate_limit_exceeded":
+		return true
+	default:
+		return false
+	}
+}
+
 // isRequestScopedModelNotFoundMessage identifies the OpenAI-style 404 emitted
 // when request/model routing or Codex client identity is rejected. This shape
 // is not evidence of unhealthy credentials, and penalizing each auth can

--- a/sdk/cliproxy/auth/conductor_reconcile_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_reconcile_cooldown_test.go
@@ -109,6 +109,146 @@ func TestManager_ReconcileRegistryModelStatesPreservesFutureQuotaCooldown(t *tes
 	}
 }
 
+func TestManager_ReconcileRegistryModelStatesRestoresCooldownForRegisteredThinkingSuffix(t *testing.T) {
+	const (
+		authID       = "reconcile-thinking-suffix-auth"
+		model        = "reconcile-thinking-suffix-model(8192)"
+		siblingModel = "reconcile-thinking-suffix-model(16384)"
+	)
+	ctx := context.Background()
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}, {ID: siblingModel}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	if _, err := manager.Register(ctx, &Auth{ID: authID, Provider: "codex"}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	manager.MarkResult(ctx, Result{
+		AuthID: authID, Provider: "codex", Model: model,
+		Error: &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"},
+	})
+
+	before, ok := manager.GetByID(authID)
+	if !ok || before.ModelStates[model] == nil {
+		t.Fatal("thinking-suffix cooldown was not recorded")
+	}
+	resetAggregatedAuthStateForReconcileTest(t, manager, before)
+
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}, {ID: siblingModel}})
+	manager.ReconcileRegistryModelStates(ctx, authID)
+	if count := reg.GetModelCount(model); count != 0 {
+		t.Fatalf("registry model count after reconciliation = %d, want 0", count)
+	}
+	if count := reg.GetModelCount(siblingModel); count != 1 {
+		t.Fatalf("sibling registry model count = %d, want unaffected suffix available", count)
+	}
+}
+
+func TestManager_ReconcileRegistryModelStatesCanonicalStateAppliesToEntireRegisteredFamily(t *testing.T) {
+	const (
+		authID       = "reconcile-canonical-thinking-auth"
+		model        = "reconcile-canonical-thinking-model"
+		firstSuffix  = "reconcile-canonical-thinking-model(8192)"
+		secondSuffix = "reconcile-canonical-thinking-model(16384)"
+	)
+	ctx := context.Background()
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}, {ID: firstSuffix}, {ID: secondSuffix}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	if _, err := manager.Register(ctx, &Auth{ID: authID, Provider: "codex"}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	manager.MarkResult(ctx, Result{
+		AuthID: authID, Provider: "codex", Model: model,
+		Error: &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"},
+	})
+
+	before, ok := manager.GetByID(authID)
+	if !ok || before.ModelStates[model] == nil {
+		t.Fatal("canonical model cooldown was not recorded")
+	}
+	resetAggregatedAuthStateForReconcileTest(t, manager, before)
+
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}, {ID: firstSuffix}, {ID: secondSuffix}})
+	manager.ReconcileRegistryModelStates(ctx, authID)
+	for _, registeredModel := range []string{model, firstSuffix, secondSuffix} {
+		if count := reg.GetModelCount(registeredModel); count != 0 {
+			t.Fatalf("registry count for %s = %d, want cooldown restored", registeredModel, count)
+		}
+	}
+}
+
+func TestManager_ReconcileRegistryModelStatesMissingSuffixFallsBackToRegisteredCanonicalModel(t *testing.T) {
+	const (
+		authID         = "reconcile-missing-suffix-auth"
+		canonicalModel = "reconcile-missing-suffix-model"
+		stateModel     = "reconcile-missing-suffix-model(8192)"
+	)
+	ctx := context.Background()
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: canonicalModel}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	if _, err := manager.Register(ctx, &Auth{ID: authID, Provider: "codex"}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	manager.MarkResult(ctx, Result{
+		AuthID: authID, Provider: "codex", Model: stateModel,
+		Error: &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"},
+	})
+
+	before, ok := manager.GetByID(authID)
+	if !ok || before.ModelStates[stateModel] == nil {
+		t.Fatal("suffix model cooldown was not recorded")
+	}
+	resetAggregatedAuthStateForReconcileTest(t, manager, before)
+
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: canonicalModel}})
+	manager.ReconcileRegistryModelStates(ctx, authID)
+	if count := reg.GetModelCount(canonicalModel); count != 0 {
+		t.Fatalf("canonical registry count = %d, want missing suffix cooldown restored", count)
+	}
+}
+
+func TestManager_ReconcileRegistryModelStatesDoesNotRestoreCooldownAfterRacedSuccess(t *testing.T) {
+	const (
+		authID = "reconcile-raced-success-auth"
+		model  = "reconcile-raced-success-model"
+	)
+	ctx := context.Background()
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	manager := NewManager(nil, &FillFirstSelector{}, nil)
+	if _, err := manager.Register(ctx, &Auth{ID: authID, Provider: "codex"}); err != nil {
+		t.Fatalf("Register() error = %v", err)
+	}
+	manager.MarkResult(ctx, Result{
+		AuthID: authID, Provider: "codex", Model: model,
+		Error: &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"},
+	})
+
+	reg.RegisterClient(authID, "codex", []*registry.ModelInfo{{ID: model}})
+	manager.reconcileBeforeRegistryRestoreHook = func() {
+		manager.reconcileBeforeRegistryRestoreHook = nil
+		manager.MarkResult(ctx, Result{AuthID: authID, Provider: "codex", Model: model, Success: true})
+	}
+
+	manager.ReconcileRegistryModelStates(ctx, authID)
+	if count := reg.GetModelCount(model); count != 1 {
+		t.Fatalf("registry model count after raced success = %d, want 1", count)
+	}
+	updated, ok := manager.GetByID(authID)
+	if !ok || updated.ModelStates[model] == nil || !modelStateIsClean(updated.ModelStates[model]) {
+		t.Fatalf("model state after raced success = %+v, want clean", updated)
+	}
+}
+
 func TestManager_ReconcileRegistryModelStatesKeepsCloudflareCooldownRoutingAvailable(t *testing.T) {
 	const (
 		authID = "reconcile-cloudflare-auth"

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -194,22 +194,32 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 	}
 
 	supportedModels := registry.GetGlobalRegistry().GetModelsForClient(authID)
-	supported := make(map[string]struct{}, len(supportedModels))
+	supported := make(map[string][]string, len(supportedModels))
 	for _, model := range supportedModels {
 		if model == nil {
 			continue
 		}
+		rawModelID := strings.TrimSpace(model.ID)
 		modelKey := canonicalModelKey(model.ID)
-		if modelKey == "" {
+		if modelKey == "" || rawModelID == "" {
 			continue
 		}
-		supported[modelKey] = struct{}{}
+		registered := supported[modelKey]
+		alreadyRegistered := false
+		for _, existingModelID := range registered {
+			if existingModelID == rawModelID {
+				alreadyRegistered = true
+				break
+			}
+		}
+		if !alreadyRegistered {
+			supported[modelKey] = append(registered, rawModelID)
+		}
 	}
 
 	type registryCooldown struct {
-		model  string
-		reason string
-		quota  bool
+		stateModel       string
+		registeredModels []string
 	}
 
 	var snapshot *Auth
@@ -226,7 +236,12 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 			if baseModel == "" {
 				baseModel = strings.TrimSpace(modelKey)
 			}
-			if _, supportedModel := supported[baseModel]; !supportedModel {
+			registeredModels, supportedModel := supported[baseModel]
+			if supportedModel {
+				registeredModels = registeredModelsForReconciledState(modelKey, baseModel, registeredModels)
+				supportedModel = len(registeredModels) > 0
+			}
+			if !supportedModel {
 				// Drop state for models that disappeared from the current registry
 				// snapshot. Keeping them around leaks stale errors into auth-level
 				// status, management output, and websocket fallback checks.
@@ -242,11 +257,10 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 			}
 			if state.Unavailable && state.NextRetryAfter.After(now) {
 				preserved = true
-				if reason, quota, suspend := registrySuspensionForModelState(state); suspend {
+				if _, _, suspend := registrySuspensionForModelState(state); suspend {
 					cooldowns = append(cooldowns, registryCooldown{
-						model:  baseModel,
-						reason: reason,
-						quota:  quota,
+						stateModel:       modelKey,
+						registeredModels: append([]string(nil), registeredModels...),
 					})
 				}
 				continue
@@ -293,17 +307,65 @@ func (m *Manager) ReconcileRegistryModelStates(ctx context.Context, authID strin
 	}
 	m.mu.Unlock()
 
-	reg := registry.GetGlobalRegistry()
-	for _, cooldown := range cooldowns {
-		if cooldown.quota {
-			reg.SetModelQuotaExceeded(authID, cooldown.model)
-		}
-		reg.SuspendClientModel(authID, cooldown.model, cooldown.reason)
+	if m.reconcileBeforeRegistryRestoreHook != nil {
+		m.reconcileBeforeRegistryRestoreHook()
 	}
+
+	reg := registry.GetGlobalRegistry()
+	m.mu.Lock()
+	currentAuth := m.auths[authID]
+	for _, cooldown := range cooldowns {
+		if currentAuth == nil {
+			break
+		}
+		state := currentAuth.ModelStates[cooldown.stateModel]
+		if state == nil || !state.Unavailable || !state.NextRetryAfter.After(time.Now()) {
+			continue
+		}
+		reason, quota, suspend := registrySuspensionForModelState(state)
+		if !suspend {
+			continue
+		}
+		for _, registeredModel := range cooldown.registeredModels {
+			if quota {
+				reg.SetModelQuotaExceeded(authID, registeredModel)
+			}
+			reg.SuspendClientModel(authID, registeredModel, reason)
+		}
+	}
+	if snapshot != nil && currentAuth != nil {
+		snapshot = currentAuth.Clone()
+	}
+	m.mu.Unlock()
 
 	if m.scheduler != nil && snapshot != nil {
 		m.scheduler.upsertAuth(snapshot)
 	}
+}
+
+// registeredModelsForReconciledState maps one persisted ModelState back to
+// concrete registry IDs without spreading a suffix-specific cooldown to sibling
+// suffixes. Canonical state applies to the full registered family.
+func registeredModelsForReconciledState(stateModel, baseModel string, registeredModels []string) []string {
+	stateModel = strings.TrimSpace(stateModel)
+	baseModel = strings.TrimSpace(baseModel)
+	if stateModel == "" || baseModel == "" {
+		return nil
+	}
+	if strings.EqualFold(stateModel, baseModel) {
+		return append([]string(nil), registeredModels...)
+	}
+	for _, registeredModel := range registeredModels {
+		if strings.EqualFold(strings.TrimSpace(registeredModel), stateModel) {
+			return []string{registeredModel}
+		}
+	}
+	for _, registeredModel := range registeredModels {
+		if strings.EqualFold(strings.TrimSpace(registeredModel), baseModel) {
+			return []string{registeredModel}
+		}
+	}
+	return nil
 }
 
 // jitteredCooldownWait adds a small random delay to a cooldown wait so

--- a/sdk/cliproxy/auth/conductor_update_test.go
+++ b/sdk/cliproxy/auth/conductor_update_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -204,6 +205,110 @@ func TestManager_Update_ActiveInheritsModelStates(t *testing.T) {
 	}
 	if state.Quota.BackoffLevel != backoffLevel {
 		t.Fatalf("expected BackoffLevel to be %d, got %d", backoffLevel, state.Quota.BackoffLevel)
+	}
+}
+
+func TestManager_Update_ProviderChangeDoesNotInheritRuntimeState(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	staleRetry := time.Now().Add(time.Hour)
+	staleRuntime := &struct{ provider string }{provider: "claude"}
+	if _, err := m.Register(context.Background(), &Auth{
+		ID: "auth-provider-change", Provider: "claude", Status: StatusActive,
+		Runtime: staleRuntime, Success: 5, Failed: 3,
+		ModelStates: map[string]*ModelState{
+			"shared-model": {Unavailable: true, Status: StatusError, NextRetryAfter: staleRetry},
+		},
+	}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	if _, err := m.Update(context.Background(), &Auth{
+		ID: "auth-provider-change", Provider: "xai", Status: StatusError,
+		StatusMessage: "stale provider error", Unavailable: true,
+		Quota:           QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: staleRetry},
+		LastError:       &Error{Code: "stale", Message: "stale provider error"},
+		LastRefreshedAt: staleRetry.Add(-2 * time.Hour), NextRefreshAfter: staleRetry,
+		NextRetryAfter: staleRetry, Runtime: staleRuntime, Success: 9, Failed: 7,
+		ModelStates: map[string]*ModelState{
+			"incoming-stale-model": {
+				Unavailable: true, Status: StatusError, NextRetryAfter: staleRetry,
+				Quota: QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: staleRetry},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("update auth: %v", err)
+	}
+
+	updated, ok := m.GetByID("auth-provider-change")
+	if !ok || updated == nil {
+		t.Fatal("expected updated auth")
+	}
+	if len(updated.ModelStates) != 0 {
+		t.Fatalf("provider change retained ModelStates: %+v", updated.ModelStates)
+	}
+	if updated.Status != StatusActive || updated.Unavailable || updated.StatusMessage != "" || updated.LastError != nil {
+		t.Fatalf("provider change retained auth error state: %+v", updated)
+	}
+	if updated.Quota != (QuotaState{}) || !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("provider change retained quota/retry state: quota=%+v retry=%v", updated.Quota, updated.NextRetryAfter)
+	}
+	if !updated.LastRefreshedAt.IsZero() || !updated.NextRefreshAfter.IsZero() {
+		t.Fatalf("provider change retained refresh state: last=%v next=%v", updated.LastRefreshedAt, updated.NextRefreshAfter)
+	}
+	if updated.Success != 0 || updated.Failed != 0 || updated.Runtime != nil {
+		t.Fatalf("provider change retained runtime state: success=%d failed=%d runtime=%#v", updated.Success, updated.Failed, updated.Runtime)
+	}
+}
+
+func TestManager_Update_ProviderChangePersistsCooldownClear(t *testing.T) {
+	ctx := context.Background()
+	const authID = "auth-provider-change-persisted-cooldown"
+	retryAfter := 30 * time.Minute
+	store := &recordingCooldownStateStore{}
+	manager := NewManager(nil, nil, nil)
+	manager.SetCooldownStateStore(store)
+	if _, err := manager.Register(WithSkipPersist(ctx), &Auth{ID: authID, Provider: "claude", Status: StatusActive}); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+	manager.MarkResult(ctx, Result{
+		AuthID: authID, Provider: "claude", Model: "shared-model",
+		Error:      &Error{Code: "rate_limit", Message: "quota", HTTPStatus: http.StatusTooManyRequests},
+		RetryAfter: &retryAfter,
+	})
+
+	store.mu.Lock()
+	before := cloneCooldownStateRecords(store.records)
+	store.mu.Unlock()
+	if len(before) == 0 {
+		t.Fatal("provider cooldown was not persisted before provider change")
+	}
+
+	if _, err := manager.Update(ctx, &Auth{ID: authID, Provider: "xai", Status: StatusActive}); err != nil {
+		t.Fatalf("update auth provider: %v", err)
+	}
+
+	store.mu.Lock()
+	persistedAfterUpdate := cloneCooldownStateRecords(store.records)
+	store.mu.Unlock()
+
+	restartStore := &recordingCooldownStateStore{load: persistedAfterUpdate}
+	restarted := NewManager(nil, nil, nil)
+	restarted.SetCooldownStateStore(restartStore)
+	if _, err := restarted.Register(WithSkipPersist(ctx), &Auth{ID: authID, Provider: "xai", Status: StatusActive}); err != nil {
+		t.Fatalf("register auth after restart: %v", err)
+	}
+	if err := restarted.RestoreCooldownStates(ctx); err != nil {
+		t.Fatalf("restore cooldown states: %v", err)
+	}
+	restored, ok := restarted.GetByID(authID)
+	if !ok || restored == nil {
+		t.Fatal("restarted auth missing")
+	}
+	if len(persistedAfterUpdate) != 0 {
+		t.Fatalf("provider change left persisted cooldown records: %#v", persistedAfterUpdate)
+	}
+	if len(restored.ModelStates) != 0 || restored.Unavailable || restored.Quota.Exceeded || !restored.NextRetryAfter.IsZero() {
+		t.Fatalf("old provider cooldown revived after restart: %+v", restored)
 	}
 }
 

--- a/sdk/cliproxy/service_auth.go
+++ b/sdk/cliproxy/service_auth.go
@@ -283,7 +283,8 @@ func (s *Service) prepareCoreAuthForModelRegistration(ctx context.Context, auth 
 	var err error
 	if existing, ok := s.coreManager.GetByID(auth.ID); ok {
 		auth.CreatedAt = existing.CreatedAt
-		if !existing.Disabled && existing.Status != coreauth.StatusDisabled && !auth.Disabled && auth.Status != coreauth.StatusDisabled {
+		sameProvider := strings.EqualFold(strings.TrimSpace(existing.Provider), strings.TrimSpace(auth.Provider))
+		if sameProvider && !existing.Disabled && existing.Status != coreauth.StatusDisabled && !auth.Disabled && auth.Status != coreauth.StatusDisabled {
 			auth.LastRefreshedAt = existing.LastRefreshedAt
 			auth.NextRefreshAfter = existing.NextRefreshAfter
 			if len(auth.ModelStates) == 0 && len(existing.ModelStates) > 0 {

--- a/sdk/cliproxy/service_stale_state_test.go
+++ b/sdk/cliproxy/service_stale_state_test.go
@@ -73,6 +73,56 @@ func TestServiceApplyCoreAuthAddOrUpdate_DeleteReAddDoesNotInheritStaleRuntimeSt
 	}
 }
 
+func TestServiceApplyCoreAuthAddOrUpdate_ProviderChangeDoesNotInheritRuntimeState(t *testing.T) {
+	service := &Service{
+		cfg:         &config.Config{},
+		coreManager: coreauth.NewManager(nil, nil, nil),
+	}
+	const authID = "service-provider-change-auth"
+	staleRetry := time.Now().Add(time.Hour)
+	t.Cleanup(func() { GlobalModelRegistry().UnregisterClient(authID) })
+
+	service.applyCoreAuthAddOrUpdate(context.Background(), &coreauth.Auth{
+		ID: authID, Provider: "claude", Status: coreauth.StatusActive,
+		LastRefreshedAt: time.Now().Add(-time.Hour), NextRefreshAfter: staleRetry,
+		ModelStates: map[string]*coreauth.ModelState{
+			"shared-model": {Unavailable: true, Status: coreauth.StatusError, NextRetryAfter: staleRetry},
+		},
+	})
+
+	service.applyCoreAuthAddOrUpdate(context.Background(), &coreauth.Auth{
+		ID: authID, Provider: "xai", Status: coreauth.StatusError,
+		StatusMessage: "incoming stale provider error", Unavailable: true,
+		Quota:           coreauth.QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: staleRetry},
+		LastError:       &coreauth.Error{Code: "stale", Message: "incoming stale provider error"},
+		LastRefreshedAt: staleRetry.Add(-2 * time.Hour), NextRefreshAfter: staleRetry,
+		NextRetryAfter: staleRetry,
+		ModelStates: map[string]*coreauth.ModelState{
+			"incoming-stale-model": {
+				Unavailable: true, Status: coreauth.StatusError, NextRetryAfter: staleRetry,
+				Quota: coreauth.QuotaState{Exceeded: true, Reason: "quota", NextRecoverAt: staleRetry},
+			},
+		},
+	})
+
+	updated, ok := service.coreManager.GetByID(authID)
+	if !ok || updated == nil {
+		t.Fatal("expected updated auth")
+	}
+	if !updated.LastRefreshedAt.IsZero() || !updated.NextRefreshAfter.IsZero() {
+		t.Fatalf("provider change inherited refresh timestamps: last=%v next=%v", updated.LastRefreshedAt, updated.NextRefreshAfter)
+	}
+	if len(updated.ModelStates) != 0 {
+		t.Fatalf("provider change inherited ModelStates: %+v", updated.ModelStates)
+	}
+	if updated.Status != coreauth.StatusActive || updated.Unavailable || updated.StatusMessage != "" || updated.LastError != nil {
+		t.Fatalf("provider change retained auth error state: %+v", updated)
+	}
+	if updated.Quota != (coreauth.QuotaState{}) || !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("provider change retained quota/retry state: quota=%+v retry=%v", updated.Quota, updated.NextRetryAfter)
+	}
+}
+
 func TestForceHomeRuntimeConfigEnablesUsageStatistics(t *testing.T) {
 	cfg := &config.Config{
 		UsageStatisticsEnabled: false,


### PR DESCRIPTION
## 结果与合并约束

恢复并手工适配 closed PR #192 中仍然独有的前两段实现（`4c8250c5`、`a39fb5ee`），基于 v7.2.116 后拆分的 executor/conductor 文件完成 provider runtime state、Codex 429 taxonomy、stream reconstruction 与 registry reconcile 修复。

不 cherry-pick PR #192 的 integration merge `502c3af2` / `201a5ed8`。最后一段 `29851edf` auth lifecycle generation fence 仍保持独立，待本 PR 合入后另开 PR。因为新增 downstream patch 的 `introduced_in` 指向实现提交，本 PR 必须使用 **Create a merge commit**；禁止 squash/rebase。

## Type

- [ ] Protected upstream full-sync
- [ ] Staged upstream full-sync
- [x] LTS protected-delta patch
- [x] LTS feature / downstream patch maintenance
- [ ] Maintenance docs / CI
- [ ] Emergency hotfix

## 主要变化

- 非 buffering Codex stream 超过 optional completion reconstruction cap 时只丢弃重建状态；不会在客户端已经收到 delta 后再发送 `stream-buffer-limit`。
- Codex `rate_limit_error` / `rate_limit_exceeded` 通过 typed capability 保留为 transient rate limit，不再按 usage quota 挂起 registry model。
- 旧的 active confirmed quota 不会被较晚到达的 transient result 擦除；非 Codex 429 行为保持不变。
- persisted thinking-suffix state 精确恢复到 raw suffix、canonical family 或显式 canonical fallback，不污染 sibling suffix；registry restore 前重新检查 manager state，避免 raced success 后重新挂起。
- 同 auth ID 从一个 provider 切换到另一个 provider 时，清理 health counter、recent requests、auth/model quota、refresh timestamp、retry deadline、Runtime 与持久 cooldown；同 provider 更新仍保留既有连续性。
- 新增 `provider-runtime-state-isolation` downstream patch ledger entry，affected upstream 固定到 `a88197f8` / `v7.2.116`。

## 验证

以下检查在 exact head `99e03e69f9137b2e07d39ad63189c63fc4f7487f` 通过：

- [x] `scripts/check-lts-contract.sh`
- [x] `go run ./scripts/ltsregistry --root .`
- [x] `go test ./internal/runtime/executor ./sdk/cliproxy/... -count=1`
- [x] `go test -race ./sdk/cliproxy/auth -count=1`
- [x] `go test -json ./sdk/cliproxy/auth -count=10`（10 轮均通过）
- [x] `go list ./... | rg -v '/tmp$' | xargs go test -count=1`
- [x] `go build -o /tmp/cpa-core-provider-state ./cmd/server`
- [x] `git diff --check`

新增/恢复的定向 regression 覆盖：non-buffering delta、typed/raw transient 429、有/无 model、active quota preservation、non-Codex 429、exact/canonical thinking suffix、raced success、provider update、cooldown restart 和 Service registration。

## 边界

- 不修改配置格式、provider 路由、Desktop tool overlay、Multi-Agent plaintext 或 Panel API。
- 不包含 `29851edf` 的 execute/stream/count/prepare/refresh generation fence，避免把两个不同风险面的生命周期改动混成一次 review。
- 不创建 tag/Release、不构建发布资产、不部署运行时。
