### PR TITLE
fix(release): 要求显式 LTS 摘要与配套版本

### DIFF
--- a/.github/workflows/lts-contract.yml
+++ b/.github/workflows/lts-contract.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Test release notes contract
+        run: scripts/generate-lts-release-notes_test.sh
+
       - name: Check LTS protected sentinels
         run: scripts/check-lts-contract.sh
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,11 @@ on:
         description: 'Release tag to build and publish, for example v1-tls-0.0.3'
         required: true
         type: string
+      rewrite_release_notes:
+        description: 'Replace the title and notes when the Release already exists'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -18,6 +23,7 @@ env:
   GH_REPO: ${{ github.repository }}
   GO_VERSION: '1.26.4'
   RELEASE_TAG: ${{ github.event.inputs.release_tag || github.ref_name }}
+  REWRITE_RELEASE_NOTES: ${{ github.event_name == 'workflow_dispatch' && inputs.rewrite_release_notes || false }}
 
 jobs:
   validate-release-catalog:
@@ -72,16 +78,24 @@ jobs:
             exit 1
           fi
 
+          release_exists=false
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            release_exists=true
+          fi
+          if [[ "$release_exists" == "true" && "$REWRITE_RELEASE_NOTES" != "true" ]]; then
+            echo "Release ${RELEASE_TAG} already exists; preserving its title and notes."
+            exit 0
+          fi
+
           notes_file="$(mktemp)"
           title_file="$(mktemp)"
           trap 'rm -f "$notes_file" "$title_file"' EXIT
           bash scripts/generate-lts-release-notes.sh \
-            --product core \
             --tag "${RELEASE_TAG}" \
             --notes-file "$notes_file" \
             --title-file "$title_file"
           title="$(tr -d '\n' < "$title_file")"
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+          if [[ "$release_exists" == "true" ]]; then
             gh release edit "$RELEASE_TAG" --title "$title" --notes-file "$notes_file"
           else
             gh release create "$RELEASE_TAG" --title "$title" --notes-file "$notes_file"

--- a/docs/lts/sync-runbook.md
+++ b/docs/lts/sync-runbook.md
@@ -216,6 +216,18 @@ git diff --check
 - Management usage response shape：`usage`、`failed_requests`、`apis`、`models`、`details`。
 - export/import roundtrip：导出后导入仍保留核心字段。
 
+## Release note contract
+
+正式发版使用 annotated `v*-tls-*` tag。tag subject 是用户可见摘要，tag body 必须包含且只能包含一条显式配套版本：
+
+```text
+Core LTS: upstream full-sync through ..., retained LTS fixes
+
+Companion-Panel: v1-tls-0.0.13
+```
+
+`scripts/generate-lts-release-notes.sh` 不按发布时间猜测 Panel 版本，也不从 PR 顺序合成摘要。`workflow_dispatch` 重跑已有 Release 时默认保留人工修订过的标题和正文；只有明确启用 `rewrite_release_notes` 才重新生成。发版前运行 `scripts/generate-lts-release-notes_test.sh`，并在发布后回读配套链接、资产和 Latest 状态。
+
 ## PR body checklist
 
 每个 sync PR 必须写清：

--- a/scripts/generate-lts-release-notes.sh
+++ b/scripts/generate-lts-release-notes.sh
@@ -1,36 +1,41 @@
 #!/usr/bin/env bash
-# Generate scannable GitHub release notes for a CPA LTS tag.
-# Previous TLS tag discovery only considers v*-tls-* refs, never upstream v7.* / v1.8.* tags.
+# Generate a CPA-Core-LTS Release body from an authoritative annotated tag.
 set -euo pipefail
