### PR TITLE
docs(agents): 补全高风险目录导航卡

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -2,19 +2,20 @@
 
 `.github/` owns repository automation: PR guards, LTS contract checks, build smoke, Docker image publishing, and release workflows.
 Read this card before modifying any workflow, PR template, permissions block, trigger, release asset logic, or path guard.
-Key files: `workflows/agents-md-guard.yml`, `workflows/pr-path-guard.yml`, `workflows/lts-contract.yml`, `workflows/pr-test-build.yml`, `workflows/docker-image.yml`, `workflows/release.yaml`, `pull_request_template.md`.
+Key files: `workflows/agents-md-guard.yml`, `workflows/pr-path-guard.yml`, `workflows/lts-contract.yml`, `workflows/pr-test-build.yml`, `workflows/docker-image.yml`, `workflows/release.yaml`, `scripts/refresh-model-catalogs.sh`, `pull_request_template.md`.
 
 ## Why this is high-risk
 
 - Workflow changes can publish artifacts, close PRs, change required checks, or alter LTS protected contract enforcement.
 - `release.yaml` uses tag-triggered `gh release` upload paths and `GITHUB_TOKEN`.
 - `docker-image.yml` can publish container images, so trigger and tag logic matter.
-- `pr-test-build.yml` refreshes `internal/registry/models/models.json` from `router-for-me/models.git` before build.
+- PR/release/container workflows use `scripts/refresh-model-catalogs.sh` to refresh embedded model catalogs before validation/build.
 
 ## Required before changes
 
 - Read the target workflow end to end and confirm its `on`, `permissions`, and external network/API usage.
 - For LTS guard changes, also read `docs/lts/AGENTS.md` and `scripts/check-lts-contract.sh`.
+- For catalog refresh changes, also read `internal/registry/AGENTS.md` and validate both provider and Codex client catalog contracts.
 - For release changes, identify whether a local check is only static/build validation because real release requires tag context and token.
 
 ## Do not

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 - 子目录 `AGENTS.md` 是按需 navigation card。从根目录启动时，它们通常不会自动进入上下文。
 - 修改带有本地 `AGENTS.md` 的目录前，先运行 `cat <path>/AGENTS.md` 读取对应卡片。
 - 如果目标路径上有多层 `AGENTS.md`，按从浅到深的顺序读取；冲突时更深层规则优先。
+- 当前仓库没有 `AGENTS.override.md`。不要为绕过现有层级创建 override；如果未来出现 override，先确认它会替换而不是补充同目录 `AGENTS.md`。
 - `.github/workflows/agents-md-guard.yml` 会限制修改 `AGENTS.md` 的 PR：OWNER 可直接放行，MEMBER/COLLABORATOR 需要 `allow-agents-md-update` label，外部 PR 触碰 `AGENTS.md` 会被关闭。除非用户明确要求维护 agent 指令，不要把 AGENTS 改动混入产品代码 PR。
 
 ## LTS contract
@@ -40,22 +41,29 @@
 | `.codex/` | 本地 Codex 配置/临时上下文 | No | 仅当用户明确要求维护本地 Codex 资产 |
 | `.gocache/` | 本地 Go build/test cache | No | 默认忽略，不纳入产品改动或验收结论 |
 | `.playwright-mcp/` | 本地 Playwright MCP 运行残留/配置 | No | 默认忽略，不纳入产品改动 |
-| `assets/` | README 展示图片和赞助资产 | No | 修改 README 图片引用或展示资产前 |
 | `auths/` | auth 目录占位；运行时挂载真实凭据目录 | No | 默认不要提交真实 token/auth file；形状变更读 `internal/auth/` 和 `internal/watcher/` |
+| `cmd/` | Server and catalog/validation command entrypoints | No | 修改具体命令前按下方子目录/关联 domain 读取卡片 |
 | `cmd/server/` | 服务端入口、CLI flags、TUI/standalone/home 启动 | Yes | 修改启动参数、登录流程入口、build metadata、server mode 前 |
 | `cmd/fetch_antigravity_models/` | Antigravity model catalog 辅助拉取命令 | No | 修改模型拉取辅助工具前，同时读 `internal/auth/`、`internal/registry/` 卡片 |
 | `cmd/fetch_codex_models/` | Codex model catalog 辅助拉取命令 | No | 修改 Codex 模型拉取、token refresh、client_version 或输出格式前 |
+| `cmd/validate_codex_models/` | Codex client model catalog LTS compatibility validator | No | 修改 validator contract 或 catalog schema 前，同时读 `internal/registry/` 与 `docs/lts/` 卡片 |
 | `config.example.yaml` | 用户配置示例和 schema 可见面 | No | 新增/改名/删除 config key 前，同时读 `internal/config/AGENTS.md` |
 | `Dockerfile` / `docker-compose*.yml` / `docker-build.*` | 容器构建和本地 Docker 运行 | No | 修改镜像、端口、volume、usage backup 脚本前 |
 | `docs/` | SDK 文档、多语言 README 相关资料 | No | 修改 SDK 行为或公开接口文档前 |
 | `docs/lts/` | LTS contract registry、protected delta、sync runbook、Codex abnormal retry 指南 | Yes | 修改 protected contract、sync runbook、guard marker、Codex abnormal retry 配置指南前 |
 | `examples/` | SDK/translator/plugin/http-request 示例 | No | 修改公开示例或 API 使用方式前，必要时检查对应 SDK 卡片 |
+| `internal/` | Core server implementation and downstream compatibility seams | No | 修改具体模块前按下方目录地图读取最近的本地卡片 |
 | `internal/access/` | API key/access manager 适配 | No | 修改鉴权判定或 auth manager 集成前，同时读 `internal/auth/AGENTS.md` |
 | `internal/api/` | Gin server、middleware、Management API、Amp/WebSocket endpoints | Yes | 修改 routes、middleware、Management API、Amp endpoints、HTTP/WebSocket 协议前 |
+| `internal/api/handlers/management/` | Management API handlers、config/auth/usage/plugin 管理面 | Yes | 修改 Management response shape、持久化、OAuth session、auth CRUD、usage import/export 前；先读父卡再读本卡 |
 | `internal/auth/` | OAuth/device auth、token storage、credential helpers | Yes | 修改 token、OAuth callback、auth file、credential 保存/刷新前 |
-| `internal/cache/` | Signature/cache helpers | No | 修改 Antigravity/Claude signature cache 前，同时读 translator/executor 卡片 |
+| `internal/cache/` | Signature/reasoning replay cache、Home KV fallback 边界 | Yes | 修改 replay scope、signature cache、CAS/TTL、local/Home cache 语义前 |
+| `internal/client/codex/` | Codex client models、Multi-Agent v2 adaptation、Realtime/Live bridge | Yes | 修改 Codex client catalog、official-client rewrite、Realtime secret/WebRTC/session 行为前 |
 | `internal/cmd/` | CLI login/import command helpers | No | 修改登录命令、vertex import、auth manager CLI 前 |
 | `internal/config/` | YAML config model、defaults、sanitize、compat helpers | Yes | 新增/迁移/删除 config key 或改变默认值前 |
+| `internal/codexmetadata/` | Codex outbound client metadata normalization/privacy policy | Yes | 修改 `client_metadata`、workspace policy、turn metadata header 或 repair/strict/drop 语义前 |
+| `internal/home/` | Home control-plane client、dispatch/KV、membership/concurrency lifecycle | Yes | 修改 Home protocol、cluster failover、dispatch ambiguity、KV 或 release/in-flight wire shape 前 |
+| `internal/homeplugins/` | Home/plugin sync manifest、artifact apply and status report boundary | Yes | 修改 Home plugin inventory、artifact validation/apply、task/status wire contract 前 |
 | `internal/logging/` | request/global logging、request metadata、log rotation | Yes | 修改日志格式、落盘策略、request metadata、redaction 前 |
 | `internal/managementasset/` | `management.html` 下载和更新 | Yes | 修改面板下载源、缓存路径、auto-update 行为前 |
 | `internal/pluginhost/` | Dynamic plugin ABI host、callbacks、scheduler、management routes | Yes | 修改 plugin lifecycle、callbacks、ABI/RPC、scheduler、stream bridge 前 |
@@ -63,6 +71,9 @@
 | `internal/redisqueue/` | Redis-compatible usage queue plugin and wire payload | Yes | 修改 `/usage-queue`、usage event schema、retention/toggle 语义前 |
 | `internal/registry/` | model registry、remote model updates、embedded model catalogs、quota state | Yes | 修改模型注册、catalog JSON、quota routing state、remote refresh 前 |
 | `internal/runtime/executor/` | Provider executors、upstream calls、stream/WebSocket handling | Yes | 修改 Codex/Claude/Gemini/Kimi/Antigravity executor、retry、streaming、timeout 前 |
+| `internal/signature/` | Provider thinking signature/encrypted-content validation and sanitization | Yes | 修改 signature 识别、跨 provider 兼容、sanitize 或 replay acceptance 前 |
+| `internal/store/` | Git/Postgres/object-store config/auth persistence and secure local rendering | Yes | 修改 remote store、auth path containment、atomic write、Windows/POSIX file safety 前 |
+| `internal/thinking/` | Unified reasoning/thinking config、summary intent、provider appliers | Yes | 修改 suffix、level/budget、summary、provider apply 或 plugin thinking provider 前 |
 | `internal/translator/` | Provider protocol translators and token-count adapters | Yes | 修改 request/response translation、tool call、usage metadata、signature handling 前 |
 | `internal/tui/` | Terminal UI and TUI management client | No | 修改 TUI views 或 management client calls 前，检查 affected API card |
 | `internal/usage/` | LTS 完整 usage statistics 聚合和导入导出结构 | Yes | 任何统计字段、聚合、import/export、success/failure 语义改动前 |
