### PR TITLE
sync: protected upstream through v7.2.127

### DIFF
--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -4,7 +4,7 @@ patches:
   - id: codex-model-fallback
     reason: Codex usage-limit and model-capacity failures need an opt-in ordered model fallback after same-model credentials are exhausted, including a confirmed-usage-cooldown-only global target list when source mappings cannot deliver, while cross-model retries must not replay model-private reasoning signatures or replay a stream after client-visible delivery.
     introduced_in: 0bd5a46fd34dff4711fe5618afe66c93f316897b
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); upstream now drops overlong encrypted reasoning items and reuses normalized Codex payloads, while LTS preserves those request-shaping changes together with its typed configurable cross-model fallback, conservative source/target reasoning-continuity gates, target-model auth reselection, pre-delivery stream safety, and legacy replay migration.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); upstream now drops overlong encrypted reasoning items and reuses normalized Codex payloads, while LTS preserves those request-shaping changes together with its typed configurable cross-model fallback, conservative source/target reasoning-continuity gates, target-model auth reselection, pre-delivery stream safety, and legacy replay migration.
     files:
       - config.example.yaml
       - docs/lts/codex-429-resilience.md
@@ -84,7 +84,7 @@ patches:
   - id: codex-rate-limit-continuity
     reason: A fresh Codex session can receive usage_limit_reached while previously successful sessions on the same auth/model are still allowed to finish, so Core needs a bounded observation state instead of immediately suspending the auth/model for every session.
     introduced_in: 6ee281422e460ac7d5db8d69ef3fe6b49560e96a
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); 65fc536e preserves session affinity across priorities, 1674aaf4 shares canonical thinking-family cooldown state, and 8392b180 classifies connection lifecycle errors, but these are only adjacent state/selection changes. Upstream still immediately writes model quota cooldown for every 429 and has no Healthy/FreshBlocked/ConfirmedCooldown phases, established lease plus incumbent evidence, single-canary confirmation, lifecycle invalidation, or continuity generation guard. LTS therefore keeps delayed final-auth publication so fallback and hedge losers cannot become the selected trace or session pin.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); 65fc536e preserves session affinity across priorities, 1674aaf4 shares canonical thinking-family cooldown state, and 8392b180 classifies connection lifecycle errors, but these are only adjacent state/selection changes. Upstream still immediately writes model quota cooldown for every 429 and has no Healthy/FreshBlocked/ConfirmedCooldown phases, established lease plus incumbent evidence, single-canary confirmation, lifecycle invalidation, or continuity generation guard. LTS therefore keeps delayed final-auth publication so fallback and hedge losers cannot become the selected trace or session pin.
     files:
       - config.example.yaml
       - docs/lts/codex-429-resilience.md
@@ -143,7 +143,7 @@ patches:
   - id: codex-interactions-service-tier-response
     reason: Codex Interactions requests can send priority service, but the shared response translator hardcodes streaming completion metadata to standard and omits the non-streaming tier instead of reporting the effective outbound or upstream tier.
     introduced_in: be649f04a4a66b952d5210c7cdf74e1d90a12b76
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); da087d7f maps Claude Code speed fast to priority requests, but the separate Codex Interactions response translator still does not report the effective service_tier for streaming, non-streaming, and DONE-fallback responses, so router-for-me/CLIProxyAPI#4189 remains only partially relevant.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); da087d7f maps Claude Code speed fast to priority requests, but the separate Codex Interactions response translator still does not report the effective service_tier for streaming, non-streaming, and DONE-fallback responses, so router-for-me/CLIProxyAPI#4189 remains only partially relevant.
     files:
       - internal/translator/codex/interactions/interactions_codex_response.go
       - internal/translator/codex/interactions/interactions_codex_test.go
@@ -174,7 +174,7 @@ patches:
   - id: plugin-configured-enable-default
     reason: A configured plugin without an explicit enabled field must inherit the enabled plugin subsystem default instead of being silently disabled during YAML parsing or runtime config synthesis.
     introduced_in: f3ff2f889026c6a28dc2d14f602c4fef108a0347
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); the new Home plugin synchronization and auth-revision plumbing do not replace the configured-plugin enable default through YAML parsing and runtime host synthesis; an omitted per-plugin enabled field must still inherit true while the subsystem-level switch remains authoritative.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); the new Home plugin synchronization and auth-revision plumbing do not replace the configured-plugin enable default through YAML parsing and runtime host synthesis; an omitted per-plugin enabled field must still inherit true while the subsystem-level switch remains authoritative.
     files:
       - internal/config/config.go
       - internal/config/plugin_config_test.go
@@ -191,7 +191,7 @@ patches:
   - id: home-plugin-sync-cancellation
     reason: Canceling a dedicated Home plugin-sync request must close its one-command Redis connection so a client-installed two-minute read deadline cannot overwrite an earlier cancellation deadline and stall shutdown or request cleanup.
     introduced_in: 125cd6c244f1c723781680c23e61edaa88aac5ef
-    affected_upstream_range: introduced by b651a1a8fd8ea1a43d061a08b42cef8fa3160179 and still required through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); upstream sets an immediate deadline on cancellation but the Redis client can install its long read deadline afterward, which reproduced as a full two-minute stall on Linux CI.
+    affected_upstream_range: introduced by b651a1a8fd8ea1a43d061a08b42cef8fa3160179 and still required through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); upstream sets an immediate deadline on cancellation but the Redis client can install its long read deadline afterward, which reproduced as a full two-minute stall on Linux CI.
     files:
       - internal/home/client.go
       - internal/home/client_test.go
@@ -206,7 +206,7 @@ patches:
   - id: codex-gpt56-ultra-level
     reason: Upstream now publishes and remotely refreshes Codex client metadata with logical Sol/Terra Ultra and Luna max-only, but it still does not provide the CPA-Core-LTS server-side capability overlay, custom-model policy, payload-override-safe wire canonicalization, usage/retry alignment, or HTTP/WebSocket enforcement. CPA-Core-LTS therefore validates the refreshed client catalog as an LTS prerequisite while retaining the downstream runtime patch.
     introduced_in: 6e12fb1dd6d522ca80a02644d286d765d7a649bd
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); upstream PR #4276 provides the revisioned Codex client catalog, while e5ea945e/7fef08ea add the separate API-key model is-compat gate. The newer replay, input-ID, Responses Lite, trace, payload-reuse, and WebSocket changes do not replace the downstream provider lookup/tier overlay, model-aware custom-model behavior, payload-override-safe final reasoning.effort, usage/retry alignment, or HTTP/WebSocket enforcement.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); upstream PR #4276 provides the revisioned Codex client catalog, while e5ea945e/7fef08ea add the separate API-key model is-compat gate. The newer replay, input-ID, Responses Lite, trace, payload-reuse, and WebSocket changes do not replace the downstream provider lookup/tier overlay, model-aware custom-model behavior, payload-override-safe final reasoning.effort, usage/retry alignment, or HTTP/WebSocket enforcement.
     files:
       - .github/scripts/refresh-model-catalogs.sh
       - .github/workflows/docker-image.yml
@@ -276,7 +276,7 @@ patches:
   - id: codex-client-media-model-visibility
     reason: Codex client catalogs must hide image and video endpoint models in both catalog builders so Codex clients do not list media-only models as normal Responses choices. Upstream v7.2.120 added Grok Imagine Video 1.5 GA to the internal/Home builder and cross-route expectation, but omitted the SDK builder that serves non-Home /v1/models?client_version.
     introduced_in: 650a98891a3ab72b9916e4f130eda66cc059e17e
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); upstream commit abaeb55bb20e9a346cae7002c2ed8af5d82c2790 updates internal/client/codex/models and the server contract test, but not sdk/api/handlers/openai/codex_client_models.go, leaving the GA model visible on the non-Home route.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); upstream commit abaeb55bb20e9a346cae7002c2ed8af5d82c2790 updates internal/client/codex/models and the server contract test, but not sdk/api/handlers/openai/codex_client_models.go, leaving the GA model visible on the non-Home route.
     files:
       - internal/api/server_test.go
       - internal/client/codex/models/models.go
@@ -290,7 +290,7 @@ patches:
   - id: codex-model-header-provider-snapshot
     reason: Codex model override headers must be resolved from the Codex provider and captured once so the real handshake and connection key cannot disagree or be shadowed by another provider registration.
     introduced_in: 0877a26d333a3be918f5e48aadf0e4d71709ab2f
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); upstream adds raw connection target tracking and c30e60a1 reduces Codex request-body copying, but neither resolves a provider-owned immutable model-header snapshot nor includes its digest and resolved model in reusable WebSocket connection identity.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); upstream adds raw connection target tracking and c30e60a1 reduces Codex request-body copying, but neither resolves a provider-owned immutable model-header snapshot nor includes its digest and resolved model in reusable WebSocket connection identity.
     files:
       - internal/runtime/executor/codex_executor.go
       - internal/runtime/executor/codex_openai_images.go
@@ -311,7 +311,7 @@ patches:
   - id: codex-oauth-client-identity-finalization
     reason: Codex OAuth requests must finalize the official Originator, User-Agent, optional Version floor, and macOS Session_id after model-specific header overrides; otherwise the backend can reject a valid model route with a misleading 404 Model not found response.
     introduced_in: ded0314d23dc38656e2fb02220504bd98373813c
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); input-ID shortening, Responses Lite normalization, replay isolation, and WebSocket target tracking still do not add an equivalent final OAuth client-identity pass shared by HTTP, compact, streaming, WebSocket, and image paths.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); input-ID shortening, Responses Lite normalization, replay isolation, and WebSocket target tracking still do not add an equivalent final OAuth client-identity pass shared by HTTP, compact, streaming, WebSocket, and image paths.
     files:
       - config.example.yaml
       - internal/runtime/executor/codex_client_identity.go
@@ -331,7 +331,7 @@ patches:
   - id: codex-client-metadata-privacy
     reason: Current Codex clients transport one canonical x-codex-turn-metadata snapshot plus flat body and direct header compatibility projections. Core must use its stable session before auth selection and rate-limit continuity while preserving explicit execution-session priority; keep off-mode bodies byte-identical, make a body canonical source suppress conflicting direct canonical headers, and project the canonical Session_id over random client fallbacks; keep image conversion from collapsing duplicate metadata carriers or reversing default/override/filter precedence; reject unsafe header projection values; fail closed on unknown startup, SDK builder, and hot-reload config values without losing the last good config; keep projections coherent after credential selection; avoid the legacy identity-confuse partial rewrite on canonical requests; offer explicit workspace passthrough/redact/drop privacy policies; strip Git remote credentials even in passthrough mode; and prevent workspace enrichment or derived identity headers from entering downstream, upstream, deferred-error, or WebSocket request logs.
     introduced_in: dcb424d4a5d666322c641151a3e37fd3b0dcc864
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); c30e60a1, ea8882bf, and 99929209 add no-copy payload/read helpers, which are useful but only adjacent to this privacy contract. Upstream still applies the older prompt-cache and installation identity-confuse rewrite without canonical request detection, has no selectable workspace privacy policy or unconditional Git credential stripping, and records Codex turn metadata without an equivalent workspace-aware log sanitizer. LTS keeps image metadata ambiguity and payload-rule precedence intact while adopting safe no-copy helpers.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); c30e60a1, ea8882bf, and 99929209 add no-copy payload/read helpers, which are useful but only adjacent to this privacy contract. Upstream still applies the older prompt-cache and installation identity-confuse rewrite without canonical request detection, has no selectable workspace privacy policy or unconditional Git credential stripping, and records Codex turn metadata without an equivalent workspace-aware log sanitizer. LTS keeps image metadata ambiguity and payload-rule precedence intact while adopting safe no-copy helpers.
     files:
       - config.example.yaml
       - internal/api/middleware/request_logging.go
@@ -429,7 +429,7 @@ patches:
   - id: codex-model-not-found-request-scope
     reason: An OpenAI-style 404 with error.type invalid_request_error and error.param model is a request/model routing failure, not evidence of unhealthy Codex credentials; retrying every auth or applying the generic 12-hour model cooldown can suspend the entire model pool.
     introduced_in: ded0314d23dc38656e2fb02220504bd98373813c
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); fe28d582/b148af80 improve unknown-route model errors and c1d69e7b/579f5e30 generalize client-fault handling, but regular Codex execution still does not recognize the OpenAI-style invalid_request_error model 404. The 579f5e30 version of the generic classifier removed this narrower LTS case and failed the listed cooldown regression until the request-scoped classifier was restored, so this is only a partial upstream equivalent and the patch remains required.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); fe28d582/b148af80 improve unknown-route model errors and c1d69e7b/579f5e30 generalize client-fault handling, but regular Codex execution still does not recognize the OpenAI-style invalid_request_error model 404. The 579f5e30 version of the generic classifier removed this narrower LTS case and failed the listed cooldown regression until the request-scoped classifier was restored, so this is only a partial upstream equivalent and the patch remains required.
     files:
       - sdk/cliproxy/auth/conductor.go
       - sdk/cliproxy/auth/conductor_overrides_test.go
@@ -445,7 +445,7 @@ patches:
   - id: codex-websocket-reader-generation
     reason: Reusable Codex WebSocket sessions need generation ownership so a stale reader or shutdown race cannot deliver to, clear, close, or deadlock a newer request.
     introduced_in: 0877a26d333a3be918f5e48aadf0e4d71709ab2f
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); fbe11607 tracks an active raw connection and target changes, but still lacks executor-side connection generations, atomic reader/request ownership, request-owned cancellation signals, and stale-reader protection across retry, session close, and model-header profile changes.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); fbe11607 tracks an active raw connection and target changes, but still lacks executor-side connection generations, atomic reader/request ownership, request-owned cancellation signals, and stale-reader protection across retry, session close, and model-header profile changes.
     files:
       - internal/runtime/executor/codex_websockets_executor.go
       - internal/runtime/executor/codex_websockets_executor_test.go
@@ -469,7 +469,7 @@ patches:
   - id: codex-spark-reasoning-summary-compat
     reason: GPT-5.3-Codex-Spark needs reasoning effort enabled but its upstream rejects reasoning.summary, so Core must remove only that unsupported field after final payload shaping across HTTP and WebSocket transports.
     introduced_in: 37e306f939e8ef363254a49cdc7f924a6ceceff5
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); upstream adds Responses Lite normalization, encrypted reasoning-ID cleanup, and conditional payload mutations, but still forwards reasoning.summary for gpt-5.3-codex-spark and has no equivalent post-override HTTP/WebSocket sanitization. LTS applies the sanitizer after the optimized model mutation on every transport.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); upstream adds Responses Lite normalization, encrypted reasoning-ID cleanup, conditional payload mutations, and 6710a5af forwards sequential-cutoff reasoning summaries, but still forwards reasoning.summary for gpt-5.3-codex-spark and has no equivalent post-override HTTP/WebSocket sanitization. LTS applies the sanitizer after the optimized model mutation on every transport.
     files:
       - internal/runtime/executor/codex_executor.go
       - internal/runtime/executor/codex_websockets_executor.go
@@ -493,7 +493,7 @@ patches:
   - id: xai-explicit-tool-choice-none
     reason: xAI request preparation must not grant native x_search when the client declared no tools or a restricted allowlist; explicit tool_choice none must remain intact, an orphaned restriction must fail closed instead of reverting to auto, parallel_tool_calls must be removed when no tools survive, and custom declarations and choices must be canonicalized together before orphan pruning.
     introduced_in: ad7244752d324a5b179c3e30a628acf976fa995c
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); upstream promotes additional_tools and adopts conditional payload mutations, but still injects x_search without explicit client authorization. LTS preserves only client-declared tools, keeps explicit none, removes parallel_tool_calls when no tools survive, and canonicalizes custom choices before pruning.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); a6825fe9 correctly rewrites an explicitly forced web_search choice into xAI's allowed_tools shape, but it does not change whether native x_search may be injected or expand a restricted allowlist. Upstream still injects x_search without explicit client authorization. LTS preserves only client-declared tools, keeps explicit none, removes parallel_tool_calls when no tools survive, and canonicalizes custom choices before pruning.
     files:
       - internal/runtime/executor/xai_executor.go
       - internal/runtime/executor/xai_executor_test.go
@@ -511,7 +511,7 @@ patches:
   - id: kimi-claude-delegated-auth-immutability
     reason: Kimi delegates Claude-format requests to the Claude executor, but the selected Auth attributes are shared immutable credential configuration and must not be mutated per request to install the Kimi messages base URL.
     introduced_in: 772915acb699d8c6b6f6d8f9c51c1b4f3a61cf34
