### PR TITLE
fix(pluginstore): 拒绝带 userinfo 的 GitHub 仓库 URL

### DIFF
--- a/internal/pluginstore/registry.go
+++ b/internal/pluginstore/registry.go
@@ -418,7 +418,7 @@ func GitHubRepositoryParts(repository string) (string, string, error) {
 	if errParse != nil {
 		return "", "", fmt.Errorf("invalid repository URL: %w", errParse)
 	}
-	if parsed.Scheme != "https" || parsed.Host != "github.com" || parsed.RawQuery != "" || parsed.Fragment != "" {
+	if parsed.Scheme != "https" || parsed.Host != "github.com" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
 		return "", "", fmt.Errorf("repository must be https://github.com/{owner}/{repo}")
 	}
 	segments := strings.Split(strings.Trim(parsed.EscapedPath(), "/"), "/")

--- a/internal/pluginstore/registry_test.go
+++ b/internal/pluginstore/registry_test.go
@@ -326,6 +326,7 @@ func TestGitHubRepositoryPartsRejectsNonRepositoryURLs(t *testing.T) {
 		"https://github.com/owner/repo/issues",
 		"https://github.com/owner/repo.git",
 		"https://github.com/owner/repo?tab=readme",
+		"https://token@github.com/owner/repo",
 	}
 	for _, repository := range tests {
 		t.Run(repository, func(t *testing.T) {


### PR DESCRIPTION
## 结果

收紧 plugin registry 的 GitHub 仓库 URL 校验，拒绝 `https://token@github.com/owner/repo` 这类带 userinfo 的地址，避免凭据式 URL 被当作规范仓库来源接受。

## 变更

- `GitHubRepositoryParts` 要求 `parsed.User == nil`。
- 增加带 userinfo URL 的回归用例。

这是对 upstream `feat/github-release-plugin-install` 分支中独立 parser 修复的 manual adapt-port；没有吸收该分支的 `-plugin-install` CLI、远程可执行文件下载或配置持久化流程，也未改变已有合法 `https://github.com/{owner}/{repo}` 语义。

## 验证

- `go test -count=1 ./internal/pluginstore`
- `git diff --check`

请使用 Create a merge commit。未执行 release、tag 或 deployment。