@@ -71,10 +82,17 @@
 | `local/` | 本地审计/工作记录 | No | 默认不提交；只在用户明确要求整理本地材料时处理 |
 | `scripts/` | repo helper scripts | No | 修改 LTS guard 或 automation 前读目标脚本和 `docs/lts/AGENTS.md` |
 | `sdk/` | Public embeddable SDK packages | No | 修改 public package 前检查 docs、examples、tests |
+| `sdk/access/` | Public inbound request authentication provider chain | Yes | 修改 `Provider`、auth error semantics、registry order/exclusive mode、principal metadata 前 |
+| `sdk/api/` | Public protocol handlers、stream lifecycle、routing/interceptor bridge | Yes | 修改 handler API、SSE/WebSocket、headers/errors、request lifecycle 或 plugin interception 前 |
+| `sdk/auth/` | Public OAuth authenticator manager and file token store | Yes | 修改 exported authenticator、login options、token-store persistence、plugin auth parser 前 |
 | `sdk/cliproxy/` | 可嵌入服务 SDK、auth conductor、usage plugin API | Yes | 修改 public SDK type、builder、service、auth scheduler、usage record 前 |
+| `sdk/cliproxy/auth/` | Runtime auth conductor、selection、cooldown、retry、Home dispatch | Yes | 修改 auth selection/result、session affinity、cooldown、model fallback、Home execution 前；先读父卡再读本卡 |
 | `sdk/pluginabi/` | Dynamic plugin ABI method/schema constants | Yes | 修改 plugin ABI schema version、method names、RPC envelope 前 |
 | `sdk/pluginapi/` | Public plugin API types and capability contracts | Yes | 修改 plugin capability interfaces、request/response structs、public metadata 前 |
+| `sdk/pluginstore/` | Public plugin registry/install/auth facade | Yes | 修改 exported pluginstore aliases、resolved auth、manifest/install helper 或 compatibility surface 前 |
+| `sdk/translator/` | Public protocol translation registry and plugin hooks | Yes | 修改 exported formats/transforms、fallback、summary preservation、hook ordering 或 byte ownership 前 |
 | `test/` | 跨模块集成和协议 sentinel 测试 | No | 修改跨模块行为或新增回归测试前，跟随被测目录规则 |
+| `tmp/` | 本地临时运行输出 | No | 默认忽略，不作为源码、持久化或验收证据 |
 
 ## On-demand cat protocol
 
@@ -84,6 +102,7 @@ Examples:
 
 ```bash
 cat internal/api/AGENTS.md
+cat internal/api/handlers/management/AGENTS.md
 cat internal/usage/AGENTS.md
 cat internal/pluginhost/AGENTS.md
 ```
@@ -95,7 +114,7 @@ These commands are confirmed from Go tooling, CI workflows, Docker files, source
 | Command | Purpose | Scope | Sandbox notes |
 |---|---|---|---|
 | `gofmt -w <files>` | Format touched Go files | touched files | OK after Go edits; avoid repo-wide formatting unless needed |
-| `go test ./...` | Run all Go tests | repo | Usually local; first run may need module/toolchain download if cache is missing |
+| `go test ./...` | Run all Go tests | repo | Usually local; first run may need Go 1.26 toolchain/module download if cache is missing |
 | `go test -v -run TestName ./path/to/pkg` | Run targeted Go test | package | OK; replace target with real package/test |
 | `scripts/check-lts-contract.sh` | Check LTS protected sentinels | repo | OK; uses local files plus `git grep` |
 | `go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'` | Usage/Management contract tests | repo | OK; CI derives same package set with `go list` |
@@ -107,7 +126,7 @@ These commands are confirmed from Go tooling, CI workflows, Docker files, source
 | `docker compose build` | Build container image | repo | Requires Docker daemon; not default sandbox validation |
 | `./docker-build.sh [--with-usage]` | Interactive Docker build/run helper | repo | Interactive and Docker required; `--with-usage` calls Management API and stores temp secret under `temp/stats/` |
 
-Workflow notes: `pr-test-build.yml` refreshes `internal/registry/models/models.json` from `router-for-me/models.git`; `lts-contract.yml` runs contract guard, usage/management tests, build, and observes `go test ./...`; `release.yaml` is tag-triggered for `v*-tls-*` and requires release context plus `GITHUB_TOKEN`.
+Workflow notes: PR/release/container workflows call `.github/scripts/refresh-model-catalogs.sh` to refresh embedded model catalogs, including Codex client metadata; local offline copies may be stale. `lts-contract.yml` runs contract guard, usage/management tests, build, and observes `go test ./...`. `release.yaml` is tag-triggered for `v*-tls-*` and requires release context plus `GITHUB_TOKEN`.
 
 ## Global rules
 
@@ -119,6 +138,7 @@ Workflow notes: `pr-test-build.yml` refreshes `internal/registry/models/models.j
 - 不要在日志、error、test snapshot、PR 文案或公开文档中泄露 token、secret、management key、refresh token、API key、OAuth code、auth file 原文。
 - 网络 timeout 策略沿用现有设计：凭据获取阶段可以有 timeout；上游连接建立后的 streaming 行为不要随意增加 timeout。
 - Management API、Config、Auth file、API key、Public SDK / plugin API 都是外部契约；变更前检查 Panel、TUI、SDK、watcher、examples 和 tests 中的对应面。
+- Stream lifecycle、auth selection、Home dispatch、model fallback、reasoning replay 和 usage attribution 是跨模块契约；改动其中一处时按目录地图读取所有受影响卡片，不以“无文本冲突”代替行为审查。
 - 上游同步默认走 protected full-sync merge PR。任何触碰 usage、Management usage endpoints、config schema、auth/API key usage 结构、plugin runtime 或 `CPA-Panel-LTS` response shape 的冲突，必须按 protected delta 审查并保留 LTS 契约。
 
 ## Do not
@@ -131,6 +151,7 @@ Workflow notes: `pr-test-build.yml` refreshes `internal/registry/models/models.j
 - 不要把 Core 默认面板源改回上游或其他仓库，除非用户明确要求并同步检查 Panel 兼容性。
 - 不要提交真实 `auths/` 内容、`.env`、`config.yaml`、token、secret、management key、本地日志或 `temp/stats/`。
 - 不要把 `AGENTS.md` 改动混入普通产品 PR。
+- 不要创建 `AGENTS.override.md` 或给纯组织目录机械新增空卡片来追求覆盖率。
 - 不要把 CI/release/Docker 变更当作无风险文本修改；这些文件影响分发和运行路径。
 - 不要在没有对应测试或明确说明缺口的情况下声称已验证统计、auth、translator、executor、pluginhost 或 Management API 行为。
 - 不要执行发布、推送、tag、Docker destructive cleanup、release-equivalent manual build/upload commands、`terraform`、sudo 或外部平台变更，除非用户明确要求。
@@ -154,7 +175,7 @@ If validation cannot be run, say exactly which command was skipped and why. Do n
 - 当前工作区里的 `.playwright-mcp/` 和 `.gocache/` 不是产品源码；除非任务明确相关，忽略即可。
 - README 主文档实际是 `README.md`、`README_CN.md`、`README_JA.md`；用户面向文档改动要检查多语言是否需要同步。
 - `docker-build.sh --with-usage` 会通过 Management API export/import 统计并在 `temp/stats/.api_secret` 保存临时管理密钥；不要把该目录纳入 Git。
-- `internal/registry/models/models.json` 由 workflow 远程刷新；离线环境下不要假设模型目录一定最新。
+- `internal/registry/models/models.json`、`internal/registry/models/codex_client_models.json` 等嵌入 catalog 由 workflow helper 远程刷新；离线环境下不要假设本地 catalog 一定最新。
 - `docs/lts/` 是维护策略和同步 runbook 的可提交文档目录；新增或修改 contract marker 时必须同步检查 `scripts/check-lts-contract.sh`。
 - Codex abnormal reasoning retry 的配置语义、交付策略、fallback 策略和 client usage shaping 说明集中维护在 `docs/lts/codex-client-context-degradation-defense.md`。修改 `codex.abnormal-reasoning-retry` 的 config key、默认值、delivery/fallback 行为、client usage aggregation 或 hedged retry 语义时，先核对当前 Go 代码，再同步该文档、`config.example.yaml`、必要的 LTS contract marker / guard，以及 `CPA-Panel-LTS` 配置面影响。
 - HF Space `BlueSkyXN/CPA-HFS-2026-03` smoke 要区分 Space Variables、runtime log 和响应头 `x-cpa-commit` 的真实 commit。

--- a/cmd/server/AGENTS.md
+++ b/cmd/server/AGENTS.md
@@ -18,6 +18,7 @@ Key files: `main.go`, `main_test.go`.
 - New flags need source help text, parsing, and tests for mode interaction when behavior changes.
 - Config path changes require checking `internal/config/AGENTS.md` and `internal/watcher/AGENTS.md`.
 - Login/auth changes require checking `internal/auth/AGENTS.md`.
+- Home startup/JWT/config subscription changes require checking `internal/home/AGENTS.md` and `sdk/cliproxy/AGENTS.md`.
 
 ## Do not
 

--- a/docs/lts/AGENTS.md
+++ b/docs/lts/AGENTS.md
@@ -2,12 +2,13 @@
 
 `docs/lts/` owns the CPA-Core-LTS maintenance contract registry, protected delta policy, protected full-sync runbook, and LTS-specific operational guides.
 Read this card before changing contract markers, sync workflow instructions, validation gates, or feature registry entries.
