### PR TITLE
sync: 保护性同步上游 v7.2.130 并保留 LTS 契约

### DIFF
--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -4,7 +4,7 @@ patches:
   - id: codex-model-fallback
     reason: Codex usage-limit and model-capacity failures need an opt-in ordered model fallback after same-model credentials are exhausted, including a confirmed-usage-cooldown-only global target list when source mappings cannot deliver, while cross-model retries must not replay model-private reasoning signatures or replay a stream after client-visible delivery.
     introduced_in: 0bd5a46fd34dff4711fe5618afe66c93f316897b
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); upstream now drops overlong encrypted reasoning items and reuses normalized Codex payloads, while LTS preserves those request-shaping changes together with its typed configurable cross-model fallback, conservative source/target reasoning-continuity gates, target-model auth reselection, pre-delivery stream safety, and legacy replay migration.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); c845ce15 consolidates Responses WebSocket fallback-turn repair and 522b4de5 improves early SSE termination errors, but neither adds typed cross-model fallback or proves a complete transcript may reset model-private reasoning continuity. LTS adapts the new transactional fallback-turn path while retaining source/target continuity gates, target-model auth reselection, failure rollback and forced replay, pre-delivery stream safety, and legacy replay migration.
     files:
       - config.example.yaml
       - docs/lts/codex-429-resilience.md
@@ -84,7 +84,7 @@ patches:
   - id: codex-rate-limit-continuity
     reason: A fresh Codex session can receive usage_limit_reached while previously successful sessions on the same auth/model are still allowed to finish, so Core needs a bounded observation state instead of immediately suspending the auth/model for every session.
     introduced_in: 6ee281422e460ac7d5db8d69ef3fe6b49560e96a
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); 65fc536e preserves session affinity across priorities, 1674aaf4 shares canonical thinking-family cooldown state, and 8392b180 classifies connection lifecycle errors, but these are only adjacent state/selection changes. Upstream still immediately writes model quota cooldown for every 429 and has no Healthy/FreshBlocked/ConfirmedCooldown phases, established lease plus incumbent evidence, single-canary confirmation, lifecycle invalidation, or continuity generation guard. LTS therefore keeps delayed final-auth publication so fallback and hedge losers cannot become the selected trace or session pin.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); 65fc536e preserves session affinity across priorities, 1674aaf4 shares canonical thinking-family cooldown state, and 8392b180 classifies connection lifecycle errors, but the v7.2.130 stream, proxy, Kimi, Multi-Agent, and header fixes do not add Healthy/FreshBlocked/ConfirmedCooldown phases, established lease plus incumbent evidence, single-canary confirmation, lifecycle invalidation, or a continuity generation guard. LTS keeps delayed final-auth publication so fallback and hedge losers cannot become the selected trace or session pin.
     files:
       - config.example.yaml
       - docs/lts/codex-429-resilience.md
@@ -143,7 +143,7 @@ patches:
   - id: codex-interactions-service-tier-response
     reason: Codex Interactions requests can send priority service, but the shared response translator hardcodes streaming completion metadata to standard and omits the non-streaming tier instead of reporting the effective outbound or upstream tier.
     introduced_in: be649f04a4a66b952d5210c7cdf74e1d90a12b76
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); da087d7f maps Claude Code speed fast to priority requests, but the separate Codex Interactions response translator still does not report the effective service_tier for streaming, non-streaming, and DONE-fallback responses, so router-for-me/CLIProxyAPI#4189 remains only partially relevant.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); da087d7f maps Claude Code speed fast to priority requests, but the v7.2.130 stream and Responses changes still do not make the separate Codex Interactions response translator report effective service_tier for streaming, non-streaming, and DONE-fallback responses, so router-for-me/CLIProxyAPI#4189 remains only partially relevant.
     files:
       - internal/translator/codex/interactions/interactions_codex_response.go
       - internal/translator/codex/interactions/interactions_codex_test.go
@@ -174,7 +174,7 @@ patches:
   - id: plugin-configured-enable-default
     reason: A configured plugin without an explicit enabled field must inherit the enabled plugin subsystem default instead of being silently disabled during YAML parsing or runtime config synthesis.
     introduced_in: f3ff2f889026c6a28dc2d14f602c4fef108a0347
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); the new Home plugin synchronization and auth-revision plumbing do not replace the configured-plugin enable default through YAML parsing and runtime host synthesis; an omitted per-plugin enabled field must still inherit true while the subsystem-level switch remains authoritative.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); the v7.2.130 stream, proxy, translator, and provider fixes do not replace the configured-plugin enable default through YAML parsing and runtime host synthesis; an omitted per-plugin enabled field must still inherit true while the subsystem-level switch remains authoritative.
     files:
       - internal/config/config.go
       - internal/config/plugin_config_test.go
@@ -191,7 +191,7 @@ patches:
   - id: home-plugin-sync-cancellation
     reason: Canceling a dedicated Home plugin-sync request must close its one-command Redis connection so a client-installed two-minute read deadline cannot overwrite an earlier cancellation deadline and stall shutdown or request cleanup.
     introduced_in: 125cd6c244f1c723781680c23e61edaa88aac5ef
-    affected_upstream_range: introduced by b651a1a8fd8ea1a43d061a08b42cef8fa3160179 and still required through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); upstream sets an immediate deadline on cancellation but the Redis client can install its long read deadline afterward, which reproduced as a full two-minute stall on Linux CI.
+    affected_upstream_range: introduced by b651a1a8fd8ea1a43d061a08b42cef8fa3160179 and still required through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); the v7.2.130 changes do not touch Home plugin synchronization or Redis cancellation, and upstream can still install its long read deadline after the immediate cancellation deadline, which reproduced as a full two-minute stall on Linux CI.
     files:
       - internal/home/client.go
       - internal/home/client_test.go
@@ -206,7 +206,7 @@ patches:
   - id: codex-gpt56-ultra-level
     reason: Upstream now publishes and remotely refreshes Codex client metadata with logical Sol/Terra Ultra and Luna max-only, but it still does not provide the CPA-Core-LTS server-side capability overlay, custom-model policy, payload-override-safe wire canonicalization, usage/retry alignment, or HTTP/WebSocket enforcement. CPA-Core-LTS therefore validates the refreshed client catalog as an LTS prerequisite while retaining the downstream runtime patch.
     introduced_in: 6e12fb1dd6d522ca80a02644d286d765d7a649bd
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); upstream PR #4276 provides the revisioned Codex client catalog, while e5ea945e/7fef08ea add the separate API-key model is-compat gate. The newer replay, input-ID, Responses Lite, trace, payload-reuse, and WebSocket changes do not replace the downstream provider lookup/tier overlay, model-aware custom-model behavior, payload-override-safe final reasoning.effort, usage/retry alignment, or HTTP/WebSocket enforcement.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); upstream PR #4276 provides the revisioned Codex client catalog, while e5ea945e/7fef08ea add the separate API-key model is-compat gate. The v7.2.130 replay, session-header, Multi-Agent, and stream changes do not replace the downstream provider lookup/tier overlay, model-aware custom-model behavior, payload-override-safe final reasoning.effort, usage/retry alignment, or HTTP/WebSocket enforcement.
     files:
       - .github/scripts/refresh-model-catalogs.sh
       - .github/workflows/docker-image.yml
@@ -276,7 +276,7 @@ patches:
   - id: codex-client-media-model-visibility
     reason: Codex client catalogs must hide image and video endpoint models in both catalog builders so Codex clients do not list media-only models as normal Responses choices. Upstream v7.2.120 added Grok Imagine Video 1.5 GA to the internal/Home builder and cross-route expectation, but omitted the SDK builder that serves non-Home /v1/models?client_version.
     introduced_in: 650a98891a3ab72b9916e4f130eda66cc059e17e
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); upstream commit abaeb55bb20e9a346cae7002c2ed8af5d82c2790 updates internal/client/codex/models and the server contract test, but not sdk/api/handlers/openai/codex_client_models.go, leaving the GA model visible on the non-Home route.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); upstream commit abaeb55bb20e9a346cae7002c2ed8af5d82c2790 updates internal/client/codex/models and the server contract test, but v7.2.130 still does not update sdk/api/handlers/openai/codex_client_models.go, leaving the GA model visible on the non-Home route.
     files:
       - internal/api/server_test.go
       - internal/client/codex/models/models.go
@@ -290,7 +290,7 @@ patches:
   - id: codex-model-header-provider-snapshot
     reason: Codex model override headers must be resolved from the Codex provider and captured once so the real handshake and connection key cannot disagree or be shadowed by another provider registration.
     introduced_in: 0877a26d333a3be918f5e48aadf0e4d71709ab2f
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); upstream adds raw connection target tracking and c30e60a1 reduces Codex request-body copying, but neither resolves a provider-owned immutable model-header snapshot nor includes its digest and resolved model in reusable WebSocket connection identity.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); f43aad76 preloads more Codex session headers and b08fe3b4 tracks Multi-Agent state on a raw connection, but upstream still lacks a provider-owned immutable model-header snapshot and does not include its digest and resolved model in reusable WebSocket connection identity.
     files:
       - internal/runtime/executor/codex_executor.go
       - internal/runtime/executor/codex_openai_images.go
@@ -311,7 +311,7 @@ patches:
   - id: codex-oauth-client-identity-finalization
     reason: Codex OAuth requests must finalize the official Originator, User-Agent, optional Version floor, and macOS Session_id after model-specific header overrides; otherwise the backend can reject a valid model route with a misleading 404 Model not found response.
     introduced_in: ded0314d23dc38656e2fb02220504bd98373813c
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); input-ID shortening, Responses Lite normalization, replay isolation, and WebSocket target tracking still do not add an equivalent final OAuth client-identity pass shared by HTTP, compact, streaming, WebSocket, and image paths.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); f43aad76 normalizes Session-Id and preloads current Codex headers, but it still does not add an equivalent final OAuth client-identity pass shared by HTTP, compact, streaming, WebSocket, and image paths after model-specific overrides.
     files:
       - config.example.yaml
       - internal/runtime/executor/codex_client_identity.go
@@ -331,7 +331,7 @@ patches:
   - id: codex-client-metadata-privacy
     reason: Current Codex clients transport one canonical x-codex-turn-metadata snapshot plus flat body and direct header compatibility projections. Core must use its stable session before auth selection and rate-limit continuity while preserving explicit execution-session priority; keep off-mode bodies byte-identical, make a body canonical source suppress conflicting direct canonical headers, and project the canonical Session_id over random client fallbacks; keep image conversion from collapsing duplicate metadata carriers or reversing default/override/filter precedence; reject unsafe header projection values; fail closed on unknown startup, SDK builder, and hot-reload config values without losing the last good config; keep projections coherent after credential selection; avoid the legacy identity-confuse partial rewrite on canonical requests; offer explicit workspace passthrough/redact/drop privacy policies; strip Git remote credentials even in passthrough mode; and prevent workspace enrichment or derived identity headers from entering downstream, upstream, deferred-error, or WebSocket request logs.
     introduced_in: dcb424d4a5d666322c641151a3e37fd3b0dcc864
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); c30e60a1, ea8882bf, and 99929209 add no-copy payload/read helpers, which are useful but only adjacent to this privacy contract. Upstream still applies the older prompt-cache and installation identity-confuse rewrite without canonical request detection, has no selectable workspace privacy policy or unconditional Git credential stripping, and records Codex turn metadata without an equivalent workspace-aware log sanitizer. LTS keeps image metadata ambiguity and payload-rule precedence intact while adopting safe no-copy helpers.
+    affected_upstream_range: "through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); f43aad76 usefully normalizes the official session header to Session-Id and preloads current Codex headers, while 2ab25eae removes an unsupported request field. These are compatible wire-shape fixes, not equivalents for canonical metadata authority or privacy: upstream still lacks body/direct-header conflict handling, stable pre-auth continuity, selectable workspace privacy, unconditional Git credential stripping, and workspace-aware log sanitization. LTS adopts the header spelling and unsupported-field removal while retaining canonical projection and privacy behavior."
     files:
       - config.example.yaml
       - internal/api/middleware/request_logging.go
@@ -429,7 +429,7 @@ patches:
   - id: codex-model-not-found-request-scope
     reason: An OpenAI-style 404 with error.type invalid_request_error and error.param model is a request/model routing failure, not evidence of unhealthy Codex credentials; retrying every auth or applying the generic 12-hour model cooldown can suspend the entire model pool.
     introduced_in: ded0314d23dc38656e2fb02220504bd98373813c
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); fe28d582/b148af80 improve unknown-route model errors and c1d69e7b/579f5e30 generalize client-fault handling, but regular Codex execution still does not recognize the OpenAI-style invalid_request_error model 404. The 579f5e30 version of the generic classifier removed this narrower LTS case and failed the listed cooldown regression until the request-scoped classifier was restored, so this is only a partial upstream equivalent and the patch remains required.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); fe28d582/b148af80 improve unknown-route model errors and c1d69e7b/579f5e30 generalize client-fault handling, but v7.2.130 regular Codex execution still does not recognize the OpenAI-style invalid_request_error model 404. The 579f5e30 generic classifier removed this narrower LTS case and failed the listed cooldown regression until restored, so the patch remains required.
     files:
       - sdk/cliproxy/auth/conductor.go
       - sdk/cliproxy/auth/conductor_overrides_test.go
@@ -445,7 +445,7 @@ patches:
   - id: codex-websocket-reader-generation
     reason: Reusable Codex WebSocket sessions need generation ownership so a stale reader or shutdown race cannot deliver to, clear, close, or deadlock a newer request.
     introduced_in: 0877a26d333a3be918f5e48aadf0e4d71709ab2f
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); fbe11607 tracks an active raw connection and target changes, but still lacks executor-side connection generations, atomic reader/request ownership, request-owned cancellation signals, and stale-reader protection across retry, session close, and model-header profile changes.
+    affected_upstream_range: "through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); b08fe3b4 and 133047de add per-connection Multi-Agent optimization state and clear it on namespace conflicts, but upstream still has only raw-connection ownership. LTS integrates that state into its generation-safe connection lifecycle and clears it on replacement, detach, invalidation, and session close while retaining atomic reader/request ownership, request-owned cancellation, retry rebinding, and stale-reader protection."
     files:
       - internal/runtime/executor/codex_websockets_executor.go
       - internal/runtime/executor/codex_websockets_executor_test.go
@@ -469,7 +469,7 @@ patches:
   - id: codex-spark-reasoning-summary-compat
     reason: GPT-5.3-Codex-Spark needs reasoning effort enabled but its upstream rejects reasoning.summary, so Core must remove only that unsupported field after final payload shaping across HTTP and WebSocket transports.
     introduced_in: 37e306f939e8ef363254a49cdc7f924a6ceceff5
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); upstream adds Responses Lite normalization, encrypted reasoning-ID cleanup, conditional payload mutations, and 6710a5af forwards sequential-cutoff reasoning summaries, but still forwards reasoning.summary for gpt-5.3-codex-spark and has no equivalent post-override HTTP/WebSocket sanitization. LTS applies the sanitizer after the optimized model mutation on every transport.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); f43aad76 and 2ab25eae normalize headers and unsupported cache options, while 6710a5af forwards sequential-cutoff summaries, but upstream still forwards reasoning.summary for gpt-5.3-codex-spark and has no equivalent post-override HTTP/WebSocket sanitization. LTS applies the sanitizer after optimized model mutation on every transport.
     files:
       - internal/runtime/executor/codex_executor.go
       - internal/runtime/executor/codex_websockets_executor.go
@@ -493,7 +493,7 @@ patches:
   - id: xai-explicit-tool-choice-none
     reason: xAI request preparation must not grant native x_search when the client declared no tools or a restricted allowlist; explicit tool_choice none must remain intact, an orphaned restriction must fail closed instead of reverting to auto, parallel_tool_calls must be removed when no tools survive, and custom declarations and choices must be canonicalized together before orphan pruning.
     introduced_in: ad7244752d324a5b179c3e30a628acf976fa995c
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); a6825fe9 correctly rewrites an explicitly forced web_search choice into xAI's allowed_tools shape, but it does not change whether native x_search may be injected or expand a restricted allowlist. Upstream still injects x_search without explicit client authorization. LTS preserves only client-declared tools, keeps explicit none, removes parallel_tool_calls when no tools survive, and canonicalizes custom choices before pruning.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); a6825fe9 correctly rewrites an explicitly forced web_search choice into xAI's allowed_tools shape, but the v7.2.130 changes do not alter xAI authorization. Upstream still injects x_search without explicit client authorization; LTS preserves only client-declared tools, explicit none, fail-closed allowlists, and canonicalized choices.
     files:
       - internal/runtime/executor/xai_executor.go
       - internal/runtime/executor/xai_executor_test.go
@@ -511,7 +511,7 @@ patches:
   - id: kimi-claude-delegated-auth-immutability
     reason: Kimi delegates Claude-format requests to the Claude executor, but the selected Auth attributes are shared immutable credential configuration and must not be mutated per request to install the Kimi messages base URL.
     introduced_in: 772915acb699d8c6b6f6d8f9c51c1b4f3a61cf34
-    affected_upstream_range: introduced by 70c4bd78b2bc347bf988f74f2d2d7da85de5aa13 and still required through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); 36936340 canonicalizes K2.7 aliases, 8558f443 identifies Kimi signatures, 2e6b1d83 adds Claude-compatible thinking replay, and ecc9aa72 adds a useful Kimi request-shape regression, but none makes the delegated base URL request-local. Upstream still writes auth.Attributes["base_url"] directly in Execute, ExecuteStream, and CountTokens, which can panic for a nil map, race across concurrent requests, and persist a request-local route into shared auth state.
+    affected_upstream_range: 'introduced by 70c4bd78b2bc347bf988f74f2d2d7da85de5aa13 and still required through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); a2337beb correctly chooses the Kimi source format from the delegated path, but it does not make the selected credential request-local. Upstream still writes auth.Attributes["base_url"] directly in Execute, ExecuteStream, and CountTokens, which can panic for a nil map, race across concurrent requests, and persist a request-local route into shared auth state. LTS absorbs the source-format fix on top of its cloned auth view.'
     files:
       - internal/runtime/executor/kimi_executor.go
       - internal/runtime/executor/kimi_executor_test.go
@@ -524,7 +524,7 @@ patches:
   - id: request-body-panic-tempfile-cleanup
     reason: This historical patch originally closed a panic-path temporary-file leak in error-only request logging. CPA-Core-LTS now removes that request-body tempfile spool entirely, keeps only bounded in-memory request/response/upstream previews, and still requires middleware-owned unwind cleanup so panic and http.ErrAbortHandler paths close the original body and release retained buffers.
     introduced_in: ad7244752d324a5b179c3e30a628acf976fa995c
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); the plugin, replay, trace, translator, and provider changes do not alter request logging; upstream still spools large error-only bodies to temporary files, retains larger deferred upstream bodies, and performs cleanup only from the response finalizer.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); the v7.2.130 stream, WebSocket, translator, proxy, and provider changes do not alter request-log body ownership; upstream still spools large error-only bodies to temporary files, retains larger deferred upstream bodies, and performs cleanup only from the response finalizer.
     files:
       - internal/api/middleware/request_logging.go
       - internal/api/middleware/request_logging_test.go
@@ -546,7 +546,7 @@ patches:
   - id: api-request-body-size-limit
     reason: Public Claude, Gemini, OpenAI, Responses, image, and video JSON handlers previously used unbounded body reads and unbounded zstd expansion, so a small number of concurrent oversized requests could consume container memory before provider routing or normal validation ran.
     introduced_in: b2b593fad3f18bfe700fe5f11d4e88e10bbc7f16
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); the no-copy normalization work in 34364fff/c30e60a1/b7a44152 reduces payload amplification but is not a decoded-body limit. Upstream handlers still use unbounded GetRawData/io.ReadAll behavior and do not enforce the same limit on every decoded Content-Encoding layer.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); the no-copy work in 34364fff/c30e60a1/b7a44152 and the v7.2.130 Responses handler refactor reduce amplification but are not a decoded-body limit. Upstream handlers still use unbounded GetRawData/io.ReadAll behavior and do not enforce the same limit on every decoded Content-Encoding layer.
     files:
       - sdk/api/handlers/request_body.go
       - sdk/api/handlers/request_body_test.go
@@ -568,7 +568,7 @@ patches:
   - id: object-store-auth-path-containment
     reason: Object-store auth persistence must never create, overwrite, upload, delete, or render credential files outside its managed private roots, including traversal, sibling-prefix, absolute-path, pre-existing or dangling symlinks, junctions, initialized-root replacement, check/write path-swap races, and crash-persistent global-temp copies.
     introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); upstream accepts caller-provided absolute auth paths and computes object keys from unchecked filepath.Rel results, so paths outside the mirror can reach local file and remote object operations.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); the v7.2.130 changes do not touch object-store path handling. Upstream still accepts caller-provided absolute auth paths and computes object keys from unchecked filepath.Rel results, so paths outside the mirror can reach local file and remote object operations.
     files:
       - .github/workflows/pr-test-build.yml
       - internal/store/objectstore.go
@@ -614,7 +614,7 @@ patches:
   - id: auth-token-private-file-permissions
     reason: OAuth tokens and service-account credentials must be created with owner-only permissions and must tighten pre-existing wider files before replacing their contents.
     introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); Claude, Codex, Kimi, Vertex, and xAI token writers still use os.Create, which follows umask for new files and preserves wider permissions on existing files.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); the v7.2.130 provider changes do not alter token persistence. Claude, Codex, Kimi, Vertex, and xAI token writers still use os.Create, which follows umask for new files and preserves wider permissions on existing files.
     files:
       - .github/workflows/pr-test-build.yml
       - internal/misc/credential_file.go
@@ -642,7 +642,7 @@ patches:
   - id: auth-store-list-error-propagation
     reason: A damaged or unreadable auth JSON file must fail Store.List instead of silently removing that credential from routing, fallback, and usage attribution while startup reports success.
     introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); upstream now validates credential weights but expects FileTokenStore.List to silently skip an invalid persisted plugin source. LTS instead keeps fail-closed list error propagation so damaged JSON, parser failures, and invalid source weights cannot silently remove credentials from routing and attribution.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); the v7.2.130 changes do not touch FileTokenStore.List. Upstream still expects it to silently skip an invalid persisted plugin source; LTS keeps fail-closed list error propagation so damaged JSON, parser failures, and invalid weights cannot silently remove credentials from routing and attribution.
     files:
       - internal/store/gitstore.go
       - internal/store/gitstore_test.go
@@ -665,7 +665,7 @@ patches:
   - id: auth-store-metadata-hydration
     reason: Initial File, Git, Object, and Postgres store loading must hydrate the same normalized auth prefix, custom headers, and disabled state as watcher synthesis so prefixed model routing and Management auth-file output do not change after a reload event.
     introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); watcher synthesis reads normalized prefix metadata, but initial Store.List paths only apply partial metadata and the Management auth-file response omits Auth.Prefix.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); the request-scoped Management proxy addition does not change auth metadata hydration. Upstream initial Store.List paths still apply partial metadata and the Management auth-file response omits Auth.Prefix.
     files:
       - sdk/cliproxy/auth/metadata_hydrate.go
       - sdk/cliproxy/auth/metadata_hydrate_test.go
@@ -698,7 +698,7 @@ patches:
   - id: panel-release-token-isolation
     reason: Management panel release lookups must authorize only exact HTTPS GitHub release URLs and should use a dedicated panel token while retaining a guarded legacy GitStore fallback.
     introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); upstream decides whether to attach GITSTORE_GIT_TOKEN from the GitStore URL rather than the actual release URL and has no dedicated panel release token.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); the v7.2.130 changes do not touch panel asset retrieval. Upstream still decides whether to attach GITSTORE_GIT_TOKEN from the GitStore URL rather than the actual release URL and has no dedicated panel release token.
     files:
       - .env.example
       - internal/managementasset/updater.go
@@ -715,7 +715,7 @@ patches:
   - id: gemini-unknown-method-not-found
     reason: Gemini-compatible routes must reject unknown RPC method suffixes with a stable 404 invalid_request_error before reading the request body, instead of consuming the body and falling through to generateContent behavior.
     introduced_in: 6b0f185939f914983514d6a5e62378a8d91164e7
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); upstream still dispatches every non-stream and non-count suffix through generateContent and has no method allowlist before body decoding.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); the v7.2.130 changes do not touch Gemini route dispatch. Upstream still sends every non-stream and non-count suffix through generateContent and has no method allowlist before body decoding.
     files:
       - sdk/api/handlers/gemini/gemini_handlers.go
       - sdk/api/handlers/gemini/gemini_handlers_test.go
@@ -728,7 +728,7 @@ patches:
   - id: count-tokens-not-found-no-cooldown
     reason: A provider-specific count_tokens endpoint can be absent even when normal generation works, so its 404 must still record the failed request and publish hooks while remaining request-scoped and allowing another credential to serve the count request.
     introduced_in: 6b0f185939f914983514d6a5e62378a8d91164e7
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); upstream commit 36ed0ca5ce4130efcd7532d86c1386ee11ed0e2d / issue #4410 adds generic endpoint-404 detection, while c1d69e7b/579f5e30 further generalize request-fault handling. These are only partial equivalents: upstream still lacks the LTS count_tokens generic-route-404 versus explicit-model-miss scope, failure publication, and credential-fallback combination. LTS preserves that distinction so genuine model availability errors still cool down.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); 36ed0ca5/issue #4410 and c1d69e7b/579f5e30 remain only partial equivalents. The v7.2.130 changes do not add the LTS count_tokens generic-route-404 versus explicit-model-miss scope, failure publication, and credential-fallback combination, so genuine model availability errors remain distinct.
     files:
       - sdk/cliproxy/auth/conductor.go
       - sdk/cliproxy/auth/conductor_overrides_test.go
@@ -744,7 +744,7 @@ patches:
   - id: management-logs-bounded-response
     reason: Management log reads need a bounded default and maximum response size without breaking Panel and TUI limits or silently skipping legacy after deltas that exceed one page.
     introduced_in: 6b0f185939f914983514d6a5e62378a8d91164e7
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); upstream leaves an omitted limit unbounded and does not clamp oversized limits or provide lossless bounded pagination for legacy after reads.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); 17a479a8 adds an APICall proxy override but does not change log reads. Upstream still leaves an omitted limit unbounded and does not clamp oversized limits or provide lossless bounded pagination for legacy after reads.
     files:
       - internal/api/handlers/management/logs.go
       - internal/api/handlers/management/logs_test.go
@@ -761,7 +761,7 @@ patches:
   - id: transient-eof-cooldown
     reason: Transport EOF and unexpected EOF failures before successful completion indicate a transient upstream path failure and need a bounded 502 cooldown, including stream bootstrap, post-payload accounting, and wsrelay errors that have lost the standard-library sentinel identity.
     introduced_in: 6b0f185939f914983514d6a5e62378a8d91164e7
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); 8392b180 directly conflicts with this LTS contract by classifying EOF/UnexpectedEOF and abnormal WebSocket EOF as connection lifecycle errors that skip credential cooldown; 4b3cc55c correctly adds context cancellation/deadline status mapping but does not resolve that contradiction. LTS intentionally keeps context cancellation and normal closes cooldown-free while preserving transient 502 cooldown for terminal EOF paths; the upstream tests required adaptation rather than patch retirement.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); 522b4de5 improves premature SSE termination emission but does not replace auth cooldown classification, while 8392b180 still conflicts by skipping cooldown for terminal EOF/UnexpectedEOF. LTS keeps context cancellation and normal closes cooldown-free while preserving transient 502 cooldown for terminal EOF paths.
     files:
       - internal/runtime/executor/aistudio_executor.go
       - sdk/cliproxy/auth/conductor.go
@@ -777,7 +777,7 @@ patches:
   - id: expired-availability-pruning
     reason: Expired auth and model cooldown state must be pruned before Management availability is displayed so runtime routing, registry state, scheduler state, and persisted cooldown snapshots converge, while future, zero-deadline, disabled, Cloudflare, and independent auth-level warnings remain intact.
     introduced_in: 6b0f185939f914983514d6a5e62378a8d91164e7
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); upstream has no Management-triggered expired availability pruning and does not reconcile manager, model registry, scheduler, and cooldown-store state while separating independent auth-level warnings from model aggregates.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); 17a479a8 adds an APICall proxy override but no expired-availability pruning. Upstream still does not reconcile manager, model registry, scheduler, and cooldown-store state while separating independent auth-level warnings from model aggregates.
     files:
       - internal/api/handlers/management/auth_files.go
       - internal/api/handlers/management/auth_files_recent_requests_test.go
@@ -798,7 +798,7 @@ patches:
   - id: responses-chat-tool-call-turn-grouping
     reason: Reasoning, assistant text, or omitted assistant-side Responses items interleaved between consecutive function_call/custom_tool_call items must not split one assistant turn into adjacent assistant(tool_calls) messages. Kimi-style strict Chat Completions upstreams reject that shape with HTTP 400 ("assistant message with 'tool_calls' must be followed by tool messages"), permanently blocking affected Codex multi-agent histories routed through those upstreams. The related closed report focused on id pairing while the remaining defect is turn grouping, so LTS keeps the fix as a downstream patch.
     introduced_in: 12b542a201b1f8d083ada591cdb7687a7281b0a8
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); ecc9aa72 usefully preserves preceding assistant content/reasoning by attaching the next buffered tool_calls to that assistant message, but upstream still flushes pending calls on every non-call item and therefore still splits consecutive calls separated by reasoning, assistant text, or ignored assistant-side items. The protected merge combines upstream's assistant-content merge with the LTS output-boundary flush and user/developer turn boundary. 4906ead3 is response-side DONE finalization, 37411842 is custom-tool identity normalization, f1a21a9b/71e87111 are Claude conversion paths, and aff2095a deduplicates tool declarations; none replaces the remaining turn-grouping state machine. PR #3213 groups only bare consecutive function_call items on a pre-17a1f53c base and cannot absorb the interleaved shapes.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); c845ce15 refactors downstream Responses WebSocket transcript repair and 522b4de5 improves terminal streaming errors, but neither changes the Responses-to-Chat request converter. Upstream still splits calls separated by reasoning, assistant text, or ignored assistant-side items, so LTS retains output-boundary grouping and user/developer turn boundaries.
     files:
       - docs/lts/downstream-patches.yaml
       - internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -819,7 +819,7 @@ patches:
   - id: codex-desktop-tool-overlay
     reason: Codex Desktop registers deferred codex_app handlers that are not present in the Direct tool surface sent to third-party Responses models, so those models cannot read or coordinate existing Desktop tasks even though the app already owns the handlers. LTS therefore provides a default-off, fixed-version projection that adds only explicitly configured codex_app children after auth selection, only for provable root Desktop turns on non-GPT models, and preserves the existing provider namespace round trip without executing any app operation inside CPA.
     introduced_in: b052097362ef63bd35329c8b18d73c651078e85d
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); upstream supports namespace flattening and response restoration for OpenAI Chat and xAI, but does not project the missing Codex Desktop codex_app children into eligible third-party Direct requests with the LTS model, UA, root-turn, tool-surface, and configuration gates. The v7.2.116 Home refresh and conductor changes were adapted without replacing the overlay or its GPT/subagent isolation. The v7.2.117 Responses-boundary preparation and multi_agent_version metadata changes do not add any codex_app overlay.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); b08fe3b4 and 133047de improve collaboration namespace continuity but do not project missing codex_app children into eligible third-party Direct requests. LTS still needs its model, UA, root-turn, tool-surface, configuration, GPT, and subagent isolation gates.
     files:
       - config.example.yaml
       - docs/lts/downstream-patches.yaml
@@ -868,7 +868,7 @@ patches:
   - id: codex-multi-agent-plaintext-contract
     reason: Codex Multi-Agent history and message-tool schemas carry plaintext provenance that must not be inferred from an encrypted_content string or an unqualified short tool name. LTS therefore converts agent_message only when every content part is a non-empty string input_text, preserves opaque or mixed history on native Codex and provider paths, and removes only a JSON boolean-true message.encrypted marker from positively identified collaboration, collaboration-optimize, or complete agents namespaces.
     introduced_in: 798ad1854064361461225fe766db9b2f54a7653d
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); e5ea945e/7fef08ea add a useful model-level is-compat gate and wire the rewrite through HTTP, stream, WebSocket, and compact paths, but only partially overlap this contract. The upstream rewrite still treats string encrypted_content as portable without plaintext provenance, discovers message tools by recursive short-name matching across unrelated surfaces, and removes message.encrypted without requiring JSON boolean true. LTS absorbs the model gate while retaining fully proven plaintext, confirmed namespace, boolean-marker, and opaque/mixed-content fail-closed rules.
+    affected_upstream_range: "through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); b08fe3b4 and 133047de preserve the optimized namespace across incremental WebSocket turns and correctly clear that connection state when a request defines the reserved namespace. They improve transport continuity but do not change plaintext provenance: upstream still treats string encrypted_content as portable, recursively matches unrelated short tool names, and removes message.encrypted without requiring JSON boolean true. LTS adapts the new connection-state behavior while retaining proven-plaintext, confirmed-namespace, boolean-marker, and opaque/mixed-content fail-closed rules."
     files:
       - config.example.yaml
       - docs/lts/downstream-patches.yaml
@@ -902,7 +902,7 @@ patches:
   - id: xai-multi-agent-plaintext-provenance
     reason: xAI requires namespace tools to be flattened and cannot consume the Codex message.encrypted schema marker, while the returning Codex client needs encrypted_function_args to distinguish a plaintext Multi-Agent call. LTS therefore records the exact root or additional_tools function declarations whose boolean-true marker was removed, restores namespace and short name first, then adds encrypted_function_args as an empty array only for response calls matching that request provenance across HTTP non-stream, SSE, and WebSocket.
     introduced_in: 23caefe8b2495856c2c8df50b63823846ad6b910
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); upstream xAI handling flattens and restores namespace tools and filters internal X Search traces, but does not derive before/after plaintext provenance from the Multi-Agent schema rewrite or restore encrypted_function_args on HTTP, SSE, and WebSocket responses. The v7.2.120 Grok Shell header update does not provide an equivalent return-path contract.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); b08fe3b4 and 133047de improve Codex WebSocket namespace continuity, not xAI response provenance. Upstream xAI handling still does not derive before/after plaintext provenance from the Multi-Agent schema rewrite or restore encrypted_function_args on HTTP, SSE, and WebSocket responses.
     files:
       - docs/lts/downstream-patches.yaml
       - internal/runtime/executor/xai_executor_execute.go
@@ -926,7 +926,7 @@ patches:
   - id: provider-runtime-state-isolation
     reason: Runtime state belongs to one concrete auth provider generation and must not leak across same-ID provider replacement. Codex transient rate limits must remain distinct from quota exhaustion, non-buffering streams must not fail after delivering visible deltas merely because optional completion reconstruction exceeds its cap, and thinking-suffix cooldown reconciliation must restore only the intended concrete registry IDs without racing a newer success.
     introduced_in: e97ccfb8b41e0874745d807d6c1434bcf572840f
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); 1674aaf4 partially overlaps by canonicalizing thinking-suffix model states, and 8392b180 separates connection lifecycle errors, but the former would collapse LTS suffix-specific state if applied at MarkResult while the latter conflicts with transient EOF cooldown. Upstream still applies the abnormal-reasoning reconstruction cap to non-buffering streams, treats raw Codex rate_limit_error/rate_limit_exceeded 429s as quota, restores canonicalized cooldowns to the wrong concrete registry ID, and inherits health, model, refresh, runtime, and persisted cooldown state across same-ID provider replacement. LTS keeps exact suffix keys plus family-aware reconciliation and the still-unique behavior recovered from closed CPA-Core-LTS PR #192 commits 4c8250c5 and a39fb5ee.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); 522b4de5 improves terminal stream errors but does not isolate provider generations or rate-limit state. Upstream still caps non-buffering reconstruction, treats raw Codex rate_limit_error/rate_limit_exceeded 429s as quota, restores canonicalized cooldowns to the wrong concrete registry ID, and inherits state across same-ID provider replacement; LTS keeps exact suffix keys and generation-aware reconciliation.
     files:
       - docs/lts/downstream-patches.yaml
       - internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
@@ -970,7 +970,7 @@ patches:
   - id: auth-provider-generation-fence
     reason: Auth IDs are stable across watcher refreshes and can be reused after provider replacement or remove-and-register. An execution, stream, token count, request-auth preparation, or credential refresh that started on the previous lifecycle could therefore write quota, health, token, runtime, scheduler, registry, or persisted cooldown state into the replacement auth. LTS assigns a process-local, non-persisted generation to each auth lifecycle, carries it through every managed request path, and accepts writebacks only when both generation and provider still match.
     introduced_in: 7db4a30d3c7b489503873df855146ad911bec117
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); 65fc536e touches session-affinity selection and 01a21b77 introduces a plugin-aware refresh wrapper, but neither carries a per-auth lifecycle generation through execution or rejects stale provider writebacks. Upstream still keys asynchronous result, preparation, and refresh writebacks only by auth ID, accepts persisted cooldown records from a different provider, and allows a stale request to refresh a same-ID replacement provider. This retains the unique lifecycle behavior recovered from closed CPA-Core-LTS PR #192 commit 29851edf plus the LTS count-token, stream, and stale cross-provider refresh coverage.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); the request-scoped proxy, Kimi format, stream, namespace, and header fixes do not carry a per-auth lifecycle generation through execution or reject stale provider writebacks. Upstream still keys asynchronous result, preparation, and refresh writebacks only by auth ID and accepts persisted or refreshed state from a same-ID replacement provider.
     files:
       - docs/lts/downstream-patches.yaml
       - sdk/cliproxy/auth/conductor.go
@@ -1004,7 +1004,7 @@ patches:
   - id: codex-live-bootstrap-accounting-and-egress
     reason: Codex Live bootstrap SDP carries short-lived ICE credentials that must never enter request logs, while every actual bootstrap dispatch still needs zero-token usage attribution and local auth outcome tracking. Live and sideband also require model-scoped OAuth selection for models intentionally absent from the general proxy catalog, confirm/mark/abandon lifecycle coverage, Home retry attempt accounting without duplicate 401 records, in-memory config validation parity, and fail-closed sideband proxy handling.
     introduced_in: 4534eed92ef5cd639b377a17dd56dad2d9e41f70
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); bd34ceca adds useful standard Realtime routes, local client-secret scoping, direct WebSocket relay, call hangup, and principal ownership checks, but its new direct WebSocket and hangup dispatches initially bypassed the LTS uncatalogued-model continuity context, confirm/mark/abandon lifecycle, zero-token usage reporting, and fail-closed proxy dialer contract. The protected merge adapts those new paths to the LTS accounting and auth lifecycle while preserving SDP-safe metadata-only logging, Home retry attempt accounting, in-memory config validation parity, and fail-closed proxy behavior.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); v7.2.130 does not touch the Realtime live client. The bd34ceca direct WebSocket and hangup paths therefore still rely on the LTS adaptation for uncatalogued-model continuity, confirm/mark/abandon lifecycle, zero-token usage reporting, SDP-safe logging, Home retry accounting, config validation parity, and fail-closed proxy behavior.
     files:
       - docs/lts/downstream-patches.yaml
       - internal/client/codex/live/live.go
@@ -1035,7 +1035,7 @@ patches:
   - id: xai-implicit-responses-message-token-accounting
     reason: OpenAI Responses permits message-shaped input items with role/content and no explicit type, and xAI local token estimation must include their content instead of silently undercounting the request.
     introduced_in: 4534eed92ef5cd639b377a17dd56dad2d9e41f70
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); upstream xAI token collection still dispatches only on an explicit input item type and ignores ordinary untyped role/content messages.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); the v7.2.130 changes do not touch xAI token collection, which still dispatches only on an explicit input item type and ignores ordinary untyped role/content messages.
     files:
       - docs/lts/downstream-patches.yaml
       - internal/runtime/executor/xai_executor_test.go
@@ -1049,7 +1049,7 @@ patches:
   - id: xai-websocket-saturated-reader-invalidation
     reason: A terminal xAI WebSocket reader cannot enqueue its error when the active request channel is full; invalidation must cancel the active reader before the terminal sender waits, otherwise the reader and request can deadlock indefinitely.
     introduced_in: 4534eed92ef5cd639b377a17dd56dad2d9e41f70
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); upstream does not cancel the active read lifecycle when invalidating a saturated shared xAI WebSocket connection.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); the Codex Multi-Agent WebSocket changes do not modify xAI reader invalidation. Upstream still does not cancel the active read lifecycle when invalidating a saturated shared xAI WebSocket connection.
     files:
       - docs/lts/downstream-patches.yaml
       - internal/runtime/executor/codex_websockets_session.go
@@ -1064,7 +1064,7 @@ patches:
   - id: xai-model-bad-credentials-auth-normalization
     reason: xAI model-scoped 403 bad-credentials failures normalize the model error to unauthorized, and the auth-level LastError snapshot must use the same code so refresh and availability decisions do not continue treating the credential as an ordinary 403.
     introduced_in: 4534eed92ef5cd639b377a17dd56dad2d9e41f70
-    affected_upstream_range: through 934da2379d6272a704953a02322b666b2a2efa3e (v7.2.129, 2026-08-12); dd67f56f is a partial upstream equivalent that remaps xAI HTTP/WebSocket bad-credentials 403 responses to unauthorized, but upstream still does not guarantee that the auth-level LastError snapshot uses the same normalized code as the model state.
+    affected_upstream_range: through f43aad7637ad813745bf7d341acb5663617570c5 (v7.2.130, 2026-08-12); dd67f56f remains a partial equivalent that remaps xAI HTTP/WebSocket bad-credentials 403 responses, while v7.2.130 still does not guarantee that the auth-level LastError snapshot uses the same normalized code as the model state.
     files:
       - docs/lts/downstream-patches.yaml
       - sdk/cliproxy/auth/conductor_cooldown.go

--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -32,6 +32,7 @@ type apiCallRequest struct {
 	AuthIndexPascal *string           `json:"AuthIndex"`
 	Method          string            `json:"method"`
 	URL             string            `json:"url"`
+	ProxyURL        string            `json:"proxy_url"`
 	Header          map[string]string `json:"header"`
 	Data            string            `json:"data"`
 }
@@ -62,6 +63,8 @@ type apiCallResponse struct {
 //     If omitted or not found, credential-specific proxy/token substitution is skipped.
 //   - method (required): HTTP method, e.g. GET, POST, PUT, PATCH, DELETE.
 //   - url (required): Absolute URL including scheme and host, e.g. "https://api.example.com/v1/ping".
+//   - proxy_url (optional): Proxy used for this request. Supports HTTP, HTTPS, SOCKS5, SOCKS5H,
+//     and "direct"/"none" to explicitly bypass proxies. When set, credential and global proxies are ignored.
 //   - header (optional): Request headers map.
 //     Supports magic variable "$TOKEN$" which is replaced using the selected credential:
 //     1) metadata.access_token
@@ -72,9 +75,10 @@ type apiCallResponse struct {
 //   - data (optional): Raw request body as string (useful for POST/PUT/PATCH).
 //
 // Proxy selection (highest priority first):
-//  1. Selected credential proxy_url
-//  2. Global config proxy-url
-//  3. Direct connect (environment proxies are not used)
+//  1. Request proxy_url (when set, lower-priority proxy settings are ignored)
+//  2. Selected credential proxy_url
+//  3. Global config proxy-url
+//  4. Direct connect (environment proxies are not used)
 //
 // Response JSON (returned with HTTP 200 when the APICall itself succeeds):
 //   - status_code: Upstream HTTP status code.
@@ -116,6 +120,14 @@ func (h *Handler) APICall(c *gin.Context) {
 		return
 	}
 
+	requestProxyURL := strings.TrimSpace(body.ProxyURL)
+	if requestProxyURL != "" {
+		if _, errParseProxy := proxyutil.Parse(requestProxyURL); errParseProxy != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid proxy_url"})
+			return
+		}
+	}
+
 	authIndex := firstNonEmptyString(body.AuthIndexSnake, body.AuthIndexCamel, body.AuthIndexPascal)
 	auth := h.authByIndex(authIndex)
 
@@ -133,7 +145,7 @@ func (h *Handler) APICall(c *gin.Context) {
 			continue
 		}
 		if !tokenResolved {
-			token, tokenErr = h.resolveTokenForAuth(c.Request.Context(), auth)
+			token, tokenErr = h.resolveTokenForAuth(c.Request.Context(), auth, requestProxyURL)
 			tokenResolved = true
 		}
 		if auth != nil && token == "" {
@@ -175,7 +187,7 @@ func (h *Handler) APICall(c *gin.Context) {
 	httpClient := &http.Client{
 		Timeout: defaultAPICallTimeout,
 	}
-	httpClient.Transport = h.apiCallTransport(auth)
+	httpClient.Transport = h.apiCallTransport(auth, requestProxyURL)
 
 	resp, errDo := httpClient.Do(req)
 	if errDo != nil {
@@ -229,20 +241,20 @@ func tokenValueForAuth(auth *coreauth.Auth) string {
 	return ""
 }
 
-func (h *Handler) resolveTokenForAuth(ctx context.Context, auth *coreauth.Auth) (string, error) {
+func (h *Handler) resolveTokenForAuth(ctx context.Context, auth *coreauth.Auth, requestProxyURL string) (string, error) {
 	if auth == nil {
 		return "", nil
 	}
 
 	if strings.EqualFold(strings.TrimSpace(auth.Provider), "antigravity") {
-		token, errToken := h.refreshAntigravityOAuthAccessToken(ctx, auth)
+		token, errToken := h.refreshAntigravityOAuthAccessToken(ctx, auth, requestProxyURL)
 		return token, errToken
 	}
 
 	return tokenValueForAuth(auth), nil
 }
 
-func (h *Handler) refreshAntigravityOAuthAccessToken(ctx context.Context, auth *coreauth.Auth) (string, error) {
+func (h *Handler) refreshAntigravityOAuthAccessToken(ctx context.Context, auth *coreauth.Auth, requestProxyURL string) (string, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -283,7 +295,7 @@ func (h *Handler) refreshAntigravityOAuthAccessToken(ctx context.Context, auth *
 
 	httpClient := &http.Client{
 		Timeout:   defaultAPICallTimeout,
-		Transport: h.apiCallTransport(auth),
+		Transport: h.apiCallTransport(auth, requestProxyURL),
 	}
 	resp, errDo := httpClient.Do(req)
 	if errDo != nil {
@@ -469,7 +481,14 @@ func (h *Handler) authByIndex(authIndex string) *coreauth.Auth {
 	return nil
 }
 
-func (h *Handler) apiCallTransport(auth *coreauth.Auth) http.RoundTripper {
+func (h *Handler) apiCallTransport(auth *coreauth.Auth, requestProxyURL string) http.RoundTripper {
+	if proxyStr := strings.TrimSpace(requestProxyURL); proxyStr != "" {
+		if transport := buildProxyTransport(proxyStr); transport != nil {
+			return transport
+		}
+		return directAPICallTransport()
+	}
+
 	var proxyCandidates []string
 	if auth != nil {
 		if proxyStr := strings.TrimSpace(auth.ProxyURL); proxyStr != "" {
@@ -493,6 +512,10 @@ func (h *Handler) apiCallTransport(auth *coreauth.Auth) http.RoundTripper {
 		}
 	}
 
+	return directAPICallTransport()
+}
+
+func directAPICallTransport() http.RoundTripper {
 	transport, ok := http.DefaultTransport.(*http.Transport)
 	if !ok || transport == nil {
 		return &http.Transport{Proxy: nil}

--- a/internal/api/handlers/management/api_tools.go
+++ b/internal/api/handlers/management/api_tools.go
@@ -32,6 +32,7 @@ type apiCallRequest struct {
 	AuthIndexPascal *string           `json:"AuthIndex"`
 	Method          string            `json:"method"`
 	URL             string            `json:"url"`
+	ProxyURL        string            `json:"proxy_url"`
 	Header          map[string]string `json:"header"`
 	Data            string            `json:"data"`
 }
@@ -62,6 +63,8 @@ type apiCallResponse struct {
 //     If omitted or not found, credential-specific proxy/token substitution is skipped.
 //   - method (required): HTTP method, e.g. GET, POST, PUT, PATCH, DELETE.
 //   - url (required): Absolute URL including scheme and host, e.g. "https://api.example.com/v1/ping".
+//   - proxy_url (optional): Proxy used for this request. Supports HTTP, HTTPS, SOCKS5, SOCKS5H,
+//     and "direct"/"none" to explicitly bypass proxies. When set, credential and global proxies are ignored.
 //   - header (optional): Request headers map.
 //     Supports magic variable "$TOKEN$" which is replaced using the selected credential:
 //     1) metadata.access_token
@@ -72,9 +75,10 @@ type apiCallResponse struct {
 //   - data (optional): Raw request body as string (useful for POST/PUT/PATCH).
 //
 // Proxy selection (highest priority first):
-//  1. Selected credential proxy_url
-//  2. Global config proxy-url
-//  3. Direct connect (environment proxies are not used)
+//  1. Request proxy_url (when set, lower-priority proxy settings are ignored)
+//  2. Selected credential proxy_url
+//  3. Global config proxy-url
+//  4. Direct connect (environment proxies are not used)
 //
 // Response JSON (returned with HTTP 200 when the APICall itself succeeds):
 //   - status_code: Upstream HTTP status code.
@@ -116,6 +120,14 @@ func (h *Handler) APICall(c *gin.Context) {
 		return
 	}
 
+	requestProxyURL := strings.TrimSpace(body.ProxyURL)
+	if requestProxyURL != "" {
+		if _, errParseProxy := proxyutil.Parse(requestProxyURL); errParseProxy != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid proxy_url"})
+			return
+		}
+	}
+
 	authIndex := firstNonEmptyString(body.AuthIndexSnake, body.AuthIndexCamel, body.AuthIndexPascal)
 	auth := h.authByIndex(authIndex)
 
@@ -133,7 +145,7 @@ func (h *Handler) APICall(c *gin.Context) {
 			continue
 		}
 		if !tokenResolved {
-			token, tokenErr = h.resolveTokenForAuth(c.Request.Context(), auth)
+			token, tokenErr = h.resolveTokenForAuth(c.Request.Context(), auth, requestProxyURL)
 			tokenResolved = true
 		}
 		if auth != nil && token == "" {
@@ -175,7 +187,7 @@ func (h *Handler) APICall(c *gin.Context) {
 	httpClient := &http.Client{
 		Timeout: defaultAPICallTimeout,
 	}
-	httpClient.Transport = h.apiCallTransport(auth)
+	httpClient.Transport = h.apiCallTransport(auth, requestProxyURL)
 
 	resp, errDo := httpClient.Do(req)
 	if errDo != nil {
@@ -265,20 +277,20 @@ func tokenValueForAuth(auth *coreauth.Auth) string {
 	return ""
 }
 
-func (h *Handler) resolveTokenForAuth(ctx context.Context, auth *coreauth.Auth) (string, error) {
+func (h *Handler) resolveTokenForAuth(ctx context.Context, auth *coreauth.Auth, requestProxyURL string) (string, error) {
 	if auth == nil {
 		return "", nil
 	}
 
 	if strings.EqualFold(strings.TrimSpace(auth.Provider), "antigravity") {
-		token, errToken := h.refreshAntigravityOAuthAccessToken(ctx, auth)
+		token, errToken := h.refreshAntigravityOAuthAccessToken(ctx, auth, requestProxyURL)
 		return token, errToken
 	}
 
 	return tokenValueForAuth(auth), nil
 }
 
-func (h *Handler) refreshAntigravityOAuthAccessToken(ctx context.Context, auth *coreauth.Auth) (string, error) {
+func (h *Handler) refreshAntigravityOAuthAccessToken(ctx context.Context, auth *coreauth.Auth, requestProxyURL string) (string, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -319,7 +331,7 @@ func (h *Handler) refreshAntigravityOAuthAccessToken(ctx context.Context, auth *
 
 	httpClient := &http.Client{
 		Timeout:   defaultAPICallTimeout,
-		Transport: h.apiCallTransport(auth),
+		Transport: h.apiCallTransport(auth, requestProxyURL),
 	}
 	resp, errDo := httpClient.Do(req)
 	if errDo != nil {
@@ -505,7 +517,14 @@ func (h *Handler) authByIndex(authIndex string) *coreauth.Auth {
 	return nil
 }
 
-func (h *Handler) apiCallTransport(auth *coreauth.Auth) http.RoundTripper {
+func (h *Handler) apiCallTransport(auth *coreauth.Auth, requestProxyURL string) http.RoundTripper {
+	if proxyStr := strings.TrimSpace(requestProxyURL); proxyStr != "" {
+		if transport := buildProxyTransport(proxyStr); transport != nil {
+			return transport
+		}
+		return directAPICallTransport()
+	}
+
 	var proxyCandidates []string
 	if auth != nil {
 		if proxyStr := strings.TrimSpace(auth.ProxyURL); proxyStr != "" {
@@ -529,6 +548,10 @@ func (h *Handler) apiCallTransport(auth *coreauth.Auth) http.RoundTripper {
 		}
 	}
 
+	return directAPICallTransport()
+}
+
+func directAPICallTransport() http.RoundTripper {
 	transport, ok := http.DefaultTransport.(*http.Transport)
 	if !ok || transport == nil {
 		return &http.Transport{Proxy: nil}

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -2,13 +2,56 @@ package management
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 )
+
+func TestAPICallUsesRequestProxyURL(t *testing.T) {
+	t.Parallel()
+
+	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("proxied"))
+	}))
+	defer proxyServer.Close()
+
+	h := &Handler{
+		cfg: &config.Config{
+			SDKConfig: sdkconfig.SDKConfig{ProxyURL: "http://127.0.0.1:1"},
+		},
+	}
+	router := gin.New()
+	router.POST("/", h.APICall)
+
+	body := `{"method":"GET","url":"http://upstream.invalid/test","proxy_url":"` + proxyServer.URL + `"}`
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want %d; body = %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+
+	var response apiCallResponse
+	if errDecode := json.NewDecoder(recorder.Body).Decode(&response); errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	if response.StatusCode != http.StatusCreated {
+		t.Fatalf("upstream status code = %d, want %d", response.StatusCode, http.StatusCreated)
+	}
+	if response.Body != "proxied" {
+		t.Fatalf("upstream body = %q, want %q", response.Body, "proxied")
+	}
+}
 
 func TestAPICallTransportDirectBypassesGlobalProxy(t *testing.T) {
 	t.Parallel()
@@ -19,7 +62,7 @@ func TestAPICallTransportDirectBypassesGlobalProxy(t *testing.T) {
 		},
 	}
 
-	transport := h.apiCallTransport(&coreauth.Auth{ProxyURL: "direct"})
+	transport := h.apiCallTransport(&coreauth.Auth{ProxyURL: "direct"}, "")
 	httpTransport, ok := transport.(*http.Transport)
 	if !ok {
 		t.Fatalf("transport type = %T, want *http.Transport", transport)
@@ -38,7 +81,7 @@ func TestAPICallTransportInvalidAuthFallsBackToGlobalProxy(t *testing.T) {
 		},
 	}
 
-	transport := h.apiCallTransport(&coreauth.Auth{ProxyURL: "bad-value"})
+	transport := h.apiCallTransport(&coreauth.Auth{ProxyURL: "bad-value"}, "")
 	httpTransport, ok := transport.(*http.Transport)
 	if !ok {
 		t.Fatalf("transport type = %T, want *http.Transport", transport)
@@ -55,6 +98,56 @@ func TestAPICallTransportInvalidAuthFallsBackToGlobalProxy(t *testing.T) {
 	}
 	if proxyURL == nil || proxyURL.String() != "http://global-proxy.example.com:8080" {
 		t.Fatalf("proxy URL = %v, want http://global-proxy.example.com:8080", proxyURL)
+	}
+}
+
+func TestAPICallTransportRequestProxyOverridesCredentialAndGlobalProxy(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		cfg: &config.Config{
+			SDKConfig: sdkconfig.SDKConfig{ProxyURL: "http://global-proxy.example.com:8080"},
+		},
+	}
+	auth := &coreauth.Auth{ProxyURL: "http://credential-proxy.example.com:8080"}
+
+	transport := h.apiCallTransport(auth, " http://request-proxy.example.com:8080 ")
+	httpTransport, ok := transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", transport)
+	}
+
+	req, errRequest := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	if errRequest != nil {
+		t.Fatalf("http.NewRequest returned error: %v", errRequest)
+	}
+
+	proxyURL, errProxy := httpTransport.Proxy(req)
+	if errProxy != nil {
+		t.Fatalf("httpTransport.Proxy returned error: %v", errProxy)
+	}
+	if proxyURL == nil || proxyURL.String() != "http://request-proxy.example.com:8080" {
+		t.Fatalf("proxy URL = %v, want http://request-proxy.example.com:8080", proxyURL)
+	}
+}
+
+func TestAPICallTransportInvalidRequestProxyDoesNotFallBack(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		cfg: &config.Config{
+			SDKConfig: sdkconfig.SDKConfig{ProxyURL: "http://global-proxy.example.com:8080"},
+		},
+	}
+	auth := &coreauth.Auth{ProxyURL: "http://credential-proxy.example.com:8080"}
+
+	transport := h.apiCallTransport(auth, "bad-value")
+	httpTransport, ok := transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", transport)
+	}
+	if httpTransport.Proxy != nil {
+		t.Fatal("expected invalid request proxy to avoid lower-priority proxy settings")
 	}
 }
 
@@ -147,7 +240,7 @@ func TestAPICallTransportAPIKeyAuthFallsBackToConfigProxyURL(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			transport := h.apiCallTransport(tc.auth)
+			transport := h.apiCallTransport(tc.auth, "")
 			httpTransport, ok := transport.(*http.Transport)
 			if !ok {
 				t.Fatalf("transport type = %T, want *http.Transport", transport)

--- a/internal/api/handlers/management/api_tools_test.go
+++ b/internal/api/handlers/management/api_tools_test.go
@@ -2,14 +2,57 @@ package management
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 )
+
+func TestAPICallUsesRequestProxyURL(t *testing.T) {
+	t.Parallel()
+
+	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("proxied"))
+	}))
+	defer proxyServer.Close()
+
+	h := &Handler{
+		cfg: &config.Config{
+			SDKConfig: sdkconfig.SDKConfig{ProxyURL: "http://127.0.0.1:1"},
+		},
+	}
+	router := gin.New()
+	router.POST("/", h.APICall)
+
+	body := `{"method":"GET","url":"http://upstream.invalid/test","proxy_url":"` + proxyServer.URL + `"}`
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want %d; body = %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+
+	var response apiCallResponse
+	if errDecode := json.NewDecoder(recorder.Body).Decode(&response); errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	if response.StatusCode != http.StatusCreated {
+		t.Fatalf("upstream status code = %d, want %d", response.StatusCode, http.StatusCreated)
+	}
+	if response.Body != "proxied" {
+		t.Fatalf("upstream body = %q, want %q", response.Body, "proxied")
+	}
+}
 
 func TestAPICallTransportDirectBypassesGlobalProxy(t *testing.T) {
 	t.Parallel()
@@ -20,7 +63,7 @@ func TestAPICallTransportDirectBypassesGlobalProxy(t *testing.T) {
 		},
 	}
 
-	transport := h.apiCallTransport(&coreauth.Auth{ProxyURL: "direct"})
+	transport := h.apiCallTransport(&coreauth.Auth{ProxyURL: "direct"}, "")
 	httpTransport, ok := transport.(*http.Transport)
 	if !ok {
 		t.Fatalf("transport type = %T, want *http.Transport", transport)
@@ -39,7 +82,7 @@ func TestAPICallTransportInvalidAuthFallsBackToGlobalProxy(t *testing.T) {
 		},
 	}
 
-	transport := h.apiCallTransport(&coreauth.Auth{ProxyURL: "bad-value"})
+	transport := h.apiCallTransport(&coreauth.Auth{ProxyURL: "bad-value"}, "")
 	httpTransport, ok := transport.(*http.Transport)
 	if !ok {
 		t.Fatalf("transport type = %T, want *http.Transport", transport)
@@ -56,6 +99,56 @@ func TestAPICallTransportInvalidAuthFallsBackToGlobalProxy(t *testing.T) {
 	}
 	if proxyURL == nil || proxyURL.String() != "http://global-proxy.example.com:8080" {
 		t.Fatalf("proxy URL = %v, want http://global-proxy.example.com:8080", proxyURL)
+	}
+}
+
+func TestAPICallTransportRequestProxyOverridesCredentialAndGlobalProxy(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		cfg: &config.Config{
+			SDKConfig: sdkconfig.SDKConfig{ProxyURL: "http://global-proxy.example.com:8080"},
+		},
+	}
+	auth := &coreauth.Auth{ProxyURL: "http://credential-proxy.example.com:8080"}
+
+	transport := h.apiCallTransport(auth, " http://request-proxy.example.com:8080 ")
+	httpTransport, ok := transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", transport)
+	}
+
+	req, errRequest := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	if errRequest != nil {
+		t.Fatalf("http.NewRequest returned error: %v", errRequest)
+	}
+
+	proxyURL, errProxy := httpTransport.Proxy(req)
+	if errProxy != nil {
+		t.Fatalf("httpTransport.Proxy returned error: %v", errProxy)
+	}
+	if proxyURL == nil || proxyURL.String() != "http://request-proxy.example.com:8080" {
+		t.Fatalf("proxy URL = %v, want http://request-proxy.example.com:8080", proxyURL)
+	}
+}
+
+func TestAPICallTransportInvalidRequestProxyDoesNotFallBack(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		cfg: &config.Config{
+			SDKConfig: sdkconfig.SDKConfig{ProxyURL: "http://global-proxy.example.com:8080"},
+		},
+	}
+	auth := &coreauth.Auth{ProxyURL: "http://credential-proxy.example.com:8080"}
+
+	transport := h.apiCallTransport(auth, "bad-value")
+	httpTransport, ok := transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", transport)
+	}
+	if httpTransport.Proxy != nil {
+		t.Fatal("expected invalid request proxy to avoid lower-priority proxy settings")
 	}
 }
 
@@ -148,7 +241,7 @@ func TestAPICallTransportAPIKeyAuthFallsBackToConfigProxyURL(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			transport := h.apiCallTransport(tc.auth)
+			transport := h.apiCallTransport(tc.auth, "")
 			httpTransport, ok := transport.(*http.Transport)
 			if !ok {
 				t.Fatalf("transport type = %T, want *http.Transport", transport)

--- a/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2.go
+++ b/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2.go
@@ -482,6 +482,12 @@ func rewriteCodexSpawnAgentTools(payload []byte, toolPaths []string, models []co
 	return updated
 }
 
+// HasCodexMultiAgentV2NamespaceConflict reports whether the request defines
+// the reserved optimized namespace, which must remain untouched.
+func HasCodexMultiAgentV2NamespaceConflict(payload []byte) bool {
+	return hasCodexOptimizedCollaborationConflict(payload)
+}
+
 func hasCodexOptimizedCollaborationConflict(payload []byte) bool {
 	if codexToolsHaveOptimizedCollaborationConflict(gjson.GetBytes(payload, "tools")) {
 		return true

--- a/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2.go
+++ b/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2.go
@@ -496,6 +496,12 @@ func rewriteCodexSpawnAgentTools(payload []byte, toolPaths []string, models []co
 	return updated
 }
 
+// HasCodexMultiAgentV2NamespaceConflict reports whether the request defines
+// the reserved optimized namespace, which must remain untouched.
+func HasCodexMultiAgentV2NamespaceConflict(payload []byte) bool {
+	return hasCodexOptimizedCollaborationConflict(payload)
+}
+
 func hasCodexOptimizedCollaborationConflict(payload []byte) bool {
 	if codexToolsHaveOptimizedCollaborationConflict(gjson.GetBytes(payload, "tools")) {
 		return true

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -1586,6 +1586,13 @@ func (resolver claudeMCPAliasResolver) resolve(name string) (string, bool, error
 		return "", false, nil
 	}
 
+	repeatedServerPrefix := "mcp__" + server + "__" + server + "__"
+	if suffix, repeatedServer := strings.CutPrefix(name, repeatedServerPrefix); repeatedServer {
+		if original, exact := resolver.exact["mcp__"+server+"__"+suffix]; exact {
+			return original, true, nil
+		}
+	}
+
 	matchedOriginal := ""
 	matchCount := 0
 	for _, entry := range resolver.aliases {

--- a/internal/runtime/executor/claude_executor_request_remap_test.go
+++ b/internal/runtime/executor/claude_executor_request_remap_test.go
@@ -163,6 +163,21 @@ func TestReverseRemapOAuthToolNamesRecoversMangledAliases(t *testing.T) {
 	}
 }
 
+func TestReverseRemapOAuthToolNamesRecoversRepeatedServerAlias(t *testing.T) {
+	const alias = "mcp__hmzqrngkulqv__xuo7jlxlpzee_Bash"
+	reverseMap := map[string]string{alias: "Bash"}
+	responseAlias := "mcp__hmzqrngkulqv__hmzqrngkulqv__xuo7jlxlpzee_Bash"
+	response := []byte(fmt.Sprintf(`{"content":[{"type":"tool_use","id":"toolu_1","name":%q,"input":{}}]}`, responseAlias))
+
+	restored, errReverse := reverseRemapOAuthToolNames(response, reverseMap)
+	if errReverse != nil {
+		t.Fatalf("reverseRemapOAuthToolNames() error = %v", errReverse)
+	}
+	if got := gjson.GetBytes(restored, "content.0.name").String(); got != "Bash" {
+		t.Fatalf("repeated server alias restored to %q, want Bash", got)
+	}
+}
+
 func TestReverseRemapOAuthToolNamesRejectsUnsafeMangledAliases(t *testing.T) {
 	body := []byte(`{"tools":[{"name":"tool.name"},{"name":"tool/name"}]}`)
 	remapped, reverseMap := remapOAuthToolNamesWithOptions(body, claudeMCPAliasOptions{secret: "ambiguous-alias-caller"})

--- a/internal/runtime/executor/codex_client_identity.go
+++ b/internal/runtime/executor/codex_client_identity.go
@@ -63,7 +63,7 @@ func finalizeCodexClientIdentityHeaders(headers http.Header, auth *cliproxyauth.
 	headers.Set("User-Agent", userAgent)
 	alignCodexClientVersion(headers, userAgent)
 	if strings.Contains(userAgent, "Mac OS") && codexSessionHeaderValue(headers) == "" {
-		headers.Set("Session_id", uuid.NewString())
+		headers.Set("Session-Id", uuid.NewString())
 	}
 }
 

--- a/internal/runtime/executor/codex_client_metadata.go
+++ b/internal/runtime/executor/codex_client_metadata.go
@@ -78,7 +78,7 @@ func applyCodexOutboundMetadataHeaders(headers http.Header, state *codexIdentity
 		}
 		state.clientMetadata.ApplyHeaders(headers)
 		if state.clientMetadata.HasSessionID {
-			setCodexSessionHeaderCasePreserved(headers, "Session_id", state.clientMetadata.SessionID)
+			setCodexSessionHeaderCasePreserved(headers, "Session-Id", state.clientMetadata.SessionID)
 		}
 		return
 	}

--- a/internal/runtime/executor/codex_executor_cache_lts_test.go
+++ b/internal/runtime/executor/codex_executor_cache_lts_test.go
@@ -38,8 +38,8 @@ func TestCodexExecutorCacheHelper_OpenAIChatCompletions_PreservesExplicitPromptC
 	if got := gjson.GetBytes(body, "prompt_cache_key").String(); got != "tenant:explicit" {
 		t.Fatalf("prompt_cache_key = %q, want explicit client key; body=%s", got, body)
 	}
-	if got := httpReq.Header["Session_id"]; len(got) != 1 || got[0] != "tenant:explicit" {
-		t.Fatalf("Session_id = %#v, want [tenant:explicit]", got)
+	if got := codexSessionHeaderValue(httpReq.Header); got != "tenant:explicit" {
+		t.Fatalf("Session-Id = %q, want tenant:explicit", got)
 	}
 }
 

--- a/internal/runtime/executor/codex_executor_cache_test.go
+++ b/internal/runtime/executor/codex_executor_cache_test.go
@@ -49,11 +49,11 @@ func TestCodexExecutorCacheHelper_OpenAIChatCompletions_StablePromptCacheKeyFrom
 	if gotConversation := httpReq.Header.Get("Conversation_id"); gotConversation != "" {
 		t.Fatalf("Conversation_id = %q, want empty", gotConversation)
 	}
-	if gotSession := httpReq.Header["Session_id"]; len(gotSession) != 1 || gotSession[0] != expectedKey {
-		t.Fatalf("Session_id = %#v, want [%q]", gotSession, expectedKey)
+	if gotSession := httpReq.Header["Session-Id"]; len(gotSession) != 1 || gotSession[0] != expectedKey {
+		t.Fatalf("Session-Id = %#v, want [%q]", gotSession, expectedKey)
 	}
-	if gotCanonicalSession := httpReq.Header.Get("Session-Id"); gotCanonicalSession != "" {
-		t.Fatalf("Session-Id = %q, want empty", gotCanonicalSession)
+	if gotLegacySession := httpReq.Header.Get("Session_id"); gotLegacySession != "" {
+		t.Fatalf("Session_id = %q, want empty", gotLegacySession)
 	}
 
 	httpReq2, _, _, err := executor.cacheHelper(ctx, sdktranslator.FromString("openai"), url, nil, req, req.Payload, rawJSON)
@@ -88,8 +88,8 @@ func TestCodexExecutorCacheHelper_UsesDerivedSessionUUID(t *testing.T) {
 	if got := gjson.GetBytes(body, "prompt_cache_key").String(); got != expectedKey {
 		t.Fatalf("prompt_cache_key = %q, want %q", got, expectedKey)
 	}
-	if got := httpReq.Header.Get("Session_id"); got != expectedKey {
-		t.Fatalf("Session_id = %q, want %q", got, expectedKey)
+	if got := httpReq.Header.Get("Session-Id"); got != expectedKey {
+		t.Fatalf("Session-Id = %q, want %q", got, expectedKey)
 	}
 	if _, errParse := uuid.Parse(expectedKey); errParse != nil {
 		t.Fatalf("derived prompt cache key %q is not a UUID: %v", expectedKey, errParse)
@@ -143,11 +143,11 @@ func TestCodexExecutorCacheHelper_ClaudeUsesClaudeCodeSessionID(t *testing.T) {
 	if secondKey != firstKey {
 		t.Fatalf("same Claude Code session_id produced different prompt_cache_key: first=%q second=%q", firstKey, secondKey)
 	}
-	if gotSession := firstHTTPReq.Header["Session_id"]; len(gotSession) != 1 || gotSession[0] != firstKey {
-		t.Fatalf("first Session_id = %#v, want [%q]", gotSession, firstKey)
+	if gotSession := firstHTTPReq.Header["Session-Id"]; len(gotSession) != 1 || gotSession[0] != firstKey {
+		t.Fatalf("first Session-Id = %#v, want [%q]", gotSession, firstKey)
 	}
-	if gotSession := secondHTTPReq.Header["Session_id"]; len(gotSession) != 1 || gotSession[0] != firstKey {
-		t.Fatalf("second Session_id = %#v, want [%q]", gotSession, firstKey)
+	if gotSession := secondHTTPReq.Header["Session-Id"]; len(gotSession) != 1 || gotSession[0] != firstKey {
+		t.Fatalf("second Session-Id = %#v, want [%q]", gotSession, firstKey)
 	}
 }
 
@@ -170,11 +170,11 @@ func TestCodexExecutorCacheHelper_ClaudeRejectsBareUserID(t *testing.T) {
 	if got := gjson.GetBytes(body, "prompt_cache_key").String(); got != "" {
 		t.Fatalf("bare metadata.user_id must not create prompt_cache_key, got %q; body=%s", got, string(body))
 	}
-	if got := httpReq.Header["Session_id"]; len(got) != 0 {
-		t.Fatalf("bare metadata.user_id must not create Session_id, got %#v", got)
+	if got := httpReq.Header["Session-Id"]; len(got) != 0 {
+		t.Fatalf("bare metadata.user_id must not create Session-Id, got %#v", got)
 	}
-	if got := httpReq.Header.Get("Session-Id"); got != "" {
-		t.Fatalf("bare metadata.user_id must not create Session-Id, got %q", got)
+	if got := httpReq.Header.Get("Session_id"); got != "" {
+		t.Fatalf("bare metadata.user_id must not create Session_id, got %q", got)
 	}
 }
 
@@ -227,16 +227,16 @@ func TestCodexExecutorCacheHelper_IdentityConfuseRemapsBodyAndHeaders(t *testing
 	if gotWindowID := gjson.GetBytes(body, "client_metadata.x-codex-window-id").String(); gotWindowID != expectedPromptCacheKey+":0" {
 		t.Fatalf("client_metadata.x-codex-window-id = %q, want %q", gotWindowID, expectedPromptCacheKey+":0")
 	}
-	if gotHeader := httpReq.Header["Session_id"]; len(gotHeader) != 1 || gotHeader[0] != expectedPromptCacheKey {
-		t.Fatalf("Session_id = %#v, want [%q]", gotHeader, expectedPromptCacheKey)
+	if gotHeader := httpReq.Header["Session-Id"]; len(gotHeader) != 1 || gotHeader[0] != expectedPromptCacheKey {
+		t.Fatalf("Session-Id = %#v, want [%q]", gotHeader, expectedPromptCacheKey)
 	}
 	for _, headerName := range []string{"X-Client-Request-Id", "Thread-Id"} {
 		if gotHeader := httpReq.Header.Get(headerName); gotHeader != expectedPromptCacheKey {
 			t.Fatalf("%s = %q, want %q", headerName, gotHeader, expectedPromptCacheKey)
 		}
 	}
-	if gotCanonicalSession := httpReq.Header.Get("Session-Id"); gotCanonicalSession != "" {
-		t.Fatalf("Session-Id = %q, want empty", gotCanonicalSession)
+	if gotLegacySession := httpReq.Header.Get("Session_id"); gotLegacySession != "" {
+		t.Fatalf("Session_id = %q, want empty", gotLegacySession)
 	}
 	if gotWindow := httpReq.Header.Get("X-Codex-Window-Id"); gotWindow != expectedPromptCacheKey+":0" {
 		t.Fatalf("X-Codex-Window-Id = %q, want %q", gotWindow, expectedPromptCacheKey+":0")

--- a/internal/runtime/executor/codex_executor_request.go
+++ b/internal/runtime/executor/codex_executor_request.go
@@ -149,7 +149,7 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 		return nil, nil, codexIdentityConfuseState{}, err
 	}
 	if cache.ID != "" {
-		httpReq.Header.Set("Session_id", cache.ID)
+		httpReq.Header.Set("Session-Id", cache.ID)
 	}
 	return httpReq, rawJSON, identityState, nil
 }
@@ -195,7 +195,7 @@ func applyCodexIdentityConfuseHeaders(headers http.Header, state *codexIdentityC
 		return
 	}
 
-	setCodexSessionHeaderCasePreserved(headers, "Session_id", state.promptCacheKey)
+	setCodexSessionHeaderCasePreserved(headers, "Session-Id", state.promptCacheKey)
 	if headerValueCaseInsensitive(headers, "Conversation_id") != "" {
 		setHeaderCasePreserved(headers, "Conversation_id", state.promptCacheKey)
 	}
@@ -322,12 +322,13 @@ func applyCodexHeadersFromSources(r *http.Request, auth *cliproxyauth.Auth, toke
 	misc.EnsureHeader(r.Header, ginHeaders, "Version", "")
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Codex-Turn-Metadata", "")
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Client-Request-Id", "")
+	misc.EnsureHeader(r.Header, ginHeaders, "X-Codex-Window-Id", "")
+	misc.EnsureHeader(r.Header, ginHeaders, "Thread-Id", "")
+	misc.EnsureHeader(r.Header, ginHeaders, "Session-Id", "")
+	misc.EnsureHeader(r.Header, ginHeaders, "X-Openai-Internal-Codex-Responses-Lite", "")
+
 	cfgUserAgent, _ := codexHeaderDefaults(cfg, auth)
 	ensureHeaderWithConfigPrecedence(r.Header, ginHeaders, "User-Agent", cfgUserAgent, codexUserAgent)
-
-	if strings.Contains(r.Header.Get("User-Agent"), "Mac OS") {
-		misc.EnsureHeader(r.Header, ginHeaders, "Session_id", uuid.NewString())
-	}
 
 	if stream {
 		r.Header.Set("Accept", "text/event-stream")

--- a/internal/runtime/executor/codex_executor_request.go
+++ b/internal/runtime/executor/codex_executor_request.go
@@ -305,7 +305,7 @@ func applyModelHeaderOverrides(headers http.Header, profile codexModelHeaderProf
 		headers.Set(key, value)
 	}
 	if strings.Contains(headers.Get("User-Agent"), "Mac OS") && codexSessionHeaderValue(headers) == "" {
-		headers.Set("Session_id", uuid.NewString())
+		headers.Set("Session-Id", uuid.NewString())
 	}
 }
 

--- a/internal/runtime/executor/codex_executor_request.go
+++ b/internal/runtime/executor/codex_executor_request.go
@@ -158,7 +158,7 @@ func (e *CodexExecutor) cacheHelper(ctx context.Context, from sdktranslator.Form
 		httpReq.Header["X-Codex-Turn-Metadata"] = []string{turnMetadata}
 	}
 	if cache.ID != "" {
-		httpReq.Header.Set("Session_id", cache.ID)
+		httpReq.Header.Set("Session-Id", cache.ID)
 	}
 	return httpReq, rawJSON, identityState, nil
 }
@@ -204,7 +204,7 @@ func applyCodexIdentityConfuseHeaders(headers http.Header, state *codexIdentityC
 		return
 	}
 
-	setCodexSessionHeaderCasePreserved(headers, "Session_id", state.promptCacheKey)
+	setCodexSessionHeaderCasePreserved(headers, "Session-Id", state.promptCacheKey)
 	if headerValueCaseInsensitive(headers, "Conversation_id") != "" {
 		setHeaderCasePreserved(headers, "Conversation_id", state.promptCacheKey)
 	}
@@ -330,12 +330,13 @@ func applyCodexHeadersFromSources(r *http.Request, auth *cliproxyauth.Auth, toke
 	misc.EnsureHeader(r.Header, ginHeaders, "Version", "")
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Codex-Turn-Metadata", "")
 	misc.EnsureHeader(r.Header, ginHeaders, "X-Client-Request-Id", "")
+	misc.EnsureHeader(r.Header, ginHeaders, "X-Codex-Window-Id", "")
+	misc.EnsureHeader(r.Header, ginHeaders, "Thread-Id", "")
+	misc.EnsureHeader(r.Header, ginHeaders, "Session-Id", "")
+	misc.EnsureHeader(r.Header, ginHeaders, "X-Openai-Internal-Codex-Responses-Lite", "")
+
 	cfgUserAgent, _ := codexHeaderDefaults(cfg, auth)
 	ensureHeaderWithConfigPrecedence(r.Header, ginHeaders, "User-Agent", cfgUserAgent, codexUserAgent)
-
-	if strings.Contains(r.Header.Get("User-Agent"), "Mac OS") {
-		misc.EnsureHeader(r.Header, ginHeaders, "Session_id", uuid.NewString())
-	}
 
 	if stream {
 		r.Header.Set("Accept", "text/event-stream")

--- a/internal/runtime/executor/codex_websockets_execute.go
+++ b/internal/runtime/executor/codex_websockets_execute.go
@@ -251,8 +251,8 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		}
 	}
 
-	if optimizeMultiAgentV2 {
-		sess.markMultiAgentV2Optimized(conn)
+	if optimizeMultiAgentV2 || multiAgentV2Conflict {
+		sess.setMultiAgentV2Optimized(conn, optimizeMultiAgentV2 && !multiAgentV2Conflict)
 	}
 
 	outputItemsByIndex := make(map[int64][]byte)

--- a/internal/runtime/executor/codex_websockets_execute.go
+++ b/internal/runtime/executor/codex_websockets_execute.go
@@ -64,6 +64,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	}
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex websockets executor", body)
 	body = normalizeCodexWebsocketParallelToolCalls(body, opts.Headers)
+	multiAgentV2Conflict := helps.HasCodexMultiAgentV2NamespaceConflict(body)
 	body, optimizeMultiAgentV2 := helps.OptimizeCodexMultiAgentV2RequestForAuth(ctx, opts.Headers, body, e.cfg, auth, baseModel)
 	body, replayScope, errReplay := applyCodexReasoningReplayCacheRequired(ctx, from, req, opts, body)
 	if errReplay != nil {
@@ -182,6 +183,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 			sess.clearActive(conn, readCh)
 		}()
 	}
+	restoreMultiAgentV2 := !multiAgentV2Conflict && (optimizeMultiAgentV2 || sess.isMultiAgentV2Optimized(conn))
 
 	if errSend := writeCodexWebsocketMessage(sess, conn, wsReqBody); errSend != nil {
 		errSend = mapCodexWebsocketWriteError(sess, conn, errSend)
@@ -215,6 +217,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 					return resp, errBind
 				}
 				readCh = sess.activate(conn)
+				restoreMultiAgentV2 = !multiAgentV2Conflict && (optimizeMultiAgentV2 || sess.isMultiAgentV2Optimized(conn))
 				wsReqBodyRetry := buildCodexWebsocketRequestBody(upstreamBody)
 				helps.RecordAPIWebsocketRequest(ctx, e.cfg, helps.UpstreamRequestLog{
 					URL:       wsURL,
@@ -248,6 +251,10 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		}
 	}
 
+	if optimizeMultiAgentV2 {
+		sess.markMultiAgentV2Optimized(conn)
+	}
+
 	outputItemsByIndex := make(map[int64][]byte)
 	var outputItemsFallback [][]byte
 	for {
@@ -279,7 +286,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		reporter.MarkFirstResponseByte()
 		payload = applyCodexIdentityConfuseResponsePayload(payload, identityState)
 		helps.AppendAPIWebsocketResponse(ctx, e.cfg, payload)
-		payload = helps.RestoreCodexMultiAgentV2Response(payload, optimizeMultiAgentV2)
+		payload = helps.RestoreCodexMultiAgentV2Response(payload, restoreMultiAgentV2)
 
 		if wsErr, ok := parseCodexWebsocketError(payload); ok {
 			if sess != nil {

--- a/internal/runtime/executor/codex_websockets_execute.go
+++ b/internal/runtime/executor/codex_websockets_execute.go
@@ -72,6 +72,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 	}
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex websockets executor", body)
 	body = normalizeCodexWebsocketParallelToolCalls(body, opts.Headers)
+	multiAgentV2Conflict := helps.HasCodexMultiAgentV2NamespaceConflict(body)
 	body, optimizeMultiAgentV2 := helps.OptimizeCodexMultiAgentV2RequestForAuth(ctx, opts.Headers, body, e.cfg, auth, baseModel)
 	var skipReplay bool
 	body, replayScope, skipReplay, err = prepareCodexModelFallbackBody(ctx, from, req, opts, body)
@@ -205,6 +206,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		}
 		defer func() { sess.clearActiveConnection(connection, readCh) }()
 	}
+	restoreMultiAgentV2 := !multiAgentV2Conflict && (optimizeMultiAgentV2 || sess.isMultiAgentV2Optimized(connection))
 
 	if errSend := writeCodexWebsocketMessage(sess, connection.conn, wsReqBody); errSend != nil {
 		errSend = mapCodexWebsocketWriteError(sess, connection.conn, errSend)
@@ -255,6 +257,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 				}
 				connection = connectionRetry
 				requestSignal = retrySignal
+				restoreMultiAgentV2 = !multiAgentV2Conflict && (optimizeMultiAgentV2 || sess.isMultiAgentV2Optimized(connection))
 				if errSendRetry := writeCodexWebsocketMessage(sess, connection.conn, wsReqBodyRetry); errSendRetry == nil {
 					wsReqBody = wsReqBodyRetry
 				} else {
@@ -274,6 +277,10 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 			helps.RecordAPIWebsocketError(ctx, e.cfg, "send", errSend)
 			return resp, errSend
 		}
+	}
+
+	if optimizeMultiAgentV2 || multiAgentV2Conflict {
+		sess.setMultiAgentV2Optimized(connection, optimizeMultiAgentV2 && !multiAgentV2Conflict)
 	}
 
 	outputItemsByIndex := make(map[int64][]byte)
@@ -307,7 +314,7 @@ func (e *CodexWebsocketsExecutor) Execute(ctx context.Context, auth *cliproxyaut
 		reporter.MarkFirstResponseByte()
 		payload = applyCodexIdentityConfuseResponsePayload(payload, identityState)
 		helps.AppendAPIWebsocketResponse(ctx, e.cfg, payload)
-		payload = helps.RestoreCodexMultiAgentV2Response(payload, optimizeMultiAgentV2)
+		payload = helps.RestoreCodexMultiAgentV2Response(payload, restoreMultiAgentV2)
 
 		if wsErr, ok := parseCodexWebsocketError(payload); ok {
 			if sess != nil {

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -1096,11 +1096,11 @@ func TestApplyCodexWebsocketHeadersPassesThroughClientIdentityHeadersWhenCloakin
 	if got := headers.Get("X-Client-Request-Id"); got != "019d2233-e240-7162-992d-38df0a2a0e0d" {
 		t.Fatalf("X-Client-Request-Id = %s, want %s", got, "019d2233-e240-7162-992d-38df0a2a0e0d")
 	}
-	if got := headers["session_id"]; len(got) != 1 || got[0] != "legacy-session" {
-		t.Fatalf("session_id = %#v, want [legacy-session]", got)
+	if got := headers["Session-Id"]; len(got) != 1 || got[0] != "legacy-session" {
+		t.Fatalf("Session-Id = %#v, want [legacy-session]", got)
 	}
-	if got := headers.Get("Session-Id"); got != "" {
-		t.Fatalf("Session-Id = %s, want empty", got)
+	if got := headers.Get("Session_id"); got != "" {
+		t.Fatalf("Session_id = %s, want empty", got)
 	}
 }
 
@@ -1117,11 +1117,11 @@ func TestApplyCodexWebsocketHeadersCanonicalizesLegacyUnderscoreSessionHeader(t 
 
 	headers := applyCodexWebsocketHeaders(ctx, http.Header{}, auth, "", nil)
 
-	if got := headers["session_id"]; len(got) != 1 || got[0] != "legacy-underscore-session" {
-		t.Fatalf("session_id = %#v, want [legacy-underscore-session]", got)
+	if got := headers["Session-Id"]; len(got) != 1 || got[0] != "legacy-underscore-session" {
+		t.Fatalf("Session-Id = %#v, want [legacy-underscore-session]", got)
 	}
-	if got := headers.Get("Session-Id"); got != "" {
-		t.Fatalf("Session-Id = %s, want empty", got)
+	if got := headers.Get("Session_id"); got != "" {
+		t.Fatalf("Session_id = %s, want empty", got)
 	}
 }
 
@@ -1270,11 +1270,11 @@ func TestApplyCodexPromptCacheHeadersSetsSessionIDAndLegacyConversation(t *testi
 
 	_, headers := applyCodexPromptCacheHeaders("openai-response", req, []byte(`{"model":"gpt-5-codex"}`))
 
-	if got := headers["session_id"]; len(got) != 1 || got[0] != "cache-1" {
-		t.Fatalf("session_id = %#v, want [cache-1]", got)
+	if got := headers["Session-Id"]; len(got) != 1 || got[0] != "cache-1" {
+		t.Fatalf("Session-Id = %#v, want [cache-1]", got)
 	}
-	if got := headers.Get("Session-Id"); got != "" {
-		t.Fatalf("Session-Id = %s, want empty", got)
+	if got := headers.Get("Session_id"); got != "" {
+		t.Fatalf("Session_id = %s, want empty", got)
 	}
 	if got := headers.Get("Conversation_id"); got != "cache-1" {
 		t.Fatalf("Conversation_id = %s, want cache-1", got)
@@ -1294,8 +1294,8 @@ func TestApplyCodexPromptCacheHeadersUsesDerivedSessionUUID(t *testing.T) {
 	if _, errParse := uuid.Parse(cacheKey); errParse != nil {
 		t.Fatalf("prompt_cache_key %q is not a UUID: %v", cacheKey, errParse)
 	}
-	if got := headers["session_id"]; len(got) != 1 || got[0] != cacheKey {
-		t.Fatalf("session_id = %#v, want [%q]", got, cacheKey)
+	if got := headers["Session-Id"]; len(got) != 1 || got[0] != cacheKey {
+		t.Fatalf("Session-Id = %#v, want [%q]", got, cacheKey)
 	}
 	if got := headers.Get("Conversation_id"); got != cacheKey {
 		t.Fatalf("Conversation_id = %q, want %q", got, cacheKey)
@@ -1357,11 +1357,11 @@ func TestApplyCodexPromptCacheHeadersClaudeUsesClaudeCodeSessionID(t *testing.T)
 	if secondKey != firstKey {
 		t.Fatalf("same Claude Code session_id produced different websocket prompt_cache_key: first=%q second=%q", firstKey, secondKey)
 	}
-	if got := firstHeaders["session_id"]; len(got) != 1 || got[0] != firstKey {
-		t.Fatalf("first session_id = %#v, want [%q]", got, firstKey)
+	if got := firstHeaders["Session-Id"]; len(got) != 1 || got[0] != firstKey {
+		t.Fatalf("first Session-Id = %#v, want [%q]", got, firstKey)
 	}
-	if got := secondHeaders["session_id"]; len(got) != 1 || got[0] != firstKey {
-		t.Fatalf("second session_id = %#v, want [%q]", got, firstKey)
+	if got := secondHeaders["Session-Id"]; len(got) != 1 || got[0] != firstKey {
+		t.Fatalf("second Session-Id = %#v, want [%q]", got, firstKey)
 	}
 }
 
@@ -1376,11 +1376,11 @@ func TestApplyCodexPromptCacheHeadersClaudeRejectsBareUserID(t *testing.T) {
 	if got := gjson.GetBytes(body, "prompt_cache_key").String(); got != "" {
 		t.Fatalf("bare metadata.user_id must not create websocket prompt_cache_key, got %q; body=%s", got, string(body))
 	}
-	if got := headers["session_id"]; len(got) != 0 {
-		t.Fatalf("bare metadata.user_id must not create websocket session_id, got %#v", got)
+	if got := headers["Session-Id"]; len(got) != 0 {
+		t.Fatalf("bare metadata.user_id must not create websocket Session-Id, got %#v", got)
 	}
-	if got := headers.Get("Session-Id"); got != "" {
-		t.Fatalf("bare metadata.user_id must not create websocket Session-Id, got %q", got)
+	if got := headers.Get("Session_id"); got != "" {
+		t.Fatalf("bare metadata.user_id must not create websocket Session_id, got %q", got)
 	}
 	if got := headers.Get("Conversation_id"); got != "" {
 		t.Fatalf("bare metadata.user_id must not create websocket Conversation_id, got %q", got)
@@ -1412,11 +1412,11 @@ func TestApplyCodexWebsocketHeadersIdentityConfuseRemapsPromptCacheKey(t *testin
 	if gotKey := gjson.GetBytes(body, "prompt_cache_key").String(); gotKey != expectedPromptCacheKey {
 		t.Fatalf("prompt_cache_key = %q, want %q", gotKey, expectedPromptCacheKey)
 	}
-	if gotSession := headers["session_id"]; len(gotSession) != 1 || gotSession[0] != expectedPromptCacheKey {
-		t.Fatalf("session_id = %#v, want [%q]", gotSession, expectedPromptCacheKey)
+	if gotSession := headers["Session-Id"]; len(gotSession) != 1 || gotSession[0] != expectedPromptCacheKey {
+		t.Fatalf("Session-Id = %#v, want [%q]", gotSession, expectedPromptCacheKey)
 	}
-	if gotCanonicalSession := headers.Get("Session-Id"); gotCanonicalSession != "" {
-		t.Fatalf("Session-Id = %q, want empty", gotCanonicalSession)
+	if gotLegacySession := headers.Get("Session_id"); gotLegacySession != "" {
+		t.Fatalf("Session_id = %q, want empty", gotLegacySession)
 	}
 	if gotRequestID := headers.Get("X-Client-Request-Id"); gotRequestID != expectedPromptCacheKey {
 		t.Fatalf("X-Client-Request-Id = %q, want %q", gotRequestID, expectedPromptCacheKey)

--- a/internal/runtime/executor/codex_websockets_lts.go
+++ b/internal/runtime/executor/codex_websockets_lts.go
@@ -165,6 +165,7 @@ func (s *codexWebsocketSession) detachConnectionRef(connection codexWebsocketCon
 		closer = s.connCloser
 		s.conn = nil
 		s.connCloser = nil
+		s.multiAgentV2OptimizedGen = 0
 		s.connKey = codexWebsocketConnectionKey{}
 		s.connGen++
 		if s.connGen == 0 {

--- a/internal/runtime/executor/codex_websockets_lts_test.go
+++ b/internal/runtime/executor/codex_websockets_lts_test.go
@@ -765,8 +765,8 @@ func TestApplyCodexPromptCacheHeadersOpenAIChatPreservesExplicitKey(t *testing.T
 	if got := gjson.GetBytes(body, "prompt_cache_key").String(); got != "tenant:explicit" {
 		t.Fatalf("prompt_cache_key = %q, want explicit client key; body=%s", got, body)
 	}
-	if got := headers["session_id"]; len(got) != 1 || got[0] != "tenant:explicit" {
-		t.Fatalf("session_id = %#v, want [tenant:explicit]", got)
+	if got := headers["Session-Id"]; len(got) != 1 || got[0] != "tenant:explicit" {
+		t.Fatalf("Session-Id = %#v, want [tenant:explicit]", got)
 	}
 	if got := headers.Get("Conversation_id"); got != "tenant:explicit" {
 		t.Fatalf("Conversation_id = %q, want tenant:explicit", got)

--- a/internal/runtime/executor/codex_websockets_lts_test.go
+++ b/internal/runtime/executor/codex_websockets_lts_test.go
@@ -296,6 +296,37 @@ func TestCodexWebsocketStaleReaderCannotCloseNewActiveChannel(t *testing.T) {
 	sess.connMu.Unlock()
 }
 
+func TestCodexWebsocketMultiAgentV2StateIsGenerationScoped(t *testing.T) {
+	conn := &websocket.Conn{}
+	first := codexWebsocketConnectionRef{conn: conn, generation: 1}
+	second := codexWebsocketConnectionRef{conn: conn, generation: 2}
+	sess := &codexWebsocketSession{conn: conn, connGen: first.generation}
+
+	sess.setMultiAgentV2Optimized(first, true)
+	if !sess.isMultiAgentV2Optimized(first) {
+		t.Fatal("first generation did not retain Multi-Agent v2 optimization state")
+	}
+
+	sess.connMu.Lock()
+	sess.connGen = second.generation
+	sess.connMu.Unlock()
+	if sess.isMultiAgentV2Optimized(second) {
+		t.Fatal("new connection generation inherited stale Multi-Agent v2 optimization state")
+	}
+
+	sess.connMu.Lock()
+	sess.multiAgentV2OptimizedGen = first.generation
+	sess.connMu.Unlock()
+	sess.setMultiAgentV2Optimized(first, false)
+	if sess.multiAgentV2OptimizedGen != first.generation {
+		t.Fatalf("stale generation cleared optimization state: got %d, want %d", sess.multiAgentV2OptimizedGen, first.generation)
+	}
+	sess.setMultiAgentV2Optimized(second, false)
+	if sess.multiAgentV2OptimizedGen != 0 {
+		t.Fatalf("current generation did not clear optimization state: got %d", sess.multiAgentV2OptimizedGen)
+	}
+}
+
 func TestCodexWebsocketGenerationRetryRebindUsesCurrentConnection(t *testing.T) {
 	sess := &codexWebsocketSession{sessionID: "retry-generation-rebind"}
 	oldConnection := codexWebsocketConnectionRef{conn: &websocket.Conn{}, generation: 1}

--- a/internal/runtime/executor/codex_websockets_request.go
+++ b/internal/runtime/executor/codex_websockets_request.go
@@ -63,7 +63,7 @@ func applyCodexPromptCacheHeadersWithContext(ctx context.Context, from sdktransl
 
 	if cache.ID != "" {
 		rawJSON = helps.SetStringIfDifferent(rawJSON, "prompt_cache_key", cache.ID)
-		setHeaderCasePreserved(headers, "session_id", cache.ID)
+		setHeaderCasePreserved(headers, "Session-Id", cache.ID)
 		headers.Set("Conversation_id", cache.ID)
 	}
 
@@ -147,9 +147,13 @@ func ensureCodexWebsocketSessionHeader(target http.Header, source http.Header, f
 		sessionID = strings.TrimSpace(fallbackValue)
 	}
 	if sessionID != "" {
-		setHeaderCasePreserved(target, "session_id", sessionID)
+		setHeaderCasePreserved(target, "Session-Id", sessionID)
 	}
-	deleteHeaderCaseInsensitive(target, "Session-Id")
+	for existingKey := range target {
+		if codexSessionHeaderKey(existingKey) && existingKey != "Session-Id" {
+			delete(target, existingKey)
+		}
+	}
 }
 
 func codexSessionHeaderValue(headers http.Header) string {

--- a/internal/runtime/executor/codex_websockets_session.go
+++ b/internal/runtime/executor/codex_websockets_session.go
@@ -51,14 +51,15 @@ type codexWebsocketSession struct {
 
 	reqMu sync.Mutex
 
-	connMu          sync.Mutex
-	conn            *websocket.Conn
-	connCloser      *websocketConnectionCloser
-	wsURL           string
-	authID          string
-	lifecycleBindMu sync.Mutex
-	lifecycle       cliproxyexecutor.ExecutionLifecycle
-	lifecycleModel  string
+	connMu                    sync.Mutex
+	conn                      *websocket.Conn
+	connCloser                *websocketConnectionCloser
+	wsURL                     string
+	authID                    string
+	multiAgentV2OptimizedConn *websocket.Conn
+	lifecycleBindMu           sync.Mutex
+	lifecycle                 cliproxyexecutor.ExecutionLifecycle
+	lifecycleModel            string
 
 	writeMu sync.Mutex
 
@@ -161,6 +162,26 @@ func (s *codexWebsocketSession) writeMessage(conn *websocket.Conn, msgType int, 
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
 	return conn.WriteMessage(msgType, payload)
+}
+
+func (s *codexWebsocketSession) markMultiAgentV2Optimized(conn *websocket.Conn) {
+	if s == nil || conn == nil {
+		return
+	}
+	s.connMu.Lock()
+	if s.conn == conn {
+		s.multiAgentV2OptimizedConn = conn
+	}
+	s.connMu.Unlock()
+}
+
+func (s *codexWebsocketSession) isMultiAgentV2Optimized(conn *websocket.Conn) bool {
+	if s == nil || conn == nil {
+		return false
+	}
+	s.connMu.Lock()
+	defer s.connMu.Unlock()
+	return s.conn == conn && s.multiAgentV2OptimizedConn == conn
 }
 
 // sendTerminalWebsocketRead reports whether it invalidated a full channel's connection before waiting.
@@ -272,6 +293,7 @@ func (s *codexWebsocketSession) detachConnection(conn *websocket.Conn, lifecycle
 		closer = s.connCloser
 		s.conn = nil
 		s.connCloser = nil
+		s.multiAgentV2OptimizedConn = nil
 		if s.readerConn == conn {
 			s.readerConn = nil
 		}
@@ -346,6 +368,7 @@ func detachMismatchedWebsocketSessionConn(sess *codexWebsocketSession, authID st
 	sess.lifecycleModel = ""
 	sess.conn = nil
 	sess.connCloser = nil
+	sess.multiAgentV2OptimizedConn = nil
 	if sess.readerConn == conn {
 		sess.readerConn = nil
 	}
@@ -505,6 +528,7 @@ func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *
 	}
 	sess.conn = conn
 	sess.connCloser = closer
+	sess.multiAgentV2OptimizedConn = nil
 	sess.wsURL = wsURL
 	sess.authID = authID
 	sess.readerConn = conn
@@ -602,6 +626,7 @@ func (e *CodexWebsocketsExecutor) invalidateUpstreamConnWithNotify(sess *codexWe
 	sess.lifecycleModel = ""
 	sess.conn = nil
 	sess.connCloser = nil
+	sess.multiAgentV2OptimizedConn = nil
 	if sess.readerConn == conn {
 		sess.readerConn = nil
 	}
@@ -693,6 +718,7 @@ func closeCodexWebsocketSession(sess *codexWebsocketSession, reason string) {
 	sess.lifecycleModel = ""
 	sess.conn = nil
 	sess.connCloser = nil
+	sess.multiAgentV2OptimizedConn = nil
 	if sess.readerConn == conn {
 		sess.readerConn = nil
 	}

--- a/internal/runtime/executor/codex_websockets_session.go
+++ b/internal/runtime/executor/codex_websockets_session.go
@@ -164,13 +164,17 @@ func (s *codexWebsocketSession) writeMessage(conn *websocket.Conn, msgType int, 
 	return conn.WriteMessage(msgType, payload)
 }
 
-func (s *codexWebsocketSession) markMultiAgentV2Optimized(conn *websocket.Conn) {
+func (s *codexWebsocketSession) setMultiAgentV2Optimized(conn *websocket.Conn, optimized bool) {
 	if s == nil || conn == nil {
 		return
 	}
 	s.connMu.Lock()
 	if s.conn == conn {
-		s.multiAgentV2OptimizedConn = conn
+		if optimized {
+			s.multiAgentV2OptimizedConn = conn
+		} else {
+			s.multiAgentV2OptimizedConn = nil
+		}
 	}
 	s.connMu.Unlock()
 }

--- a/internal/runtime/executor/codex_websockets_session.go
+++ b/internal/runtime/executor/codex_websockets_session.go
@@ -51,18 +51,19 @@ type codexWebsocketSession struct {
 
 	reqMu sync.Mutex
 
-	connMu          sync.Mutex
-	conn            *websocket.Conn
-	connCloser      *websocketConnectionCloser
-	connGen         uint64
-	connKey         codexWebsocketConnectionKey
-	wsURL           string
-	authID          string
-	closed          bool
-	lifecycleBindMu sync.Mutex
-	lifecycle       cliproxyexecutor.ExecutionLifecycle
-	lifecycleModel  string
-	lifecycleGen    uint64
+	connMu                   sync.Mutex
+	conn                     *websocket.Conn
+	connCloser               *websocketConnectionCloser
+	connGen                  uint64
+	connKey                  codexWebsocketConnectionKey
+	wsURL                    string
+	authID                   string
+	multiAgentV2OptimizedGen uint64
+	closed                   bool
+	lifecycleBindMu          sync.Mutex
+	lifecycle                cliproxyexecutor.ExecutionLifecycle
+	lifecycleModel           string
+	lifecycleGen             uint64
 
 	writeMu sync.Mutex
 
@@ -182,6 +183,30 @@ func (s *codexWebsocketSession) writeMessage(conn *websocket.Conn, msgType int, 
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
 	return conn.WriteMessage(msgType, payload)
+}
+
+func (s *codexWebsocketSession) setMultiAgentV2Optimized(connection codexWebsocketConnectionRef, optimized bool) {
+	if s == nil || connection.conn == nil {
+		return
+	}
+	s.connMu.Lock()
+	if s.conn == connection.conn && s.connGen == connection.generation {
+		if optimized {
+			s.multiAgentV2OptimizedGen = connection.generation
+		} else {
+			s.multiAgentV2OptimizedGen = 0
+		}
+	}
+	s.connMu.Unlock()
+}
+
+func (s *codexWebsocketSession) isMultiAgentV2Optimized(connection codexWebsocketConnectionRef) bool {
+	if s == nil || connection.conn == nil {
+		return false
+	}
+	s.connMu.Lock()
+	defer s.connMu.Unlock()
+	return s.conn == connection.conn && s.connGen == connection.generation && s.multiAgentV2OptimizedGen == connection.generation
 }
 
 // sendTerminalWebsocketRead reports whether it invalidated a full channel's connection before waiting.
@@ -369,6 +394,7 @@ func detachMismatchedWebsocketSessionConn(sess *codexWebsocketSession, authID st
 	if sess.connGen == 0 {
 		sess.connGen++
 	}
+	sess.multiAgentV2OptimizedGen = 0
 	if sess.readerConn == conn {
 		sess.readerConn = nil
 		sess.readerGen = 0
@@ -518,6 +544,7 @@ func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *
 	if connection.conn != nil {
 		sess.conn = nil
 		sess.connCloser = nil
+		sess.multiAgentV2OptimizedGen = 0
 		sess.lifecycle = nil
 		sess.lifecycleModel = ""
 		sess.lifecycleGen = 0
@@ -584,6 +611,7 @@ func (e *CodexWebsocketsExecutor) ensureUpstreamConn(ctx context.Context, auth *
 	sess.connKey = wantedKey
 	sess.wsURL = wantedKey.wsURL
 	sess.authID = wantedKey.authID
+	sess.multiAgentV2OptimizedGen = 0
 	sess.readerConn = conn
 	sess.readerGen = connection.generation
 	sess.connMu.Unlock()
@@ -654,6 +682,7 @@ func (e *CodexWebsocketsExecutor) invalidateUpstreamConnWithNotify(sess *codexWe
 	sess.conn = nil
 	sess.connCloser = nil
 	sess.connKey = codexWebsocketConnectionKey{}
+	sess.multiAgentV2OptimizedGen = 0
 	if sess.readerConn == connection.conn && sess.readerGen == connection.generation {
 		sess.readerConn = nil
 		sess.readerGen = 0
@@ -748,6 +777,7 @@ func closeCodexWebsocketSession(sess *codexWebsocketSession, reason string) {
 	sess.lifecycleModel = ""
 	sess.lifecycleGen = 0
 	sess.connCloser = nil
+	sess.multiAgentV2OptimizedGen = 0
 	sessionID := sess.sessionID
 	sess.closed = true
 	sess.conn = nil

--- a/internal/runtime/executor/codex_websockets_spawn_agent_test.go
+++ b/internal/runtime/executor/codex_websockets_spawn_agent_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/gorilla/websocket"
@@ -14,6 +16,147 @@ import (
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	"github.com/tidwall/gjson"
 )
+
+func TestCodexWebsocketsExecutorRestoresMultiAgentV2NamespaceAcrossIncrementalTurns(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		stream bool
+	}{
+		{name: "execute"},
+		{name: "stream", stream: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+			capturedPayload := make(chan []byte, 6)
+			var connectionCount atomic.Int32
+			var requestCount atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				connectionCount.Add(1)
+				conn, errUpgrade := upgrader.Upgrade(w, request, nil)
+				if errUpgrade != nil {
+					t.Errorf("upgrade websocket: %v", errUpgrade)
+					return
+				}
+				defer func() { _ = conn.Close() }()
+
+				for {
+					_, payload, errRead := conn.ReadMessage()
+					if errRead != nil {
+						return
+					}
+					capturedPayload <- append([]byte(nil), payload...)
+					turn := requestCount.Add(1)
+					completed := []byte(fmt.Sprintf(`{"type":"response.completed","response":{"id":"resp_%d","object":"response","status":"completed","output":[{"type":"function_call","name":"spawn_agent","namespace":"collaboration-optimize","arguments":"{}","call_id":"call_%d"}]}}`, turn, turn))
+					if errWrite := conn.WriteMessage(websocket.TextMessage, completed); errWrite != nil {
+						t.Errorf("write websocket response: %v", errWrite)
+						return
+					}
+					if turn == 6 {
+						return
+					}
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			executor := NewCodexWebsocketsExecutor(&config.Config{Codex: config.CodexConfig{OptimizeMultiAgentV2: true}})
+			const executionSessionID = "multi-agent-v2-incremental"
+			t.Cleanup(func() { executor.CloseExecutionSession(executionSessionID) })
+			auth := &cliproxyauth.Auth{
+				ID: "codex-test",
+				Attributes: map[string]string{
+					"base_url": server.URL,
+					"api_key":  "test",
+				},
+			}
+			opts := cliproxyexecutor.Options{
+				SourceFormat:   sdktranslator.FromString("openai-response"),
+				ResponseFormat: sdktranslator.FromString("openai-response"),
+				Headers:        http.Header{"User-Agent": []string{"overridden-client/1.0"}},
+				Metadata: map[string]any{
+					cliproxyexecutor.ExecutionSessionMetadataKey: executionSessionID,
+				},
+			}
+			execute := func(payload []byte) []byte {
+				t.Helper()
+				req := cliproxyexecutor.Request{Model: "gpt-5.4", Payload: payload}
+				if !tt.stream {
+					response, errExecute := executor.Execute(codexSpawnAgentTestContext(), auth, req, opts)
+					if errExecute != nil {
+						t.Fatalf("Execute() error = %v", errExecute)
+					}
+					return response.Payload
+				}
+
+				result, errExecute := executor.ExecuteStream(codexSpawnAgentTestContext(), auth, req, opts)
+				if errExecute != nil {
+					t.Fatalf("ExecuteStream() error = %v", errExecute)
+				}
+				var responsePayload []byte
+				for chunk := range result.Chunks {
+					if chunk.Err != nil {
+						t.Fatalf("stream chunk error = %v", chunk.Err)
+					}
+					responsePayload = append(responsePayload, chunk.Payload...)
+				}
+				return responsePayload
+			}
+
+			firstClientPayload := execute(codexSpawnAgentTestPayload())
+			firstUpstreamPayload := <-capturedPayload
+			if namespace := gjson.GetBytes(firstUpstreamPayload, "input.0.tools.0.name").String(); namespace != "collaboration-optimize" {
+				t.Fatalf("first upstream namespace = %q, want collaboration-optimize", namespace)
+			}
+			assertCodexSpawnAgentClientNamespace(t, firstClientPayload)
+
+			secondRequest := []byte(`{"model":"gpt-5.4","previous_response_id":"resp_1","input":[{"type":"function_call_output","call_id":"call_1","output":"done"}]}`)
+			secondClientPayload := execute(secondRequest)
+			secondUpstreamPayload := <-capturedPayload
+			if strings.Contains(string(secondUpstreamPayload), "collaboration") || strings.Contains(string(secondUpstreamPayload), "spawn_agent") {
+				t.Fatalf("incremental upstream request unexpectedly contains collaboration tools: %s", secondUpstreamPayload)
+			}
+			assertCodexSpawnAgentClientNamespace(t, secondClientPayload)
+
+			conflictingRequest := []byte(`{"model":"gpt-5.4","tools":[{"type":"namespace","name":"collaboration-optimize","tools":[{"type":"function","name":"spawn_agent","description":"User-defined tool."}]}],"input":[{"type":"message","role":"user","content":"use the user-defined namespace"}]}`)
+			conflictingClientPayload := execute(conflictingRequest)
+			conflictingUpstreamPayload := <-capturedPayload
+			if namespace := gjson.GetBytes(conflictingUpstreamPayload, "tools.0.name").String(); namespace != "collaboration-optimize" {
+				t.Fatalf("conflicting upstream namespace = %q, want collaboration-optimize", namespace)
+			}
+			if !strings.Contains(string(conflictingClientPayload), `"namespace":"collaboration-optimize"`) {
+				t.Fatalf("user-defined collaboration-optimize namespace was rewritten: %s", conflictingClientPayload)
+			}
+
+			fourthRequest := []byte(`{"model":"gpt-5.4","previous_response_id":"resp_3","input":[{"type":"function_call_output","call_id":"call_3","output":"done"}]}`)
+			fourthClientPayload := execute(fourthRequest)
+			fourthUpstreamPayload := <-capturedPayload
+			if strings.Contains(string(fourthUpstreamPayload), "collaboration") || strings.Contains(string(fourthUpstreamPayload), "spawn_agent") {
+				t.Fatalf("post-conflict incremental upstream request unexpectedly contains collaboration tools: %s", fourthUpstreamPayload)
+			}
+			if !strings.Contains(string(fourthClientPayload), `"namespace":"collaboration-optimize"`) {
+				t.Fatalf("user-defined namespace was rewritten on the post-conflict incremental turn: %s", fourthClientPayload)
+			}
+
+			fifthClientPayload := execute(codexSpawnAgentTestPayload())
+			fifthUpstreamPayload := <-capturedPayload
+			if namespace := gjson.GetBytes(fifthUpstreamPayload, "input.0.tools.0.name").String(); namespace != "collaboration-optimize" {
+				t.Fatalf("re-enabled upstream namespace = %q, want collaboration-optimize", namespace)
+			}
+			assertCodexSpawnAgentClientNamespace(t, fifthClientPayload)
+
+			sixthRequest := []byte(`{"model":"gpt-5.4","previous_response_id":"resp_5","input":[{"type":"function_call_output","call_id":"call_5","output":"done"}]}`)
+			sixthClientPayload := execute(sixthRequest)
+			sixthUpstreamPayload := <-capturedPayload
+			if strings.Contains(string(sixthUpstreamPayload), "collaboration") || strings.Contains(string(sixthUpstreamPayload), "spawn_agent") {
+				t.Fatalf("re-enabled incremental upstream request unexpectedly contains collaboration tools: %s", sixthUpstreamPayload)
+			}
+			assertCodexSpawnAgentClientNamespace(t, sixthClientPayload)
+
+			if got := connectionCount.Load(); got != 1 {
+				t.Fatalf("upstream websocket connections = %d, want 1", got)
+			}
+		})
+	}
+}
 
 func TestCodexWebsocketsExecutorOptimizeMultiAgentV2(t *testing.T) {
 	modelID := "codex-websocket-spawn-agent-test-model"

--- a/internal/runtime/executor/codex_websockets_spawn_agent_test.go
+++ b/internal/runtime/executor/codex_websockets_spawn_agent_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/gorilla/websocket"
@@ -14,6 +16,122 @@ import (
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
 	"github.com/tidwall/gjson"
 )
+
+func TestCodexWebsocketsExecutorRestoresMultiAgentV2NamespaceAcrossIncrementalTurns(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		stream bool
+	}{
+		{name: "execute"},
+		{name: "stream", stream: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+			capturedPayload := make(chan []byte, 3)
+			var connectionCount atomic.Int32
+			var requestCount atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				connectionCount.Add(1)
+				conn, errUpgrade := upgrader.Upgrade(w, request, nil)
+				if errUpgrade != nil {
+					t.Errorf("upgrade websocket: %v", errUpgrade)
+					return
+				}
+				defer func() { _ = conn.Close() }()
+
+				for {
+					_, payload, errRead := conn.ReadMessage()
+					if errRead != nil {
+						return
+					}
+					capturedPayload <- append([]byte(nil), payload...)
+					turn := requestCount.Add(1)
+					completed := []byte(fmt.Sprintf(`{"type":"response.completed","response":{"id":"resp_%d","object":"response","status":"completed","output":[{"type":"function_call","name":"spawn_agent","namespace":"collaboration-optimize","arguments":"{}","call_id":"call_%d"}]}}`, turn, turn))
+					if errWrite := conn.WriteMessage(websocket.TextMessage, completed); errWrite != nil {
+						t.Errorf("write websocket response: %v", errWrite)
+						return
+					}
+					if turn == 3 {
+						return
+					}
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			executor := NewCodexWebsocketsExecutor(&config.Config{Codex: config.CodexConfig{OptimizeMultiAgentV2: true}})
+			const executionSessionID = "multi-agent-v2-incremental"
+			t.Cleanup(func() { executor.CloseExecutionSession(executionSessionID) })
+			auth := &cliproxyauth.Auth{
+				ID: "codex-test",
+				Attributes: map[string]string{
+					"base_url": server.URL,
+					"api_key":  "test",
+				},
+			}
+			opts := cliproxyexecutor.Options{
+				SourceFormat:   sdktranslator.FromString("openai-response"),
+				ResponseFormat: sdktranslator.FromString("openai-response"),
+				Headers:        http.Header{"User-Agent": []string{"overridden-client/1.0"}},
+				Metadata: map[string]any{
+					cliproxyexecutor.ExecutionSessionMetadataKey: executionSessionID,
+				},
+			}
+			execute := func(payload []byte) []byte {
+				t.Helper()
+				req := cliproxyexecutor.Request{Model: "gpt-5.4", Payload: payload}
+				if !tt.stream {
+					response, errExecute := executor.Execute(codexSpawnAgentTestContext(), auth, req, opts)
+					if errExecute != nil {
+						t.Fatalf("Execute() error = %v", errExecute)
+					}
+					return response.Payload
+				}
+
+				result, errExecute := executor.ExecuteStream(codexSpawnAgentTestContext(), auth, req, opts)
+				if errExecute != nil {
+					t.Fatalf("ExecuteStream() error = %v", errExecute)
+				}
+				var responsePayload []byte
+				for chunk := range result.Chunks {
+					if chunk.Err != nil {
+						t.Fatalf("stream chunk error = %v", chunk.Err)
+					}
+					responsePayload = append(responsePayload, chunk.Payload...)
+				}
+				return responsePayload
+			}
+
+			firstClientPayload := execute(codexSpawnAgentTestPayload())
+			firstUpstreamPayload := <-capturedPayload
+			if namespace := gjson.GetBytes(firstUpstreamPayload, "input.0.tools.0.name").String(); namespace != "collaboration-optimize" {
+				t.Fatalf("first upstream namespace = %q, want collaboration-optimize", namespace)
+			}
+			assertCodexSpawnAgentClientNamespace(t, firstClientPayload)
+
+			secondRequest := []byte(`{"model":"gpt-5.4","previous_response_id":"resp_1","input":[{"type":"function_call_output","call_id":"call_1","output":"done"}]}`)
+			secondClientPayload := execute(secondRequest)
+			secondUpstreamPayload := <-capturedPayload
+			if strings.Contains(string(secondUpstreamPayload), "collaboration") || strings.Contains(string(secondUpstreamPayload), "spawn_agent") {
+				t.Fatalf("incremental upstream request unexpectedly contains collaboration tools: %s", secondUpstreamPayload)
+			}
+			assertCodexSpawnAgentClientNamespace(t, secondClientPayload)
+
+			conflictingRequest := []byte(`{"model":"gpt-5.4","tools":[{"type":"namespace","name":"collaboration-optimize","tools":[{"type":"function","name":"spawn_agent","description":"User-defined tool."}]}],"input":[{"type":"message","role":"user","content":"use the user-defined namespace"}]}`)
+			conflictingClientPayload := execute(conflictingRequest)
+			conflictingUpstreamPayload := <-capturedPayload
+			if namespace := gjson.GetBytes(conflictingUpstreamPayload, "tools.0.name").String(); namespace != "collaboration-optimize" {
+				t.Fatalf("conflicting upstream namespace = %q, want collaboration-optimize", namespace)
+			}
+			if !strings.Contains(string(conflictingClientPayload), `"namespace":"collaboration-optimize"`) {
+				t.Fatalf("user-defined collaboration-optimize namespace was rewritten: %s", conflictingClientPayload)
+			}
+
+			if got := connectionCount.Load(); got != 1 {
+				t.Fatalf("upstream websocket connections = %d, want 1", got)
+			}
+		})
+	}
+}
 
 func TestCodexWebsocketsExecutorOptimizeMultiAgentV2(t *testing.T) {
 	modelID := "codex-websocket-spawn-agent-test-model"

--- a/internal/runtime/executor/codex_websockets_spawn_agent_test.go
+++ b/internal/runtime/executor/codex_websockets_spawn_agent_test.go
@@ -27,7 +27,7 @@ func TestCodexWebsocketsExecutorRestoresMultiAgentV2NamespaceAcrossIncrementalTu
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
-			capturedPayload := make(chan []byte, 3)
+			capturedPayload := make(chan []byte, 6)
 			var connectionCount atomic.Int32
 			var requestCount atomic.Int32
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
@@ -51,7 +51,7 @@ func TestCodexWebsocketsExecutorRestoresMultiAgentV2NamespaceAcrossIncrementalTu
 						t.Errorf("write websocket response: %v", errWrite)
 						return
 					}
-					if turn == 3 {
+					if turn == 6 {
 						return
 					}
 				}
@@ -125,6 +125,31 @@ func TestCodexWebsocketsExecutorRestoresMultiAgentV2NamespaceAcrossIncrementalTu
 			if !strings.Contains(string(conflictingClientPayload), `"namespace":"collaboration-optimize"`) {
 				t.Fatalf("user-defined collaboration-optimize namespace was rewritten: %s", conflictingClientPayload)
 			}
+
+			fourthRequest := []byte(`{"model":"gpt-5.4","previous_response_id":"resp_3","input":[{"type":"function_call_output","call_id":"call_3","output":"done"}]}`)
+			fourthClientPayload := execute(fourthRequest)
+			fourthUpstreamPayload := <-capturedPayload
+			if strings.Contains(string(fourthUpstreamPayload), "collaboration") || strings.Contains(string(fourthUpstreamPayload), "spawn_agent") {
+				t.Fatalf("post-conflict incremental upstream request unexpectedly contains collaboration tools: %s", fourthUpstreamPayload)
+			}
+			if !strings.Contains(string(fourthClientPayload), `"namespace":"collaboration-optimize"`) {
+				t.Fatalf("user-defined namespace was rewritten on the post-conflict incremental turn: %s", fourthClientPayload)
+			}
+
+			fifthClientPayload := execute(codexSpawnAgentTestPayload())
+			fifthUpstreamPayload := <-capturedPayload
+			if namespace := gjson.GetBytes(fifthUpstreamPayload, "input.0.tools.0.name").String(); namespace != "collaboration-optimize" {
+				t.Fatalf("re-enabled upstream namespace = %q, want collaboration-optimize", namespace)
+			}
+			assertCodexSpawnAgentClientNamespace(t, fifthClientPayload)
+
+			sixthRequest := []byte(`{"model":"gpt-5.4","previous_response_id":"resp_5","input":[{"type":"function_call_output","call_id":"call_5","output":"done"}]}`)
+			sixthClientPayload := execute(sixthRequest)
+			sixthUpstreamPayload := <-capturedPayload
+			if strings.Contains(string(sixthUpstreamPayload), "collaboration") || strings.Contains(string(sixthUpstreamPayload), "spawn_agent") {
+				t.Fatalf("re-enabled incremental upstream request unexpectedly contains collaboration tools: %s", sixthUpstreamPayload)
+			}
+			assertCodexSpawnAgentClientNamespace(t, sixthClientPayload)
 
 			if got := connectionCount.Load(); got != 1 {
 				t.Fatalf("upstream websocket connections = %d, want 1", got)

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -258,8 +258,8 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		}
 	}
 
-	if optimizeMultiAgentV2 {
-		sess.markMultiAgentV2Optimized(conn)
+	if optimizeMultiAgentV2 || multiAgentV2Conflict {
+		sess.setMultiAgentV2Optimized(conn, optimizeMultiAgentV2 && !multiAgentV2Conflict)
 	}
 
 	out := make(chan cliproxyexecutor.StreamChunk)

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -61,6 +61,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	}
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex websockets executor", body)
 	body = normalizeCodexWebsocketParallelToolCalls(body, opts.Headers)
+	multiAgentV2Conflict := helps.HasCodexMultiAgentV2NamespaceConflict(body)
 	body, optimizeMultiAgentV2 := helps.OptimizeCodexMultiAgentV2RequestForAuth(ctx, opts.Headers, body, e.cfg, auth, baseModel)
 	body, replayScope, errReplay := applyCodexReasoningReplayCacheRequired(ctx, from, req, opts, body)
 	if errReplay != nil {
@@ -183,6 +184,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	if sess != nil {
 		readCh = sess.activate(conn)
 	}
+	restoreMultiAgentV2 := !multiAgentV2Conflict && (optimizeMultiAgentV2 || sess.isMultiAgentV2Optimized(conn))
 
 	if errSend := writeCodexWebsocketMessage(sess, conn, wsReqBody); errSend != nil {
 		errSend = mapCodexWebsocketWriteError(sess, conn, errSend)
@@ -223,6 +225,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 				return nil, errBind
 			}
 			readCh = sess.activate(conn)
+			restoreMultiAgentV2 = !multiAgentV2Conflict && (optimizeMultiAgentV2 || sess.isMultiAgentV2Optimized(conn))
 			wsReqBodyRetry := buildCodexWebsocketRequestBody(upstreamBody)
 			helps.RecordAPIWebsocketRequest(ctx, e.cfg, helps.UpstreamRequestLog{
 				URL:       wsURL,
@@ -253,6 +256,10 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			}
 			return nil, errSend
 		}
+	}
+
+	if optimizeMultiAgentV2 {
+		sess.markMultiAgentV2Optimized(conn)
 	}
 
 	out := make(chan cliproxyexecutor.StreamChunk)
@@ -336,7 +343,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			reporter.MarkFirstResponseByte()
 			payload = applyCodexIdentityConfuseResponsePayload(payload, identityState)
 			helps.AppendAPIWebsocketResponse(ctx, e.cfg, payload)
-			payload = helps.RestoreCodexMultiAgentV2Response(payload, optimizeMultiAgentV2)
+			payload = helps.RestoreCodexMultiAgentV2Response(payload, restoreMultiAgentV2)
 
 			if wsErr, ok := parseCodexWebsocketError(payload); ok {
 				terminateReason = "upstream_error"

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -69,6 +69,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 	}
 	body = sanitizeOpenAIResponsesReasoningEncryptedContent(ctx, "codex websockets executor", body)
 	body = normalizeCodexWebsocketParallelToolCalls(body, opts.Headers)
+	multiAgentV2Conflict := helps.HasCodexMultiAgentV2NamespaceConflict(body)
 	body, optimizeMultiAgentV2 := helps.OptimizeCodexMultiAgentV2RequestForAuth(ctx, opts.Headers, body, e.cfg, auth, baseModel)
 	var skipReplay bool
 	body, replayScope, skipReplay, err = prepareCodexModelFallbackBody(ctx, from, req, opts, body)
@@ -197,6 +198,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			return nil, errActive
 		}
 	}
+	restoreMultiAgentV2 := !multiAgentV2Conflict && (optimizeMultiAgentV2 || sess.isMultiAgentV2Optimized(connection))
 
 	if errSend := writeCodexWebsocketMessage(sess, connection.conn, wsReqBody); errSend != nil {
 		errSend = mapCodexWebsocketWriteError(sess, connection.conn, errSend)
@@ -258,6 +260,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			}
 			connection = connectionRetry
 			requestSignal = retrySignal
+			restoreMultiAgentV2 = !multiAgentV2Conflict && (optimizeMultiAgentV2 || sess.isMultiAgentV2Optimized(connection))
 			if errSendRetry := writeCodexWebsocketMessage(sess, connection.conn, wsReqBodyRetry); errSendRetry != nil {
 				errSendRetry = mapCodexWebsocketWriteError(sess, connection.conn, errSendRetry)
 				helps.RecordAPIWebsocketError(ctx, e.cfg, "send_retry", errSendRetry)
@@ -274,6 +277,10 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			}
 			return nil, errSend
 		}
+	}
+
+	if optimizeMultiAgentV2 || multiAgentV2Conflict {
+		sess.setMultiAgentV2Optimized(connection, optimizeMultiAgentV2 && !multiAgentV2Conflict)
 	}
 
 	out := make(chan cliproxyexecutor.StreamChunk)
@@ -360,7 +367,7 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			reporter.MarkFirstResponseByte()
 			payload = applyCodexIdentityConfuseResponsePayload(payload, identityState)
 			helps.AppendAPIWebsocketResponse(ctx, e.cfg, payload)
-			payload = helps.RestoreCodexMultiAgentV2Response(payload, optimizeMultiAgentV2)
+			payload = helps.RestoreCodexMultiAgentV2Response(payload, restoreMultiAgentV2)
 
 			if wsErr, ok := parseCodexWebsocketError(payload); ok {
 				terminateReason = "upstream_error"

--- a/internal/runtime/executor/helps/codex_multi_agent_v2.go
+++ b/internal/runtime/executor/helps/codex_multi_agent_v2.go
@@ -97,6 +97,12 @@ func TranslateRequestWithAPIKeyModelCompatibility(ctx context.Context, headers h
 	return thinking.ApplySummaryConfigForModel(translated, to.String(), model, summaryConfig)
 }
 
+// HasCodexMultiAgentV2NamespaceConflict reports whether the request defines
+// the reserved optimized namespace, which must remain untouched.
+func HasCodexMultiAgentV2NamespaceConflict(payload []byte) bool {
+	return multiagentv2.HasCodexMultiAgentV2NamespaceConflict(payload)
+}
+
 // OptimizeCodexMultiAgentV2Request rewrites an eligible spawn_agent request and
 // reports whether the collaboration namespace was renamed for upstream use.
 func OptimizeCodexMultiAgentV2Request(ctx context.Context, headers http.Header, payload []byte, cfg *config.Config) ([]byte, bool) {

--- a/internal/runtime/executor/helps/codex_multi_agent_v2.go
+++ b/internal/runtime/executor/helps/codex_multi_agent_v2.go
@@ -103,6 +103,12 @@ func TranslateRequestWithAPIKeyModelCompatibility(ctx context.Context, headers h
 	return thinking.ApplySummaryConfigForModel(translated, to.String(), model, summaryConfig)
 }
 
+// HasCodexMultiAgentV2NamespaceConflict reports whether the request defines
+// the reserved optimized namespace, which must remain untouched.
+func HasCodexMultiAgentV2NamespaceConflict(payload []byte) bool {
+	return multiagentv2.HasCodexMultiAgentV2NamespaceConflict(payload)
+}
+
 // OptimizeCodexMultiAgentV2Request rewrites an eligible spawn_agent request and
 // reports whether the collaboration namespace was renamed for upstream use.
 func OptimizeCodexMultiAgentV2Request(ctx context.Context, headers http.Header, payload []byte, cfg *config.Config) ([]byte, bool) {

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -50,6 +50,14 @@ func NewKimiExecutor(cfg *config.Config) *KimiExecutor {
 // Identifier returns the executor identifier.
 func (e *KimiExecutor) Identifier() string { return "kimi" }
 
+// RequestToFormat reports the upstream request format used after auth selection.
+func (e *KimiExecutor) RequestToFormat(_ cliproxyexecutor.Request, opts cliproxyexecutor.Options) sdktranslator.Format {
+	if opts.SourceFormat == sdktranslator.FormatClaude {
+		return sdktranslator.FormatClaude
+	}
+	return sdktranslator.FormatOpenAI
+}
+
 // PrepareRequest injects Kimi credentials into the outgoing HTTP request.
 func (e *KimiExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Auth) error {
 	if req == nil {

--- a/internal/runtime/executor/kimi_executor_test.go
+++ b/internal/runtime/executor/kimi_executor_test.go
@@ -28,6 +28,41 @@ func TestNewKimiExecutorInitializesDelegatedClaudeConfig(t *testing.T) {
 	}
 }
 
+func TestKimiExecutorRequestToFormatMatchesWireProtocol(t *testing.T) {
+	type requestToFormatReporter interface {
+		RequestToFormat(cliproxyexecutor.Request, cliproxyexecutor.Options) sdktranslator.Format
+	}
+
+	executor := NewKimiExecutor(&config.Config{})
+	reporter, ok := any(executor).(requestToFormatReporter)
+	if !ok {
+		t.Fatal("Kimi executor does not report its upstream request format")
+	}
+
+	tests := []struct {
+		name   string
+		stream bool
+		source sdktranslator.Format
+		want   sdktranslator.Format
+	}{
+		{name: "Claude non-streaming", source: sdktranslator.FormatClaude, want: sdktranslator.FormatClaude},
+		{name: "Claude streaming", stream: true, source: sdktranslator.FormatClaude, want: sdktranslator.FormatClaude},
+		{name: "OpenAI non-streaming", source: sdktranslator.FormatOpenAI, want: sdktranslator.FormatOpenAI},
+		{name: "OpenAI streaming", stream: true, source: sdktranslator.FormatOpenAI, want: sdktranslator.FormatOpenAI},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := reporter.RequestToFormat(cliproxyexecutor.Request{}, cliproxyexecutor.Options{
+				SourceFormat: tt.source,
+				Stream:       tt.stream,
+			})
+			if got != tt.want {
+				t.Fatalf("RequestToFormat() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestKimiExecutorClaudeRequestPreservesInternalModelSemantics(t *testing.T) {
 	var upstreamBody []byte
 	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", kimiRoundTripperFunc(func(req *http.Request) (*http.Response, error) {

--- a/internal/runtime/executor/kimi_executor_test.go
+++ b/internal/runtime/executor/kimi_executor_test.go
@@ -29,6 +29,41 @@ func TestNewKimiExecutorInitializesDelegatedClaudeConfig(t *testing.T) {
 	}
 }
 
+func TestKimiExecutorRequestToFormatMatchesWireProtocol(t *testing.T) {
+	type requestToFormatReporter interface {
+		RequestToFormat(cliproxyexecutor.Request, cliproxyexecutor.Options) sdktranslator.Format
+	}
+
+	executor := NewKimiExecutor(&config.Config{})
+	reporter, ok := any(executor).(requestToFormatReporter)
+	if !ok {
+		t.Fatal("Kimi executor does not report its upstream request format")
+	}
+
+	tests := []struct {
+		name   string
+		stream bool
+		source sdktranslator.Format
+		want   sdktranslator.Format
+	}{
+		{name: "Claude non-streaming", source: sdktranslator.FormatClaude, want: sdktranslator.FormatClaude},
+		{name: "Claude streaming", stream: true, source: sdktranslator.FormatClaude, want: sdktranslator.FormatClaude},
+		{name: "OpenAI non-streaming", source: sdktranslator.FormatOpenAI, want: sdktranslator.FormatOpenAI},
+		{name: "OpenAI streaming", stream: true, source: sdktranslator.FormatOpenAI, want: sdktranslator.FormatOpenAI},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := reporter.RequestToFormat(cliproxyexecutor.Request{}, cliproxyexecutor.Options{
+				SourceFormat: tt.source,
+				Stream:       tt.stream,
+			})
+			if got != tt.want {
+				t.Fatalf("RequestToFormat() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestKimiExecutorClaudeRequestPreservesInternalModelSemantics(t *testing.T) {
 	var upstreamBody []byte
 	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", kimiRoundTripperFunc(func(req *http.Request) (*http.Response, error) {

--- a/internal/runtime/executor/openai_compat_executor.go
+++ b/internal/runtime/executor/openai_compat_executor.go
@@ -419,55 +419,117 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 		var param any
 		var streamUsage helps.StreamUsageBuffer
 		var seenDone bool
+		var streamFailed bool
+		var streamAborted bool
+		var upstreamEvent string
+		var frameData [][]byte
 		defer streamUsage.Publish(ctx, reporter)
+
+		publishStreamError := func(streamErr statusErr, containsPayload bool) {
+			loggedErr := streamErr
+			if containsPayload {
+				loggedErr = statusErr{code: streamErr.code, msg: "upstream stream returned an error payload"}
+			}
+			helps.RecordAPIResponseError(ctx, e.cfg, loggedErr)
+			reporter.PublishFailure(ctx, loggedErr)
+			select {
+			case out <- cliproxyexecutor.StreamChunk{Err: streamErr}:
+			case <-ctx.Done():
+			}
+			streamFailed = true
+		}
+
+		processFrame := func() bool {
+			eventName := upstreamEvent
+			upstreamEvent = ""
+			dataLines := frameData
+			frameData = nil
+			if len(dataLines) == 0 {
+				if openAICompatErrorEvent(eventName) {
+					publishStreamError(statusErr{code: http.StatusBadGateway, msg: "upstream error event ended without data"}, false)
+					return true
+				}
+				return false
+			}
+
+			if len(dataLines) > 1 {
+				for _, dataLine := range dataLines {
+					if bytes.Equal(bytes.TrimSpace(dataLine), []byte("[DONE]")) {
+						publishStreamError(statusErr{code: http.StatusBadGateway, msg: "upstream stream ended with incomplete data before [DONE]"}, false)
+						return true
+					}
+				}
+			}
+			dataPayload := bytes.TrimSpace(bytes.Join(dataLines, []byte("\n")))
+			isDone := bytes.Equal(dataPayload, []byte("[DONE]"))
+			if isDone && openAICompatErrorEvent(eventName) {
+				publishStreamError(statusErr{code: http.StatusBadGateway, msg: "upstream error event ended before [DONE]"}, false)
+				return true
+			}
+			if !isDone && !json.Valid(dataPayload) {
+				publishStreamError(statusErr{code: http.StatusBadGateway, msg: "upstream stream ended with incomplete SSE data frame"}, false)
+				return true
+			}
+			if !isDone {
+				if streamErr, isError := openAICompatStreamDataError(dataPayload, eventName); isError {
+					publishStreamError(streamErr, true)
+					return true
+				}
+			}
+
+			streamLine := append([]byte("data: "), dataPayload...)
+			chunks := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, opts.OriginalRequest, translated, streamLine, &param, claudeInputTokens)
+			for i := range chunks {
+				select {
+				case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}:
+				case <-ctx.Done():
+					streamAborted = true
+					return true
+				}
+			}
+			if isDone {
+				seenDone = true
+				return true
+			}
+			return false
+		}
+
+	scanLoop:
 		for scanner.Scan() {
 			line := scanner.Bytes()
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 			streamUsage.ObserveOpenAIStream(line)
 			trimmedLine := bytes.TrimSpace(line)
 			if len(trimmedLine) == 0 {
-				continue
-			}
-
-			if !bytes.HasPrefix(trimmedLine, []byte("data:")) {
-				if bytes.HasPrefix(trimmedLine, []byte(":")) || bytes.HasPrefix(trimmedLine, []byte("event:")) ||
-					bytes.HasPrefix(trimmedLine, []byte("id:")) || bytes.HasPrefix(trimmedLine, []byte("retry:")) {
-					continue
-				}
-				if bytes.HasPrefix(trimmedLine, []byte("{")) || bytes.HasPrefix(trimmedLine, []byte("[")) {
-					streamErr := statusErr{code: http.StatusBadGateway, msg: string(trimmedLine)}
-					helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
-					reporter.PublishFailure(ctx, streamErr)
-					select {
-					case out <- cliproxyexecutor.StreamChunk{Err: streamErr}:
-					case <-ctx.Done():
-					}
-					return
+				if processFrame() {
+					break scanLoop
 				}
 				continue
 			}
-
-			// OpenAI SSE treats data: [DONE] as the terminal event. Process it once,
-			// then stop so trailing non-spec chunks (e.g. cost metadata after DONE)
-			// are not reordered ahead of the handler-emitted terminal marker.
-			dataPayload := bytes.TrimSpace(trimmedLine[len("data:"):])
-			isDone := bytes.Equal(dataPayload, []byte("[DONE]"))
-
-			// OpenAI-compatible streams must use SSE data lines.
-			chunks := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, opts.OriginalRequest, translated, bytes.Clone(trimmedLine), &param, claudeInputTokens)
-			for i := range chunks {
-				select {
-				case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}:
-				case <-ctx.Done():
-					return
-				}
+			if bytes.HasPrefix(trimmedLine, []byte("data:")) {
+				frameData = append(frameData, bytes.Clone(bytes.TrimSpace(trimmedLine[len("data:"):])))
+				continue
 			}
-			if isDone {
-				seenDone = true
+			if bytes.HasPrefix(trimmedLine, []byte("event:")) {
+				upstreamEvent = strings.TrimSpace(string(trimmedLine[len("event:"):]))
+				continue
+			}
+			if bytes.HasPrefix(trimmedLine, []byte(":")) || bytes.HasPrefix(trimmedLine, []byte("id:")) || bytes.HasPrefix(trimmedLine, []byte("retry:")) {
+				continue
+			}
+			if bytes.HasPrefix(trimmedLine, []byte("{")) || bytes.HasPrefix(trimmedLine, []byte("[")) {
+				publishStreamError(statusErr{code: http.StatusBadGateway, msg: string(trimmedLine)}, true)
 				break
 			}
 		}
-		if errScan := scanner.Err(); errScan != nil {
+		errScan := scanner.Err()
+		if errScan == nil && !seenDone && !streamFailed && !streamAborted && len(frameData) > 0 {
+			_ = processFrame()
+		}
+		if streamFailed || streamAborted {
+			return
+		}
+		if errScan != nil {
 			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
 			reporter.PublishFailure(ctx, errScan)
 			select {
@@ -475,9 +537,20 @@ func (e *OpenAICompatExecutor) ExecuteStream(ctx context.Context, auth *cliproxy
 			case <-ctx.Done():
 			}
 		} else if !seenDone {
-			// Upstream closed without a terminal [DONE] marker.
-			// Feed a synthetic done marker through the translator so pending
-			// response.completed events are still emitted exactly once.
+			// Responses clients require an explicit terminal event. Treat a clean
+			// upstream EOF without [DONE] as a failed stream instead of completing it.
+			if responseFormat == sdktranslator.FormatOpenAIResponse {
+				streamErr := statusErr{code: http.StatusBadGateway, msg: "upstream stream closed before [DONE]"}
+				helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
+				reporter.PublishFailure(ctx, streamErr)
+				select {
+				case out <- cliproxyexecutor.StreamChunk{Err: streamErr}:
+				case <-ctx.Done():
+				}
+				return
+			}
+
+			// Other protocols retain compatibility with providers that omit [DONE].
 			chunks := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, opts.OriginalRequest, translated, []byte("data: [DONE]"), &param, claudeInputTokens)
 			for i := range chunks {
 				select {
@@ -896,6 +969,42 @@ func (e *OpenAICompatExecutor) overrideModel(payload []byte, model string) []byt
 		return payload
 	}
 	return helps.SetStringIfDifferent(payload, "model", model)
+}
+
+func openAICompatErrorEvent(eventName string) bool {
+	return strings.EqualFold(eventName, "error") || strings.EqualFold(eventName, "response.error") || strings.EqualFold(eventName, "response.failed")
+}
+
+func openAICompatStreamDataError(payload []byte, eventName string) (statusErr, bool) {
+	if len(payload) == 0 || !json.Valid(payload) {
+		return statusErr{}, false
+	}
+	payloadType := gjson.GetBytes(payload, "type").String()
+	hasError := false
+	for _, path := range []string{"error", "response.error"} {
+		errorNode := gjson.GetBytes(payload, path)
+		if errorNode.Exists() && errorNode.Raw != "null" {
+			hasError = true
+			break
+		}
+	}
+	hasTopLevelErrorFields := gjson.GetBytes(payload, "code").Exists() && gjson.GetBytes(payload, "message").Exists()
+	if !hasError && !strings.EqualFold(payloadType, "error") && !strings.EqualFold(payloadType, "response.error") && !strings.EqualFold(payloadType, "response.failed") &&
+		!openAICompatErrorEvent(eventName) && !hasTopLevelErrorFields {
+		return statusErr{}, false
+	}
+
+	status := 0
+	for _, path := range []string{"status", "status_code", "error.status", "error.status_code", "response.error.status", "response.error.status_code"} {
+		status = int(gjson.GetBytes(payload, path).Int())
+		if status >= http.StatusBadRequest && status <= 599 {
+			break
+		}
+	}
+	if status < http.StatusBadRequest || status > 599 {
+		status = http.StatusBadGateway
+	}
+	return statusErr{code: status, msg: string(payload)}, true
 }
 
 type statusErr struct {

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -900,6 +901,244 @@ func TestOpenAICompatExecutorStreamSkipsKeepAliveUntilDataLine(t *testing.T) {
 	}
 	if gjson.Get(got.String(), "choices.0.delta.content").String() != "hello" {
 		t.Fatalf("stream payload = %s", got.String())
+	}
+}
+
+func TestOpenAICompatExecutorResponsesStreamFailsOnEOFWithoutDone(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","created":1773896263,"model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant","content":"partial"},"finish_reason":null}]}` + "\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+	}}
+	request := []byte(`{"model":"deepseek-v4-flash","input":"hi","stream":true}`)
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash",
+		Payload: request,
+	}, cliproxyexecutor.Options{
+		SourceFormat:    sdktranslator.FormatOpenAIResponse,
+		ResponseFormat:  sdktranslator.FormatOpenAIResponse,
+		OriginalRequest: request,
+		Stream:          true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var streamed strings.Builder
+	var streamErr error
+	for chunk := range result.Chunks {
+		streamed.Write(chunk.Payload)
+		if chunk.Err != nil {
+			streamErr = chunk.Err
+		}
+	}
+	if !strings.Contains(streamed.String(), "response.output_text.delta") {
+		t.Fatalf("stream did not forward partial assistant output: %q", streamed.String())
+	}
+	if strings.Contains(streamed.String(), "response.completed") {
+		t.Fatalf("clean EOF without [DONE] was finalized as response.completed: %q", streamed.String())
+	}
+	if streamErr == nil {
+		t.Fatal("clean EOF without [DONE] did not produce a terminal stream error")
+	}
+	statusErr, ok := streamErr.(interface{ StatusCode() int })
+	if !ok || statusErr.StatusCode() != http.StatusBadGateway {
+		t.Fatalf("stream error status = %v, want %d", streamErr, http.StatusBadGateway)
+	}
+	if !strings.Contains(streamErr.Error(), "closed before [DONE]") {
+		t.Fatalf("stream error does not explain the missing terminal marker: %v", streamErr)
+	}
+}
+
+func TestOpenAICompatExecutorResponsesStreamPreservesUpstreamDataError(t *testing.T) {
+	for _, withDone := range []bool{false, true} {
+		t.Run(fmt.Sprintf("with_done=%t", withDone), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = w.Write([]byte(`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","created":1773896263,"model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant","content":"partial"},"finish_reason":null}]}` + "\n\n"))
+				_, _ = w.Write([]byte(`data: {"error":{"type":"server_error","code":"upstream_failed","message":"upstream failed"}}` + "\n\n"))
+				if withDone {
+					_, _ = w.Write([]byte("data: [DONE]\n\n"))
+				}
+			}))
+			defer server.Close()
+
+			executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{
+				"base_url": server.URL + "/v1",
+				"api_key":  "test",
+			}}
+			request := []byte(`{"model":"deepseek-v4-flash","input":"hi","stream":true}`)
+			result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+				Model:   "deepseek-v4-flash",
+				Payload: request,
+			}, cliproxyexecutor.Options{
+				SourceFormat:    sdktranslator.FormatOpenAIResponse,
+				ResponseFormat:  sdktranslator.FormatOpenAIResponse,
+				OriginalRequest: request,
+				Stream:          true,
+			})
+			if err != nil {
+				t.Fatalf("ExecuteStream error: %v", err)
+			}
+
+			var streamed strings.Builder
+			var streamErr error
+			for chunk := range result.Chunks {
+				streamed.Write(chunk.Payload)
+				if chunk.Err != nil {
+					streamErr = chunk.Err
+				}
+			}
+			if strings.Contains(streamed.String(), "response.completed") {
+				t.Fatalf("upstream data error was finalized as response.completed: %q", streamed.String())
+			}
+			if streamErr == nil || !strings.Contains(streamErr.Error(), "upstream failed") {
+				t.Fatalf("terminal stream error = %v, want original upstream failure", streamErr)
+			}
+		})
+	}
+}
+
+func TestOpenAICompatExecutorResponsesStreamPreservesNamedErrorEvent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","created":1773896263,"model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant","content":"partial"},"finish_reason":null}]}` + "\n\n"))
+		_, _ = w.Write([]byte("event: error\n"))
+		_, _ = w.Write([]byte(`data: {"code":"upstream_failed",` + "\n"))
+		_, _ = w.Write([]byte(`data: "message":"upstream failed"}` + "\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+	}}
+	request := []byte(`{"model":"deepseek-v4-flash","input":"hi","stream":true}`)
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash",
+		Payload: request,
+	}, cliproxyexecutor.Options{
+		SourceFormat:    sdktranslator.FormatOpenAIResponse,
+		ResponseFormat:  sdktranslator.FormatOpenAIResponse,
+		OriginalRequest: request,
+		Stream:          true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var streamed strings.Builder
+	var streamErr error
+	for chunk := range result.Chunks {
+		streamed.Write(chunk.Payload)
+		if chunk.Err != nil {
+			streamErr = chunk.Err
+		}
+	}
+	if strings.Contains(streamed.String(), "response.completed") {
+		t.Fatalf("named upstream error event was finalized as response.completed: %q", streamed.String())
+	}
+	if streamErr == nil || !strings.Contains(streamErr.Error(), "upstream failed") {
+		t.Fatalf("terminal stream error = %v, want named upstream failure", streamErr)
+	}
+}
+
+func TestOpenAICompatExecutorResponsesStreamHandlesAdditionalErrorShapes(t *testing.T) {
+	tests := []struct {
+		name    string
+		lines   []string
+		wantErr string
+	}{
+		{
+			name: "response failed payload",
+			lines: []string{
+				`data: {"type":"response.failed","response":{"error":{"type":"server_error","code":"upstream_failed","message":"response failed upstream"}}}` + "\n\n",
+				"data: [DONE]\n\n",
+			},
+			wantErr: "response failed upstream",
+		},
+		{
+			name: "data before named error",
+			lines: []string{
+				`data: {"detail":"data before event failure"}` + "\n",
+				"event: error\n\n",
+				"data: [DONE]\n\n",
+			},
+			wantErr: "data before event failure",
+		},
+		{
+			name: "done after incomplete error data",
+			lines: []string{
+				"event: error\n",
+				`data: {"message":"incomplete upstream failure"` + "\n",
+				"data: [DONE]\n\n",
+			},
+			wantErr: "incomplete data before [DONE]",
+		},
+		{
+			name: "done immediately after error event",
+			lines: []string{
+				"event: error\n",
+				"data: [DONE]\n\n",
+			},
+			wantErr: "error event ended before [DONE]",
+		},
+		{
+			name: "incomplete data cannot cross frame boundary",
+			lines: []string{
+				"data: {\n\n",
+				`data: "id":"chatcmpl_2","object":"chat.completion.chunk","choices":[]}` + "\n\n",
+				"data: [DONE]\n\n",
+			},
+			wantErr: "incomplete SSE data frame",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = w.Write([]byte(`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","created":1773896263,"model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant","content":"partial"},"finish_reason":null}]}` + "\n\n"))
+				for _, line := range tc.lines {
+					_, _ = w.Write([]byte(line))
+				}
+			}))
+			defer server.Close()
+
+			executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{"base_url": server.URL + "/v1", "api_key": "test"}}
+			request := []byte(`{"model":"deepseek-v4-flash","input":"hi","stream":true}`)
+			result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{Model: "deepseek-v4-flash", Payload: request}, cliproxyexecutor.Options{
+				SourceFormat: sdktranslator.FormatOpenAIResponse, ResponseFormat: sdktranslator.FormatOpenAIResponse, OriginalRequest: request, Stream: true,
+			})
+			if err != nil {
+				t.Fatalf("ExecuteStream error: %v", err)
+			}
+
+			var streamed strings.Builder
+			var streamErr error
+			for chunk := range result.Chunks {
+				streamed.Write(chunk.Payload)
+				if chunk.Err != nil {
+					streamErr = chunk.Err
+				}
+			}
+			if strings.Contains(streamed.String(), "response.completed") {
+				t.Fatalf("upstream error was finalized as response.completed: %q", streamed.String())
+			}
+			if streamErr == nil || !strings.Contains(streamErr.Error(), tc.wantErr) {
+				t.Fatalf("terminal stream error = %v, want %q", streamErr, tc.wantErr)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/executor/openai_compat_executor_compact_test.go
+++ b/internal/runtime/executor/openai_compat_executor_compact_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -1007,6 +1008,244 @@ func TestOpenAICompatExecutorStreamSkipsKeepAliveUntilDataLine(t *testing.T) {
 	}
 	if gjson.Get(got.String(), "choices.0.delta.content").String() != "hello" {
 		t.Fatalf("stream payload = %s", got.String())
+	}
+}
+
+func TestOpenAICompatExecutorResponsesStreamFailsOnEOFWithoutDone(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","created":1773896263,"model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant","content":"partial"},"finish_reason":null}]}` + "\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+	}}
+	request := []byte(`{"model":"deepseek-v4-flash","input":"hi","stream":true}`)
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash",
+		Payload: request,
+	}, cliproxyexecutor.Options{
+		SourceFormat:    sdktranslator.FormatOpenAIResponse,
+		ResponseFormat:  sdktranslator.FormatOpenAIResponse,
+		OriginalRequest: request,
+		Stream:          true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var streamed strings.Builder
+	var streamErr error
+	for chunk := range result.Chunks {
+		streamed.Write(chunk.Payload)
+		if chunk.Err != nil {
+			streamErr = chunk.Err
+		}
+	}
+	if !strings.Contains(streamed.String(), "response.output_text.delta") {
+		t.Fatalf("stream did not forward partial assistant output: %q", streamed.String())
+	}
+	if strings.Contains(streamed.String(), "response.completed") {
+		t.Fatalf("clean EOF without [DONE] was finalized as response.completed: %q", streamed.String())
+	}
+	if streamErr == nil {
+		t.Fatal("clean EOF without [DONE] did not produce a terminal stream error")
+	}
+	statusErr, ok := streamErr.(interface{ StatusCode() int })
+	if !ok || statusErr.StatusCode() != http.StatusBadGateway {
+		t.Fatalf("stream error status = %v, want %d", streamErr, http.StatusBadGateway)
+	}
+	if !strings.Contains(streamErr.Error(), "closed before [DONE]") {
+		t.Fatalf("stream error does not explain the missing terminal marker: %v", streamErr)
+	}
+}
+
+func TestOpenAICompatExecutorResponsesStreamPreservesUpstreamDataError(t *testing.T) {
+	for _, withDone := range []bool{false, true} {
+		t.Run(fmt.Sprintf("with_done=%t", withDone), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = w.Write([]byte(`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","created":1773896263,"model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant","content":"partial"},"finish_reason":null}]}` + "\n\n"))
+				_, _ = w.Write([]byte(`data: {"error":{"type":"server_error","code":"upstream_failed","message":"upstream failed"}}` + "\n\n"))
+				if withDone {
+					_, _ = w.Write([]byte("data: [DONE]\n\n"))
+				}
+			}))
+			defer server.Close()
+
+			executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{
+				"base_url": server.URL + "/v1",
+				"api_key":  "test",
+			}}
+			request := []byte(`{"model":"deepseek-v4-flash","input":"hi","stream":true}`)
+			result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+				Model:   "deepseek-v4-flash",
+				Payload: request,
+			}, cliproxyexecutor.Options{
+				SourceFormat:    sdktranslator.FormatOpenAIResponse,
+				ResponseFormat:  sdktranslator.FormatOpenAIResponse,
+				OriginalRequest: request,
+				Stream:          true,
+			})
+			if err != nil {
+				t.Fatalf("ExecuteStream error: %v", err)
+			}
+
+			var streamed strings.Builder
+			var streamErr error
+			for chunk := range result.Chunks {
+				streamed.Write(chunk.Payload)
+				if chunk.Err != nil {
+					streamErr = chunk.Err
+				}
+			}
+			if strings.Contains(streamed.String(), "response.completed") {
+				t.Fatalf("upstream data error was finalized as response.completed: %q", streamed.String())
+			}
+			if streamErr == nil || !strings.Contains(streamErr.Error(), "upstream failed") {
+				t.Fatalf("terminal stream error = %v, want original upstream failure", streamErr)
+			}
+		})
+	}
+}
+
+func TestOpenAICompatExecutorResponsesStreamPreservesNamedErrorEvent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","created":1773896263,"model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant","content":"partial"},"finish_reason":null}]}` + "\n\n"))
+		_, _ = w.Write([]byte("event: error\n"))
+		_, _ = w.Write([]byte(`data: {"code":"upstream_failed",` + "\n"))
+		_, _ = w.Write([]byte(`data: "message":"upstream failed"}` + "\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL + "/v1",
+		"api_key":  "test",
+	}}
+	request := []byte(`{"model":"deepseek-v4-flash","input":"hi","stream":true}`)
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "deepseek-v4-flash",
+		Payload: request,
+	}, cliproxyexecutor.Options{
+		SourceFormat:    sdktranslator.FormatOpenAIResponse,
+		ResponseFormat:  sdktranslator.FormatOpenAIResponse,
+		OriginalRequest: request,
+		Stream:          true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var streamed strings.Builder
+	var streamErr error
+	for chunk := range result.Chunks {
+		streamed.Write(chunk.Payload)
+		if chunk.Err != nil {
+			streamErr = chunk.Err
+		}
+	}
+	if strings.Contains(streamed.String(), "response.completed") {
+		t.Fatalf("named upstream error event was finalized as response.completed: %q", streamed.String())
+	}
+	if streamErr == nil || !strings.Contains(streamErr.Error(), "upstream failed") {
+		t.Fatalf("terminal stream error = %v, want named upstream failure", streamErr)
+	}
+}
+
+func TestOpenAICompatExecutorResponsesStreamHandlesAdditionalErrorShapes(t *testing.T) {
+	tests := []struct {
+		name    string
+		lines   []string
+		wantErr string
+	}{
+		{
+			name: "response failed payload",
+			lines: []string{
+				`data: {"type":"response.failed","response":{"error":{"type":"server_error","code":"upstream_failed","message":"response failed upstream"}}}` + "\n\n",
+				"data: [DONE]\n\n",
+			},
+			wantErr: "response failed upstream",
+		},
+		{
+			name: "data before named error",
+			lines: []string{
+				`data: {"detail":"data before event failure"}` + "\n",
+				"event: error\n\n",
+				"data: [DONE]\n\n",
+			},
+			wantErr: "data before event failure",
+		},
+		{
+			name: "done after incomplete error data",
+			lines: []string{
+				"event: error\n",
+				`data: {"message":"incomplete upstream failure"` + "\n",
+				"data: [DONE]\n\n",
+			},
+			wantErr: "incomplete data before [DONE]",
+		},
+		{
+			name: "done immediately after error event",
+			lines: []string{
+				"event: error\n",
+				"data: [DONE]\n\n",
+			},
+			wantErr: "error event ended before [DONE]",
+		},
+		{
+			name: "incomplete data cannot cross frame boundary",
+			lines: []string{
+				"data: {\n\n",
+				`data: "id":"chatcmpl_2","object":"chat.completion.chunk","choices":[]}` + "\n\n",
+				"data: [DONE]\n\n",
+			},
+			wantErr: "incomplete SSE data frame",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = w.Write([]byte(`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","created":1773896263,"model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant","content":"partial"},"finish_reason":null}]}` + "\n\n"))
+				for _, line := range tc.lines {
+					_, _ = w.Write([]byte(line))
+				}
+			}))
+			defer server.Close()
+
+			executor := NewOpenAICompatExecutor("openai-compatibility", &config.Config{})
+			auth := &cliproxyauth.Auth{Attributes: map[string]string{"base_url": server.URL + "/v1", "api_key": "test"}}
+			request := []byte(`{"model":"deepseek-v4-flash","input":"hi","stream":true}`)
+			result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{Model: "deepseek-v4-flash", Payload: request}, cliproxyexecutor.Options{
+				SourceFormat: sdktranslator.FormatOpenAIResponse, ResponseFormat: sdktranslator.FormatOpenAIResponse, OriginalRequest: request, Stream: true,
+			})
+			if err != nil {
+				t.Fatalf("ExecuteStream error: %v", err)
+			}
+
+			var streamed strings.Builder
+			var streamErr error
+			for chunk := range result.Chunks {
+				streamed.Write(chunk.Payload)
+				if chunk.Err != nil {
+					streamErr = chunk.Err
+				}
+			}
+			if strings.Contains(streamed.String(), "response.completed") {
+				t.Fatalf("upstream error was finalized as response.completed: %q", streamed.String())
+			}
+			if streamErr == nil || !strings.Contains(streamErr.Error(), tc.wantErr) {
+				t.Fatalf("terminal stream error = %v, want %q", streamErr, tc.wantErr)
+			}
+		})
 	}
 }
 

--- a/internal/translator/codex/openai/responses/codex_openai-responses_request.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request.go
@@ -30,7 +30,7 @@ func ConvertOpenAIResponsesRequestToCodex(modelName string, inputRawJSON []byte,
 		rawJSON = deleteCodexRequestFields(rawJSON, "service_tier")
 	}
 
-	rawJSON = deleteCodexRequestFields(rawJSON, "truncation")
+	rawJSON = deleteCodexRequestFields(rawJSON, "truncation", "prompt_cache_options")
 	rawJSON = applyResponsesCompactionCompatibility(rawJSON)
 
 	// Delete the user field as it is not supported by the Codex upstream.

--- a/internal/translator/codex/openai/responses/codex_openai-responses_request_test.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request_test.go
@@ -252,6 +252,7 @@ func TestConvertOpenAIResponsesRequestToCodexNormalizesRequiredFields(t *testing
 		"top_p":0.9,
 		"service_tier":"standard",
 		"truncation":"auto",
+		"prompt_cache_options":{"mode":"implicit"},
 		"user":"request-owner",
 		"input":[{"type":"message","role":"system","content":"hello"}]
 	}`)
@@ -281,6 +282,7 @@ func TestConvertOpenAIResponsesRequestToCodexNormalizesRequiredFields(t *testing
 		"top_p",
 		"service_tier",
 		"truncation",
+		"prompt_cache_options",
 		"user",
 	} {
 		if gjson.GetBytes(output, path).Exists() {

--- a/internal/translator/codex/openai/responses/codex_openai-responses_request_test.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request_test.go
@@ -226,7 +226,7 @@ func TestConvertOpenAIResponsesRequestToCodex_OriginalIssue(t *testing.T) {
 	}
 }
 
-func TestConvertOpenAIResponsesRequestToCodexPreservesPromptCacheControls(t *testing.T) {
+func TestConvertOpenAIResponsesRequestToCodexPreservesSupportedPromptCacheControls(t *testing.T) {
 	input := []byte(`{
 		"model":"gpt-5.6-sol",
 		"prompt_cache_key":"tenant:responses",
@@ -238,8 +238,8 @@ func TestConvertOpenAIResponsesRequestToCodexPreservesPromptCacheControls(t *tes
 	if got := gjson.GetBytes(out, "prompt_cache_key").String(); got != "tenant:responses" {
 		t.Fatalf("prompt_cache_key = %q, want tenant:responses; output=%s", got, out)
 	}
-	if got := gjson.GetBytes(out, "prompt_cache_options.mode").String(); got != "explicit" {
-		t.Fatalf("prompt_cache_options.mode = %q, want explicit; output=%s", got, out)
+	if gjson.GetBytes(out, "prompt_cache_options").Exists() {
+		t.Fatalf("unsupported prompt_cache_options was preserved; output=%s", out)
 	}
 	if got := gjson.GetBytes(out, "input.0.content.0.prompt_cache_breakpoint.mode").String(); got != "explicit" {
 		t.Fatalf("prompt_cache_breakpoint.mode = %q, want explicit; output=%s", got, out)
@@ -272,6 +272,7 @@ func TestConvertOpenAIResponsesRequestToCodexNormalizesRequiredFields(t *testing
 		"top_p":0.9,
 		"service_tier":"standard",
 		"truncation":"auto",
+		"prompt_cache_options":{"mode":"implicit"},
 		"user":"request-owner",
 		"input":[{"type":"message","role":"system","content":"hello"}]
 	}`)
@@ -301,6 +302,7 @@ func TestConvertOpenAIResponsesRequestToCodexNormalizesRequiredFields(t *testing
 		"top_p",
 		"service_tier",
 		"truncation",
+		"prompt_cache_options",
 		"user",
 	} {
 		if gjson.GetBytes(output, path).Exists() {

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -557,6 +557,9 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 
 	if isDone {
 		finalizeOpenItems()
+		if len(st.MsgItemAdded) == 0 && len(st.FuncItemAdded) == 0 {
+			return out
+		}
 		st.CompletedEmitted = true
 		out = append(out, buildResponsesCompletedEvent(st, requestForNamespace, nextSeq))
 		return out

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
@@ -1069,3 +1069,28 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_Restores
 		t.Fatalf("output input = %q, want pwd; response=%s", got, resp)
 	}
 }
+
+func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_DoesNotCompleteReasoningOnlyStream(t *testing.T) {
+	request := []byte(`{"model":"deepseek-v4-flash"}`)
+	chunks := []string{
+		`data: {"id":"resp_reasoning_only","object":"chat.completion.chunk","created":1773896263,"model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"still thinking"},"finish_reason":null}]}`,
+		`data: [DONE]`,
+	}
+
+	var param any
+	reasoningSeen := false
+	for _, line := range chunks {
+		for _, chunk := range ConvertOpenAIChatCompletionsResponseToOpenAIResponses(context.Background(), "deepseek-v4-flash", request, request, []byte(line), &param) {
+			event, _ := parseOpenAIResponsesSSEEvent(t, chunk)
+			if event == "response.reasoning_summary_text.delta" {
+				reasoningSeen = true
+			}
+			if event == "response.completed" {
+				t.Fatalf("reasoning-only stream was finalized as response.completed: %s", chunk)
+			}
+		}
+	}
+	if !reasoningSeen {
+		t.Fatal("test stream did not exercise reasoning output")
+	}
+}

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -125,6 +125,10 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 		close(closed)
 		chunks = closed
 	}
+	var responseSSEValidator *sseJSONValidationState
+	if responseProtocol == "openai-response" {
+		responseSSEValidator = &sseJSONValidationState{}
+	}
 	go func() {
 		completionOutcome := pluginapi.RequestCompletionSucceeded
 		completionStatus := http.StatusOK
@@ -147,6 +151,22 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 				return
 			}
 			if !ok {
+				if responseSSEValidator != nil {
+					if errValidate := responseSSEValidator.Finish(); errValidate != nil {
+						completionOutcome = pluginapi.RequestCompletionFailed
+						completionStatus = http.StatusBadGateway
+						completionErr = errValidate
+						select {
+						case errChan <- &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: errValidate}:
+						case <-done:
+							completionOutcome = pluginapi.RequestCompletionCanceled
+							completionStatus = 0
+							if ctx != nil {
+								completionErr = ctx.Err()
+							}
+						}
+					}
+				}
 				return
 			}
 			if chunk.Err != nil {
@@ -200,8 +220,9 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 			} else {
 				chunkIndex++
 			}
-			if responseProtocol == "openai-response" {
-				if errValidate := validateSSEDataJSON(payload); errValidate != nil {
+			if responseSSEValidator != nil {
+				validatedPayload, errValidate := responseSSEValidator.AddChunk(payload)
+				if errValidate != nil {
 					completionOutcome = pluginapi.RequestCompletionFailed
 					completionStatus = http.StatusBadGateway
 					completionErr = errValidate
@@ -215,6 +236,10 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 						}
 					}
 					return
+				}
+				payload = validatedPayload
+				if len(payload) == 0 {
+					continue
 				}
 			}
 			select {
@@ -372,6 +397,11 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 		streamHeaderInitialized = true
 	}
 
+	var responseSSEValidator *sseJSONValidationState
+	if responseProtocol == "openai-response" {
+		responseSSEValidator = &sseJSONValidationState{}
+	}
+
 	transformStreamPayload := func(payload []byte, chunkIndex *int, historyChunks [][]byte) ([]byte, bool, *interfaces.ErrorMessage) {
 		applyStreamHeaderInit()
 		payload = cloneBytes(payload)
@@ -406,9 +436,14 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 		} else {
 			(*chunkIndex)++
 		}
-		if responseProtocol == "openai-response" {
-			if errValidate := validateSSEDataJSON(payload); errValidate != nil {
+		if responseSSEValidator != nil {
+			validatedPayload, errValidate := responseSSEValidator.AddChunk(payload)
+			if errValidate != nil {
 				return nil, false, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: errValidate}
+			}
+			payload = validatedPayload
+			if len(payload) == 0 {
+				return nil, false, nil
 			}
 		}
 		return payload, true, nil
@@ -508,6 +543,9 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 		bootstrapPayload = nil
 		bootstrapChunkIndex = 0
 		bootstrapHistoryChunks = nil
+		if responseSSEValidator != nil {
+			responseSSEValidator = &sseJSONValidationState{}
+		}
 		chunks = retryResult.Chunks
 		if chunks == nil {
 			closed := make(chan coreexecutor.StreamChunk)
@@ -608,6 +646,15 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 				return
 			}
 			if !ok {
+				if responseSSEValidator != nil {
+					if errValidate := responseSSEValidator.Finish(); errValidate != nil {
+						errMsg := &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: errValidate}
+						completionOutcome = pluginapi.RequestCompletionFailed
+						completionStatus = errMsg.StatusCode
+						completionErr = errMsg.Error
+						_ = sendErr(errMsg)
+					}
+				}
 				return
 			}
 			if chunk.Err != nil {
@@ -656,31 +703,115 @@ func (h *BaseAPIHandler) executeStreamWithAuthManagerFormats(ctx context.Context
 	return dataChan, upstreamHeaders, errChan
 }
 
-func validateSSEDataJSON(chunk []byte) error {
-	for _, line := range bytes.Split(chunk, []byte("\n")) {
-		line = bytes.TrimSpace(line)
-		if len(line) == 0 {
-			continue
+type sseJSONValidationState struct {
+	pending    []byte
+	pendingErr error
+}
+
+func (s *sseJSONValidationState) AddChunk(chunk []byte) ([]byte, error) {
+	if s.pendingErr != nil {
+		errPending := s.pendingErr
+		s.pendingErr = nil
+		return nil, errPending
+	}
+	if len(chunk) == 0 {
+		return nil, nil
+	}
+	chunk = bytes.ReplaceAll(chunk, []byte("\r\n"), []byte("\n"))
+	chunk = bytes.ReplaceAll(chunk, []byte("\r"), []byte("\n"))
+	if len(s.pending) > 0 && !bytes.HasSuffix(s.pending, []byte("\n")) && !bytes.HasPrefix(chunk, []byte("\n")) {
+		first := bytes.TrimSpace(bytes.SplitN(chunk, []byte("\n"), 2)[0])
+		if bytes.HasPrefix(first, []byte("data:")) || bytes.HasPrefix(first, []byte("event:")) {
+			s.pending = append(s.pending, '\n')
 		}
+	}
+	s.pending = append(s.pending, chunk...)
+
+	var output []byte
+	for {
+		frameEnd := bytes.Index(s.pending, []byte("\n\n"))
+		if frameEnd < 0 {
+			break
+		}
+		frameEnd += 2
+		frame := s.pending[:frameEnd]
+		if errValidate := validateSSEFrameDataJSON(frame); errValidate != nil {
+			if len(output) > 0 {
+				s.pending = s.pending[:0]
+				s.pendingErr = errValidate
+				return output, nil
+			}
+			return nil, errValidate
+		}
+		output = append(output, frame...)
+		copy(s.pending, s.pending[frameEnd:])
+		s.pending = s.pending[:len(s.pending)-frameEnd]
+	}
+
+	if len(bytes.TrimSpace(s.pending)) == 0 {
+		s.pending = s.pending[:0]
+		return output, nil
+	}
+	payload, found := sseJSONValidationDataPayload(s.pending)
+	payload = bytes.TrimSpace(payload)
+	if !found || len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) || json.Valid(payload) {
+		output = append(output, s.pending...)
+		s.pending = s.pending[:0]
+	}
+	return output, nil
+}
+
+func (s *sseJSONValidationState) Finish() error {
+	if s.pendingErr != nil {
+		errPending := s.pendingErr
+		s.pendingErr = nil
+		s.pending = nil
+		return errPending
+	}
+	if len(bytes.TrimSpace(s.pending)) == 0 {
+		s.pending = nil
+		return nil
+	}
+	errValidate := validateSSEFrameDataJSON(s.pending)
+	s.pending = nil
+	return errValidate
+}
+
+func sseJSONValidationDataPayload(frame []byte) ([]byte, bool) {
+	var payload []byte
+	found := false
+	for _, line := range bytes.Split(frame, []byte("\n")) {
+		line = bytes.TrimSpace(line)
 		if !bytes.HasPrefix(line, []byte("data:")) {
 			continue
 		}
-		data := bytes.TrimSpace(line[5:])
-		if len(data) == 0 {
-			continue
+		if found {
+			payload = append(payload, '\n')
 		}
-		if bytes.Equal(data, []byte("[DONE]")) {
-			continue
-		}
-		if json.Valid(data) {
-			continue
-		}
-		const max = 512
-		preview := data
-		if len(preview) > max {
-			preview = preview[:max]
-		}
-		return fmt.Errorf("invalid SSE data JSON (len=%d): %q", len(data), preview)
+		payload = append(payload, bytes.TrimSpace(line[len("data:"):])...)
+		found = true
 	}
-	return nil
+	return payload, found
+}
+
+func validateSSEFrameDataJSON(frame []byte) error {
+	payload, found := sseJSONValidationDataPayload(frame)
+	payload = bytes.TrimSpace(payload)
+	if !found || len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) || json.Valid(payload) {
+		return nil
+	}
+	const max = 512
+	preview := payload
+	if len(preview) > max {
+		preview = preview[:max]
+	}
+	return fmt.Errorf("invalid SSE data JSON (len=%d): %q", len(payload), preview)
+}
+
+func validateSSEDataJSON(chunk []byte) error {
+	state := &sseJSONValidationState{}
+	if _, errAdd := state.AddChunk(chunk); errAdd != nil {
+		return errAdd
+	}
+	return state.Finish()
 }

--- a/sdk/api/handlers/handlers_stream_bootstrap_test.go
+++ b/sdk/api/handlers/handlers_stream_bootstrap_test.go
@@ -555,6 +555,35 @@ func TestExecuteStreamWithAuthManager_RetriesAfterDroppedBootstrapPayload(t *tes
 	}
 }
 
+func TestExecuteStreamWithAuthManager_ResetsResponsesValidatorOnBootstrapRetry(t *testing.T) {
+	executor := &bootstrapStreamExecutor{stream: func(_ context.Context, call int) (*coreexecutor.StreamResult, error) {
+		chunks := make(chan coreexecutor.StreamChunk, 2)
+		if call == 1 {
+			chunks <- coreexecutor.StreamChunk{Payload: []byte("event: response.completed\ndata: {\"type\":\"response.completed\",")}
+			chunks <- coreexecutor.StreamChunk{Err: &coreauth.Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"}}
+		} else {
+			chunks <- coreexecutor.StreamChunk{Payload: []byte("event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n")}
+		}
+		close(chunks)
+		return &coreexecutor.StreamResult{Chunks: chunks}, nil
+	}}
+	handler, _ := registerBootstrapExecutor(t, executor)
+
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai-response", "bootstrap-model", []byte(`{"model":"bootstrap-model"}`), "")
+	var got []byte
+	for chunk := range dataChan {
+		got = append(got, chunk...)
+	}
+	for msg := range errChan {
+		if msg != nil {
+			t.Fatalf("unexpected stream error after retry: %+v", msg)
+		}
+	}
+	if executor.Calls() != 2 || !strings.Contains(string(got), "response.completed") {
+		t.Fatalf("retry calls=%d payload=%q", executor.Calls(), got)
+	}
+}
+
 func TestExecuteStreamWithAuthManager_CancelDuringSynchronousBootstrap(t *testing.T) {
 	started := make(chan struct{})
 	executor := &bootstrapStreamExecutor{stream: func(_ context.Context, _ int) (*coreexecutor.StreamResult, error) {

--- a/sdk/api/handlers/openai/openai_images_handlers.go
+++ b/sdk/api/handlers/openai/openai_images_handlers.go
@@ -88,20 +88,21 @@ func writeImagesStreamKeepAlive(c *gin.Context, flusher http.Flusher) {
 	flusher.Flush()
 }
 
-func writeImagesStreamErrorEvent(c *gin.Context, errMsg *interfaces.ErrorMessage) {
+func writeImagesStreamErrorEvent(c *gin.Context, errMsg *interfaces.ErrorMessage) *interfaces.ErrorMessage {
+	original := errMsg
+	errMsg = sanitizeResponsesStreamErrorMessage(errMsg)
 	if errMsg == nil {
-		return
+		return nil
 	}
-	status := http.StatusInternalServerError
-	if errMsg.StatusCode > 0 {
-		status = errMsg.StatusCode
+	if original != nil {
+		*original = *errMsg
+		errMsg = original
 	}
-	errText := http.StatusText(status)
-	if errMsg.Error != nil && strings.TrimSpace(errMsg.Error.Error()) != "" {
-		errText = errMsg.Error.Error()
-	}
+	status := errMsg.StatusCode
+	errText := responsesStreamErrorText(errMsg, status)
 	body := handlers.BuildErrorResponseBody(status, errText)
 	_, _ = fmt.Fprintf(c.Writer, "event: error\ndata: %s\n\n", string(body))
+	return errMsg
 }
 
 func (h *OpenAIAPIHandler) waitImagesStreamExecution(c *gin.Context, flusher http.Flusher, execute func() imagesStreamExecutionResult) (imagesStreamExecutionResult, bool, bool) {
@@ -137,18 +138,22 @@ func (a *sseFrameAccumulator) AddChunk(chunk []byte) [][]byte {
 		return nil
 	}
 
+	var frames [][]byte
+	if responsesSSEStartsNewDataFrame(a.pending, chunk) {
+		frames = append(frames, bytes.Clone(a.pending))
+		a.pending = a.pending[:0]
+	}
 	if responsesSSENeedsLineBreak(a.pending, chunk) {
 		a.pending = append(a.pending, '\n')
 	}
 	a.pending = append(a.pending, chunk...)
 
-	var frames [][]byte
 	for {
 		frameLen := responsesSSEFrameLen(a.pending)
 		if frameLen == 0 {
 			break
 		}
-		frames = append(frames, a.pending[:frameLen])
+		frames = append(frames, bytes.Clone(a.pending[:frameLen]))
 		copy(a.pending, a.pending[frameLen:])
 		a.pending = a.pending[:len(a.pending)-frameLen]
 	}
@@ -160,7 +165,7 @@ func (a *sseFrameAccumulator) AddChunk(chunk []byte) [][]byte {
 	if len(a.pending) == 0 || !responsesSSECanEmitWithoutDelimiter(a.pending) {
 		return frames
 	}
-	frames = append(frames, a.pending)
+	frames = append(frames, bytes.Clone(a.pending))
 	a.pending = a.pending[:0]
 	return frames
 }
@@ -176,7 +181,7 @@ func (a *sseFrameAccumulator) Flush() [][]byte {
 		if frameLen == 0 {
 			break
 		}
-		frames = append(frames, a.pending[:frameLen])
+		frames = append(frames, bytes.Clone(a.pending[:frameLen]))
 		copy(a.pending, a.pending[frameLen:])
 		a.pending = a.pending[:len(a.pending)-frameLen]
 	}
@@ -185,8 +190,8 @@ func (a *sseFrameAccumulator) Flush() [][]byte {
 		a.pending = nil
 		return frames
 	}
-	if responsesSSECanEmitWithoutDelimiter(a.pending) {
-		frames = append(frames, a.pending)
+	if responsesSSECanFlushWithoutDelimiter(a.pending) {
+		frames = append(frames, bytes.Clone(a.pending))
 	}
 	a.pending = nil
 	return frames
@@ -1231,6 +1236,16 @@ func (h *OpenAIAPIHandler) streamRoutedImages(c *gin.Context, imageReq []byte, i
 		case chunk, ok := <-dataChan:
 			if !ok {
 				stopKeepAlive()
+				if errMsg, hasPendingError := handlers.PendingStreamError(errChan); hasPendingError {
+					if streamStarted {
+						writeImagesStreamErrorEvent(c, errMsg)
+						flusher.Flush()
+					} else {
+						h.WriteErrorResponse(c, errMsg)
+					}
+					cliCancel(errMsg.Error)
+					return
+				}
 				setImagesSSEHeaders(c)
 				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 				_, _ = c.Writer.Write([]byte("\n"))
@@ -1284,6 +1299,14 @@ func (h *OpenAIAPIHandler) forwardRawImageStream(ctx context.Context, c *gin.Con
 			errs = nil
 		case chunk, ok := <-data:
 			if !ok {
+				if errMsg, hasPendingError := handlers.PendingStreamError(errs); hasPendingError {
+					writeImagesStreamErrorEvent(c, errMsg)
+					if flusher, ok := c.Writer.(http.Flusher); ok {
+						flusher.Flush()
+					}
+					cancel(errMsg.Error)
+					return
+				}
 				cancel(nil)
 				return
 			}
@@ -1359,6 +1382,16 @@ func (h *OpenAIAPIHandler) streamOpenAICompatImages(c *gin.Context, compatReq []
 		case chunk, ok := <-dataChan:
 			if !ok {
 				stopKeepAlive()
+				if errMsg, hasPendingError := handlers.PendingStreamError(errChan); hasPendingError {
+					if streamStarted {
+						writeImagesStreamErrorEvent(c, errMsg)
+						flusher.Flush()
+					} else {
+						h.WriteErrorResponse(c, errMsg)
+					}
+					cliCancel(errMsg.Error)
+					return
+				}
 				setImagesSSEHeaders(c)
 				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 				flusher.Flush()
@@ -1373,6 +1406,7 @@ func (h *OpenAIAPIHandler) streamOpenAICompatImages(c *gin.Context, compatReq []
 			flusher.Flush()
 			streamStarted = true
 			h.ForwardStream(c, flusher, func(err error) { cliCancel(err) }, dataChan, errChan, handlers.StreamForwardOptions{
+				NormalizeTerminalError: sanitizeResponsesStreamErrorMessage,
 				WriteChunk: func(next []byte) {
 					_, _ = c.Writer.Write(next)
 				},
@@ -1571,40 +1605,33 @@ func collectImagesFromResponsesStream(ctx context.Context, data <-chan []byte, e
 	acc := &sseFrameAccumulator{}
 
 	processFrame := func(frame []byte) ([]byte, bool, *interfaces.ErrorMessage) {
-		for _, line := range bytes.Split(frame, []byte("\n")) {
-			trimmed := bytes.TrimSpace(bytes.TrimRight(line, "\r"))
-			if len(trimmed) == 0 {
-				continue
-			}
-			if !bytes.HasPrefix(trimmed, []byte("data:")) {
-				continue
-			}
-			payload := bytes.TrimSpace(trimmed[len("data:"):])
-			if len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) {
-				continue
-			}
-			if !json.Valid(payload) {
-				return nil, false, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("invalid SSE data JSON")}
-			}
-
-			if gjson.GetBytes(payload, "type").String() != "response.completed" {
-				continue
-			}
-
-			results, createdAt, usageRaw, firstMeta, err := extractImagesFromResponsesCompleted(payload)
-			if err != nil {
-				return nil, false, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: err}
-			}
-			if len(results) == 0 {
-				return nil, false, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("upstream did not return image output")}
-			}
-			out, err := buildImagesAPIResponse(results, createdAt, usageRaw, firstMeta, responseFormat)
-			if err != nil {
-				return nil, false, &interfaces.ErrorMessage{StatusCode: http.StatusInternalServerError, Error: err}
-			}
-			return out, true, nil
+		payload, ok := responsesSSEDataPayload(frame)
+		if !ok || len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) {
+			return nil, false, nil
 		}
-		return nil, false, nil
+		if !json.Valid(payload) {
+			return nil, false, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("invalid SSE data JSON")}
+		}
+		payloadType := gjson.GetBytes(payload, "type").String()
+		if responsesSSEErrorEvent(payloadType) || responsesSSEErrorEvent(responsesSSEEventName(frame)) || responsesSSEPayloadHasError(payload) {
+			return nil, false, responsesSSEPayloadErrorMessage(payload)
+		}
+		if payloadType != "response.completed" {
+			return nil, false, nil
+		}
+
+		results, createdAt, usageRaw, firstMeta, err := extractImagesFromResponsesCompleted(payload)
+		if err != nil {
+			return nil, false, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: err}
+		}
+		if len(results) == 0 {
+			return nil, false, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("upstream did not return image output")}
+		}
+		out, err := buildImagesAPIResponse(results, createdAt, usageRaw, firstMeta, responseFormat)
+		if err != nil {
+			return nil, false, &interfaces.ErrorMessage{StatusCode: http.StatusInternalServerError, Error: err}
+		}
+		return out, true, nil
 	}
 
 	for {
@@ -1628,6 +1655,9 @@ func collectImagesFromResponsesStream(ctx context.Context, data <-chan []byte, e
 					} else if done {
 						return out, nil
 					}
+				}
+				if errMsg, hasPendingError := handlers.PendingStreamError(errs); hasPendingError {
+					return nil, errMsg
 				}
 				return nil, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("stream disconnected before completion")}
 			}
@@ -1800,6 +1830,16 @@ func (h *OpenAIAPIHandler) streamImagesFromResponses(c *gin.Context, responsesRe
 		case chunk, ok := <-dataChan:
 			if !ok {
 				stopKeepAlive()
+				if errMsg, hasPendingError := handlers.PendingStreamError(errChan); hasPendingError {
+					if streamStarted {
+						writeImagesStreamErrorEvent(c, errMsg)
+						flusher.Flush()
+					} else {
+						h.WriteErrorResponse(c, errMsg)
+					}
+					cliCancel(errMsg.Error)
+					return
+				}
 				setImagesSSEHeaders(c)
 				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
 				_, _ = c.Writer.Write([]byte("\n"))
@@ -1837,75 +1877,88 @@ func (h *OpenAIAPIHandler) forwardImagesStream(ctx context.Context, c *gin.Conte
 		}
 	}()
 
-	emitError := func(errMsg *interfaces.ErrorMessage) {
-		writeImagesStreamErrorEvent(c, errMsg)
+	emitError := func(errMsg *interfaces.ErrorMessage) *interfaces.ErrorMessage {
+		errMsg = writeImagesStreamErrorEvent(c, errMsg)
 		flusher.Flush()
+		return errMsg
 	}
 
-	processFrame := func(frame []byte) (done bool) {
-		for _, line := range bytes.Split(frame, []byte("\n")) {
-			trimmed := bytes.TrimSpace(bytes.TrimRight(line, "\r"))
-			if len(trimmed) == 0 || !bytes.HasPrefix(trimmed, []byte("data:")) {
-				continue
-			}
-			payload := bytes.TrimSpace(trimmed[len("data:"):])
-			if len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) || !json.Valid(payload) {
-				continue
-			}
+	processFrame := func(frame []byte) (bool, *interfaces.ErrorMessage) {
+		payload, ok := responsesSSEDataPayload(frame)
+		if !ok || len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) {
+			return false, nil
+		}
+		if !json.Valid(payload) {
+			return true, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("invalid SSE data JSON")}
+		}
+		payloadType := gjson.GetBytes(payload, "type").String()
+		if responsesSSEErrorEvent(payloadType) || responsesSSEErrorEvent(responsesSSEEventName(frame)) || responsesSSEPayloadHasError(payload) {
+			return true, responsesSSEPayloadErrorMessage(payload)
+		}
 
-			switch gjson.GetBytes(payload, "type").String() {
-			case "response.image_generation_call.partial_image":
-				b64 := strings.TrimSpace(gjson.GetBytes(payload, "partial_image_b64").String())
-				if b64 == "" {
-					continue
-				}
-				outputFormat := strings.TrimSpace(gjson.GetBytes(payload, "output_format").String())
-				index := gjson.GetBytes(payload, "partial_image_index").Int()
-				eventName := streamPrefix + ".partial_image"
-				data := []byte(`{"type":"","partial_image_index":0}`)
+		switch payloadType {
+		case "response.image_generation_call.partial_image":
+			b64 := strings.TrimSpace(gjson.GetBytes(payload, "partial_image_b64").String())
+			if b64 == "" {
+				return false, nil
+			}
+			outputFormat := strings.TrimSpace(gjson.GetBytes(payload, "output_format").String())
+			index := gjson.GetBytes(payload, "partial_image_index").Int()
+			eventName := streamPrefix + ".partial_image"
+			data := []byte(`{"type":"","partial_image_index":0}`)
+			data, _ = sjson.SetBytes(data, "type", eventName)
+			data, _ = sjson.SetBytes(data, "partial_image_index", index)
+			if responseFormat == "url" {
+				mt := mimeTypeFromOutputFormat(outputFormat)
+				data, _ = sjson.SetBytes(data, "url", "data:"+mt+";base64,"+b64)
+			} else {
+				data, _ = sjson.SetBytes(data, "b64_json", b64)
+			}
+			writeEvent(eventName, data)
+		case "response.completed":
+			results, _, usageRaw, _, err := extractImagesFromResponsesCompleted(payload)
+			if err != nil {
+				return true, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: err}
+			}
+			if len(results) == 0 {
+				return true, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("upstream did not return image output")}
+			}
+			eventName := streamPrefix + ".completed"
+			for _, img := range results {
+				data := []byte(`{"type":""}`)
 				data, _ = sjson.SetBytes(data, "type", eventName)
-				data, _ = sjson.SetBytes(data, "partial_image_index", index)
 				if responseFormat == "url" {
-					mt := mimeTypeFromOutputFormat(outputFormat)
-					data, _ = sjson.SetBytes(data, "url", "data:"+mt+";base64,"+b64)
+					mt := mimeTypeFromOutputFormat(img.OutputFormat)
+					data, _ = sjson.SetBytes(data, "url", "data:"+mt+";base64,"+img.Result)
 				} else {
-					data, _ = sjson.SetBytes(data, "b64_json", b64)
+					data, _ = sjson.SetBytes(data, "b64_json", img.Result)
+				}
+				if len(usageRaw) > 0 && json.Valid(usageRaw) {
+					data, _ = sjson.SetRawBytes(data, "usage", usageRaw)
 				}
 				writeEvent(eventName, data)
-			case "response.completed":
-				results, _, usageRaw, _, err := extractImagesFromResponsesCompleted(payload)
-				if err != nil {
-					emitError(&interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: err})
-					return true
-				}
-				if len(results) == 0 {
-					emitError(&interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("upstream did not return image output")})
-					return true
-				}
-				eventName := streamPrefix + ".completed"
-				for _, img := range results {
-					data := []byte(`{"type":""}`)
-					data, _ = sjson.SetBytes(data, "type", eventName)
-					if responseFormat == "url" {
-						mt := mimeTypeFromOutputFormat(img.OutputFormat)
-						data, _ = sjson.SetBytes(data, "url", "data:"+mt+";base64,"+img.Result)
-					} else {
-						data, _ = sjson.SetBytes(data, "b64_json", img.Result)
-					}
-					if len(usageRaw) > 0 && json.Valid(usageRaw) {
-						data, _ = sjson.SetRawBytes(data, "usage", usageRaw)
-					}
-					writeEvent(eventName, data)
-				}
-				return true
 			}
+			return true, nil
 		}
-		return false
+		return false, nil
+	}
+
+	handleFrame := func(frame []byte) bool {
+		done, errMsg := processFrame(frame)
+		if !done {
+			return false
+		}
+		if errMsg != nil {
+			errMsg = emitError(errMsg)
+			cancel(errMsg.Error)
+		} else {
+			cancel(nil)
+		}
+		return true
 	}
 
 	for _, frame := range acc.AddChunk(firstChunk) {
-		if processFrame(frame) {
-			cancel(nil)
+		if handleFrame(frame) {
 			return
 		}
 	}
@@ -1917,7 +1970,7 @@ func (h *OpenAIAPIHandler) forwardImagesStream(ctx context.Context, c *gin.Conte
 			return
 		case errMsg, ok := <-errs:
 			if ok && errMsg != nil {
-				emitError(errMsg)
+				errMsg = emitError(errMsg)
 				cancel(errMsg.Error)
 				return
 			}
@@ -1925,17 +1978,20 @@ func (h *OpenAIAPIHandler) forwardImagesStream(ctx context.Context, c *gin.Conte
 		case chunk, ok := <-data:
 			if !ok {
 				for _, frame := range acc.Flush() {
-					if processFrame(frame) {
-						cancel(nil)
+					if handleFrame(frame) {
 						return
 					}
+				}
+				if errMsg, hasPendingError := handlers.PendingStreamError(errs); hasPendingError {
+					errMsg = emitError(errMsg)
+					cancel(errMsg.Error)
+					return
 				}
 				cancel(nil)
 				return
 			}
 			for _, frame := range acc.AddChunk(chunk) {
-				if processFrame(frame) {
-					cancel(nil)
+				if handleFrame(frame) {
 					return
 				}
 			}

--- a/sdk/api/handlers/openai/openai_images_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_images_handlers_test.go
@@ -2,6 +2,8 @@ package openai
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -13,6 +15,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
@@ -342,5 +345,148 @@ func TestImagesEdits_DisableImageGenerationChat_DoesNotReturn404(t *testing.T) {
 
 	if resp.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d: %s", resp.Code, http.StatusBadRequest, resp.Body.String())
+	}
+}
+
+func TestSSEFrameAccumulatorFlushesDataOnlyFrame(t *testing.T) {
+	accumulator := &sseFrameAccumulator{}
+	chunk := []byte(`data: {"type":"image_generation.partial","partial_image_index":0}`)
+
+	if frames := accumulator.AddChunk(chunk); len(frames) != 0 {
+		t.Fatalf("AddChunk() emitted an unterminated data-only frame: %q", frames)
+	}
+	frames := accumulator.Flush()
+	if len(frames) != 1 || string(frames[0]) != string(chunk) {
+		t.Fatalf("Flush() frames = %q, want [%q]", frames, chunk)
+	}
+}
+
+func TestWriteImagesStreamErrorEventSanitizesPayload(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	raw := `{"error":{"code":"upstream_failed","message":"token=image-secret"},"debug":"` + strings.Repeat("x", 8192) + `"}`
+	writeImagesStreamErrorEvent(c, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: errors.New(raw)})
+
+	body := recorder.Body.String()
+	if strings.Contains(body, "image-secret") || len(body) > 4096 || !strings.Contains(body, "[REDACTED]") {
+		t.Fatalf("image stream error was not safely bounded: len=%d body=%q", len(body), body)
+	}
+}
+
+func TestCollectImagesRejectsPayloadErrorBeforeCompleted(t *testing.T) {
+	data := make(chan []byte, 1)
+	data <- []byte("event: error\ndata: {\"type\":\"provider.error\",\"error\":{\"code\":\"failed\",\"message\":\"token=image-secret\"}}\n\n" +
+		"event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"output\":[{\"type\":\"image_generation_call\",\"result\":\"aW1hZ2U=\"}]}}\n\n")
+	close(data)
+	errs := make(chan *interfaces.ErrorMessage)
+	close(errs)
+
+	out, errMsg := collectImagesFromResponsesStream(context.Background(), data, errs, "b64_json")
+	if len(out) != 0 || errMsg == nil || errMsg.Error == nil {
+		t.Fatalf("payload error result out=%q err=%#v", out, errMsg)
+	}
+	if strings.Contains(errMsg.Error.Error(), "image-secret") || !strings.Contains(errMsg.Error.Error(), "[REDACTED]") {
+		t.Fatalf("payload error was not sanitized: %q", errMsg.Error.Error())
+	}
+}
+
+func TestForwardImagesStreamCancelsWithPayloadError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := NewOpenAIAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil))
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", nil)
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		t.Fatal("expected gin writer to implement http.Flusher")
+	}
+	data := make(chan []byte)
+	close(data)
+	errs := make(chan *interfaces.ErrorMessage)
+	close(errs)
+	var canceled error
+	firstChunk := []byte("event: error\ndata: {\"error\":{\"message\":\"token=image-secret\"}}\n\n")
+
+	h.forwardImagesStream(context.Background(), c, flusher, func(err error) { canceled = err }, data, errs, firstChunk, "b64_json", "image_generation", func(string, []byte) {})
+	if canceled == nil || strings.Contains(canceled.Error(), "image-secret") || !strings.Contains(canceled.Error(), "[REDACTED]") {
+		t.Fatalf("payload error cancel = %v body=%q", canceled, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "event: error") {
+		t.Fatalf("payload error event missing: %q", recorder.Body.String())
+	}
+}
+
+func TestForwardRawImageStreamPrefersPendingErrorOnClose(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := NewOpenAIAPIHandler(handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil))
+	for i := 0; i < 100; i++ {
+		recorder := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(recorder)
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", nil)
+		data := make(chan []byte)
+		close(data)
+		errs := make(chan *interfaces.ErrorMessage, 1)
+		errs <- &interfaces.ErrorMessage{StatusCode: http.StatusTooManyRequests, Error: errors.New("image upstream busy")}
+		close(errs)
+		var canceled error
+
+		h.forwardRawImageStream(context.Background(), c, func(err error) { canceled = err }, data, errs)
+		if canceled == nil || !strings.Contains(canceled.Error(), "image upstream busy") {
+			t.Fatalf("iteration %d: cancel=%v body=%q", i, canceled, recorder.Body.String())
+		}
+	}
+}
+
+func TestCollectImagesPrefersPendingErrorWhenDataChannelCloses(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		data := make(chan []byte)
+		close(data)
+		errs := make(chan *interfaces.ErrorMessage, 1)
+		want := &interfaces.ErrorMessage{
+			StatusCode:     http.StatusTooManyRequests,
+			Error:          errors.New("image upstream busy"),
+			DirectResponse: true,
+			Headers:        http.Header{"Retry-After": []string{"9"}},
+		}
+		errs <- want
+		close(errs)
+
+		_, got := collectImagesFromResponsesStream(context.Background(), data, errs, "b64_json")
+		if got != want {
+			t.Fatalf("iteration %d: pending error = %#v, want original %#v", i, got, want)
+		}
+	}
+}
+
+func TestCollectImagesAllowsMultilineSSEData(t *testing.T) {
+	data := make(chan []byte, 1)
+	data <- []byte("event: response.completed\n" +
+		"data: {\"type\":\"response.completed\",\n" +
+		"data: \"response\":{\"created_at\":1,\"output\":[{\"type\":\"image_generation_call\",\"result\":\"aW1hZ2U=\"}]}}\n\n")
+	close(data)
+	errs := make(chan *interfaces.ErrorMessage)
+	close(errs)
+
+	out, errMsg := collectImagesFromResponsesStream(context.Background(), data, errs, "b64_json")
+	if errMsg != nil {
+		t.Fatalf("collectImagesFromResponsesStream() error = %v", errMsg.Error)
+	}
+	if !strings.Contains(string(out), `"b64_json":"aW1hZ2U="`) {
+		t.Fatalf("multiline image response = %q", out)
+	}
+}
+
+func TestSSEFrameAccumulatorKeepsMultipleFramesDistinct(t *testing.T) {
+	accumulator := &sseFrameAccumulator{}
+	first := "event: first\ndata: {\"type\":\"first\"}\n\n"
+	second := "event: second\ndata: {\"type\":\"second\"}\n\n"
+
+	frames := accumulator.AddChunk([]byte(first + second))
+	if len(frames) != 2 {
+		t.Fatalf("AddChunk() returned %d frames, want 2: %q", len(frames), frames)
+	}
+	if string(frames[0]) != first || string(frames[1]) != second {
+		t.Fatalf("frames were overwritten during buffer compaction: %q", frames)
 	}
 }

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -52,11 +53,23 @@ type responsesSSEFramer struct {
 	outputItems          map[int][]byte
 	outputOrder          []int
 	unindexedOutputItems [][]byte
+	lastEvent            string
+	terminalEvent        string
+	terminalError        *interfaces.ErrorMessage
+	failureEvent         string
+	dataFrames           int
 }
 
 func (f *responsesSSEFramer) WriteChunk(w io.Writer, chunk []byte) {
-	if len(chunk) == 0 {
+	if len(chunk) == 0 || f.terminalEvent != "" {
 		return
+	}
+	if responsesSSEStartsNewDataFrame(f.pending, chunk) {
+		f.writeFrame(w, f.pending)
+		f.pending = f.pending[:0]
+		if f.terminalEvent != "" {
+			return
+		}
 	}
 	if responsesSSENeedsLineBreak(f.pending, chunk) {
 		f.pending = append(f.pending, '\n')
@@ -70,6 +83,10 @@ func (f *responsesSSEFramer) WriteChunk(w io.Writer, chunk []byte) {
 		f.writeFrame(w, f.pending[:frameLen])
 		copy(f.pending, f.pending[frameLen:])
 		f.pending = f.pending[:len(f.pending)-frameLen]
+		if f.terminalEvent != "" {
+			f.pending = f.pending[:0]
+			return
+		}
 	}
 	if len(bytes.TrimSpace(f.pending)) == 0 {
 		f.pending = f.pending[:0]
@@ -83,14 +100,14 @@ func (f *responsesSSEFramer) WriteChunk(w io.Writer, chunk []byte) {
 }
 
 func (f *responsesSSEFramer) Flush(w io.Writer) {
-	if len(f.pending) == 0 {
+	if len(f.pending) == 0 || f.terminalEvent != "" {
 		return
 	}
 	if len(bytes.TrimSpace(f.pending)) == 0 {
 		f.pending = f.pending[:0]
 		return
 	}
-	if !responsesSSECanEmitWithoutDelimiter(f.pending) {
+	if !responsesSSECanFlushWithoutDelimiter(f.pending) {
 		f.pending = f.pending[:0]
 		return
 	}
@@ -104,11 +121,43 @@ func (f *responsesSSEFramer) writeFrame(w io.Writer, frame []byte) {
 
 func (f *responsesSSEFramer) repairFrame(frame []byte) []byte {
 	payload, ok := responsesSSEDataPayload(frame)
-	if !ok || len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) || !json.Valid(payload) {
+	if !ok || len(payload) == 0 {
 		return frame
 	}
+	if bytes.Equal(payload, []byte("[DONE]")) {
+		f.dataFrames++
+		return frame
+	}
+	if !json.Valid(payload) {
+		return frame
+	}
+	f.dataFrames++
 
-	switch gjson.GetBytes(payload, "type").String() {
+	payloadType := gjson.GetBytes(payload, "type").String()
+	if responsesSSEErrorEvent(payloadType) || responsesSSEPayloadHasError(payload) {
+		if payloadType != "" {
+			f.lastEvent = sanitizeResponsesStreamEventName(payloadType)
+		}
+		return f.repairErrorPayload(payload)
+	}
+	streamEvent := responsesSSEEventName(frame)
+	eventType := payloadType
+	if responsesSSETerminalEvent(streamEvent) {
+		eventType = streamEvent
+	} else if eventType == "" {
+		eventType = streamEvent
+	}
+	if eventType != "" {
+		f.lastEvent = sanitizeResponsesStreamEventName(eventType)
+	}
+	if responsesSSEErrorEvent(eventType) {
+		return f.repairErrorPayload(payload)
+	}
+	if responsesSSETerminalEvent(eventType) {
+		f.terminalEvent = eventType
+	}
+
+	switch eventType {
 	case "response.output_item.done":
 		f.recordOutputItem(payload)
 	case "response.completed":
@@ -118,6 +167,64 @@ func (f *responsesSSEFramer) repairFrame(frame []byte) []byte {
 		}
 	}
 	return frame
+}
+
+func responsesSSEPayloadErrorMessage(payload []byte) *interfaces.ErrorMessage {
+	status := http.StatusBadGateway
+	for _, path := range []string{"status", "status_code", "error.status", "error.status_code", "response.error.status", "response.error.status_code"} {
+		candidate := int(gjson.GetBytes(payload, path).Int())
+		if candidate >= http.StatusBadRequest && candidate <= 599 {
+			status = candidate
+			break
+		}
+	}
+	return sanitizeResponsesStreamErrorMessage(&interfaces.ErrorMessage{StatusCode: status, Error: fmt.Errorf("%s", payload)})
+}
+
+func (f *responsesSSEFramer) repairErrorPayload(payload []byte) []byte {
+	errMsg := responsesSSEPayloadErrorMessage(payload)
+	status := errMsg.StatusCode
+	f.terminalError = errMsg
+	failureEvent := f.failureEvent
+	if failureEvent != "response.failed" {
+		failureEvent = "error"
+	}
+	f.terminalEvent = failureEvent
+	errText := responsesStreamErrorText(errMsg, status)
+	if failureEvent == "response.failed" {
+		chunk := handlers.BuildOpenAIResponsesStreamFailedChunk(status, errText, 0)
+		return []byte(fmt.Sprintf("event: response.failed\ndata: %s\n\n", chunk))
+	}
+	chunk := handlers.BuildOpenAIResponsesStreamErrorChunk(status, errText, 0)
+	return []byte(fmt.Sprintf("event: error\ndata: %s\n\n", chunk))
+}
+
+func responsesSSEErrorEvent(eventType string) bool {
+	switch eventType {
+	case "response.failed", "response.error", "error":
+		return true
+	default:
+		return false
+	}
+}
+
+func responsesSSETerminalEvent(eventType string) bool {
+	switch eventType {
+	case "response.completed", "response.incomplete", "response.failed", "response.done", "response.error", "error":
+		return true
+	default:
+		return false
+	}
+}
+
+func responsesSSEPayloadHasError(payload []byte) bool {
+	for _, path := range []string{"error", "response.error"} {
+		result := gjson.GetBytes(payload, path)
+		if result.Exists() && result.Type != gjson.Null {
+			return true
+		}
+	}
+	return gjson.GetBytes(payload, "code").Exists() && gjson.GetBytes(payload, "message").Exists()
 }
 
 func responsesSSEDataPayload(frame []byte) ([]byte, bool) {
@@ -270,35 +377,45 @@ func responsesSSEHasField(chunk []byte, prefix []byte) bool {
 
 func responsesSSECanEmitWithoutDelimiter(chunk []byte) bool {
 	trimmed := bytes.TrimSpace(chunk)
-	if len(trimmed) == 0 || responsesSSENeedsMoreData(trimmed) || !responsesSSEHasField(trimmed, []byte("data:")) {
+	if len(trimmed) == 0 || responsesSSENeedsMoreData(trimmed) ||
+		!responsesSSEHasField(trimmed, []byte("event:")) || !responsesSSEHasField(trimmed, []byte("data:")) {
 		return false
 	}
 	return responsesSSEDataLinesValid(trimmed)
 }
 
-func responsesSSEDataLinesValid(chunk []byte) bool {
-	s := chunk
-	for len(s) > 0 {
-		line := s
-		if i := bytes.IndexByte(s, '\n'); i >= 0 {
-			line = s[:i]
-			s = s[i+1:]
-		} else {
-			s = nil
-		}
-		line = bytes.TrimSpace(line)
-		if len(line) == 0 || !bytes.HasPrefix(line, []byte("data:")) {
-			continue
-		}
-		data := bytes.TrimSpace(line[len("data:"):])
-		if len(data) == 0 || bytes.Equal(data, []byte("[DONE]")) {
-			continue
-		}
-		if !json.Valid(data) {
-			return false
+func responsesSSECanFlushWithoutDelimiter(chunk []byte) bool {
+	trimmed := bytes.TrimSpace(chunk)
+	return len(trimmed) > 0 && responsesSSEHasField(trimmed, []byte("data:")) && responsesSSEDataLinesValid(trimmed)
+}
+
+func responsesSSEStartsNewDataFrame(pending, chunk []byte) bool {
+	trimmedPending := bytes.TrimSpace(pending)
+	if len(trimmedPending) == 0 || responsesSSEHasField(trimmedPending, []byte("event:")) ||
+		!responsesSSEHasField(trimmedPending, []byte("data:")) || !responsesSSEDataLinesValid(trimmedPending) {
+		return false
+	}
+	trimmedChunk := bytes.TrimLeft(chunk, " \t\r\n")
+	return bytes.HasPrefix(trimmedChunk, []byte("data:"))
+}
+
+func responsesSSEEventName(frame []byte) string {
+	for _, line := range bytes.Split(frame, []byte("\n")) {
+		trimmed := bytes.TrimSpace(bytes.TrimRight(line, "\r"))
+		if bytes.HasPrefix(trimmed, []byte("event:")) {
+			return strings.TrimSpace(string(trimmed[len("event:"):]))
 		}
 	}
-	return true
+	return ""
+}
+
+func responsesSSEDataLinesValid(chunk []byte) bool {
+	payload, found := responsesSSEDataPayload(chunk)
+	if !found {
+		return true
+	}
+	payload = bytes.TrimSpace(payload)
+	return len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) || json.Valid(payload)
 }
 
 func responsesSSENeedsLineBreak(pending, chunk []byte) bool {
@@ -526,9 +643,14 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 		c.Header("Connection", "keep-alive")
 		c.Header("Access-Control-Allow-Origin", "*")
 	}
-	framer := &responsesSSEFramer{}
+	failureEvent := "error"
+	if isCodexResponsesClientRequest(c) {
+		failureEvent = "response.failed"
+	}
+	framer := &responsesSSEFramer{failureEvent: failureEvent}
+	var initialOutput bytes.Buffer
 
-	// Peek at the first chunk
+	// Peek at the first complete SSE data frame.
 	for {
 		select {
 		case <-c.Request.Context().Done():
@@ -540,34 +662,94 @@ func (h *OpenAIResponsesAPIHandler) handleStreamingResponse(c *gin.Context, rawJ
 				errChan = nil
 				continue
 			}
-			// Upstream failed immediately. Return proper error status and JSON.
-			h.WriteErrorResponse(c, errMsg)
-			if errMsg != nil {
-				cliCancel(errMsg.Error)
+			framer.Flush(&initialOutput)
+			safeErrMsg := sanitizeResponsesStreamErrorMessage(errMsg)
+			if framer.dataFrames == 0 {
+				safeErrMsg = sanitizeResponsesInitialErrorMessage(errMsg)
+			}
+			if safeErrMsg != nil && framer.dataFrames > 0 {
+				setSSEHeaders()
+				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+				_, _ = c.Writer.Write(initialOutput.Bytes())
+				flusher.Flush()
+				pendingErrors := make(chan *interfaces.ErrorMessage, 1)
+				pendingErrors <- safeErrMsg
+				close(pendingErrors)
+				h.forwardResponsesStream(c, flusher, func(err error) { cliCancel(err) }, make(chan []byte), pendingErrors, framer)
+				return
+			}
+			// Upstream failed before a complete SSE data frame. Return JSON.
+			h.LoggingAPIResponseError(context.WithValue(context.Background(), "gin", c), safeErrMsg)
+			h.WriteErrorResponse(c, safeErrMsg)
+			if safeErrMsg != nil {
+				cliCancel(safeErrMsg.Error)
 			} else {
 				cliCancel(nil)
 			}
 			return
 		case chunk, ok := <-dataChan:
 			if !ok {
-				// Stream closed without data? Send headers and done.
-				setSSEHeaders()
-				handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
-				_, _ = c.Writer.Write([]byte("\n"))
-				flusher.Flush()
-				cliCancel(nil)
+				framer.Flush(&initialOutput)
+				errMsg, hasPendingError := handlers.PendingStreamError(errChan)
+				if !hasPendingError && framer.terminalEvent == "" {
+					message := "upstream stream closed before first payload"
+					if framer.dataFrames > 0 {
+						message = "upstream stream closed before a terminal event"
+					}
+					errMsg = &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("%s", message)}
+				}
+				if framer.dataFrames > 0 {
+					errMsg = sanitizeResponsesStreamErrorMessage(errMsg)
+				} else {
+					errMsg = sanitizeResponsesInitialErrorMessage(errMsg)
+				}
+
+				if framer.dataFrames > 0 {
+					setSSEHeaders()
+					handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
+					_, _ = c.Writer.Write(initialOutput.Bytes())
+					flusher.Flush()
+					if framer.terminalError != nil {
+						h.logResponsesStreamError(c, framer, framer.terminalError)
+						cliCancel(framer.terminalError.Error)
+						return
+					}
+					if errMsg == nil {
+						cliCancel(nil)
+						return
+					}
+					pendingErrors := make(chan *interfaces.ErrorMessage, 1)
+					pendingErrors <- errMsg
+					close(pendingErrors)
+					h.forwardResponsesStream(c, flusher, func(err error) { cliCancel(err) }, make(chan []byte), pendingErrors, framer)
+					return
+				}
+
+				h.LoggingAPIResponseError(context.WithValue(context.Background(), "gin", c), errMsg)
+				h.WriteErrorResponse(c, errMsg)
+				if errMsg != nil {
+					cliCancel(errMsg.Error)
+				} else {
+					cliCancel(nil)
+				}
 				return
 			}
 
-			// Success! Set headers.
+			framer.WriteChunk(&initialOutput, chunk)
+			if framer.dataFrames == 0 {
+				continue
+			}
+
 			setSSEHeaders()
 			handlers.WriteUpstreamHeaders(c.Writer.Header(), upstreamHeaders)
-
-			// Write first chunk logic (matching forwardResponsesStream)
-			framer.WriteChunk(c.Writer, chunk)
+			_, _ = c.Writer.Write(initialOutput.Bytes())
 			flusher.Flush()
+			if framer.terminalError != nil {
+				h.logResponsesStreamError(c, framer, framer.terminalError)
+				cliCancel(framer.terminalError.Error)
+				return
+			}
 
-			// Continue
 			h.forwardResponsesStream(c, flusher, func(err error) { cliCancel(err) }, dataChan, errChan, framer)
 			return
 		}
@@ -591,34 +773,197 @@ func isCodexResponsesClientRequest(c *gin.Context) bool {
 	}
 }
 
+const (
+	responsesStreamErrorMessageLimit = 2048
+	responsesStreamErrorFieldLimit   = 256
+)
+
+var (
+	responsesStreamSensitiveValuePattern = regexp.MustCompile(`(?i)((?:"?(?:api[_-]?key|access[_-]?token|token|authorization|secret)"?)\s*[=:]\s*"?)([^\s"&,;}]+)`)
+	responsesStreamBearerPattern         = regexp.MustCompile(`(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+`)
+)
+
+func truncateResponsesStreamErrorText(text string, limit int) string {
+	runes := []rune(text)
+	if len(runes) <= limit {
+		return text
+	}
+	return string(runes[:limit]) + "…"
+}
+
+func redactResponsesStreamErrorText(text string) string {
+	text = responsesStreamSensitiveValuePattern.ReplaceAllString(text, `${1}[REDACTED]`)
+	return responsesStreamBearerPattern.ReplaceAllString(text, "Bearer [REDACTED]")
+}
+
+func sanitizeResponsesStreamEventName(eventName string) string {
+	return truncateResponsesStreamErrorText(redactResponsesStreamErrorText(strings.TrimSpace(eventName)), responsesStreamErrorFieldLimit)
+}
+
+func responsesStreamErrorText(errMsg *interfaces.ErrorMessage, status int) string {
+	text := http.StatusText(status)
+	if errMsg != nil && errMsg.Error != nil && strings.TrimSpace(errMsg.Error.Error()) != "" {
+		text = strings.TrimSpace(errMsg.Error.Error())
+	}
+	if !json.Valid([]byte(text)) {
+		return truncateResponsesStreamErrorText(redactResponsesStreamErrorText(text), responsesStreamErrorMessageLimit)
+	}
+
+	root := gjson.Parse(text)
+	errorNode := root.Get("error")
+	if !errorNode.Exists() || !errorNode.IsObject() {
+		errorNode = root.Get("response.error")
+	}
+	if errorNode.Exists() && errorNode.IsObject() {
+		safe := []byte(`{"error":{}}`)
+		copied := false
+		for _, field := range []string{"type", "code", "message", "param"} {
+			value := errorNode.Get(field)
+			if !value.Exists() || value.Type == gjson.Null {
+				continue
+			}
+			limit := responsesStreamErrorFieldLimit
+			if field == "message" {
+				limit = responsesStreamErrorMessageLimit
+			}
+			safe, _ = sjson.SetBytes(safe, "error."+field, truncateResponsesStreamErrorText(redactResponsesStreamErrorText(value.String()), limit))
+			copied = true
+		}
+		if copied {
+			return string(safe)
+		}
+	}
+
+	safe := []byte(`{"type":"error"}`)
+	copied := false
+	for _, field := range []string{"code", "message", "param"} {
+		value := root.Get(field)
+		if !value.Exists() || value.Type == gjson.Null {
+			continue
+		}
+		limit := responsesStreamErrorFieldLimit
+		if field == "message" {
+			limit = responsesStreamErrorMessageLimit
+		}
+		safe, _ = sjson.SetBytes(safe, field, truncateResponsesStreamErrorText(redactResponsesStreamErrorText(value.String()), limit))
+		copied = true
+	}
+	if copied {
+		return string(safe)
+	}
+	return http.StatusText(status)
+}
+
+type responsesStreamSanitizedError struct {
+	message string
+	cause   error
+}
+
+func (e *responsesStreamSanitizedError) Error() string { return e.message }
+func (e *responsesStreamSanitizedError) Unwrap() error { return e.cause }
+
+func sanitizeResponsesInitialErrorMessage(errMsg *interfaces.ErrorMessage) *interfaces.ErrorMessage {
+	if errMsg != nil && errMsg.DirectResponse {
+		return errMsg
+	}
+	return sanitizeResponsesStreamErrorMessage(errMsg)
+}
+
+func sanitizeResponsesStreamErrorMessage(errMsg *interfaces.ErrorMessage) *interfaces.ErrorMessage {
+	if errMsg == nil {
+		return nil
+	}
+	status := errMsg.StatusCode
+	if status < http.StatusBadRequest || status > 599 {
+		status = http.StatusInternalServerError
+	}
+	safe := *errMsg
+	safe.StatusCode = status
+	safe.Error = &responsesStreamSanitizedError{message: responsesStreamErrorText(errMsg, status), cause: errMsg.Error}
+	safe.DirectResponse = false
+	safe.Body = nil
+	return &safe
+}
+
+func (h *OpenAIResponsesAPIHandler) logResponsesStreamError(c *gin.Context, framer *responsesSSEFramer, errMsg *interfaces.ErrorMessage) {
+	if errMsg == nil {
+		return
+	}
+	status := errMsg.StatusCode
+	if status < http.StatusBadRequest || status > 599 {
+		status = http.StatusInternalServerError
+	}
+	lastEvent := "none"
+	if framer != nil && framer.lastEvent != "" {
+		lastEvent = framer.lastEvent
+	}
+	errText := responsesStreamErrorText(errMsg, status)
+	h.LoggingAPIResponseError(context.WithValue(context.Background(), "gin", c), &interfaces.ErrorMessage{
+		StatusCode: status,
+		Error:      fmt.Errorf("responses stream terminated after %s: %s", lastEvent, errText),
+	})
+}
+
 func (h *OpenAIResponsesAPIHandler) forwardResponsesStream(c *gin.Context, flusher http.Flusher, cancel func(error), data <-chan []byte, errs <-chan *interfaces.ErrorMessage, framer *responsesSSEFramer) {
 	if framer == nil {
 		framer = &responsesSSEFramer{}
 	}
+	if isCodexResponsesClientRequest(c) {
+		framer.failureEvent = "response.failed"
+	} else {
+		framer.failureEvent = "error"
+	}
+	writeTerminalError := func(errMsg *interfaces.ErrorMessage) {
+		framer.Flush(c.Writer)
+		if errMsg == nil {
+			return
+		}
+		status := http.StatusInternalServerError
+		if errMsg.StatusCode > 0 {
+			status = errMsg.StatusCode
+		}
+		errText := responsesStreamErrorText(errMsg, status)
+		h.logResponsesStreamError(c, framer, errMsg)
+		if framer.terminalEvent != "" {
+			return
+		}
+		if isCodexResponsesClientRequest(c) {
+			chunk := handlers.BuildOpenAIResponsesStreamFailedChunk(status, errText, 0)
+			_, _ = fmt.Fprintf(c.Writer, "\nevent: response.failed\ndata: %s\n\n", string(chunk))
+			return
+		}
+		chunk := handlers.BuildOpenAIResponsesStreamErrorChunk(status, errText, 0)
+		_, _ = fmt.Fprintf(c.Writer, "\nevent: error\ndata: %s\n\n", string(chunk))
+	}
+
 	h.ForwardStream(c, flusher, cancel, data, errs, handlers.StreamForwardOptions{
+		NormalizeTerminalError: sanitizeResponsesStreamErrorMessage,
 		WriteChunk: func(chunk []byte) {
 			framer.WriteChunk(c.Writer, chunk)
 		},
-		WriteTerminalError: func(errMsg *interfaces.ErrorMessage) {
+		ChunkError: func() *interfaces.ErrorMessage {
+			if framer.terminalError != nil {
+				h.logResponsesStreamError(c, framer, framer.terminalError)
+			}
+			return framer.terminalError
+		},
+		WriteTerminalError: writeTerminalError,
+		CloseError: func() *interfaces.ErrorMessage {
 			framer.Flush(c.Writer)
-			if !shouldExposeResponsesUpstreamError(errMsg) {
-				return
+			if framer.terminalError != nil {
+				return framer.terminalError
 			}
-			status := http.StatusInternalServerError
-			if errMsg.StatusCode > 0 {
-				status = errMsg.StatusCode
+			if framer.terminalEvent != "" {
+				return nil
 			}
-			errText := http.StatusText(status)
-			if errMsg.Error != nil && errMsg.Error.Error() != "" {
-				errText = errMsg.Error.Error()
+			lastEvent := framer.lastEvent
+			if lastEvent == "" {
+				lastEvent = "none"
 			}
-			if isCodexResponsesClientRequest(c) {
-				chunk := handlers.BuildOpenAIResponsesStreamFailedChunk(status, errText, 0)
-				_, _ = fmt.Fprintf(c.Writer, "\nevent: response.failed\ndata: %s\n\n", string(chunk))
-				return
+			return &interfaces.ErrorMessage{
+				StatusCode: http.StatusBadGateway,
+				Error:      fmt.Errorf("upstream stream closed before a terminal event (last event: %s)", lastEvent),
 			}
-			chunk := handlers.BuildOpenAIResponsesStreamErrorChunk(status, errText, 0)
-			_, _ = fmt.Fprintf(c.Writer, "\nevent: error\ndata: %s\n\n", string(chunk))
 		},
 		WriteDone: func() {
 			framer.Flush(c.Writer)

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_error_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_error_test.go
@@ -1,7 +1,9 @@
 package openai
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -9,14 +11,451 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 )
 
-// TestForwardResponsesStreamExposesOnlyClientErrors pins the SSE side: only
-// request-shape failures reach the client. Credential, quota and transport
-// failures end the stream silently so the client retries on its own.
-func TestForwardResponsesStreamExposesOnlyClientErrors(t *testing.T) {
+const (
+	prematureResponsesStreamModel       = "premature-responses-stream-model"
+	initialFailureResponsesModel        = "initial-failure-responses-stream-model"
+	emptyResponsesStreamModel           = "empty-responses-stream-model"
+	incompleteFirstFrameResponsesModel  = "incomplete-first-frame-responses-model"
+	dataOnlyFirstFrameResponsesModel    = "data-only-first-frame-responses-model"
+	dataOnlyCleanCloseResponsesModel    = "data-only-clean-close-responses-model"
+	sensitiveInitialErrorResponsesModel = "sensitive-initial-error-responses-model"
+	directInitialErrorResponsesModel    = "direct-initial-error-responses-model"
+	crossChunkMultilineResponsesModel   = "cross-chunk-multiline-responses-model"
+	validThenMalformedResponsesModel    = "valid-then-malformed-responses-model"
+)
+
+type prematureResponsesStreamExecutor struct{}
+
+func (*prematureResponsesStreamExecutor) Identifier() string { return "premature-responses-stream" }
+
+func (*prematureResponsesStreamExecutor) Execute(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (*prematureResponsesStreamExecutor) ExecuteStream(_ context.Context, _ *coreauth.Auth, req coreexecutor.Request, _ coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	if req.Model == directInitialErrorResponsesModel {
+		return nil, &coreexecutor.RequestTerminatedError{
+			HTTPStatus: http.StatusTooManyRequests,
+			Header:     http.Header{"Retry-After": []string{"17"}, "X-Plugin-Response": []string{"true"}},
+			Body:       []byte(`{"error":{"message":"plugin direct response"}}`),
+		}
+	}
+	chunks := make(chan coreexecutor.StreamChunk, 2)
+	if req.Model == validThenMalformedResponsesModel {
+		chunks <- coreexecutor.StreamChunk{Payload: []byte("event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n" +
+			"event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\"\n\n")}
+		close(chunks)
+		return &coreexecutor.StreamResult{Chunks: chunks}, nil
+	}
+	if req.Model == crossChunkMultilineResponsesModel {
+		chunks <- coreexecutor.StreamChunk{Payload: []byte("event: response.completed\ndata: {\"type\":\"response.completed\",")}
+		chunks <- coreexecutor.StreamChunk{Payload: []byte("data: \"response\":{\"id\":\"resp-1\",\"status\":\"completed\"}}\n\n")}
+		close(chunks)
+		return &coreexecutor.StreamResult{Chunks: chunks}, nil
+	}
+	if req.Model == sensitiveInitialErrorResponsesModel {
+		chunks <- coreexecutor.StreamChunk{Err: errors.New(`{"error":{"type":"server_error","code":"upstream_failed","message":"initial upstream failure: {\"api_key\":\"initial-message-secret\"}"},"debug":{"token":"initial-debug-secret","trace":"` + strings.Repeat("x", 8192) + `"}}`)}
+		close(chunks)
+		return &coreexecutor.StreamResult{Chunks: chunks}, nil
+	}
+	if req.Model == dataOnlyFirstFrameResponsesModel || req.Model == dataOnlyCleanCloseResponsesModel {
+		chunks <- coreexecutor.StreamChunk{Payload: []byte(`data: {"type":"response.output_text.delta","delta":"partial"}`)}
+		if req.Model == dataOnlyFirstFrameResponsesModel {
+			chunks <- coreexecutor.StreamChunk{Err: errors.New("upstream failed after data-only frame")}
+		}
+		close(chunks)
+		return &coreexecutor.StreamResult{Chunks: chunks}, nil
+	}
+	if req.Model == incompleteFirstFrameResponsesModel {
+		chunks <- coreexecutor.StreamChunk{Payload: []byte("event: response.created")}
+		chunks <- coreexecutor.StreamChunk{Err: errors.New("upstream failed before first complete frame")}
+		close(chunks)
+		return &coreexecutor.StreamResult{Chunks: chunks}, nil
+	}
+	if req.Model == emptyResponsesStreamModel {
+		close(chunks)
+		return &coreexecutor.StreamResult{Chunks: chunks}, nil
+	}
+	if req.Model == initialFailureResponsesModel {
+		chunks <- coreexecutor.StreamChunk{Err: errors.New("upstream failed before first payload")}
+		close(chunks)
+		return &coreexecutor.StreamResult{Chunks: chunks}, nil
+	}
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n")}
+	chunks <- coreexecutor.StreamChunk{Err: errors.New("unexpected EOF")}
+	close(chunks)
+	return &coreexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (*prematureResponsesStreamExecutor) Refresh(_ context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (*prematureResponsesStreamExecutor) CountTokens(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (*prematureResponsesStreamExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestResponsesHandlerEmitsFailureWhenExecutorStopsAfterPartialOutput(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &prematureResponsesStreamExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{ID: "premature-responses-stream-auth", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: prematureResponsesStreamModel}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{RequestLog: true}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses", h.Responses)
+
+	request := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"premature-responses-stream-model","input":"hi","stream":true}`))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("User-Agent", "Codex Desktop/26.803.41515")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after stream start; body=%s", recorder.Code, recorder.Body.String())
+	}
+	body := recorder.Body.String()
+	if !strings.Contains(body, "response.output_text.delta") || !strings.Contains(body, "event: response.failed") {
+		t.Fatalf("handler did not preserve partial output and terminal failure: %q", body)
+	}
+	if !strings.Contains(body, "unexpected EOF") {
+		t.Fatalf("handler terminal failure lost executor error: %q", body)
+	}
+}
+
+func TestSanitizeResponsesStreamErrorMessageNormalizesSuccessStatus(t *testing.T) {
+	got := sanitizeResponsesStreamErrorMessage(&interfaces.ErrorMessage{StatusCode: http.StatusOK, Error: errors.New("upstream failed")})
+	if got == nil || got.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("sanitized status = %#v, want %d", got, http.StatusInternalServerError)
+	}
+}
+
+func TestResponsesHandlerCommitsValidFrameBeforeMalformedFrameInSameChunk(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &prematureResponsesStreamExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{ID: "valid-then-malformed-responses-auth", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: validThenMalformedResponsesModel}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses", h.Responses)
+	request := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"valid-then-malformed-responses-model","input":"hi","stream":true}`))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("User-Agent", "Codex Desktop/26.803.41515")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK || !strings.Contains(recorder.Body.String(), "response.output_text.delta") || !strings.Contains(recorder.Body.String(), "event: response.failed") {
+		t.Fatalf("valid then malformed response status=%d body=%q", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestResponsesHandlerAcceptsMultilineDataAcrossExecutorChunks(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &prematureResponsesStreamExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{ID: "cross-chunk-multiline-responses-auth", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: crossChunkMultilineResponsesModel}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses", h.Responses)
+	request := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"cross-chunk-multiline-responses-model","input":"hi","stream":true}`))
+	request.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK || !strings.Contains(recorder.Body.String(), "event: response.completed") {
+		t.Fatalf("cross-chunk multiline response status=%d body=%q", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestResponsesHandlerPreservesDirectResponseBeforeFirstFrame(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &prematureResponsesStreamExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{ID: "direct-initial-error-responses-auth", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: directInitialErrorResponsesModel}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses", h.Responses)
+	request := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"direct-initial-error-responses-model","input":"hi","stream":true}`))
+	request.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusTooManyRequests || recorder.Header().Get("Retry-After") != "17" || recorder.Header().Get("X-Plugin-Response") != "true" {
+		t.Fatalf("direct response status=%d headers=%v body=%q", recorder.Code, recorder.Header(), recorder.Body.String())
+	}
+	if recorder.Body.String() != `{"error":{"message":"plugin direct response"}}` {
+		t.Fatalf("direct response body = %q", recorder.Body.String())
+	}
+}
+
+func TestResponsesHandlerSanitizesErrorBeforeFirstFrame(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &prematureResponsesStreamExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{ID: "sensitive-initial-error-responses-auth", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: sensitiveInitialErrorResponsesModel}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{RequestLog: true}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses", h.Responses)
+
+	request := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"sensitive-initial-error-responses-model","input":"hi","stream":true}`))
+	request.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+
+	body := recorder.Body.String()
+	if recorder.Code == http.StatusOK || !strings.Contains(body, "upstream_failed") || !strings.Contains(body, "initial upstream failure") {
+		t.Fatalf("initial error response = status %d body %q", recorder.Code, body)
+	}
+	for _, secret := range []string{"initial-message-secret", "initial-debug-secret"} {
+		if strings.Contains(body, secret) {
+			t.Fatalf("initial error leaked %q: %q", secret, body)
+		}
+	}
+	if len(body) > 4096 {
+		t.Fatalf("initial error response remained unbounded: len=%d", len(body))
+	}
+}
+
+func TestResponsesHandlerFlushesDataOnlyFrameBeforeStreamingError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &prematureResponsesStreamExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{ID: "data-only-first-frame-responses-auth", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: dataOnlyFirstFrameResponsesModel}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses", h.Responses)
+
+	request := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"data-only-first-frame-responses-model","input":"hi","stream":true}`))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("User-Agent", "Codex Desktop/26.803.41515")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after complete data frame; body=%q", recorder.Code, recorder.Body.String())
+	}
+	body := recorder.Body.String()
+	if !strings.Contains(body, "response.output_text.delta") || !strings.Contains(body, "event: response.failed") {
+		t.Fatalf("data-only frame or terminal failure was lost: %q", body)
+	}
+}
+
+func TestResponsesHandlerEmitsFailureWhenDataOnlyStreamClosesCleanly(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &prematureResponsesStreamExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{ID: "data-only-clean-close-responses-auth", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: dataOnlyCleanCloseResponsesModel}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses", h.Responses)
+
+	request := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"data-only-clean-close-responses-model","input":"hi","stream":true}`))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("User-Agent", "Codex Desktop/26.803.41515")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 after complete data frame; body=%q", recorder.Code, recorder.Body.String())
+	}
+	body := recorder.Body.String()
+	if !strings.Contains(body, "response.output_text.delta") || !strings.Contains(body, "event: response.failed") {
+		t.Fatalf("clean close did not retain data and emit terminal failure: %q", body)
+	}
+	if strings.Contains(body, "event: response.completed") {
+		t.Fatalf("clean close synthesized completion: %q", body)
+	}
+}
+
+func TestResponsesHandlerDoesNotCommitHeadersForIncompleteFirstFrame(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &prematureResponsesStreamExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{ID: "incomplete-first-frame-responses-auth", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: incompleteFirstFrameResponsesModel}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses", h.Responses)
+
+	request := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"incomplete-first-frame-responses-model","input":"hi","stream":true}`))
+	request.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code == http.StatusOK {
+		t.Fatalf("incomplete first SSE frame committed HTTP 200: %q", recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "upstream failed before first complete frame") {
+		t.Fatalf("initial frame error was lost: status=%d body=%q", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestResponsesHandlerRejectsStreamClosedBeforeFirstPayload(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	executor := &prematureResponsesStreamExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+	auth := &coreauth.Auth{ID: "empty-responses-stream-auth", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: emptyResponsesStreamModel}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses", h.Responses)
+
+	request := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"empty-responses-stream-model","input":"hi","stream":true}`))
+	request.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code == http.StatusOK {
+		t.Fatalf("empty upstream stream returned HTTP 200: %q", recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "closed before first payload") {
+		t.Fatalf("empty upstream stream error is unclear: status=%d body=%q", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestResponsesHandlerDoesNotLoseErrorBeforeFirstPayload(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	for i := 0; i < 100; i++ {
+		executor := &prematureResponsesStreamExecutor{}
+		manager := coreauth.NewManager(nil, nil, nil)
+		manager.RegisterExecutor(executor)
+		auth := &coreauth.Auth{ID: fmt.Sprintf("initial-failure-responses-stream-auth-%d", i), Provider: executor.Identifier(), Status: coreauth.StatusActive}
+		if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+			t.Fatalf("register auth %d: %v", i, errRegister)
+		}
+		registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: initialFailureResponsesModel}})
+
+		base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+		h := NewOpenAIResponsesAPIHandler(base)
+		router := gin.New()
+		router.POST("/v1/responses", h.Responses)
+
+		request := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"initial-failure-responses-stream-model","input":"hi","stream":true}`))
+		request.Header.Set("Content-Type", "application/json")
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, request)
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+
+		if recorder.Code == http.StatusOK {
+			t.Fatalf("request %d lost the buffered initial error and returned HTTP 200: %q", i, recorder.Body.String())
+		}
+		if !strings.Contains(recorder.Body.String(), "upstream failed before first payload") {
+			t.Fatalf("request %d lost the initial upstream error: status=%d body=%q", i, recorder.Code, recorder.Body.String())
+		}
+	}
+}
+
+// TestForwardResponsesStreamExposesTerminalErrors pins the SSE side: once a
+// Responses stream has started, every terminal upstream error reaches the client.
+func TestForwardResponsesStreamExposesTerminalErrors(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	tests := []struct {
@@ -48,13 +487,13 @@ func TestForwardResponsesStreamExposesOnlyClientErrors(t *testing.T) {
 		{name: "conflict", status: http.StatusConflict, message: "conflict", wantExposed: true},
 		{name: "message too big", status: http.StatusRequestEntityTooLarge, message: "too large", wantExposed: true},
 		{name: "unprocessable entity", status: http.StatusUnprocessableEntity, message: "invalid input", wantExposed: true},
-		{name: "authentication", status: http.StatusUnauthorized, message: "invalid credential"},
-		{name: "payment required", status: http.StatusPaymentRequired, message: "insufficient credits"},
-		{name: "quota error", status: http.StatusTooManyRequests, message: "usage limit reached"},
-		{name: "request timeout", status: http.StatusRequestTimeout, message: "upstream timeout"},
-		{name: "transport error", status: http.StatusInternalServerError, message: "unexpected EOF"},
+		{name: "authentication", status: http.StatusUnauthorized, message: "invalid credential", wantExposed: true},
+		{name: "payment required", status: http.StatusPaymentRequired, message: "insufficient credits", wantExposed: true},
+		{name: "quota error", status: http.StatusTooManyRequests, message: "usage limit reached", wantExposed: true},
+		{name: "request timeout", status: http.StatusRequestTimeout, message: "upstream timeout", wantExposed: true},
+		{name: "transport error", status: http.StatusInternalServerError, message: "unexpected EOF", wantExposed: true},
 		{name: "upstream websocket drop", status: http.StatusInternalServerError,
-			message: `{"error":{"message":"websocket: close 1006 (abnormal closure): unexpected EOF","type":"server_error","code":"internal_server_error"}}`},
+			message: `{"error":{"message":"websocket: close 1006 (abnormal closure): unexpected EOF","type":"server_error","code":"internal_server_error"}}`, wantExposed: true},
 	}
 
 	for _, tc := range tests {
@@ -123,5 +562,332 @@ func TestForwardResponsesStreamUsesResponseFailedForCodex(t *testing.T) {
 	}
 	if !strings.Contains(body, `"type":"invalid_request"`) || !strings.Contains(body, `"code":"cyber_policy"`) {
 		t.Fatalf("missing nested Codex error detail: %q", body)
+	}
+}
+
+func TestForwardResponsesStreamExposesTransportErrorAfterOutputForCodex(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{RequestLog: true}, nil)
+	h := NewOpenAIResponsesAPIHandler(base)
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Request.Header.Set("User-Agent", "Codex Desktop/26.803.41515")
+
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		t.Fatal("expected gin writer to implement http.Flusher")
+	}
+
+	framer := &responsesSSEFramer{}
+	framer.WriteChunk(c.Writer, []byte("event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n"))
+	data := make(chan []byte)
+	errs := make(chan *interfaces.ErrorMessage, 1)
+	errs <- &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: errors.New("unexpected EOF")}
+	close(errs)
+
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, framer)
+	body := recorder.Body.String()
+	if !strings.Contains(body, "event: response.failed") {
+		t.Fatalf("transport failure ended without response.failed: %q", body)
+	}
+	if !strings.Contains(body, "unexpected EOF") {
+		t.Fatalf("response.failed lost the upstream error: %q", body)
+	}
+
+	loggedValue, ok := c.Get("API_RESPONSE_ERROR")
+	if !ok {
+		t.Fatal("request log did not retain the stream error")
+	}
+	loggedErrors, ok := loggedValue.([]*interfaces.ErrorMessage)
+	if !ok || len(loggedErrors) != 1 || loggedErrors[0] == nil || loggedErrors[0].Error == nil {
+		t.Fatalf("unexpected request-log errors: %#v", loggedValue)
+	}
+	diagnostic := loggedErrors[0].Error.Error()
+	if !strings.Contains(diagnostic, "response.output_text.delta") || !strings.Contains(diagnostic, "unexpected EOF") {
+		t.Fatalf("request-log diagnostic lacks last event or upstream error: %q", diagnostic)
+	}
+}
+
+func TestForwardResponsesStreamSanitizesDiagnosticErrorDetails(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{RequestLog: true}, nil)
+	h := NewOpenAIResponsesAPIHandler(base)
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		t.Fatal("expected gin writer to implement http.Flusher")
+	}
+
+	debugSecret := "super-secret-provider-debug-value"
+	messageSecret := "super-secret-provider-message-value"
+	rawError := `{"error":{"type":"server_error","code":"upstream_failed","message":"upstream failed: {\"api_key\":\"` + messageSecret + `\"}"},"debug":{"api_key":"` + debugSecret + `","trace":"` + strings.Repeat("x", 8192) + `"}}`
+	framer := &responsesSSEFramer{}
+	framer.WriteChunk(c.Writer, []byte("event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n"))
+	data := make(chan []byte)
+	errs := make(chan *interfaces.ErrorMessage, 1)
+	errs <- &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: errors.New(rawError)}
+	close(errs)
+
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, framer)
+	body := recorder.Body.String()
+	if !strings.Contains(body, "upstream failed") || !strings.Contains(body, "upstream_failed") {
+		t.Fatalf("client error lost safe structured fields: %q", body)
+	}
+	if strings.Contains(body, debugSecret) || strings.Contains(body, messageSecret) {
+		t.Fatalf("client error leaked provider secret: %q", body)
+	}
+
+	loggedValue, ok := c.Get("API_RESPONSE_ERROR")
+	if !ok {
+		t.Fatal("request log did not retain the sanitized stream error")
+	}
+	loggedErrors, ok := loggedValue.([]*interfaces.ErrorMessage)
+	if !ok || len(loggedErrors) != 1 || loggedErrors[0] == nil || loggedErrors[0].Error == nil {
+		t.Fatalf("unexpected request-log errors: %#v", loggedValue)
+	}
+	diagnostic := loggedErrors[0].Error.Error()
+	if strings.Contains(diagnostic, debugSecret) || strings.Contains(diagnostic, messageSecret) || len(diagnostic) > 4096 {
+		t.Fatalf("request-log diagnostic leaked or retained an unbounded upstream body: len=%d diagnostic=%q", len(diagnostic), diagnostic)
+	}
+	if !strings.Contains(diagnostic, "upstream failed") {
+		t.Fatalf("sanitized request-log diagnostic lost upstream message: %q", diagnostic)
+	}
+}
+
+func TestForwardResponsesStreamPreservesNestedResponseError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{RequestLog: true}, nil)
+	h := NewOpenAIResponsesAPIHandler(base)
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Request.Header.Set("User-Agent", "Codex Desktop/26.803.41515")
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		t.Fatal("expected gin writer to implement http.Flusher")
+	}
+
+	framer := &responsesSSEFramer{}
+	framer.WriteChunk(c.Writer, []byte("event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n"))
+	data := make(chan []byte)
+	errs := make(chan *interfaces.ErrorMessage, 1)
+	errs <- &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: errors.New(`{"type":"response.failed","response":{"error":{"type":"server_error","code":"upstream_failed","message":"nested response failure","param":"input"}}}`)}
+	close(errs)
+
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, framer)
+	body := recorder.Body.String()
+	for _, want := range []string{"nested response failure", "upstream_failed", "server_error"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("response.failed lost nested response error field %q: %q", want, body)
+		}
+	}
+}
+
+func TestForwardResponsesStreamSanitizesLastEventDiagnostic(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{RequestLog: true}, nil)
+	h := NewOpenAIResponsesAPIHandler(base)
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		t.Fatal("expected gin writer to implement http.Flusher")
+	}
+
+	eventSecret := "event-secret-value"
+	eventName := "custom-event-Bearer " + eventSecret + strings.Repeat("x", 1024)
+	framer := &responsesSSEFramer{}
+	framer.WriteChunk(c.Writer, []byte("event: "+eventName+"\ndata: {\"message\":\"partial\"}\n\n"))
+	data := make(chan []byte)
+	errs := make(chan *interfaces.ErrorMessage, 1)
+	errs <- &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: errors.New("unexpected EOF")}
+	close(errs)
+
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, framer)
+	loggedValue, ok := c.Get("API_RESPONSE_ERROR")
+	if !ok {
+		t.Fatal("request log did not retain the stream error")
+	}
+	loggedErrors, ok := loggedValue.([]*interfaces.ErrorMessage)
+	if !ok || len(loggedErrors) != 1 || loggedErrors[0] == nil || loggedErrors[0].Error == nil {
+		t.Fatalf("unexpected request-log errors: %#v", loggedValue)
+	}
+	diagnostic := loggedErrors[0].Error.Error()
+	if strings.Contains(diagnostic, eventSecret) || len(diagnostic) > 1024 {
+		t.Fatalf("last-event diagnostic leaked or remained unbounded: len=%d diagnostic=%q", len(diagnostic), diagnostic)
+	}
+}
+
+func TestForwardResponsesStreamSanitizesPayloadErrorsAndStopsAtFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		frame string
+	}{
+		{
+			name:  "event error with payload type",
+			frame: "event: error\ndata: {\"type\":\"provider.error\",\"error\":{\"code\":\"failed\",\"message\":\"token=payload-secret\"}}\n\n",
+		},
+		{
+			name:  "typed nested error",
+			frame: "data: {\"type\":\"provider.error\",\"error\":{\"code\":\"failed\",\"message\":\"token=payload-secret\"}}\n\n",
+		},
+		{
+			name:  "top level error fields",
+			frame: "data: {\"code\":\"failed\",\"message\":\"token=payload-secret\"}\n\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{RequestLog: true}, nil)
+			h := NewOpenAIResponsesAPIHandler(base)
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+			c.Request.Header.Set("User-Agent", "Codex Desktop/26.803.41515")
+			flusher, ok := c.Writer.(http.Flusher)
+			if !ok {
+				t.Fatal("expected gin writer to implement http.Flusher")
+			}
+
+			data := make(chan []byte, 1)
+			data <- []byte(tc.frame + "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n")
+			close(data)
+			errs := make(chan *interfaces.ErrorMessage)
+			close(errs)
+			var canceled error
+
+			h.forwardResponsesStream(c, flusher, func(err error) { canceled = err }, data, errs, &responsesSSEFramer{})
+			body := recorder.Body.String()
+			if canceled == nil {
+				t.Fatalf("payload error canceled with nil: %q", body)
+			}
+			if strings.Contains(body, "payload-secret") || strings.Contains(body, "event: response.completed") {
+				t.Fatalf("payload error leaked or accepted later completion: %q", body)
+			}
+			if strings.Count(body, "event: response.failed") != 1 || !strings.Contains(body, "[REDACTED]") {
+				t.Fatalf("payload error was not converted to one sanitized response.failed: %q", body)
+			}
+		})
+	}
+}
+
+func TestForwardResponsesStreamReportsDataOnlyErrorFlushedAtEOF(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{RequestLog: true}, nil)
+	h := NewOpenAIResponsesAPIHandler(base)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Request.Header.Set("User-Agent", "Codex Desktop/26.803.41515")
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		t.Fatal("expected gin writer to implement http.Flusher")
+	}
+
+	data := make(chan []byte, 1)
+	data <- []byte(`data: {"type":"error","error":{"message":"failed at EOF"}}`)
+	close(data)
+	errs := make(chan *interfaces.ErrorMessage)
+	close(errs)
+	var canceled error
+	h.forwardResponsesStream(c, flusher, func(err error) { canceled = err }, data, errs, &responsesSSEFramer{})
+
+	if canceled == nil || !strings.Contains(canceled.Error(), "failed at EOF") {
+		t.Fatalf("EOF error cancel = %v, body=%q", canceled, recorder.Body.String())
+	}
+	if strings.Count(recorder.Body.String(), "event: response.failed") != 1 {
+		t.Fatalf("EOF error terminal output = %q", recorder.Body.String())
+	}
+	if _, okLog := c.Get("API_RESPONSE_ERROR"); !okLog {
+		t.Fatal("EOF error was not retained in request diagnostics")
+	}
+}
+
+func TestForwardResponsesStreamDoesNotAppendFailureAfterTerminalEvent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{RequestLog: true}, nil)
+	h := NewOpenAIResponsesAPIHandler(base)
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Request.Header.Set("User-Agent", "Codex Desktop/26.803.41515")
+
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		t.Fatal("expected gin writer to implement http.Flusher")
+	}
+
+	framer := &responsesSSEFramer{}
+	framer.WriteChunk(c.Writer, []byte("event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-1\",\"status\":\"completed\"}}\n\n"))
+	data := make(chan []byte)
+	errs := make(chan *interfaces.ErrorMessage, 1)
+	errs <- &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: errors.New("unexpected EOF after completion")}
+	close(errs)
+
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, framer)
+	body := recorder.Body.String()
+	if strings.Contains(body, "event: response.failed") || strings.Contains(body, "event: error") {
+		t.Fatalf("stream appended a second terminal event after response.completed: %q", body)
+	}
+
+	loggedValue, ok := c.Get("API_RESPONSE_ERROR")
+	if !ok {
+		t.Fatal("request log did not retain the post-terminal upstream error")
+	}
+	loggedErrors, ok := loggedValue.([]*interfaces.ErrorMessage)
+	if !ok || len(loggedErrors) != 1 || loggedErrors[0] == nil || loggedErrors[0].Error == nil {
+		t.Fatalf("unexpected request-log errors: %#v", loggedValue)
+	}
+	diagnostic := loggedErrors[0].Error.Error()
+	if !strings.Contains(diagnostic, "response.completed") || !strings.Contains(diagnostic, "unexpected EOF after completion") {
+		t.Fatalf("request-log diagnostic lacks terminal event or upstream error: %q", diagnostic)
+	}
+}
+
+func TestForwardResponsesStreamFailsWhenUpstreamClosesWithoutTerminalEvent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	h := NewOpenAIResponsesAPIHandler(base)
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Request.Header.Set("User-Agent", "Codex Desktop/26.803.41515")
+
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		t.Fatal("expected gin writer to implement http.Flusher")
+	}
+
+	framer := &responsesSSEFramer{}
+	framer.WriteChunk(c.Writer, []byte("event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n"))
+	data := make(chan []byte)
+	close(data)
+	errs := make(chan *interfaces.ErrorMessage)
+
+	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, framer)
+	body := recorder.Body.String()
+	if !strings.Contains(body, "event: response.failed") {
+		t.Fatalf("unterminated stream ended without response.failed: %q", body)
+	}
+	if !strings.Contains(body, "closed before a terminal event") {
+		t.Fatalf("response.failed does not explain the premature close: %q", body)
 	}
 }

--- a/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers_stream_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -30,6 +31,67 @@ func newResponsesStreamTestHandler(t *testing.T) (*OpenAIResponsesAPIHandler, *h
 	}
 
 	return h, recorder, c, flusher
+}
+
+func TestResponsesSSEFramerWaitsForEventFieldAfterData(t *testing.T) {
+	var output bytes.Buffer
+	framer := &responsesSSEFramer{}
+
+	framer.WriteChunk(&output, []byte(`data: {"response":{"id":"resp-1","status":"completed"}}`))
+	if output.Len() != 0 {
+		t.Fatalf("framer emitted data before a following event field arrived: %q", output.String())
+	}
+
+	framer.WriteChunk(&output, []byte("event: response.completed"))
+	if framer.terminalEvent != "response.completed" {
+		t.Fatalf("terminal event = %q, want response.completed", framer.terminalEvent)
+	}
+	got := output.String()
+	if !strings.Contains(got, "data: ") || !strings.Contains(got, "event: response.completed") {
+		t.Fatalf("framer did not preserve data-before-event fields in one frame: %q", got)
+	}
+}
+
+func TestResponsesSSEFramerFlushesMultilineDataWithoutDelimiter(t *testing.T) {
+	var output bytes.Buffer
+	framer := &responsesSSEFramer{}
+	chunk := []byte("event: response.completed\n" +
+		"data: {\"type\":\"response.completed\",\n" +
+		"data: \"response\":{\"id\":\"resp-1\",\"status\":\"completed\"}}")
+	framer.WriteChunk(&output, chunk)
+	framer.Flush(&output)
+
+	if framer.terminalEvent != "response.completed" || !strings.Contains(output.String(), "response.completed") {
+		t.Fatalf("multiline data-only terminal frame was dropped: terminal=%q output=%q", framer.terminalEvent, output.String())
+	}
+}
+
+func TestResponsesSSEFramerUsesPayloadErrorOverCompletedEvent(t *testing.T) {
+	var output bytes.Buffer
+	framer := &responsesSSEFramer{failureEvent: "response.failed"}
+	framer.WriteChunk(&output, []byte("data: {\"type\":\"response.failed\",\"response\":{\"status\":\"failed\"}}\nevent: response.completed\n\n"))
+
+	if framer.terminalEvent != "response.failed" || strings.Contains(output.String(), "event: response.completed") {
+		t.Fatalf("payload error was overridden by completed event: terminal=%q output=%q", framer.terminalEvent, output.String())
+	}
+	if strings.Count(output.String(), "event: response.failed") != 1 {
+		t.Fatalf("payload error output = %q, want one response.failed", output.String())
+	}
+}
+
+func TestResponsesSSEFramerUsesErrorEventOverPayloadType(t *testing.T) {
+	var output bytes.Buffer
+	framer := &responsesSSEFramer{}
+	framer.WriteChunk(&output, []byte("event: error\ndata: {\"type\":\"provider.error\",\"message\":\"failed\"}\n\n"))
+	if framer.terminalEvent != "error" {
+		t.Fatalf("terminal event = %q, want error", framer.terminalEvent)
+	}
+
+	framer = &responsesSSEFramer{}
+	framer.WriteChunk(&output, []byte("data: {\"response\":{\"error\":{\"message\":\"failed\"}}}\n\n"))
+	if framer.terminalEvent != "error" {
+		t.Fatalf("nested response error terminal event = %q, want error", framer.terminalEvent)
+	}
 }
 
 func TestForwardResponsesStreamSeparatesDataOnlySSEChunks(t *testing.T) {
@@ -169,10 +231,13 @@ func TestForwardResponsesStreamReassemblesSplitSSEEventChunks(t *testing.T) {
 
 	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
 
-	got := strings.TrimSuffix(recorder.Body.String(), "\n")
-	want := "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n"
-	if got != want {
-		t.Fatalf("unexpected split-event framing.\nGot:  %q\nWant: %q", got, want)
+	got := recorder.Body.String()
+	wantPrefix := "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n"
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Fatalf("unexpected split-event framing.\nGot:        %q\nWant prefix: %q", got, wantPrefix)
+	}
+	if !strings.Contains(got, "event: error") {
+		t.Fatalf("unterminated framing test stream did not end with an error: %q", got)
 	}
 }
 
@@ -188,9 +253,12 @@ func TestForwardResponsesStreamPreservesValidFullSSEEventChunks(t *testing.T) {
 
 	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
 
-	got := strings.TrimSuffix(recorder.Body.String(), "\n")
-	if got != string(chunk) {
-		t.Fatalf("unexpected full-event framing.\nGot:  %q\nWant: %q", got, string(chunk))
+	got := recorder.Body.String()
+	if !strings.HasPrefix(got, string(chunk)) {
+		t.Fatalf("unexpected full-event framing.\nGot:        %q\nWant prefix: %q", got, string(chunk))
+	}
+	if !strings.Contains(got, "event: error") {
+		t.Fatalf("unterminated framing test stream did not end with an error: %q", got)
 	}
 }
 
@@ -207,9 +275,12 @@ func TestForwardResponsesStreamBuffersSplitDataPayloadChunks(t *testing.T) {
 	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
 
 	got := recorder.Body.String()
-	want := "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n\n"
-	if got != want {
-		t.Fatalf("unexpected split-data framing.\nGot:  %q\nWant: %q", got, want)
+	wantPrefix := "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\n\n"
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Fatalf("unexpected split-data framing.\nGot:        %q\nWant prefix: %q", got, wantPrefix)
+	}
+	if !strings.Contains(got, "event: error") {
+		t.Fatalf("unterminated framing test stream did not end with an error: %q", got)
 	}
 }
 
@@ -233,7 +304,11 @@ func TestForwardResponsesStreamDropsIncompleteTrailingDataChunkOnFlush(t *testin
 
 	h.forwardResponsesStream(c, flusher, func(error) {}, data, errs, nil)
 
-	if got := recorder.Body.String(); got != "\n" {
-		t.Fatalf("expected incomplete trailing data to be dropped on flush.\nGot: %q", got)
+	got := recorder.Body.String()
+	if strings.Contains(got, `data: {"type":"response.created"`) {
+		t.Fatalf("incomplete trailing data was not dropped on flush: %q", got)
+	}
+	if !strings.Contains(got, "event: error") {
+		t.Fatalf("unterminated framing test stream did not end with an error: %q", got)
 	}
 }

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -1,7 +1,6 @@
 package openai
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"net"
@@ -542,21 +541,15 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 			continue
 		}
 
-		toolCacheTurn := newResponsesWebsocketToolCacheTurn(downstreamSessionKey)
-		previousLastRequest := bytes.Clone(lastRequest)
-		previousLastResponseOutput := bytes.Clone(lastResponseOutput)
-		previousLastResponseID := lastResponseID
-		previousLastResponsePendingToolCallIDs := append([]string(nil), lastResponsePendingToolCallIDs...)
+		var toolCacheTurn *responsesWebsocketToolCacheTurn
+		nextLastRequest := lastRequest
 		if nativeWebsocketPassthrough {
 			if modelName := strings.TrimSpace(gjson.GetBytes(requestJSON, "model").String()); modelName != "" {
 				passthroughModelName = modelName
 			}
 		} else {
-			toolCacheTurn.recordRequest(requestJSON)
-			requestJSON = repairResponsesWebsocketToolCallsWithoutRecording(downstreamSessionKey, requestJSON)
-			requestJSON = dedupeResponsesWebsocketInputItemsByID(requestJSON)
-			updatedLastRequest = bytes.Clone(requestJSON)
-			lastRequest = updatedLastRequest
+			requestJSON, toolCacheTurn = prepareResponsesWebsocketFallbackTurn(downstreamSessionKey, requestJSON)
+			nextLastRequest = requestJSON
 		}
 
 		modelName := gjson.GetBytes(requestJSON, "model").String()
@@ -627,10 +620,6 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 			return
 		}
 		if forwardErrMsg != nil {
-			lastRequest = previousLastRequest
-			lastResponseOutput = previousLastResponseOutput
-			lastResponseID = previousLastResponseID
-			lastResponsePendingToolCallIDs = previousLastResponsePendingToolCallIDs
 			if pinnedAuthAttempted && shouldReleaseResponsesWebsocketPinnedAuth(forwardErrMsg) {
 				forgetPinnedAuth()
 			}
@@ -662,6 +651,7 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 			lastResponsePendingToolCallIDs = nil
 		} else {
 			upstreamWebsocketAuthID = ""
+			lastRequest = nextLastRequest
 			lastResponseOutput = completedOutput
 			lastResponseID = strings.TrimSpace(completedResponseID)
 			lastResponsePendingToolCallIDs = append([]string(nil), completedPendingToolCallIDs...)

--- a/sdk/api/handlers/openai/openai_responses_websocket.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket.go
@@ -543,7 +543,8 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 			continue
 		}
 
-		toolCacheTurn := newResponsesWebsocketToolCacheTurn(downstreamSessionKey)
+		var toolCacheTurn *responsesWebsocketToolCacheTurn
+		nextLastRequest := lastRequest
 		previousLastRequest := bytes.Clone(lastRequest)
 		previousLastResponseOutput := bytes.Clone(lastResponseOutput)
 		previousLastResponseID := lastResponseID
@@ -558,11 +559,8 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 				passthroughModelName = modelName
 			}
 		} else {
-			toolCacheTurn.recordRequest(requestJSON)
-			requestJSON = repairResponsesWebsocketToolCallsWithoutRecording(downstreamSessionKey, requestJSON)
-			requestJSON = dedupeResponsesWebsocketInputItemsByID(requestJSON)
-			updatedLastRequest = bytes.Clone(requestJSON)
-			lastRequest = updatedLastRequest
+			requestJSON, toolCacheTurn = prepareResponsesWebsocketFallbackTurn(downstreamSessionKey, requestJSON)
+			nextLastRequest = requestJSON
 		}
 
 		modelName := gjson.GetBytes(requestJSON, "model").String()
@@ -681,6 +679,7 @@ func (h *OpenAIResponsesAPIHandler) ResponsesWebsocket(c *gin.Context) {
 		} else {
 			upstreamWebsocketAuthID = ""
 			forgetPinnedAuth()
+			lastRequest = nextLastRequest
 			lastResponseOutput = completedOutput
 			lastResponseID = strings.TrimSpace(completedResponseID)
 			lastResponsePendingToolCallIDs = append([]string(nil), completedPendingToolCallIDs...)

--- a/sdk/api/handlers/openai/openai_responses_websocket_prewarm.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_prewarm.go
@@ -1,7 +1,6 @@
 package openai
 
 import (
-	"encoding/json"
 	"strings"
 	"time"
 
@@ -96,33 +95,6 @@ func syntheticResponsesWebsocketPrewarmPayloads(requestJSON []byte) ([][]byte, e
 	}
 
 	return [][]byte{createdPayload, completedPayload}, nil
-}
-
-func mergeJSONArrayRaw(existingRaw, appendRaw string) (string, error) {
-	existingRaw = strings.TrimSpace(existingRaw)
-	appendRaw = strings.TrimSpace(appendRaw)
-	if existingRaw == "" {
-		existingRaw = "[]"
-	}
-	if appendRaw == "" {
-		appendRaw = "[]"
-	}
-
-	var existing []json.RawMessage
-	if err := json.Unmarshal([]byte(existingRaw), &existing); err != nil {
-		return "", err
-	}
-	var appendItems []json.RawMessage
-	if err := json.Unmarshal([]byte(appendRaw), &appendItems); err != nil {
-		return "", err
-	}
-
-	merged := append(existing, appendItems...)
-	out, err := json.Marshal(merged)
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
 }
 
 // inputContainsFullTranscript returns true when the input array carries compact

--- a/sdk/api/handlers/openai/openai_responses_websocket_requests.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_requests.go
@@ -139,31 +139,14 @@ func normalizeResponseSubsequentRequest(rawJSON []byte, lastRequest []byte, last
 			appendInputRaw = inputWithoutCompactionItems(nextInput)
 		}
 
-		existingInput := gjson.GetBytes(lastRequest, "input")
 		var errMerge error
-		mergedInput, errMerge = mergeJSONArrayRaw(existingInput.Raw, normalizeJSONArrayRaw(lastResponseOutput))
+		mergedInput, errMerge = mergeResponsesWebsocketInput(lastRequest, lastResponseOutput, appendInputRaw)
 		if errMerge != nil {
 			return nil, lastRequest, &interfaces.ErrorMessage{
 				StatusCode: http.StatusBadRequest,
-				Error:      fmt.Errorf("invalid previous response output: %w", errMerge),
+				Error:      errMerge,
 			}
 		}
-
-		mergedInput, errMerge = mergeJSONArrayRaw(mergedInput, appendInputRaw)
-		if errMerge != nil {
-			return nil, lastRequest, &interfaces.ErrorMessage{
-				StatusCode: http.StatusBadRequest,
-				Error:      fmt.Errorf("invalid request input: %w", errMerge),
-			}
-		}
-	}
-	dedupedInput, errDedupeFunctionCalls := dedupeFunctionCallsByCallID(mergedInput)
-	if errDedupeFunctionCalls == nil {
-		mergedInput = dedupedInput
-	}
-	dedupedInput, errDedupeItemIDs := dedupeInputItemsByID(mergedInput)
-	if errDedupeItemIDs == nil {
-		mergedInput = dedupedInput
 	}
 
 	normalized, errDelete := sjson.DeleteBytes(rawJSON, "type")
@@ -171,14 +154,6 @@ func normalizeResponseSubsequentRequest(rawJSON []byte, lastRequest []byte, last
 		normalized = bytes.Clone(rawJSON)
 	}
 	normalized, _ = sjson.DeleteBytes(normalized, "previous_response_id")
-	var errSet error
-	normalized, errSet = sjson.SetRawBytes(normalized, "input", []byte(mergedInput))
-	if errSet != nil {
-		return nil, lastRequest, &interfaces.ErrorMessage{
-			StatusCode: http.StatusBadRequest,
-			Error:      fmt.Errorf("failed to merge websocket input: %w", errSet),
-		}
-	}
 	if !gjson.GetBytes(normalized, "model").Exists() {
 		modelName := strings.TrimSpace(gjson.GetBytes(lastRequest, "model").String())
 		if modelName != "" {
@@ -192,7 +167,15 @@ func normalizeResponseSubsequentRequest(rawJSON []byte, lastRequest []byte, last
 		}
 	}
 	normalized, _ = sjson.SetBytes(normalized, "stream", true)
-	return normalized, bytes.Clone(normalized), nil
+	var errSet error
+	normalized, errSet = sjson.SetRawBytes(normalized, "input", []byte(mergedInput))
+	if errSet != nil {
+		return nil, lastRequest, &interfaces.ErrorMessage{
+			StatusCode: http.StatusBadRequest,
+			Error:      fmt.Errorf("failed to merge websocket input: %w", errSet),
+		}
+	}
+	return normalized, normalized, nil
 }
 
 func shouldReplaceWebsocketTranscript(rawJSON []byte, nextInput gjson.Result) bool {
@@ -329,40 +312,182 @@ func normalizeResponseTranscriptReplacement(rawJSON []byte, lastRequest []byte) 
 	return bytes.Clone(normalized)
 }
 
-func dedupeFunctionCallsByCallID(rawArray string) (string, error) {
+type responsesWebsocketInputItem struct {
+	raw      json.RawMessage
+	itemType string
+	id       string
+	callID   string
+}
+
+func mergeResponsesWebsocketInput(lastRequest []byte, lastResponseOutput []byte, appendRaw string) (string, error) {
+	var previousRequest struct {
+		Input []json.RawMessage `json:"input"`
+	}
+	if errUnmarshal := json.Unmarshal(lastRequest, &previousRequest); errUnmarshal != nil {
+		return "", fmt.Errorf("invalid previous request input: %w", errUnmarshal)
+	}
+	items, errExisting := appendResponsesWebsocketRawInputItems(nil, previousRequest.Input)
+	if errExisting != nil {
+		return "", fmt.Errorf("invalid previous request input: %w", errExisting)
+	}
+
+	var responseItems []json.RawMessage
+	trimmedResponse := bytes.TrimSpace(lastResponseOutput)
+	if len(trimmedResponse) > 0 && trimmedResponse[0] == '[' && json.Valid(trimmedResponse) {
+		if errUnmarshal := json.Unmarshal(trimmedResponse, &responseItems); errUnmarshal != nil {
+			return "", fmt.Errorf("invalid previous response output: %w", errUnmarshal)
+		}
+	}
+	items, errResponse := appendResponsesWebsocketRawInputItems(items, responseItems)
+	if errResponse != nil {
+		return "", fmt.Errorf("invalid previous response output: %w", errResponse)
+	}
+
+	items, errAppend := appendResponsesWebsocketInputItems(items, appendRaw)
+	if errAppend != nil {
+		return "", fmt.Errorf("invalid request input: %w", errAppend)
+	}
+
+	items = dedupeResponsesWebsocketFunctionCalls(items)
+	items = dedupeResponsesWebsocketInputItems(items)
+	return marshalResponsesWebsocketInputItems(items)
+}
+
+func parseResponsesWebsocketInputItems(rawArray string) ([]responsesWebsocketInputItem, error) {
+	return appendResponsesWebsocketInputItems(nil, rawArray)
+}
+
+func appendResponsesWebsocketInputItems(items []responsesWebsocketInputItem, rawArray string) ([]responsesWebsocketInputItem, error) {
 	rawArray = strings.TrimSpace(rawArray)
 	if rawArray == "" {
-		return "[]", nil
+		rawArray = "[]"
 	}
-	var items []json.RawMessage
-	if errUnmarshal := json.Unmarshal([]byte(rawArray), &items); errUnmarshal != nil {
-		return "", errUnmarshal
+	var rawItems []json.RawMessage
+	if errUnmarshal := json.Unmarshal([]byte(rawArray), &rawItems); errUnmarshal != nil {
+		return nil, errUnmarshal
 	}
+	return appendResponsesWebsocketRawInputItems(items, rawItems)
+}
 
-	seenCallIDs := make(map[string]struct{}, len(items))
-	filtered := make([]json.RawMessage, 0, len(items))
-	for _, item := range items {
-		if len(item) == 0 {
-			continue
+func appendResponsesWebsocketRawInputItems(items []responsesWebsocketInputItem, rawItems []json.RawMessage) ([]responsesWebsocketInputItem, error) {
+	for _, rawItem := range rawItems {
+		item, errItem := parseResponsesWebsocketInputItem(rawItem)
+		if errItem != nil {
+			return nil, errItem
 		}
-		itemType := strings.TrimSpace(gjson.GetBytes(item, "type").String())
-		if isResponsesToolCallType(itemType) {
-			callID := strings.TrimSpace(gjson.GetBytes(item, "call_id").String())
-			if callID != "" {
-				if _, ok := seenCallIDs[callID]; ok {
-					continue
-				}
-				seenCallIDs[callID] = struct{}{}
-			}
-		}
-		filtered = append(filtered, item)
+		items = append(items, item)
 	}
+	return items, nil
+}
 
-	out, errMarshal := json.Marshal(filtered)
+func parseResponsesWebsocketInputItem(rawItem json.RawMessage) (responsesWebsocketInputItem, error) {
+	item := responsesWebsocketInputItem{raw: rawItem}
+	trimmed := bytes.TrimSpace(rawItem)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return item, nil
+	}
+	var metadata struct {
+		Type   json.RawMessage `json:"type"`
+		ID     json.RawMessage `json:"id"`
+		CallID json.RawMessage `json:"call_id"`
+	}
+	if errUnmarshal := json.Unmarshal(trimmed, &metadata); errUnmarshal != nil {
+		return responsesWebsocketInputItem{}, errUnmarshal
+	}
+	item.itemType = responsesWebsocketMetadataString(metadata.Type)
+	item.id = responsesWebsocketMetadataString(metadata.ID)
+	item.callID = responsesWebsocketMetadataString(metadata.CallID)
+	return item, nil
+}
+
+func responsesWebsocketMetadataString(raw json.RawMessage) string {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return ""
+	}
+	if raw[0] == '"' {
+		var value string
+		if errUnmarshal := json.Unmarshal(raw, &value); errUnmarshal == nil {
+			return strings.TrimSpace(value)
+		}
+	}
+	return strings.TrimSpace(string(raw))
+}
+
+func marshalResponsesWebsocketInputItems(items []responsesWebsocketInputItem) (string, error) {
+	rawItems := make([]json.RawMessage, len(items))
+	for index := range items {
+		rawItems[index] = items[index].raw
+	}
+	out, errMarshal := json.Marshal(rawItems)
 	if errMarshal != nil {
 		return "", errMarshal
 	}
 	return string(out), nil
+}
+
+func dedupeResponsesWebsocketFunctionCalls(items []responsesWebsocketInputItem) []responsesWebsocketInputItem {
+	seenCallIDs := make(map[string]struct{}, len(items))
+	filtered := items[:0]
+	for _, item := range items {
+		if isResponsesToolCallType(item.itemType) && item.callID != "" {
+			if _, ok := seenCallIDs[item.callID]; ok {
+				continue
+			}
+			seenCallIDs[item.callID] = struct{}{}
+		}
+		filtered = append(filtered, item)
+	}
+	clear(items[len(filtered):])
+	return filtered
+}
+
+func dedupeResponsesWebsocketInputItems(items []responsesWebsocketInputItem) []responsesWebsocketInputItem {
+	// Collect the call_ids that are still referenced by tool-call output
+	// items. When several input items share the same id, the one we keep must
+	// preserve any call_id that has a matching output; otherwise the upstream
+	// rejects the request with "No tool call found for function call output".
+	referencedCallIDs := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		switch item.itemType {
+		case "function_call_output", "custom_tool_call_output":
+			if item.callID != "" {
+				referencedCallIDs[item.callID] = struct{}{}
+			}
+		}
+	}
+
+	// For each id, choose the index to keep. The default is the last
+	// occurrence (matching the original dedupe behavior), but we never replace
+	// an item whose call_id still has a matching output with one that does not.
+	keepIndexByID := make(map[string]int, len(items))
+	keepReferencedByID := make(map[string]bool, len(items))
+	for index, item := range items {
+		if item.id == "" {
+			continue
+		}
+		_, referenced := referencedCallIDs[item.callID]
+		referenced = referenced && item.callID != ""
+		if _, seen := keepIndexByID[item.id]; !seen {
+			keepIndexByID[item.id] = index
+			keepReferencedByID[item.id] = referenced
+			continue
+		}
+		if referenced || !keepReferencedByID[item.id] {
+			keepIndexByID[item.id] = index
+			keepReferencedByID[item.id] = referenced
+		}
+	}
+
+	filtered := items[:0]
+	for index, item := range items {
+		if item.id != "" && keepIndexByID[item.id] != index {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	clear(items[len(filtered):])
+	return filtered
 }
 
 func dedupeResponsesWebsocketInputItemsByID(payload []byte) []byte {
@@ -382,94 +507,11 @@ func dedupeResponsesWebsocketInputItemsByID(payload []byte) []byte {
 }
 
 func dedupeInputItemsByID(rawArray string) (string, error) {
-	rawArray = strings.TrimSpace(rawArray)
-	if rawArray == "" {
-		return "[]", nil
+	items, errParse := parseResponsesWebsocketInputItems(rawArray)
+	if errParse != nil {
+		return "", errParse
 	}
-	var items []json.RawMessage
-	if errUnmarshal := json.Unmarshal([]byte(rawArray), &items); errUnmarshal != nil {
-		return "", errUnmarshal
-	}
-
-	// Parse each item's type, id and call_id once; gjson is a scan-based
-	// parser, so reusing this metadata avoids rescanning every item in each of
-	// the loops below as the conversation history grows.
-	type itemMetadata struct {
-		itemType string
-		id       string
-		callID   string
-	}
-	meta := make([]itemMetadata, len(items))
-	for i, item := range items {
-		if len(item) == 0 {
-			continue
-		}
-		res := gjson.GetManyBytes(item, "type", "id", "call_id")
-		meta[i] = itemMetadata{
-			itemType: strings.TrimSpace(res[0].String()),
-			id:       strings.TrimSpace(res[1].String()),
-			callID:   strings.TrimSpace(res[2].String()),
-		}
-	}
-
-	// Collect the call_ids that are still referenced by tool-call output
-	// items. When several input items share the same id, the one we keep must
-	// preserve any call_id that has a matching output; otherwise the upstream
-	// rejects the request with "No tool call found for function call output".
-	referencedCallIDs := make(map[string]struct{}, len(items))
-	for i := range items {
-		switch meta[i].itemType {
-		case "function_call_output", "custom_tool_call_output":
-			if meta[i].callID != "" {
-				referencedCallIDs[meta[i].callID] = struct{}{}
-			}
-		}
-	}
-
-	// For each id, choose the index to keep. The default is the last
-	// occurrence (matching the original dedupe behavior), but we never replace
-	// an item whose call_id still has a matching output with one that does not.
-	// This keeps a single item per id while ensuring retained tool calls stay
-	// paired with their outputs.
-	keepIndexByID := make(map[string]int, len(items))
-	keepReferencedByID := make(map[string]bool, len(items))
-	for i := range items {
-		itemID := meta[i].id
-		if itemID == "" {
-			continue
-		}
-		_, referenced := referencedCallIDs[meta[i].callID]
-		referenced = referenced && meta[i].callID != ""
-		if _, seen := keepIndexByID[itemID]; !seen {
-			keepIndexByID[itemID] = i
-			keepReferencedByID[itemID] = referenced
-			continue
-		}
-		if referenced || !keepReferencedByID[itemID] {
-			keepIndexByID[itemID] = i
-			keepReferencedByID[itemID] = referenced
-		}
-	}
-
-	filtered := make([]json.RawMessage, 0, len(items))
-	for i, item := range items {
-		if len(item) == 0 {
-			continue
-		}
-		itemID := meta[i].id
-		if itemID != "" {
-			if keepIndexByID[itemID] != i {
-				continue
-			}
-		}
-		filtered = append(filtered, item)
-	}
-
-	out, errMarshal := json.Marshal(filtered)
-	if errMarshal != nil {
-		return "", errMarshal
-	}
-	return string(out), nil
+	return marshalResponsesWebsocketInputItems(dedupeResponsesWebsocketInputItems(items))
 }
 
 func normalizeResponsesWebsocketPassthroughRequest(rawJSON []byte, modelName string) ([]byte, *interfaces.ErrorMessage) {

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -1188,6 +1189,87 @@ func TestNormalizeResponsesWebsocketRequestCreate(t *testing.T) {
 	}
 }
 
+func TestNormalizeResponseSubsequentRequestBoundsTranscriptAllocations(t *testing.T) {
+	makeInput := func(count int, role string) string {
+		var input strings.Builder
+		input.WriteByte('[')
+		content := strings.Repeat("x", 1024)
+		for index := 0; index < count; index++ {
+			if index > 0 {
+				input.WriteByte(',')
+			}
+			fmt.Fprintf(&input, `{"type":"message","role":%q,"id":"%s-%d","content":%q}`, role, role, index, content)
+		}
+		input.WriteByte(']')
+		return input.String()
+	}
+
+	lastRequest := []byte(`{"model":"test-model","stream":true,"input":` + makeInput(128, "user") + `}`)
+	lastResponseOutput := []byte(makeInput(64, "assistant"))
+	raw := []byte(`{"type":"response.create","input":[{"type":"message","role":"user","id":"user-next","content":"continue"}]}`)
+	inputBytes := len(lastRequest) + len(lastResponseOutput) + len(raw)
+
+	result := testing.Benchmark(func(b *testing.B) {
+		b.ReportAllocs()
+		for index := 0; index < b.N; index++ {
+			normalized, next, errMsg := normalizeResponsesWebsocketRequestWithMode(raw, lastRequest, lastResponseOutput, false, false)
+			if errMsg != nil {
+				b.Fatalf("unexpected error: %v", errMsg.Error)
+			}
+			runtime.KeepAlive(normalized)
+			runtime.KeepAlive(next)
+		}
+	})
+
+	const maxAllocationMultiple = 14
+	maxAllocatedBytes := int64(inputBytes * maxAllocationMultiple)
+	t.Logf("normalization allocated %d bytes per operation for %d input bytes", result.AllocedBytesPerOp(), inputBytes)
+	if allocatedBytes := result.AllocedBytesPerOp(); allocatedBytes > maxAllocatedBytes {
+		t.Fatalf("normalizing %d input bytes allocated %d bytes per operation, want at most %d", inputBytes, allocatedBytes, maxAllocatedBytes)
+	}
+}
+
+func TestResponsesWebsocketFallbackTurnBoundsTranscriptAllocations(t *testing.T) {
+	makeInput := func(count int, role string) string {
+		var input strings.Builder
+		input.WriteByte('[')
+		content := strings.Repeat("x", 1024)
+		for index := 0; index < count; index++ {
+			if index > 0 {
+				input.WriteByte(',')
+			}
+			fmt.Fprintf(&input, `{"type":"message","role":%q,"id":"%s-%d","content":%q}`, role, role, index, content)
+		}
+		input.WriteByte(']')
+		return input.String()
+	}
+
+	lastRequest := []byte(`{"model":"test-model","stream":true,"input":` + makeInput(128, "user") + `}`)
+	lastResponseOutput := []byte(makeInput(64, "assistant"))
+	raw := []byte(`{"type":"response.create","input":[{"type":"message","role":"user","id":"user-next","content":"continue"}]}`)
+	inputBytes := len(lastRequest) + len(lastResponseOutput) + len(raw)
+
+	result := testing.Benchmark(func(b *testing.B) {
+		b.ReportAllocs()
+		for index := 0; index < b.N; index++ {
+			requestJSON, _, errMsg := normalizeResponsesWebsocketRequestWithMode(raw, lastRequest, lastResponseOutput, false, false)
+			if errMsg != nil {
+				b.Fatalf("unexpected error: %v", errMsg.Error)
+			}
+			requestJSON, turn := prepareResponsesWebsocketFallbackTurn("allocation-session", requestJSON)
+			runtime.KeepAlive(requestJSON)
+			runtime.KeepAlive(turn)
+		}
+	})
+
+	const maxAllocationMultiple = 14
+	maxAllocatedBytes := int64(inputBytes * maxAllocationMultiple)
+	t.Logf("fallback turn allocated %d bytes per operation for %d input bytes", result.AllocedBytesPerOp(), inputBytes)
+	if allocatedBytes := result.AllocedBytesPerOp(); allocatedBytes > maxAllocatedBytes {
+		t.Fatalf("processing a fallback turn with %d input bytes allocated %d bytes per operation, want at most %d", inputBytes, allocatedBytes, maxAllocatedBytes)
+	}
+}
+
 func TestNormalizeResponsesWebsocketRequestCreateWithHistory(t *testing.T) {
 	lastRequest := []byte(`{"model":"test-model","stream":true,"input":[{"type":"message","id":"msg-1"}]}`)
 	lastResponseOutput := []byte(`[
@@ -1862,13 +1944,62 @@ func TestRepairResponsesWebsocketToolCallsInsertsCachedOutput(t *testing.T) {
 	}
 }
 
+func TestRepairResponsesWebsocketToolCallsDeduplicatesInputItemsByID(t *testing.T) {
+	cache := newWebsocketToolOutputCache(time.Minute, 10)
+	raw := []byte(`{"input":[{"type":"message","id":"msg-1","content":"old"},{"type":"message","id":"msg-1","content":"new"}]}`)
+
+	for _, sessionKey := range []string{"dedupe-session", ""} {
+		t.Run(fmt.Sprintf("session_key_%q", sessionKey), func(t *testing.T) {
+			repaired := repairResponsesWebsocketToolCallsWithCache(cache, sessionKey, raw)
+
+			items := gjson.GetBytes(repaired, "input").Array()
+			if len(items) != 1 {
+				t.Fatalf("repaired input len = %d, want 1: %s", len(items), repaired)
+			}
+			if got := items[0].Get("content").String(); got != "new" {
+				t.Fatalf("repaired input content = %q, want new: %s", got, repaired)
+			}
+		})
+	}
+}
+
+func TestResponsesWebsocketToolCacheTurnDoesNotRetainRequestBackingStorage(t *testing.T) {
+	const (
+		paddingSize     = 32 << 20
+		maxRetainedHeap = 8 << 20
+	)
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	prefix := []byte(`{"input":[{"type":"message","id":"padding","content":"`)
+	suffix := []byte(`"},{"type":"function_call_output","id":"fco-1","call_id":"call-1","output":"ok"}]}`)
+	payload := make([]byte, len(prefix)+paddingSize+len(suffix))
+	copy(payload, prefix)
+	for index := len(prefix); index < len(prefix)+paddingSize; index++ {
+		payload[index] = 'x'
+	}
+	copy(payload[len(prefix)+paddingSize:], suffix)
+
+	_, turn := prepareResponsesWebsocketFallbackTurn("backing-storage-session", payload)
+	payload = nil
+	runtime.GC()
+
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	runtime.KeepAlive(turn)
+	retainedHeap := int64(after.HeapAlloc) - int64(before.HeapAlloc)
+	if retainedHeap > maxRetainedHeap {
+		t.Fatalf("tool cache turn retained %d bytes after request release, want at most %d", retainedHeap, maxRetainedHeap)
+	}
+}
+
 func TestResponsesWebsocketToolCacheTurnCommitsOnlyOnSuccess(t *testing.T) {
 	const sessionKey = "tool-cache-turn-commit-session"
 	defer defaultWebsocketToolOutputCache.deleteSession(sessionKey)
 	defer defaultWebsocketToolCallCache.deleteSession(sessionKey)
 
-	turn := newResponsesWebsocketToolCacheTurn(sessionKey)
-	turn.recordRequest([]byte(`{"input":[{"type":"function_call_output","id":"fco-1","call_id":"call-1","output":"cached result"}]}`))
+	_, turn := prepareResponsesWebsocketFallbackTurn(sessionKey, []byte(`{"input":[{"type":"function_call_output","id":"fco-1","call_id":"call-1","output":"cached result"}]}`))
 	beforeCommit := repairResponsesWebsocketToolCallsWithoutRecording(sessionKey, []byte(`{"input":[{"type":"function_call","id":"fc-next","call_id":"call-1","name":"lookup","arguments":"{}"}]}`))
 	if gjson.GetBytes(beforeCommit, "input.#").Int() != 0 {
 		t.Fatalf("uncommitted turn populated global cache: %s", beforeCommit)
@@ -1886,8 +2017,7 @@ func TestResponsesWebsocketToolCacheRetainPreventsOverlappingReleaseDeletion(t *
 	const sessionKey = "tool-cache-overlapping-retain-session"
 	retainResponsesWebsocketToolCaches(sessionKey)
 	retainResponsesWebsocketToolCaches(sessionKey)
-	turn := newResponsesWebsocketToolCacheTurn(sessionKey)
-	turn.recordRequest([]byte(`{"input":[{"type":"function_call_output","id":"fco-1","call_id":"call-1","output":"kept"}]}`))
+	_, turn := prepareResponsesWebsocketFallbackTurn(sessionKey, []byte(`{"input":[{"type":"function_call_output","id":"fco-1","call_id":"call-1","output":"kept"}]}`))
 	turn.commit()
 
 	releaseResponsesWebsocketToolCaches(sessionKey)

--- a/sdk/api/handlers/openai/openai_responses_websocket_test.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_test.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -1188,6 +1189,87 @@ func TestNormalizeResponsesWebsocketRequestCreate(t *testing.T) {
 	}
 }
 
+func TestNormalizeResponseSubsequentRequestBoundsTranscriptAllocations(t *testing.T) {
+	makeInput := func(count int, role string) string {
+		var input strings.Builder
+		input.WriteByte('[')
+		content := strings.Repeat("x", 1024)
+		for index := 0; index < count; index++ {
+			if index > 0 {
+				input.WriteByte(',')
+			}
+			fmt.Fprintf(&input, `{"type":"message","role":%q,"id":"%s-%d","content":%q}`, role, role, index, content)
+		}
+		input.WriteByte(']')
+		return input.String()
+	}
+
+	lastRequest := []byte(`{"model":"test-model","stream":true,"input":` + makeInput(128, "user") + `}`)
+	lastResponseOutput := []byte(makeInput(64, "assistant"))
+	raw := []byte(`{"type":"response.create","input":[{"type":"message","role":"user","id":"user-next","content":"continue"}]}`)
+	inputBytes := len(lastRequest) + len(lastResponseOutput) + len(raw)
+
+	result := testing.Benchmark(func(b *testing.B) {
+		b.ReportAllocs()
+		for index := 0; index < b.N; index++ {
+			normalized, next, errMsg := normalizeResponsesWebsocketRequestWithMode(raw, lastRequest, lastResponseOutput, false, false)
+			if errMsg != nil {
+				b.Fatalf("unexpected error: %v", errMsg.Error)
+			}
+			runtime.KeepAlive(normalized)
+			runtime.KeepAlive(next)
+		}
+	})
+
+	const maxAllocationMultiple = 14
+	maxAllocatedBytes := int64(inputBytes * maxAllocationMultiple)
+	t.Logf("normalization allocated %d bytes per operation for %d input bytes", result.AllocedBytesPerOp(), inputBytes)
+	if allocatedBytes := result.AllocedBytesPerOp(); allocatedBytes > maxAllocatedBytes {
+		t.Fatalf("normalizing %d input bytes allocated %d bytes per operation, want at most %d", inputBytes, allocatedBytes, maxAllocatedBytes)
+	}
+}
+
+func TestResponsesWebsocketFallbackTurnBoundsTranscriptAllocations(t *testing.T) {
+	makeInput := func(count int, role string) string {
+		var input strings.Builder
+		input.WriteByte('[')
+		content := strings.Repeat("x", 1024)
+		for index := 0; index < count; index++ {
+			if index > 0 {
+				input.WriteByte(',')
+			}
+			fmt.Fprintf(&input, `{"type":"message","role":%q,"id":"%s-%d","content":%q}`, role, role, index, content)
+		}
+		input.WriteByte(']')
+		return input.String()
+	}
+
+	lastRequest := []byte(`{"model":"test-model","stream":true,"input":` + makeInput(128, "user") + `}`)
+	lastResponseOutput := []byte(makeInput(64, "assistant"))
+	raw := []byte(`{"type":"response.create","input":[{"type":"message","role":"user","id":"user-next","content":"continue"}]}`)
+	inputBytes := len(lastRequest) + len(lastResponseOutput) + len(raw)
+
+	result := testing.Benchmark(func(b *testing.B) {
+		b.ReportAllocs()
+		for index := 0; index < b.N; index++ {
+			requestJSON, _, errMsg := normalizeResponsesWebsocketRequestWithMode(raw, lastRequest, lastResponseOutput, false, false)
+			if errMsg != nil {
+				b.Fatalf("unexpected error: %v", errMsg.Error)
+			}
+			requestJSON, turn := prepareResponsesWebsocketFallbackTurn("allocation-session", requestJSON)
+			runtime.KeepAlive(requestJSON)
+			runtime.KeepAlive(turn)
+		}
+	})
+
+	const maxAllocationMultiple = 14
+	maxAllocatedBytes := int64(inputBytes * maxAllocationMultiple)
+	t.Logf("fallback turn allocated %d bytes per operation for %d input bytes", result.AllocedBytesPerOp(), inputBytes)
+	if allocatedBytes := result.AllocedBytesPerOp(); allocatedBytes > maxAllocatedBytes {
+		t.Fatalf("processing a fallback turn with %d input bytes allocated %d bytes per operation, want at most %d", inputBytes, allocatedBytes, maxAllocatedBytes)
+	}
+}
+
 func TestNormalizeResponsesWebsocketRequestCreateWithHistory(t *testing.T) {
 	lastRequest := []byte(`{"model":"test-model","stream":true,"input":[{"type":"message","id":"msg-1"}]}`)
 	lastResponseOutput := []byte(`[
@@ -1881,13 +1963,62 @@ func TestRepairResponsesWebsocketToolCallsInsertsCachedOutput(t *testing.T) {
 	}
 }
 
+func TestRepairResponsesWebsocketToolCallsDeduplicatesInputItemsByID(t *testing.T) {
+	cache := newWebsocketToolOutputCache(time.Minute, 10)
+	raw := []byte(`{"input":[{"type":"message","id":"msg-1","content":"old"},{"type":"message","id":"msg-1","content":"new"}]}`)
+
+	for _, sessionKey := range []string{"dedupe-session", ""} {
+		t.Run(fmt.Sprintf("session_key_%q", sessionKey), func(t *testing.T) {
+			repaired := repairResponsesWebsocketToolCallsWithCache(cache, sessionKey, raw)
+
+			items := gjson.GetBytes(repaired, "input").Array()
+			if len(items) != 1 {
+				t.Fatalf("repaired input len = %d, want 1: %s", len(items), repaired)
+			}
+			if got := items[0].Get("content").String(); got != "new" {
+				t.Fatalf("repaired input content = %q, want new: %s", got, repaired)
+			}
+		})
+	}
+}
+
+func TestResponsesWebsocketToolCacheTurnDoesNotRetainRequestBackingStorage(t *testing.T) {
+	const (
+		paddingSize     = 32 << 20
+		maxRetainedHeap = 8 << 20
+	)
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	prefix := []byte(`{"input":[{"type":"message","id":"padding","content":"`)
+	suffix := []byte(`"},{"type":"function_call_output","id":"fco-1","call_id":"call-1","output":"ok"}]}`)
+	payload := make([]byte, len(prefix)+paddingSize+len(suffix))
+	copy(payload, prefix)
+	for index := len(prefix); index < len(prefix)+paddingSize; index++ {
+		payload[index] = 'x'
+	}
+	copy(payload[len(prefix)+paddingSize:], suffix)
+
+	_, turn := prepareResponsesWebsocketFallbackTurn("backing-storage-session", payload)
+	payload = nil
+	runtime.GC()
+
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	runtime.KeepAlive(turn)
+	retainedHeap := int64(after.HeapAlloc) - int64(before.HeapAlloc)
+	if retainedHeap > maxRetainedHeap {
+		t.Fatalf("tool cache turn retained %d bytes after request release, want at most %d", retainedHeap, maxRetainedHeap)
+	}
+}
+
 func TestResponsesWebsocketToolCacheTurnCommitsOnlyOnSuccess(t *testing.T) {
 	const sessionKey = "tool-cache-turn-commit-session"
 	defer defaultWebsocketToolOutputCache.deleteSession(sessionKey)
 	defer defaultWebsocketToolCallCache.deleteSession(sessionKey)
 
-	turn := newResponsesWebsocketToolCacheTurn(sessionKey)
-	turn.recordRequest([]byte(`{"input":[{"type":"function_call_output","id":"fco-1","call_id":"call-1","output":"cached result"}]}`))
+	_, turn := prepareResponsesWebsocketFallbackTurn(sessionKey, []byte(`{"input":[{"type":"function_call_output","id":"fco-1","call_id":"call-1","output":"cached result"}]}`))
 	beforeCommit := repairResponsesWebsocketToolCallsWithoutRecording(sessionKey, []byte(`{"input":[{"type":"function_call","id":"fc-next","call_id":"call-1","name":"lookup","arguments":"{}"}]}`))
 	if gjson.GetBytes(beforeCommit, "input.#").Int() != 0 {
 		t.Fatalf("uncommitted turn populated global cache: %s", beforeCommit)
@@ -1905,8 +2036,7 @@ func TestResponsesWebsocketToolCacheRetainPreventsOverlappingReleaseDeletion(t *
 	const sessionKey = "tool-cache-overlapping-retain-session"
 	retainResponsesWebsocketToolCaches(sessionKey)
 	retainResponsesWebsocketToolCaches(sessionKey)
-	turn := newResponsesWebsocketToolCacheTurn(sessionKey)
-	turn.recordRequest([]byte(`{"input":[{"type":"function_call_output","id":"fco-1","call_id":"call-1","output":"kept"}]}`))
+	_, turn := prepareResponsesWebsocketFallbackTurn(sessionKey, []byte(`{"input":[{"type":"function_call_output","id":"fco-1","call_id":"call-1","output":"kept"}]}`))
 	turn.commit()
 
 	releaseResponsesWebsocketToolCaches(sessionKey)

--- a/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
+++ b/sdk/api/handlers/openai/openai_responses_websocket_toolcall_repair.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -58,7 +59,7 @@ func newWebsocketToolOutputCache(ttl time.Duration, maxPerSession int) *websocke
 
 func (c *websocketToolOutputCache) record(sessionKey string, callID string, item json.RawMessage) {
 	sessionKey = strings.TrimSpace(sessionKey)
-	callID = strings.TrimSpace(callID)
+	callID = strings.Clone(strings.TrimSpace(callID))
 	if sessionKey == "" || callID == "" || c == nil {
 		return
 	}
@@ -86,6 +87,7 @@ func (c *websocketToolOutputCache) record(sessionKey string, callID string, item
 
 	for len(session.order) > c.maxPerSession {
 		evict := session.order[0]
+		session.order[0] = ""
 		session.order = session.order[1:]
 		delete(session.outputs, evict)
 	}
@@ -242,19 +244,6 @@ func newResponsesWebsocketToolCacheTurn(sessionKey string) *responsesWebsocketTo
 	}
 }
 
-func (t *responsesWebsocketToolCacheTurn) recordRequest(payload []byte) {
-	if t == nil || len(payload) == 0 {
-		return
-	}
-	input := gjson.GetBytes(payload, "input")
-	if !input.Exists() || !input.IsArray() {
-		return
-	}
-	for _, item := range input.Array() {
-		t.recordItem(item)
-	}
-}
-
 func (t *responsesWebsocketToolCacheTurn) recordResponse(payload []byte) {
 	if t == nil || len(payload) == 0 {
 		return
@@ -282,18 +271,29 @@ func (t *responsesWebsocketToolCacheTurn) recordItem(item gjson.Result) {
 	if t == nil || !item.Exists() {
 		return
 	}
-	callID := strings.TrimSpace(item.Get("call_id").String())
-	if callID == "" || strings.TrimSpace(item.Raw) == "" {
+	t.recordRawItem(item.Get("type").String(), item.Get("call_id").String(), []byte(item.Raw))
+}
+
+func (t *responsesWebsocketToolCacheTurn) recordInputItem(item responsesWebsocketInputItem) {
+	if t == nil {
 		return
 	}
-	raw := append(json.RawMessage(nil), item.Raw...)
+	t.recordRawItem(item.itemType, item.callID, item.raw)
+}
+
+func (t *responsesWebsocketToolCacheTurn) recordRawItem(itemType string, callID string, rawItem []byte) {
+	callID = strings.Clone(strings.TrimSpace(callID))
+	if t == nil || callID == "" || len(bytes.TrimSpace(rawItem)) == 0 {
+		return
+	}
+	raw := append(json.RawMessage(nil), rawItem...)
 	switch {
-	case isResponsesToolCallOutputType(item.Get("type").String()):
+	case isResponsesToolCallOutputType(itemType):
 		if _, exists := t.outputs[callID]; !exists {
 			t.outputOrder = append(t.outputOrder, callID)
 		}
 		t.outputs[callID] = raw
-	case isResponsesToolCallType(item.Get("type").String()):
+	case isResponsesToolCallType(itemType):
 		if _, exists := t.calls[callID]; !exists {
 			t.callOrder = append(t.callOrder, callID)
 		}
@@ -326,7 +326,22 @@ func repairResponsesWebsocketToolCalls(sessionKey string, payload []byte) []byte
 func repairResponsesWebsocketToolCallsWithoutRecording(sessionKey string, payload []byte) []byte {
 	defaultWebsocketToolCacheTransactionMu.RLock()
 	defer defaultWebsocketToolCacheTransactionMu.RUnlock()
-	return repairResponsesWebsocketToolCallsWithCachesMode(defaultWebsocketToolOutputCache, defaultWebsocketToolCallCache, sessionKey, payload, false)
+	return repairResponsesWebsocketToolCallsWithCachesMode(defaultWebsocketToolOutputCache, defaultWebsocketToolCallCache, sessionKey, payload, false, nil)
+}
+
+func prepareResponsesWebsocketFallbackTurn(sessionKey string, payload []byte) ([]byte, *responsesWebsocketToolCacheTurn) {
+	turn := newResponsesWebsocketToolCacheTurn(sessionKey)
+	defaultWebsocketToolCacheTransactionMu.RLock()
+	defer defaultWebsocketToolCacheTransactionMu.RUnlock()
+	payload = repairResponsesWebsocketToolCallsWithCachesMode(
+		defaultWebsocketToolOutputCache,
+		defaultWebsocketToolCallCache,
+		sessionKey,
+		payload,
+		false,
+		turn,
+	)
+	return payload, turn
 }
 
 func repairResponsesWebsocketToolCallsWithCache(cache *websocketToolOutputCache, sessionKey string, payload []byte) []byte {
@@ -334,26 +349,52 @@ func repairResponsesWebsocketToolCallsWithCache(cache *websocketToolOutputCache,
 }
 
 func repairResponsesWebsocketToolCallsWithCaches(outputCache, callCache *websocketToolOutputCache, sessionKey string, payload []byte) []byte {
-	return repairResponsesWebsocketToolCallsWithCachesMode(outputCache, callCache, sessionKey, payload, true)
+	return repairResponsesWebsocketToolCallsWithCachesMode(outputCache, callCache, sessionKey, payload, true, nil)
 }
 
-func repairResponsesWebsocketToolCallsWithCachesMode(outputCache, callCache *websocketToolOutputCache, sessionKey string, payload []byte, record bool) []byte {
+func repairResponsesWebsocketToolCallsWithCachesMode(
+	outputCache, callCache *websocketToolOutputCache,
+	sessionKey string,
+	payload []byte,
+	record bool,
+	turn *responsesWebsocketToolCacheTurn,
+) []byte {
+	if len(payload) == 0 {
+		return payload
+	}
+
+	var request struct {
+		Input              []json.RawMessage `json:"input"`
+		PreviousResponseID json.RawMessage   `json:"previous_response_id"`
+	}
+	if errUnmarshal := json.Unmarshal(payload, &request); errUnmarshal != nil || request.Input == nil {
+		return payload
+	}
+	items, errParse := appendResponsesWebsocketRawInputItems(nil, request.Input)
+	if errParse != nil {
+		return payload
+	}
+
 	sessionKey = strings.TrimSpace(sessionKey)
-	if sessionKey == "" || outputCache == nil || len(payload) == 0 {
+	repairEnabled := sessionKey != "" && outputCache != nil
+	updatedItems, errRepair := repairResponsesToolCallItems(
+		outputCache,
+		callCache,
+		sessionKey,
+		items,
+		repairEnabled && responsesWebsocketMetadataString(request.PreviousResponseID) != "",
+		record && repairEnabled,
+		turn,
+		repairEnabled,
+	)
+	if errRepair != nil || responsesWebsocketInputItemsEqualRaw(updatedItems, request.Input) {
 		return payload
 	}
 
-	input := gjson.GetBytes(payload, "input")
-	if !input.Exists() || !input.IsArray() {
+	updatedRaw, errMarshal := marshalResponsesWebsocketInputItems(updatedItems)
+	if errMarshal != nil {
 		return payload
 	}
-
-	allowOrphanOutputs := strings.TrimSpace(gjson.GetBytes(payload, "previous_response_id").String()) != ""
-	updatedRaw, errRepair := repairResponsesToolCallsArray(outputCache, callCache, sessionKey, input.Raw, allowOrphanOutputs, record)
-	if errRepair != nil || updatedRaw == "" || updatedRaw == input.Raw {
-		return payload
-	}
-
 	updated, errSet := sjson.SetRawBytes(payload, "input", []byte(updatedRaw))
 	if errSet != nil {
 		return payload
@@ -361,62 +402,56 @@ func repairResponsesWebsocketToolCallsWithCachesMode(outputCache, callCache *web
 	return updated
 }
 
-func repairResponsesToolCallsArray(outputCache, callCache *websocketToolOutputCache, sessionKey string, rawArray string, allowOrphanOutputs bool, record bool) (string, error) {
-	rawArray = strings.TrimSpace(rawArray)
-	if rawArray == "" {
-		return "[]", nil
-	}
-
-	var items []json.RawMessage
-	if errUnmarshal := json.Unmarshal([]byte(rawArray), &items); errUnmarshal != nil {
-		return "", errUnmarshal
+func repairResponsesToolCallItems(
+	outputCache, callCache *websocketToolOutputCache,
+	sessionKey string,
+	items []responsesWebsocketInputItem,
+	allowOrphanOutputs bool,
+	record bool,
+	turn *responsesWebsocketToolCacheTurn,
+	repairEnabled bool,
+) ([]responsesWebsocketInputItem, error) {
+	if !repairEnabled {
+		return dedupeResponsesWebsocketInputItems(items), nil
 	}
 
 	// First pass: record tool outputs and remember which call_ids have outputs in this payload.
 	outputPresent := make(map[string]struct{}, len(items))
 	callPresent := make(map[string]struct{}, len(items))
 	for _, item := range items {
-		if len(item) == 0 {
-			continue
+		if turn != nil {
+			turn.recordInputItem(item)
 		}
-		itemType := strings.TrimSpace(gjson.GetBytes(item, "type").String())
 		switch {
-		case isResponsesToolCallOutputType(itemType):
-			callID := strings.TrimSpace(gjson.GetBytes(item, "call_id").String())
-			if callID == "" {
+		case isResponsesToolCallOutputType(item.itemType):
+			if item.callID == "" {
 				continue
 			}
-			outputPresent[callID] = struct{}{}
+			outputPresent[item.callID] = struct{}{}
 			if record {
-				outputCache.record(sessionKey, callID, item)
+				outputCache.record(sessionKey, item.callID, item.raw)
 			}
-		case isResponsesToolCallType(itemType):
-			callID := strings.TrimSpace(gjson.GetBytes(item, "call_id").String())
-			if callID == "" {
+		case isResponsesToolCallType(item.itemType):
+			if item.callID == "" {
 				continue
 			}
-			callPresent[callID] = struct{}{}
+			callPresent[item.callID] = struct{}{}
 			if record && callCache != nil {
-				callCache.record(sessionKey, callID, item)
+				callCache.record(sessionKey, item.callID, item.raw)
 			}
 		}
 	}
 
-	filtered := make([]json.RawMessage, 0, len(items))
+	filtered := make([]responsesWebsocketInputItem, 0, len(items))
 	insertedCalls := make(map[string]struct{}, len(items))
 	for _, item := range items {
-		if len(item) == 0 {
-			continue
-		}
-		itemType := strings.TrimSpace(gjson.GetBytes(item, "type").String())
-		if isResponsesToolCallOutputType(itemType) {
-			callID := strings.TrimSpace(gjson.GetBytes(item, "call_id").String())
-			if callID == "" {
+		if isResponsesToolCallOutputType(item.itemType) {
+			if item.callID == "" {
 				// Upstream rejects tool outputs without a call_id; drop it.
 				continue
 			}
 
-			if _, ok := callPresent[callID]; ok {
+			if _, ok := callPresent[item.callID]; ok {
 				filtered = append(filtered, item)
 				continue
 			}
@@ -427,11 +462,15 @@ func repairResponsesToolCallsArray(outputCache, callCache *websocketToolOutputCa
 			}
 
 			if callCache != nil {
-				if cached, ok := callCache.get(sessionKey, callID); ok {
-					if _, already := insertedCalls[callID]; !already {
-						filtered = append(filtered, cached)
-						insertedCalls[callID] = struct{}{}
-						callPresent[callID] = struct{}{}
+				if cached, ok := callCache.get(sessionKey, item.callID); ok {
+					if _, already := insertedCalls[item.callID]; !already {
+						cachedItem, errCached := parseResponsesWebsocketInputItem(cached)
+						if errCached != nil {
+							return nil, errCached
+						}
+						filtered = append(filtered, cachedItem)
+						insertedCalls[item.callID] = struct{}{}
+						callPresent[item.callID] = struct{}{}
 					}
 					filtered = append(filtered, item)
 					continue
@@ -441,18 +480,17 @@ func repairResponsesToolCallsArray(outputCache, callCache *websocketToolOutputCa
 			// Drop orphaned function_call_output items; upstream rejects transcripts with missing calls.
 			continue
 		}
-		if !isResponsesToolCallType(itemType) {
+		if !isResponsesToolCallType(item.itemType) {
 			filtered = append(filtered, item)
 			continue
 		}
 
-		callID := strings.TrimSpace(gjson.GetBytes(item, "call_id").String())
-		if callID == "" {
+		if item.callID == "" {
 			// Upstream rejects tool calls without a call_id; drop it.
 			continue
 		}
 
-		if _, ok := outputPresent[callID]; ok {
+		if _, ok := outputPresent[item.callID]; ok {
 			filtered = append(filtered, item)
 			continue
 		}
@@ -462,21 +500,32 @@ func repairResponsesToolCallsArray(outputCache, callCache *websocketToolOutputCa
 			continue
 		}
 
-		if cached, ok := outputCache.get(sessionKey, callID); ok {
-			filtered = append(filtered, item)
-			filtered = append(filtered, cached)
-			outputPresent[callID] = struct{}{}
+		if cached, ok := outputCache.get(sessionKey, item.callID); ok {
+			cachedItem, errCached := parseResponsesWebsocketInputItem(cached)
+			if errCached != nil {
+				return nil, errCached
+			}
+			filtered = append(filtered, item, cachedItem)
+			outputPresent[item.callID] = struct{}{}
 			continue
 		}
 
 		// Drop orphaned function_call items; upstream rejects transcripts with missing outputs.
 	}
 
-	out, errMarshal := json.Marshal(filtered)
-	if errMarshal != nil {
-		return "", errMarshal
+	return dedupeResponsesWebsocketInputItems(filtered), nil
+}
+
+func responsesWebsocketInputItemsEqualRaw(items []responsesWebsocketInputItem, rawItems []json.RawMessage) bool {
+	if len(items) != len(rawItems) {
+		return false
 	}
-	return string(out), nil
+	for index := range items {
+		if !bytes.Equal(items[index].raw, rawItems[index]) {
+			return false
+		}
+	}
+	return true
 }
 
 func recordResponsesWebsocketToolCallsFromPayload(sessionKey string, payload []byte) {

--- a/sdk/api/handlers/stream_forwarder.go
+++ b/sdk/api/handlers/stream_forwarder.go
@@ -8,6 +8,21 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 )
 
+// PendingStreamError returns an immediately available non-nil stream error.
+func PendingStreamError(errs <-chan *interfaces.ErrorMessage) (*interfaces.ErrorMessage, bool) {
+	if errs == nil {
+		return nil, false
+	}
+	select {
+	case errMsg, ok := <-errs:
+		if ok && errMsg != nil {
+			return errMsg, true
+		}
+	default:
+	}
+	return nil, false
+}
+
 type StreamForwardOptions struct {
 	// KeepAliveInterval overrides the configured streaming keep-alive interval.
 	// If nil, the configured default is used. If set to <= 0, keep-alives are disabled.
@@ -16,9 +31,21 @@ type StreamForwardOptions struct {
 	// WriteChunk writes a single data chunk to the response body. It should not flush.
 	WriteChunk func(chunk []byte)
 
+	// ChunkError optionally reports that WriteChunk emitted a terminal failure.
+	// The failure is passed to cancel without writing another terminal payload.
+	ChunkError func() *interfaces.ErrorMessage
+
+	// NormalizeTerminalError optionally replaces an upstream error before it is
+	// written or passed to cancel.
+	NormalizeTerminalError func(errMsg *interfaces.ErrorMessage) *interfaces.ErrorMessage
+
 	// WriteTerminalError writes an error payload to the response body when streaming fails
 	// after headers have already been committed. It should not flush.
 	WriteTerminalError func(errMsg *interfaces.ErrorMessage)
+
+	// CloseError optionally validates a clean upstream channel close before WriteDone.
+	// Returning an error surfaces it through WriteTerminalError instead of completing the stream.
+	CloseError func() *interfaces.ErrorMessage
 
 	// WriteDone optionally writes a terminal marker when the upstream data channel closes
 	// without an error (e.g. OpenAI's `[DONE]`). It should not flush.
@@ -71,13 +98,15 @@ func (h *BaseAPIHandler) ForwardStream(c *gin.Context, flusher http.Flusher, can
 			if !ok {
 				// Prefer surfacing a terminal error if one is pending.
 				if terminalErr == nil {
-					select {
-					case errMsg, ok := <-errs:
-						if ok && errMsg != nil {
-							terminalErr = errMsg
+					if errMsg, ok := PendingStreamError(errs); ok {
+						terminalErr = errMsg
+						if opts.NormalizeTerminalError != nil {
+							terminalErr = opts.NormalizeTerminalError(terminalErr)
 						}
-					default:
 					}
+				}
+				if terminalErr == nil && opts.CloseError != nil {
+					terminalErr = opts.CloseError()
 				}
 				if terminalErr != nil {
 					if opts.WriteTerminalError != nil {
@@ -96,20 +125,38 @@ func (h *BaseAPIHandler) ForwardStream(c *gin.Context, flusher http.Flusher, can
 			}
 			writeChunk(chunk)
 			flusher.Flush()
+			if opts.ChunkError != nil {
+				chunkErr := opts.ChunkError()
+				if chunkErr != nil {
+					if opts.NormalizeTerminalError != nil {
+						chunkErr = opts.NormalizeTerminalError(chunkErr)
+					}
+					if chunkErr != nil {
+						cancel(chunkErr.Error)
+					} else {
+						cancel(nil)
+					}
+					return
+				}
+			}
 		case errMsg, ok := <-errs:
 			if !ok {
+				errs = nil
 				continue
 			}
 			if errMsg != nil {
 				terminalErr = errMsg
+				if opts.NormalizeTerminalError != nil {
+					terminalErr = opts.NormalizeTerminalError(terminalErr)
+				}
 				if opts.WriteTerminalError != nil {
-					opts.WriteTerminalError(errMsg)
+					opts.WriteTerminalError(terminalErr)
 					flusher.Flush()
 				}
 			}
 			var execErr error
-			if errMsg != nil {
-				execErr = errMsg.Error
+			if terminalErr != nil {
+				execErr = terminalErr.Error
 			}
 			cancel(execErr)
 			return

--- a/sdk/api/handlers/stream_forwarder_test.go
+++ b/sdk/api/handlers/stream_forwarder_test.go
@@ -1,0 +1,84 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+)
+
+func TestPendingStreamErrorReturnsBufferedError(t *testing.T) {
+	errs := make(chan *interfaces.ErrorMessage, 1)
+	want := &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: errors.New("upstream failed")}
+	errs <- want
+	close(errs)
+
+	got, ok := PendingStreamError(errs)
+	if !ok || got != want {
+		t.Fatalf("PendingStreamError() = (%#v, %t), want (%#v, true)", got, ok, want)
+	}
+}
+
+func TestValidateSSEDataJSONAllowsMultilinePayload(t *testing.T) {
+	chunk := []byte("event: response.completed\n" +
+		"data: {\"type\":\"response.completed\",\n" +
+		"data: \"response\":{\"status\":\"completed\"}}\n\n")
+	if err := validateSSEDataJSON(chunk); err != nil {
+		t.Fatalf("validateSSEDataJSON() error = %v, want nil", err)
+	}
+}
+
+func TestForwardStreamNormalizesErrorBeforeWriteAndCancel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	data := make(chan []byte)
+	close(data)
+	errs := make(chan *interfaces.ErrorMessage, 1)
+	errs <- &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: errors.New("raw secret")}
+	close(errs)
+
+	var written, canceled string
+	disabledKeepAlive := time.Duration(0)
+	h := &BaseAPIHandler{}
+	h.ForwardStream(c, recorder, func(err error) {
+		if err != nil {
+			canceled = err.Error()
+		}
+	}, data, errs, StreamForwardOptions{
+		KeepAliveInterval: &disabledKeepAlive,
+		NormalizeTerminalError: func(errMsg *interfaces.ErrorMessage) *interfaces.ErrorMessage {
+			return &interfaces.ErrorMessage{StatusCode: errMsg.StatusCode, Error: errors.New("safe error")}
+		},
+		WriteTerminalError: func(errMsg *interfaces.ErrorMessage) {
+			written = errMsg.Error.Error()
+		},
+	})
+
+	if written != "safe error" || canceled != "safe error" {
+		t.Fatalf("written=%q canceled=%q, want sanitized error", written, canceled)
+	}
+}
+
+func TestPendingStreamErrorIgnoresUnavailableErrors(t *testing.T) {
+	closed := make(chan *interfaces.ErrorMessage)
+	close(closed)
+
+	for name, errs := range map[string]<-chan *interfaces.ErrorMessage{
+		"nil":          nil,
+		"closed empty": closed,
+		"open empty":   make(chan *interfaces.ErrorMessage),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got, ok := PendingStreamError(errs); ok || got != nil {
+				t.Fatalf("PendingStreamError() = (%#v, %t), want (nil, false)", got, ok)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 结果

将 `router-for-me/CLIProxyAPI` 从 `934da2379d6272a704953a02322b666b2a2efa3e`（v7.2.129）保护性同步到 `f43aad7637ad813745bf7d341acb5663617570c5`（v7.2.130），吸收 9 个 upstream first-parent commits，同时保留 CPA-Core-LTS 的 usage、Management API、Codex fallback/metadata、WebSocket generation 与 delegated-auth 契约。

本 PR 必须使用 **Create a merge commit** 合入；不能 squash 或 rebase。未执行 release、tag、deployment 或运行时切换。

## 上游变更

- 正确发出提前终止 SSE 的 terminal error。
- 为 Management `APICall` 增加 request-scoped `proxy_url`。
- 按 source format 选择 Kimi 委托格式。
- 重构 Responses WebSocket request merge/repair，降低 transcript allocation，并增加 transactional tool cache。
- 移除不受 Codex upstream 支持的 `prompt_cache_options`。
- 修复 Claude duplicated alias prefix 的 tool-name 恢复。
- 跨 incremental WebSocket turns 保留 Multi-Agent v2 namespace，并在冲突时清除状态。
- 将 Codex session header 规范为 `Session-Id` 并预载当前 client headers。

## Protected delta review

冲突文件：

- `internal/api/handlers/management/api_tools_test.go`
- `internal/runtime/executor/codex_websockets_execute.go`
- `internal/runtime/executor/codex_websockets_session.go`
- `internal/runtime/executor/codex_websockets_stream.go`
- `sdk/api/handlers/openai/openai_responses_websocket.go`

关键适配：

- 保留 `codexWebsocketConnectionRef`、connection generation、target/header-profile identity、request-owned cancellation、stale-reader 与 lifecycle guards；新的 Multi-Agent optimization state 也按 generation 归属，不能由同一指针的新 generation 继承。
- 保留 Responses WebSocket 的 previous transcript rollback、`forceTranscriptReplayNextRequest`、cross-model context-reset attest、pinned-auth release/replay；在其上采用 upstream 的 `prepareResponsesWebsocketFallbackTurn`、dedupe/repair 与 transactional cache。
- 完整采用 canonical `Session-Id`，并更新 LTS metadata projection、WebSocket fallback 与回归测试，不保留 mixed legacy output。
- 保留 Kimi delegated auth clone，吸收 request source-format 选择，不把 request-local base URL 写回共享 `Auth`。
- `docs/lts/downstream-patches.yaml` 的 37 个 active patch 全部重新审计到 v7.2.130；`codex-image-generation-tool-dedup` 仍为已登记 retired baseline，不在本 PR 扩大清理范围。

## 兼容性边界

- 完整 usage statistics、`/v0/management/usage*`、usage queue 与 Panel asset source 未移除或降级。
- 未修改 release workflow、tag、artifact publishing、deployment 或 live runtime。
- 上游历史通过二父 merge commit 保留。

## 验证

本分支当前 head `364dc87f69afc88beb74aafa5daf047bcc6af9f5` 已通过：

- `scripts/check-lts-contract.sh`
- `go run ./scripts/ltsregistry --root .`
- Management、executor/helpers、Codex/OpenAI Responses translators、SDK handlers、usage 与 contract target packages 的无缓存测试
- `go test -race -count=1 ./internal/runtime/executor ./internal/runtime/executor/helps ./sdk/cliproxy/auth ./internal/client/codex/live ./internal/pluginhost`
- `go test -count=1 ./...`
- `go build -o <temporary-output> ./cmd/server`
- `git diff --check origin/main...HEAD`

初次冲突解决后的测试暴露两处 LTS expectation 漂移（canonical session header、unsupported `prompt_cache_options`），已修正并在最终 head 重跑验证通过。

## Review focus

1. Multi-Agent state 是否在 retry、replacement、detach、invalidate、session close 中严格遵守 connection generation。
2. Responses WebSocket failure rollback 与成功后的 `nextLastRequest` 更新是否同时成立。
3. `Session-Id` canonicalization 是否仍保留 LTS metadata continuity 与 privacy precedence。
4. `docs/lts/downstream-patches.yaml` 对 v7.2.130 的 protected review 是否完整。