-    affected_upstream_range: introduced by 70c4bd78b2bc347bf988f74f2d2d7da85de5aa13 and still required through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); 36936340 canonicalizes K2.7 aliases, 8558f443 identifies Kimi signatures, and 2e6b1d83 adds separate Claude-compatible thinking replay, but none makes the delegated base URL request-local. Upstream still writes auth.Attributes["base_url"] directly in Execute, ExecuteStream, and CountTokens, which can panic for a nil map, race across concurrent requests, and persist a request-local route into shared auth state.
+    affected_upstream_range: introduced by 70c4bd78b2bc347bf988f74f2d2d7da85de5aa13 and still required through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); 36936340 canonicalizes K2.7 aliases, 8558f443 identifies Kimi signatures, 2e6b1d83 adds Claude-compatible thinking replay, and ecc9aa72 adds a useful Kimi request-shape regression, but none makes the delegated base URL request-local. Upstream still writes auth.Attributes["base_url"] directly in Execute, ExecuteStream, and CountTokens, which can panic for a nil map, race across concurrent requests, and persist a request-local route into shared auth state.
     files:
       - internal/runtime/executor/kimi_executor.go
       - internal/runtime/executor/kimi_executor_test.go
@@ -524,7 +524,7 @@ patches:
   - id: request-body-panic-tempfile-cleanup
     reason: This historical patch originally closed a panic-path temporary-file leak in error-only request logging. CPA-Core-LTS now removes that request-body tempfile spool entirely, keeps only bounded in-memory request/response/upstream previews, and still requires middleware-owned unwind cleanup so panic and http.ErrAbortHandler paths close the original body and release retained buffers.
     introduced_in: ad7244752d324a5b179c3e30a628acf976fa995c
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); the plugin, replay, trace, translator, and provider changes do not alter request logging; upstream still spools large error-only bodies to temporary files, retains larger deferred upstream bodies, and performs cleanup only from the response finalizer.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); the plugin, replay, trace, translator, and provider changes do not alter request logging; upstream still spools large error-only bodies to temporary files, retains larger deferred upstream bodies, and performs cleanup only from the response finalizer.
     files:
       - internal/api/middleware/request_logging.go
       - internal/api/middleware/request_logging_test.go
@@ -546,7 +546,7 @@ patches:
   - id: api-request-body-size-limit
     reason: Public Claude, Gemini, OpenAI, Responses, image, and video JSON handlers previously used unbounded body reads and unbounded zstd expansion, so a small number of concurrent oversized requests could consume container memory before provider routing or normal validation ran.
     introduced_in: b2b593fad3f18bfe700fe5f11d4e88e10bbc7f16
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); the no-copy normalization work in 34364fff/c30e60a1/b7a44152 reduces payload amplification but is not a decoded-body limit. Upstream handlers still use unbounded GetRawData/io.ReadAll behavior and do not enforce the same limit on every decoded Content-Encoding layer.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); the no-copy normalization work in 34364fff/c30e60a1/b7a44152 reduces payload amplification but is not a decoded-body limit. Upstream handlers still use unbounded GetRawData/io.ReadAll behavior and do not enforce the same limit on every decoded Content-Encoding layer.
     files:
       - sdk/api/handlers/request_body.go
       - sdk/api/handlers/request_body_test.go
@@ -568,7 +568,7 @@ patches:
   - id: object-store-auth-path-containment
     reason: Object-store auth persistence must never create, overwrite, upload, delete, or render credential files outside its managed private roots, including traversal, sibling-prefix, absolute-path, pre-existing or dangling symlinks, junctions, initialized-root replacement, check/write path-swap races, and crash-persistent global-temp copies.
     introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); upstream accepts caller-provided absolute auth paths and computes object keys from unchecked filepath.Rel results, so paths outside the mirror can reach local file and remote object operations.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); upstream accepts caller-provided absolute auth paths and computes object keys from unchecked filepath.Rel results, so paths outside the mirror can reach local file and remote object operations.
     files:
       - .github/workflows/pr-test-build.yml
       - internal/store/objectstore.go
@@ -614,7 +614,7 @@ patches:
   - id: auth-token-private-file-permissions
     reason: OAuth tokens and service-account credentials must be created with owner-only permissions and must tighten pre-existing wider files before replacing their contents.
     introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); Claude, Codex, Kimi, Vertex, and xAI token writers still use os.Create, which follows umask for new files and preserves wider permissions on existing files.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); Claude, Codex, Kimi, Vertex, and xAI token writers still use os.Create, which follows umask for new files and preserves wider permissions on existing files.
     files:
       - .github/workflows/pr-test-build.yml
       - internal/misc/credential_file.go
@@ -642,7 +642,7 @@ patches:
   - id: auth-store-list-error-propagation
     reason: A damaged or unreadable auth JSON file must fail Store.List instead of silently removing that credential from routing, fallback, and usage attribution while startup reports success.
     introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); upstream now validates credential weights but expects FileTokenStore.List to silently skip an invalid persisted plugin source. LTS instead keeps fail-closed list error propagation so damaged JSON, parser failures, and invalid source weights cannot silently remove credentials from routing and attribution.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); upstream now validates credential weights but expects FileTokenStore.List to silently skip an invalid persisted plugin source. LTS instead keeps fail-closed list error propagation so damaged JSON, parser failures, and invalid source weights cannot silently remove credentials from routing and attribution.
     files:
       - internal/store/gitstore.go
       - internal/store/gitstore_test.go
@@ -665,7 +665,7 @@ patches:
   - id: auth-store-metadata-hydration
     reason: Initial File, Git, Object, and Postgres store loading must hydrate the same normalized auth prefix, custom headers, and disabled state as watcher synthesis so prefixed model routing and Management auth-file output do not change after a reload event.
     introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); watcher synthesis reads normalized prefix metadata, but initial Store.List paths only apply partial metadata and the Management auth-file response omits Auth.Prefix.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); watcher synthesis reads normalized prefix metadata, but initial Store.List paths only apply partial metadata and the Management auth-file response omits Auth.Prefix.
     files:
       - sdk/cliproxy/auth/metadata_hydrate.go
       - sdk/cliproxy/auth/metadata_hydrate_test.go
@@ -698,7 +698,7 @@ patches:
   - id: panel-release-token-isolation
     reason: Management panel release lookups must authorize only exact HTTPS GitHub release URLs and should use a dedicated panel token while retaining a guarded legacy GitStore fallback.
     introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); upstream decides whether to attach GITSTORE_GIT_TOKEN from the GitStore URL rather than the actual release URL and has no dedicated panel release token.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); upstream decides whether to attach GITSTORE_GIT_TOKEN from the GitStore URL rather than the actual release URL and has no dedicated panel release token.
     files:
       - .env.example
       - internal/managementasset/updater.go
@@ -715,7 +715,7 @@ patches:
   - id: gemini-unknown-method-not-found
     reason: Gemini-compatible routes must reject unknown RPC method suffixes with a stable 404 invalid_request_error before reading the request body, instead of consuming the body and falling through to generateContent behavior.
     introduced_in: 6b0f185939f914983514d6a5e62378a8d91164e7
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); upstream still dispatches every non-stream and non-count suffix through generateContent and has no method allowlist before body decoding.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); upstream still dispatches every non-stream and non-count suffix through generateContent and has no method allowlist before body decoding.
     files:
       - sdk/api/handlers/gemini/gemini_handlers.go
       - sdk/api/handlers/gemini/gemini_handlers_test.go
@@ -728,7 +728,7 @@ patches:
   - id: count-tokens-not-found-no-cooldown
     reason: A provider-specific count_tokens endpoint can be absent even when normal generation works, so its 404 must still record the failed request and publish hooks while remaining request-scoped and allowing another credential to serve the count request.
     introduced_in: 6b0f185939f914983514d6a5e62378a8d91164e7
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); upstream commit 36ed0ca5ce4130efcd7532d86c1386ee11ed0e2d / issue #4410 adds generic endpoint-404 detection, while c1d69e7b/579f5e30 further generalize request-fault handling. These are only partial equivalents: upstream still lacks the LTS count_tokens generic-route-404 versus explicit-model-miss scope, failure publication, and credential-fallback combination. LTS preserves that distinction so genuine model availability errors still cool down.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); upstream commit 36ed0ca5ce4130efcd7532d86c1386ee11ed0e2d / issue #4410 adds generic endpoint-404 detection, while c1d69e7b/579f5e30 further generalize request-fault handling. These are only partial equivalents: upstream still lacks the LTS count_tokens generic-route-404 versus explicit-model-miss scope, failure publication, and credential-fallback combination. LTS preserves that distinction so genuine model availability errors still cool down.
     files:
       - sdk/cliproxy/auth/conductor.go
       - sdk/cliproxy/auth/conductor_overrides_test.go
@@ -744,7 +744,7 @@ patches:
   - id: management-logs-bounded-response
     reason: Management log reads need a bounded default and maximum response size without breaking Panel and TUI limits or silently skipping legacy after deltas that exceed one page.
     introduced_in: 6b0f185939f914983514d6a5e62378a8d91164e7
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); upstream leaves an omitted limit unbounded and does not clamp oversized limits or provide lossless bounded pagination for legacy after reads.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); upstream leaves an omitted limit unbounded and does not clamp oversized limits or provide lossless bounded pagination for legacy after reads.
     files:
       - internal/api/handlers/management/logs.go
       - internal/api/handlers/management/logs_test.go
@@ -761,7 +761,7 @@ patches:
   - id: transient-eof-cooldown
     reason: Transport EOF and unexpected EOF failures before successful completion indicate a transient upstream path failure and need a bounded 502 cooldown, including stream bootstrap, post-payload accounting, and wsrelay errors that have lost the standard-library sentinel identity.
     introduced_in: 6b0f185939f914983514d6a5e62378a8d91164e7
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); 8392b180 directly conflicts with this LTS contract by classifying EOF/UnexpectedEOF and abnormal WebSocket EOF as connection lifecycle errors that skip credential cooldown; 4b3cc55c correctly adds context cancellation/deadline status mapping but does not resolve that contradiction. LTS intentionally keeps context cancellation and normal closes cooldown-free while preserving transient 502 cooldown for terminal EOF paths; the upstream tests required adaptation rather than patch retirement.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); 8392b180 directly conflicts with this LTS contract by classifying EOF/UnexpectedEOF and abnormal WebSocket EOF as connection lifecycle errors that skip credential cooldown; 4b3cc55c correctly adds context cancellation/deadline status mapping but does not resolve that contradiction. LTS intentionally keeps context cancellation and normal closes cooldown-free while preserving transient 502 cooldown for terminal EOF paths; the upstream tests required adaptation rather than patch retirement.
     files:
       - internal/runtime/executor/aistudio_executor.go
       - sdk/cliproxy/auth/conductor.go
@@ -777,7 +777,7 @@ patches:
   - id: expired-availability-pruning
     reason: Expired auth and model cooldown state must be pruned before Management availability is displayed so runtime routing, registry state, scheduler state, and persisted cooldown snapshots converge, while future, zero-deadline, disabled, Cloudflare, and independent auth-level warnings remain intact.
     introduced_in: 6b0f185939f914983514d6a5e62378a8d91164e7
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); upstream has no Management-triggered expired availability pruning and does not reconcile manager, model registry, scheduler, and cooldown-store state while separating independent auth-level warnings from model aggregates.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); upstream has no Management-triggered expired availability pruning and does not reconcile manager, model registry, scheduler, and cooldown-store state while separating independent auth-level warnings from model aggregates.
     files:
       - internal/api/handlers/management/auth_files.go
       - internal/api/handlers/management/auth_files_recent_requests_test.go
@@ -798,7 +798,7 @@ patches:
   - id: responses-chat-tool-call-turn-grouping
     reason: Reasoning, assistant text, or omitted assistant-side Responses items interleaved between consecutive function_call/custom_tool_call items must not split one assistant turn into adjacent assistant(tool_calls) messages. Kimi-style strict Chat Completions upstreams reject that shape with HTTP 400 ("assistant message with 'tool_calls' must be followed by tool messages"), permanently blocking affected Codex multi-agent histories routed through those upstreams. The related closed report focused on id pairing while the remaining defect is turn grouping, so LTS keeps the fix as a downstream patch.
     introduced_in: 12b542a201b1f8d083ada591cdb7687a7281b0a8
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); upstream still flushes buffered calls on any non-call input item and splits the turn. f1a21a9b/71e87111 merge turns on Claude conversion paths and aff2095a deduplicates the Responses tool declaration surface, but none replaces the separate Responses-to-Chat buffered call/assistant-reasoning/text state machine. Structured tool-output/image support (4d498ec7), Kimi thinking replay (8c37dd98), text-only OpenAI tool-result normalization (13435c93), and collaboration message schema handling from PR #4748 (ffdb9c9f) remain non-equivalent. PR #3213 groups only bare consecutive function_call items on a pre-17a1f53c base and cannot absorb reasoning/assistant-text splits.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); ecc9aa72 usefully preserves preceding assistant content/reasoning by attaching the next buffered tool_calls to that assistant message, but upstream still flushes pending calls on every non-call item and therefore still splits consecutive calls separated by reasoning, assistant text, or ignored assistant-side items. The protected merge combines upstream's assistant-content merge with the LTS output-boundary flush and user/developer turn boundary. 4906ead3 is response-side DONE finalization, 37411842 is custom-tool identity normalization, f1a21a9b/71e87111 are Claude conversion paths, and aff2095a deduplicates tool declarations; none replaces the remaining turn-grouping state machine. PR #3213 groups only bare consecutive function_call items on a pre-17a1f53c base and cannot absorb the interleaved shapes.
     files:
       - docs/lts/downstream-patches.yaml
       - internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -819,7 +819,7 @@ patches:
   - id: codex-desktop-tool-overlay
     reason: Codex Desktop registers deferred codex_app handlers that are not present in the Direct tool surface sent to third-party Responses models, so those models cannot read or coordinate existing Desktop tasks even though the app already owns the handlers. LTS therefore provides a default-off, fixed-version projection that adds only explicitly configured codex_app children after auth selection, only for provable root Desktop turns on non-GPT models, and preserves the existing provider namespace round trip without executing any app operation inside CPA.
     introduced_in: b052097362ef63bd35329c8b18d73c651078e85d
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); upstream supports namespace flattening and response restoration for OpenAI Chat and xAI, but does not project the missing Codex Desktop codex_app children into eligible third-party Direct requests with the LTS model, UA, root-turn, tool-surface, and configuration gates. The v7.2.116 Home refresh and conductor changes were adapted without replacing the overlay or its GPT/subagent isolation. The v7.2.117 Responses-boundary preparation and multi_agent_version metadata changes do not add any codex_app overlay.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); upstream supports namespace flattening and response restoration for OpenAI Chat and xAI, but does not project the missing Codex Desktop codex_app children into eligible third-party Direct requests with the LTS model, UA, root-turn, tool-surface, and configuration gates. The v7.2.116 Home refresh and conductor changes were adapted without replacing the overlay or its GPT/subagent isolation. The v7.2.117 Responses-boundary preparation and multi_agent_version metadata changes do not add any codex_app overlay.
     files:
       - config.example.yaml
       - docs/lts/downstream-patches.yaml
@@ -868,7 +868,7 @@ patches:
   - id: codex-multi-agent-plaintext-contract
     reason: Codex Multi-Agent history and message-tool schemas carry plaintext provenance that must not be inferred from an encrypted_content string or an unqualified short tool name. LTS therefore converts agent_message only when every content part is a non-empty string input_text, preserves opaque or mixed history on native Codex and provider paths, and removes only a JSON boolean-true message.encrypted marker from positively identified collaboration, collaboration-optimize, or complete agents namespaces.
     introduced_in: 798ad1854064361461225fe766db9b2f54a7653d
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); e5ea945e/7fef08ea add a useful model-level is-compat gate and wire the rewrite through HTTP, stream, WebSocket, and compact paths, but only partially overlap this contract. The upstream rewrite still treats string encrypted_content as portable without plaintext provenance, discovers message tools by recursive short-name matching across unrelated surfaces, and removes message.encrypted without requiring JSON boolean true. LTS absorbs the model gate while retaining fully proven plaintext, confirmed namespace, boolean-marker, and opaque/mixed-content fail-closed rules.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); e5ea945e/7fef08ea add a useful model-level is-compat gate and wire the rewrite through HTTP, stream, WebSocket, and compact paths, but only partially overlap this contract. The upstream rewrite still treats string encrypted_content as portable without plaintext provenance, discovers message tools by recursive short-name matching across unrelated surfaces, and removes message.encrypted without requiring JSON boolean true. LTS absorbs the model gate while retaining fully proven plaintext, confirmed namespace, boolean-marker, and opaque/mixed-content fail-closed rules.
     files:
       - config.example.yaml
       - docs/lts/downstream-patches.yaml
