### PR TITLE
fix(auth): 隔离同 ID provider 生命周期的过期回写

### DIFF
--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -952,3 +952,37 @@ patches:
     upstream_issue_or_pr: not-filed
     state: required
     retire_when: Upstream separates Codex transient rate limits from usage quota at executor and auth-state boundaries, preserves active confirmed quota against older transient results, keeps non-buffering delivered streams independent from reconstruction memory caps, restores exact/canonical thinking-family cooldowns without stale races, clears all provider-owned runtime and persisted cooldown state on same-ID provider replacement, and every listed regression passes after removing the downstream implementation.
+
+  - id: auth-provider-generation-fence
+    reason: Auth IDs are stable across watcher refreshes and can be reused after provider replacement or remove-and-register. An execution, stream, token count, request-auth preparation, or credential refresh that started on the previous lifecycle could therefore write quota, health, token, runtime, scheduler, registry, or persisted cooldown state into the replacement auth. LTS assigns a process-local, non-persisted generation to each auth lifecycle, carries it through every managed request path, and accepts writebacks only when both generation and provider still match.
+    introduced_in: 7db4a30d3c7b489503873df855146ad911bec117
+    affected_upstream_range: through a88197f845c979132c8978ea223c6af05cc81536 (v7.2.116, 2026-08-03); upstream still keys asynchronous result, preparation, and refresh writebacks only by auth ID, accepts persisted cooldown records from a different provider, and allows a stale request to refresh a same-ID replacement provider. This adapts the unique lifecycle behavior recovered from closed CPA-Core-LTS PR #192 commit 29851edf to the post-v7.2.116 split conductor files, while adding count-token, stream, and stale cross-provider refresh coverage absent from the recovered patch.
+    files:
+      - docs/lts/downstream-patches.yaml
+      - sdk/cliproxy/auth/conductor.go
+      - sdk/cliproxy/auth/conductor_cooldown.go
+      - sdk/cliproxy/auth/conductor_cooldown_provider_test.go
+      - sdk/cliproxy/auth/conductor_execution.go
+      - sdk/cliproxy/auth/conductor_generation.go
+      - sdk/cliproxy/auth/conductor_generation_test.go
+      - sdk/cliproxy/auth/conductor_home.go
+      - sdk/cliproxy/auth/conductor_lifecycle.go
+      - sdk/cliproxy/auth/conductor_lts.go
+      - sdk/cliproxy/auth/conductor_refresh.go
+      - sdk/cliproxy/auth/conductor_stream.go
+      - sdk/cliproxy/auth/types.go
+    regression_tests:
+      - TestManager_ProviderTransitionRejectsStaleExecutionGeneration
+      - TestManager_ProviderTransitionRejectsStaleCountTokensGeneration
+      - TestManager_ProviderTransitionRejectsStaleStreamGeneration
+      - TestManager_ProviderTransitionRejectsStaleRequestAuthPreparation
+      - TestManager_SelectAuthForRequestGenerationRejectsStaleExternalResult
+      - TestManager_StaleRequestCannotRefreshReplacementProvider
+      - TestManager_MarkResultRejectsStaleProviderWithoutGenerationContext
+      - TestManager_SelectAuthForRequestGenerationRejectsSameProviderReplacement
+      - TestManager_ProviderTransitionRejectsStaleRefreshSuccessGeneration
+      - TestManager_ProviderTransitionRejectsStaleRefreshFailureGeneration
+      - TestManager_RestoreCooldownRecordProviderCompatibility
+    upstream_issue_or_pr: not-filed
+    state: required
+    retire_when: Upstream gives every auth lifecycle a non-persisted generation, carries it through execute, stream, token-count, external selection, request preparation, refresh, model-pool, fallback, and Home-compatible paths, rejects stale provider or generation writebacks before hooks, persistence, scheduler, registry, and cooldown mutations, rejects persisted cooldown records from another provider, prevents an old request from refreshing a replacement provider, and all listed regressions pass after removing the downstream implementation.

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -114,7 +114,9 @@ type Manager struct {
 	mu                        sync.RWMutex
 	configCooldownMu          sync.Mutex
 	auths                     map[string]*Auth
-	scheduler                 *authScheduler
+	// authGeneration is allocated under mu and never persisted.
+	authGeneration uint64
+	scheduler      *authScheduler
 	// pluginScheduler runs outside m.mu before falling back to native selection.
 	pluginScheduler PluginScheduler
 	// homeRuntimeAuths retains legacy session auth lookups for non-execution callers.

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -350,6 +350,10 @@ func (m *Manager) restoreCooldownRecordLocked(record CooldownStateRecord, now ti
 	if auth == nil || auth.Disabled || auth.Status == StatusDisabled || m.cooldownDisabledForAuth(auth) {
 		return false
 	}
+	recordProvider := strings.TrimSpace(record.Provider)
+	if recordProvider != "" && !strings.EqualFold(recordProvider, strings.TrimSpace(auth.Provider)) {
+		return false
+	}
 	updatedAt := record.UpdatedAt
 	if updatedAt.IsZero() {
 		updatedAt = now
@@ -748,6 +752,12 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	cooldownStateChanged := false
 
 	m.mu.Lock()
+	auth := m.auths[result.AuthID]
+	if !resultMatchesAuthGeneration(ctx, result, auth) {
+		m.mu.Unlock()
+		m.abandonCodexRateLimitContinuityAttempt(ctx)
+		return
+	}
 	// The continuity state transition and the ModelState/cooldown mutation must
 	// be one manager critical section. begin() rechecks the continuity state
 	// before dispatch, so an in-flight candidate cannot clear a newly confirmed
@@ -756,7 +766,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	if m.continuityTransitionHook != nil {
 		m.continuityTransitionHook()
 	}
-	if auth, ok := m.auths[result.AuthID]; ok && auth != nil {
+	if auth != nil {
 		now := time.Now()
 		var cooldownRecordsBefore []CooldownStateRecord
 		trackCooldownState := m.cooldownStore != nil
@@ -1000,7 +1010,12 @@ func (m *Manager) recordAvailabilityNeutralResult(ctx context.Context, result Re
 
 	var authSnapshot *Auth
 	m.mu.Lock()
-	if auth, ok := m.auths[result.AuthID]; ok && auth != nil {
+	auth := m.auths[result.AuthID]
+	if !resultMatchesAuthGeneration(ctx, result, auth) {
+		m.mu.Unlock()
+		return
+	}
+	if auth != nil {
 		now := time.Now()
 		auth.recordRecentRequest(now, result.Success)
 		if result.Success {

--- a/sdk/cliproxy/auth/conductor_cooldown_provider_test.go
+++ b/sdk/cliproxy/auth/conductor_cooldown_provider_test.go
@@ -1,0 +1,84 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestManager_RestoreCooldownRecordProviderCompatibility(t *testing.T) {
+	now := time.Now().UTC()
+	nextRetry := now.Add(time.Hour)
+
+	tests := []struct {
+		name           string
+		recordProvider string
+		model          string
+		wantRestored   bool
+	}{
+		{name: "auth level provider mismatch", recordProvider: "claude", wantRestored: false},
+		{name: "model level provider mismatch", recordProvider: "claude", model: "grok-4", wantRestored: false},
+		{name: "auth level legacy empty provider", recordProvider: "", wantRestored: true},
+		{name: "model level legacy empty provider", recordProvider: "", model: "grok-4", wantRestored: true},
+		{name: "auth level matching provider is case insensitive", recordProvider: " XAI ", wantRestored: true},
+		{name: "model level matching provider is case insensitive", recordProvider: "Xai", model: "grok-4", wantRestored: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manager := NewManager(nil, nil, nil)
+			const authID = "restore-provider-compatibility"
+			if _, err := manager.Register(WithSkipPersist(context.Background()), &Auth{
+				ID:       authID,
+				Provider: "xai",
+				Status:   StatusActive,
+			}); err != nil {
+				t.Fatalf("register auth: %v", err)
+			}
+
+			record := CooldownStateRecord{
+				Provider:       test.recordProvider,
+				AuthID:         authID,
+				Model:          test.model,
+				NextRetryAfter: nextRetry,
+				Reason:         "quota",
+				Quota: QuotaState{
+					Exceeded:      true,
+					Reason:        "quota",
+					NextRecoverAt: nextRetry,
+				},
+				LastError: &Error{HTTPStatus: http.StatusTooManyRequests, Message: "rate limited"},
+				UpdatedAt: now,
+			}
+
+			manager.mu.Lock()
+			restored := manager.restoreCooldownRecordLocked(record, now)
+			manager.mu.Unlock()
+			if restored != test.wantRestored {
+				t.Fatalf("restoreCooldownRecordLocked() = %v, want %v", restored, test.wantRestored)
+			}
+
+			auth, ok := manager.GetByID(authID)
+			if !ok || auth == nil {
+				t.Fatal("auth missing after cooldown restore")
+			}
+			if !test.wantRestored {
+				if auth.Status != StatusActive || auth.Unavailable || !auth.NextRetryAfter.IsZero() || auth.LastError != nil || len(auth.ModelStates) != 0 {
+					t.Fatalf("provider mismatch mutated auth: %#v", auth)
+				}
+				return
+			}
+			if test.model == "" {
+				if auth.Status != StatusError || !auth.Unavailable || !auth.NextRetryAfter.Equal(nextRetry) || auth.LastError == nil {
+					t.Fatalf("legacy auth-level cooldown was not restored: %#v", auth)
+				}
+				return
+			}
+			state := auth.ModelStates[test.model]
+			if state == nil || state.Status != StatusError || !state.Unavailable || !state.NextRetryAfter.Equal(nextRetry) || state.LastError == nil {
+				t.Fatalf("legacy model-level cooldown was not restored: %#v", state)
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -297,6 +297,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			lastErr = codexRateLimitObservationPendingError{}
 			continue
 		}
+		attemptCtx = contextWithAuthGeneration(attemptCtx, auth)
 		if m.continuityBeforeDispatchHook != nil {
 			m.continuityBeforeDispatchHook()
 		}
@@ -327,11 +328,12 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			if errCancel := claudeOAuthRequestCancellation(execCtx, auth, errPrepare); errCancel != nil {
 				return cliproxyexecutor.Response{}, errCancel
 			}
-			result := Result{AuthID: auth.ID, Provider: provider, Model: routeModel, Success: false, Error: resultErrorFromError(errPrepare)}
+			result := resultForAuth(auth, provider, routeModel, false, resultErrorFromError(errPrepare))
 			m.MarkResult(execCtx, result)
 			lastErr = errPrepare
 			continue
 		}
+		execCtx = contextWithAuthGeneration(execCtx, auth)
 		var authErr error
 		didRefreshOnUnauthorized := false
 		selectedPublished := false
@@ -376,6 +378,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				}
 				if refreshed, okRefresh := m.tryRefreshAfterUnauthorized(execCtx, auth, errExec, didRefreshOnUnauthorized); okRefresh {
 					auth = refreshed
+					execCtx = contextWithAuthGeneration(execCtx, auth)
 					didRefreshOnUnauthorized = true
 					markCodexModelFallbackDispatch(execOpts, auth.ID)
 					resp, errExec = executor.Execute(execCtx, auth, execReq, execOpts)
@@ -395,7 +398,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			if errCancel := claudeOAuthRequestCancellation(execCtx, auth, errExec); errCancel != nil {
 				return cliproxyexecutor.Response{}, errCancel
 			}
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: errExec == nil}
+			result := resultForAuth(auth, provider, resultModel, errExec == nil, nil)
 			if errExec != nil {
 				result.Error = resultErrorFromError(errExec)
 				if ra := retryAfterFromError(errExec); ra != nil {
@@ -464,7 +467,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 		}
 
 		tried[auth.ID] = struct{}{}
-		execCtx := ctx
+		execCtx := contextWithAuthGeneration(ctx, auth)
 		if rt := m.roundTripperFor(auth); rt != nil {
 			execCtx = context.WithValue(execCtx, roundTripperContextKey{}, rt)
 			execCtx = context.WithValue(execCtx, "cliproxy.roundtripper", rt)
@@ -482,11 +485,12 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			if errCancel := claudeOAuthRequestCancellation(execCtx, auth, errPrepare); errCancel != nil {
 				return cliproxyexecutor.Response{}, errCancel
 			}
-			result := Result{AuthID: auth.ID, Provider: provider, Model: routeModel, Success: false, Error: resultErrorFromError(errPrepare)}
+			result := resultForAuth(auth, provider, routeModel, false, resultErrorFromError(errPrepare))
 			m.MarkResult(execCtx, result)
 			lastErr = errPrepare
 			continue
 		}
+		execCtx = contextWithAuthGeneration(execCtx, auth)
 		var authErr error
 		didRefreshOnUnauthorized := false
 		selectedPublished := false
@@ -523,6 +527,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				}
 				if refreshed, okRefresh := m.tryRefreshAfterUnauthorized(execCtx, auth, errExec, didRefreshOnUnauthorized); okRefresh {
 					auth = refreshed
+					execCtx = contextWithAuthGeneration(execCtx, auth)
 					didRefreshOnUnauthorized = true
 					resp, errExec = executor.CountTokens(execCtx, auth, execReq, execOpts)
 					if errExec != nil {
@@ -538,7 +543,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			if errCancel := claudeOAuthRequestCancellation(execCtx, auth, errExec); errCancel != nil {
 				return cliproxyexecutor.Response{}, errCancel
 			}
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: errExec == nil}
+			result := resultForAuth(auth, provider, resultModel, errExec == nil, nil)
 			if errExec != nil {
 				result.Error = countTokensResultErrorFromError(errExec, execReq.Model)
 				if ra := retryAfterFromError(errExec); ra != nil {
@@ -654,6 +659,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			lastErr = codexRateLimitObservationPendingError{}
 			continue
 		}
+		attemptCtx = contextWithAuthGeneration(attemptCtx, auth)
 		if m.continuityBeforeDispatchHook != nil {
 			m.continuityBeforeDispatchHook()
 		}
@@ -717,7 +723,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 					return nil, errCancel
 				}
 			}
-			result := Result{AuthID: auth.ID, Provider: provider, Model: routeModel, Success: false, Error: resultErrorFromError(errPrepare)}
+			result := resultForAuth(auth, provider, routeModel, false, resultErrorFromError(errPrepare))
 			if selection != nil {
 				m.reportHomeResult(execCtx, result, auth)
 				releaseAttempt()
@@ -732,6 +738,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			}
 			continue
 		}
+		execCtx = contextWithAuthGeneration(execCtx, auth)
 		execReq := sanitizeDownstreamWebsocketFallbackRequest(execCtx, auth, req)
 		streamExecutionModel := ""
 		if restoreExecutionModel {
@@ -966,9 +973,15 @@ func (m *Manager) prepareRequestAuth(ctx context.Context, executor ProviderExecu
 	defer lock.mu.Unlock()
 
 	target := auth.Clone()
+	managed := false
 	m.mu.RLock()
 	if current := m.auths[id]; current != nil {
+		if auth.generation != 0 && current.generation != auth.generation {
+			m.mu.RUnlock()
+			return auth, authLifecycleChangedError()
+		}
 		target = current.Clone()
+		managed = true
 	}
 	m.mu.RUnlock()
 
@@ -984,9 +997,15 @@ func (m *Manager) prepareRequestAuth(ctx context.Context, executor ProviderExecu
 		return target, nil
 	}
 
-	saved, errUpdate := m.Update(ctx, updated)
+	if !managed {
+		return updated, nil
+	}
+	saved, applied, errUpdate := m.updateIfGeneration(ctx, updated, target.generation)
 	if errUpdate != nil {
 		return updated, errUpdate
+	}
+	if !applied {
+		return auth, authLifecycleChangedError()
 	}
 	if saved != nil {
 		return saved, nil

--- a/sdk/cliproxy/auth/conductor_generation.go
+++ b/sdk/cliproxy/auth/conductor_generation.go
@@ -1,0 +1,77 @@
+package auth
+
+import (
+	"context"
+	"strings"
+)
+
+type authGenerationContextKey struct{}
+
+type authGenerationContextValue struct {
+	authID     string
+	generation uint64
+}
+
+func (m *Manager) nextAuthGenerationLocked() uint64 {
+	m.authGeneration++
+	if m.authGeneration == 0 {
+		m.authGeneration++
+	}
+	return m.authGeneration
+}
+
+func contextWithAuthGeneration(ctx context.Context, auth *Auth) context.Context {
+	if auth == nil || auth.ID == "" || auth.generation == 0 {
+		return ctx
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, authGenerationContextKey{}, authGenerationContextValue{
+		authID:     auth.ID,
+		generation: auth.generation,
+	})
+}
+
+func authGenerationFromContext(ctx context.Context, authID string) uint64 {
+	if ctx == nil || authID == "" {
+		return 0
+	}
+	value, ok := ctx.Value(authGenerationContextKey{}).(authGenerationContextValue)
+	if !ok || value.authID != authID {
+		return 0
+	}
+	return value.generation
+}
+
+func resultForAuth(auth *Auth, provider, model string, success bool, resultErr *Error) Result {
+	result := Result{
+		Provider: provider,
+		Model:    model,
+		Success:  success,
+		Error:    resultErr,
+	}
+	if auth != nil {
+		result.AuthID = auth.ID
+	}
+	return result
+}
+
+func resultMatchesAuthGeneration(ctx context.Context, result Result, auth *Auth) bool {
+	if auth != nil {
+		resultProvider := strings.TrimSpace(result.Provider)
+		authProvider := strings.TrimSpace(auth.Provider)
+		if resultProvider != "" && authProvider != "" && !strings.EqualFold(resultProvider, authProvider) {
+			return false
+		}
+	}
+	expectedGeneration := authGenerationFromContext(ctx, result.AuthID)
+	if expectedGeneration == 0 {
+		return true
+	}
+	return auth != nil && auth.generation == expectedGeneration
+}
+
+func authLifecycleChangedError() *Error {
+	return &Error{Code: "auth_lifecycle_changed", Message: "auth changed while preparing request", Retryable: true}
+}

--- a/sdk/cliproxy/auth/conductor_generation_test.go
+++ b/sdk/cliproxy/auth/conductor_generation_test.go
@@ -1,0 +1,788 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"reflect"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type providerTransitionTestExecutor struct {
+	provider       string
+	executeStarted chan struct{}
+	executeRelease chan struct{}
+	streamStarted  chan struct{}
+	streamRelease  chan struct{}
+	countStarted   chan struct{}
+	countRelease   chan struct{}
+	prepareStarted chan struct{}
+	prepareRelease chan struct{}
+	refreshStarted chan struct{}
+	refreshRelease chan struct{}
+	refreshErr     error
+}
+
+func (e *providerTransitionTestExecutor) Identifier() string { return e.provider }
+
+func (e *providerTransitionTestExecutor) ShouldPrepareRequestAuth(*Auth) bool {
+	return e.prepareStarted != nil
+}
+
+func (e *providerTransitionTestExecutor) PrepareRequestAuth(_ context.Context, auth *Auth) (*Auth, error) {
+	if e.prepareStarted != nil {
+		close(e.prepareStarted)
+	}
+	if e.prepareRelease != nil {
+		<-e.prepareRelease
+	}
+	updated := auth.Clone()
+	updated.Metadata = map[string]any{"epoch": "old-provider-prepared"}
+	updated.Runtime = "old-provider-prepared-runtime"
+	return updated, nil
+}
+
+func (e *providerTransitionTestExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	if e.executeStarted != nil {
+		close(e.executeStarted)
+	}
+	if e.executeRelease != nil {
+		<-e.executeRelease
+	}
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusTooManyRequests, Message: "old provider quota"}
+}
+
+func (e *providerTransitionTestExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	if e.streamStarted != nil {
+		close(e.streamStarted)
+	}
+	if e.streamRelease != nil {
+		<-e.streamRelease
+	}
+	return nil, &Error{HTTPStatus: http.StatusTooManyRequests, Message: "old provider stream quota"}
+}
+
+func (e *providerTransitionTestExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	if e.refreshStarted != nil {
+		close(e.refreshStarted)
+	}
+	if e.refreshRelease != nil {
+		<-e.refreshRelease
+	}
+	if e.refreshErr != nil {
+		return nil, e.refreshErr
+	}
+	updated := auth.Clone()
+	updated.Metadata = map[string]any{
+		"access_token":  "old-provider-refreshed-token",
+		"refresh_token": "old-provider-refresh-token",
+	}
+	updated.Runtime = "old-provider-refreshed-runtime"
+	return updated, nil
+}
+
+func (e *providerTransitionTestExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	if e.countStarted != nil {
+		close(e.countStarted)
+	}
+	if e.countRelease != nil {
+		<-e.countRelease
+	}
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusTooManyRequests, Message: "old provider count quota"}
+}
+
+func (*providerTransitionTestExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+type providerTransitionTestHook struct {
+	updated atomic.Int32
+	results atomic.Int32
+}
+
+func (*providerTransitionTestHook) OnAuthRegistered(context.Context, *Auth) {}
+
+func (h *providerTransitionTestHook) OnAuthUpdated(context.Context, *Auth) {
+	h.updated.Add(1)
+}
+
+func (h *providerTransitionTestHook) OnResult(context.Context, Result) {
+	h.results.Add(1)
+}
+
+func waitProviderTransitionSignal(t *testing.T, signal <-chan struct{}, name string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", name)
+	}
+}
+
+func transitionTestAuthProvider(t *testing.T, manager *Manager, authID, provider string) *Auth {
+	t.Helper()
+	current, ok := manager.GetByID(authID)
+	if !ok || current == nil {
+		t.Fatalf("auth %q missing before provider transition", authID)
+	}
+	updated := current.Clone()
+	updated.Provider = provider
+	updated.Metadata = map[string]any{
+		"access_token":  "new-provider-token",
+		"refresh_token": "new-provider-refresh-token",
+		"epoch":         "new-provider",
+	}
+	updated.Attributes = map[string]string{"epoch": "new-provider"}
+	updated.Runtime = "new-provider-runtime"
+	saved, err := manager.Update(WithSkipPersist(context.Background()), updated)
+	if err != nil {
+		t.Fatalf("transition auth provider: %v", err)
+	}
+	if saved == nil || saved.Provider != provider {
+		t.Fatalf("provider transition saved auth = %#v, want provider %q", saved, provider)
+	}
+	snapshot, ok := manager.GetByID(authID)
+	if !ok || snapshot == nil {
+		t.Fatalf("auth %q missing after provider transition", authID)
+	}
+	return snapshot
+}
+
+func assertProviderTransitionSnapshotUnchanged(t *testing.T, manager *Manager, authID string, want *Auth) {
+	t.Helper()
+	got, ok := manager.GetByID(authID)
+	if !ok || got == nil {
+		t.Fatalf("auth %q missing after stale writeback", authID)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("auth changed after stale writeback\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestManager_ProviderTransitionRejectsStaleExecutionGeneration(t *testing.T) {
+	const (
+		authID      = "provider-transition-execute"
+		oldProvider = "generation-old-execute"
+		newProvider = "generation-new-execute"
+		model       = "generation-execute-model"
+	)
+
+	store := &countingStore{}
+	hook := &providerTransitionTestHook{}
+	manager := NewManager(store, nil, hook)
+	executor := &providerTransitionTestExecutor{
+		provider:       oldProvider,
+		executeStarted: make(chan struct{}),
+		executeRelease: make(chan struct{}),
+	}
+	manager.RegisterExecutor(executor)
+	manager.SetRetryConfig(0, 0, 1)
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, oldProvider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+
+	auth := &Auth{
+		ID:       authID,
+		Provider: oldProvider,
+		Metadata: map[string]any{
+			"access_token":  "old-provider-token",
+			"refresh_token": "old-provider-refresh-token",
+		},
+		Runtime: "old-provider-runtime",
+	}
+	if _, err := manager.Register(WithSkipPersist(context.Background()), auth); err != nil {
+		t.Fatalf("register old provider auth: %v", err)
+	}
+
+	executeDone := make(chan error, 1)
+	go func() {
+		_, err := manager.Execute(context.Background(), []string{oldProvider}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+		executeDone <- err
+	}()
+	waitProviderTransitionSignal(t, executor.executeStarted, "old provider execution")
+
+	reg.RegisterClient(authID, newProvider, []*registry.ModelInfo{{ID: model}})
+	want := transitionTestAuthProvider(t, manager, authID, newProvider)
+	store.saveCount.Store(0)
+	hook.updated.Store(0)
+	hook.results.Store(0)
+	if models := reg.GetAvailableModels(newProvider); len(models) != 1 {
+		t.Fatalf("available models before stale result = %d, want 1", len(models))
+	}
+
+	close(executor.executeRelease)
+	select {
+	case err := <-executeDone:
+		if err == nil {
+			t.Fatal("Execute() error = nil, want old provider failure")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for old provider execution to finish")
+	}
+
+	assertProviderTransitionSnapshotUnchanged(t, manager, authID, want)
+	if got := store.saveCount.Load(); got != 0 {
+		t.Fatalf("stale execution persisted auth %d times, want 0", got)
+	}
+	if got := hook.results.Load(); got != 0 {
+		t.Fatalf("stale execution emitted %d result hooks, want 0", got)
+	}
+	if got := hook.updated.Load(); got != 0 {
+		t.Fatalf("stale execution emitted %d auth update hooks, want 0", got)
+	}
+	if models := reg.GetAvailableModels(newProvider); len(models) != 1 {
+		t.Fatalf("available models after stale result = %d, want 1", len(models))
+	}
+}
+
+func TestManager_ProviderTransitionRejectsStaleCountTokensGeneration(t *testing.T) {
+	const (
+		authID      = "provider-transition-count"
+		oldProvider = "generation-old-count"
+		newProvider = "generation-new-count"
+		model       = "generation-count-model"
+	)
+
+	store := &countingStore{}
+	hook := &providerTransitionTestHook{}
+	manager := NewManager(store, nil, hook)
+	executor := &providerTransitionTestExecutor{
+		provider:     oldProvider,
+		countStarted: make(chan struct{}),
+		countRelease: make(chan struct{}),
+	}
+	manager.RegisterExecutor(executor)
+	manager.SetRetryConfig(0, 0, 1)
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, oldProvider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+	if _, err := manager.Register(WithSkipPersist(context.Background()), &Auth{ID: authID, Provider: oldProvider}); err != nil {
+		t.Fatalf("register old provider auth: %v", err)
+	}
+
+	countDone := make(chan error, 1)
+	go func() {
+		_, err := manager.ExecuteCount(context.Background(), []string{oldProvider}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+		countDone <- err
+	}()
+	waitProviderTransitionSignal(t, executor.countStarted, "old provider count-tokens execution")
+
+	reg.RegisterClient(authID, newProvider, []*registry.ModelInfo{{ID: model}})
+	want := transitionTestAuthProvider(t, manager, authID, newProvider)
+	store.saveCount.Store(0)
+	hook.updated.Store(0)
+	hook.results.Store(0)
+	close(executor.countRelease)
+
+	select {
+	case err := <-countDone:
+		if err == nil {
+			t.Fatal("ExecuteCount() error = nil, want old provider failure")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for old provider count-tokens execution")
+	}
+
+	assertProviderTransitionSnapshotUnchanged(t, manager, authID, want)
+	if got := store.saveCount.Load(); got != 0 {
+		t.Fatalf("stale count-tokens execution persisted auth %d times, want 0", got)
+	}
+	if got := hook.results.Load(); got != 0 {
+		t.Fatalf("stale count-tokens execution emitted %d result hooks, want 0", got)
+	}
+	if got := hook.updated.Load(); got != 0 {
+		t.Fatalf("stale count-tokens execution emitted %d auth update hooks, want 0", got)
+	}
+}
+
+func TestManager_ProviderTransitionRejectsStaleStreamGeneration(t *testing.T) {
+	const (
+		authID      = "provider-transition-stream"
+		oldProvider = "generation-old-stream"
+		newProvider = "generation-new-stream"
+		model       = "generation-stream-model"
+	)
+
+	store := &countingStore{}
+	hook := &providerTransitionTestHook{}
+	manager := NewManager(store, nil, hook)
+	executor := &providerTransitionTestExecutor{
+		provider:      oldProvider,
+		streamStarted: make(chan struct{}),
+		streamRelease: make(chan struct{}),
+	}
+	manager.RegisterExecutor(executor)
+	manager.SetRetryConfig(0, 0, 1)
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, oldProvider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+	if _, err := manager.Register(WithSkipPersist(context.Background()), &Auth{ID: authID, Provider: oldProvider}); err != nil {
+		t.Fatalf("register old provider auth: %v", err)
+	}
+
+	streamDone := make(chan struct{}, 1)
+	go func() {
+		result, _ := manager.ExecuteStream(context.Background(), []string{oldProvider}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{Stream: true})
+		if result != nil && result.Chunks != nil {
+			for range result.Chunks {
+			}
+		}
+		streamDone <- struct{}{}
+	}()
+	waitProviderTransitionSignal(t, executor.streamStarted, "old provider stream execution")
+
+	reg.RegisterClient(authID, newProvider, []*registry.ModelInfo{{ID: model}})
+	want := transitionTestAuthProvider(t, manager, authID, newProvider)
+	store.saveCount.Store(0)
+	hook.updated.Store(0)
+	hook.results.Store(0)
+	close(executor.streamRelease)
+
+	select {
+	case <-streamDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for old provider stream execution")
+	}
+
+	assertProviderTransitionSnapshotUnchanged(t, manager, authID, want)
+	if got := store.saveCount.Load(); got != 0 {
+		t.Fatalf("stale stream execution persisted auth %d times, want 0", got)
+	}
+	if got := hook.results.Load(); got != 0 {
+		t.Fatalf("stale stream execution emitted %d result hooks, want 0", got)
+	}
+	if got := hook.updated.Load(); got != 0 {
+		t.Fatalf("stale stream execution emitted %d auth update hooks, want 0", got)
+	}
+}
+
+func TestManager_ProviderTransitionRejectsStaleRequestAuthPreparation(t *testing.T) {
+	const (
+		authID      = "provider-transition-request-prepare"
+		oldProvider = "generation-old-request-prepare"
+		newProvider = "generation-new-request-prepare"
+		model       = "generation-request-prepare-model"
+	)
+
+	store := &countingStore{}
+	hook := &providerTransitionTestHook{}
+	manager := NewManager(store, nil, hook)
+	executor := &providerTransitionTestExecutor{
+		provider:       oldProvider,
+		prepareStarted: make(chan struct{}),
+		prepareRelease: make(chan struct{}),
+	}
+	manager.RegisterExecutor(executor)
+	manager.SetRetryConfig(0, 0, 1)
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, oldProvider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+	if _, err := manager.Register(WithSkipPersist(context.Background()), &Auth{
+		ID:       authID,
+		Provider: oldProvider,
+		Metadata: map[string]any{"epoch": "old-provider"},
+		Runtime:  "old-provider-runtime",
+	}); err != nil {
+		t.Fatalf("register old provider auth: %v", err)
+	}
+
+	executeDone := make(chan error, 1)
+	go func() {
+		_, err := manager.Execute(context.Background(), []string{oldProvider}, cliproxyexecutor.Request{Model: model}, cliproxyexecutor.Options{})
+		executeDone <- err
+	}()
+	waitProviderTransitionSignal(t, executor.prepareStarted, "old provider request preparation")
+
+	reg.RegisterClient(authID, newProvider, []*registry.ModelInfo{{ID: model}})
+	want := transitionTestAuthProvider(t, manager, authID, newProvider)
+	store.saveCount.Store(0)
+	hook.updated.Store(0)
+	hook.results.Store(0)
+	close(executor.prepareRelease)
+
+	select {
+	case err := <-executeDone:
+		if err == nil {
+			t.Fatal("Execute() error = nil, want stale request preparation rejection")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for stale request preparation")
+	}
+
+	assertProviderTransitionSnapshotUnchanged(t, manager, authID, want)
+	if got := store.saveCount.Load(); got != 0 {
+		t.Fatalf("stale request preparation persisted auth %d times, want 0", got)
+	}
+	if got := hook.results.Load(); got != 0 {
+		t.Fatalf("stale request preparation emitted %d result hooks, want 0", got)
+	}
+	if got := hook.updated.Load(); got != 0 {
+		t.Fatalf("stale request preparation emitted %d auth update hooks, want 0", got)
+	}
+}
+
+func TestManager_SelectAuthForRequestGenerationRejectsStaleExternalResult(t *testing.T) {
+	const (
+		authID      = "provider-transition-external-result"
+		oldProvider = "generation-old-external-result"
+		newProvider = "generation-new-external-result"
+		model       = "generation-external-result-model"
+	)
+
+	store := &countingStore{}
+	hook := &providerTransitionTestHook{}
+	manager := NewManager(store, nil, hook)
+	manager.RegisterExecutor(&providerTransitionTestExecutor{provider: oldProvider})
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, oldProvider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+	if _, err := manager.Register(WithSkipPersist(context.Background()), &Auth{
+		ID:       authID,
+		Provider: oldProvider,
+	}); err != nil {
+		t.Fatalf("register old provider auth: %v", err)
+	}
+
+	selected, resultCtx, err := manager.SelectAuthForRequest(context.Background(), oldProvider, model, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("SelectAuthForRequest() error = %v", err)
+	}
+	if selected == nil || selected.ID != authID {
+		t.Fatalf("SelectAuthForRequest() auth = %#v, want %q", selected, authID)
+	}
+
+	reg.RegisterClient(authID, newProvider, []*registry.ModelInfo{{ID: model}})
+	want := transitionTestAuthProvider(t, manager, authID, newProvider)
+	store.saveCount.Store(0)
+	hook.updated.Store(0)
+	hook.results.Store(0)
+
+	manager.MarkResult(resultCtx, Result{
+		AuthID:   authID,
+		Provider: oldProvider,
+		Model:    model,
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusTooManyRequests, Message: "old provider quota"},
+	})
+
+	assertProviderTransitionSnapshotUnchanged(t, manager, authID, want)
+	if got := store.saveCount.Load(); got != 0 {
+		t.Fatalf("stale external result persisted auth %d times, want 0", got)
+	}
+	if got := hook.results.Load(); got != 0 {
+		t.Fatalf("stale external result emitted %d result hooks, want 0", got)
+	}
+	if got := hook.updated.Load(); got != 0 {
+		t.Fatalf("stale external result emitted %d auth update hooks, want 0", got)
+	}
+	if models := reg.GetAvailableModels(newProvider); len(models) != 1 {
+		t.Fatalf("available models after stale external result = %d, want 1", len(models))
+	}
+}
+
+func TestManager_StaleRequestCannotRefreshReplacementProvider(t *testing.T) {
+	const (
+		authID      = "provider-transition-refresh-context"
+		oldProvider = "generation-old-refresh-context"
+		newProvider = "generation-new-refresh-context"
+		model       = "generation-refresh-context-model"
+	)
+
+	manager := NewManager(nil, nil, nil)
+	manager.RegisterExecutor(&providerTransitionTestExecutor{provider: oldProvider})
+	newRefreshStarted := make(chan struct{})
+	manager.RegisterExecutor(&providerTransitionTestExecutor{provider: newProvider, refreshStarted: newRefreshStarted})
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, oldProvider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+	if _, err := manager.Register(WithSkipPersist(context.Background()), &Auth{
+		ID:       authID,
+		Provider: oldProvider,
+		Metadata: map[string]any{"access_token": "old-provider-token", "refresh_token": "old-provider-refresh-token"},
+	}); err != nil {
+		t.Fatalf("register old provider auth: %v", err)
+	}
+
+	_, requestCtx, err := manager.SelectAuthForRequest(context.Background(), oldProvider, model, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("SelectAuthForRequest() error = %v", err)
+	}
+	reg.RegisterClient(authID, newProvider, []*registry.ModelInfo{{ID: model}})
+	want := transitionTestAuthProvider(t, manager, authID, newProvider)
+
+	refreshed, err := manager.refreshAuthForRequest(requestCtx, authID, "old-provider-token")
+	if refreshed != nil {
+		t.Fatalf("stale refresh returned auth %#v, want nil", refreshed)
+	}
+	var lifecycleErr *Error
+	if !errors.As(err, &lifecycleErr) || lifecycleErr.Code != "auth_lifecycle_changed" {
+		t.Fatalf("stale refresh error = %v, want auth_lifecycle_changed", err)
+	}
+	select {
+	case <-newRefreshStarted:
+		t.Fatal("stale request invoked replacement provider refresh")
+	default:
+	}
+	assertProviderTransitionSnapshotUnchanged(t, manager, authID, want)
+}
+
+func TestManager_MarkResultRejectsStaleProviderWithoutGenerationContext(t *testing.T) {
+	const (
+		authID      = "provider-transition-provider-fence"
+		oldProvider = "generation-old-provider-fence"
+		newProvider = "generation-new-provider-fence"
+		model       = "generation-provider-fence-model"
+	)
+
+	store := &countingStore{}
+	hook := &providerTransitionTestHook{}
+	manager := NewManager(store, nil, hook)
+	if _, err := manager.Register(WithSkipPersist(context.Background()), &Auth{ID: authID, Provider: oldProvider}); err != nil {
+		t.Fatalf("register old provider auth: %v", err)
+	}
+	want := transitionTestAuthProvider(t, manager, authID, newProvider)
+	store.saveCount.Store(0)
+	hook.updated.Store(0)
+	hook.results.Store(0)
+
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   authID,
+		Provider: oldProvider,
+		Model:    model,
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusTooManyRequests, Message: "old provider quota"},
+	})
+
+	assertProviderTransitionSnapshotUnchanged(t, manager, authID, want)
+	if got := store.saveCount.Load(); got != 0 {
+		t.Fatalf("stale provider result persisted auth %d times, want 0", got)
+	}
+	if got := hook.results.Load(); got != 0 {
+		t.Fatalf("stale provider result emitted %d result hooks, want 0", got)
+	}
+}
+
+func TestManager_SelectAuthForRequestGenerationRejectsSameProviderReplacement(t *testing.T) {
+	const (
+		authID   = "provider-transition-same-provider-replacement"
+		provider = "generation-same-provider-replacement"
+		model    = "generation-same-provider-model"
+	)
+
+	store := &countingStore{}
+	hook := &providerTransitionTestHook{}
+	manager := NewManager(store, nil, hook)
+	manager.RegisterExecutor(&providerTransitionTestExecutor{provider: provider})
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+	if _, err := manager.Register(WithSkipPersist(context.Background()), &Auth{
+		ID:       authID,
+		Provider: provider,
+		Metadata: map[string]any{"epoch": "old"},
+	}); err != nil {
+		t.Fatalf("register original auth: %v", err)
+	}
+
+	_, resultCtx, err := manager.SelectAuthForRequest(context.Background(), provider, model, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("SelectAuthForRequest() error = %v", err)
+	}
+	manager.Remove(context.Background(), authID)
+	if _, err = manager.Register(WithSkipPersist(context.Background()), &Auth{
+		ID:       authID,
+		Provider: provider,
+		Metadata: map[string]any{"epoch": "replacement"},
+	}); err != nil {
+		t.Fatalf("register replacement auth: %v", err)
+	}
+	want, ok := manager.GetByID(authID)
+	if !ok || want == nil {
+		t.Fatal("replacement auth missing")
+	}
+	store.saveCount.Store(0)
+	hook.updated.Store(0)
+	hook.results.Store(0)
+
+	manager.MarkResult(resultCtx, Result{
+		AuthID:   authID,
+		Provider: provider,
+		Model:    model,
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusTooManyRequests, Message: "old lifecycle quota"},
+	})
+
+	assertProviderTransitionSnapshotUnchanged(t, manager, authID, want)
+	if got := store.saveCount.Load(); got != 0 {
+		t.Fatalf("stale generation persisted auth %d times, want 0", got)
+	}
+	if got := hook.results.Load(); got != 0 {
+		t.Fatalf("stale generation emitted %d result hooks, want 0", got)
+	}
+}
+
+func TestManager_ProviderTransitionRejectsStaleRefreshSuccessGeneration(t *testing.T) {
+	const (
+		authID      = "provider-transition-refresh-success"
+		oldProvider = "generation-old-refresh-success"
+		newProvider = "generation-new-refresh-success"
+		model       = "generation-refresh-success-model"
+	)
+
+	store := &countingStore{}
+	hook := &providerTransitionTestHook{}
+	manager := NewManager(store, nil, hook)
+	executor := &providerTransitionTestExecutor{
+		provider:       oldProvider,
+		refreshStarted: make(chan struct{}),
+		refreshRelease: make(chan struct{}),
+	}
+	manager.RegisterExecutor(executor)
+
+	oldAuth := &Auth{
+		ID:       authID,
+		Provider: oldProvider,
+		Metadata: map[string]any{
+			"access_token":  "old-provider-token",
+			"refresh_token": "old-provider-refresh-token",
+		},
+		Runtime: "old-provider-runtime",
+		ModelStates: map[string]*ModelState{
+			model: {
+				Status:      StatusError,
+				Unavailable: true,
+				LastError:   &Error{Code: "unauthorized", HTTPStatus: http.StatusUnauthorized, Message: "old provider unauthorized"},
+			},
+		},
+	}
+	if _, err := manager.Register(WithSkipPersist(context.Background()), oldAuth); err != nil {
+		t.Fatalf("register old provider auth: %v", err)
+	}
+
+	type refreshOutcome struct {
+		auth *Auth
+		err  error
+	}
+	refreshDone := make(chan refreshOutcome, 1)
+	go func() {
+		updated, err := manager.refreshAuthForRequest(context.Background(), authID, "")
+		refreshDone <- refreshOutcome{auth: updated, err: err}
+	}()
+	waitProviderTransitionSignal(t, executor.refreshStarted, "old provider refresh")
+
+	want := transitionTestAuthProvider(t, manager, authID, newProvider)
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(authID, newProvider, []*registry.ModelInfo{{ID: model}})
+	reg.SuspendClientModel(authID, model, "new-provider-maintenance")
+	t.Cleanup(func() { reg.UnregisterClient(authID) })
+	store.saveCount.Store(0)
+	hook.updated.Store(0)
+	hook.results.Store(0)
+	if models := reg.GetAvailableModels(newProvider); len(models) != 0 {
+		t.Fatalf("available models before stale refresh = %d, want 0", len(models))
+	}
+
+	close(executor.refreshRelease)
+	select {
+	case outcome := <-refreshDone:
+		if outcome.err != nil {
+			t.Fatalf("stale successful refresh returned error: %v", outcome.err)
+		}
+		if outcome.auth != nil {
+			t.Fatalf("stale successful refresh returned auth %#v, want nil", outcome.auth)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for old provider refresh to finish")
+	}
+
+	assertProviderTransitionSnapshotUnchanged(t, manager, authID, want)
+	if got := store.saveCount.Load(); got != 0 {
+		t.Fatalf("stale refresh persisted auth %d times, want 0", got)
+	}
+	if got := hook.updated.Load(); got != 0 {
+		t.Fatalf("stale refresh emitted %d auth update hooks, want 0", got)
+	}
+	if got := hook.results.Load(); got != 0 {
+		t.Fatalf("stale refresh emitted %d result hooks, want 0", got)
+	}
+	if models := reg.GetAvailableModels(newProvider); len(models) != 0 {
+		t.Fatalf("stale refresh resumed new provider model; available models = %d, want 0", len(models))
+	}
+}
+
+func TestManager_ProviderTransitionRejectsStaleRefreshFailureGeneration(t *testing.T) {
+	const (
+		authID      = "provider-transition-refresh-failure"
+		oldProvider = "generation-old-refresh-failure"
+		newProvider = "generation-new-refresh-failure"
+	)
+
+	store := &countingStore{}
+	hook := &providerTransitionTestHook{}
+	manager := NewManager(store, nil, hook)
+	expectedErr := errors.New("old provider refresh failed")
+	executor := &providerTransitionTestExecutor{
+		provider:       oldProvider,
+		refreshStarted: make(chan struct{}),
+		refreshRelease: make(chan struct{}),
+		refreshErr:     expectedErr,
+	}
+	manager.RegisterExecutor(executor)
+
+	oldAuth := &Auth{
+		ID:       authID,
+		Provider: oldProvider,
+		Metadata: map[string]any{
+			"access_token":  "old-provider-token",
+			"refresh_token": "old-provider-refresh-token",
+		},
+		Runtime: "old-provider-runtime",
+	}
+	if _, err := manager.Register(WithSkipPersist(context.Background()), oldAuth); err != nil {
+		t.Fatalf("register old provider auth: %v", err)
+	}
+
+	refreshDone := make(chan error, 1)
+	go func() {
+		_, err := manager.refreshAuthForRequest(context.Background(), authID, "")
+		refreshDone <- err
+	}()
+	waitProviderTransitionSignal(t, executor.refreshStarted, "old provider refresh")
+
+	want := transitionTestAuthProvider(t, manager, authID, newProvider)
+	store.saveCount.Store(0)
+	hook.updated.Store(0)
+	hook.results.Store(0)
+
+	close(executor.refreshRelease)
+	select {
+	case err := <-refreshDone:
+		if !errors.Is(err, expectedErr) {
+			t.Fatalf("refresh error = %v, want %v", err, expectedErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for old provider refresh to finish")
+	}
+
+	assertProviderTransitionSnapshotUnchanged(t, manager, authID, want)
+	if got := store.saveCount.Load(); got != 0 {
+		t.Fatalf("stale failed refresh persisted auth %d times, want 0", got)
+	}
+	if got := hook.updated.Load(); got != 0 {
+		t.Fatalf("stale failed refresh emitted %d auth update hooks, want 0", got)
+	}
+	if got := hook.results.Load(); got != 0 {
+		t.Fatalf("stale failed refresh emitted %d result hooks, want 0", got)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -1093,7 +1093,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 		if ctx.Err() != nil {
 			return cliproxyexecutor.Response{}, false, nil
 		}
-		creditsCtx := WithAntigravityCredits(ctx)
+		creditsCtx := contextWithAuthGeneration(WithAntigravityCredits(ctx), c.auth)
 		if rt := m.roundTripperFor(c.auth); rt != nil {
 			creditsCtx = context.WithValue(creditsCtx, roundTripperContextKey{}, rt)
 			creditsCtx = context.WithValue(creditsCtx, "cliproxy.roundtripper", rt)
@@ -1105,6 +1105,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 			continue
 		}
 		c.auth = preparedAuth
+		creditsCtx = contextWithAuthGeneration(creditsCtx, c.auth)
 		publishSelectedAuthMetadata(creditsOpts.Metadata, c.auth)
 		models, pooled, aliasResult, routing := m.executionModelCandidatesWithAlias(c.auth, routeModel)
 		if len(models) == 0 {
@@ -1115,7 +1116,7 @@ func (m *Manager) tryAntigravityCreditsExecute(ctx context.Context, req cliproxy
 			execReq := req
 			execReq.Model = upstreamModel
 			resp, errExec := c.executor.Execute(creditsCtx, c.auth, execReq, creditsOpts)
-			result := Result{AuthID: c.auth.ID, Provider: c.provider, Model: resultModel, Success: errExec == nil}
+			result := resultForAuth(c.auth, c.provider, resultModel, errExec == nil, nil)
 			if errExec != nil {
 				result.Error = resultErrorFromError(errExec)
 				if ra := retryAfterFromError(errExec); ra != nil {
@@ -1149,7 +1150,7 @@ func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cl
 		if ctx.Err() != nil {
 			return nil, false, nil
 		}
-		creditsCtx := WithAntigravityCredits(ctx)
+		creditsCtx := contextWithAuthGeneration(WithAntigravityCredits(ctx), c.auth)
 		if rt := m.roundTripperFor(c.auth); rt != nil {
 			creditsCtx = context.WithValue(creditsCtx, roundTripperContextKey{}, rt)
 			creditsCtx = context.WithValue(creditsCtx, "cliproxy.roundtripper", rt)
@@ -1160,6 +1161,7 @@ func (m *Manager) tryAntigravityCreditsExecuteStream(ctx context.Context, req cl
 			continue
 		}
 		c.auth = preparedAuth
+		creditsCtx = contextWithAuthGeneration(creditsCtx, c.auth)
 		publishSelectedAuthMetadata(creditsOpts.Metadata, c.auth)
 		models, pooled, aliasResult, routing := m.executionModelCandidatesWithAlias(c.auth, routeModel)
 		if len(models) == 0 {

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -81,8 +81,9 @@ func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 		clearedCooldown = clearCooldownStateForAuth(auth, now)
 	}
 	auth.EnsureIndex()
-	authClone := auth.Clone()
 	m.mu.Lock()
+	auth.generation = m.nextAuthGenerationLocked()
+	authClone := auth.Clone()
 	m.auths[auth.ID] = authClone
 	m.mu.Unlock()
 	if !shouldDeferAPIKeyModelAliasRebuild(ctx) {
@@ -102,17 +103,30 @@ func (m *Manager) Register(ctx context.Context, auth *Auth) (*Auth, error) {
 
 // Update replaces an existing auth entry and notifies hooks.
 func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
+	saved, _, err := m.update(ctx, auth, 0, false)
+	return saved, err
+}
+
+func (m *Manager) updateIfGeneration(ctx context.Context, auth *Auth, expectedGeneration uint64) (*Auth, bool, error) {
+	return m.update(ctx, auth, expectedGeneration, true)
+}
+
+func (m *Manager) update(ctx context.Context, auth *Auth, expectedGeneration uint64, requireGeneration bool) (*Auth, bool, error) {
 	if auth == nil || auth.ID == "" {
-		return nil, nil
+		return nil, false, nil
 	}
 	if errWeight := ValidateAuthWeight(auth); errWeight != nil {
-		return nil, fmt.Errorf("update auth: %w", errWeight)
+		return nil, false, fmt.Errorf("update auth: %w", errWeight)
 	}
 	m.mu.Lock()
 	existing, ok := m.auths[auth.ID]
 	if !ok || existing == nil {
 		m.mu.Unlock()
-		return nil, nil
+		return nil, false, nil
+	}
+	if requireGeneration && existing.generation != expectedGeneration {
+		m.mu.Unlock()
+		return nil, false, nil
 	}
 	if !auth.indexAssigned && auth.Index == "" {
 		auth.Index = existing.Index
@@ -121,6 +135,10 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 	now := time.Now()
 	sameProvider := strings.EqualFold(strings.TrimSpace(existing.Provider), strings.TrimSpace(auth.Provider))
 	if sameProvider {
+		auth.generation = existing.generation
+		if auth.generation == 0 {
+			auth.generation = m.nextAuthGenerationLocked()
+		}
 		auth.Success = existing.Success
 		auth.Failed = existing.Failed
 		auth.recentRequests = existing.recentRequests
@@ -130,6 +148,7 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 			}
 		}
 	} else {
+		auth.generation = m.nextAuthGenerationLocked()
 		clearProviderRuntimeState(auth, now)
 	}
 	clearedCooldown := false
@@ -152,7 +171,7 @@ func (m *Manager) Update(ctx context.Context, auth *Auth) (*Auth, error) {
 	if clearedCooldown || !sameProvider {
 		m.persistCooldownStates(ctx)
 	}
-	return auth.Clone(), nil
+	return auth.Clone(), true, nil
 }
 
 // Remove deletes an auth from runtime state without persisting.
@@ -248,6 +267,7 @@ func (m *Manager) Load(ctx context.Context) error {
 			continue
 		}
 		auth.EnsureIndex()
+		auth.generation = m.nextAuthGenerationLocked()
 		m.auths[auth.ID] = auth.Clone()
 	}
 	cfg, _ := m.runtimeConfig.Load().(*internalconfig.Config)

--- a/sdk/cliproxy/auth/conductor_lts.go
+++ b/sdk/cliproxy/auth/conductor_lts.go
@@ -1088,7 +1088,7 @@ func (m *Manager) selectAuthForRequest(ctx context.Context, provider, model, req
 		}
 		attemptCtx, allowed := m.beginCodexRateLimitContinuityAttempt(ctx, selected, provider, model, opts)
 		if allowed {
-			return selected, attemptCtx, nil
+			return selected, contextWithAuthGeneration(attemptCtx, selected), nil
 		}
 		tried[authID] = struct{}{}
 		if homeMode {

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -516,6 +516,10 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 	if auth == nil || exec == nil {
 		return nil, errors.New("auth or executor not found")
 	}
+	expectedGeneration := auth.generation
+	if requestGeneration := authGenerationFromContext(ctx, id); requestGeneration != 0 && requestGeneration != expectedGeneration {
+		return nil, authLifecycleChangedError()
+	}
 
 	// Another request may already have refreshed this credential.
 	if failedAccessToken != "" {
@@ -536,7 +540,7 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 		unauthorized := isUnauthorizedError(err)
 		shouldReschedule := false
 		m.mu.Lock()
-		if current := m.auths[id]; current != nil {
+		if current := m.auths[id]; current != nil && current.generation == expectedGeneration {
 			current.LastError = refreshErrorFromError(err)
 			if unauthorized {
 				current.NextRefreshAfter = time.Time{}
@@ -551,6 +555,9 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 			if m.scheduler != nil {
 				m.scheduler.upsertAuth(current.Clone())
 			}
+		} else {
+			m.mu.Unlock()
+			return nil, err
 		}
 		m.mu.Unlock()
 		if shouldReschedule {
@@ -579,7 +586,10 @@ func (m *Manager) refreshAuthForRequest(ctx context.Context, id, failedAccessTok
 	if m.shouldRefresh(updated, now) {
 		updated.NextRefreshAfter = now.Add(refreshIneffectiveBackoff)
 	}
-	saved, errUpdate := m.Update(ctx, updated)
+	saved, applied, errUpdate := m.updateIfGeneration(ctx, updated, expectedGeneration)
+	if !applied {
+		return nil, nil
+	}
 	for _, model := range modelsToResume {
 		registry.GetGlobalRegistry().ResumeClientModel(id, model)
 	}

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -128,15 +128,10 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 				failed = true
 				if !isRetryWithoutPenaltyError(chunk.Err) {
 					rerr := resultErrorFromError(chunk.Err)
-					m.recordExecutionResult(ctx, Result{
-						AuthID:              auth.ID,
-						Provider:            provider,
-						Model:               resultModel,
-						Success:             false,
-						Error:               rerr,
-						RetryAfter:          retryAfterFromError(chunk.Err),
-						ModelFallbackReason: modelFallbackReasonFromError(chunk.Err),
-					}, auth, ephemeralResult)
+					result := resultForAuth(auth, provider, resultModel, false, rerr)
+					result.RetryAfter = retryAfterFromError(chunk.Err)
+					result.ModelFallbackReason = modelFallbackReasonFromError(chunk.Err)
+					m.recordExecutionResult(ctx, result, auth, ephemeralResult)
 				}
 			}
 			if !forward {
@@ -194,7 +189,7 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 			}
 		}
 		if !failed && (ephemeralResult || claudeOAuthRequestCancellation(ctx, auth, nil) == nil) {
-			m.recordExecutionResult(ctx, Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: true}, auth, ephemeralResult)
+			m.recordExecutionResult(ctx, resultForAuth(auth, provider, resultModel, true, nil), auth, ephemeralResult)
 		}
 	}()
 	return &cliproxyexecutor.StreamResult{Headers: headers, Chunks: out, Metadata: cloneSchedulerAnyMap(metadata)}
@@ -212,6 +207,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 	if executor == nil {
 		return nil, &Error{Code: "executor_not_found", Message: "executor not registered"}
 	}
+	ctx = contextWithAuthGeneration(ctx, auth)
 	ctx = contextWithRequestedModelAlias(ctx, opts, routeModel)
 	var lastErr error
 	didRefreshOnUnauthorized := false
@@ -272,6 +268,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 					errStream = errRefresh
 				} else if okRefresh {
 					auth = refreshed
+					ctx = contextWithAuthGeneration(ctx, auth)
 					m.replaceHomeExecutionLifecycleAuth(execOpts.ExecutionLifecycle, auth)
 					publishSelectedAuthMetadata(execOpts.Metadata, auth)
 					didRefreshOnUnauthorized = true
@@ -299,7 +296,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		streamResult, errStream = validateStreamResult(streamResult, errStream)
 		if errStream != nil {
 			rerr := resultErrorFromError(errStream)
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
+			result := resultForAuth(auth, provider, resultModel, false, rerr)
 			result.RetryAfter = retryAfterFromError(errStream)
 			result.ModelFallbackReason = modelFallbackReasonFromError(errStream)
 			m.recordExecutionResult(ctx, result, auth, ephemeralResult)
@@ -337,6 +334,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				} else if okRefresh {
 					discardStreamChunks(streamResult.Chunks)
 					auth = refreshed
+					ctx = contextWithAuthGeneration(ctx, auth)
 					m.replaceHomeExecutionLifecycleAuth(execOpts.ExecutionLifecycle, auth)
 					publishSelectedAuthMetadata(execOpts.Metadata, auth)
 					didRefreshOnUnauthorized = true
@@ -369,7 +367,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			}
 			if isRequestInvalidError(bootstrapErr) {
 				rerr := resultErrorFromError(bootstrapErr)
-				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
+				result := resultForAuth(auth, provider, resultModel, false, rerr)
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
 				result.ModelFallbackReason = modelFallbackReasonFromError(bootstrapErr)
 				m.recordExecutionResult(ctx, result, auth, ephemeralResult)
@@ -378,7 +376,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 			}
 			if idx < len(execModels)-1 {
 				rerr := resultErrorFromError(bootstrapErr)
-				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
+				result := resultForAuth(auth, provider, resultModel, false, rerr)
 				result.RetryAfter = retryAfterFromError(bootstrapErr)
 				result.ModelFallbackReason = modelFallbackReasonFromError(bootstrapErr)
 				m.recordExecutionResult(ctx, result, auth, ephemeralResult)
@@ -387,7 +385,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				continue
 			}
 			rerr := resultErrorFromError(bootstrapErr)
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr}
+			result := resultForAuth(auth, provider, resultModel, false, rerr)
 			result.RetryAfter = retryAfterFromError(bootstrapErr)
 			result.ModelFallbackReason = modelFallbackReasonFromError(bootstrapErr)
 			m.recordExecutionResult(ctx, result, auth, ephemeralResult)
@@ -397,7 +395,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 
 		if closed && len(buffered) == 0 {
 			emptyErr := &Error{Code: "empty_stream", Message: "upstream stream closed before first payload", Retryable: true}
-			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: emptyErr}
+			result := resultForAuth(auth, provider, resultModel, false, emptyErr)
 			m.recordExecutionResult(ctx, result, auth, ephemeralResult)
 			if idx < len(execModels)-1 {
 				lastErr = emptyErr

--- a/sdk/cliproxy/auth/types.go
+++ b/sdk/cliproxy/auth/types.go
@@ -98,6 +98,10 @@ type Auth struct {
 
 	recentRequests recentRequestRing `json:"-"`
 	indexAssigned  bool              `json:"-"`
+	// generation is a process-local lifecycle epoch. It changes when an auth is
+	// registered or changes provider so stale asynchronous work cannot write back
+	// into a replacement auth with the same ID.
+	generation uint64 `json:"-"`
 }
 
 const (


### PR DESCRIPTION
## 结果

同一 auth ID 在 provider 替换、删除后重新注册或 `Load` 后会获得新的进程内 generation。旧生命周期尚未结束的 execute、stream、count-tokens、request-auth preparation、refresh 与外部 `MarkResult` 不再把状态回写到新 auth。

本 PR 含 `introduced_in` downstream patch，必须使用 merge commit；尚未发布或部署。

## 主要变更

- 为 managed auth 分配不持久化的 lifecycle generation；同 provider 普通 `Update` 保留 generation，provider 替换和重新注册切换 generation。
- 将 generation 传入普通执行、token count、stream/model-pool、Antigravity fallback 和外部 selection context；`MarkResult` 同时校验 generation 与 `Result.Provider`。
- request preparation 与 refresh 使用 generation-aware update；旧请求不能触发 replacement provider 的 refresh。
- refresh 成功/失败、registry resume、scheduler、hook、persist 与 cooldown mutation 均在 generation 门禁之后执行。
- persisted cooldown record 的 provider 与当前 auth 不匹配时拒绝恢复。
- 从已关闭 PR #192 的唯一提交 `29851edf` 手工适配到 v7.2.116 拆分后的 conductor 文件；没有 replay merge integration artifacts，并补充 count-token、stream 与 cross-provider refresh 回归。

## 兼容性与边界

- generation 为 `json:"-"` 的进程内字段，不改变 auth file、Management API 或 SDK JSON schema。
- Home dispatch auth 不写入本地 Manager state，继续走 observation-only 回程；本门禁只约束 managed local auth 的状态回写。
- 不修改 provider 选择、重试次数、quota 分类或现有 Codex Desktop tool overlay。
- Release、发布资产和生产部署不在本 PR 内。

## 验证

- `go test ./sdk/cliproxy/auth -count=1`
- `go test -race ./sdk/cliproxy/auth -count=1`
- focused generation/cooldown tests `-count=10`
- `scripts/check-lts-contract.sh`
- `go run ./scripts/ltsregistry --root .`
- `go test ./sdk/cliproxy/... -count=1`
- `go test ./internal/runtime/executor -count=1`
- `go test ./internal/translator/openai/openai/responses -count=1`
- `go build -o /tmp/cpa-core-auth-generation ./cmd/server`
- `go list ./... | rg -v "/tmp$" | xargs go test -count=1`
- `git diff --check`

以上均通过。

## Review focus

重点检查 `sdk/cliproxy/auth/conductor_generation.go` 的兼容门禁、`conductor_refresh.go` 的 stale request refresh 拒绝顺序，以及 `conductor_lifecycle.go` 中同 provider update 与 provider replacement 的 generation 语义。