### PR TITLE
fix(lts): close retained Core review gaps

### DIFF
--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -986,3 +986,73 @@ patches:
     upstream_issue_or_pr: not-filed
     state: required
     retire_when: Upstream gives every auth lifecycle a non-persisted generation, carries it through execute, stream, token-count, external selection, request preparation, refresh, model-pool, fallback, and Home-compatible paths, rejects stale provider or generation writebacks before hooks, persistence, scheduler, registry, and cooldown mutations, rejects persisted cooldown records from another provider, prevents an old request from refreshing a replacement provider, and all listed regressions pass after removing the downstream implementation.
+
+  - id: codex-live-bootstrap-accounting-and-egress
+    reason: Codex Live bootstrap SDP carries short-lived ICE credentials that must never enter request logs, while every actual bootstrap dispatch still needs zero-token usage attribution and local auth outcome tracking. Live and sideband also require model-scoped OAuth selection for models intentionally absent from the general proxy catalog, confirm/mark/abandon lifecycle coverage, Home retry attempt accounting without duplicate 401 records, in-memory config validation parity, and fail-closed sideband proxy handling.
+    introduced_in: 4534eed92ef5cd639b377a17dd56dad2d9e41f70
+    affected_upstream_range: through ea37d13a9eced4af835cad10bcb030d770a5ba88 (v7.2.120, 2026-08-06); upstream does not provide this LTS-owned Codex Live route, SDP-safe metadata-only logging, per-attempt usage accounting, uncatalogued-model OAuth selection, or fail-closed sideband proxy behavior.
+    files:
+      - docs/lts/downstream-patches.yaml
+      - internal/client/codex/live/live.go
+      - internal/client/codex/live/live_test.go
+      - internal/client/codex/live/sideband.go
+      - internal/config/codex_live_test.go
+      - internal/config/parse.go
+      - sdk/cliproxy/auth/conductor_lts.go
+      - sdk/cliproxy/auth/conductor_selection.go
+      - sdk/cliproxy/executor/types.go
+    regression_tests:
+      - TestHandlerRewritesLiveCallAndSchedulesOAuth
+      - TestHandlerLogsLiveBootstrapMetadataWithoutSDPCredentials
+      - TestHandlerPublishesZeroTokenUsageAndMarksLocalAuthResult
+      - TestHandlerRefreshesUnauthorizedHomeSelectionOnce
+      - TestNewSidebandDialerRejectsInvalidProxyWithoutFallback
+      - TestParseConfigBytesValidatesCodexLiveMediaRelay
+      - TestHandleSidebandPinsAuthAndRelaysBidirectionally
+    upstream_issue_or_pr: "CPA-Core-LTS PR #195 review residue; upstream not-filed"
+    state: required
+    retire_when: Upstream or a replacement Live implementation records no SDP request or response body, emits one attributed zero-token usage record per real bootstrap attempt including Home refresh retries, completes model-scoped local auth outcome lifecycle without requiring Live models in the general catalog, validates media relay settings on every config parse path, fails closed for invalid explicit sideband proxies, and all listed regressions pass without the downstream implementation.
+
+  - id: xai-implicit-responses-message-token-accounting
+    reason: OpenAI Responses permits message-shaped input items with role/content and no explicit type, and xAI local token estimation must include their content instead of silently undercounting the request.
+    introduced_in: 4534eed92ef5cd639b377a17dd56dad2d9e41f70
+    affected_upstream_range: through ea37d13a9eced4af835cad10bcb030d770a5ba88 (v7.2.120, 2026-08-06); upstream xAI token collection still dispatches only on an explicit input item type and ignores ordinary untyped role/content messages.
+    files:
+      - docs/lts/downstream-patches.yaml
+      - internal/runtime/executor/xai_executor_test.go
+      - internal/runtime/executor/xai_executor_tokens.go
+    regression_tests:
+      - TestCountXAIInputTokensExcludesRequestStructure
+    upstream_issue_or_pr: "CPA-Core-LTS PR #194 review residue; upstream not-filed"
+    state: required
+    retire_when: Upstream counts message-shaped Responses input with omitted type while preserving structure exclusion and function/tool item handling, and the listed regression passes without the downstream implementation.
+
+  - id: xai-websocket-saturated-reader-invalidation
+    reason: A terminal xAI WebSocket reader cannot enqueue its error when the active request channel is full; invalidation must cancel the active reader before the terminal sender waits, otherwise the reader and request can deadlock indefinitely.
+    introduced_in: 4534eed92ef5cd639b377a17dd56dad2d9e41f70
+    affected_upstream_range: through ea37d13a9eced4af835cad10bcb030d770a5ba88 (v7.2.120, 2026-08-06); upstream does not cancel the active read lifecycle when invalidating a saturated shared xAI WebSocket connection.
+    files:
+      - docs/lts/downstream-patches.yaml
+      - internal/runtime/executor/codex_websockets_session.go
+      - internal/runtime/executor/xai_websockets_executor.go
+      - internal/runtime/executor/xai_websockets_executor_test.go
+    regression_tests:
+      - TestXAIWebsocketTerminalReadInvalidationCancelsSaturatedActiveChannel
+    upstream_issue_or_pr: "CPA-Core-LTS PR #194 review residue; upstream not-filed"
+    state: required
+    retire_when: Upstream invalidation wakes a terminal sender blocked behind a full active request channel without dropping queued messages or relying on a test-only callback to close the done channel, and the listed regression passes without the downstream implementation.
+
+  - id: xai-model-bad-credentials-auth-normalization
+    reason: xAI model-scoped 403 bad-credentials failures normalize the model error to unauthorized, and the auth-level LastError snapshot must use the same code so refresh and availability decisions do not continue treating the credential as an ordinary 403.
+    introduced_in: 4534eed92ef5cd639b377a17dd56dad2d9e41f70
+    affected_upstream_range: through ea37d13a9eced4af835cad10bcb030d770a5ba88 (v7.2.120, 2026-08-06); upstream leaves the auth-level bad-credentials snapshot at its raw 403 code after normalizing only the model state.
+    files:
+      - docs/lts/downstream-patches.yaml
+      - sdk/cliproxy/auth/conductor_cooldown.go
+      - sdk/cliproxy/auth/xai_bad_credentials_test.go
+    regression_tests:
+      - TestManager_MarkResult_XaiBadCredentialsMarksModelUnauthorized
+      - TestManager_MarkResult_XaiBadCredentialsMarksAuthUnauthorized
+    upstream_issue_or_pr: "CPA-Core-LTS PR #183 review residue; upstream not-filed"
+    state: required
+    retire_when: Upstream keeps model-level and auth-level xAI bad-credentials error codes aligned as unauthorized, prevents redundant refresh classification, and both listed regressions pass without the downstream implementation.

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -1000,7 +1000,6 @@ patches:
       - internal/config/parse.go
       - sdk/cliproxy/auth/conductor_lts.go
       - sdk/cliproxy/auth/conductor_selection.go
-      - sdk/cliproxy/executor/types.go
     regression_tests:
       - TestHandlerRewritesLiveCallAndSchedulesOAuth
       - TestHandlerLogsLiveBootstrapMetadataWithoutSDPCredentials

