### PR TITLE
test(codex): stabilize incremental WebSocket fixture shutdown

### DIFF
--- a/internal/runtime/executor/codex_websockets_spawn_agent_test.go
+++ b/internal/runtime/executor/codex_websockets_spawn_agent_test.go
@@ -28,6 +28,8 @@ func TestCodexWebsocketsExecutorRestoresMultiAgentV2NamespaceAcrossIncrementalTu
 		t.Run(tt.name, func(t *testing.T) {
 			upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
 			capturedPayload := make(chan []byte, 6)
+			serverRelease := make(chan struct{})
+			defer close(serverRelease)
 			var connectionCount atomic.Int32
 			var requestCount atomic.Int32
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
@@ -52,6 +54,7 @@ func TestCodexWebsocketsExecutorRestoresMultiAgentV2NamespaceAcrossIncrementalTu
 						return
 					}
 					if turn == 6 {
+						<-serverRelease
 						return
 					}
 				}

--- a/internal/runtime/executor/websocket_session_target_test.go
+++ b/internal/runtime/executor/websocket_session_target_test.go
@@ -240,6 +240,8 @@ func TestWebsocketRetryBindFailureClearsActiveSessionState(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+			serverRelease := make(chan struct{})
+			defer close(serverRelease)
 			var connections atomic.Int32
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				conn, errUpgrade := upgrader.Upgrade(w, r, nil)
@@ -263,6 +265,7 @@ func TestWebsocketRetryBindFailureClearsActiveSessionState(t *testing.T) {
 				if errWrite := conn.WriteMessage(websocket.TextMessage, completed); errWrite != nil {
 					t.Errorf("write websocket completion: %v", errWrite)
 				}
+				<-serverRelease
 			}))
 			defer server.Close()
 


### PR DESCRIPTION
## 问题

PR #215 合并后的 `main` push run `31590957952` 中，`TestCodexWebsocketsExecutorRestoresMultiAgentV2NamespaceAcrossIncrementalTurns/stream` 偶发收到 `websocket: close 1006 (abnormal closure): unexpected EOF`。第一版修复后的 PR run `31591525992` 又把同类竞态暴露在既有 `TestWebsocketRetryBindFailureClearsActiveSessionState` fixture：test server 写出 `response.completed` 后立即关闭 socket，reader goroutine 可能先投递 EOF，抢在 completion event 被被测 stream 消费之前。

## 修复

仅调整两处 test fixture：terminal response 写出后保持 server connection 存活，直到对应 subtest 完成再释放。没有修改 runtime 行为、公共接口或 LTS 契约，也没有通过 retry 或放宽断言隐藏失败。

## 验证

- `go test -count=200 ./internal/runtime/executor -run '^TestCodexWebsocketsExecutorRestoresMultiAgentV2NamespaceAcrossIncrementalTurns/stream$'`
- `go test -count=200 ./internal/runtime/executor -run '^TestWebsocketRetryBindFailureClearsActiveSessionState/Codex_(nonstream|stream)$'`
- `go test -race -count=20 ./internal/runtime/executor -run '^(TestCodexWebsocketsExecutorRestoresMultiAgentV2NamespaceAcrossIncrementalTurns|TestWebsocketRetryBindFailureClearsActiveSessionState)$'`
- `go test -count=1 ./...`
- `git diff --check`

请使用 Create a merge commit。未执行 release、tag 或 deployment。