### PR TITLE
feat(xai): 保存并展示 billing user_id

### DIFF
--- a/docs/lts/core-feature-contracts.yaml
+++ b/docs/lts/core-feature-contracts.yaml
@@ -137,7 +137,7 @@ features:
     support: protected
     owner: cpa-core-lts
     upstream_relation: divergent
-    reason: Usage and provider status views require stable API key, auth source, and auth_index attribution.
+    reason: Usage and provider status views require stable API key, auth source, and auth_index attribution. xAI billing additionally requires the non-secret /user user_id while keeping OIDC sub and tokens private.
     core_files:
       - internal/access/
       - internal/api/handlers/management/auth_files.go
@@ -152,6 +152,10 @@ features:
       - source
       - api-key
       - APIKey
+      - user_id
+      - UserEndpoint
+      - UserEndpointUserAgent
+      - x86_64
     validation:
       - go test ./internal/api/handlers/management -run 'Auth|auth|Usage|usage'
       - go test ./internal/watcher ./internal/auth/...

--- a/internal/api/handlers/management/auth_files.go
+++ b/internal/api/handlers/management/auth_files.go
@@ -249,6 +249,14 @@ func (h *Handler) listAuthFilesFromDisk(c *gin.Context) {
 				emailValue := gjson.GetBytes(data, "email").String()
 				fileData["type"] = typeValue
 				fileData["email"] = emailValue
+				// xAI's billing identity is a non-secret value returned by the
+				// official /user endpoint. Do not expose OIDC sub or any token
+				// from the disk fallback.
+				if strings.EqualFold(strings.TrimSpace(typeValue), "xai") {
+					if userID := strings.TrimSpace(gjson.GetBytes(data, "user_id").String()); userID != "" {
+						fileData["user_id"] = userID
+					}
+				}
 				if projectID := strings.TrimSpace(gjson.GetBytes(data, "project_id").String()); projectID != "" {
 					fileData["project_id"] = projectID
 				}
@@ -347,6 +355,9 @@ func (h *Handler) buildAuthFileEntryLocked(auth *coreauth.Auth) gin.H {
 	entry["recent_requests"] = auth.RecentRequestsSnapshot(time.Now())
 	if email := authEmail(auth); email != "" {
 		entry["email"] = email
+	}
+	if userID := authUserID(auth); userID != "" {
+		entry["user_id"] = userID
 	}
 	if projectID := authProjectID(auth); projectID != "" {
 		entry["project_id"] = projectID
@@ -556,6 +567,23 @@ func authEmail(auth *coreauth.Auth) string {
 		if v := strings.TrimSpace(auth.Attributes["account_email"]); v != "" {
 			return v
 		}
+	}
+	return ""
+}
+
+func authUserID(auth *coreauth.Auth) string {
+	if auth == nil || !strings.EqualFold(strings.TrimSpace(auth.Provider), "xai") {
+		return ""
+	}
+	if auth.Metadata != nil {
+		if value, ok := auth.Metadata["user_id"].(string); ok {
+			if userID := strings.TrimSpace(value); userID != "" {
+				return userID
+			}
+		}
+	}
+	if auth.Attributes != nil {
+		return strings.TrimSpace(auth.Attributes["user_id"])
 	}
 	return ""
 }

--- a/internal/api/handlers/management/auth_files_filter_test.go
+++ b/internal/api/handlers/management/auth_files_filter_test.go
@@ -130,6 +130,70 @@ func TestListAuthFilesFromDiskFiltersByNameAndRejectsAuthIndex(t *testing.T) {
 	}
 }
 
+func TestListAuthFilesXAIUserIDIsNonSecretOnly(t *testing.T) {
+	t.Setenv("MANAGEMENT_PASSWORD", "")
+	authDir := t.TempDir()
+	fileName := "xai-user.json"
+	data := []byte(`{"type":"xai","user_id":"billing-user-1","sub":"oidc-sub","access_token":"secret-access","refresh_token":"secret-refresh"}`)
+	if errWrite := os.WriteFile(filepath.Join(authDir, fileName), data, 0o600); errWrite != nil {
+		t.Fatalf("write auth file: %v", errWrite)
+	}
+
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: authDir}, nil)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/v0/management/auth-files?name="+fileName, nil)
+	h.ListAuthFiles(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "secret-access") || strings.Contains(rec.Body.String(), "secret-refresh") {
+		t.Fatalf("auth-files response leaked token: %s", rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "oidc-sub") {
+		t.Fatalf("auth-files response exposed OIDC sub: %s", rec.Body.String())
+	}
+	var payload struct {
+		Files []map[string]any `json:"files"`
+	}
+	if errDecode := json.Unmarshal(rec.Body.Bytes(), &payload); errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	if len(payload.Files) != 1 || payload.Files[0]["user_id"] != "billing-user-1" {
+		t.Fatalf("files = %#v, want xAI user_id", payload.Files)
+	}
+}
+
+func TestBuildAuthFileEntryXAIUserIDIsNonSecretOnly(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "xai-user.json",
+		FileName: "xai-user.json",
+		Provider: "xai",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"path": "/tmp/xai-user.json",
+		},
+		Metadata: map[string]any{
+			"user_id":       "billing-user-2",
+			"sub":           "oidc-sub",
+			"access_token":  "secret-access",
+			"refresh_token": "secret-refresh",
+		},
+	}
+	h := NewHandlerWithoutConfigFilePath(&config.Config{AuthDir: t.TempDir()}, nil)
+	entry := h.buildAuthFileEntry(auth)
+	if entry == nil || entry["user_id"] != "billing-user-2" {
+		t.Fatalf("entry = %#v, want xAI user_id", entry)
+	}
+	if _, ok := entry["sub"]; ok {
+		t.Fatalf("entry exposed OIDC sub: %#v", entry)
+	}
+	if _, ok := entry["access_token"]; ok {
+		t.Fatalf("entry exposed access token: %#v", entry)
+	}
+}
+
 func TestPatchAuthFileStatusVerifiesAuthIndex(t *testing.T) {
 	t.Setenv("MANAGEMENT_PASSWORD", "")
 

--- a/internal/api/handlers/management/auth_files_provider_oauth.go
+++ b/internal/api/handlers/management/auth_files_provider_oauth.go
@@ -581,6 +581,9 @@ func (h *Handler) RequestXAIToken(c *gin.Context) {
 		if tokenStorage.Subject != "" {
 			metadata["sub"] = tokenStorage.Subject
 		}
+		if tokenStorage.UserID != "" {
+			metadata["user_id"] = tokenStorage.UserID
+		}
 
 		record := &coreauth.Auth{
 			ID:       fileName,

--- a/internal/auth/xai/token.go
+++ b/internal/auth/xai/token.go
@@ -23,6 +23,7 @@ type TokenStorage struct {
 	LastRefresh   string `json:"last_refresh,omitempty"`
 	Email         string `json:"email,omitempty"`
 	Subject       string `json:"sub,omitempty"`
+	UserID        string `json:"user_id,omitempty"`
 	BaseURL       string `json:"base_url,omitempty"`
 	RedirectURI   string `json:"redirect_uri,omitempty"`
 	TokenEndpoint string `json:"token_endpoint,omitempty"`

--- a/internal/auth/xai/token_permissions_test.go
+++ b/internal/auth/xai/token_permissions_test.go
@@ -3,6 +3,7 @@
 package xai
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,5 +27,28 @@ func TestSaveTokenToFileUsesPrivatePermissions(t *testing.T) {
 	}
 	if got := info.Mode().Perm(); got != 0o600 {
 		t.Fatalf("mode = %v, want 0600", got)
+	}
+}
+
+func TestSaveTokenToFilePersistsUserID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "xai.json")
+	storage := &TokenStorage{
+		AccessToken:  "access-token-fixture",
+		RefreshToken: "refresh-token-fixture",
+		UserID:       "billing-user-fixture",
+	}
+	if err := storage.SaveTokenToFile(path); err != nil {
+		t.Fatalf("SaveTokenToFile: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read token file: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("decode token file: %v", err)
+	}
+	if got := payload["user_id"]; got != "billing-user-fixture" {
+		t.Fatalf("user_id = %#v, want billing-user-fixture", got)
 	}
 }

--- a/internal/auth/xai/types.go
+++ b/internal/auth/xai/types.go
@@ -1,7 +1,11 @@
 // Package xai provides OAuth2 authentication helpers for xAI Grok.
 package xai
 
-import "time"
+import (
+	"fmt"
+	"runtime"
+	"time"
+)
 
 const (
 	// DefaultAPIBaseURL is the default official xAI API base URL.
@@ -27,6 +31,16 @@ const (
 	httpClientTimeout = 30 * time.Second
 	// MaxPollDuration is the upper bound for waiting on user authorization.
 	MaxPollDuration = 30 * time.Minute
+	// UserEndpoint is the official Grok CLI identity endpoint. Its response
+	// contains the billing user_id; the OIDC sub claim is not interchangeable.
+	UserEndpoint = CLIChatProxyBaseURL + "/user"
+	// UserEndpointTokenAuthValue identifies the official Grok CLI OAuth caller.
+	UserEndpointTokenAuthValue = "xai-grok-cli"
+	// UserEndpointClientVersion matches the current official Grok Shell request
+	// identity (it is independent of chat-proxy's API version).
+	UserEndpointClientVersion = "1.0.3"
+	// UserEndpointClientMode selects the interactive OAuth identity contract.
+	UserEndpointClientMode = "interactive"
 )
 
 var refreshLead = 5 * time.Minute
@@ -34,6 +48,33 @@ var refreshLead = 5 * time.Minute
 // RefreshLead returns the refresh lead time for xAI OAuth credentials.
 func RefreshLead() time.Duration {
 	return refreshLead
+}
+
+// UserEndpointUserAgent returns the current official interactive Grok client
+// identity with the host platform rendered using Grok Shell's wire labels.
+func UserEndpointUserAgent() string {
+	return userEndpointUserAgent(runtime.GOOS, runtime.GOARCH)
+}
+
+func userEndpointUserAgent(goos, goarch string) string {
+	osName := goos
+	if osName == "darwin" {
+		osName = "macos"
+	}
+	archName := goarch
+	switch archName {
+	case "arm64":
+		archName = "aarch64"
+	case "amd64":
+		archName = "x86_64"
+	}
+	return fmt.Sprintf(
+		"grok-pager/%s grok-shell/%s (%s; %s)",
+		UserEndpointClientVersion,
+		UserEndpointClientVersion,
+		osName,
+		archName,
+	)
 }
 
 // Discovery contains OAuth endpoints resolved from xAI OIDC discovery.
@@ -63,6 +104,9 @@ type TokenData struct {
 	Expire       string `json:"expired,omitempty"`
 	Email        string `json:"email,omitempty"`
 	Subject      string `json:"sub,omitempty"`
+	// UserID is the billing identity returned by UserEndpoint. It is kept
+	// separate from Subject because the OIDC sub claim is not a billing ID.
+	UserID string `json:"user_id,omitempty"`
 }
 
 // AuthBundle aggregates token data and OAuth metadata for persistence.

--- a/internal/auth/xai/xai.go
+++ b/internal/auth/xai/xai.go
@@ -181,6 +181,11 @@ func (a *XAIAuth) WaitForAuthorization(ctx context.Context, deviceCode *DeviceCo
 	if err != nil {
 		return nil, err
 	}
+	// xAI's OIDC sub identifies the OAuth subject, not the billing account.
+	// Enrich the token when the official Grok CLI identity endpoint is
+	// available, but keep OAuth login compatible with accounts/endpoints that
+	// do not expose it yet.
+	a.enrichTokenDataUserID(ctx, tokenData)
 	tokenEndpoint := ""
 	if deviceCode != nil {
 		tokenEndpoint = strings.TrimSpace(deviceCode.TokenEndpoint)
@@ -364,7 +369,86 @@ func (a *XAIAuth) refreshTokensSingleFlight(ctx context.Context, refreshToken, t
 		"client_id":     {ClientID},
 		"refresh_token": {refreshToken},
 	}
-	return a.postTokenForm(ctx, tokenEndpoint, form)
+	tokenData, err := a.postTokenForm(ctx, tokenEndpoint, form)
+	if err != nil {
+		return nil, err
+	}
+	// Refresh remains usable for legacy credentials when identity enrichment is
+	// unavailable. Callers may enrich this token best-effort with its new
+	// access token without making refresh success depend on /user.
+	return tokenData, nil
+}
+
+// FetchUserID retrieves the non-secret billing identity used by xAI billing.
+// It intentionally does not derive the value from the OIDC sub claim.
+func (a *XAIAuth) FetchUserID(ctx context.Context, accessToken string) (string, error) {
+	return a.fetchUserIDAt(ctx, accessToken, UserEndpoint)
+}
+
+func (a *XAIAuth) fetchUserIDAt(ctx context.Context, accessToken, endpoint string) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	accessToken = strings.TrimSpace(accessToken)
+	if accessToken == "" {
+		return "", fmt.Errorf("xai user identity: access token is required")
+	}
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return "", fmt.Errorf("xai user identity: endpoint is required")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", fmt.Errorf("xai user identity: create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("X-XAI-Token-Auth", UserEndpointTokenAuthValue)
+	req.Header.Set("x-grok-client-version", UserEndpointClientVersion)
+	req.Header.Set("x-grok-client-mode", UserEndpointClientMode)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", UserEndpointUserAgent())
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("xai user identity request failed: %w", err)
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			log.Errorf("xai user identity: close response body error: %v", errClose)
+		}
+	}()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("xai user identity: read response: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		// Do not include the upstream body: identity responses can contain
+		// account details and error bodies must never echo credential material.
+		return "", fmt.Errorf("xai user identity request failed with status %d", resp.StatusCode)
+	}
+	var payload struct {
+		UserID      string `json:"user_id"`
+		UserIDCamel string `json:"userId"`
+	}
+	if err = json.Unmarshal(body, &payload); err != nil {
+		return "", fmt.Errorf("xai user identity: parse response: %w", err)
+	}
+	userID := firstNonEmpty(payload.UserID, payload.UserIDCamel)
+	if userID == "" {
+		return "", fmt.Errorf("xai user identity response missing user_id")
+	}
+	return userID, nil
+}
+
+func (a *XAIAuth) enrichTokenDataUserID(ctx context.Context, tokenData *TokenData) {
+	if tokenData == nil || strings.TrimSpace(tokenData.AccessToken) == "" {
+		return
+	}
+	userID, err := a.FetchUserID(ctx, tokenData.AccessToken)
+	if err != nil {
+		log.WithError(err).Debug("xai user identity enrichment unavailable")
+		return
+	}
+	tokenData.UserID = userID
 }
 
 func (a *XAIAuth) postTokenForm(ctx context.Context, tokenEndpoint string, form url.Values) (*TokenData, error) {
@@ -426,6 +510,7 @@ func (a *XAIAuth) CreateTokenStorage(bundle *AuthBundle) *TokenStorage {
 		LastRefresh:   bundle.LastRefresh,
 		Email:         strings.TrimSpace(bundle.TokenData.Email),
 		Subject:       bundle.TokenData.Subject,
+		UserID:        strings.TrimSpace(bundle.TokenData.UserID),
 		BaseURL:       firstNonEmpty(bundle.BaseURL, DefaultAPIBaseURL),
 		RedirectURI:   bundle.RedirectURI,
 		TokenEndpoint: bundle.TokenEndpoint,

--- a/internal/auth/xai/xai_auth_test.go
+++ b/internal/auth/xai/xai_auth_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -258,6 +259,157 @@ func TestRefreshTokensPostsClientIDAndRefreshToken(t *testing.T) {
 	}
 }
 
+func TestFetchUserIDUsesOfficialIdentityHeadersAndDoesNotLeakToken(t *testing.T) {
+	const accessToken = "access-token-for-test"
+	var got http.Header
+	auth := NewXAIAuth(nil)
+	auth.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		got = req.Header.Clone()
+		return jsonHTTPResponse(http.StatusOK, `{"user_id":"billing-user-1"}`), nil
+	})}
+
+	userID, err := auth.FetchUserID(context.Background(), accessToken)
+	if err != nil {
+		t.Fatalf("FetchUserID() error = %v", err)
+	}
+	if userID != "billing-user-1" {
+		t.Fatalf("user_id = %q, want billing-user-1", userID)
+	}
+	if got.Get("Authorization") != "Bearer "+accessToken {
+		t.Fatalf("Authorization = %q, want bearer token", got.Get("Authorization"))
+	}
+	if got.Get("X-XAI-Token-Auth") != UserEndpointTokenAuthValue {
+		t.Fatalf("X-XAI-Token-Auth = %q, want %q", got.Get("X-XAI-Token-Auth"), UserEndpointTokenAuthValue)
+	}
+	if got.Get("x-grok-client-version") != UserEndpointClientVersion {
+		t.Fatalf("x-grok-client-version = %q, want %q", got.Get("x-grok-client-version"), UserEndpointClientVersion)
+	}
+	if got.Get("x-grok-client-mode") != UserEndpointClientMode {
+		t.Fatalf("x-grok-client-mode = %q, want %q", got.Get("x-grok-client-mode"), UserEndpointClientMode)
+	}
+	if got.Get("User-Agent") != UserEndpointUserAgent() {
+		t.Fatalf("User-Agent = %q, want %q", got.Get("User-Agent"), UserEndpointUserAgent())
+	}
+
+	auth.httpClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return jsonHTTPResponse(http.StatusUnauthorized, `{"error":"`+accessToken+`"}`), nil
+	})}
+	_, err = auth.FetchUserID(context.Background(), accessToken)
+	if err == nil || strings.Contains(err.Error(), accessToken) {
+		t.Fatalf("FetchUserID() error = %v, want redacted non-nil error", err)
+	}
+}
+
+func TestUserEndpointUserAgentUsesOfficialPlatformLabels(t *testing.T) {
+	tests := []struct {
+		name   string
+		goos   string
+		goarch string
+		want   string
+	}{
+		{
+			name:   "mac arm64",
+			goos:   "darwin",
+			goarch: "arm64",
+			want:   "grok-pager/1.0.3 grok-shell/1.0.3 (macos; aarch64)",
+		},
+		{
+			name:   "linux amd64",
+			goos:   "linux",
+			goarch: "amd64",
+			want:   "grok-pager/1.0.3 grok-shell/1.0.3 (linux; x86_64)",
+		},
+		{
+			name:   "windows amd64",
+			goos:   "windows",
+			goarch: "amd64",
+			want:   "grok-pager/1.0.3 grok-shell/1.0.3 (windows; x86_64)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := userEndpointUserAgent(tt.goos, tt.goarch); got != tt.want {
+				t.Fatalf("userEndpointUserAgent() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFetchUserIDAcceptsCamelCaseResponse(t *testing.T) {
+	auth := NewXAIAuth(nil)
+	auth.httpClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return jsonHTTPResponse(http.StatusOK, `{"userId":"billing-user-camel"}`), nil
+	})}
+	userID, err := auth.FetchUserID(context.Background(), "access-token")
+	if err != nil {
+		t.Fatalf("FetchUserID() error = %v", err)
+	}
+	if userID != "billing-user-camel" {
+		t.Fatalf("user_id = %q, want billing-user-camel", userID)
+	}
+}
+
+func TestWaitForAuthorizationEnrichesUserIDBestEffort(t *testing.T) {
+	auth := NewXAIAuth(nil)
+	auth.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.String() {
+		case "https://auth.x.ai/oauth2/token":
+			return jsonHTTPResponse(http.StatusOK, `{"access_token":"access-token","refresh_token":"refresh-token","expires_in":3600}`), nil
+		case UserEndpoint:
+			return jsonHTTPResponse(http.StatusOK, `{"user_id":"billing-user-wait"}`), nil
+		default:
+			return jsonHTTPResponse(http.StatusNotFound, `{}`), nil
+		}
+	})}
+	bundle, err := auth.WaitForAuthorization(context.Background(), &DeviceCodeResponse{
+		DeviceCode:    "device-code",
+		TokenEndpoint: "https://auth.x.ai/oauth2/token",
+	})
+	if err != nil {
+		t.Fatalf("WaitForAuthorization() error = %v", err)
+	}
+	if bundle == nil || bundle.TokenData.UserID != "billing-user-wait" {
+		t.Fatalf("bundle = %#v, want enriched user id", bundle)
+	}
+}
+
+func TestRefreshTokensKeepsLegacySuccessWithoutIdentityEnrichment(t *testing.T) {
+	const accessToken = "new-access-token"
+	var userRequests int
+	auth := NewXAIAuth(nil)
+	auth.httpClient = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.String() == UserEndpoint {
+			userRequests++
+			return jsonHTTPResponse(http.StatusUnauthorized, `{}`), nil
+		}
+		return jsonHTTPResponse(http.StatusOK, `{"access_token":"`+accessToken+`","refresh_token":"new-refresh","expires_in":3600}`), nil
+	})}
+
+	tokenData, err := auth.RefreshTokens(context.Background(), "old-refresh", "https://auth.x.ai/oauth2/token")
+	if err != nil {
+		t.Fatalf("RefreshTokens() error = %v", err)
+	}
+	if tokenData == nil || tokenData.AccessToken != accessToken {
+		t.Fatalf("token data = %#v, want refreshed access token", tokenData)
+	}
+	if tokenData.UserID != "" {
+		t.Fatalf("UserID = %q, want empty before executor enrichment", tokenData.UserID)
+	}
+	if userRequests != 0 {
+		t.Fatalf("RefreshTokens() made %d identity requests, want none", userRequests)
+	}
+}
+
+func TestCreateTokenStoragePreservesNonSecretUserID(t *testing.T) {
+	storage := NewXAIAuth(nil).CreateTokenStorage(&AuthBundle{TokenData: TokenData{
+		AccessToken: "access-token",
+		UserID:      "billing-user-2",
+	}})
+	if storage == nil || storage.UserID != "billing-user-2" {
+		t.Fatalf("storage = %#v, want billing user id", storage)
+	}
+}
+
 func TestRefreshTokens_DeduplicatesConcurrentRefresh(t *testing.T) {
 	resetXAIRefreshGroupForTest()
 	t.Cleanup(resetXAIRefreshGroupForTest)
@@ -324,4 +476,18 @@ func fakeJWTWithEmail(email, subject string) string {
 	header := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
 	payload := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString([]byte(`{"email":"` + email + `","sub":"` + subject + `"}`))
 	return header + "." + payload + ".sig"
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func jsonHTTPResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}
 }

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -62,7 +62,8 @@ var xaiXSearchToolJSON = []byte(`{"type":"x_search"}`)
 
 // XAIExecutor is a stateless executor for xAI Grok's Responses API.
 type XAIExecutor struct {
-	cfg *config.Config
+	cfg           *config.Config
+	userIDFetcher func(context.Context, string, string) (string, error)
 }
 
 // NewXAIExecutor creates a new xAI executor.