@@ -902,7 +902,7 @@ patches:
   - id: xai-multi-agent-plaintext-provenance
     reason: xAI requires namespace tools to be flattened and cannot consume the Codex message.encrypted schema marker, while the returning Codex client needs encrypted_function_args to distinguish a plaintext Multi-Agent call. LTS therefore records the exact root or additional_tools function declarations whose boolean-true marker was removed, restores namespace and short name first, then adds encrypted_function_args as an empty array only for response calls matching that request provenance across HTTP non-stream, SSE, and WebSocket.
     introduced_in: 23caefe8b2495856c2c8df50b63823846ad6b910
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); upstream xAI handling flattens and restores namespace tools and filters internal X Search traces, but does not derive before/after plaintext provenance from the Multi-Agent schema rewrite or restore encrypted_function_args on HTTP, SSE, and WebSocket responses. The v7.2.120 Grok Shell header update does not provide an equivalent return-path contract.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); upstream xAI handling flattens and restores namespace tools and filters internal X Search traces, but does not derive before/after plaintext provenance from the Multi-Agent schema rewrite or restore encrypted_function_args on HTTP, SSE, and WebSocket responses. The v7.2.120 Grok Shell header update does not provide an equivalent return-path contract.
     files:
       - docs/lts/downstream-patches.yaml
       - internal/runtime/executor/xai_executor_execute.go
@@ -926,7 +926,7 @@ patches:
   - id: provider-runtime-state-isolation
     reason: Runtime state belongs to one concrete auth provider generation and must not leak across same-ID provider replacement. Codex transient rate limits must remain distinct from quota exhaustion, non-buffering streams must not fail after delivering visible deltas merely because optional completion reconstruction exceeds its cap, and thinking-suffix cooldown reconciliation must restore only the intended concrete registry IDs without racing a newer success.
     introduced_in: e97ccfb8b41e0874745d807d6c1434bcf572840f
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); 1674aaf4 partially overlaps by canonicalizing thinking-suffix model states, and 8392b180 separates connection lifecycle errors, but the former would collapse LTS suffix-specific state if applied at MarkResult while the latter conflicts with transient EOF cooldown. Upstream still applies the abnormal-reasoning reconstruction cap to non-buffering streams, treats raw Codex rate_limit_error/rate_limit_exceeded 429s as quota, restores canonicalized cooldowns to the wrong concrete registry ID, and inherits health, model, refresh, runtime, and persisted cooldown state across same-ID provider replacement. LTS keeps exact suffix keys plus family-aware reconciliation and the still-unique behavior recovered from closed CPA-Core-LTS PR #192 commits 4c8250c5 and a39fb5ee.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); 1674aaf4 partially overlaps by canonicalizing thinking-suffix model states, and 8392b180 separates connection lifecycle errors, but the former would collapse LTS suffix-specific state if applied at MarkResult while the latter conflicts with transient EOF cooldown. Upstream still applies the abnormal-reasoning reconstruction cap to non-buffering streams, treats raw Codex rate_limit_error/rate_limit_exceeded 429s as quota, restores canonicalized cooldowns to the wrong concrete registry ID, and inherits health, model, refresh, runtime, and persisted cooldown state across same-ID provider replacement. LTS keeps exact suffix keys plus family-aware reconciliation and the still-unique behavior recovered from closed CPA-Core-LTS PR #192 commits 4c8250c5 and a39fb5ee.
     files:
       - docs/lts/downstream-patches.yaml
       - internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
@@ -970,7 +970,7 @@ patches:
   - id: auth-provider-generation-fence
     reason: Auth IDs are stable across watcher refreshes and can be reused after provider replacement or remove-and-register. An execution, stream, token count, request-auth preparation, or credential refresh that started on the previous lifecycle could therefore write quota, health, token, runtime, scheduler, registry, or persisted cooldown state into the replacement auth. LTS assigns a process-local, non-persisted generation to each auth lifecycle, carries it through every managed request path, and accepts writebacks only when both generation and provider still match.
     introduced_in: 7db4a30d3c7b489503873df855146ad911bec117
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); 65fc536e touches session-affinity selection and 01a21b77 introduces a plugin-aware refresh wrapper, but neither carries a per-auth lifecycle generation through execution or rejects stale provider writebacks. Upstream still keys asynchronous result, preparation, and refresh writebacks only by auth ID, accepts persisted cooldown records from a different provider, and allows a stale request to refresh a same-ID replacement provider. This retains the unique lifecycle behavior recovered from closed CPA-Core-LTS PR #192 commit 29851edf plus the LTS count-token, stream, and stale cross-provider refresh coverage.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); 65fc536e touches session-affinity selection and 01a21b77 introduces a plugin-aware refresh wrapper, but neither carries a per-auth lifecycle generation through execution or rejects stale provider writebacks. Upstream still keys asynchronous result, preparation, and refresh writebacks only by auth ID, accepts persisted cooldown records from a different provider, and allows a stale request to refresh a same-ID replacement provider. This retains the unique lifecycle behavior recovered from closed CPA-Core-LTS PR #192 commit 29851edf plus the LTS count-token, stream, and stale cross-provider refresh coverage.
     files:
       - docs/lts/downstream-patches.yaml
       - sdk/cliproxy/auth/conductor.go
@@ -1004,7 +1004,7 @@ patches:
   - id: codex-live-bootstrap-accounting-and-egress
     reason: Codex Live bootstrap SDP carries short-lived ICE credentials that must never enter request logs, while every actual bootstrap dispatch still needs zero-token usage attribution and local auth outcome tracking. Live and sideband also require model-scoped OAuth selection for models intentionally absent from the general proxy catalog, confirm/mark/abandon lifecycle coverage, Home retry attempt accounting without duplicate 401 records, in-memory config validation parity, and fail-closed sideband proxy handling.
     introduced_in: 4534eed92ef5cd639b377a17dd56dad2d9e41f70
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); 4b3cc55c usefully centralizes Live/Sideband context-cancellation and deadline HTTP status mapping, but does not provide this LTS-owned Codex Live route's SDP-safe metadata-only logging, per-attempt usage accounting, uncatalogued-model OAuth selection, confirm/mark/abandon lifecycle, or fail-closed sideband proxy behavior.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); 4b3cc55c usefully centralizes Live/Sideband context-cancellation and deadline HTTP status mapping, but does not provide this LTS-owned Codex Live route's SDP-safe metadata-only logging, per-attempt usage accounting, uncatalogued-model OAuth selection, confirm/mark/abandon lifecycle, or fail-closed sideband proxy behavior.
     files:
       - docs/lts/downstream-patches.yaml
       - internal/client/codex/live/live.go
@@ -1029,7 +1029,7 @@ patches:
   - id: xai-implicit-responses-message-token-accounting
     reason: OpenAI Responses permits message-shaped input items with role/content and no explicit type, and xAI local token estimation must include their content instead of silently undercounting the request.
     introduced_in: 4534eed92ef5cd639b377a17dd56dad2d9e41f70
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); upstream xAI token collection still dispatches only on an explicit input item type and ignores ordinary untyped role/content messages.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); upstream xAI token collection still dispatches only on an explicit input item type and ignores ordinary untyped role/content messages.
     files:
       - docs/lts/downstream-patches.yaml
       - internal/runtime/executor/xai_executor_test.go
@@ -1043,7 +1043,7 @@ patches:
   - id: xai-websocket-saturated-reader-invalidation
     reason: A terminal xAI WebSocket reader cannot enqueue its error when the active request channel is full; invalidation must cancel the active reader before the terminal sender waits, otherwise the reader and request can deadlock indefinitely.
     introduced_in: 4534eed92ef5cd639b377a17dd56dad2d9e41f70
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); upstream does not cancel the active read lifecycle when invalidating a saturated shared xAI WebSocket connection.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); upstream does not cancel the active read lifecycle when invalidating a saturated shared xAI WebSocket connection.
     files:
       - docs/lts/downstream-patches.yaml
       - internal/runtime/executor/codex_websockets_session.go
@@ -1058,7 +1058,7 @@ patches:
   - id: xai-model-bad-credentials-auth-normalization
     reason: xAI model-scoped 403 bad-credentials failures normalize the model error to unauthorized, and the auth-level LastError snapshot must use the same code so refresh and availability decisions do not continue treating the credential as an ordinary 403.
     introduced_in: 4534eed92ef5cd639b377a17dd56dad2d9e41f70
-    affected_upstream_range: through 2e6b1d83f6c304a102aa33c1faf0a4f94d0d331e (v7.2.125, 2026-08-09); dd67f56f is a partial upstream equivalent that remaps xAI HTTP/WebSocket bad-credentials 403 responses to unauthorized, but upstream still does not guarantee that the auth-level LastError snapshot uses the same normalized code as the model state.
+    affected_upstream_range: through ecc9aa72b32f34b680d03b0724b531a21ae74472 (v7.2.127, 2026-08-10); dd67f56f is a partial upstream equivalent that remaps xAI HTTP/WebSocket bad-credentials 403 responses to unauthorized, but upstream still does not guarantee that the auth-level LastError snapshot uses the same normalized code as the model state.
     files:
       - docs/lts/downstream-patches.yaml
       - sdk/cliproxy/auth/conductor_cooldown.go

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -240,13 +240,25 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 			if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
 				reporter.Publish(ctx, detail)
 			}
-			lines[i] = restoreClaudeOAuthToolNamesFromStreamLine(line, oauthToolNamesReverseMap)
+			restoredLine, errRestore := restoreClaudeOAuthToolNamesFromStreamLine(line, oauthToolNamesReverseMap)
+			if errRestore != nil {
+				errRestore = fmt.Errorf("restore Claude OAuth tool name from streaming response: %w", errRestore)
+				helps.RecordAPIResponseError(ctx, e.cfg, errRestore)
+				return resp, wrapClaudeFastRequestError(fastRequest, httpResp.StatusCode, errRestore)
+			}
+			lines[i] = restoredLine
 		}
 		data = bytes.Join(lines, []byte("\n"))
 	} else {
 		commitClaudeDiagnostics(diagnosticsState, claudeMessageIDFromResponse(data))
 		reporter.Publish(ctx, helps.ParseClaudeUsage(data))
-		data = restoreClaudeOAuthToolNamesFromResponse(data, oauthToolNamesReverseMap)
+		var errRestore error
+		data, errRestore = restoreClaudeOAuthToolNamesFromResponse(data, oauthToolNamesReverseMap)
+		if errRestore != nil {
+			errRestore = fmt.Errorf("restore Claude OAuth tool name from response: %w", errRestore)
+			helps.RecordAPIResponseError(ctx, e.cfg, errRestore)
+			return resp, wrapClaudeFastRequestError(fastRequest, httpResp.StatusCode, errRestore)
+		}
 	}
 	data = e.restoreResponseModel(data, req.Model)
 	cacheClaudeThinkingReplayResponse(ctx, replayScope, data)

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -916,11 +916,11 @@ func prepareClaudeOAuthToolNamesForUpstream(body []byte, mcpAliases claudeMCPAli
 	return remapOAuthToolNamesWithOptions(body, mcpAliases)
 }
 