--- a/internal/client/codex/live/live.go
+++ b/internal/client/codex/live/live.go
@@ -15,14 +15,17 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	runtimeexecutor "github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	log "github.com/sirupsen/logrus"
+	"github.com/tidwall/gjson"
 )
 
 const (
@@ -38,6 +41,32 @@ var liveProtocolHeaders = []string{
 	"Thread-Id",
 	"Originator",
 	"X-Oai-Attestation",
+}
+
+type liveBootstrapAttempt struct {
+	reporter   *helps.UsageReporter
+	selected   *auth.Auth
+	dispatched bool
+	statusCode int
+	body       []byte
+	err        error
+	finalized  bool
+}
+
+type liveHTTPStatusError struct {
+	statusCode int
+}
+
+func (e liveHTTPStatusError) Error() string {
+	message := http.StatusText(e.statusCode)
+	if message == "" {
+		message = "upstream request failed"
+	}
+	return message
+}
+
+func (e liveHTTPStatusError) StatusCode() int {
+	return e.statusCode
 }
 
 // Handler forwards Codex live session requests through the shared auth scheduler.
@@ -199,8 +228,11 @@ func (h *Handler) Handle(c *gin.Context) {
 	selectionOpts := coreexecutor.Options{
 		Headers:         c.Request.Header.Clone(),
 		OriginalRequest: body,
+		Metadata: map[string]any{
+			coreexecutor.SkipModelCapabilityCheckMetadataKey: true,
+		},
 	}
-	selection, selected, errSelect := h.selectOAuth(ctx, model, selectionOpts)
+	selection, selected, resultCtx, errSelect := h.selectOAuth(ctx, model, selectionOpts)
 	if errSelect != nil {
 		writeSelectionError(c, errSelect)
 		return
@@ -211,6 +243,10 @@ func (h *Handler) Handle(c *gin.Context) {
 		}
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Codex auth unavailable"})
 		return
+	}
+	if selection == nil {
+		ctx = resultCtx
+		defer h.authManager.AbandonSelectedAuthRequest(resultCtx)
 	}
 
 	if selection != nil {
@@ -265,26 +301,42 @@ func (h *Handler) Handle(c *gin.Context) {
 
 	baseHeaders := protocolHeaders(c.Request.Header)
 	baseHeaders.Set("Content-Type", upstreamContentType)
-	performRequest := func(current *auth.Auth) (*http.Response, error) {
+	performRequest := func(current *auth.Auth, confirmDispatch bool) (*liveBootstrapAttempt, *http.Response, error) {
 		headers := baseHeaders.Clone()
 		setAccountHeader(headers, current)
 		req, errRequest := h.authManager.NewHttpRequest(ctx, current, http.MethodPost, upstreamCallURL, upstreamBody, headers)
 		if errRequest != nil {
-			return nil, errRequest
+			return nil, nil, errRequest
+		}
+		if confirmDispatch {
+			if errConfirm := h.authManager.ConfirmSelectedAuthDispatch(resultCtx); errConfirm != nil {
+				return nil, nil, errConfirm
+			}
 		}
 		authType, authValue := current.AccountInfo()
 		helps.RecordAPIRequest(ctx, runtimeConfig, helps.UpstreamRequestLog{
 			URL:       upstreamCallURL,
 			Method:    http.MethodPost,
 			Headers:   headersForLogging(req.Header),
-			Body:      upstreamBody,
+			Body:      nil,
 			Provider:  "codex",
 			AuthID:    current.ID,
 			AuthLabel: current.Label,
 			AuthType:  authType,
 			AuthValue: authValue,
 		})
-		return h.authManager.HttpRequest(ctx, current, req)
+		attempt := &liveBootstrapAttempt{
+			reporter:   helps.NewUsageReporter(ctx, "codex", model, current),
+			selected:   current,
+			dispatched: true,
+		}
+		attempt.reporter.StartResponseTTFT()
+		resp, errRequest := h.authManager.HttpRequest(ctx, current, req)
+		if resp != nil {
+			attempt.statusCode = resp.StatusCode
+			attempt.reporter.ObserveResponse(resp)
+		}
+		return attempt, resp, errRequest
 	}
 
 	if errContext := ctx.Err(); errContext != nil {
@@ -294,8 +346,12 @@ func (h *Handler) Handle(c *gin.Context) {
 		c.JSON(http.StatusRequestTimeout, gin.H{"error": errContext.Error()})
 		return
 	}
-	resp, errRequest := performRequest(selected)
+	activeAttempt, resp, errRequest := performRequest(selected, selection == nil)
 	if errRequest != nil {
+		if activeAttempt != nil {
+			activeAttempt.err = errRequest
+			activeAttempt.finalize(ctx, h.authManager, resultCtx, model, selection == nil)
+		}
 		if selection != nil {
 			selection.End("request_failed")
 		}
@@ -303,13 +359,19 @@ func (h *Handler) Handle(c *gin.Context) {
 		c.JSON(http.StatusBadGateway, gin.H{"error": errRequest.Error()})
 		return
 	}
+	defer func() {
+		if activeAttempt != nil {
+			activeAttempt.finalize(ctx, h.authManager, resultCtx, model, selection == nil)
+		}
+	}()
 	if selection != nil && resp.StatusCode == http.StatusUnauthorized {
-		h.authManager.ReportHomeUnauthorized(ctx, selected, "codex", model)
 		helps.RecordAPIResponseMetadata(ctx, runtimeConfig, resp.StatusCode, callResponseHeaders(resp.Header))
 		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
 		if errClose := resp.Body.Close(); errClose != nil {
 			log.Errorf("codex live: close unauthorized response body error: %v", errClose)
 		}
+		activeAttempt.finalize(ctx, h.authManager, resultCtx, model, false)
+		activeAttempt = nil
 		refreshed, didRefresh, errRefresh := h.authManager.RefreshHomeSelectionAfterUnauthorized(ctx, selection, selected)
 		if errRefresh != nil {
 			selection.End("refresh_failed")
@@ -323,15 +385,17 @@ func (h *Handler) Handle(c *gin.Context) {
 		}
 		selected = refreshed
 		logging.SetGinCPATraceID(c, selected.EnsureIndex())
-		resp, errRequest = performRequest(selected)
+		activeAttempt, resp, errRequest = performRequest(selected, false)
 		if errRequest != nil {
+			if activeAttempt != nil {
+				activeAttempt.err = errRequest
+				activeAttempt.finalize(ctx, h.authManager, resultCtx, model, false)
+				activeAttempt = nil
+			}
 			selection.End("retry_failed")
 			helps.RecordAPIResponseError(ctx, runtimeConfig, errRequest)
 			c.JSON(http.StatusBadGateway, gin.H{"error": errRequest.Error()})
 			return
-		}
-		if resp.StatusCode == http.StatusUnauthorized {
-			h.authManager.ReportHomeUnauthorized(ctx, selected, "codex", model)
 		}
 	}
 
@@ -359,6 +423,9 @@ func (h *Handler) Handle(c *gin.Context) {
 	helps.RecordAPIResponseMetadata(ctx, runtimeConfig, resp.StatusCode, responseHeaders)
 	responseBody, errResponse := readLimitedBody(resp.Body)
 	if errResponse != nil {
+		if activeAttempt != nil {
+			activeAttempt.err = errResponse
+		}
 		helps.RecordAPIResponseError(ctx, runtimeConfig, errResponse)
 		message := "Failed to read Codex live response"
 		if errors.Is(errResponse, errBodyTooLarge) {
@@ -367,7 +434,9 @@ func (h *Handler) Handle(c *gin.Context) {
 		c.JSON(http.StatusBadGateway, gin.H{"error": message})
 		return
 	}
-	helps.AppendAPIResponseChunk(ctx, runtimeConfig, responseBody)
+	if activeAttempt != nil {
+		activeAttempt.body = responseBody
+	}
 	responseBodyToWrite := responseBody
 	success := resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices
 	callID := ""
@@ -443,6 +512,84 @@ func (h *Handler) Handle(c *gin.Context) {
 	}
 }
 
+func (a *liveBootstrapAttempt) finalize(ctx context.Context, manager *auth.Manager, resultCtx context.Context, model string, trackAuthResult bool) {
+	if a == nil || a.finalized {
+		return
+	}
+	a.finalized = true
+
+	if a.reporter != nil {
+		switch {
+		case a.err != nil:
+			a.reporter.PublishFailure(ctx, a.err)
+		case liveStatusSuccessful(a.statusCode):
+			a.reporter.EnsurePublished(ctx)
+		default:
+			a.reporter.PublishFailure(ctx, liveHTTPStatusError{statusCode: a.statusCode})
+		}
+	}
+	if !trackAuthResult || manager == nil || a.selected == nil || !a.dispatched {
+		return
+	}
+	if a.err != nil && (ctx.Err() != nil || errors.Is(a.err, context.Canceled) || errors.Is(a.err, context.DeadlineExceeded)) {
+		return
+	}
+	markLiveAuthResult(manager, resultCtx, a.selected, model, a.statusCode, a.body, a.err)
+}
+
+func markLiveAuthResult(manager *auth.Manager, ctx context.Context, selected *auth.Auth, model string, statusCode int, body []byte, requestErr error) {
+	if manager == nil || selected == nil {
+		return
+	}
+	if statusError, ok := requestErr.(interface{ StatusCode() int }); ok && statusError.StatusCode() > 0 {
+		statusCode = statusError.StatusCode()
+	}
+	if statusCode <= 0 && requestErr != nil {
+		statusCode = http.StatusBadGateway
+	}
+	classification := runtimeexecutor.ClassifyCodexUpstreamError(statusCode, body, time.Now())
+	statusCode = classification.HTTPStatus
+	result := auth.Result{
+		AuthID:   selected.ID,
+		Provider: "codex",
+		Model:    strings.TrimSpace(model),
+		Success:  requestErr == nil && liveStatusSuccessful(statusCode),
+	}
+	if !result.Success {
+		code := liveResponseErrorField(body, "error.code", "error.type", "code", "type")
+		message := liveResponseErrorField(body, "error.message", "message")
+		if classification.RequestInvalid {
+			code = "request_scoped"
+		}
+		if requestErr != nil {
+			message = requestErr.Error()
+		}
+		if message == "" {
+			message = http.StatusText(statusCode)
+		}
+		if message == "" {
+			message = "Codex live request failed"
+		}
+		result.Error = &auth.Error{Code: code, Message: message, HTTPStatus: statusCode}
+		result.RetryAfter = classification.RetryAfter
+		result.ModelFallbackReason = classification.ModelFallbackReason
+	}
+	manager.MarkResult(ctx, result)
+}
+
+func liveStatusSuccessful(statusCode int) bool {
+	return statusCode == http.StatusSwitchingProtocols || (statusCode >= http.StatusOK && statusCode < http.StatusMultipleChoices)
+}
+
+func liveResponseErrorField(body []byte, paths ...string) string {
+	for _, path := range paths {
+		if value := strings.TrimSpace(gjson.GetBytes(body, path).String()); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
 func mediaCredentialName(selected *auth.Auth, authIndex string) string {
 	if selected == nil {
 		return strings.TrimSpace(authIndex)
@@ -458,9 +605,10 @@ func mediaCredentialName(selected *auth.Auth, authIndex string) string {
 	return strings.TrimSpace(authIndex)
 }
 
-func (h *Handler) selectOAuth(ctx context.Context, model string, opts coreexecutor.Options) (*auth.HomeDispatchSelection, *auth.Auth, error) {
+func (h *Handler) selectOAuth(ctx context.Context, model string, opts coreexecutor.Options) (*auth.HomeDispatchSelection, *auth.Auth, context.Context, error) {
 	var selection *auth.HomeDispatchSelection
 	var selected *auth.Auth
+	resultCtx := ctx
 	var errSelect error
 	if h.authManager.HomeEnabled() {
 		selection, errSelect = h.authManager.SelectHomeAuthByKind(ctx, "codex", model, auth.AuthKindOAuth, opts)
@@ -468,12 +616,12 @@ func (h *Handler) selectOAuth(ctx context.Context, model string, opts coreexecut
 			selected = selection.CloneAuth()
 		}
 	} else {
-		selected, errSelect = h.authManager.SelectAuthByKind(ctx, "codex", "", auth.AuthKindOAuth, opts)
+		selected, resultCtx, errSelect = h.authManager.SelectAuthForRequestByKind(ctx, "codex", model, auth.AuthKindOAuth, opts)
 	}
 	if errSelect != nil && selection != nil {
 		selection.End("selection_failed")
 	}
-	return selection, selected, errSelect
+	return selection, selected, resultCtx, errSelect
 }
 
 var errBodyTooLarge = errors.New("Codex live request body too large")

--- a/internal/client/codex/live/live.go
+++ b/internal/client/codex/live/live.go
@@ -228,9 +228,6 @@ func (h *Handler) Handle(c *gin.Context) {
 	selectionOpts := coreexecutor.Options{
 		Headers:         c.Request.Header.Clone(),
 		OriginalRequest: body,
-		Metadata: map[string]any{
-			coreexecutor.SkipModelCapabilityCheckMetadataKey: true,
-		},
 	}
 	selection, selected, resultCtx, errSelect := h.selectOAuth(ctx, model, selectionOpts)
 	if errSelect != nil {
@@ -616,7 +613,7 @@ func (h *Handler) selectOAuth(ctx context.Context, model string, opts coreexecut
 			selected = selection.CloneAuth()
 		}
 	} else {
-		selected, resultCtx, errSelect = h.authManager.SelectAuthForRequestByKind(ctx, "codex", model, auth.AuthKindOAuth, opts)
+		selected, resultCtx, errSelect = h.authManager.SelectAuthForRequestByKindWithUncataloguedModel(ctx, "codex", model, auth.AuthKindOAuth, opts)
 	}
 	if errSelect != nil && selection != nil {
 		selection.End("selection_failed")

--- a/internal/client/codex/live/live_test.go
+++ b/internal/client/codex/live/live_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executionregistry"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 )
 
 type apiKeyFirstSelector struct{}
@@ -43,6 +44,45 @@ type captureExecutor struct {
 	statuses     []int
 	httpCalls    atomic.Int32
 	refreshCalls atomic.Int32
+}
+
+type captureLiveUsagePlugin struct {
+	records chan usage.Record
+	authID  string
+}
+
+func (p *captureLiveUsagePlugin) HandleUsage(_ context.Context, record usage.Record) {
+	if p == nil || record.Provider != "codex" || record.Model != defaultLiveModel || record.AuthID != p.authID {
+		return
+	}
+	select {
+	case p.records <- record:
+	default:
+	}
+}
+
+type noopLiveUsagePlugin struct{}
+
+func (noopLiveUsagePlugin) HandleUsage(context.Context, usage.Record) {}
+
+func waitForLiveUsageRecord(t *testing.T, records <-chan usage.Record) usage.Record {
+	t.Helper()
+	select {
+	case record := <-records:
+		return record
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for Codex Live usage record")
+		return usage.Record{}
+	}
+}
+
+func assertNoAdditionalLiveUsageRecord(t *testing.T, records <-chan usage.Record) {
+	t.Helper()
+	select {
+	case record := <-records:
+		t.Fatalf("received additional Codex Live usage record: %+v", record)
+	case <-time.After(100 * time.Millisecond):
+	}
 }
 
 func (*captureExecutor) Identifier() string { return "codex" }
@@ -339,6 +379,109 @@ func TestHandlerRewritesLiveCallAndSchedulesOAuth(t *testing.T) {
 	}
 }
 
+func TestHandlerLogsLiveBootstrapMetadataWithoutSDPCredentials(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	manager := auth.NewManager(nil, nil, nil)
+	executor := &captureExecutor{
+		responseBody: &trackedResponseBody{Reader: strings.NewReader("v=0\r\na=ice-ufrag:upstream-secret\r\na=ice-pwd:upstream-password\r\n")},
+	}
+	manager.RegisterExecutor(executor)
+	registerCredential(t, manager, &auth.Auth{
+		ID:       "codex-live-log-oauth",
+		Provider: "codex",
+		Status:   auth.StatusActive,
+		Metadata: map[string]any{"access_token": "oauth-token"},
+	})
+	cfg := &config.Config{SDKConfig: config.SDKConfig{RequestLog: true}}
+	handler := NewHandler(manager, cfg)
+
+	var requestLog, responseLog []byte
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Next()
+		if value, ok := c.Get("API_REQUEST"); ok {
+			requestLog, _ = value.([]byte)
+		}
+		if value, ok := c.Get("API_RESPONSE"); ok {
+			responseLog, _ = value.([]byte)
+		}
+	})
+	router.POST("/v1/live", handler.Handle)
+
+	const boundary = "live-log-boundary"
+	body := multipartBody(
+		boundary,
+		"v=0\r\na=ice-ufrag:client-secret\r\na=ice-pwd:client-password\r\n",
+		`{"model":"gpt-live-1-codex"}`,
+	)
+	req := httptest.NewRequest(http.MethodPost, "/v1/live", strings.NewReader(body))
+	req.Header.Set("Content-Type", "multipart/form-data; boundary="+boundary)
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+	logs := string(append(append([]byte(nil), requestLog...), responseLog...))
+	if requestLog == nil || responseLog == nil {
+		t.Fatalf("request/response metadata logs were not captured: request=%q response=%q", requestLog, responseLog)
+	}
+	for _, secret := range []string{"client-secret", "client-password", "upstream-secret", "upstream-password", "ice-ufrag", "ice-pwd"} {
+		if strings.Contains(logs, secret) {
+			t.Fatalf("Codex Live metadata log leaked SDP credential marker %q: %s", secret, logs)
+		}
+	}
+}
+
+func TestHandlerPublishesZeroTokenUsageAndMarksLocalAuthResult(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	records := make(chan usage.Record, 4)
+	const pluginName = "codex-live-bootstrap-success-test"
+	usage.RegisterNamedPlugin(pluginName, &captureLiveUsagePlugin{records: records, authID: "codex-live-usage-oauth"})
+	t.Cleanup(func() { usage.RegisterNamedPlugin(pluginName, noopLiveUsagePlugin{}) })
+
+	manager := auth.NewManager(nil, nil, nil)
+	executor := &captureExecutor{
+		responseBody: &trackedResponseBody{Reader: strings.NewReader("v=0\r\n")},
+	}
+	manager.RegisterExecutor(executor)
+	credential := &auth.Auth{
+		ID:       "codex-live-usage-oauth",
+		Provider: "codex",
+		Status:   auth.StatusActive,
+		Metadata: map[string]any{"access_token": "oauth-token"},
+	}
+	registerCredential(t, manager, credential)
+
+	handler := NewHandler(manager, nil)
+	router := gin.New()
+	router.POST("/v1/live", handler.Handle)
+	req := httptest.NewRequest(http.MethodPost, "/v1/live", strings.NewReader(`{"model":"gpt-live-1-codex","sdp":"v=0"}`))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+	record := waitForLiveUsageRecord(t, records)
+	if record.Failed || record.Model != defaultLiveModel || record.AuthID != credential.ID || record.AuthIndex == "" {
+		t.Fatalf("Codex Live usage record = %+v", record)
+	}
+	if record.RequestedAt.IsZero() || record.Latency <= 0 {
+		t.Fatalf("Codex Live usage timing = requested_at:%v latency:%v", record.RequestedAt, record.Latency)
+	}
+	if record.Detail.InputTokens != 0 || record.Detail.OutputTokens != 0 || record.Detail.TotalTokens != 0 {
+		t.Fatalf("Codex Live token usage = %+v, want zero-token request record", record.Detail)
+	}
+	assertNoAdditionalLiveUsageRecord(t, records)
+
+	updated, ok := manager.GetByID(credential.ID)
+	if !ok || updated.Success != 1 || updated.Failed != 0 {
+		t.Fatalf("local auth outcome = %#v, ok=%t; want one successful Live result", updated, ok)
+	}
+}
+
 func TestMediaCredentialNameUsesSafeIdentity(t *testing.T) {
 	for name, testCase := range map[string]struct {
 		selected *auth.Auth
@@ -380,6 +523,24 @@ func TestProxyURLForAuthPrefersCredentialOverride(t *testing.T) {
 	}
 	if got := proxyURLForAuth(cfg, &auth.Auth{ProxyURL: "direct"}); got != "direct" {
 		t.Fatalf("effective proxy URL = %q, want explicit direct override", got)
+	}
+}
+
+func TestNewSidebandDialerRejectsInvalidProxyWithoutFallback(t *testing.T) {
+	for name, proxyURL := range map[string]string{
+		"invalid URL":        "://invalid",
+		"unsupported scheme": "ftp://proxy.example:21",
+		"invalid SOCKS":      "socks5://",
+	} {
+		t.Run(name, func(t *testing.T) {
+			dialer, err := newSidebandDialer(proxyURL)
+			if err == nil {
+				t.Fatalf("newSidebandDialer(%q) error = nil, want proxy configuration error", proxyURL)
+			}
+			if dialer != nil {
+				t.Fatalf("newSidebandDialer(%q) returned a fallback dialer after error", proxyURL)
+			}
+		})
 	}
 }
 
@@ -608,6 +769,10 @@ func TestHandlerClosesMediaWhenResponseWriteFails(t *testing.T) {
 
 func TestHandlerRefreshesUnauthorizedHomeSelectionOnce(t *testing.T) {
 	gin.SetMode(gin.TestMode)
+	records := make(chan usage.Record, 4)
+	const pluginName = "codex-live-home-refresh-usage-test"
+	usage.RegisterNamedPlugin(pluginName, &captureLiveUsagePlugin{records: records, authID: "home-codex-live"})
+	t.Cleanup(func() { usage.RegisterNamedPlugin(pluginName, noopLiveUsagePlugin{}) })
 	manager := auth.NewManager(nil, nil, nil)
 	manager.SetConfig(&config.Config{Home: config.HomeConfig{Enabled: true}})
 	registry := executionregistry.New()
@@ -635,6 +800,15 @@ func TestHandlerRefreshesUnauthorizedHomeSelectionOnce(t *testing.T) {
 	if got := executor.request.Header.Get("Authorization"); got != "Bearer refreshed-home-live-token" {
 		t.Fatalf("retry Authorization = %q, want refreshed token", got)
 	}
+	firstAttempt := waitForLiveUsageRecord(t, records)
+	secondAttempt := waitForLiveUsageRecord(t, records)
+	if !firstAttempt.Failed || firstAttempt.Fail.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("first Home Live usage attempt = %+v, want failed 401", firstAttempt)
+	}
+	if secondAttempt.Failed || secondAttempt.AuthIndex == "" {
+		t.Fatalf("second Home Live usage attempt = %+v, want successful refreshed auth", secondAttempt)
+	}
+	assertNoAdditionalLiveUsageRecord(t, records)
 	if errDrain := registry.Drain(context.Background()); errDrain != nil {
 		t.Fatalf("Drain() error = %v", errDrain)
 	}

--- a/internal/client/codex/live/sideband.go
+++ b/internal/client/codex/live/sideband.go
@@ -1,8 +1,10 @@
 package live
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -338,6 +340,7 @@ func (h *Handler) HandleSideband(c *gin.Context) {
 	ctx := context.WithValue(c.Request.Context(), "gin", c)
 	var selection *auth.HomeDispatchSelection
 	var selected *auth.Auth
+	resultCtx := ctx
 	var errSelect error
 	if session.homeSelection != nil {
 		if !session.homeSelection.Active() {
@@ -351,11 +354,12 @@ func (h *Handler) HandleSideband(c *gin.Context) {
 		selectionOpts := coreexecutor.Options{
 			Headers: c.Request.Header.Clone(),
 			Metadata: map[string]any{
-				coreexecutor.PinnedAuthMetadataKey:       session.authID,
-				coreexecutor.ExecutionSessionMetadataKey: callID,
+				coreexecutor.PinnedAuthMetadataKey:               session.authID,
+				coreexecutor.ExecutionSessionMetadataKey:         callID,
+				coreexecutor.SkipModelCapabilityCheckMetadataKey: true,
 			},
 		}
-		selection, selected, errSelect = h.selectOAuth(ctx, session.model, selectionOpts)
+		selection, selected, resultCtx, errSelect = h.selectOAuth(ctx, session.model, selectionOpts)
 	}
 	if errSelect != nil {
 		writeSelectionError(c, errSelect)
@@ -364,6 +368,10 @@ func (h *Handler) HandleSideband(c *gin.Context) {
 	if selected == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Codex auth unavailable"})
 		return
+	}
+	if selection == nil {
+		ctx = resultCtx
+		defer h.authManager.AbandonSelectedAuthRequest(resultCtx)
 	}
 
 	if selection != nil {
@@ -380,15 +388,25 @@ func (h *Handler) HandleSideband(c *gin.Context) {
 
 	upstreamURL := buildSidebandURL(h.sidebandAPIBaseURL, style, callID)
 	upstreamHTTPURL := websocketHTTPURL(upstreamURL)
-	dialUpstream := func(current *auth.Auth) (*websocket.Conn, *http.Response, error) {
+	dialUpstream := func(current *auth.Auth, confirmDispatch bool) (*websocket.Conn, *http.Response, bool, error) {
 		req, errRequest := http.NewRequestWithContext(ctx, http.MethodGet, upstreamHTTPURL, nil)
 		if errRequest != nil {
-			return nil, nil, errRequest
+			return nil, nil, false, errRequest
 		}
 		req.Header = protocolHeaders(c.Request.Header)
 		setAccountHeader(req.Header, current)
 		if errPrepare := h.authManager.PrepareHttpRequest(ctx, current, req); errPrepare != nil {
-			return nil, nil, errPrepare
+			return nil, nil, false, errPrepare
+		}
+		dialer, errDialer := newProxyAwareSidebandDialer(runtimeConfig, current)
+		if errDialer != nil {
+			return nil, nil, false, errDialer
+		}
+		dialer.Subprotocols = websocket.Subprotocols(c.Request)
+		if confirmDispatch {
+			if errConfirm := h.authManager.ConfirmSelectedAuthDispatch(resultCtx); errConfirm != nil {
+				return nil, nil, false, errConfirm
+			}
 		}
 		authType, authValue := current.AccountInfo()
 		helps.RecordAPIWebsocketRequest(ctx, runtimeConfig, helps.UpstreamRequestLog{
@@ -401,12 +419,11 @@ func (h *Handler) HandleSideband(c *gin.Context) {
 			AuthType:  authType,
 			AuthValue: authValue,
 		})
-		dialer := newProxyAwareSidebandDialer(runtimeConfig, current)
-		dialer.Subprotocols = websocket.Subprotocols(c.Request)
-		return dialer.DialContext(ctx, upstreamURL, req.Header)
+		upstream, response, errDial := dialer.DialContext(ctx, upstreamURL, req.Header)
+		return upstream, response, true, errDial
 	}
 
-	upstream, handshakeResponse, errDial := dialUpstream(selected)
+	upstream, handshakeResponse, dispatched, errDial := dialUpstream(selected, selection == nil)
 	if errDial != nil && selection != nil && handshakeResponse != nil && handshakeResponse.StatusCode == http.StatusUnauthorized {
 		h.authManager.ReportHomeUnauthorized(ctx, selected, "codex", session.model)
 		helps.RecordAPIWebsocketHandshake(ctx, runtimeConfig, handshakeResponse.StatusCode, callResponseHeaders(handshakeResponse.Header))
@@ -426,10 +443,17 @@ func (h *Handler) HandleSideband(c *gin.Context) {
 		}
 		selected = refreshed
 		logging.SetGinCPATraceID(c, selected.EnsureIndex())
-		upstream, handshakeResponse, errDial = dialUpstream(selected)
+		upstream, handshakeResponse, _, errDial = dialUpstream(selected, false)
 		if errDial != nil && handshakeResponse != nil && handshakeResponse.StatusCode == http.StatusUnauthorized {
 			h.authManager.ReportHomeUnauthorized(ctx, selected, "codex", session.model)
 		}
+	}
+	if selection == nil && dispatched && (errDial == nil || (ctx.Err() == nil && !errors.Is(errDial, context.Canceled) && !errors.Is(errDial, context.DeadlineExceeded))) {
+		statusCode := http.StatusSwitchingProtocols
+		if handshakeResponse != nil && handshakeResponse.StatusCode > 0 {
+			statusCode = handshakeResponse.StatusCode
+		}
+		markLiveAuthResult(h.authManager, resultCtx, selected, session.model, statusCode, sidebandHandshakeBody(handshakeResponse), errDial)
 	}
 	if errDial != nil {
 		handleSidebandDialError(c, ctx, runtimeConfig, handshakeResponse, errDial)
@@ -566,6 +590,16 @@ func handleSidebandDialError(c *gin.Context, ctx context.Context, cfg *config.Co
 	c.JSON(status, gin.H{"error": "Codex live sideband upstream unavailable"})
 }
 
+func sidebandHandshakeBody(response *http.Response) []byte {
+	if response == nil || response.Body == nil {
+		return nil
+	}
+	body, _ := io.ReadAll(io.LimitReader(response.Body, 1<<20))
+	_ = response.Body.Close()
+	response.Body = io.NopCloser(bytes.NewReader(body))
+	return body
+}
+
 func websocketCloseFunc(name string, conn *websocket.Conn) func() error {
 	var once sync.Once
 	var closeErr error
@@ -640,7 +674,7 @@ func isNormalWebsocketClose(err error) bool {
 	return websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway, websocket.CloseNoStatusReceived)
 }
 
-func newProxyAwareSidebandDialer(cfg *config.Config, selected *auth.Auth) *websocket.Dialer {
+func newProxyAwareSidebandDialer(cfg *config.Config, selected *auth.Auth) (*websocket.Dialer, error) {
 	return newSidebandDialer(proxyURLForAuth(cfg, selected))
 }
 
@@ -654,24 +688,23 @@ func proxyURLForAuth(cfg *config.Config, selected *auth.Auth) string {
 	return ""
 }
 
-func newSidebandDialer(proxyURL string) *websocket.Dialer {
+func newSidebandDialer(proxyURL string) (*websocket.Dialer, error) {
 	dialer := &websocket.Dialer{Proxy: http.ProxyFromEnvironment}
 	if strings.TrimSpace(proxyURL) == "" {
-		return dialer
+		return dialer, nil
 	}
 
 	setting, errParse := proxyutil.Parse(proxyURL)
 	if errParse != nil {
-		log.Errorf("codex live sideband: %v", errParse)
-		return dialer
+		return nil, fmt.Errorf("codex live sideband proxy: %w", errParse)
 	}
 	switch setting.Mode {
 	case proxyutil.ModeDirect:
 		dialer.Proxy = nil
-		return dialer
+		return dialer, nil
 	case proxyutil.ModeProxy:
 	default:
-		return dialer
+		return nil, fmt.Errorf("codex live sideband proxy: unsupported mode")
 	}
 
 	switch setting.URL.Scheme {
@@ -684,8 +717,7 @@ func newSidebandDialer(proxyURL string) *websocket.Dialer {
 		}
 		socksDialer, errSOCKS5 := xproxy.SOCKS5("tcp", setting.URL.Host, proxyAuth, xproxy.Direct)
 		if errSOCKS5 != nil {
-			log.Errorf("codex live sideband: create SOCKS5 dialer failed: %v", errSOCKS5)
-			return dialer
+			return nil, fmt.Errorf("codex live sideband proxy: create SOCKS5 dialer: %w", errSOCKS5)
 		}
 		dialer.Proxy = nil
 		if contextDialer, ok := socksDialer.(xproxy.ContextDialer); ok {
@@ -698,7 +730,7 @@ func newSidebandDialer(proxyURL string) *websocket.Dialer {
 	case "http", "https":
 		dialer.Proxy = http.ProxyURL(setting.URL)
 	default:
-		log.Errorf("codex live sideband: unsupported proxy scheme: %s", setting.URL.Scheme)
+		return nil, fmt.Errorf("codex live sideband proxy: unsupported scheme %q", setting.URL.Scheme)
 	}
-	return dialer
+	return dialer, nil
 }

--- a/internal/client/codex/live/sideband.go
+++ b/internal/client/codex/live/sideband.go
@@ -354,9 +354,8 @@ func (h *Handler) HandleSideband(c *gin.Context) {
 		selectionOpts := coreexecutor.Options{
 			Headers: c.Request.Header.Clone(),
 			Metadata: map[string]any{
-				coreexecutor.PinnedAuthMetadataKey:               session.authID,
-				coreexecutor.ExecutionSessionMetadataKey:         callID,
-				coreexecutor.SkipModelCapabilityCheckMetadataKey: true,
+				coreexecutor.PinnedAuthMetadataKey:       session.authID,
+				coreexecutor.ExecutionSessionMetadataKey: callID,
 			},
 		}
 		selection, selected, resultCtx, errSelect = h.selectOAuth(ctx, session.model, selectionOpts)

--- a/internal/config/codex_live_test.go
+++ b/internal/config/codex_live_test.go
@@ -117,3 +117,18 @@ func TestCodexLiveMediaRelayConfigRejectsInvalidValues(t *testing.T) {
 		})
 	}
 }
+
+func TestParseConfigBytesValidatesCodexLiveMediaRelay(t *testing.T) {
+	_, err := ParseConfigBytes([]byte(`codex:
+  live-media-relay:
+    enabled: true
+    udp-port-min: 40100
+    udp-port-max: 40000
+`))
+	if err == nil {
+		t.Fatal("ParseConfigBytes() accepted an invalid Codex Live media relay port range")
+	}
+	if !strings.Contains(err.Error(), "udp-port-min") {
+		t.Fatalf("ParseConfigBytes() error = %q, want Live media relay validation error", err)
+	}
+}

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -47,6 +47,9 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 	if err := cfg.Codex.DesktopToolOverlay.normalizeAndValidate(); err != nil {
 		return nil, fmt.Errorf("parse config payload: %w", err)
 	}
+	if err := cfg.Codex.LiveMediaRelay.Validate(); err != nil {
+		return nil, fmt.Errorf("parse config payload: %w", err)
+	}
 
 	cfg.CredentialConcurrency = cfg.CredentialConcurrency.WithDefaults()
 	if errValidate := cfg.CredentialInFlight.Validate(); errValidate != nil {

--- a/internal/runtime/executor/codex_websockets_session.go
+++ b/internal/runtime/executor/codex_websockets_session.go
@@ -158,6 +158,20 @@ func (s *codexWebsocketSession) clearActive(conn *websocket.Conn, ch chan codexW
 	return true
 }
 
+// cancelActiveRead interrupts a reader waiting on the active channel without
+// clearing the channel ownership. The reader that owns the channel performs
+// the subsequent clear/close transition after observing the cancellation.
+func (s *codexWebsocketSession) cancelActiveRead() {
+	if s == nil {
+		return
+	}
+	s.activeMu.Lock()
+	if s.activeCancel != nil {
+		s.activeCancel()
+	}
+	s.activeMu.Unlock()
+}
+
 func (s *codexWebsocketSession) writeMessage(conn *websocket.Conn, msgType int, payload []byte) error {
 	if s == nil {
 		return fmt.Errorf("codex websockets executor: session is nil")

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -98,6 +98,10 @@ func TestCountXAIInputTokensExcludesRequestStructure(t *testing.T) {
 			body:     []byte(`{"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"unique message text"}]}]}`),
 			expected: "unique message text",
 		},
+		"implicit message content": {
+			body:     []byte(`{"input":[{"role":"user","content":"unique implicit message text"}]}`),
+			expected: "unique implicit message text",
+		},
 		"refusal": {
 			body:     []byte(`{"input":[{"type":"message","content":[{"type":"refusal","refusal":"unique refusal text"}]}]}`),
 			expected: "unique refusal text",

--- a/internal/runtime/executor/xai_executor_tokens.go
+++ b/internal/runtime/executor/xai_executor_tokens.go
@@ -70,7 +70,11 @@ func xaiCollectInputTokenSegments(input gjson.Result, segments *[]string) {
 		return
 	}
 	for _, item := range input.Array() {
-		switch item.Get("type").String() {
+		itemType := strings.TrimSpace(item.Get("type").String())
+		if itemType == "" && (item.Get("role").Exists() || item.Get("content").Exists()) {
+			itemType = "message"
+		}
+		switch itemType {
 		case "message":
 			xaiCollectContentTokenSegments(item.Get("content"), segments)
 		case "function_call":

--- a/internal/runtime/executor/xai_websockets_executor.go
+++ b/internal/runtime/executor/xai_websockets_executor.go
@@ -1303,6 +1303,9 @@ func (e *XAIWebsocketsExecutor) invalidateUpstreamConnWithNotify(sess *codexWebs
 	}
 	sess.connMu.Unlock()
 
+	// Wake a saturated reader channel before the terminal sender waits for
+	// capacity. The reader owns the eventual channel cleanup.
+	sess.cancelActiveRead()
 	logXAIWebsocketDisconnected(sessionID, authID, wsURL, reason, err)
 	if notify {
 		sess.notifyUpstreamDisconnect(err)

--- a/internal/runtime/executor/xai_websockets_executor_test.go
+++ b/internal/runtime/executor/xai_websockets_executor_test.go
@@ -34,6 +34,54 @@ func TestXAIWebsocketsEnabledForConfigAPIKey(t *testing.T) {
 	}
 }
 
+func TestXAIWebsocketTerminalReadInvalidationCancelsSaturatedActiveChannel(t *testing.T) {
+	conn := &websocket.Conn{}
+	sess := &codexWebsocketSession{
+		conn:                 conn,
+		connCloser:           &websocketConnectionCloser{},
+		authID:               "xai-auth",
+		wsURL:                "ws://example.test/responses",
+		upstreamDisconnectCh: make(chan error, 1),
+	}
+	ch := sess.activate(conn)
+	for i := 0; i < cap(ch); i++ {
+		ch <- codexWebsocketRead{payload: []byte("queued")}
+	}
+	_, done := sess.activeForConn(conn)
+	if done == nil {
+		t.Fatal("active done channel is nil")
+	}
+
+	exec := &XAIWebsocketsExecutor{}
+	terminalErr := errors.New("upstream disconnected")
+	result := make(chan bool, 1)
+	go func() {
+		result <- sendTerminalWebsocketRead(ch, done, codexWebsocketRead{conn: conn, err: terminalErr}, func() {
+			exec.invalidateUpstreamConn(sess, conn, "upstream_disconnected", terminalErr)
+		})
+	}()
+
+	select {
+	case invalidated := <-result:
+		if !invalidated {
+			t.Fatal("saturated terminal read should report invalidation")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("terminal read remained blocked after connection invalidation")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("connection invalidation did not cancel active reader")
+	}
+	if sess.conn != nil {
+		t.Fatal("invalidated connection still attached to session")
+	}
+	if got := len(ch); got != cap(ch) {
+		t.Fatalf("saturated channel length = %d, want %d queued items preserved", got, cap(ch))
+	}
+}
+
 func TestXAIAutoExecutorRequiredUpstreamWebsocketRejectsHTTPFallback(t *testing.T) {
 	exec := NewXAIAutoExecutor(&config.Config{})
 	auth := &cliproxyauth.Auth{

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -172,9 +172,6 @@ require_grep 'json:"response_service_tier,omitempty"' internal/usage
 require_grep 'json:"effective_service_tier,omitempty"' internal/usage internal/redisqueue
 forbid_grep 'BillingBasis|billing_basis' sdk/cliproxy/usage internal/runtime/executor/helps/usage_helpers.go internal/usage/logger_plugin.go internal/redisqueue/plugin.go internal/pluginhost sdk/pluginapi
 require_grep 'json:"EffectiveServiceTier,omitempty"' sdk/pluginapi/types.go
-require_grep "TestUsageAdapterPreservesEffectiveServiceTier" internal/pluginhost/adapters_test.go
-require_grep "TestRPCUsageIncludesEffectiveServiceTier" internal/pluginhost/host_test.go
-require_grep "TestPublishCodexImageToolUsagePreservesResponseTierPrecedence" internal/runtime/executor/codex_openai_images_test.go
 require_grep 'json:"generate"' internal/usage internal/redisqueue
 require_grep "GenerateEnabled" internal/usage internal/redisqueue sdk/cliproxy/usage
 require_grep "CanonicalExportVersion" internal/usage/logger_plugin.go internal/api/handlers/management/usage.go docs/lts/core-feature-contracts.yaml docs/lts/protected-deltas.yaml

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -849,6 +849,9 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 						if state.LastError != nil {
 							state.LastError.Code = "unauthorized"
 						}
+						if auth.LastError != nil {
+							auth.LastError.Code = "unauthorized"
+						}
 						if disableCooling {
 							state.NextRetryAfter = time.Time{}
 						} else {

--- a/sdk/cliproxy/auth/conductor_lts.go
+++ b/sdk/cliproxy/auth/conductor_lts.go
@@ -1056,6 +1056,9 @@ func (m *Manager) selectAuthForRequest(ctx context.Context, provider, model, req
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	if requiredKind != "" {
+		ctx = withRequiredAuthKind(ctx, requiredKind)
+	}
 	ctx = m.withCodexRateLimitContinuityLifecycle(ctx)
 	homeMode := m.HomeEnabled()
 	homeAuthCount := homeAuthCountFromMetadata(opts.Metadata)

--- a/sdk/cliproxy/auth/conductor_lts.go
+++ b/sdk/cliproxy/auth/conductor_lts.go
@@ -1052,6 +1052,23 @@ func (m *Manager) SelectAuthForRequestByKind(ctx context.Context, provider, mode
 	return m.selectAuthForRequest(ctx, provider, model, requiredKind, opts)
 }
 
+// SelectAuthForRequestByKindWithUncataloguedModel preserves model-scoped auth
+// availability and request lifecycle tracking for an endpoint-specific model
+// that is intentionally absent from the general proxy capability registry.
+func (m *Manager) SelectAuthForRequestByKindWithUncataloguedModel(ctx context.Context, provider, model, requiredKind string, opts cliproxyexecutor.Options) (*Auth, context.Context, error) {
+	requiredKind = normalizeAuthKind(requiredKind)
+	if requiredKind == "" {
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		return nil, ctx, &Error{Code: "invalid_auth_kind", Message: "required auth kind is invalid", HTTPStatus: http.StatusBadRequest}
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return m.selectAuthForRequest(withUncataloguedEndpointModel(ctx), provider, model, requiredKind, opts)
+}
+
 func (m *Manager) selectAuthForRequest(ctx context.Context, provider, model, requiredKind string, opts cliproxyexecutor.Options) (*Auth, context.Context, error) {
 	if ctx == nil {
 		ctx = context.Background()

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -83,6 +83,14 @@ func authSelectionEligibilityForRequest(ctx context.Context, opts cliproxyexecut
 	return eligibility
 }
 
+func skipModelCapabilityCheck(opts cliproxyexecutor.Options) bool {
+	if len(opts.Metadata) == 0 {
+		return false
+	}
+	value, _ := opts.Metadata[cliproxyexecutor.SkipModelCapabilityCheckMetadataKey].(bool)
+	return value
+}
+
 func (e authSelectionEligibility) allows(auth *Auth) bool {
 	if auth == nil {
 		return false
@@ -1123,7 +1131,7 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 		if _, used := tried[candidate.ID]; used {
 			continue
 		}
-		if modelKey != "" && !m.authSupportsRouteModel(registryRef, candidate, model) {
+		if modelKey != "" && !skipModelCapabilityCheck(opts) && !m.authSupportsRouteModel(registryRef, candidate, model) {
 			continue
 		}
 		candidates = append(candidates, candidate)
@@ -1333,6 +1341,9 @@ func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cli
 	if m.HomeEnabled() {
 		auth, exec, _, err := m.pickNextViaHome(ctx, model, opts, tried)
 		return auth, exec, err
+	}
+	if skipModelCapabilityCheck(opts) {
+		return m.pickNextLegacy(ctx, provider, model, opts, tried)
 	}
 
 	if m.hasPluginScheduler() || !m.useSchedulerFastPath() {

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -51,6 +51,7 @@ func isBuiltInSelector(selector Selector) bool {
 
 type requiredAuthKindContextKey struct{}
 type credentialPolicyContextKey struct{}
+type uncataloguedEndpointModelContextKey struct{}
 
 type authSelectionEligibility struct {
 	requiredKind     string
@@ -83,11 +84,15 @@ func authSelectionEligibilityForRequest(ctx context.Context, opts cliproxyexecut
 	return eligibility
 }
 
-func skipModelCapabilityCheck(opts cliproxyexecutor.Options) bool {
-	if len(opts.Metadata) == 0 {
+func withUncataloguedEndpointModel(ctx context.Context) context.Context {
+	return context.WithValue(ctx, uncataloguedEndpointModelContextKey{}, true)
+}
+
+func usesUncataloguedEndpointModel(ctx context.Context) bool {
+	if ctx == nil {
 		return false
 	}
-	value, _ := opts.Metadata[cliproxyexecutor.SkipModelCapabilityCheckMetadataKey].(bool)
+	value, _ := ctx.Value(uncataloguedEndpointModelContextKey{}).(bool)
 	return value
 }
 
@@ -1131,7 +1136,7 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 		if _, used := tried[candidate.ID]; used {
 			continue
 		}
-		if modelKey != "" && !skipModelCapabilityCheck(opts) && !m.authSupportsRouteModel(registryRef, candidate, model) {
+		if modelKey != "" && !usesUncataloguedEndpointModel(ctx) && !m.authSupportsRouteModel(registryRef, candidate, model) {
 			continue
 		}
 		candidates = append(candidates, candidate)
@@ -1342,7 +1347,7 @@ func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cli
 		auth, exec, _, err := m.pickNextViaHome(ctx, model, opts, tried)
 		return auth, exec, err
 	}
-	if skipModelCapabilityCheck(opts) {
+	if usesUncataloguedEndpointModel(ctx) {
 		return m.pickNextLegacy(ctx, provider, model, opts, tried)
 	}
 

--- a/sdk/cliproxy/auth/xai_bad_credentials_test.go
+++ b/sdk/cliproxy/auth/xai_bad_credentials_test.go
@@ -83,6 +83,9 @@ func TestManager_MarkResult_XaiBadCredentialsMarksModelUnauthorized(t *testing.T
 	if state.LastError == nil || state.LastError.Code != "unauthorized" {
 		t.Fatalf("expected model LastError.Code = unauthorized, got %+v", state.LastError)
 	}
+	if updated.LastError == nil || updated.LastError.Code != "unauthorized" {
+		t.Fatalf("expected auth LastError.Code = unauthorized, got %+v", updated.LastError)
+	}
 	if count := reg.GetModelCount(model); count != 0 {
 		t.Fatalf("expected registry model suspension, count = %d", count)
 	}

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -23,11 +23,6 @@ const DisallowFreeAuthMetadataKey = "disallow_free_auth"
 // AuthSelectionModelMetadataKey overrides the model used only for auth selection.
 const AuthSelectionModelMetadataKey = "auth_selection_model"
 
-// SkipModelCapabilityCheckMetadataKey allows endpoint-specific requests to use
-// model-scoped auth availability without requiring the model in the general
-// proxy capability registry.
-const SkipModelCapabilityCheckMetadataKey = "skip_model_capability_check"
-
 // ReasoningEffortMetadataKey stores the client-requested reasoning effort for usage logs.
 const ReasoningEffortMetadataKey = "reasoning_effort"
 

--- a/sdk/cliproxy/executor/types.go
+++ b/sdk/cliproxy/executor/types.go
@@ -23,6 +23,11 @@ const DisallowFreeAuthMetadataKey = "disallow_free_auth"
 // AuthSelectionModelMetadataKey overrides the model used only for auth selection.
 const AuthSelectionModelMetadataKey = "auth_selection_model"
 
+// SkipModelCapabilityCheckMetadataKey allows endpoint-specific requests to use
+// model-scoped auth availability without requiring the model in the general
+// proxy capability registry.
+const SkipModelCapabilityCheckMetadataKey = "skip_model_capability_check"
+
 // ReasoningEffortMetadataKey stores the client-requested reasoning effort for usage logs.
 const ReasoningEffortMetadataKey = "reasoning_effort"
 


### PR DESCRIPTION
## Summary

- close retained actionable review gaps from CPA-Core-LTS PRs #195, #194, #183 and #175
- make Codex Live logging SDP-safe, publish one zero-token usage record per real bootstrap attempt, and complete local auth confirm/mark/abandon handling
- fail closed for invalid Live sideband proxies and validate Live media relay config on in-memory parse paths
- fix xAI implicit Responses message token accounting, saturated WebSocket reader invalidation, and auth-level bad-credentials normalization
- remove brittle LTS guard dependencies on exact service-tier test function names

## LTS classification

This is a retained downstream repair batch, not an upstream sync. Four required patches are registered in `docs/lts/downstream-patches.yaml`; their `introduced_in` points to implementation commit `4534eed92ef5cd639b377a17dd56dad2d9e41f70`. The general model catalog remains unchanged: Codex Live uses an explicit auth-manager entry point for its endpoint-specific uncatalogued model while preserving model-scoped cooldown and request lifecycle tracking.

## Validation

- `go test -p=1 ./internal/client/codex/live ./internal/config ./internal/runtime/executor ./sdk/cliproxy/auth -count=1`
- `go test -p=1 ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage' -count=1`
- `go test -p=1 ./sdk/cliproxy/... -count=1`
- `go test ./... -count=1`
- `go build -o <temporary-path>/server ./cmd/server`
- `go run ./scripts/ltsregistry --root . --base-ref origin/main`
- `scripts/check-lts-contract.sh`
- `git diff --check origin/main...HEAD`

All checks passed locally. A read-only post-implementation review found no remaining P0/P1/P2 issue after commit `5d8cc128` narrowed the uncatalogued-model selection capability.

## Merge policy

Merge commit required. No squash or rebase. This PR does not publish a release, tag, deployment, container, or runtime change.