--- a/internal/runtime/executor/xai_executor_auth.go
+++ b/internal/runtime/executor/xai_executor_auth.go
@@ -31,6 +31,21 @@ func (e *XAIExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cl
 	if err != nil {
 		return nil, err
 	}
+	// Re-resolve the billing identity after every successful token refresh. The
+	// official client also refreshes /user-derived fields after rotation; a
+	// stale user_id must not survive an account change. Enrichment remains
+	// best-effort so a valid token refresh never depends on /user availability.
+	fetchUserID := svc.FetchUserID
+	if e.userIDFetcher != nil {
+		fetchUserID = func(ctx context.Context, accessToken string) (string, error) {
+			return e.userIDFetcher(ctx, accessToken, auth.ProxyURL)
+		}
+	}
+	if userID, errUserID := fetchUserID(ctx, td.AccessToken); errUserID == nil {
+		td.UserID = userID
+	} else {
+		log.WithError(errUserID).Debug("xai user identity enrichment unavailable after refresh")
+	}
 	if auth.Metadata == nil {
 		auth.Metadata = make(map[string]any)
 	}
@@ -57,6 +72,9 @@ func (e *XAIExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (*cl
 	}
 	if td.Subject != "" {
 		auth.Metadata["sub"] = td.Subject
+	}
+	if td.UserID != "" {
+		auth.Metadata["user_id"] = td.UserID
 	}
 	if tokenEndpoint != "" {
 		auth.Metadata["token_endpoint"] = tokenEndpoint

--- a/internal/runtime/executor/xai_executor_auth_test.go
+++ b/internal/runtime/executor/xai_executor_auth_test.go
@@ -1,0 +1,90 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestXAIExecutorRefreshReplacesStaleBillingUserID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "fresh-access-token",
+			"refresh_token": "fresh-refresh-token",
+			"expires_in":    3600,
+		})
+	}))
+	defer server.Close()
+
+	exec := NewXAIExecutor(&config.Config{})
+	var fetchedAccessToken string
+	exec.userIDFetcher = func(_ context.Context, accessToken, proxyURL string) (string, error) {
+		fetchedAccessToken = accessToken
+		if proxyURL != "" {
+			t.Fatalf("proxy URL = %q, want empty", proxyURL)
+		}
+		return "fresh-billing-user", nil
+	}
+	auth := &cliproxyauth.Auth{
+		Provider: "xai",
+		Metadata: map[string]any{
+			"access_token":   "stale-access-token",
+			"refresh_token":  "stale-refresh-token",
+			"token_endpoint": server.URL,
+			"user_id":        "stale-billing-user",
+		},
+	}
+
+	refreshed, err := exec.Refresh(context.Background(), auth)
+	if err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+	if fetchedAccessToken != "fresh-access-token" {
+		t.Fatalf("identity access token = %q, want fresh token", fetchedAccessToken)
+	}
+	if got := xaiMetadataString(refreshed.Metadata, "user_id"); got != "fresh-billing-user" {
+		t.Fatalf("user_id = %q, want fresh-billing-user", got)
+	}
+}
+
+func TestXAIExecutorRefreshKeepsExistingUserIDWhenEnrichmentFails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "fresh-access-token",
+			"refresh_token": "fresh-refresh-token",
+			"expires_in":    3600,
+		})
+	}))
+	defer server.Close()
+
+	exec := NewXAIExecutor(&config.Config{})
+	exec.userIDFetcher = func(context.Context, string, string) (string, error) {
+		return "", context.DeadlineExceeded
+	}
+	auth := &cliproxyauth.Auth{
+		Provider: "xai",
+		Metadata: map[string]any{
+			"refresh_token":  "stale-refresh-token",
+			"token_endpoint": server.URL,
+			"user_id":        "existing-billing-user",
+		},
+	}
+
+	refreshed, err := exec.Refresh(context.Background(), auth)
+	if err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+	if got := xaiMetadataString(refreshed.Metadata, "user_id"); got != "existing-billing-user" {
+		t.Fatalf("user_id = %q, want existing-billing-user", got)
+	}
+}

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -164,6 +164,12 @@ require_grep "codex_client_models.json" .github/scripts/refresh-model-catalogs.s
 require_grep "responsesWebsocketCanAttestContextReset" sdk/api/handlers/openai/openai_responses_websocket.go sdk/api/handlers/openai/openai_responses_websocket_test.go
 require_grep "ModelFallbackZeroDispatch" sdk/cliproxy/auth/codex_model_fallback.go docs/lts/core-feature-contracts.yaml
 require_grep "auth_index" internal/usage internal/api/handlers/management internal/runtime/executor/helps internal/redisqueue