-Key files: `sync-runbook.md`, `protected-deltas.yaml`, `core-feature-contracts.yaml`, `codex-client-context-degradation-defense.md`, `scripts/check-lts-contract.sh`.
+Key files: `sync-runbook.md`, `protected-deltas.yaml`, `core-feature-contracts.yaml`, `downstream-patches.yaml`, `change-control/`, `codex-client-context-degradation-defense.md`, `codex-429-resilience.md`, `scripts/check-lts-contract.sh`.
 
 ## Local invariants
 
 - Core maintenance mode is protected full-sync, not Panel-style selective-port.
 - `core-feature-contracts.yaml` is the feature registry; `protected-deltas.yaml` is the product boundary and sync policy.
+- `downstream-patches.yaml` records maintained downstream patch ownership; `change-control/` holds approved schema/baseline decisions that the guard and registries reference.
 - `scripts/check-lts-contract.sh` is a sentinel gate, not a replacement for behavior-level usage/API tests.
 - Registry entries should protect stable contracts: routes, config keys, JSON fields, release asset names, directory boundaries, and review-adjacent seams.
 - `codex-client-context-degradation-defense.md` is the canonical user/developer guide for `codex.abnormal-reasoning-retry` configuration semantics. It explains code defaults, HFS deployment recommendations, candidate delivery policy, fallback policy, and client usage shaping. It is not a local research-note index and should not cite `local/` materials as operational source of truth.