-func restoreClaudeOAuthToolNamesFromResponse(body []byte, reverseMap map[string]string) []byte {
+func restoreClaudeOAuthToolNamesFromResponse(body []byte, reverseMap map[string]string) ([]byte, error) {
 	return reverseRemapOAuthToolNames(body, reverseMap)
 }
 
-func restoreClaudeOAuthToolNamesFromStreamLine(line []byte, reverseMap map[string]string) []byte {
+func restoreClaudeOAuthToolNamesFromStreamLine(line []byte, reverseMap map[string]string) ([]byte, error) {
 	return reverseRemapOAuthToolNamesFromStreamLine(line, reverseMap)
 }
 
@@ -1397,29 +1397,164 @@ func remapOAuthToolNamesWithOptionsLegacy(body []byte, mcpAliases claudeMCPAlias
 	return body, reverseMap
 }
 
+type claudeMCPAliasParts struct {
+	server   string
+	toolID   string
+	semantic string
+}
+
+type claudeMCPAliasEntry struct {
+	alias    string
+	original string
+	parts    claudeMCPAliasParts
+}
+
+type claudeMCPAliasResolver struct {
+	exact   map[string]string
+	aliases []claudeMCPAliasEntry
+	servers map[string]struct{}
+}
+
+func newClaudeMCPAliasResolver(reverseMap map[string]string) claudeMCPAliasResolver {
+	resolver := claudeMCPAliasResolver{
+		exact:   reverseMap,
+		aliases: make([]claudeMCPAliasEntry, 0, len(reverseMap)),
+		servers: make(map[string]struct{}),
+	}
+	for alias, original := range reverseMap {
+		parts, ok := parseClaudeMCPAlias(alias)
+		if !ok {
+			continue
+		}
+		resolver.aliases = append(resolver.aliases, claudeMCPAliasEntry{
+			alias:    alias,
+			original: original,
+			parts:    parts,
+		})
+		resolver.servers[parts.server] = struct{}{}
+	}
+	return resolver
+}
+
+func parseClaudeMCPAlias(name string) (claudeMCPAliasParts, bool) {
+	rest, ok := strings.CutPrefix(name, "mcp__")
+	if !ok {
+		return claudeMCPAliasParts{}, false
+	}
+	server, tool, ok := strings.Cut(rest, "__")
+	if !ok || !isClaudeMCPAliasDigest(server) {
+		return claudeMCPAliasParts{}, false
+	}
+	toolID, semantic, ok := strings.Cut(tool, "_")
+	if !ok || !isClaudeMCPAliasDigest(toolID) || semantic == "" {
+		return claudeMCPAliasParts{}, false
+	}
+	return claudeMCPAliasParts{server: server, toolID: toolID, semantic: semantic}, true
+}
+
+func isClaudeMCPAliasDigest(value string) bool {
+	if len(value) != 12 {
+		return false
+	}
+	for _, char := range value {
+		if (char < 'a' || char > 'z') && (char < '2' || char > '7') {
+			return false
+		}
+	}
+	return true
+}
+
+func claudeMCPAliasServer(name string) string {
+	rest, ok := strings.CutPrefix(name, "mcp__")
+	if !ok {
+		return ""
+	}
+	server, _, ok := strings.Cut(rest, "__")
+	if !ok {
+		return ""
+	}
+	return server
+}
+
+func (resolver claudeMCPAliasResolver) resolve(name string) (string, bool, error) {
+	if original, ok := resolver.exact[name]; ok {
+		return original, true, nil
+	}
+
+	server := claudeMCPAliasServer(name)
+	if _, known := resolver.servers[server]; !known {
+		return "", false, nil
+	}
+
+	matchedOriginal := ""
+	matchCount := 0
+	for _, entry := range resolver.aliases {
+		if entry.parts.server == server && strings.HasSuffix(name, entry.alias) {
+			matchedOriginal = entry.original
+			matchCount++
+		}
+	}
+	if matchCount == 1 {
+		return matchedOriginal, true, nil
+	}
+	if matchCount > 1 {
+		return "", false, fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: matched multiple declared aliases", name)
+	}
+
+	parts, ok := parseClaudeMCPAlias(name)
+	if ok {
+		for _, entry := range resolver.aliases {
+			if entry.parts.server == parts.server && entry.parts.semantic == parts.semantic {
+				matchedOriginal = entry.original
+				matchCount++
+			}
+		}
+		if matchCount == 1 {
+			return matchedOriginal, true, nil
+		}
+		if matchCount > 1 {
+			return "", false, fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: semantic suffix matches multiple declared tools", name)
+		}
+	}
+
+	return "", false, fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: no unique request-local match", name)
+}
+
 // reverseRemapOAuthToolNames reverses the tool name mapping for non-stream responses
-// using the per-request map produced by remapOAuthToolNames. Names the client sent
-// that were NOT forward-renamed are passed through unchanged.
-func reverseRemapOAuthToolNames(body []byte, reverseMap map[string]string) []byte {
+// using the per-request map produced by remapOAuthToolNames. Names outside the
+// request-local generated MCP server are passed through unchanged.
+func reverseRemapOAuthToolNames(body []byte, reverseMap map[string]string) ([]byte, error) {
 	if len(reverseMap) == 0 {
-		return body
+		return body, nil
 	}
 	content := gjson.GetBytes(body, "content")
 	if !content.Exists() || !content.IsArray() {
-		return body
+		return body, nil
 	}
+	resolver := newClaudeMCPAliasResolver(reverseMap)
+	var resolveErr error
 	content.ForEach(func(index, part gjson.Result) bool {
 		partType := part.Get("type").String()
 		switch partType {
 		case "tool_use":
 			name := part.Get("name").String()
-			if origName, ok := reverseMap[name]; ok {
+			origName, matched, errResolve := resolver.resolve(name)
+			if errResolve != nil {
+				resolveErr = errResolve
+				return false
+			}
+			if matched {
 				path := fmt.Sprintf("content.%d.name", index.Int())
 				body, _ = sjson.SetBytes(body, path, origName)
 			}
 		case "tool_reference":
 			toolName := part.Get("tool_name").String()
-			if origName, ok := reverseMap[toolName]; ok {
+			origName, matched, errResolve := resolver.resolve(toolName)
+			if errResolve != nil {
+				resolveErr = errResolve
+				return false
+			}
+			if matched {
 				path := fmt.Sprintf("content.%d.tool_name", index.Int())
 				body, _ = sjson.SetBytes(body, path, origName)
 			}
@@ -1431,7 +1566,12 @@ func reverseRemapOAuthToolNames(body []byte, reverseMap map[string]string) []byt
 						return true
 					}
 					toolName := nestedPart.Get("tool_name").String()
-					if origName, ok := reverseMap[toolName]; ok {
+					origName, matched, errResolve := resolver.resolve(toolName)
+					if errResolve != nil {
+						resolveErr = errResolve
+						return false
+					}
+					if matched {
 						path := fmt.Sprintf("content.%d.content.%d.tool_name", index.Int(), nestedIndex.Int())
 						body, _ = sjson.SetBytes(body, path, origName)
 					}
@@ -1439,27 +1579,28 @@ func reverseRemapOAuthToolNames(body []byte, reverseMap map[string]string) []byt
 				})
 			}
 		}
-		return true
+		return resolveErr == nil
 	})
-	return body
+	return body, resolveErr
 }
 
 // reverseRemapOAuthToolNamesFromStreamLine reverses the tool name mapping for SSE
 // stream lines, using the per-request reverseMap produced by remapOAuthToolNames.
-func reverseRemapOAuthToolNamesFromStreamLine(line []byte, reverseMap map[string]string) []byte {
+func reverseRemapOAuthToolNamesFromStreamLine(line []byte, reverseMap map[string]string) ([]byte, error) {
 	if len(reverseMap) == 0 {
-		return line
+		return line, nil
 	}
 	payload := helps.JSONPayload(line)
 	if len(payload) == 0 || !gjson.ValidBytes(payload) {
-		return line
+		return line, nil
 	}
 
 	contentBlock := gjson.GetBytes(payload, "content_block")
 	if !contentBlock.Exists() {
-		return line
+		return line, nil
 	}
 
+	resolver := newClaudeMCPAliasResolver(reverseMap)
 	blockType := contentBlock.Get("type").String()
 	var updated []byte
 	var err error
@@ -1467,33 +1608,36 @@ func reverseRemapOAuthToolNamesFromStreamLine(line []byte, reverseMap map[string
 	switch blockType {
 	case "tool_use":
 		name := contentBlock.Get("name").String()
-		if origName, ok := reverseMap[name]; ok {
-			updated, err = sjson.SetBytes(payload, "content_block.name", origName)
-			if err != nil {
-				return line
-			}
-		} else {
-			return line
+		origName, matched, errResolve := resolver.resolve(name)
+		if errResolve != nil {
+			return line, errResolve
 		}
+		if !matched {
+			return line, nil
+		}
+		updated, err = sjson.SetBytes(payload, "content_block.name", origName)
 	case "tool_reference":
 		toolName := contentBlock.Get("tool_name").String()
-		if origName, ok := reverseMap[toolName]; ok {
-			updated, err = sjson.SetBytes(payload, "content_block.tool_name", origName)
-			if err != nil {
-				return line
-			}
-		} else {
-			return line
+		origName, matched, errResolve := resolver.resolve(toolName)
+		if errResolve != nil {
+			return line, errResolve
 		}
+		if !matched {
+			return line, nil
+		}
+		updated, err = sjson.SetBytes(payload, "content_block.tool_name", origName)
 	default:
-		return line
+		return line, nil
+	}
+	if err != nil {
+		return line, fmt.Errorf("rewrite Claude OAuth MCP tool alias: %w", err)
 	}
 
 	trimmed := bytes.TrimSpace(line)
 	if bytes.HasPrefix(trimmed, []byte("data:")) {
-		return append([]byte("data: "), updated...)
+		return append([]byte("data: "), updated...), nil
 	}
-	return updated
+	return updated, nil
 }
 
 func applyClaudeToolPrefix(body []byte, prefix string) []byte {

--- a/internal/runtime/executor/claude_executor_request_remap_test.go
+++ b/internal/runtime/executor/claude_executor_request_remap_test.go
@@ -94,6 +94,141 @@ func TestRemapOAuthToolNamesWithOptionsFallsBackForMalformedJSON(t *testing.T) {
 	}
 }
 
+func TestReverseRemapOAuthToolNamesRecoversMangledAliases(t *testing.T) {
+	body := []byte(`{"tools":[{"name":"glob","input_schema":{"type":"object"}},{"name":"read","input_schema":{"type":"object"}}]}`)
+	remapped, reverseMap := remapOAuthToolNamesWithOptions(body, claudeMCPAliasOptions{secret: "mangled-alias-caller"})
+	globAlias := gjson.GetBytes(remapped, "tools.0.name").String()
+	readAlias := gjson.GetBytes(remapped, "tools.1.name").String()
+	globParts, ok := parseClaudeMCPAlias(globAlias)
+	if !ok {
+		t.Fatalf("glob alias is invalid: %q", globAlias)
+	}
+	readParts, ok := parseClaudeMCPAlias(readAlias)
+	if !ok {
+		t.Fatalf("read alias is invalid: %q", readAlias)
+	}
+
+	repeatedAlias := "mcp__" + globParts.server + "__" + globAlias
+	mixedAlias := "mcp__" + globParts.server + "__" + globParts.toolID + "_" + readParts.semantic
+	response := []byte(fmt.Sprintf(`{"content":[
+		{"type":"tool_use","id":"toolu_glob","name":%q,"input":{}},
+		{"type":"tool_reference","tool_name":%q},
+		{"type":"tool_result","tool_use_id":"toolu_read","content":[{"type":"tool_reference","tool_name":%q}]}
+	]}`, repeatedAlias, mixedAlias, mixedAlias))
+
+	restored, errReverse := reverseRemapOAuthToolNames(response, reverseMap)
+	if errReverse != nil {
+		t.Fatalf("reverseRemapOAuthToolNames() error = %v", errReverse)
+	}
+	if got := gjson.GetBytes(restored, "content.0.name").String(); got != "glob" {
+		t.Fatalf("repeated alias restored to %q, want glob", got)
+	}
+	if got := gjson.GetBytes(restored, "content.1.tool_name").String(); got != "read" {
+		t.Fatalf("mixed alias restored to %q, want read", got)
+	}
+	if got := gjson.GetBytes(restored, "content.2.content.0.tool_name").String(); got != "read" {
+		t.Fatalf("nested mixed alias restored to %q, want read", got)
+	}
+
+	streamTests := []struct {
+		name      string
+		block     string
+		fieldPath string
+		want      string
+	}{
+		{
+			name:      "repeated tool use alias",
+			block:     fmt.Sprintf(`{"type":"tool_use","id":"toolu_glob","name":%q,"input":{}}`, repeatedAlias),
+			fieldPath: "content_block.name",
+			want:      "glob",
+		},
+		{
+			name:      "mixed tool reference alias",
+			block:     fmt.Sprintf(`{"type":"tool_reference","tool_name":%q}`, mixedAlias),
+			fieldPath: "content_block.tool_name",
+			want:      "read",
+		},
+	}
+	for _, test := range streamTests {
+		t.Run(test.name, func(t *testing.T) {
+			line := []byte(`data: {"type":"content_block_start","index":0,"content_block":` + test.block + `}`)
+			restoredLine, errStream := reverseRemapOAuthToolNamesFromStreamLine(line, reverseMap)
+			if errStream != nil {
+				t.Fatalf("reverseRemapOAuthToolNamesFromStreamLine() error = %v", errStream)
+			}
+			if got := gjson.GetBytes(helps.JSONPayload(restoredLine), test.fieldPath).String(); got != test.want {
+				t.Fatalf("restored stream name = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestReverseRemapOAuthToolNamesRejectsUnsafeMangledAliases(t *testing.T) {
+	body := []byte(`{"tools":[{"name":"tool.name"},{"name":"tool/name"}]}`)
+	remapped, reverseMap := remapOAuthToolNamesWithOptions(body, claudeMCPAliasOptions{secret: "ambiguous-alias-caller"})
+	firstAlias := gjson.GetBytes(remapped, "tools.0.name").String()
+	secondAlias := gjson.GetBytes(remapped, "tools.1.name").String()
+	firstParts, ok := parseClaudeMCPAlias(firstAlias)
+	if !ok {
+		t.Fatalf("first alias is invalid: %q", firstAlias)
+	}
+	secondParts, ok := parseClaudeMCPAlias(secondAlias)
+	if !ok {
+		t.Fatalf("second alias is invalid: %q", secondAlias)
+	}
+	if firstParts.semantic != secondParts.semantic {
+		t.Fatalf("semantic suffixes differ: %q != %q", firstParts.semantic, secondParts.semantic)
+	}
+
+	unknownToolID := "aaaaaaaaaaaa"
+	if unknownToolID == firstParts.toolID || unknownToolID == secondParts.toolID {
+		unknownToolID = "bbbbbbbbbbbb"
+	}
+	tests := []struct {
+		name      string
+		alias     string
+		wantError string
+	}{
+		{
+			name:      "ambiguous semantic suffix",
+			alias:     "mcp__" + firstParts.server + "__" + unknownToolID + "_" + firstParts.semantic,
+			wantError: "semantic suffix matches multiple declared tools",
+		},
+		{
+			name:      "unrecoverable semantic suffix",
+			alias:     "mcp__" + firstParts.server + "__" + unknownToolID + "_missing_tool",
+			wantError: "no unique request-local match",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response := []byte(fmt.Sprintf(`{"content":[{"type":"tool_use","id":"toolu_1","name":%q,"input":{}}]}`, test.alias))
+			if _, errReverse := reverseRemapOAuthToolNames(response, reverseMap); errReverse == nil || !strings.Contains(errReverse.Error(), test.wantError) {
+				t.Fatalf("reverseRemapOAuthToolNames() error = %v, want %q", errReverse, test.wantError)
+			}
+
+			line := []byte(fmt.Sprintf(`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":%q,"input":{}}}`, test.alias))
+			if _, errStream := reverseRemapOAuthToolNamesFromStreamLine(line, reverseMap); errStream == nil || !strings.Contains(errStream.Error(), test.wantError) {
+				t.Fatalf("reverseRemapOAuthToolNamesFromStreamLine() error = %v, want %q", errStream, test.wantError)
+			}
+		})
+	}
+}
+
+func TestReverseRemapOAuthToolNamesPreservesUnrelatedMCPName(t *testing.T) {
+	body := []byte(`{"tools":[{"name":"glob"}]}`)
+	_, reverseMap := remapOAuthToolNamesWithOptions(body, claudeMCPAliasOptions{secret: "unrelated-mcp-caller"})
+	response := []byte(`{"content":[{"type":"tool_use","id":"toolu_1","name":"mcp__external__query","input":{}}]}`)
+
+	restored, errReverse := reverseRemapOAuthToolNames(response, reverseMap)
+	if errReverse != nil {
+		t.Fatalf("reverseRemapOAuthToolNames() error = %v", errReverse)
+	}
+	if got := gjson.GetBytes(restored, "content.0.name").String(); got != "mcp__external__query" {
+		t.Fatalf("unrelated MCP name = %q, want unchanged", got)
+	}
+}
+
 func TestApplyClaudeRawJSONEditsRejectsInvalidRanges(t *testing.T) {
 	body := []byte(`{"a":"one","b":"two"}`)
 	tests := []struct {

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -237,6 +237,15 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			}
 			return true
 		}
+		emitResponseError := func(errResponse error) {
+			errResponse = wrapClaudeFastRequestError(fastRequest, httpResp.StatusCode, errResponse)
+			helps.RecordAPIResponseError(ctx, e.cfg, errResponse)
+			reporter.PublishFailure(ctx, errResponse)
+			select {
+			case out <- cliproxyexecutor.StreamChunk{Err: errResponse}:
+			case <-ctx.Done():
+			}
+		}
 
 		// If the response target is Claude, directly forward complete SSE events without translation.
 		if responseFormat == to {
@@ -265,8 +274,12 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
 					reporter.Publish(ctx, detail)
 				}
-				line = restoreClaudeOAuthToolNamesFromStreamLine(line, oauthToolNamesReverseMap)
-				line = e.restoreResponseModel(line, req.Model)
+				restoredLine, errRestore := restoreClaudeOAuthToolNamesFromStreamLine(line, oauthToolNamesReverseMap)
+				if errRestore != nil {
+					emitResponseError(fmt.Errorf("restore Claude OAuth tool name from streaming response: %w", errRestore))
+					return
+				}
+				line = e.restoreResponseModel(restoredLine, req.Model)
 				event.Write(line)
 				event.WriteByte('\n')
 				if len(bytes.TrimSpace(line)) == 0 && !flushEvent() {
@@ -310,8 +323,12 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
 				reporter.Publish(ctx, detail)
 			}
-			line = restoreClaudeOAuthToolNamesFromStreamLine(line, oauthToolNamesReverseMap)
-			line = e.restoreResponseModel(line, req.Model)
+			restoredLine, errRestore := restoreClaudeOAuthToolNamesFromStreamLine(line, oauthToolNamesReverseMap)
+			if errRestore != nil {
+				emitResponseError(fmt.Errorf("restore Claude OAuth tool name from streaming response: %w", errRestore))
+				return
+			}
+			line = e.restoreResponseModel(restoredLine, req.Model)
 			chunks := sdktranslator.TranslateStream(
 				ctx,
 				to,

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -4478,7 +4478,10 @@ func TestRemapOAuthToolNames_AllClientNamesUseMCPAliases(t *testing.T) {
 				t.Fatalf("reverseMap = %v, want %q -> %q", reverseMap, alias, original)
 			}
 			resp := []byte(`{"content":[{"type":"tool_use","id":"toolu_01","name":` + fmt.Sprintf("%q", alias) + `,"input":{}}]}`)
-			reversed := reverseRemapOAuthToolNames(resp, reverseMap)
+			reversed, errReverse := reverseRemapOAuthToolNames(resp, reverseMap)
+			if errReverse != nil {
+				t.Fatalf("reverseRemapOAuthToolNames() error = %v", errReverse)
+			}
 			if got := gjson.GetBytes(reversed, "content.0.name").String(); got != original {
 				t.Fatalf("content.0.name = %q, want %q", got, original)
 			}
@@ -4577,7 +4580,10 @@ func TestRemapOAuthToolNames_AllClientToolsAsMCP(t *testing.T) {
 		{"type":"tool_reference","tool_name":%q},
 		{"type":"tool_result","tool_use_id":"toolu_unknown","content":[{"type":"tool_reference","tool_name":%q}]}
 	]}`, searchAlias, caseAlias, searchAlias))
-	restored := reverseRemapOAuthToolNames(response, reverseMap)
+	restored, errReverse := reverseRemapOAuthToolNames(response, reverseMap)
+	if errReverse != nil {
+		t.Fatalf("reverseRemapOAuthToolNames() error = %v", errReverse)
+	}
 	if got := gjson.GetBytes(restored, "content.0.name").String(); got != "search_web" {
 		t.Fatalf("restored tool_use.name = %q, want search_web", got)
 	}
@@ -4589,7 +4595,10 @@ func TestRemapOAuthToolNames_AllClientToolsAsMCP(t *testing.T) {
 	}
 
 	streamLine := []byte(fmt.Sprintf(`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_unknown","name":%q,"input":{}}}`, searchAlias))
-	restoredLine := reverseRemapOAuthToolNamesFromStreamLine(streamLine, reverseMap)
+	restoredLine, errReverse := reverseRemapOAuthToolNamesFromStreamLine(streamLine, reverseMap)
+	if errReverse != nil {
+		t.Fatalf("reverseRemapOAuthToolNamesFromStreamLine() error = %v", errReverse)
+	}
 	if got := gjson.GetBytes(helps.JSONPayload(restoredLine), "content_block.name").String(); got != "search_web" {
 		t.Fatalf("restored stream name = %q, want search_web: %s", got, restoredLine)
 	}
@@ -4690,7 +4699,10 @@ func TestRemapOAuthToolNames_SemanticAliasRestoresLongOriginal(t *testing.T) {
 		t.Fatalf("semantic alias is not stable across requests: %q != %q", got, alias)
 	}
 	response := []byte(`{"content":[{"type":"tool_use","id":"toolu_1","name":` + fmt.Sprintf("%q", alias) + `,"input":{}}]}`)
-	restored := reverseRemapOAuthToolNames(response, reverseMap)
+	restored, errReverse := reverseRemapOAuthToolNames(response, reverseMap)
+	if errReverse != nil {
+		t.Fatalf("reverseRemapOAuthToolNames() error = %v", errReverse)
+	}
 	if got := gjson.GetBytes(restored, "content.0.name").String(); got != original {
 		t.Fatalf("restored tool name = %q, want exact original %q", got, original)
 	}
@@ -4768,7 +4780,10 @@ func TestReverseRemapOAuthToolNamesFromStreamLine_HonorsPerRequestMap(t *testing
 
 	// Bash block was never renamed, must pass through as-is.
 	bashLine := []byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01","name":"Bash","input":{}}}`)
-	out := reverseRemapOAuthToolNamesFromStreamLine(bashLine, reverseMap)
+	out, errReverse := reverseRemapOAuthToolNamesFromStreamLine(bashLine, reverseMap)
+	if errReverse != nil {
+		t.Fatalf("reverseRemapOAuthToolNamesFromStreamLine() error = %v", errReverse)
+	}
 	if !bytes.Contains(out, []byte(`"name":"Bash"`)) {
 		t.Fatalf("Bash should be preserved, got: %s", string(out))
 	}
@@ -4778,7 +4793,10 @@ func TestReverseRemapOAuthToolNamesFromStreamLine_HonorsPerRequestMap(t *testing
 
 	// Glob block IS in the reverseMap, must be restored to `glob`.
 	globLine := []byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_02","name":"Glob","input":{}}}`)
-	out = reverseRemapOAuthToolNamesFromStreamLine(globLine, reverseMap)
+	out, errReverse = reverseRemapOAuthToolNamesFromStreamLine(globLine, reverseMap)
+	if errReverse != nil {
+		t.Fatalf("reverseRemapOAuthToolNamesFromStreamLine() error = %v", errReverse)
+	}
 	if !bytes.Contains(out, []byte(`"name":"glob"`)) {
 		t.Fatalf("Glob should be restored to glob, got: %s", string(out))
 	}

--- a/internal/runtime/executor/codex_executor_stream.go
+++ b/internal/runtime/executor/codex_executor_stream.go
@@ -58,7 +58,11 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	body, _ = sjson.DeleteBytes(body, "generate")
 	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
 	body, _ = sjson.DeleteBytes(body, "safety_identifier")
+	reasoningSummaryDelivery := gjson.GetBytes(body, "stream_options.reasoning_summary_delivery")
 	body, _ = sjson.DeleteBytes(body, "stream_options")
+	if reasoningSummaryDelivery.Exists() {
+		body, _ = sjson.SetBytes(body, "stream_options.reasoning_summary_delivery", reasoningSummaryDelivery.Value())
+	}
 	body = helps.SetStringIfDifferent(body, "model", baseModel)
 	body = normalizeCodexInstructions(body)
 	if e.cfg == nil || e.cfg.DisableImageGeneration == config.DisableImageGenerationOff {

--- a/internal/runtime/executor/codex_executor_stream_output_test.go
+++ b/internal/runtime/executor/codex_executor_stream_output_test.go
@@ -288,6 +288,56 @@ func TestCodexExecutorExecuteStreamExplicitTerminalFailureIsNotSuccessful(t *tes
 	assertNotRequestScopedTestError(t, streamErr)
 }
 
+func TestCodexAutoExecutorHTTPFallbackForwardsSequentialCutoffReasoningSummaryDelivery(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		if gjson.GetBytes(body, "stream_options.include_usage").Exists() {
+			t.Errorf("unsupported stream option was forwarded: %s", body)
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		if delivery := gjson.GetBytes(body, "stream_options.reasoning_summary_delivery").String(); delivery == "sequential_cutoff" {
+			_, _ = w.Write([]byte(`data: {"type":"response.reasoning_summary_text.done","item_id":"rs_1","summary_index":0,"text":"Checking"}` + "\n\n"))
+		} else {
+			_, _ = w.Write([]byte(`data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_1","summary_index":0,"delta":"Checking"}` + "\n\n"))
+		}
+		_, _ = w.Write([]byte(`data: {"type":"response.completed","response":{"id":"resp_1","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}` + "\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexAutoExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+	result, err := executor.ExecuteStream(cliproxyexecutor.WithDownstreamWebsocket(context.Background()), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.6-sol",
+		Payload: []byte(`{"model":"gpt-5.6-sol","input":"hello","reasoning":{"summary":"detailed"},"stream_options":{"reasoning_summary_delivery":"sequential_cutoff","include_usage":true}}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FromString("openai-response"),
+		ResponseFormat: sdktranslator.FromString("openai-response"),
+		Stream:         true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var output bytes.Buffer
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream error: %v", chunk.Err)
+		}
+		output.Write(chunk.Payload)
+	}
+	if !strings.Contains(output.String(), `"type":"response.reasoning_summary_text.done"`) {
+		t.Fatalf("missing sequential-cutoff summary event; output=%s", output.String())
+	}
+}
+
 func TestCodexExecutorTransportFailureBeforeTerminalIsRequestScoped(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/runtime/executor/helps/codex_input_ids.go
+++ b/internal/runtime/executor/helps/codex_input_ids.go
@@ -12,11 +12,12 @@ import (
 )
 
 const (
-	codexInputItemIDLimit           = 64
-	codexMessageItemIDPrefix        = "msg"
-	codexReasoningItemIDPrefix      = "rs"
-	codexFunctionCallItemIDPrefix   = "fc"
-	codexCustomToolCallItemIDPrefix = "ctc"
+	codexInputItemIDLimit                 = 64
+	codexMessageItemIDPrefix              = "msg"
+	codexReasoningItemIDPrefix            = "rs"
+	codexFunctionCallItemIDPrefix         = "fc"
+	codexCustomToolCallItemIDPrefix       = "ctc"
+	codexCustomToolCallOutputItemIDPrefix = "ctco"
 )
 
 // SanitizeCodexInputItemIDs normalizes supported input item IDs for Codex, removes encrypted
@@ -106,6 +107,8 @@ func normalizeCodexInputItemID(item gjson.Result, id string) string {
 		prefix = codexFunctionCallItemIDPrefix
 	case "custom_tool_call":
 		prefix = codexCustomToolCallItemIDPrefix
+	case "custom_tool_call_output":
+		prefix = codexCustomToolCallOutputItemIDPrefix
 	default:
 		return id
 	}

--- a/internal/runtime/executor/helps/codex_input_ids_test.go
+++ b/internal/runtime/executor/helps/codex_input_ids_test.go
@@ -104,6 +104,34 @@ func TestSanitizeCodexInputItemIDsNormalizesCustomToolCallIDs(t *testing.T) {
 	}
 }
 
+func TestSanitizeCodexInputItemIDsNormalizesCustomToolCallOutputIDs(t *testing.T) {
+	const (
+		invalidID = "item_44e13caebc1ddf25f1337cbe_output"
+		validID   = "ctco-existing"
+	)
+	body := []byte(`{"input":[` +
+		`{"type":"custom_tool_call_output","id":"` + invalidID + `","call_id":"call-1","output":"done"},` +
+		`{"type":"custom_tool_call_output","id":"` + validID + `","call_id":"call-2","output":"done"}` +
+		`]}`)
+
+	first := SanitizeCodexInputItemIDs(body)
+	second := SanitizeCodexInputItemIDs(body)
+	normalizedAgain := SanitizeCodexInputItemIDs(first)
+
+	if actual := gjson.GetBytes(first, "input.0.id").String(); actual != "ctco_"+invalidID {
+		t.Fatalf("custom_tool_call_output ID = %q, want ctco-prefixed ID", actual)
+	}
+	if actual := gjson.GetBytes(first, "input.1.id").String(); actual != validID {
+		t.Fatalf("valid custom_tool_call_output ID changed: %q", actual)
+	}
+	if string(first) != string(second) {
+		t.Fatalf("custom_tool_call_output ID normalization is not deterministic: first=%s second=%s", first, second)
+	}
+	if string(first) != string(normalizedAgain) {
+		t.Fatalf("custom_tool_call_output ID normalization is not idempotent: first=%s normalized_again=%s", first, normalizedAgain)
+	}
+}
+
 func TestSanitizeCodexInputItemIDsDropsOverlongEncryptedReasoningItem(t *testing.T) {
 	longReasoningID := "rs_" + strings.Repeat("a", 64)
 	shortReasoningID := "rs_" + strings.Repeat("b", 48)

--- a/internal/runtime/executor/kimi_executor_test.go
+++ b/internal/runtime/executor/kimi_executor_test.go
@@ -73,6 +73,68 @@ func TestKimiExecutorClaudeRequestPreservesInternalModelSemantics(t *testing.T) 
 	}
 }
 
+func TestKimiExecutorPreservesAssistantContentAndToolCallsFromResponsesHistory(t *testing.T) {
+	var upstreamBody []byte
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", kimiRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		var errRead error
+		upstreamBody, errRead = io.ReadAll(req.Body)
+		if errRead != nil {
+			return nil, errRead
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(
+				`{"id":"chatcmpl_test","object":"chat.completion","created":1,"model":"k3","choices":[{"index":0,"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+			)),
+		}, nil
+	}))
+
+	executor := NewKimiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{},
+		Metadata:   map[string]any{"access_token": "test-token"},
+	}
+	payload := []byte(`{
+		"model":"kimi-k3",
+		"input":[
+			{"type":"reasoning","id":"rs_1","summary":[{"type":"summary_text","text":"inspect the next step"}]},
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Step 3 completed; continue to step 4."}]},
+			{"type":"function_call","call_id":"call_4","name":"exec_command","arguments":"{\"cmd\":\"pwd\"}"},
+			{"type":"function_call_output","call_id":"call_4","output":"ok"}
+		]
+	}`)
+
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "kimi-k3",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat:    sdktranslator.FormatOpenAIResponse,
+		OriginalRequest: payload,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	messages := gjson.GetBytes(upstreamBody, "messages").Array()
+	if got := len(messages); got != 2 {
+		t.Fatalf("upstream messages count = %d, want 2; body=%s", got, upstreamBody)
+	}
+	assistant := messages[0]
+	if got := assistant.Get("content.0.text").String(); got != "Step 3 completed; continue to step 4." {
+		t.Fatalf("assistant content = %q, want preserved text; body=%s", got, upstreamBody)
+	}
+	if got := assistant.Get("reasoning_content").String(); got != "inspect the next step" {
+		t.Fatalf("assistant reasoning_content = %q, want inspect the next step; body=%s", got, upstreamBody)
+	}
+	if got := assistant.Get("tool_calls.0.id").String(); got != "call_4" {
+		t.Fatalf("assistant tool call ID = %q, want call_4; body=%s", got, upstreamBody)
+	}
+	if got := messages[1].Get("tool_call_id").String(); got != "call_4" {
+		t.Fatalf("tool output call ID = %q, want call_4; body=%s", got, upstreamBody)
+	}
+}
+
 func TestKimiExecutorCountTokensUsesCanonicalUpstreamModel(t *testing.T) {
 	var upstreamRequest *http.Request
 	var upstreamBody []byte

--- a/internal/runtime/executor/xai_executor_request.go
+++ b/internal/runtime/executor/xai_executor_request.go
@@ -97,6 +97,7 @@ func (e *XAIExecutor) prepareResponsesRequestTo(ctx context.Context, req cliprox
 	// Drop choices that point at tools removed by normalizeXAITools before any
 	// configured x_search injection, so no surviving choice references a deleted tool.
 	body = normalizeXAINamespaceToolChoice(body)
+	body = normalizeXAIForcedWebSearchToolChoice(body)
 	body = pruneXAIOrphanedToolChoice(body)
 	body = normalizeXAIToolChoiceForTools(body)
 	if e.cfg != nil && e.cfg.XAI.InjectXSearch {
@@ -582,6 +583,26 @@ func ensureXAINativeXSearchAllowedTools(body []byte) []byte {
 	}
 	body, _ = sjson.SetRawBytes(body, "tool_choice.tools.-1", xaiXSearchToolJSON)
 	return body
+}
+
+// normalizeXAIForcedWebSearchToolChoice rewrites Codex's hosted-tool choice
+// into the allowed_tools form accepted by xAI's ModelToolChoice schema.
+func normalizeXAIForcedWebSearchToolChoice(body []byte) []byte {
+	choice := gjson.GetBytes(body, "tool_choice")
+	if !choice.IsObject() || strings.TrimSpace(choice.Get("type").String()) != xaiWebSearchToolType {
+		return body
+	}
+
+	allowedChoice := []byte(`{"type":"allowed_tools","mode":"required","tools":[]}`)
+	allowedChoice, errSetAllowed := sjson.SetRawBytes(allowedChoice, "tools.-1", []byte(choice.Raw))
+	if errSetAllowed != nil {
+		return body
+	}
+	updated, errSetChoice := sjson.SetRawBytes(body, "tool_choice", allowedChoice)
+	if errSetChoice != nil {
+		return body
+	}
+	return updated
 }
 
 // pruneXAIOrphanedToolChoice removes tool_choice entries that no longer match

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -802,6 +802,46 @@ func TestEnsureXAINativeXSearchTool(t *testing.T) {
 	}
 }
 
+func TestXAIExecutorPrepareNormalizesClaudeWebSearchToolChoice(t *testing.T) {
+	t.Parallel()
+
+	exec := NewXAIExecutor(&config.Config{})
+	prepared, errPrepare := exec.prepareResponsesRequest(context.Background(), cliproxyexecutor.Request{
+		Model: "grok-4.5",
+		Payload: []byte(`{
+			"model":"grok-4.5",
+			"max_tokens":4096,
+			"stream":true,
+			"output_config":{"effort":"high"},
+			"thinking":{"type":"disabled"},
+			"messages":[{"role":"user","content":[{"type":"text","text":"Perform a web search"}]}],
+			"tool_choice":{"type":"tool","name":"web_search"},
+			"tools":[{"type":"web_search_20250305","name":"web_search","max_uses":8}]
+		}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatClaude,
+		Stream:       true,
+	}, true)
+	if errPrepare != nil {
+		t.Fatalf("prepareResponsesRequest() error = %v", errPrepare)
+	}
+
+	choice := gjson.GetBytes(prepared.body, "tool_choice")
+	if got := choice.Get("type").String(); got != "allowed_tools" {
+		t.Fatalf("tool_choice.type = %q, want allowed_tools; body=%s", got, prepared.body)
+	}
+	if got := choice.Get("mode").String(); got != "required" {
+		t.Fatalf("tool_choice.mode = %q, want required; body=%s", got, prepared.body)
+	}
+	allowed := choice.Get("tools").Array()
+	if len(allowed) != 1 {
+		t.Fatalf("tool_choice.tools length = %d, want 1; body=%s", len(allowed), prepared.body)
+	}
+	if got := allowed[0].Get("type").String(); got != "web_search" {
+		t.Fatalf("tool_choice.tools.0.type = %q, want web_search; body=%s", got, prepared.body)
+	}
+}
+
 func TestPruneXAIOrphanedToolChoice(t *testing.T) {
 	t.Parallel()
 

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request.go
@@ -1054,7 +1054,7 @@ func splitResponsesQualifiedFunctionCallFromRequest(requestRawJSON []byte, quali
 	if !ok {
 		return qualifiedName, ""
 	}
-	if descriptor.toolType == "function" && !descriptor.direct {
+	if !descriptor.direct {
 		return descriptor.childName, descriptor.namespace
 	}
 	return qualifiedName, ""

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response.go
@@ -137,19 +137,7 @@ func pickRequestJSON(originalRequestRawJSON, requestRawJSON []byte) []byte {
 
 func applyResponsesFunctionCallNamespaceFields(item []byte, requestRawJSON []byte, qualifiedName string, itemPath string) []byte {
 	name, namespace := splitResponsesQualifiedFunctionCallFromRequest(requestRawJSON, qualifiedName)
-	namePath := "name"
-	namespacePath := "namespace"
-	if itemPath != "" {
-		namePath = itemPath + ".name"
-		namespacePath = itemPath + ".namespace"
-	}
-	item, _ = sjson.SetBytes(item, namePath, name)
-	if namespace != "" {
-		item, _ = sjson.SetBytes(item, namespacePath, namespace)
-	} else {
-		item, _ = sjson.DeleteBytes(item, namespacePath)
-	}
-	return item
+	return translatorcommon.SetResponsesToolCallIdentity(item, name, namespace, itemPath)
 }
 
 func emitEvent(event string, payload []byte) []byte {
@@ -370,7 +358,7 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 				item = []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"custom_tool_call","status":"in_progress","input":"","call_id":"","name":""}}`)
 				item, _ = sjson.SetBytes(item, "item.id", fmt.Sprintf("ctc_%s", st.CurrentFCID))
 				item, _ = sjson.SetBytes(item, "item.call_id", st.CurrentFCID)
-				item, _ = sjson.SetBytes(item, "item.name", name)
+				item = applyResponsesFunctionCallNamespaceFields(item, requestForToolMetadata, name, "item")
 			} else {
 				item = []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"in_progress","arguments":"","call_id":"","name":""}}`)
 				item, _ = sjson.SetBytes(item, "item.id", fmt.Sprintf("fc_%s", st.CurrentFCID))
@@ -501,7 +489,7 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 				itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("ctc_%s", st.CurrentFCID))
 				itemDone, _ = sjson.SetBytes(itemDone, "item.input", input)
 				itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", st.CurrentFCID)
-				itemDone, _ = sjson.SetBytes(itemDone, "item.name", st.FuncNames[idx])
+				itemDone = applyResponsesFunctionCallNamespaceFields(itemDone, requestForToolMetadata, st.FuncNames[idx], "item")
 				out = append(out, emitEvent("response.output_item.done", itemDone))
 			} else {
 				fcDone := []byte(`{"type":"response.function_call_arguments.done","sequence_number":0,"item_id":"","output_index":0,"arguments":""}`)
@@ -688,7 +676,7 @@ func ConvertClaudeResponseToOpenAIResponses(ctx context.Context, modelName strin
 					item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("ctc_%s", callID))
 					item, _ = sjson.SetBytes(item, "input", unwrapCustomToolInput(args))
 					item, _ = sjson.SetBytes(item, "call_id", callID)
-					item, _ = sjson.SetBytes(item, "name", name)
+					item = applyResponsesFunctionCallNamespaceFields(item, reqBytes, name, "")
 					outputsWrapper, _ = sjson.SetRawBytes(outputsWrapper, fmt.Sprintf("arr.%d", st.FuncOutputIndices[idx]), item)
 				} else {
 					item := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
@@ -994,7 +982,7 @@ func ConvertClaudeResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 				item, _ = sjson.SetBytes(item, "id", outputItem.id)
 				item, _ = sjson.SetBytes(item, "input", unwrapCustomToolInput(outputItem.args.String()))
 				item, _ = sjson.SetBytes(item, "call_id", outputItem.callID)
-				item, _ = sjson.SetBytes(item, "name", outputItem.name)
+				item = applyResponsesFunctionCallNamespaceFields(item, reqBytes, outputItem.name, "")
 				break
 			}
 			args := outputItem.args.String()

--- a/internal/translator/claude/openai/responses/claude_openai-responses_response_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_response_test.go
@@ -877,14 +877,16 @@ func TestConvertClaudeResponseToOpenAIResponsesNonStream_ReportsCacheTokens(t *t
 	}
 }
 
-func TestConvertClaudeResponseToOpenAIResponses_RestoresAdditionalCustomToolCall(t *testing.T) {
+func TestConvertClaudeResponseToOpenAIResponses_RestoresAdditionalNamespaceCustomToolCall(t *testing.T) {
 	originalRequest := []byte(`{
 		"model":"gpt-test",
-		"input":[{"type":"additional_tools","role":"developer","tools":[{"type":"custom","name":"exec"}]}]
+		"input":[{"type":"additional_tools","role":"developer","tools":[
+			{"type":"namespace","name":"functions","tools":[{"type":"custom","name":"exec"}]}
+		]}]
 	}`)
 	chunks := [][]byte{
 		[]byte(`data: {"type":"message_start","message":{"id":"msg_custom","usage":{"input_tokens":1,"output_tokens":0}}}`),
-		[]byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"call_custom","name":"exec","input":{}}}`),
+		[]byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"call_custom","name":"functions__exec","input":{}}}`),
 		[]byte(`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"input\":\"pwd\"}"}}`),
 		[]byte(`data: {"type":"content_block_stop","index":0}`),
 		[]byte(`data: {"type":"message_stop"}`),
@@ -921,8 +923,20 @@ func TestConvertClaudeResponseToOpenAIResponses_RestoresAdditionalCustomToolCall
 	if functionEvents != 0 {
 		t.Fatalf("function call events = %d, want 0", functionEvents)
 	}
-	if got := added.Get("item.name").String(); got != "exec" {
-		t.Fatalf("added name = %q, want exec", got)
+	for _, test := range []struct {
+		label string
+		item  gjson.Result
+	}{
+		{label: "added", item: added.Get("item")},
+		{label: "done", item: done.Get("item")},
+		{label: "completed", item: completed.Get("response.output.0")},
+	} {
+		if got := test.item.Get("name").String(); got != "exec" {
+			t.Fatalf("%s name = %q, want exec", test.label, got)
+		}
+		if got := test.item.Get("namespace").String(); got != "functions" {
+			t.Fatalf("%s namespace = %q, want functions", test.label, got)
+		}
 	}
 	if got := inputDone.Get("input").String(); got != "pwd" {
 		t.Fatalf("custom input.done input = %q, want pwd", got)
@@ -970,6 +984,13 @@ func TestConvertClaudeResponseToOpenAIResponses_DirectCustomWinsNamespaceCollisi
 	if got := streamCompleted.Get("response.output.0.input").String(); got != "pwd" {
 		t.Fatalf("stream output input = %q, want pwd", got)
 	}
+	item := streamCompleted.Get("response.output.0")
+	if got := item.Get("name").String(); got != "n__x" {
+		t.Fatalf("name = %q, want n__x", got)
+	}
+	if item.Get("namespace").Exists() {
+		t.Fatalf("unexpected namespace: %s", item.Get("namespace").Raw)
+	}
 
 	nonStreamRaw := []byte(strings.Join([]string{
 		`data: {"type":"message_start","message":{"id":"msg_collision_nonstream","usage":{"input_tokens":1,"output_tokens":0}}}`,
@@ -985,16 +1006,25 @@ func TestConvertClaudeResponseToOpenAIResponses_DirectCustomWinsNamespaceCollisi
 	if got := nonStream.Get("output.0.input").String(); got != "pwd" {
 		t.Fatalf("non-stream output input = %q, want pwd", got)
 	}
+	item = nonStream.Get("output.0")
+	if got := item.Get("name").String(); got != "n__x" {
+		t.Fatalf("name = %q, want n__x", got)
+	}
+	if item.Get("namespace").Exists() {
+		t.Fatalf("unexpected namespace: %s", item.Get("namespace").Raw)
+	}
 }
 
-func TestConvertClaudeResponseToOpenAIResponsesNonStream_RestoresAdditionalCustomToolCall(t *testing.T) {
+func TestConvertClaudeResponseToOpenAIResponsesNonStream_RestoresAdditionalNamespaceCustomToolCall(t *testing.T) {
 	originalRequest := []byte(`{
 		"model":"gpt-test",
-		"input":[{"type":"additional_tools","role":"developer","tools":[{"type":"custom","name":"exec"}]}]
+		"input":[{"type":"additional_tools","role":"developer","tools":[
+			{"type":"namespace","name":"functions","tools":[{"type":"custom","name":"exec"}]}
+		]}]
 	}`)
 	raw := []byte(strings.Join([]string{
 		`data: {"type":"message_start","message":{"id":"msg_custom_nonstream","usage":{"input_tokens":1,"output_tokens":0}}}`,
-		`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"call_custom_nonstream","name":"exec","input":{}}}`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"call_custom_nonstream","name":"functions__exec","input":{}}}`,
 		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"input\":\"pwd\"}"}}`,
 		`data: {"type":"content_block_stop","index":0}`,
 		`data: {"type":"message_stop"}`,
@@ -1009,6 +1039,12 @@ func TestConvertClaudeResponseToOpenAIResponsesNonStream_RestoresAdditionalCusto
 	}
 	if got := root.Get("output.0.call_id").String(); got != "call_custom_nonstream" {
 		t.Fatalf("non-stream call_id = %q, want call_custom_nonstream", got)
+	}
+	if got := root.Get("output.0.name").String(); got != "exec" {
+		t.Fatalf("non-stream name = %q, want exec; output=%s", got, root.Raw)
+	}
+	if got := root.Get("output.0.namespace").String(); got != "functions" {
+		t.Fatalf("non-stream namespace = %q, want functions; output=%s", got, root.Raw)
 	}
 }
 

--- a/internal/translator/common/responses.go
+++ b/internal/translator/common/responses.go
@@ -1,0 +1,20 @@
+package common
+
+import "github.com/tidwall/sjson"
+
+// SetResponsesToolCallIdentity writes a resolved Responses tool name and namespace.
+func SetResponsesToolCallIdentity(item []byte, name, namespace, itemPath string) []byte {
+	namePath := "name"
+	namespacePath := "namespace"
+	if itemPath != "" {
+		namePath = itemPath + ".name"
+		namespacePath = itemPath + ".namespace"
+	}
+	item, _ = sjson.SetBytes(item, namePath, name)
+	if namespace != "" {
+		item, _ = sjson.SetBytes(item, namespacePath, namespace)
+	} else {
+		item, _ = sjson.DeleteBytes(item, namespacePath)
+	}
+	return item
+}

--- a/internal/translator/common/responses_test.go
+++ b/internal/translator/common/responses_test.go
@@ -1,0 +1,70 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestSetResponsesToolCallIdentity(t *testing.T) {
+	tests := []struct {
+		name                string
+		input               string
+		toolName            string
+		namespace           string
+		itemPath            string
+		namePath            string
+		namespacePath       string
+		wantName            string
+		wantNamespace       string
+		wantNamespaceExists bool
+	}{
+		{
+			name:                "top level",
+			input:               `{"name":"functions__exec"}`,
+			toolName:            "exec",
+			namespace:           "functions",
+			namePath:            "name",
+			namespacePath:       "namespace",
+			wantName:            "exec",
+			wantNamespace:       "functions",
+			wantNamespaceExists: true,
+		},
+		{
+			name:                "nested item",
+			input:               `{"item":{"name":"functions__exec"}}`,
+			toolName:            "exec",
+			namespace:           "functions",
+			itemPath:            "item",
+			namePath:            "item.name",
+			namespacePath:       "item.namespace",
+			wantName:            "exec",
+			wantNamespace:       "functions",
+			wantNamespaceExists: true,
+		},
+		{
+			name:          "remove stale namespace",
+			input:         `{"name":"old","namespace":"stale"}`,
+			toolName:      "plain",
+			namePath:      "name",
+			namespacePath: "namespace",
+			wantName:      "plain",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := SetResponsesToolCallIdentity([]byte(test.input), test.toolName, test.namespace, test.itemPath)
+			if actual := gjson.GetBytes(got, test.namePath).String(); actual != test.wantName {
+				t.Fatalf("name = %q, want %q; output=%s", actual, test.wantName, got)
+			}
+			namespace := gjson.GetBytes(got, test.namespacePath)
+			if namespace.Exists() != test.wantNamespaceExists {
+				t.Fatalf("namespace exists = %t, want %t; output=%s", namespace.Exists(), test.wantNamespaceExists, got)
+			}
+			if test.wantNamespaceExists && namespace.String() != test.wantNamespace {
+				t.Fatalf("namespace = %q, want %q; output=%s", namespace.String(), test.wantNamespace, got)
+			}
+		})
+	}
+}

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -85,6 +85,7 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 		pendingReasoningContent := ""
 		awaitingToolOutputs := make(map[string]struct{})
 		deferredMessages := make([][]byte, 0)
+		mergeableAssistantIndex := -1
 
 		takePendingReasoningContent := func() string {
 			reasoningContent := pendingReasoningContent
@@ -95,12 +96,29 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 			if len(pendingToolCalls) == 0 {
 				return
 			}
-			assistantMessage := []byte(`{"role":"assistant","tool_calls":[]}`)
-			assistantMessage, _ = sjson.SetBytes(assistantMessage, "tool_calls", pendingToolCalls)
-			if reasoningContent := takePendingReasoningContent(); reasoningContent != "" {
-				assistantMessage, _ = sjson.SetBytes(assistantMessage, "reasoning_content", reasoningContent)
+
+			reasoningContent := takePendingReasoningContent()
+			mergedIntoAssistant := false
+			if mergeableAssistantIndex >= 0 && mergeableAssistantIndex == len(messages)-1 {
+				assistantMessage := gjson.ParseBytes(messages[mergeableAssistantIndex])
+				if assistantMessage.Get("role").String() == "assistant" && !assistantMessage.Get("tool_calls").Exists() {
+					updatedMessage, _ := sjson.SetBytes(messages[mergeableAssistantIndex], "tool_calls", pendingToolCalls)
+					combinedReasoning := combineOpenAIResponsesReasoning(assistantMessage.Get("reasoning_content").String(), reasoningContent)
+					if combinedReasoning != "" {
+						updatedMessage, _ = sjson.SetBytes(updatedMessage, "reasoning_content", combinedReasoning)
+					}
+					messages[mergeableAssistantIndex] = updatedMessage
+					mergedIntoAssistant = true
+				}
 			}
-			appendMessage(assistantMessage)
+			if !mergedIntoAssistant {
+				assistantMessage := []byte(`{"role":"assistant","tool_calls":[]}`)
+				assistantMessage, _ = sjson.SetBytes(assistantMessage, "tool_calls", pendingToolCalls)
+				if reasoningContent != "" {
+					assistantMessage, _ = sjson.SetBytes(assistantMessage, "reasoning_content", reasoningContent)
+				}
+				appendMessage(assistantMessage)
+			}
 			for _, id := range pendingToolCallIDs {
 				if strings.TrimSpace(id) == "" {
 					continue
@@ -109,6 +127,7 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 			}
 			pendingToolCalls = pendingToolCalls[:0]
 			pendingToolCallIDs = pendingToolCallIDs[:0]
+			mergeableAssistantIndex = -1
 		}
 		flushDeferredMessages := func() {
 			for _, message := range deferredMessages {
@@ -124,14 +143,15 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 			}
 			return false
 		}
-		appendRegularMessage := func(message []byte) {
+		appendRegularMessage := func(message []byte) int {
 			// Keep tool-call adjacency strict for providers that require
 			// assistant(tool_calls) -> tool(tool_call_id) with no message in between.
 			if hasAwaitingToolOutput() {
 				deferredMessages = append(deferredMessages, message)
-				return
+				return -1
 			}
 			appendMessage(message)
+			return len(messages) - 1
 		}
 		appendPendingReasoningMessage := func() {
 			reasoningContent := takePendingReasoningContent()
@@ -159,6 +179,7 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 				if role == "developer" {
 					role = "user"
 				}
+				mergeableAssistantIndex = -1
 				if role != "assistant" {
 					appendPendingReasoningMessage()
 				}
@@ -196,28 +217,23 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 				}
 
 				if role == "assistant" {
-					reasoningContent := item.Get("reasoning_content").String()
-					if reasoningContent == "" {
-						reasoningContent = takePendingReasoningContent()
-					} else {
-						pendingReasoningContent = ""
-					}
+					reasoningContent := combineOpenAIResponsesReasoning(takePendingReasoningContent(), item.Get("reasoning_content").String())
 					if reasoningContent != "" {
 						message, _ = sjson.SetBytes(message, "reasoning_content", reasoningContent)
 					}
 				}
 
-				appendRegularMessage(message)
+				messageIndex := appendRegularMessage(message)
+				if role == "assistant" {
+					mergeableAssistantIndex = messageIndex
+				}
 
 			case "reasoning":
 				reasoningContent := collectOpenAIResponsesReasoningContent(item)
-				if pendingReasoningContent == "" {
-					pendingReasoningContent = reasoningContent
-				} else {
-					pendingReasoningContent += reasoningContent
-				}
+				pendingReasoningContent = combineOpenAIResponsesReasoning(pendingReasoningContent, reasoningContent)
 
 			case "function_call":
+				pendingReasoningContent = combineOpenAIResponsesReasoning(pendingReasoningContent, item.Get("reasoning_content").String())
 				// Buffer consecutive function calls and emit them as one assistant message.
 				toolCall := []byte(`{"id":"","type":"function","function":{"name":"","arguments":""}}`)
 
@@ -242,6 +258,7 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 				}
 
 			case "function_call_output":
+				mergeableAssistantIndex = -1
 				// Handle function call output conversion to tool message
 				toolMessage := []byte(`{"role":"tool","tool_call_id":"","content":""}`)
 				callID := ""
@@ -264,6 +281,7 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 				}
 
 			case "custom_tool_call":
+				pendingReasoningContent = combineOpenAIResponsesReasoning(pendingReasoningContent, item.Get("reasoning_content").String())
 				// Codex freeform tool call replay: wrap the raw input so it
 				// matches the {"input": string} function shape used when
 				// converting custom tool definitions.
@@ -278,6 +296,7 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 				}
 
 			case "custom_tool_call_output":
+				mergeableAssistantIndex = -1
 				toolMessage := []byte(`{"role":"tool","tool_call_id":"","content":""}`)
 				callID := strings.TrimSpace(item.Get("call_id").String())
 				toolMessage, _ = sjson.SetBytes(toolMessage, "tool_call_id", callID)
@@ -289,6 +308,9 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 				if len(awaitingToolOutputs) == 0 && len(deferredMessages) > 0 {
 					flushDeferredMessages()
 				}
+
+			default:
+				mergeableAssistantIndex = -1
 			}
 
 		}
@@ -502,4 +524,22 @@ func collectOpenAIResponsesReasoningContent(item gjson.Result) string {
 		return "[reasoning unavailable]"
 	}
 	return reasoningText.String()
+}
+
+func combineOpenAIResponsesReasoning(existing, incoming string) string {
+	existingTrimmed := strings.TrimSpace(existing)
+	incomingTrimmed := strings.TrimSpace(incoming)
+
+	switch {
+	case existingTrimmed == "":
+		return incoming
+	case incomingTrimmed == "":
+		return existing
+	case existingTrimmed == "[reasoning unavailable]":
+		return incoming
+	case incomingTrimmed == "[reasoning unavailable]", existingTrimmed == incomingTrimmed:
+		return existing
+	default:
+		return existing + "\n\n" + incoming
+	}
 }

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
@@ -299,6 +299,119 @@ func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_AttachesReasoningT
 	}
 }
 
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_PreservesAssistantContentWithToolCalls(t *testing.T) {
+	raw := []byte(`{
+		"input": [
+			{
+				"type": "reasoning",
+				"id": "rs_1",
+				"summary": [{"type": "summary_text", "text": "inspect the next step"}]
+			},
+			{
+				"type": "message",
+				"role": "assistant",
+				"content": [{"type": "output_text", "text": "Step 3 completed; continue to step 4."}]
+			},
+			{"type":"function_call","call_id":"call_4","name":"exec_command","arguments":"{\"cmd\":\"pwd\"}"},
+			{"type":"function_call_output","call_id":"call_4","output":"ok"}
+		]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("kimi-k3", raw, false)
+
+	messages := gjson.GetBytes(out, "messages").Array()
+	if got := len(messages); got != 2 {
+		t.Fatalf("messages count = %d, want 2; output=%s", got, out)
+	}
+	assistant := messages[0]
+	if got := assistant.Get("role").String(); got != "assistant" {
+		t.Fatalf("assistant role = %q, want assistant; output=%s", got, out)
+	}
+	if got := assistant.Get("reasoning_content").String(); got != "inspect the next step" {
+		t.Fatalf("assistant reasoning_content = %q, want inspect the next step; output=%s", got, out)
+	}
+	if got := assistant.Get("content.0.text").String(); got != "Step 3 completed; continue to step 4." {
+		t.Fatalf("assistant content = %q, want preserved text; output=%s", got, out)
+	}
+	if got := assistant.Get("tool_calls.0.id").String(); got != "call_4" {
+		t.Fatalf("assistant tool call ID = %q, want call_4; output=%s", got, out)
+	}
+	if got := messages[1].Get("tool_call_id").String(); got != "call_4" {
+		t.Fatalf("tool output call ID = %q, want call_4; output=%s", got, out)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_DoesNotMergeToolCallsAcrossUserMessage(t *testing.T) {
+	raw := []byte(`{
+		"input": [
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"next"}]},
+			{"type":"function_call","call_id":"call_next","name":"exec_command","arguments":"{}"},
+			{"type":"function_call_output","call_id":"call_next","output":"ok"}
+		]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("kimi-k3", raw, false)
+
+	messages := gjson.GetBytes(out, "messages").Array()
+	if got := len(messages); got != 4 {
+		t.Fatalf("messages count = %d, want 4; output=%s", got, out)
+	}
+	if messages[0].Get("tool_calls").Exists() {
+		t.Fatalf("messages.0 unexpectedly contains tool calls; output=%s", out)
+	}
+	if got := messages[1].Get("role").String(); got != "user" {
+		t.Fatalf("messages.1 role = %q, want user; output=%s", got, out)
+	}
+	if got := messages[2].Get("tool_calls.0.id").String(); got != "call_next" {
+		t.Fatalf("messages.2 tool call ID = %q, want call_next; output=%s", got, out)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_MergesDistinctReasoningWithinAssistantTurn(t *testing.T) {
+	raw := []byte(`{
+		"input": [
+			{"type":"reasoning","summary":[{"type":"summary_text","text":"first"}]},
+			{"type":"message","role":"assistant","reasoning_content":"first","content":[{"type":"output_text","text":"working"}]},
+			{"type":"reasoning","summary":[{"type":"summary_text","text":"second"}]},
+			{"type":"function_call","call_id":"call_reasoning","name":"exec_command","arguments":"{}"}
+		]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("kimi-k3", raw, false)
+
+	messages := gjson.GetBytes(out, "messages").Array()
+	if got := len(messages); got != 1 {
+		t.Fatalf("messages count = %d, want 1; output=%s", got, out)
+	}
+	if got := messages[0].Get("reasoning_content").String(); got != "first\n\nsecond" {
+		t.Fatalf("reasoning_content = %q, want %q; output=%s", got, "first\n\nsecond", out)
+	}
+	if got := messages[0].Get("tool_calls.0.id").String(); got != "call_reasoning" {
+		t.Fatalf("tool call ID = %q, want call_reasoning; output=%s", got, out)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_ReplacesUnavailableReasoningWithinAssistantTurn(t *testing.T) {
+	raw := []byte(`{
+		"input": [
+			{"type":"reasoning","summary":[]},
+			{"type":"message","role":"assistant","reasoning_content":"real reasoning","content":[{"type":"output_text","text":"working"}]},
+			{"type":"function_call","call_id":"call_real_reasoning","name":"exec_command","arguments":"{}"}
+		]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("kimi-k3", raw, false)
+
+	messages := gjson.GetBytes(out, "messages").Array()
+	if got := len(messages); got != 1 {
+		t.Fatalf("messages count = %d, want 1; output=%s", got, out)
+	}
+	if got := messages[0].Get("reasoning_content").String(); got != "real reasoning" {
+		t.Fatalf("reasoning_content = %q, want real reasoning; output=%s", got, out)
+	}
+}
+
 func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_AttachesReasoningToToolCallMessage(t *testing.T) {
 	raw := []byte(`{
 		"input": [

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -176,7 +176,7 @@ func buildResponsesCompletedEvent(st *oaiToResponsesState, requestRawJSON []byte
 				item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("ctc_%s", callID))
 				item, _ = sjson.SetBytes(item, "input", unwrapCustomToolInput(args))
 				item, _ = sjson.SetBytes(item, "call_id", callID)
-				item, _ = sjson.SetBytes(item, "name", name)
+				item = applyResponsesFunctionCallNamespaceFields(item, requestRawJSON, name, "")
 				outputItems = append(outputItems, completedOutputItem{index: st.FuncOutputIx[key], raw: item})
 				continue
 			}
@@ -326,7 +326,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 			o, _ = sjson.SetBytes(o, "output_index", outputIndex)
 			o, _ = sjson.SetBytes(o, "item.id", fmt.Sprintf("ctc_%s", callID))
 			o, _ = sjson.SetBytes(o, "item.call_id", callID)
-			o, _ = sjson.SetBytes(o, "item.name", name)
+			o = applyResponsesFunctionCallNamespaceFields(o, requestForNamespace, name, "item")
 			out = append(out, emitRespEvent("response.output_item.added", o))
 		} else {
 			o := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"in_progress","arguments":"","call_id":"","name":""}}`)
@@ -529,7 +529,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 				itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("ctc_%s", callID))
 				itemDone, _ = sjson.SetBytes(itemDone, "item.input", input)
 				itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", callID)
-				itemDone, _ = sjson.SetBytes(itemDone, "item.name", st.FuncNames[key])
+				itemDone = applyResponsesFunctionCallNamespaceFields(itemDone, requestForNamespace, st.FuncNames[key], "item")
 				out = append(out, emitRespEvent("response.output_item.done", itemDone))
 				st.FuncItemDone[key] = true
 				st.FuncArgsDone[key] = true
@@ -840,7 +840,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 							item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("ctc_%s", callID))
 							item, _ = sjson.SetBytes(item, "input", unwrapCustomToolInput(args))
 							item, _ = sjson.SetBytes(item, "call_id", callID)
-							item, _ = sjson.SetBytes(item, "name", name)
+							item = applyResponsesFunctionCallNamespaceFields(item, requestForNamespace, name, "")
 							outputsWrapper, _ = sjson.SetRawBytes(outputsWrapper, "arr.-1", item)
 							return true
 						}

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -244,21 +244,20 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 		return [][]byte{}
 	}
 	requestForNamespace := pickRequestJSON(originalRequestRawJSON, requestRawJSON)
-	if bytes.Equal(rawJSON, []byte("[DONE]")) {
-		if st.Started && !st.CompletedEmitted {
-			st.CompletedEmitted = true
-			return [][]byte{buildResponsesCompletedEvent(st, requestForNamespace, func() int { st.Seq++; return st.Seq })}
-		}
+	isDone := bytes.Equal(rawJSON, []byte("[DONE]"))
+	if isDone && (!st.Started || st.CompletedEmitted) {
 		return [][]byte{}
 	}
 
 	root := gjson.ParseBytes(rawJSON)
-	obj := root.Get("object")
-	if obj.Exists() && obj.String() != "" && obj.String() != "chat.completion.chunk" {
-		return [][]byte{}
-	}
-	if !root.Get("choices").Exists() || !root.Get("choices").IsArray() {
-		return [][]byte{}
+	if !isDone {
+		obj := root.Get("object")
+		if obj.Exists() && obj.String() != "" && obj.String() != "chat.completion.chunk" {
+			return [][]byte{}
+		}
+		if !root.Get("choices").Exists() || !root.Get("choices").IsArray() {
+			return [][]byte{}
+		}
 	}
 
 	if usage := root.Get("usage"); usage.Exists() {
@@ -440,6 +439,129 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 		st.ReasoningID = ""
 	}
 
+	emitMessageItemDone := func(idx int) {
+		if !st.MsgItemAdded[idx] || st.MsgItemDone[idx] {
+			return
+		}
+		msgOutputIndex := st.MsgOutputIx[idx]
+		fullText := ""
+		if b := st.MsgTextBuf[idx]; b != nil {
+			fullText = b.String()
+		}
+		done := []byte(`{"type":"response.output_text.done","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"text":"","logprobs":[]}`)
+		done, _ = sjson.SetBytes(done, "sequence_number", nextSeq())
+		done, _ = sjson.SetBytes(done, "item_id", fmt.Sprintf("msg_%s_%d", st.ResponseID, idx))
+		done, _ = sjson.SetBytes(done, "output_index", msgOutputIndex)
+		done, _ = sjson.SetBytes(done, "content_index", 0)
+		done, _ = sjson.SetBytes(done, "text", fullText)
+		out = append(out, emitRespEvent("response.output_text.done", done))
+
+		partDone := []byte(`{"type":"response.content_part.done","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}`)
+		partDone, _ = sjson.SetBytes(partDone, "sequence_number", nextSeq())
+		partDone, _ = sjson.SetBytes(partDone, "item_id", fmt.Sprintf("msg_%s_%d", st.ResponseID, idx))
+		partDone, _ = sjson.SetBytes(partDone, "output_index", msgOutputIndex)
+		partDone, _ = sjson.SetBytes(partDone, "content_index", 0)
+		partDone, _ = sjson.SetBytes(partDone, "part.text", fullText)
+		out = append(out, emitRespEvent("response.content_part.done", partDone))
+
+		itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":""}],"role":"assistant"}}`)
+		itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
+		itemDone, _ = sjson.SetBytes(itemDone, "output_index", msgOutputIndex)
+		itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("msg_%s_%d", st.ResponseID, idx))
+		itemDone, _ = sjson.SetBytes(itemDone, "item.content.0.text", fullText)
+		out = append(out, emitRespEvent("response.output_item.done", itemDone))
+		st.MsgItemDone[idx] = true
+	}
+
+	finalizeOpenItems := func() {
+		if len(st.MsgItemAdded) > 0 {
+			idxs := make([]int, 0, len(st.MsgItemAdded))
+			for idx := range st.MsgItemAdded {
+				idxs = append(idxs, idx)
+			}
+			sort.Slice(idxs, func(i, j int) bool { return st.MsgOutputIx[idxs[i]] < st.MsgOutputIx[idxs[j]] })
+			for _, idx := range idxs {
+				emitMessageItemDone(idx)
+			}
+		}
+
+		if st.ReasoningID != "" {
+			stopReasoning(st.ReasoningBuf.String())
+			st.ReasoningBuf.Reset()
+		}
+
+		if len(st.FuncArgsBuf) == 0 {
+			return
+		}
+		keys := make([]string, 0, len(st.FuncArgsBuf))
+		for key := range st.FuncArgsBuf {
+			keys = append(keys, key)
+		}
+		sort.Slice(keys, func(i, j int) bool {
+			left := st.FuncOutputIx[keys[i]]
+			right := st.FuncOutputIx[keys[j]]
+			return left < right || (left == right && keys[i] < keys[j])
+		})
+		for _, key := range keys {
+			emitToolItem(key, true)
+			emitPendingFunctionArgs(key)
+			callID := st.FuncCallIDs[key]
+			if callID == "" || st.FuncItemDone[key] {
+				continue
+			}
+			outputIndex := st.FuncOutputIx[key]
+			args := "{}"
+			if b := st.FuncArgsBuf[key]; b != nil && b.Len() > 0 {
+				args = b.String()
+			}
+			if st.FuncItemCustom[key] {
+				input := unwrapCustomToolInput(args)
+				inputDone := []byte(`{"type":"response.custom_tool_call_input.done","sequence_number":0,"item_id":"","output_index":0,"input":""}`)
+				inputDone, _ = sjson.SetBytes(inputDone, "sequence_number", nextSeq())
+				inputDone, _ = sjson.SetBytes(inputDone, "item_id", fmt.Sprintf("ctc_%s", callID))
+				inputDone, _ = sjson.SetBytes(inputDone, "output_index", outputIndex)
+				inputDone, _ = sjson.SetBytes(inputDone, "input", input)
+				out = append(out, emitRespEvent("response.custom_tool_call_input.done", inputDone))
+
+				itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"custom_tool_call","status":"completed","input":"","call_id":"","name":""}}`)
+				itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
+				itemDone, _ = sjson.SetBytes(itemDone, "output_index", outputIndex)
+				itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("ctc_%s", callID))
+				itemDone, _ = sjson.SetBytes(itemDone, "item.input", input)
+				itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", callID)
+				itemDone, _ = sjson.SetBytes(itemDone, "item.name", st.FuncNames[key])
+				out = append(out, emitRespEvent("response.output_item.done", itemDone))
+				st.FuncItemDone[key] = true
+				st.FuncArgsDone[key] = true
+				continue
+			}
+			fcDone := []byte(`{"type":"response.function_call_arguments.done","sequence_number":0,"item_id":"","output_index":0,"arguments":""}`)
+			fcDone, _ = sjson.SetBytes(fcDone, "sequence_number", nextSeq())
+			fcDone, _ = sjson.SetBytes(fcDone, "item_id", fmt.Sprintf("fc_%s", callID))
+			fcDone, _ = sjson.SetBytes(fcDone, "output_index", outputIndex)
+			fcDone, _ = sjson.SetBytes(fcDone, "arguments", args)
+			out = append(out, emitRespEvent("response.function_call_arguments.done", fcDone))
+
+			itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}}`)
+			itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
+			itemDone, _ = sjson.SetBytes(itemDone, "output_index", outputIndex)
+			itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("fc_%s", callID))
+			itemDone, _ = sjson.SetBytes(itemDone, "item.arguments", args)
+			itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", callID)
+			itemDone = applyResponsesFunctionCallNamespaceFields(itemDone, requestForNamespace, st.FuncNames[key], "item")
+			out = append(out, emitRespEvent("response.output_item.done", itemDone))
+			st.FuncItemDone[key] = true
+			st.FuncArgsDone[key] = true
+		}
+	}
+
+	if isDone {
+		finalizeOpenItems()
+		st.CompletedEmitted = true
+		out = append(out, buildResponsesCompletedEvent(st, requestForNamespace, nextSeq))
+		return out
+	}
+
 	// choices[].delta content / tool_calls / reasoning_content
 	if choices := root.Get("choices"); choices.Exists() && choices.IsArray() {
 		choices.ForEach(func(_, choice gjson.Result) bool {
@@ -527,36 +649,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 					}
 					// Before emitting any function events, if a message is open for this index,
 					// close its text/content to match Codex expected ordering.
-					if st.MsgItemAdded[idx] && !st.MsgItemDone[idx] {
-						msgOutputIndex := st.MsgOutputIx[idx]
-						fullText := ""
-						if b := st.MsgTextBuf[idx]; b != nil {
-							fullText = b.String()
-						}
-						done := []byte(`{"type":"response.output_text.done","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"text":"","logprobs":[]}`)
-						done, _ = sjson.SetBytes(done, "sequence_number", nextSeq())
-						done, _ = sjson.SetBytes(done, "item_id", fmt.Sprintf("msg_%s_%d", st.ResponseID, idx))
-						done, _ = sjson.SetBytes(done, "output_index", msgOutputIndex)
-						done, _ = sjson.SetBytes(done, "content_index", 0)
-						done, _ = sjson.SetBytes(done, "text", fullText)
-						out = append(out, emitRespEvent("response.output_text.done", done))
-
-						partDone := []byte(`{"type":"response.content_part.done","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}`)
-						partDone, _ = sjson.SetBytes(partDone, "sequence_number", nextSeq())
-						partDone, _ = sjson.SetBytes(partDone, "item_id", fmt.Sprintf("msg_%s_%d", st.ResponseID, idx))
-						partDone, _ = sjson.SetBytes(partDone, "output_index", msgOutputIndex)
-						partDone, _ = sjson.SetBytes(partDone, "content_index", 0)
-						partDone, _ = sjson.SetBytes(partDone, "part.text", fullText)
-						out = append(out, emitRespEvent("response.content_part.done", partDone))
-
-						itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":""}],"role":"assistant"}}`)
-						itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
-						itemDone, _ = sjson.SetBytes(itemDone, "output_index", msgOutputIndex)
-						itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("msg_%s_%d", st.ResponseID, idx))
-						itemDone, _ = sjson.SetBytes(itemDone, "item.content.0.text", fullText)
-						out = append(out, emitRespEvent("response.output_item.done", itemDone))
-						st.MsgItemDone[idx] = true
-					}
+					emitMessageItemDone(idx)
 
 					tcs.ForEach(func(_, tc gjson.Result) bool {
 						toolIndex := int(tc.Get("index").Int())
@@ -587,116 +680,7 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 			// deferred until the terminal [DONE] marker so late usage-only chunks can
 			// still populate response.usage.
 			if fr := choice.Get("finish_reason"); fr.Exists() && fr.String() != "" {
-				// Emit message done events for all indices that started a message
-				if len(st.MsgItemAdded) > 0 {
-					// sort indices for deterministic order
-					idxs := make([]int, 0, len(st.MsgItemAdded))
-					for i := range st.MsgItemAdded {
-						idxs = append(idxs, i)
-					}
-					sort.Slice(idxs, func(i, j int) bool { return st.MsgOutputIx[idxs[i]] < st.MsgOutputIx[idxs[j]] })
-					for _, i := range idxs {
-						if st.MsgItemAdded[i] && !st.MsgItemDone[i] {
-							msgOutputIndex := st.MsgOutputIx[i]
-							fullText := ""
-							if b := st.MsgTextBuf[i]; b != nil {
-								fullText = b.String()
-							}
-							done := []byte(`{"type":"response.output_text.done","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"text":"","logprobs":[]}`)
-							done, _ = sjson.SetBytes(done, "sequence_number", nextSeq())
-							done, _ = sjson.SetBytes(done, "item_id", fmt.Sprintf("msg_%s_%d", st.ResponseID, i))
-							done, _ = sjson.SetBytes(done, "output_index", msgOutputIndex)
-							done, _ = sjson.SetBytes(done, "content_index", 0)
-							done, _ = sjson.SetBytes(done, "text", fullText)
-							out = append(out, emitRespEvent("response.output_text.done", done))
-
-							partDone := []byte(`{"type":"response.content_part.done","sequence_number":0,"item_id":"","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}`)
-							partDone, _ = sjson.SetBytes(partDone, "sequence_number", nextSeq())
-							partDone, _ = sjson.SetBytes(partDone, "item_id", fmt.Sprintf("msg_%s_%d", st.ResponseID, i))
-							partDone, _ = sjson.SetBytes(partDone, "output_index", msgOutputIndex)
-							partDone, _ = sjson.SetBytes(partDone, "content_index", 0)
-							partDone, _ = sjson.SetBytes(partDone, "part.text", fullText)
-							out = append(out, emitRespEvent("response.content_part.done", partDone))
-
-							itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":""}],"role":"assistant"}}`)
-							itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
-							itemDone, _ = sjson.SetBytes(itemDone, "output_index", msgOutputIndex)
-							itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("msg_%s_%d", st.ResponseID, i))
-							itemDone, _ = sjson.SetBytes(itemDone, "item.content.0.text", fullText)
-							out = append(out, emitRespEvent("response.output_item.done", itemDone))
-							st.MsgItemDone[i] = true
-						}
-					}
-				}
-
-				if st.ReasoningID != "" {
-					stopReasoning(st.ReasoningBuf.String())
-					st.ReasoningBuf.Reset()
-				}
-
-				// Emit function call done events for any active function calls
-				if len(st.FuncArgsBuf) > 0 {
-					keys := make([]string, 0, len(st.FuncArgsBuf))
-					for key := range st.FuncArgsBuf {
-						keys = append(keys, key)
-					}
-					sort.Slice(keys, func(i, j int) bool {
-						left := st.FuncOutputIx[keys[i]]
-						right := st.FuncOutputIx[keys[j]]
-						return left < right || (left == right && keys[i] < keys[j])
-					})
-					for _, key := range keys {
-						emitToolItem(key, true)
-						emitPendingFunctionArgs(key)
-						callID := st.FuncCallIDs[key]
-						if callID == "" || st.FuncItemDone[key] {
-							continue
-						}
-						outputIndex := st.FuncOutputIx[key]
-						args := "{}"
-						if b := st.FuncArgsBuf[key]; b != nil && b.Len() > 0 {
-							args = b.String()
-						}
-						if st.FuncItemCustom[key] {
-							input := unwrapCustomToolInput(args)
-							inputDone := []byte(`{"type":"response.custom_tool_call_input.done","sequence_number":0,"item_id":"","output_index":0,"input":""}`)
-							inputDone, _ = sjson.SetBytes(inputDone, "sequence_number", nextSeq())
-							inputDone, _ = sjson.SetBytes(inputDone, "item_id", fmt.Sprintf("ctc_%s", callID))
-							inputDone, _ = sjson.SetBytes(inputDone, "output_index", outputIndex)
-							inputDone, _ = sjson.SetBytes(inputDone, "input", input)
-							out = append(out, emitRespEvent("response.custom_tool_call_input.done", inputDone))
-
-							itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"custom_tool_call","status":"completed","input":"","call_id":"","name":""}}`)
-							itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
-							itemDone, _ = sjson.SetBytes(itemDone, "output_index", outputIndex)
-							itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("ctc_%s", callID))
-							itemDone, _ = sjson.SetBytes(itemDone, "item.input", input)
-							itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", callID)
-							itemDone, _ = sjson.SetBytes(itemDone, "item.name", st.FuncNames[key])
-							out = append(out, emitRespEvent("response.output_item.done", itemDone))
-							st.FuncItemDone[key] = true
-							st.FuncArgsDone[key] = true
-							continue
-						}
-						fcDone := []byte(`{"type":"response.function_call_arguments.done","sequence_number":0,"item_id":"","output_index":0,"arguments":""}`)
-						fcDone, _ = sjson.SetBytes(fcDone, "sequence_number", nextSeq())
-						fcDone, _ = sjson.SetBytes(fcDone, "item_id", fmt.Sprintf("fc_%s", callID))
-						fcDone, _ = sjson.SetBytes(fcDone, "output_index", outputIndex)
-						fcDone, _ = sjson.SetBytes(fcDone, "arguments", args)
-						out = append(out, emitRespEvent("response.function_call_arguments.done", fcDone))
-
-						itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}}`)
-						itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
-						itemDone, _ = sjson.SetBytes(itemDone, "output_index", outputIndex)
-						itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("fc_%s", callID))
-						itemDone, _ = sjson.SetBytes(itemDone, "item.arguments", args)
-						itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", callID)
-						itemDone = applyResponsesFunctionCallNamespaceFields(itemDone, requestForNamespace, st.FuncNames[key], "item")
-						out = append(out, emitRespEvent("response.output_item.done", itemDone))
-						st.FuncItemDone[key] = true
-						st.FuncArgsDone[key] = true
-					}
-				}
+				finalizeOpenItems()
 			}
 
 			return true

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
@@ -163,6 +163,85 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_ResponseCompleted
 	}
 }
 
+func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_FinalizesOpenMessageAtStreamEnd(t *testing.T) {
+	t.Parallel()
+
+	request := []byte(`{"model":"gpt-5.4"}`)
+	tests := []struct {
+		name  string
+		chunk string
+	}{
+		{
+			name:  "missing finish reason",
+			chunk: `data: {"id":"resp_missing_finish_reason","object":"chat.completion.chunk","created":1773896263,"model":"model","choices":[{"index":0,"delta":{"role":"assistant","content":"hello"}}]}`,
+		},
+		{
+			name:  "null finish reason",
+			chunk: `data: {"id":"resp_null_finish_reason","object":"chat.completion.chunk","created":1773896263,"model":"model","choices":[{"index":0,"delta":{"role":"assistant","content":"hello"},"finish_reason":null}]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var param any
+			var events []string
+			var textDone gjson.Result
+			var partDone gjson.Result
+			var itemDone gjson.Result
+			var completed gjson.Result
+
+			for _, line := range []string{tt.chunk, `data: [DONE]`} {
+				for _, chunk := range ConvertOpenAIChatCompletionsResponseToOpenAIResponses(context.Background(), "model", request, request, []byte(line), &param) {
+					event, data := parseOpenAIResponsesSSEEvent(t, chunk)
+					events = append(events, event)
+					switch event {
+					case "response.output_text.done":
+						textDone = data
+					case "response.content_part.done":
+						partDone = data
+					case "response.output_item.done":
+						itemDone = data
+					case "response.completed":
+						completed = data
+					}
+				}
+			}
+
+			wantEvents := []string{
+				"response.created",
+				"response.in_progress",
+				"response.output_item.added",
+				"response.content_part.added",
+				"response.output_text.delta",
+				"response.output_text.done",
+				"response.content_part.done",
+				"response.output_item.done",
+				"response.completed",
+			}
+			if len(events) != len(wantEvents) {
+				t.Fatalf("events = %v, want %v", events, wantEvents)
+			}
+			for i := range wantEvents {
+				if events[i] != wantEvents[i] {
+					t.Fatalf("event %d = %q, want %q; events = %v", i, events[i], wantEvents[i], events)
+				}
+			}
+			if got := textDone.Get("text").String(); got != "hello" {
+				t.Fatalf("output_text.done text = %q, want hello", got)
+			}
+			if got := partDone.Get("part.text").String(); got != "hello" {
+				t.Fatalf("content_part.done text = %q, want hello", got)
+			}
+			if got := itemDone.Get("item.content.0.text").String(); got != "hello" {
+				t.Fatalf("output_item.done text = %q, want hello", got)
+			}
+			if got := completed.Get("response.status").String(); got != "completed" {
+				t.Fatalf("response.completed status = %q, want completed", got)
+			}
+		})
+	}
+}
+
 func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_MultipleToolCallsRemainSeparate(t *testing.T) {
 	in := []string{
 		`data: {"id":"resp_test","object":"chat.completion.chunk","created":1773896263,"model":"model","choices":[{"index":0,"delta":{"role":"assistant","content":null,"reasoning_content":null,"tool_calls":[{"index":0,"id":"call_read","type":"function","function":{"name":"read","arguments":""}}]},"finish_reason":null}]}`,

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
@@ -973,13 +973,13 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_RestoresAdditiona
 			"type":"additional_tools",
 			"tools":[{
 				"type":"namespace",
-				"name":"terminal",
+				"name":"functions",
 				"tools":[{"type":"custom","name":"exec"}]
 			}]
 		}]
 	}`)
 	chunks := []string{
-		`data: {"id":"chatcmpl_additional_namespace_custom_stream","object":"chat.completion.chunk","created":1773896263,"model":"model","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_exec","type":"function","function":{"name":"terminal__exec","arguments":""}}]},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl_additional_namespace_custom_stream","object":"chat.completion.chunk","created":1773896263,"model":"model","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_exec","type":"function","function":{"name":"functions__exec","arguments":""}}]},"finish_reason":null}]}`,
 		`data: {"id":"chatcmpl_additional_namespace_custom_stream","object":"chat.completion.chunk","created":1773896263,"model":"model","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"input\":\"pwd\"}"}}]},"finish_reason":"tool_calls"}]}`,
 		`data: [DONE]`,
 	}
@@ -1022,8 +1022,11 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_RestoresAdditiona
 		if got := tc.got.Get(tc.path + ".type").String(); got != "custom_tool_call" {
 			t.Fatalf("%s type = %q, want custom_tool_call", tc.label, got)
 		}
-		if got := tc.got.Get(tc.path + ".name").String(); got != "terminal__exec" {
-			t.Fatalf("%s name = %q, want terminal__exec", tc.label, got)
+		if got := tc.got.Get(tc.path + ".name").String(); got != "exec" {
+			t.Fatalf("%s name = %q, want exec", tc.label, got)
+		}
+		if got := tc.got.Get(tc.path + ".namespace").String(); got != "functions" {
+			t.Fatalf("%s namespace = %q, want functions", tc.label, got)
 		}
 	}
 	if got := inputDone.Get("input").String(); got != "pwd" {
@@ -1044,20 +1047,23 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_Restores
 			"type":"additional_tools",
 			"tools":[{
 				"type":"namespace",
-				"name":"terminal",
+				"name":"functions",
 				"tools":[{"type":"custom","name":"exec"}]
 			}]
 		}]
 	}`)
-	raw := []byte(`{"id":"chatcmpl_additional_namespace_custom_nonstream","object":"chat.completion","created":1773896263,"model":"model","choices":[{"index":0,"message":{"role":"assistant","tool_calls":[{"id":"call_exec","type":"function","function":{"name":"terminal__exec","arguments":"{\"input\":\"pwd\"}"}}]},"finish_reason":"tool_calls"}]}`)
+	raw := []byte(`{"id":"chatcmpl_additional_namespace_custom_nonstream","object":"chat.completion","created":1773896263,"model":"model","choices":[{"index":0,"message":{"role":"assistant","tool_calls":[{"id":"call_exec","type":"function","function":{"name":"functions__exec","arguments":"{\"input\":\"pwd\"}"}}]},"finish_reason":"tool_calls"}]}`)
 
 	resp := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(context.Background(), "model", originalRequest, nil, raw, nil)
 	data := gjson.ParseBytes(resp)
 	if got := data.Get("output.0.type").String(); got != "custom_tool_call" {
 		t.Fatalf("output type = %q, want custom_tool_call; response=%s", got, resp)
 	}
-	if got := data.Get("output.0.name").String(); got != "terminal__exec" {
-		t.Fatalf("output name = %q, want terminal__exec; response=%s", got, resp)
+	if got := data.Get("output.0.name").String(); got != "exec" {
+		t.Fatalf("output name = %q, want exec; response=%s", got, resp)
+	}
+	if got := data.Get("output.0.namespace").String(); got != "functions" {
+		t.Fatalf("output namespace = %q, want functions; response=%s", got, resp)
 	}
 	if got := data.Get("output.0.input").String(); got != "pwd" {
 		t.Fatalf("output input = %q, want pwd; response=%s", got, resp)

--- a/internal/translator/openai/openai/responses/openai_openai-responses_tools.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_tools.go
@@ -3,6 +3,7 @@ package responses
 import (
 	"strings"
 
+	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -321,17 +322,5 @@ func pickRequestJSON(originalRequestRawJSON, requestRawJSON []byte) []byte {
 
 func applyResponsesFunctionCallNamespaceFields(item []byte, requestRawJSON []byte, qualifiedName string, itemPath string) []byte {
 	name, namespace := splitResponsesQualifiedFunctionCallFromRequest(requestRawJSON, qualifiedName)
-	namePath := "name"
-	namespacePath := "namespace"
-	if itemPath != "" {
-		namePath = itemPath + ".name"
-		namespacePath = itemPath + ".namespace"
-	}
-	item, _ = sjson.SetBytes(item, namePath, name)
-	if namespace != "" {
-		item, _ = sjson.SetBytes(item, namespacePath, namespace)
-	} else {
-		item, _ = sjson.DeleteBytes(item, namespacePath)
-	}
-	return item
+	return translatorcommon.SetResponsesToolCallIdentity(item, name, namespace, itemPath)
 }


### PR DESCRIPTION
## Summary

- merge upstream `ecc9aa72` (`v7.2.127`) into the LTS line with a two-parent merge commit
- retain the downstream Responses-to-Chat parallel tool-turn grouping while accepting upstream assistant-content merging
- retain both the LTS Kimi request-local base URL regression and upstream Kimi assistant-content/tool-call regression
- re-audit every downstream patch through the new upstream boundary

## Upstream intake

Previous audited upstream boundary: `2e6b1d83` (`v7.2.125`).

- `direct/full-sync`: DONE finalization, shared custom-tool identity normalization, sequential cutoff summaries, Codex custom tool output IDs, forced xAI web search choice normalization, and malformed Claude OAuth MCP alias recovery
- `adapt-port / protected merge`: `ecc9aa72` assistant-content merging is combined with the existing LTS output-boundary flush and user/developer turn boundary
- `defer`: upstream `dev` commit `45ffd115` remains outside this PR until it reaches upstream `main`
- no downstream patch was retired; the patch ledger records the remaining non-equivalent boundaries

## Validation

- `go test ./...`
- `scripts/check-lts-contract.sh`
- `go run ./scripts/ltsregistry --root .`
- `git diff --check origin/main...HEAD`

No tag, release, deployment, runtime takeover, or persistence change is included.