+require_grep "UserEndpoint" internal/auth/xai/types.go internal/auth/xai/xai.go docs/lts/core-feature-contracts.yaml
+require_grep "UserEndpointUserAgent" internal/auth/xai/types.go internal/auth/xai/xai.go docs/lts/core-feature-contracts.yaml
+require_grep 'case "amd64"' internal/auth/xai/types.go
+require_grep 'archName = "x86_64"' internal/auth/xai/types.go
+require_grep 'entry\["user_id"\]' internal/api/handlers/management/auth_files.go
+require_grep 'metadata\["user_id"\]' internal/api/handlers/management/auth_files_provider_oauth.go internal/runtime/executor/xai_executor_auth.go sdk/auth/xai.go
 require_grep "latency_ms" internal/usage internal/redisqueue internal/tui
 require_grep 'json:"reasoning_effort,omitempty"' internal/usage
 require_grep 'json:"service_tier,omitempty"' internal/usage

--- a/sdk/auth/xai.go
+++ b/sdk/auth/xai.go
@@ -114,6 +114,9 @@ func (a XAIAuthenticator) Login(ctx context.Context, cfg *config.Config, opts *L
 	if tokenStorage.Subject != "" {
 		metadata["sub"] = tokenStorage.Subject
 	}
+	if tokenStorage.UserID != "" {
+		metadata["user_id"] = tokenStorage.UserID
+	}
 
 	fmt.Println("xAI authentication successful")
 


### PR DESCRIPTION
## 结果

xAI OAuth 凭据现在会保存官方 `/user` 接口返回的 billing `user_id`，不再把 OIDC `sub` 当作计费身份。登录和 token refresh 都会 best-effort 刷新该字段，Management auth-files 响应仅暴露这个非秘密标识，不暴露 token 或 OIDC subject。

## 主要变更

- 按官方 Grok CLI 请求头和平台标签调用 `/user`，兼容 `user_id` 与 `userId` 响应。
- 在 xAI token storage、SDK login metadata 和 executor refresh metadata 中保留 `user_id`。
- `/v0/management/auth-files` 的内存与磁盘 fallback 路径只对 xAI 返回非空 `user_id`。
- identity enrichment 失败不阻断既有登录或 refresh；旧 auth file 继续兼容。
- 将该行为纳入 `auth-identity-attribution` LTS contract sentinel。

## 兼容性与边界

- 不改变 OAuth `sub` 的含义，也不将其作为 billing ID。
- 不记录或回显 access token、refresh token、OIDC subject 或 `/user` 原始错误 body。
- 本 PR 只完成源码与测试交付；未发布、未部署、未做真实 xAI 账号登录 smoke。

## 验证

- `go test ./internal/auth/...`
- `go test ./internal/api/handlers/management`
- `go test ./internal/runtime/executor`
- `go test ./sdk/auth`
- `scripts/check-lts-contract.sh`
- `git diff --check`

上述本地检查均通过。

## Review focus

- `/user` wire headers 与 macOS/Linux/Windows architecture label 映射。
- refresh enrichment 失败时保留既有 `user_id` 的兼容语义。
- Management API 仅暴露 `user_id` 的过滤边界。