+
+DEFAULT_REPO="BlueSkyXN/CPA-Core-LTS"
+COMPANION_LABEL="CPA-Panel-LTS"
+DEFAULT_COMPANION_REPO="BlueSkyXN/CPA-Panel-LTS"
+COMPANION_TRAILER="Companion-Panel"
 
 usage() {
   cat <<'EOF'
-Usage: scripts/generate-lts-release-notes.sh --product core|panel --tag v1-tls-X.Y.Z [options]
+Usage: scripts/generate-lts-release-notes.sh --tag v1-tls-X.Y.Z [options]
+
+The tag must be annotated. Its subject is the user-facing summary and its body
+must contain exactly one companion trailer, for example:
+
+  Core LTS: upstream sync and retained LTS fixes
+
+  Companion-Panel: v1-tls-0.0.13
 
 Options:
-  --product core|panel   Required. Selects companion repo and asset section.
-  --tag TAG              Required. Existing v*-tls-* tag.
-  --repo OWNER/NAME      Override GitHub repo. Defaults from --product.
-  --companion OWNER/NAME Override companion repo. Defaults from --product.
-  --notes-file PATH      Write notes to PATH instead of stdout.
-  --title-file PATH      Write the release title to PATH.
-  -h, --help             Show this help.
+  --tag TAG                   Required. Existing annotated v*-tls-* tag.
+  --repo OWNER/NAME           Override the Core repository.
+  --companion-repo OWNER/NAME Override the Panel repository.
+  --notes-file PATH           Write notes to PATH instead of stdout.
+  --title-file PATH           Write the release title to PATH.
+  -h, --help                  Show this help.
 EOF
 }
 
-product=""
 tag=""
-repo=""
-companion=""
+repo="${GH_REPO:-$DEFAULT_REPO}"
+companion_repo="$DEFAULT_COMPANION_REPO"
 notes_file=""
 title_file=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --product)
-      product="${2:-}"
-      shift 2
-      ;;
     --tag)
       tag="${2:-}"
       shift 2
@@ -39,8 +44,8 @@ while [[ $# -gt 0 ]]; do
       repo="${2:-}"
       shift 2
       ;;
-    --companion)
-      companion="${2:-}"
+    --companion-repo)
+      companion_repo="${2:-}"
       shift 2
       ;;
     --notes-file)
@@ -63,40 +68,62 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "$product" || -z "$tag" ]]; then
-  echo "--product and --tag are required" >&2
+if [[ -z "$tag" ]]; then
+  echo "--tag is required" >&2
   usage >&2
   exit 2
 fi
 
-case "$product" in
-  core)
-    repo="${repo:-${GH_REPO:-BlueSkyXN/CPA-Core-LTS}}"
-    companion="${companion:-BlueSkyXN/CPA-Panel-LTS}"
-    companion_label="CPA-Panel-LTS"
-    ;;
-  panel)
-    repo="${repo:-${GH_REPO:-BlueSkyXN/CPA-Panel-LTS}}"
-    companion="${companion:-BlueSkyXN/CPA-Core-LTS}"
-    companion_label="CPA-Core-LTS"
-    ;;
-  *)
-    echo "--product must be core or panel" >&2
-    exit 2
-    ;;
-esac
-
-SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH='' cd -- "$SCRIPT_DIR/.." && pwd)
 cd "$REPO_ROOT"
 
 if [[ "$tag" != v*-tls-* ]]; then
-  echo "Only LTS release tags matching v*-tls-* are supported: $tag" >&2
+  echo "Only Core LTS release tags matching v*-tls-* are supported: $tag" >&2
   exit 1
 fi
 
-if ! git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+tag_ref="refs/tags/${tag}"
+if ! git rev-parse -q --verify "$tag_ref" >/dev/null; then
   echo "Release tag ${tag} does not exist in this checkout." >&2