@@ -16,6 +17,7 @@ Key files: `sync-runbook.md`, `protected-deltas.yaml`, `core-feature-contracts.y
 
 - Adding a protected feature requires a clear reason why it is an LTS product boundary, not one sync's temporary concern.
 - If YAML markers change, update `scripts/check-lts-contract.sh` in the same change.
+- Keep registry links, downstream patch ownership, change-control evidence, and guard markers mutually consistent; the guard also runs `scripts/ltsregistry` structural validation.
 - Sync runbook edits must keep preflight, rehearsal, validation, PR body, merge policy, and HF smoke responsibilities distinct.
 - When `codex.abnormal-reasoning-retry` config keys, defaults, delivery/fallback behavior, client usage aggregation, or hedged retry semantics change, update `codex-client-context-degradation-defense.md` alongside `config.example.yaml` and contract markers as needed. If Panel config surface changes, call out the `CPA-Panel-LTS` follow-up explicitly.
 

--- a/internal/api/AGENTS.md
+++ b/internal/api/AGENTS.md
@@ -2,21 +2,23 @@
 
 `internal/api/` owns the Gin server, middleware, Management API routes, provider routes, WebSocket handling, and Amp module.
 Read this card before editing routes, middleware, management handlers, Amp endpoints, auth gates, plugin management routes, or response writers.
-Key files: `server.go`, `handlers/management/`, `middleware/`, `modules/amp/`.
+Key files: `server_routes.go`, `server_management.go`, `server_middleware.go`, `handlers/management/`, `middleware/`, `modules/amp/`.
 
 ## Local invariants
 
-- Management routes live under `/v0/management` and require a management secret.
+- Built-in Management routes live under `/v0/management`; normal endpoints pass the availability middleware and `Handler.Middleware()`. The state/session-validated `/oauth-callback` route is an intentional management-key exception.
+- Management availability, route registration, remote-access policy, and credential validation are separate layers. Home mode keeps the Management surface unavailable.
 - Management usage endpoints must remain available as `/usage`, `/usage/export`, `/usage/import`, `/usage-queue`, and `/usage-statistics-enabled` under `/v0/management`.
 - Management middleware must keep localhost/remote behavior aligned with `remote-management.secret-key` and `remote-management.allow-remote`.
 - Provider routes must preserve OpenAI/Gemini/Claude/Codex/Amp compatible wire shapes.
-- WebSocket auth behavior is controlled by `websocket-auth`; do not make it always-on or always-off.
+- WebSocket auth behavior is controlled by `ws-auth`; do not make it always-on or always-off.
 - Plugin Management API routes must stay namespaced and must not override built-in Management endpoints.
 - Logging must avoid secret leakage and must not consume streaming bodies.
 
 ## Local rules
 
-- Route changes require checking both registration in `server.go` and handler tests under `handlers/management/`.
+- Route changes require checking registration in `server_routes.go` / `server_management.go` and handler tests under `handlers/management/`.
+- Management handler changes must also read `handlers/management/AGENTS.md`.
 - Amp route changes require checking `internal/api/modules/amp/*_test.go` and `test/amp_management_test.go`.
 - Middleware changes require HTTP and streaming/WebSocket coverage when applicable.
 - Management API response shape changes are Panel/TUI/SDK breaking changes unless proven compatible.
@@ -29,8 +31,6 @@ Key files: `server.go`, `handlers/management/`, `middleware/`, `modules/amp/`.
 
 ## Validation
 
-- `go test ./internal/api`
-- `go test ./internal/api/handlers/management`
-- `go test ./internal/api/modules/amp`
+- `go test ./internal/api/...`
 - `go test ./test -run Amp`
 - Usage route changes also run the validation listed in `internal/usage/AGENTS.md`.

--- a/internal/api/handlers/management/AGENTS.md
+++ b/internal/api/handlers/management/AGENTS.md
@@ -1,0 +1,28 @@
+# internal/api/handlers/management navigation card
+
+`internal/api/handlers/management/` owns the external Management API for config, auth files/OAuth sessions, usage import/export, logs, quota, and plugin management.
+Read this card after `internal/api/AGENTS.md` before changing any Management handler, response shape, persistence path, or side effect.
+Key files: `handler.go`, `config_*.go`, `auth_files*.go`, `oauth_sessions.go`, `usage.go`, `plugins.go`, `plugin_store.go`.
+
+## Local invariants
+
+- Built-in routes are registered in `internal/api/server_management.go`; normal `/v0/management/*` endpoints pass availability and `Handler.Middleware()` checks.
+- `/v0/management/oauth-callback` is an intentional route-level exception to management-key middleware and is protected by OAuth state/session validation. Do not generalize that exception.
+- Management availability, route registration, remote-access policy, and credential validation are separate concerns. Home mode keeps the Management surface unavailable.
+- Config writes must preserve comments/order through existing config helpers and must trigger the established generation-ordered reload path.
+- Auth file upload/download/delete/patch must preserve safe filename/path handling, private-file permissions, registered-record synchronization, plugin-virtual-source rules, and the rollback behavior implemented by each flow.
+- Usage export/import follows the canonical v2 contract in `internal/usage/AGENTS.md`; malformed, unsupported, ambiguous, or overflowing imports fail atomically with stable error codes.
+- Plugin routes must remain namespaced and must not collide with built-in method/path pairs.
+
+## Do not
+
+- 不要 add a Management endpoint outside the existing middleware/availability model without an explicit contract decision.
+- 不要 echo secrets, raw auth files, OAuth codes, untrusted paths, or raw upstream bodies in errors.
+- 不要 treat a successful HTTP mutation as complete until the intended config/auth/runtime readback or reload path has succeeded.
+
+## Validation
+
+- `go test ./internal/api/handlers/management`
+- Focused surface: `go test ./internal/api/handlers/management -run 'Auth|OAuth|Config|Usage|Plugin'`
+- Usage changes: `go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'`
+- Route/middleware changes: `go test ./internal/api/...`

--- a/internal/auth/AGENTS.md
+++ b/internal/auth/AGENTS.md
@@ -2,7 +2,7 @@
 
 `internal/auth/` owns provider OAuth/device flows, token storage structs, credential import helpers, and auth file naming.
 Read this card before changing OAuth URLs, PKCE/device flow code, token refresh fields, auth file serialization, or provider credential parsing.
-Key files: provider subdirectories under `antigravity/`, `claude/`, `codex/`, `gemini/`, `kimi/`, `vertex/`, plus `models.go`.
+Key files: provider subdirectories under `antigravity/`, `claude/`, `codex/`, `empty/`, `kimi/`, `vertex/`, `xai/`, plus `models.go`.
 
 ## Why this is high-risk
 
@@ -15,6 +15,8 @@ Key files: provider subdirectories under `antigravity/`, `claude/`, `codex/`, `g
 - Trace the provider through CLI command, token storage, watcher/auth manager, executor, SDK conductor, and management handlers.
 - Confirm logs use redacted summaries, not raw token payloads.
 - Preserve existing auth file compatibility unless a migration is explicitly requested.
+- OAuth/browser flow changes also inspect `internal/cmd/*_login.go`, `cmd/server/main.go`, and Management OAuth session handlers.
+- Token storage keeps private parent directories and `0600` credential files on supported platforms.
 
 ## Do not
 
@@ -22,9 +24,11 @@ Key files: provider subdirectories under `antigravity/`, `claude/`, `codex/`, `g
 - 不要 hard-code user credentials into source, examples, tests, or docs.
 - 不要 change auth filename conventions without checking watcher and Management API download/delete paths.
 - 不要 make OAuth flows require interactive browser opening when `--no-browser` is set.
+- 不要 move Management OAuth session/cancel/save/rollback decisions into a provider package without checking the Management handler contract.
 
 ## Validation
 
-- Provider-local tests, for example `go test ./internal/auth/codex` or `go test ./internal/auth/claude`.
+- Provider-local tests: `go test ./internal/auth/...`.
+- CLI login flow changes: `go test ./internal/cmd ./cmd/server`.
 - SDK auth integration changes: `go test ./sdk/cliproxy/auth`.
 - Management auth-file changes: `go test ./internal/api/handlers/management -run Auth`.

--- a/internal/cache/AGENTS.md
+++ b/internal/cache/AGENTS.md
@@ -1,0 +1,24 @@
+# internal/cache navigation card
+
+`internal/cache/` owns bounded local signature/reasoning replay caches and their Home KV-backed equivalents.
+Read this card before changing cache keys, scope resolution, TTL, CAS/generation logic, signature bypass, or replay append/delete behavior.
+Key files: `signature_cache.go`, `codex_reasoning_replay_cache.go`, `codex_reasoning_replay_scope.go`, provider replay caches, `bounded_lru.go`.
+
+## Local invariants
+
+- Replay state is scoped by the existing model/session identity; do not widen a cache key to share provider-private signatures or reasoning across unrelated models, auths, or sessions.
+- When Home mode owns a required read/write, Home failure or miss must follow the explicit required/best-effort contract; do not silently fall back to stale local state.
+- Codex append preserves cumulative turn boundaries and bounded retention; Antigravity conditional mutation preserves generation/CAS fencing against stale and ABA writers.
+- Signature validation and special sentinels stay aligned with `internal/signature`, translators, and executors.
+- Cache values and logs must not expose raw credentials, prompts, or full private reasoning payloads.
+
+## Do not
+
+- 不要 change key prefixes, hashing inputs, TTL, tombstone, or eviction semantics without migration/compatibility reasoning and focused tests.
+- 不要 replay `reasoning.encrypted_content` or thinking signatures across a model-fallback boundary unless the existing typed continuity policy explicitly permits it.
+
+## Validation
+
+- `go test ./internal/cache`
+- Signature changes: `go test ./internal/cache ./internal/signature ./internal/translator/...`
+- Codex replay/fallback changes: `go test ./internal/cache ./internal/runtime/executor ./sdk/cliproxy/auth -run 'Codex.*Replay|Codex.*Signature|CodexModelFallback'`

--- a/internal/client/codex/AGENTS.md
+++ b/internal/client/codex/AGENTS.md
@@ -1,0 +1,25 @@
+# internal/client/codex navigation card
+
+`internal/client/codex/` adapts CPA to official Codex clients: model catalog responses, guarded Multi-Agent v2 rewrites, and Realtime/Live HTTP, WebSocket, WebRTC, and sideband flows.
+Read this card before changing official-client detection, model metadata, collaboration tools, ephemeral secrets, Live sessions, media relay, or Codex client routes.
+Key files: `models/`, `optimize-multi-agent-v2/`, `live/`, plus route wiring in `internal/api/server_routes.go`.
+
+## Local invariants
+
+- Client-specific rewrites run only for positively identified official Codex clients and enabled config; namespace conflicts, opaque/mixed agent content, and unproven tool shapes fail closed or remain untouched.
+- Model responses derive capabilities from registry/catalog evidence. Preserve reasoning levels, visibility, context limits, input modalities, and search-tool eligibility; do not advertise unsupported upstream behavior.
+- Realtime client secrets are short-lived, bounded, locally scoped, and bound to the issuing API principal/provider. Session/hangup/sideband calls must reject cross-principal or model scope mismatches.
+- Live/Realtime auth selection, Home dispatch, usage attribution, response headers, session cleanup, and at-most-once unauthorized refresh remain coordinated.
+- Media/sideband proxying must retain target validation, credential redaction, cancellation, bounded body/frame handling, and no unsafe direct-network fallback after a configured proxy failure.
+
+## Do not
+
+- 不要 make a Codex-only rewrite affect generic OpenAI-compatible clients.
+- 不要 log ephemeral secrets, SDP credentials, attestation values, proxy credentials, or raw private session metadata.
+- 不要 claim unsupported translation, transcription-only, or SIP capabilities; preserve the explicit error envelope.
+
+## Validation
+
+- `go test ./internal/client/codex/...`
+- Route/handler changes: `go test ./internal/api ./sdk/api/handlers/openai`
+- Multi-Agent/translator changes: `go test ./internal/client/codex/optimize-multi-agent-v2 ./internal/translator/... ./sdk/api/handlers/openai -run 'MultiAgent|Multi_Agent|multi_agent'`

--- a/internal/codexmetadata/AGENTS.md
+++ b/internal/codexmetadata/AGENTS.md
@@ -1,0 +1,23 @@
+# internal/codexmetadata navigation card
+
+`internal/codexmetadata/` normalizes Codex `client_metadata`, applies workspace privacy policy, regenerates compatibility projections, and redacts metadata for logs.
+Read this card before changing repair/strict/off mode, workspace policy, canonical turn metadata, derived headers, session identity, or log sanitization.
+Key files: `request.go`, `log.go`, `errors.go`, and their tests.
+
+## Local invariants
+
+- `client_metadata.x-codex-turn-metadata` is the canonical source when present; flat body/header fields are compatibility projections, not independent authority.
+- `strict` rejects malformed, duplicate, ambiguous, or conflicting carriers; `repair` normalizes known-safe input; `off` does not mutate payloads but may derive unambiguous state.
+- Workspace `passthrough`, `redact`, and `drop` are distinct public policies. Redaction remains deterministic within its configured scope without exposing original paths/remotes.
+- Projection values must pass header safety and size limits. Validation errors are safe request-scoped 400s and never echo untrusted metadata.
+- Log sanitizers clone input, remove workspace enrichment, mask derived session/window/parent/subagent headers, and fail closed on malformed/ambiguous canonical data.
+
+## Do not
+
+- 不要 trust a flat session/window/subagent projection over conflicting canonical metadata.
+- 不要 loosen depth/count/size bounds or include workspace paths/remotes or derived session/window/parent/subagent header values in logs; any broader metadata reduction is a separate privacy-contract change.
+
+## Validation
+
+- `go test ./internal/codexmetadata`
+- Outbound integration changes: `go test ./internal/runtime/executor ./sdk/cliproxy/auth -run 'ClientMetadata|Workspace|TurnMetadata|Identity'`

--- a/internal/config/AGENTS.md
+++ b/internal/config/AGENTS.md
@@ -2,32 +2,34 @@
 
 `internal/config/` owns the YAML/JSON config model, defaults, compatibility helpers, sanitization, and generated config preservation behavior.
 Read this card before adding, renaming, deleting, migrating, or changing the default of any config key.
-Key files: `config.go`, `sdk_config.go`, `disable_image_generation_mode.go`, `vertex_compat.go`, `config.example.yaml`.
+Key files: `config.go`, `config_types.go`, `config_defaults.go`, `config_load.go`, `parse.go`, `config_normalization.go`, `config_yaml.go`, `sdk_config.go`, `config.example.yaml`.
 
 ## Why this is high-risk
 
 - Config keys are user data and Management API surface, not just internal structs.
 - YAML tags, JSON tags, defaults, sanitize logic, hot reload, TUI labels, Panel forms, watcher diff, and SDK config can all depend on the same key.
-- Startup legacy migration is intentionally disabled in current code; do not re-enable persistence accidentally.
+- Load/parse paths perform in-memory defaults, compatibility normalization, and sanitization. `ParseConfigBytes` does not write disk; `LoadConfigOptional` may intentionally persist a plaintext `remote-management.secret-key` as a bcrypt hash after validation.
 - `usage-statistics-enabled`, `redis-usage-queue-*`, and `panel-github-repository` are LTS contract-adjacent.
 
 ## Required before changes
 
 - Search for the exact key in `internal/`, `sdk/`, `test/`, `config.example.yaml`, and Management API handlers.
 - Check whether the key appears in TUI config tabs, Panel-facing endpoints, watcher diff, or SDK config structs.
-- Do not infer runtime defaults from `config.example.yaml` alone; verify `config.go` and `parse.go`.
+- Do not infer runtime defaults from `config.example.yaml` alone; verify `config_load.go`, `parse.go`, and `config_defaults.go`.
 - Decide whether old config files must keep loading without mutation.
+- Keep `LoadConfigOptional` and `ParseConfigBytes` aligned for defaults, validation, and sanitize semantics, while preserving their documented persistence difference.
 
 ## Do not
 
 - 不要 silently rename config keys without compatibility handling.
-- 不要在 startup 期间自动重写用户 `config.yaml`，除非用户明确要求恢复迁移持久化。
+- 不要 add startup writes beyond an explicit, tested persistence contract such as validated remote-management secret hashing.
 - 不要把 secret defaults 写进 `config.example.yaml`。
-- 不要移除 `panel-github-repository` 指向 `CPA-Panel-LTS` 的默认意图。
+- 不要移除 `remote-management.panel-github-repository` 指向 `CPA-Panel-LTS` 的默认意图。
 
 ## Validation
 
 - `go test ./internal/config`
 - Config Management API changes: `go test ./internal/api/handlers/management`
 - Watcher/diff changes: `go test ./internal/watcher/diff`
+- Cross-surface schema changes: `go test ./internal/config ./internal/watcher/... ./internal/api/handlers/management -run 'Config|config|Usage|usage'`
 - Broad config schema changes should finish with `go test ./...`.

--- a/internal/home/AGENTS.md
+++ b/internal/home/AGENTS.md
@@ -1,0 +1,26 @@
+# internal/home navigation card
+
+`internal/home/` implements the Home control-plane client for config subscription, auth dispatch, membership/failover, KV commands, in-flight snapshots, concurrency release, and plugin status.
+Read this card before changing Home wire commands, lifecycle state, cluster discovery, dispatch classification, KV semantics, heartbeat, or release frames.
+Key files: `client.go`, `requests.go`, `concurrency_release.go`, `kv_helpers.go`, `certificate.go`, `plugin_status.go`.
+
+## Local invariants
+
+- Home settings are runtime-only and originate from the Home JWT/control plane; ordinary YAML parsing must not synthesize or persist `HomeConfig`.
+- Dispatch distinguishes deterministic pre-send failure from ambiguous post-send/read failure. Ambiguity fences takeover/redispatch until the lifecycle proves it safe.
+- Membership, command pools, subscriber lifetime, heartbeat readiness, cluster failover, and global `Current()` publication move together; stale lifetimes must not become current.
+- Credential in-flight and concurrency release frames are wire contracts. Release flushing is cumulative, retryable, bounded on shutdown, and must not lose a sequence during concurrent updates.
+- `Required` KV helpers surface Home-mode errors/misses; `BestEffort` helpers may swallow errors only with secret-safe key-prefix logging. CAS, NX, expiry, and miss semantics are not interchangeable.
+- Plugin status and other dedicated command paths retain their own timeout/cancellation behavior rather than inheriting an unrelated base timeout.
+
+## Do not
+
+- 不要 log Home JWT, full Redis/Home keys, dispatched credentials, certificates, or raw control-plane payloads.
+- 不要 add local fallback after an ambiguous dispatch or required Home KV failure.
+- 不要 update Home protocol fields without checking `sdk/cliproxy/service_home.go`, `sdk/cliproxy/auth`, and executor/Home tests.
+
+## Validation
+
+- `go test ./internal/home`
+- Home service/auth changes: `go test ./internal/home ./sdk/cliproxy/...`
+- Wire or concurrency lifecycle changes: `go test -race ./internal/home ./sdk/cliproxy/auth -run 'Home|Concurrency|InFlight|Release|Membership'`

--- a/internal/homeplugins/AGENTS.md
+++ b/internal/homeplugins/AGENTS.md
@@ -1,0 +1,24 @@
+# internal/homeplugins navigation card
+
+`internal/homeplugins/` applies Home-resolved plugin install/delete work and produces node status reports.
+Read this card before changing plugin sync manifests, resolved auth lifetime, artifact installation/deletion, load verification, task phases, or report JSON.
+Key files: `sync.go`, `sync_test.go`, `sdk/pluginstore/`, `internal/pluginstore/`, and `internal/pluginhost/`.
+
+## Local invariants
+
+- Home plugin operations run only when both Home and plugins are enabled and use the resolved plugin root/platform.
+- Resolved auth is temporary, expiry-bounded, and cleared after use; reports and errors never include secret values or private auth URLs.
+- Install/delete honors plugin busy/unload state, manifest/platform validation, checksum/archive safeguards delegated to pluginstore, and context cancellation before destructive steps.
+- Sync reports preserve stable schema/task/phase/status fields and distinguish install outcome from runtime load outcome.
+- An installed plugin that fails to load is not a successful completed sync; missing delete targets remain idempotent success where the current contract says so.
+
+## Do not
+
+- 不要 execute a downloaded plugin as an installation check or bypass pluginstore validation.
+- 不要 overwrite/delete a busy or loaded plugin outside the existing unload/BeforeWrite contract.
+- 不要 retain resolved auth after completion, expiry, cancellation, or failure.
+
+## Validation
+
+- `go test ./internal/homeplugins`
+- Store/host interactions: `go test ./internal/homeplugins ./internal/pluginstore ./internal/pluginhost ./sdk/pluginstore`

--- a/internal/logging/AGENTS.md
+++ b/internal/logging/AGENTS.md
@@ -2,28 +2,32 @@
 
 `internal/logging/` owns global logging, request logging, request IDs, request metadata, home log forwarding, and log directory cleanup.
 Read this card before changing log formats, request/response body capture, metadata keys, redaction, log file paths, rotation, or streaming log behavior.
-Key files: `request_logger.go`, `requestmeta.go`, `requestid.go`, `gin_logger.go`, `global_logger.go`, `home_app_log_forwarder.go`.
+Key files: `request_logger.go`, `request_logger_lts.go`, `request_logger_streaming.go`, `requestmeta.go`, `requestid.go`, `cpa_trace.go`, `gin_logger.go`, `global_logger.go`, `home_app_log_forwarder.go`.
 
 ## Why this is high-risk
 
 - Logs can contain user prompts, provider responses, API keys, OAuth tokens, cookies, auth headers, management secrets, and internal URLs.
 - Request metadata feeds usage attribution, Redis queue payload, debugging, home forwarding, and management views.
 - Streaming logging can accidentally consume or buffer response bodies and break clients.
+- `X-CPA-TRACE-ID` is a downstream-visible correlation contract derived after request/auth identity is known and before response commitment.
 
 ## Required before changes
 
 - Trace whether metadata is read by `internal/usage`, `internal/redisqueue`, `internal/runtime/executor`, `sdk/cliproxy/auth`, or Management handlers.
 - Confirm any new logged field is redacted or safe by construction.
 - For body logging changes, test both non-streaming and streaming paths.
+- Request metadata/header holders used asynchronously must copy mutable values rather than retain request/Gin-owned buffers.
+- Body capture changes preserve config gates, size/truncation limits, compression handling, deferred cleanup, and redaction.
 
 ## Do not
 
-- 不要 log Authorization headers, cookies, raw tokens, raw auth files, management secret, or complete upstream bodies containing user content.
+- 不要 log Authorization headers, cookies, raw tokens, raw auth files, management secret, or unredacted metadata/body content outside the established request-log policy.
 - 不要 change request ID propagation without checking Gin middleware and SDK auth selector logs.
 - 不要 add blocking disk/network work to hot request paths without a bounded reason.
 
 ## Validation
 
 - `go test ./internal/logging`
+- Middleware/trace changes: `go test ./internal/logging ./internal/api/middleware ./internal/api -run 'Trace|RequestLog|Websocket|Streaming'`
 - Metadata/usage changes: `go test ./internal/usage ./internal/redisqueue`
 - API logging middleware changes: `go test ./internal/api`

--- a/internal/pluginstore/AGENTS.md
+++ b/internal/pluginstore/AGENTS.md
@@ -27,4 +27,5 @@ Key files: `registry.go`, `github.go`, `install.go`, `checksum.go`, `version.go`
 
 - `go test ./internal/pluginstore`
 - Host integration changes: `go test ./internal/pluginhost`
+- Public facade changes: read `sdk/pluginstore/AGENTS.md` and run `go test ./sdk/pluginstore`
 - Management plugin-store endpoint changes: `go test ./internal/api/handlers/management -run Plugin`

--- a/internal/redisqueue/AGENTS.md
+++ b/internal/redisqueue/AGENTS.md
@@ -10,6 +10,9 @@ Key files: `plugin.go`, `queue.go`, `usage_toggle.go`, `*_test.go`.
 - Payload fields such as `auth_index`, `latency_ms`, `tokens`, success/failure status, endpoint, request ID, and response headers are downstream-facing.
 - Token totals should follow the same normalization semantics as the full usage logger.
 - Async delivery must not depend on recycled Gin contexts.
+- This package implements a Redis-compatible HTTP/wire queue, not an external Redis persistence client. With subscribers it broadcasts directly; without them it retains bounded in-memory events according to current semantics.
+- Disable clears retained events and closes subscribers; slow subscribers may be removed. Error events remain broadcast-only where the current protocol specifies it.
+- Response headers are copied and filtered to remove Authorization, Proxy-Authorization, Cookie, and Set-Cookie values.
 
 ## Local rules
 
@@ -20,10 +23,12 @@ Key files: `plugin.go`, `queue.go`, `usage_toggle.go`, `*_test.go`.
 
 - 不要 publish raw prompt, raw response, token, auth file content, management secret, or Authorization headers in queue payloads.
 - 不要 make queue availability a prerequisite for core request handling.
+- 不要 let the queue toggle drift from the shared `usage-statistics-enabled` recording contract.
 - 不要 remove `/v0/management/usage-queue` from the LTS contract.
 
 ## Validation
 
 - `go test ./internal/redisqueue`
+- Queue/API behavior: `go test ./internal/redisqueue ./internal/api -run 'Redis|redis|Usage|usage'`
 - Route/config changes: `go test ./internal/api ./internal/config ./internal/watcher/diff`
 - Contract guard: `scripts/check-lts-contract.sh`

--- a/internal/registry/AGENTS.md
+++ b/internal/registry/AGENTS.md
@@ -2,18 +2,18 @@
 
 `internal/registry/` owns model registration, embedded model catalogs, remote model refresh hooks, client/model availability, and quota-related routing state.
 Read this card before changing model catalog JSON, model aliases, quota state, registry refresh behavior, provider model metadata, or client availability logic.
-Key files: `model_registry.go`, `model_definitions.go`, `model_updater.go`, `codex_client_models.go`, `models/models.json`, `models/codex_client_models.json`.
+Key files: `model_registry.go`, `model_definitions.go`, `model_updater.go`, `codex_client_models.go`, `models/models.json`, `models/codex_client_models.json`, `.github/scripts/refresh-model-catalogs.sh`.
 
 ## Local invariants
 
 - Go module path remains `github.com/router-for-me/CLIProxyAPI/v7`; registry changes must not introduce legacy `/v6` imports.
-- `models/models.json` is refreshed in CI from `router-for-me/models.git`; local copies may be stale when offline.
+- Embedded model catalogs are refreshed by `.github/scripts/refresh-model-catalogs.sh` in PR/release/container workflows; local copies may be stale when offline.
 - Quota state and suspended clients affect runtime routing and auth conductor behavior.
 - Model metadata may be exposed through Management API, SDK, and provider routing.
 
 ## Local rules
 
-- Treat embedded JSON catalogs as generated/externally refreshed unless the task is explicitly catalog maintenance.
+- Treat embedded JSON catalogs as generated/externally refreshed unless the task is explicitly catalog maintenance; update helper validation together with a catalog-shape change.
 - Codex/Antigravity helper command changes need auth and registry review together.
 - Quota reset or routing-state changes require checking `sdk/cliproxy/auth` and relevant Management API tests.
 

--- a/internal/runtime/executor/AGENTS.md
+++ b/internal/runtime/executor/AGENTS.md
@@ -16,6 +16,7 @@ Key files: `codex_executor.go`, `codex_websockets_executor.go`, `claude_executor
 
 - Prefer existing helpers in `helps/` for proxy, token, payload, cache, logging, and usage behavior.
 - Codex WebSocket output needs tests for event shape and final stream output.
+- Codex client metadata changes require `internal/codexmetadata/AGENTS.md`; replay/signature/thinking changes require the matching `internal/cache/`, `internal/signature/`, and `internal/thinking/` cards.
 - Antigravity/Claude signature changes need translator/cache tests too, not only executor tests.
 - Plugin executor changes also require `internal/pluginhost/` and `sdk/pluginapi/` review.
 

--- a/internal/signature/AGENTS.md
+++ b/internal/signature/AGENTS.md
@@ -1,0 +1,23 @@
+# internal/signature navigation card
+
+`internal/signature/` validates and sanitizes provider-specific thinking signatures and encrypted reasoning content.
+Read this card before changing signature detection, provider compatibility, malformed-content handling, Claude/Gemini/GPT/Grok/Kimi validation, or sanitization.
+Key files: `provider_compatibility.go`, provider `*_validation.go` files, `claude_messages_sanitize.go`, `gemini_sanitize.go`.
+
+## Local invariants
+
+- A signature/encrypted-content value is provider-private unless an explicit compatibility classifier proves otherwise; unknown or malformed values never become portable by default.
+- Sanitizers preserve valid blocks and required empty placeholders while removing only content proven incompatible for the target protocol.
+- Claude classic/CAIS, Gemini, GPT/Codex encrypted content, Grok, and Kimi have distinct validation semantics; model/provider fallback must not collapse them.
+- Validation and sanitize behavior stays aligned with `internal/cache`, translators, executors, and reasoning replay tests.
+
+## Do not
+
+- 不要 accept opaque content merely because it is base64-shaped or non-empty.
+- 不要 strip valid signatures/thinking blocks to make a translator pass, or replay them across an incompatible target.
+- 不要 include full signature/encrypted-content values in logs or test failure snapshots.
+
+## Validation
+
+- `go test ./internal/signature`
+- Cross-protocol changes: `go test ./internal/signature ./internal/cache ./internal/translator/... ./internal/runtime/executor -run 'Signature|Encrypted|Thinking|Replay'`

--- a/internal/store/AGENTS.md
+++ b/internal/store/AGENTS.md
@@ -1,0 +1,30 @@
+# internal/store navigation card
+
+`internal/store/` implements Git, PostgreSQL, and S3-compatible object stores for config/auth persistence plus secure local auth-file rendering.
+Read this card before changing remote persistence, sync/recovery, spool paths, auth path resolution, atomic writes, deletion, file permissions, symlink/reparse handling, or cooldown storage.
+Key files: `gitstore.go`, `objectstore.go`, `postgresstore.go`, `postgres_cooldown_store.go`, `objectstore_render_*`, `objectstore_secure_*`.
+
+## Why this is high-risk
+
+- These stores hold credential material and can write/delete both remote objects/rows and local rendered auth files.
+- Path containment, atomic installation, private permissions, and POSIX/Windows anti-symlink/reparse behavior are security and compatibility contracts.
+- Git recovery and remote sync must preserve local dirty config/auth changes instead of replacing the whole worktree blindly.
+
+## Required before changes
+
+- Trace the caller through `sdk/auth`, `internal/watcher`, `sdk/cliproxy`, and the selected backend.
+- Preserve root identity/containment checks, relative-ID validation, `0700` directories, `0600` auth files, temp-file cleanup, and atomic rename/install semantics.
+- Keep backend configuration, credentials, bucket/database/repository values out of logs and errors.
+
+## Do not
+
+- 不要 use `RemoveAll` for auth-root replacement or deletion unless the existing backend-specific safe procedure explicitly does so.
+- 不要 accept traversing remote object keys or rendered-target relative IDs, and never bypass containment, symlink, junction/reparse, or root-identity checks. Git/PostgreSQL callers may supply trusted absolute auth paths through the existing compatibility flow; tightening that public behavior requires an explicit migration and regression tests.
+- 不要 run live remote-store mutation tests without explicit user authorization and disposable resources.
+
+## Validation
+
+- `go test ./internal/store`
+- Race-sensitive store changes: `go test -race ./internal/store`
+- Windows-specific DACL/reparse behavior requires Windows CI/VM; local non-Windows tests are not equivalent.
+- PostgreSQL/S3/Git live integration needs external services, network, and disposable credentials; unit tests remain the default local check.

--- a/internal/thinking/AGENTS.md
+++ b/internal/thinking/AGENTS.md
@@ -1,0 +1,25 @@
+# internal/thinking navigation card
+
+`internal/thinking/` provides provider-neutral reasoning/thinking parsing, validation, summary intent, suffix handling, and provider-specific request application.
+Read this card before changing level/budget modes, model suffixes, summary visibility, model capability validation, provider appliers, or Codex wire canonicalization.
+Key files: `types.go`, `apply.go`, `suffix.go`, `summary.go`, `validate.go`, `codex_wire.go`, `provider/`.
+
+## Local invariants
+
+- Model suffix configuration has explicit precedence over request-body thinking settings; base model identity remains available for routing and registry lookup.
+- Thinking effort and summary visibility are orthogonal. Preserve explicit summary intent across translation and provider-specific rewrites.
+- Known catalog models follow registry capability limits; unknown/user-defined models pass supported config through for upstream validation rather than inheriting an unrelated built-in model contract.
+- `max` and Codex-client `ultra` are distinct user-facing levels even where official Codex wire canonicalizes Ultra to Max.
+- Provider appliers are idempotent, return a modified copy, and do not mutate shared config/model metadata. Native provider names cannot be replaced by plugin providers.
+
+## Do not
+
+- 不要 infer summary enablement from effort for protocols that have an explicit summary field; OpenAI Chat is the documented compatibility exception.
+- 不要 silently clamp, drop, or translate a level/budget without the provider/model rule and regression coverage.
+- 不要 invent provider names outside the existing registry/plugin ownership model.
+
+## Validation
+
+- `go test ./internal/thinking/...`
+- Translator/executor integration: `go test ./internal/thinking/... ./internal/translator/... ./internal/runtime/executor -run 'Thinking|Reasoning|Summary|Ultra|Max'`
+- Sentinel coverage: `go test ./test -run 'thinking|Thinking|Summary'`

--- a/internal/translator/AGENTS.md
+++ b/internal/translator/AGENTS.md
@@ -16,7 +16,8 @@ Key files: `init.go`, `translator/translator.go`, provider pair directories such
 
 - Use structured JSON helpers already present in the codebase instead of ad hoc string concatenation.
 - Add table-driven tests near the translator pair being changed.
-- If a change affects SDK-facing behavior, check `sdk/translator`, `sdk/pluginapi`, and examples.
+- If a change affects SDK-facing behavior, read `sdk/translator/AGENTS.md` and check `sdk/pluginapi` plus examples.
+- Signature/thinking changes also read `internal/signature/AGENTS.md`, `internal/cache/AGENTS.md`, and `internal/thinking/AGENTS.md` as applicable.
 
 ## Do not
 

--- a/internal/usage/AGENTS.md
+++ b/internal/usage/AGENTS.md
@@ -9,14 +9,17 @@ Key files: `logger_plugin.go`, `internal/api/handlers/management/usage.go`, `sdk
 - `usage-statistics-enabled` 只控制是否继续记录新数据；不要破坏已有 snapshot/export/import 的读取能力。
 - Snapshot JSON 字段要继续兼容 Panel：`total_requests`、`success_count`、`failure_count`、`total_tokens`、`apis`、`models`、`details`、day/hour buckets。
 - Request detail 必须保留 timestamp、latency、source、auth_index、token breakdown、failed 状态。
-- Token 统计要兼容 input/output/reasoning/cached/total，并保留现有 normalise 逻辑。
-- Import 必须 merge，而不是覆盖；重复记录要按现有去重语义跳过。
-- 没有 API key 时继续通过 context/auth metadata 解析统计归属，不要退化成单一 unknown bucket。
+- Canonical v2 request detail 还包括 alias、`reasoning_effort`、request/outbound/response/effective service tier、`generate`、`failure_reason`、`failure_status`。
+- Token 统计要兼容 input/output/reasoning/cached/cache-read/cache-creation/total，并保留现有 normalise 逻辑。
+- Export 使用 `CanonicalExportVersion = 2`。Import 只接受受支持的 canonical v2 或可证明语义的 released v1 migration，并返回稳定 error code / migration receipt。
+- Import 必须先完整校验 shape、token semantics 和 aggregate overflow，再原子 merge；不能部分写入。重复记录按现有 dedup identity 跳过。
+- 没有 API key 时统计 key 依次使用 request endpoint、provider、`unknown`；不要把所有非 API-key 请求折叠到同一 bucket。
 
 ## Local rules
 
 - 改统计字段时，同时检查 Management API usage handlers、Panel usage 页面、TUI dashboard、SDK usage record、Redis queue payload。
 - 新增字段优先向后兼容：旧 export payload 能导入，新 export payload 不应让旧字段消失。
+- 不要在未迁移既有数据的情况下改变 dedup identity；当前 identity 包括 API/model/timestamp/source/auth/failure/token shape，不包括 latency 与 service-tier metadata。
 - 统计存储当前是 in-memory；不要在本目录里偷偷引入外部数据库、文件写入或后台网络依赖。
 
 ## Do not
@@ -30,4 +33,6 @@ Key files: `logger_plugin.go`, `internal/api/handlers/management/usage.go`, `sdk
 - `go test ./internal/usage`
 - `go test ./internal/api/handlers/management -run Usage`
 - `go test ./test -run Usage`
+- Canonical import/export changes: `go test ./internal/usage ./internal/api/handlers/management -run 'MigrateV1|CanonicalV2|UsageManagementImport'`
+- Contract guard: `scripts/check-lts-contract.sh`
 - 跨字段或 import/export 兼容性改动后，再运行 `go test ./...`。

--- a/internal/watcher/AGENTS.md
+++ b/internal/watcher/AGENTS.md
@@ -2,13 +2,15 @@
 
 `internal/watcher/` owns config/auth file watching, config diff summaries, auth synthesis, plugin auth parsing, runtime auth updates, and hot reload dispatch.
 Read this card before changing file watch events, debounce behavior, auth file parsing/synthesis, config reload, diff redaction, or watcher-to-SDK update flow.
-Key files: `watcher.go`, `events.go`, `config_reload.go`, `diff/`, `synthesizer/`.
+Key files: `watcher.go`, `events.go`, `config_reload.go`, `clients.go`, `dispatcher.go`, `diff/`, `synthesizer/`.
 
 ## Why this is high-risk
 
 - Watcher output can change live auth availability, routing, plugin models, and Management/TUI state without restart.
 - Diff summaries may mention secrets if redaction is wrong.
 - Auth synthesis touches file-backed credentials, config API keys, plugin auth files, and SDK auth conductor updates.
+- Config events are Write/Create/Rename; auth events are top-level `.json` Create/Write/Remove/Rename. Debounce/content checks and atomic-replace classification prevent duplicate or false deletes.
+- Optional `StorePersister` owns remote config/auth persistence after accepted reload/update; watcher behavior without a persister remains local/runtime-only.
 
 ## Required before changes
 
@@ -20,10 +22,10 @@ Key files: `watcher.go`, `events.go`, `config_reload.go`, `diff/`, `synthesizer/
 
 - 不要 include token, API key, OAuth secret, service-account JSON, or full auth file content in diff summaries.
 - 不要 silently drop delete events that should disable or remove an auth entry.
-- 不要 auto-persist rewritten config/auth files unless the caller explicitly owns that flow.
+- 不要 bypass `StorePersister` ownership or add an independent remote-write path; without a configured persister, do not create remote/extra copies.
 
 ## Validation
 
-- `go test ./internal/watcher ./internal/watcher/diff ./internal/watcher/synthesizer`
+- `go test ./internal/watcher/...`
 - Config changes: `go test ./internal/config`
 - SDK update flow changes: `go test ./sdk/cliproxy/...`

--- a/sdk/access/AGENTS.md
+++ b/sdk/access/AGENTS.md
@@ -1,0 +1,24 @@
+# sdk/access navigation card
+
+`sdk/access/` is the public inbound-request authentication provider chain used by the server and embedders.
+Read this card before changing exported provider/result/error types, registry ordering, exclusive-provider behavior, principal metadata, or manager aggregation.
+Key files: `registry.go`, `manager.go`, `types.go`, `errors.go`, `docs/sdk-access*.md`, `internal/access/`.
+
+## Local invariants
+
+- `Provider.Authenticate` distinguishes `not_handled`, `no_credentials`, `invalid_credential`, and internal errors; manager traversal and HTTP status behavior depend on those exact classes.
+- Providers are evaluated in stable registration order. Exclusive mode restricts the snapshot only when the named provider exists; clearing it restores the registered chain.
+- A nil/empty manager means access control is disabled for the embedding caller; do not turn that into implicit rejection without an API decision.
+- `Result.Principal` may feed API-key attribution and request context. Never place raw credentials in metadata or logs unless the established config API-key contract requires the matched principal internally.
+- Registry mutation and manager snapshots remain concurrency-safe and defensively copied.
+
+## Do not
+
+- 不要 rename exported error codes, interfaces, fields, or default provider identifiers without compatibility handling.
+- 不要 make a provider claim requests it does not recognize; return `not_handled` so later providers can run.
+- 不要 log headers, query credentials, API keys, or principals.
+
+## Validation
+
+- `go test ./sdk/access ./internal/access/...`
+- Server/SDK integration: `go test ./internal/api ./sdk/cliproxy -run 'Access|AuthProvider|APIKey'`

--- a/sdk/api/AGENTS.md
+++ b/sdk/api/AGENTS.md
@@ -1,0 +1,27 @@
+# sdk/api navigation card
+
+`sdk/api/` is the public protocol-handler layer for OpenAI/Responses, Claude, Gemini/Interactions, images/video, SSE/WebSocket streaming, model routing, and plugin interception.
+Read this card before changing handler types/options, request lifecycle, protocol error envelopes, stream forwarding, header policy, routing metadata, or interceptor behavior.
+Key files: `handlers/handlers*.go`, `handlers/model_execution.go`, `handlers/stream_forwarder.go`, `handlers/header_filter.go`, protocol subdirectories, `options.go`.
+
+## Local invariants
+
+- Once a `requestLifecycleTracker` has been created, handler execution must complete it exactly once across non-stream, stream, direct plugin executor, and tracked termination paths; `sync.Once` enforces at-most-once delivery. Routing/provider/plugin-host failures that occur before tracker creation do not emit `RequestCompletion` under the current contract.
+- Streaming may retry/fallback only before committed payload according to the auth/executor contract; after first payload it must preserve ordering, terminal errors, cancellation, and protocol-specific SSE/WebSocket framing.
+- OpenAI Responses streams validate event JSON and terminal state without losing valid preceding frames; error envelopes must not expose raw upstream bodies or credentials.
+- Request routing/interceptors preserve original/requested/selected model, entry/exit protocol, query, headers, and skip-plugin identity. Home mode and plugin-direct execution fail closed where required.
+- Upstream response headers are cloned and filtered: remove hop-by-hop, connection-scoped, `Set-Cookie`, gateway-identifying, and CPA-reserved headers; do not overwrite headers already owned by CPA.
+- Execution metadata carries the LTS usage/session/fallback fields consumed by auth, executor, logging, and usage layers.
+
+## Do not
+
+- 不要 write headers or a success frame before synchronous stream bootstrap/validation has produced a committable payload.
+- 不要 replay a non-idempotent request or switch auth/model after output has been delivered.
+- 不要 let plugin interceptors receive mutable shared header/body buffers or run after a terminal completion.
+
+## Validation
+
+- `go test ./sdk/api/...`
+- Responses/WebSocket changes: `go test ./sdk/api/handlers/openai -run 'Responses|Websocket|Stream|Compact'`
+- Lifecycle/routing/plugin changes: `go test ./sdk/api/handlers -run 'Lifecycle|Interceptor|ModelRouter|ExecuteModel|Stream'`
+- Server route integration: `go test ./internal/api/...`

--- a/sdk/auth/AGENTS.md
+++ b/sdk/auth/AGENTS.md
@@ -1,0 +1,25 @@
+# sdk/auth navigation card
+
+`sdk/auth/` is the public provider-login layer and file token store used by CLI commands and embedders.
+Read this card before changing exported authenticator/login options, refresh lead registration, plugin auth parsing, token-store selection, file serialization, or delete/list behavior.
+Key files: `interfaces.go`, `manager.go`, provider files, `filestore.go`, `store_registry.go`, `refresh_registry.go`.
+
+## Local invariants
+
+- `LoginOptions.NoBrowser`, callback port, prompt function, project ID, and provider metadata remain caller-controlled; authenticators must honor noninteractive/no-browser flows.
+- `Manager.Login` may return a valid auth record without a saved path when no store is configured; persistence errors return the record plus error for caller-controlled recovery.
+- File token storage preserves auth weight validation, `disabled` metadata, `0700` directories, `0600` files, source/path attributes, and plugin multi-auth expansion semantics.
+- Plugin auth parsers may intentionally handle/suppress built-in parsing. Registration remains safe for concurrent reads and never exposes raw auth JSON outside the approved parser contract.
+- Global token-store and refresh-lead registries stay compatible with `internal/auth`, watcher synthesis, Management auth-file handlers, and `sdk/cliproxy/auth`.
+
+## Do not
+
+- 不要 let a plain logical ID escape the configured auth root. Caller-supplied explicit paths (`Attributes["path"]`, absolute `FileName`/ID, or a separator-bearing delete ID) are an existing public compatibility surface; containing or removing that behavior requires an explicit migration and regression tests.
+- 不要 log tokens, OAuth codes, service-account JSON, raw auth files, or provider login responses.
+- 不要 make public login helpers depend on process-global browser/UI state when the caller supplied options.
+
+## Validation
+
+- `go test ./sdk/auth`
+- Provider internals: `go test ./sdk/auth ./internal/auth/...`
+- Watcher/Management integration: `go test ./sdk/auth ./internal/watcher/... ./internal/api/handlers/management -run 'Auth|OAuth|Token|File'`

--- a/sdk/cliproxy/AGENTS.md
+++ b/sdk/cliproxy/AGENTS.md
@@ -8,6 +8,7 @@ Key files: `builder.go`, `service.go`, `types.go`, `providers.go`, `rtprovider.g
 
 - Public structs, methods, and package paths are external API; avoid breaking changes unless user explicitly asks for a major contract change.
 - SDK auth conductor behavior must stay compatible with core auth manager, watcher updates, provider availability, cooldown, quota state, and recent request tracking.
+- Changes inside `auth/` must also read `auth/AGENTS.md`; Home, model fallback, rate-limit continuity, and retry semantics are narrower contracts than this parent card.
 - SDK usage records feed `internal/usage`; preserve token, auth index, source, latency, model, and failed state where available.
 - `sdk/config`, `internal/config`, `internal/pluginhost`, and `internal/watcher` compatibility matters when embedding the service.
 

--- a/sdk/cliproxy/auth/AGENTS.md
+++ b/sdk/cliproxy/auth/AGENTS.md
@@ -1,0 +1,29 @@
+# sdk/cliproxy/auth navigation card
+
+`sdk/cliproxy/auth/` owns runtime credential registration, selection, execution, cooldown/result classification, session affinity, Home dispatch, model fallback, refresh, and retry policy.
+Read this card after `sdk/cliproxy/AGENTS.md` before changing auth state, selector/scheduler, conductor execution, error classification, fallback, or Home lifecycle.
+Key files: `conductor*.go`, `selector.go`, `scheduler.go`, `classification.go`, `cooldown_state.go`, `codex_model_fallback.go`, `codex_rate_limit_continuity.go`, `home_*.go`.
+
+## Local invariants
+
+- Auth identity/index, provider, model alias, selected model, session key, and result attribution remain stable across selection, execution, callbacks, usage, and Management views.
+- Cooldown and retry depend on typed/request-scoped classifications. Connection-lifecycle/cancellation/local preparation failures must not become quota cooldown merely from matching error text.
+- Stream retries/fallbacks occur only before first delivered payload; established sessions, pinned auth, Home selections, and selected-auth callbacks preserve per-dispatch ownership and dedup contracts.
+- Codex model fallback is opt-in and trigger-typed. It must not replay model-private reasoning across models unless the configured continuity mode and context-reset evidence allow it.
+- Rate-limit continuity distinguishes fresh blocked observations from confirmed shared cooldown and preserves established/incumbent work until the protected confirmation rules are met.
+- Home dispatch/attempt/release and local selection are different lifecycles; ambiguous Home dispatch, unauthorized refresh, in-flight accounting, and release flushing must not double-dispatch or leak capacity.
+- Manager locks do not cover plugin scheduler callbacks, executor network calls, or long-running refresh work.
+
+## Do not
+
+- 不要 mark an auth unavailable, cool it, or remove session state solely from an untyped string match.
+- 不要 rotate auth/model after response commitment, reuse stale Home selections, or publish selected-auth metadata more than once for the same actual dispatch/attempt. Fallback/retry may legitimately report source attempts and the final target according to the collector contract; never report a target that was not dispatched.
+- 不要 expose raw token/auth metadata to scheduler plugins, callbacks, logs, or errors.
+
+## Validation
+
+- `go test ./sdk/cliproxy/auth`
+- Selection/cooldown/race changes: `go test -race ./sdk/cliproxy/auth`
+- Codex resilience: `go test ./sdk/cliproxy/auth -run 'CodexModelFallback|CodexRateLimitContinuity|HedgedRetry|RetryWithoutPenalty|SessionAffinity'`
+- Home changes: `go test ./internal/home ./sdk/cliproxy/auth -run 'Home|Concurrency|InFlight|Unauthorized|Dispatch'`
+- Cross-layer execution changes: `go test ./sdk/api/... ./internal/runtime/executor`

--- a/sdk/pluginapi/AGENTS.md
+++ b/sdk/pluginapi/AGENTS.md
@@ -19,7 +19,7 @@ Key files: package Go files under this directory, plus examples under `examples/
 
 ## Do not
 
-- 不要 expose raw token, API key, cookie, service-account JSON, or full auth file content through public plugin structs.
+- 不要 expose credential material through scheduler, Management, usage, logging, or other non-credential capabilities. Existing auth-provider, executor, and host-auth callback fields such as `AuthData.StorageJSON`, `AuthParseRequest.RawJSON`, `HostAuthGetResponse.JSON`, and executor storage data are explicit credential-bearing contracts; keep them scoped to those approved flows and redact them everywhere else.
 - 不要 make plugin APIs depend on process-global state or interactive flows.
 - 不要 change JSON tags without migration/compatibility reasoning.
 

--- a/sdk/pluginstore/AGENTS.md
+++ b/sdk/pluginstore/AGENTS.md
@@ -1,0 +1,23 @@
+# sdk/pluginstore navigation card
+
+`sdk/pluginstore/` is the public facade for plugin registry, manifest, artifact installation, and scoped store-auth helpers.
+Read this card before changing exported aliases/constants, client constructors, resolved auth, manifest/install helpers, or update/version semantics.
+Key files: `pluginstore.go`, `pluginstore_test.go`, `internal/pluginstore/AGENTS.md`, `internal/homeplugins/AGENTS.md`.
+
+## Local invariants
+
+- Exported aliases/constants mirror `internal/pluginstore` and are compatibility surface for embedders; keep schema, install/auth types, and error identity aligned.
+- Client constructors normalize configured auth; resolved auth remains request-target/kind scoped and may be expiry-bounded. The owning caller must invoke `Client.ClearAuth()` after the final request; Home sync already owns that cleanup, and the client does not clear itself automatically.
+- Fetch/install methods delegate checksum, archive, path, platform, and loaded-plugin safeguards to the internal implementation without weakening them.
+- Manifest/version/update helpers remain deterministic and side-effect free.
+
+## Do not
+
+- 不要 expose or log resolved secret values, private registry URLs, or auth headers.
+- 不要 add a facade path that bypasses internal plugin validation or executes downloaded code.
+- 不要 rename/remove exported aliases or constants without an explicit public compatibility strategy.
+
+## Validation
+
+- `go test ./sdk/pluginstore ./internal/pluginstore`
+- Home/host integration: `go test ./sdk/pluginstore ./internal/homeplugins ./internal/pluginhost`

--- a/sdk/translator/AGENTS.md
+++ b/sdk/translator/AGENTS.md
@@ -1,0 +1,25 @@
+# sdk/translator navigation card
+
+`sdk/translator/` is the public translation registry for request, response, stream, token-count, and plugin-provided protocol transforms.
+Read this card before changing exported formats/types, registry lookup, fallback behavior, summary preservation, hook ordering, or byte ownership.
+Key files: `registry.go`, `types.go`, `format.go`, `plugin_hooks.go`, `pipeline.go`, `builtin/`, `internal/translator/AGENTS.md`.
+
+## Local invariants
+
+- Registration and lookup remain concurrency-safe; request maps use source-to-target while response lookup preserves the established target/source orientation.
+- Missing request transforms return the original shape after normalizing only the resolved `model`; missing response transforms preserve the normalized input instead of dropping output.
+- Reasoning summary intent is extracted before native translation and restored for the target model. Plugin normalizers/translators run in the documented before/native-or-plugin/after order.
+- Transform and hook APIs do not guarantee that input `[]byte` is cloned, and the current hook API does not carry headers. A transform/hook that retains or mutates a backing array must clone it explicitly; callers must not assume registry isolation.
+- Stream transforms preserve chunk order and per-stream state through the supplied `param` without leaking state across requests.
+
+## Do not
+
+- 不要 silently change format strings, exported transform signatures, default registry behavior, or fallback output.
+- 不要 apply target-protocol summary fields when no translation occurred and no plugin handled the route.
+- 不要 hide malformed payloads by returning empty success output.
+
+## Validation
+
+- `go test ./sdk/translator/...`
+- Built-in/internal integration: `go test ./sdk/translator/... ./internal/translator/...`
+- Handler/executor integration: `go test ./sdk/api/handlers ./internal/runtime/executor -run 'Translation|Translator|Summary|Stream'`


### PR DESCRIPTION
## 结果

补全 CPA-Core-LTS 高风险目录的 `AGENTS.md` navigation cards，并收紧根目录与既有卡片中的路由说明，使后续修改能在进入 auth、Management API、runtime、store、Home、signature、thinking 和 public SDK 等边界前读取对应约束。

## 主要变更

- 新增 15 个高风险目录卡片，覆盖 Management handlers、cache、Codex client metadata、Home/plugin sync、signature、store、thinking 与 public SDK seams。
- 更新根目录 directory map、on-demand cat protocol 与现有卡片的跨目录路由。
- 明确 auth file path compatibility、request lifecycle、streaming、secret redaction、plugin lifecycle 和 protected LTS validation 边界。

## 兼容性与边界

- 仅修改 `AGENTS.md`；不改变产品代码、workflow、配置 schema、API 或运行时行为。
- 不创建 `AGENTS.override.md`，也不为纯组织目录机械增加空卡片。
- 本 PR 不与任何产品功能变更混合；未发布、未部署。

## 验证

- `scripts/check-lts-contract.sh`
- `git diff --check`

上述本地检查均通过。仓库 `agents-md-guard` 仍按 OWNER/label 规则执行。

## Review focus

- 新卡片的目录所有权与跨模块验证命令是否准确。
- 根目录 router 是否与实际 card 层级一致。