+  exit 1
+fi
+if [[ "$(git cat-file -t "$tag_ref" 2>/dev/null || true)" != "tag" ]]; then
+  echo "Release tag ${tag} must be an annotated tag." >&2
+  exit 1
+fi
+
+tag_message="$(git for-each-ref --format='%(contents)' "$tag_ref")"
+summary="$(git for-each-ref --format='%(contents:subject)' "$tag_ref" | sed -n '1p')"
+
+is_placeholder_summary() {
+  local candidate="$1"
+  local current="$2"
+  local compact tag_compact
+  compact="$(printf '%s' "$candidate" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:][:punct:]')"
+  tag_compact="$(printf '%s' "$current" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:][:punct:]')"
+  [[ -z "$compact" || "$compact" == "$tag_compact" || \
+    ( ${#candidate} -le 48 && "$compact" == *"$tag_compact"* ) ]]
+}
+
+if is_placeholder_summary "$summary" "$tag"; then
+  echo "Release tag ${tag} must contain a meaningful user-facing summary." >&2
+  exit 1
+fi
+
+companion_lines="$(
+  printf '%s\n' "$tag_message" |
+    sed -n "s/^${COMPANION_TRAILER}:[[:space:]]*//p" |
+    sed 's/[[:space:]]*$//'
+)"
+companion_count="$(printf '%s\n' "$companion_lines" | awk 'NF { count++ } END { print count + 0 }')"
+if [[ "$companion_count" -ne 1 ]]; then
+  echo "Release tag ${tag} must contain exactly one ${COMPANION_TRAILER}: v*-tls-* trailer." >&2
+  exit 1
+fi
+companion_tag="$(printf '%s\n' "$companion_lines" | sed -n '1p')"
+if [[ "$companion_tag" != v*-tls-* ]]; then
+  echo "${COMPANION_TRAILER} value must match v*-tls-*: ${companion_tag}" >&2
   exit 1
 fi
 
@@ -113,110 +140,56 @@ previous_tls_tag() {
   return 1
 }
 
-tag_subject() {
-  local current="$1"
-  local subject
-  subject="$(git tag --list --format='%(contents:subject)' "$current" | sed -n '1p')"
-  printf '%s' "$subject"
-}
+previous=""
+if previous="$(previous_tls_tag "$tag")"; then
+  :
+else
+  previous=""
+fi
 
-is_placeholder_subject() {
-  local subject="$1"
-  local current="$2"
-  local compact tagcompact
-  compact="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:][:punct:]')"
-  tagcompact="$(printf '%s' "$current" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:][:punct:]')"
-  if [[ -z "$compact" ]]; then
-    return 0
+generated_file="$(mktemp)"
+notes_tmp="$(mktemp)"
+trap 'rm -f "$generated_file" "$notes_tmp"' EXIT
+
+if command -v gh >/dev/null 2>&1; then
+  generate_args=(api "repos/${repo}/releases/generate-notes" -f "tag_name=${tag}")
+  if [[ -n "$previous" ]]; then
+    generate_args+=(-f "previous_tag_name=${previous}")
   fi
-  if [[ "$compact" == "$tagcompact" ]]; then
-    return 0
+  gh "${generate_args[@]}" --jq .body >"$generated_file" 2>/dev/null || true
+fi
+if [[ ! -s "$generated_file" ]]; then
+  if [[ -n "$previous" ]]; then
+    printf '**完整变更**: https://github.com/%s/compare/%s...%s\n' \
+      "$repo" "$previous" "$tag" >"$generated_file"
+  else
+    printf '**完整变更**: https://github.com/%s/commits/%s\n' \
+      "$repo" "$tag" >"$generated_file"
   fi
-  if [[ ${#subject} -le 48 && "$compact" == *"$tagcompact"* ]]; then
-    return 0
-  fi
-  return 1
-}
+fi
 
-brief_first_parent_line() {
-  local subject="$1"
-  local pr rest
-  if [[ "$subject" == "Merge pull request #"* ]]; then
-    pr="$(printf '%s' "$subject" | sed -n 's/^Merge pull request \(#[0-9][0-9]*\).*/\1/p')"
-    rest="$(printf '%s' "$subject" | sed -n 's/^Merge pull request #[0-9][0-9]* from [^/]*\///p')"
-    if [[ -n "$pr" && -n "$rest" ]]; then
-      printf '%s — %s\n' "$pr" "$rest"
-      return 0
-    fi
-  fi
-  printf '%s\n' "$subject"
-}
+short_summary="$(printf '%s' "$summary" | python3 -c 'import sys
+text = sys.stdin.read().strip()
+limit = 140
+if len(text) <= limit:
+    print(text)
+    raise SystemExit
+cut = text[:limit]
+for sep in ("；", ";", ",", "，", " "):
+    index = cut.rfind(sep)
+    if index >= 48:
+        cut = cut[:index].rstrip("；;,， ")
+        break
+print(cut + "...")
+')"
+title="${tag} — ${short_summary}"
 
-iso_from_tag() {
-  local current="$1"
-  git for-each-ref --format='%(creatordate:iso-strict)' "refs/tags/${current}" | sed -n '1p'
-}
+{
+  printf '## 摘要\n\n%s\n\n' "$summary"
+  printf '## 配套版本\n\n'
+  printf -- '- 配套 %s：[%s](https://github.com/%s/releases/tag/%s)\n\n' \
+    "$COMPANION_LABEL" "$companion_tag" "$companion_repo" "$companion_tag"
 
-normalize_iso() {
-  local raw="$1"
-  python3 -c 'import sys
-from datetime import datetime, timezone
-raw = sys.argv[1].strip()
-if not raw:
-    raise SystemExit(1)
-text = raw.replace("Z", "+00:00")
-dt = datetime.fromisoformat(text)
-if dt.tzinfo is None:
-    dt = dt.replace(tzinfo=timezone.utc)
-print(dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))
-' "$raw"
-}
-
-companion_choice() {
-  local companion_repo="$1"
-  local current_iso="$2"
-  if [[ -z "$current_iso" ]]; then
-    return 1
-  fi
-  if ! command -v gh >/dev/null 2>&1; then
-    return 1
-  fi
-  local payload
-  if ! payload="$(gh release list --repo "$companion_repo" --limit 30 --json tagName,publishedAt 2>/dev/null)"; then
-    return 1
-  fi
-  python3 -c 'import json, sys
-from datetime import datetime, timezone
-
-def parse(value):
-    text = value.replace("Z", "+00:00")
-    dt = datetime.fromisoformat(text)
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(timezone.utc)
-
-current = parse(sys.argv[1])
-releases = json.loads(sys.argv[2])
-eligible = []
-for item in releases:
-    published = item.get("publishedAt") or ""
-    tag_name = item.get("tagName") or ""
-    if not published or not tag_name:
-        continue
-    dt = parse(published)
-    if dt.timestamp() <= current.timestamp() + 7200:
-        eligible.append((dt, tag_name, published))
-if not eligible:
-    raise SystemExit(1)
-eligible.sort(key=lambda row: row[0], reverse=True)
-chosen = eligible[0]
-delta = abs((chosen[0] - current).total_seconds())
-kind = "paired" if delta <= 36 * 3600 else "latest"
-print(f"{chosen[1]}\t{kind}\t{chosen[2]}")
-' "$current_iso" "$payload"
-}
-
-core_asset_section() {
   cat <<'EOF'
 <!-- cliproxyapi-linux-release-assets:start -->
 ## 发布资产
@@ -230,167 +203,17 @@ core_asset_section() {
 - `CLIProxyAPI_<version>_freebsd_aarch64_no-plugin.tar.gz` 是 FreeBSD arm64 构建，关闭 CGO，不支持动态库插件。
 
 <!-- cliproxyapi-linux-release-assets:end -->
+
 EOF
-}
-
-panel_asset_section() {
-  cat <<'EOF'
-## 发布资产
-
-- `management.html`：单文件管理面板，供 `CPA-Core-LTS` 按资产名下载。
-EOF
-}
-
-previous=""
-if previous="$(previous_tls_tag "$tag")"; then
-  range="${previous}..${tag}"
-else
-  previous=""
-  range="$tag"
-fi
-
-subject="$(tag_subject "$tag")"
-highlights_file="$(mktemp)"
-briefs_file="$(mktemp)"
-generated_file="$(mktemp)"
-trap 'rm -f "$highlights_file" "$briefs_file" "$generated_file"' EXIT
-
-if [[ -n "$previous" ]]; then
-  git log --first-parent --reverse --pretty=format:'%s' "$range" > "$highlights_file" || true
-else
-  : > "$highlights_file"
-fi
-
-while IFS= read -r line || [[ -n "${line:-}" ]]; do
-  [[ -z "$line" ]] && continue
-  brief_first_parent_line "$line" >> "$briefs_file"
-done < "$highlights_file"
-
-if command -v gh >/dev/null 2>&1; then
-  generate_args=(api "repos/${repo}/releases/generate-notes" -f "tag_name=${tag}")
-  if [[ -n "$previous" ]]; then
-    generate_args+=(-f "previous_tag_name=${previous}")
-  fi
-  gh "${generate_args[@]}" --jq .body > "$generated_file" 2>/dev/null || true
-fi
-if [[ ! -s "$generated_file" ]]; then
-  if [[ -n "$previous" ]]; then
-    printf '**完整变更**: https://github.com/%s/compare/%s...%s\n' "$repo" "$previous" "$tag" > "$generated_file"
-  else
-    printf '**完整变更**: https://github.com/%s/commits/%s\n' "$repo" "$tag" > "$generated_file"
-  fi
-fi
-
-summary_from_generated_notes() {
-  python3 -c 'import re, sys
-text = sys.stdin.read()
-titles = []
-for line in text.splitlines():
-    match = re.match(r"^\* (.+?) by @", line)
-    if match:
-        titles.append(match.group(1).strip())
-print("；".join(titles[:3]))
-'
-}
-
-summary="$subject"
-if is_placeholder_subject "$subject" "$tag"; then
-  summary=""
-  if [[ -s "$generated_file" ]]; then
-    summary="$(summary_from_generated_notes < "$generated_file")"
-  fi
-  if [[ -z "$summary" && -s "$briefs_file" ]]; then
-    summary="$(sed -n '1,3p' "$briefs_file" | paste -sd '；' -)"
-  fi
-fi
-if [[ -z "$summary" ]]; then
-  summary="${tag}"
-fi
-
-title="$tag"
-if [[ "$summary" != "$tag" ]]; then
-  short_summary="$(printf '%s' "$summary" | python3 -c 'import sys
-text = sys.stdin.read().strip()
-limit = 140
-if len(text) <= limit:
-    print(text)
-    raise SystemExit
-cut = text[:limit]
-for sep in ("；", ";", ",", "，", " "):
-    idx = cut.rfind(sep)
-    if idx >= 48:
-        cut = cut[:idx].rstrip("；;,， ")
-        break
-print(cut + "...")
-')"
-  title="${tag} — ${short_summary}"
-fi
-
-current_iso=""
-if raw_iso="$(iso_from_tag "$tag")"; then
-  current_iso="$(normalize_iso "$raw_iso" || true)"
-fi
-if [[ -z "$current_iso" ]] && command -v gh >/dev/null 2>&1; then
-  published="$(gh release view "$tag" --repo "$repo" --json publishedAt --jq .publishedAt 2>/dev/null || true)"
-  if [[ -n "$published" ]]; then
-    current_iso="$(normalize_iso "$published" || true)"
-  fi
-fi
-
-companion_tag=""
-companion_kind=""
-if companion_row="$(companion_choice "$companion" "$current_iso" 2>/dev/null)"; then
-  companion_tag="$(printf '%s' "$companion_row" | awk -F '\t' 'NR==1{print $1}')"
-  companion_kind="$(printf '%s' "$companion_row" | awk -F '\t' 'NR==1{print $2}')"
-fi
-
-notes_tmp="$(mktemp)"
-{
-  printf '## 摘要\n\n%s\n\n' "$summary"
-
-  printf '## 配套版本\n\n'
-  if [[ -n "$companion_tag" ]]; then
-    if [[ "$companion_kind" == "paired" ]]; then
-      printf -- '- 同期配套 %s：[%s](https://github.com/%s/releases/tag/%s)\n\n' \
-        "$companion_label" "$companion_tag" "$companion" "$companion_tag"
-    else
-      printf -- '- 发布时可用的 %s Latest：[%s](https://github.com/%s/releases/tag/%s)\n\n' \
-        "$companion_label" "$companion_tag" "$companion" "$companion_tag"
-    fi
-  else
-    printf -- '- 配套 %s：未能从 GitHub 解析同期 Release，请按发布当天的 Latest 核对。\n\n' "$companion_label"
-  fi
-
-  printf '## 本版要点\n\n'
-  if [[ -s "$briefs_file" ]]; then
-    while IFS= read -r brief || [[ -n "${brief:-}" ]]; do
-      [[ -z "$brief" ]] && continue
-      printf -- '- %s\n' "$brief"
-    done < "$briefs_file"
-    printf '\n'
-  else
-    printf -- '- 本 tag 没有可列出的 first-parent 变更。\n\n'
-  fi
-
-  if [[ "$product" == "core" ]]; then
-    core_asset_section
-    printf '\n'
-  else
-    panel_asset_section
-    printf '\n'
-  fi
-
   cat "$generated_file"
   printf '\n'
-} > "$notes_tmp"
+} >"$notes_tmp"
 
 if [[ -n "$title_file" ]]; then
-  printf '%s\n' "$title" > "$title_file"
+  printf '%s\n' "$title" >"$title_file"
 fi
-
 if [[ -n "$notes_file" ]]; then
-  cat "$notes_tmp" > "$notes_file"
+  cat "$notes_tmp" >"$notes_file"
 else
   cat "$notes_tmp"
 fi
-rm -f "$notes_tmp"

--- a/scripts/generate-lts-release-notes_test.sh
+++ b/scripts/generate-lts-release-notes_test.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+GENERATOR="$ROOT_DIR/scripts/generate-lts-release-notes.sh"
+
+fail() {
+  printf 'release notes generator test failed: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  if ! grep -Fq -- "$expected" "$file"; then
+    printf 'expected %s to contain: %s\n' "$file" "$expected" >&2
+    sed -n '1,120p' "$file" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local unexpected="$2"
+  if grep -Fq -- "$unexpected" "$file"; then
+    printf 'expected %s not to contain: %s\n' "$file" "$unexpected" >&2
+    sed -n '1,120p' "$file" >&2
+    exit 1
+  fi
+}
+
+expect_failure() {
+  local expected="$1"
+  local tag="$2"
+  local stdout_file="$FIXTURE_DIR/stdout"
+  local stderr_file="$FIXTURE_DIR/stderr"
+
+  if PATH="$MOCK_BIN:$PATH" GH_MOCK_LOG="$GH_MOCK_LOG" \
+    bash "$FIXTURE_DIR/repo/scripts/generate-lts-release-notes.sh" \
+      --tag "$tag" >"$stdout_file" 2>"$stderr_file"; then
+    fail "$tag unexpectedly succeeded"
+  fi
+  assert_contains "$stderr_file" "$expected"
+}
+
+FIXTURE_DIR=$(mktemp -d)
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+MOCK_BIN="$FIXTURE_DIR/bin"
+GH_MOCK_LOG="$FIXTURE_DIR/gh.log"
+mkdir -p "$FIXTURE_DIR/repo/scripts" "$MOCK_BIN"
+cp "$GENERATOR" "$FIXTURE_DIR/repo/scripts/"
+
+cat >"$MOCK_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${GH_MOCK_LOG:?}"
+if [[ "${1:-}" == "api" ]]; then
+  if [[ "${GH_MOCK_FAIL:-false}" == "true" ]]; then
+    exit 1
+  fi
+  cat <<'NOTES'
+## What's Changed
+* fix(runtime): keep the final behavior by @maintainer in https://example.invalid/pull/1
+
+**Full Changelog**: https://example.invalid/compare
+NOTES
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$MOCK_BIN/gh"
+
+cd "$FIXTURE_DIR/repo"
+git init -q
+git config user.name fixture
+git config user.email fixture@example.invalid
+
+printf 'base\n' >fixture.txt
+git add fixture.txt
+git commit -qm base
+git tag -a v1-tls-0.0.1 \
+  -m 'Core LTS: base release' \
+  -m 'Companion-Panel: v1-tls-0.0.1'
+
+printf 'upstream\n' >>fixture.txt
+git commit -qam upstream
+git tag -a v7.99.0 -m 'upstream v7.99.0'
+
+printf 'release\n' >>fixture.txt
+git commit -qam release
+git tag -a v1-tls-0.0.2 \
+  -m 'Core LTS: explicit summary survives release ordering' \
+  -m 'Companion-Panel: v1-tls-0.0.2'
+
+output_file="$FIXTURE_DIR/release-notes.md"
+title_file="$FIXTURE_DIR/release-title.txt"
+PATH="$MOCK_BIN:$PATH" GH_MOCK_LOG="$GH_MOCK_LOG" \
+  bash scripts/generate-lts-release-notes.sh \
+    --tag v1-tls-0.0.2 \
+    --notes-file "$output_file" \
+    --title-file "$title_file"
+
+assert_contains "$output_file" 'Core LTS: explicit summary survives release ordering'
+assert_contains "$output_file" 'CPA-Panel-LTS：[v1-tls-0.0.2]'
+assert_contains "$output_file" '## What'"'"'s Changed'
+assert_not_contains "$output_file" '## 本版要点'
+assert_contains "$title_file" 'v1-tls-0.0.2 — Core LTS: explicit summary survives release ordering'
+assert_contains "$GH_MOCK_LOG" 'previous_tag_name=v1-tls-0.0.1'
+assert_not_contains "$GH_MOCK_LOG" 'previous_tag_name=v7.99.0'
+
+fallback_file="$FIXTURE_DIR/release-notes-fallback.md"
+PATH="$MOCK_BIN:$PATH" GH_MOCK_LOG="$GH_MOCK_LOG" GH_MOCK_FAIL=true \
+  bash scripts/generate-lts-release-notes.sh \
+    --tag v1-tls-0.0.2 \
+    --notes-file "$fallback_file"
+assert_contains "$fallback_file" 'Core LTS: explicit summary survives release ordering'
+assert_contains "$fallback_file" 'CPA-Core-LTS/compare/v1-tls-0.0.1...v1-tls-0.0.2'
+
+printf 'lightweight\n' >>fixture.txt
+git commit -qam lightweight
+git tag v1-tls-0.0.3
+expect_failure 'must be an annotated tag' v1-tls-0.0.3
+
+printf 'placeholder\n' >>fixture.txt
+git commit -qam placeholder
+git tag -a v1-tls-0.0.4 \
+  -m 'CPA Core LTS v1-tls-0.0.4' \
+  -m 'Companion-Panel: v1-tls-0.0.4'
+expect_failure 'meaningful user-facing summary' v1-tls-0.0.4
+
+printf 'missing companion\n' >>fixture.txt
+git commit -qam missing-companion
+git tag -a v1-tls-0.0.5 -m 'Core LTS: missing companion fixture'
+expect_failure 'Companion-Panel' v1-tls-0.0.5
+
+printf 'invalid companion\n' >>fixture.txt
+git commit -qam invalid-companion
+git tag -a v1-tls-0.0.6 \
+  -m 'Core LTS: invalid companion fixture' \
+  -m 'Companion-Panel: panel-latest'
+expect_failure 'must match v*-tls-*' v1-tls-0.0.6
+
+printf 'duplicate companion\n' >>fixture.txt
+git commit -qam duplicate-companion
+git tag -a v1-tls-0.0.7 \
+  -m 'Core LTS: duplicate companion fixture' \
+  -m $'Companion-Panel: v1-tls-0.0.6\nCompanion-Panel: v1-tls-0.0.7'
+expect_failure 'exactly one Companion-Panel' v1-tls-0.0.7
+
+printf 'release notes generator tests passed.\n'


### PR DESCRIPTION
## Type

- [x] Maintenance docs / CI

## Outcome and root cause

Release notes previously inferred the companion Panel version from release timestamps and synthesized placeholder-tag summaries from the first three PR titles. That made the first side of a Core/Panel release pair order-dependent and allowed reverted work to be advertised as the final release summary.

This PR makes the annotated tag the authoritative release contract.

## Changes

- Require an annotated `v*-tls-*` tag with a meaningful subject.
- Require exactly one `Companion-Panel: v*-tls-*` line in the tag body.
- Remove timestamp-based companion inference, PR-order summary synthesis, duplicate first-parent highlights, and cross-product `--product` selection.
- Preserve an existing Release title/body on manual dispatch unless `rewrite_release_notes` is explicitly enabled.
- Add deterministic Git fixtures for TLS previous-tag selection, lightweight/placeholder tags, missing/invalid/duplicate companion metadata, and GitHub generated-notes fallback.
- Document the tag contract in the LTS sync runbook and run the fixture in PR CI.

## Impact and boundaries

- The Core binary, usage statistics, Management API, config, auth, model catalogs, release asset names, and build matrix are unchanged.
- Existing Releases and tags are not modified by this PR.
- No new tag or Release is created.
- A real future tag-to-Release run remains the end-to-end release-context verification.

## LTS classification review

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| panel release source / release source | review seam | preserved | Panel repository and Core asset descriptions remain unchanged |
| release note metadata | maintenance CI | adapted | explicit annotated-tag summary and companion trailer with deterministic fixtures |

## Validation

- [x] `scripts/generate-lts-release-notes_test.sh`
- [x] `shellcheck scripts/generate-lts-release-notes.sh scripts/generate-lts-release-notes_test.sh`
- [x] `actionlint .github/workflows/release.yaml .github/workflows/lts-contract.yml`
- [x] `scripts/check-lts-contract.sh`
- [x] `git diff --check`
- [ ] Go package/build tests were not rerun locally because no Go source or build command changed; existing PR CI remains the build gate.
- [ ] Live release workflow was not dispatched because this PR must not publish or rewrite a Release.

## Review focus

- Annotated-tag and `Companion-Panel` validation in `scripts/generate-lts-release-notes.sh`.
- Existing-Release preservation versus explicit `rewrite_release_notes` behavior in `.github/workflows/release.yaml`.
- Fixture coverage in `scripts/generate-lts-release-notes_test.sh`.