### PR TITLE
sync(lts): 吸收 upstream 至 a834917e 并适配 retry、stream 与 usage 契约

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -732,6 +732,48 @@ nonstream-keepalive-interval: 0
 #   xai:
 #     - "grok-3-mini"
 
+# OAuth provider request-scoped error rules (custom error classification for OAuth credentials)
+# oauth-request-scoped-errors:
+#   vertex:
+#     - status: 400
+#       match:
+#         - "maximum_context_length"
+#         - "context_length_exceeded"
+#       match-regexr:
+#         - "maximum_context_length$"
+#         - "^context_length_exceeded"
+#       action: "stop" # options: "stop", "stop-and-cooldown", "continue", "continue-and-cooldown"
+#   aistudio:
+#     - status: 400
+#       match:
+#         - "invalid_argument"
+#       action: "stop"
+#   antigravity:
+#     - status: 500
+#       match:
+#         - "internal_server_error"
+#       action: "stop-and-cooldown"
+#   claude:
+#     - status: 400
+#       match:
+#         - "prompt is too long"
+#       action: "stop"
+#   codex:
+#     - status: 400
+#       match:
+#         - "context_window_exceeded"
+#       action: "stop"
+#   kimi:
+#     - status: 400
+#       match:
+#         - "length_limit"
+#       action: "stop"
+#   xai:
+#     - status: 400
+#       match:
+#         - "max_tokens_exceeded"
+#       action: "stop"
+
 # Optional payload configuration
 # payload:
 #   default: # Default rules only set parameters when they are missing in the payload.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -141,16 +141,21 @@ force-model-prefix: false
 # Default is false (disabled).
 passthrough-headers: false
 
-# Number of times to retry a request. Retries will occur if the HTTP response code is 403, 408, 500, 502, 503, or 504.
-# Individual API-key entries can override this via request-retry. OAuth/token JSON files can override via request_retry.
-# 0 disables retries for that credential; omit the field or set a negative value to keep this global setting.
+# Number of additional credential retry rounds after the first round exhausts
+# its eligible credentials. A value of 0 still allows the first round to try
+# multiple credentials.
+# Additional rounds apply to HTTP 403, 408, 429, 500, 502, 503, and 504 failures.
+# Individual credential/provider overrides take precedence; 0 disables additional
+# rounds, while an omitted or negative override inherits this global setting.
 request-retry: 3
 
-# Maximum number of different credentials to try for one failed request.
+# Maximum number of different credentials to try in each credential retry round.
 # Set to 0 to keep legacy behavior (try all available credentials).
 max-retry-credentials: 0
 
-# Maximum wait time in seconds for a cooled-down credential before triggering a retry.
+# Maximum cooldown wait in seconds between retry rounds.
+# Set to 0 or below to never wait for credential cooldown.
+# Retry rounds that need no wait remain controlled by request-retry.
 max-retry-interval: 30
 
 # When true, disable auth/model cooldown scheduling globally (prevents blackout windows after failure states).
@@ -309,7 +314,7 @@ nonstream-keepalive-interval: 0
 #     weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "test" # optional: require calls like "test/gemini-3-pro-preview" to target this credential
 #     disable-cooling: false # optional override: true disables cooling, false enables it; omit to inherit global
-#     request-retry: 3 # optional: per-auth override of the global request-retry; 0 disables retries; omit or set < 0 to use the global value
+#     request-retry: 3 # optional per-auth override; 0 disables additional rounds; omit or set < 0 to inherit global
 #     request-scoped-errors: # optional: custom rules to classify upstream errors by status and body patterns
 #       - status: 400        # HTTP status code to match
 #         match:             # optional: string contains matching
@@ -351,7 +356,7 @@ nonstream-keepalive-interval: 0
 #     weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "native" # optional: require calls like "native/gemini-3-pro-preview" to target this credential
 #     disable-cooling: false # optional override: true disables cooling, false enables it; omit to inherit global
-#     request-retry: 3 # optional: per-auth override of the global request-retry; 0 disables retries; omit or set < 0 to use the global value
+#     request-retry: 3 # optional per-auth override; 0 disables additional rounds; omit or set < 0 to inherit global
 #     request-scoped-errors: # optional: custom rules to classify upstream errors by status and body patterns
 #       - status: 400
 #         match:
@@ -381,7 +386,7 @@ nonstream-keepalive-interval: 0
 #     weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "test" # optional: require calls like "test/gpt-5-codex" to target this credential
 #     disable-cooling: false # optional override: true disables cooling, false enables it; omit to inherit global
-#     request-retry: 3 # optional: per-auth override of the global request-retry; 0 disables retries; omit or set < 0 to use the global value
+#     request-retry: 3 # optional per-auth override; 0 disables additional rounds; omit or set < 0 to inherit global
 #     request-scoped-errors: # optional: custom rules to classify upstream errors by status and body patterns
 #       - status: 400
 #         match:
@@ -423,7 +428,7 @@ nonstream-keepalive-interval: 0
 #     weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "xai" # optional: require calls like "xai/grok-4.5" to target this credential
 #     disable-cooling: false # optional override: true disables cooling, false enables it; omit to inherit global
-#     request-retry: 3 # optional: per-auth override of the global request-retry; 0 disables retries; omit or set < 0 to use the global value
+#     request-retry: 3 # optional per-auth override; 0 disables additional rounds; omit or set < 0 to inherit global
 #     request-scoped-errors: # optional: custom rules to classify upstream errors by status and body patterns
 #       - status: 400
 #         match:
@@ -458,7 +463,7 @@ nonstream-keepalive-interval: 0
 #     weight: 5 # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "test" # optional: require calls like "test/claude-sonnet-latest" to target this credential
 #     disable-cooling: false # optional override: true disables cooling, false enables it; omit to inherit global
-#     request-retry: 3 # optional: per-auth override of the global request-retry; 0 disables retries; omit or set < 0 to use the global value
+#     request-retry: 3 # optional per-auth override; 0 disables additional rounds; omit or set < 0 to inherit global
 #     request-scoped-errors: # optional: custom rules to classify upstream errors by status and body patterns
 #       - status: 400
 #         match:
@@ -603,7 +608,7 @@ nonstream-keepalive-interval: 0
 #     base-url: "https://openrouter.ai/api/v1" # The base URL of the provider.
 #     support-prompt-cache-key: false # optional: derive prompt_cache_key for requests from all input protocols
 #     disable-cooling: false # optional provider override: true disables cooling, false enables it; omit to inherit global
-#     request-retry: 3 # optional: per-provider override of the global request-retry; 0 disables retries; omit or set < 0 to use the global value
+#     request-retry: 3 # optional per-provider override; 0 disables additional rounds; omit or set < 0 to inherit global
 #     request-scoped-errors: # optional: custom rules to classify upstream errors by status and body patterns
 #       - status: 400
 #         match:
@@ -653,7 +658,7 @@ nonstream-keepalive-interval: 0
 #     weight: 5                                    # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "test"                              # optional: require calls like "test/vertex-pro" to target this credential
 #     disable-cooling: false                       # optional override: true disables cooling, false enables it; omit to inherit global
-#     request-retry: 3                             # optional: per-auth override of the global request-retry; 0 disables retries; omit or set < 0 to use the global value
+#     request-retry: 3                             # optional per-auth override; 0 disables additional rounds; omit or set < 0 to inherit global
 #     base-url: "https://example.com/api"         # optional, e.g. https://zenmux.ai/api; falls back to Google Vertex when omitted
 #     proxy-url: "socks5://proxy.example.com:1080" # optional per-key proxy override
 #     # proxy-url: "direct" # optional: explicit direct connect for this credential

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -142,15 +142,21 @@ force-model-prefix: false
 passthrough-headers: false
 
 # Number of additional credential retry rounds after the first round exhausts
-# its eligible credentials. A value of 0 still allows the first round to try
-# multiple credentials.
+# its eligible credentials. Round 0 is the initial round; round r only admits
+# credentials whose effective request-retry is at least r. Explicit non-negative
+# credential/provider overrides take precedence; omitted or negative overrides
+# inherit this global value, and explicit 0 only admits round 0. New CPA nodes
+# send retry_round=0 for the initial round and increment it for additional rounds;
+# legacy dispatch methods omit the field and keep old semantics.
 # Additional rounds apply to HTTP 403, 408, 429, 500, 502, 503, and 504 failures.
 # Individual credential/provider overrides take precedence; 0 disables additional
 # rounds, while an omitted or negative override inherits this global setting.
 request-retry: 3
 
-# Maximum number of different credentials to try in each credential retry round.
-# Set to 0 to keep legacy behavior (try all available credentials).
+# Maximum number of different credentials to try in each credential retry round
+# after per-credential round filtering. Set to 0 to try all available
+# credentials. Credentials skipped by this cap still age with the global round,
+# so the cap does not guarantee a fixed number of actual retries per credential.
 max-retry-credentials: 0
 
 # Maximum cooldown wait in seconds between retry rounds.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -228,6 +228,17 @@ codex:
   identity-confuse: false
   # Disable forcing the official Codex User-Agent and Originator headers on HTTP/SSE and WebSocket requests.
   disable-codex-cloaking: false
+  # Hold back the initial handshake events (response.created, response.in_progress and the
+  # websocket metadata frames) until the upstream emits its first generated event.
+  # Why: the upstream smuggles `server_is_overloaded` rejections *inside* an HTTP 200 stream,
+  # right after those handshake events, instead of returning 503 on the wire. Buffering them
+  # keeps the downstream response headers uncommitted long enough to transparently retry on
+  # another credential. Only overload/rate-limit rejections trigger failover; every other
+  # terminal failure is still delivered in-stream exactly as before.
+  # Trade-off: response headers are delayed until generation starts, which can trip client or
+  # reverse-proxy read timeouts (e.g. nginx proxy_read_timeout) on long reasoning requests.
+  # Default: false
+  stream-bootstrap-buffering: false
   # When true, optimize Codex Desktop, codex-tui, and codex_cli_rs requests for multi-agent v2.
   # This refreshes Codex spawn_agent model details, removes message parameter encryption,
   # normalizes encrypted agent_message content for Codex, and converts agent_message input

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -152,11 +152,15 @@ passthrough-headers: false
 # Omit the field to inherit this global setting; 0 or a negative value disables retries for that credential.
 request-retry: 3
 
-# Maximum number of different credentials to try for one failed request.
-# Set to 0 to keep legacy behavior (try all available credentials).
+# Maximum number of different credentials to try in each credential retry round
+# after per-credential round filtering. Set to 0 to try all available
+# credentials. Credentials skipped by this cap still age with the global round,
+# so the cap does not guarantee a fixed number of actual retries per credential.
 max-retry-credentials: 0
 
-# Maximum wait time in seconds for a cooled-down credential before triggering a retry.
+# Maximum cooldown wait in seconds between retry rounds.
+# Set to 0 or below to never wait for credential cooldown.
+# Retry rounds that need no wait remain controlled by request-retry.
 max-retry-interval: 30
 
 # When true, disable auth/model cooldown scheduling globally (prevents blackout windows after failure states).
@@ -238,6 +242,17 @@ codex:
   identity-confuse: false
   # Disable forcing the official Codex User-Agent and Originator headers on HTTP/SSE and WebSocket requests.
   disable-codex-cloaking: false
+  # Hold back the initial handshake events (response.created, response.in_progress and the
+  # websocket metadata frames) until the upstream emits its first generated event.
+  # Why: the upstream smuggles `server_is_overloaded` rejections *inside* an HTTP 200 stream,
+  # right after those handshake events, instead of returning 503 on the wire. Buffering them
+  # keeps the downstream response headers uncommitted long enough to transparently retry on
+  # another credential. Only overload/rate-limit rejections trigger failover; every other
+  # terminal failure is still delivered in-stream exactly as before.
+  # Trade-off: response headers are delayed until generation starts, which can trip client or
+  # reverse-proxy read timeouts (e.g. nginx proxy_read_timeout) on long reasoning requests.
+  # Default: false
+  stream-bootstrap-buffering: false
   # When true, optimize Codex Desktop, codex-tui, and codex_cli_rs requests for multi-agent v2.
   # This refreshes Codex spawn_agent model details, requests plaintext message arguments,
   # and converts only fully plaintext agent_message input. Opaque encrypted or mixed
@@ -786,6 +801,7 @@ nonstream-keepalive-interval: 0
 #   - api-key: "vk-123..."                        # x-goog-api-key header
 #     weight: 5                                    # optional: weighted-round-robin share; omitted defaults to 1; maximum 1,000,000
 #     prefix: "test"                              # optional: require calls like "test/vertex-pro" to target this credential
+#     disable-cooling: false                       # optional: per-auth override for auth/model cooldown scheduling
 #     request-retry: 3                             # optional: per-auth override of the global request-retry; omit to inherit global; 0 or a negative value disables retries
 #     base-url: "https://example.com/api"         # optional, e.g. https://zenmux.ai/api; falls back to Google Vertex when omitted
 #     proxy-url: "socks5://proxy.example.com:1080" # optional per-key proxy override
@@ -910,6 +926,48 @@ nonstream-keepalive-interval: 0
 #     - "kimi-k2-thinking"
 #   xai:
 #     - "grok-3-mini"
+
+# OAuth provider request-scoped error rules (custom error classification for OAuth credentials)
+# oauth-request-scoped-errors:
+#   vertex:
+#     - status: 400
+#       match:
+#         - "maximum_context_length"
+#         - "context_length_exceeded"
+#       match-regexr:
+#         - "maximum_context_length$"
+#         - "^context_length_exceeded"
+#       action: "stop" # options: "stop", "stop-and-cooldown", "continue", "continue-and-cooldown"
+#   aistudio:
+#     - status: 400
+#       match:
+#         - "invalid_argument"
+#       action: "stop"
+#   antigravity:
+#     - status: 500
+#       match:
+#         - "internal_server_error"
+#       action: "stop-and-cooldown"
+#   claude:
+#     - status: 400
+#       match:
+#         - "prompt is too long"
+#       action: "stop"
+#   codex:
+#     - status: 400
+#       match:
+#         - "context_window_exceeded"
+#       action: "stop"
+#   kimi:
+#     - status: 400
+#       match:
+#         - "length_limit"
+#       action: "stop"
+#   xai:
+#     - status: 400
+#       match:
+#         - "max_tokens_exceeded"
+#       action: "stop"
 
 # Optional payload configuration
 # payload:

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -4,7 +4,7 @@ patches:
   - id: codex-model-fallback
     reason: Codex usage-limit and model-capacity failures need an opt-in ordered model fallback after same-model credentials are exhausted, including a confirmed-usage-cooldown-only global target list when source mappings cannot deliver, while cross-model retries must not replay model-private reasoning signatures or replay a stream after client-visible delivery.
     introduced_in: 0bd5a46fd34dff4711fe5618afe66c93f316897b
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); c845ce15 consolidates Responses WebSocket fallback-turn repair and 522b4de5 improves early SSE termination errors, but neither adds typed cross-model fallback or proves a complete transcript may reset model-private reasoning continuity. LTS adapts the new transactional fallback-turn path while retaining source/target continuity gates, target-model auth reselection, failure rollback and forced replay, pre-delivery stream safety, and legacy replay migration.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); ec105dac scopes compact request faults, 4b9d404f adds opt-in same-model bootstrap failover, and 601ca430/0a14eb70 add credential retry rounds. Those changes are absorbed and composed with LTS, but they do not add typed ordered cross-model fallback, target-model auth reselection, reasoning-continuity reset gates, failure rollback, or post-delivery replay safety, so the patch remains required.
     files:
       - config.example.yaml
       - docs/lts/codex-429-resilience.md
@@ -84,7 +84,7 @@ patches:
   - id: codex-rate-limit-continuity
     reason: A fresh Codex session can receive usage_limit_reached while previously successful sessions on the same auth/model are still allowed to finish, so Core needs a bounded observation state instead of immediately suspending the auth/model for every session.
     introduced_in: 6ee281422e460ac7d5db8d69ef3fe6b49560e96a
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); 65fc536e preserves session affinity across priorities, 1674aaf4 shares canonical thinking-family cooldown state, and 8392b180 classifies connection lifecycle errors, but the v7.2.130 stream, proxy, Kimi, Multi-Agent, and header fixes do not add Healthy/FreshBlocked/ConfirmedCooldown phases, established lease plus incumbent evidence, single-canary confirmation, lifecycle invalidation, or a continuity generation guard. LTS keeps delayed final-auth publication so fallback and hedge losers cannot become the selected trace or session pin.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); 4b9d404f and 601ca430/0a14eb70 add bootstrap failover and request-scoped credential retry rounds, but they do not add Healthy/FreshBlocked/ConfirmedCooldown phases, established lease plus incumbent evidence, single-canary confirmation, lifecycle invalidation, or a continuity generation guard. LTS adapts the new retry-round contract while keeping delayed final-auth publication so fallback and hedge losers cannot become the selected trace or session pin.
     files:
       - config.example.yaml
       - docs/lts/codex-429-resilience.md
@@ -143,7 +143,7 @@ patches:
   - id: codex-interactions-service-tier-response
     reason: Codex Interactions requests can send priority service, but the shared response translator hardcodes streaming completion metadata to standard and omits the non-streaming tier instead of reporting the effective outbound or upstream tier.
     introduced_in: be649f04a4a66b952d5210c7cdf74e1d90a12b76
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); da087d7f maps Claude Code speed fast to priority requests, but the v7.2.130 stream and Responses changes still do not make the separate Codex Interactions response translator report effective service_tier for streaming, non-streaming, and DONE-fallback responses, so router-for-me/CLIProxyAPI#4189 remains only partially relevant.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); da087d7f maps Claude Code speed fast to priority requests, but the v7.2.130 stream and Responses changes still do not make the separate Codex Interactions response translator report effective service_tier for streaming, non-streaming, and DONE-fallback responses, so router-for-me/CLIProxyAPI#4189 remains only partially relevant.
     files:
       - internal/translator/codex/interactions/interactions_codex_response.go
       - internal/translator/codex/interactions/interactions_codex_test.go
@@ -174,7 +174,7 @@ patches:
   - id: plugin-configured-enable-default
     reason: A configured plugin without an explicit enabled field must inherit the enabled plugin subsystem default instead of being silently disabled during YAML parsing or runtime config synthesis.
     introduced_in: f3ff2f889026c6a28dc2d14f602c4fef108a0347
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); the v7.2.130 stream, proxy, translator, and provider fixes do not replace the configured-plugin enable default through YAML parsing and runtime host synthesis; an omitted per-plugin enabled field must still inherit true while the subsystem-level switch remains authoritative.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); the v7.2.130 stream, proxy, translator, and provider fixes do not replace the configured-plugin enable default through YAML parsing and runtime host synthesis; an omitted per-plugin enabled field must still inherit true while the subsystem-level switch remains authoritative.
     files:
       - internal/config/config.go
       - internal/config/plugin_config_test.go
@@ -191,7 +191,7 @@ patches:
   - id: home-plugin-sync-cancellation
     reason: Canceling a dedicated Home plugin-sync request must close its one-command Redis connection so a client-installed two-minute read deadline cannot overwrite an earlier cancellation deadline and stall shutdown or request cleanup.
     introduced_in: 125cd6c244f1c723781680c23e61edaa88aac5ef
-    affected_upstream_range: introduced by b651a1a8fd8ea1a43d061a08b42cef8fa3160179 and still required through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); the v7.2.130 changes do not touch Home plugin synchronization or Redis cancellation, and upstream can still install its long read deadline after the immediate cancellation deadline, which reproduced as a full two-minute stall on Linux CI.
+    affected_upstream_range: introduced by b651a1a8fd8ea1a43d061a08b42cef8fa3160179 and still required through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); the v7.2.130 changes do not touch Home plugin synchronization or Redis cancellation, and upstream can still install its long read deadline after the immediate cancellation deadline, which reproduced as a full two-minute stall on Linux CI.
     files:
       - internal/home/client.go
       - internal/home/client_test.go
@@ -206,7 +206,7 @@ patches:
   - id: codex-gpt56-ultra-level
     reason: Upstream now publishes and remotely refreshes Codex client metadata with logical Sol/Terra Ultra and Luna max-only, but it still does not provide the CPA-Core-LTS server-side capability overlay, custom-model policy, payload-override-safe wire canonicalization, usage/retry alignment, or HTTP/WebSocket enforcement. CPA-Core-LTS therefore validates the refreshed client catalog as an LTS prerequisite while retaining the downstream runtime patch.
     introduced_in: 6e12fb1dd6d522ca80a02644d286d765d7a649bd
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); upstream PR #4276 provides the revisioned Codex client catalog, while e5ea945e/7fef08ea add the separate API-key model is-compat gate. The v7.2.130 replay, session-header, Multi-Agent, and stream changes do not replace the downstream provider lookup/tier overlay, model-aware custom-model behavior, payload-override-safe final reasoning.effort, usage/retry alignment, or HTTP/WebSocket enforcement.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); upstream PR #4276 provides the revisioned Codex client catalog, while e5ea945e/7fef08ea add the separate API-key model is-compat gate. The v7.2.130 replay, session-header, Multi-Agent, and stream changes do not replace the downstream provider lookup/tier overlay, model-aware custom-model behavior, payload-override-safe final reasoning.effort, usage/retry alignment, or HTTP/WebSocket enforcement.
     files:
       - .github/scripts/refresh-model-catalogs.sh
       - .github/workflows/docker-image.yml
@@ -276,7 +276,7 @@ patches:
   - id: codex-client-media-model-visibility
     reason: Codex client catalogs must hide image and video endpoint models in both catalog builders so Codex clients do not list media-only models as normal Responses choices. Upstream v7.2.120 added Grok Imagine Video 1.5 GA to the internal/Home builder and cross-route expectation, but omitted the SDK builder that serves non-Home /v1/models?client_version.
     introduced_in: 650a98891a3ab72b9916e4f130eda66cc059e17e
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); upstream commit abaeb55bb20e9a346cae7002c2ed8af5d82c2790 updates internal/client/codex/models and the server contract test, but v7.2.130 still does not update sdk/api/handlers/openai/codex_client_models.go, leaving the GA model visible on the non-Home route.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); upstream commit abaeb55bb20e9a346cae7002c2ed8af5d82c2790 updates internal/client/codex/models and the server contract test, but v7.2.130 still does not update sdk/api/handlers/openai/codex_client_models.go, leaving the GA model visible on the non-Home route.
     files:
       - internal/api/server_test.go
       - internal/client/codex/models/models.go
@@ -290,7 +290,7 @@ patches:
   - id: codex-model-header-provider-snapshot
     reason: Codex model override headers must be resolved from the Codex provider and captured once so the real handshake and connection key cannot disagree or be shadowed by another provider registration.
     introduced_in: 0877a26d333a3be918f5e48aadf0e4d71709ab2f
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); f43aad76 preloads more Codex session headers and b08fe3b4 tracks Multi-Agent state on a raw connection, but upstream still lacks a provider-owned immutable model-header snapshot and does not include its digest and resolved model in reusable WebSocket connection identity.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); f43aad76 preloads more Codex session headers and b08fe3b4 tracks Multi-Agent state on a raw connection, but upstream still lacks a provider-owned immutable model-header snapshot and does not include its digest and resolved model in reusable WebSocket connection identity.
     files:
       - internal/runtime/executor/codex_executor.go
       - internal/runtime/executor/codex_openai_images.go
@@ -311,7 +311,7 @@ patches:
   - id: codex-oauth-client-identity-finalization
     reason: Codex OAuth requests must finalize the official Originator, User-Agent, optional Version floor, and macOS Session_id after model-specific header overrides; otherwise the backend can reject a valid model route with a misleading 404 Model not found response.
     introduced_in: ded0314d23dc38656e2fb02220504bd98373813c
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); f43aad76 normalizes Session-Id and preloads current Codex headers, but it still does not add an equivalent final OAuth client-identity pass shared by HTTP, compact, streaming, WebSocket, and image paths after model-specific overrides.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); f43aad76 normalizes Session-Id and preloads current Codex headers, but it still does not add an equivalent final OAuth client-identity pass shared by HTTP, compact, streaming, WebSocket, and image paths after model-specific overrides.
     files:
       - config.example.yaml
       - internal/runtime/executor/codex_client_identity.go
@@ -331,7 +331,7 @@ patches:
   - id: codex-client-metadata-privacy
     reason: Current Codex clients transport one canonical x-codex-turn-metadata snapshot plus flat body and direct header compatibility projections. Core must use its stable session before auth selection and rate-limit continuity while preserving explicit execution-session priority; keep off-mode bodies byte-identical, make a body canonical source suppress conflicting direct canonical headers, and project the canonical Session_id over random client fallbacks; keep image conversion from collapsing duplicate metadata carriers or reversing default/override/filter precedence; reject unsafe header projection values; fail closed on unknown startup, SDK builder, and hot-reload config values without losing the last good config; keep projections coherent after credential selection; avoid the legacy identity-confuse partial rewrite on canonical requests; offer explicit workspace passthrough/redact/drop privacy policies; strip Git remote credentials even in passthrough mode; and prevent workspace enrichment or derived identity headers from entering downstream, upstream, deferred-error, or WebSocket request logs.
     introduced_in: dcb424d4a5d666322c641151a3e37fd3b0dcc864
-    affected_upstream_range: "through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); f43aad76 usefully normalizes the official session header to Session-Id and preloads current Codex headers, while 2ab25eae removes an unsupported request field. These are compatible wire-shape fixes, not equivalents for canonical metadata authority or privacy: upstream still lacks body/direct-header conflict handling, stable pre-auth continuity, selectable workspace privacy, unconditional Git credential stripping, and workspace-aware log sanitization. LTS adopts the header spelling and unsupported-field removal while retaining canonical projection and privacy behavior."
+    affected_upstream_range: "through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); f43aad76 usefully normalizes the official session header to Session-Id and preloads current Codex headers, while 2ab25eae removes an unsupported request field. These are compatible wire-shape fixes, not equivalents for canonical metadata authority or privacy: upstream still lacks body/direct-header conflict handling, stable pre-auth continuity, selectable workspace privacy, unconditional Git credential stripping, and workspace-aware log sanitization. LTS adopts the header spelling and unsupported-field removal while retaining canonical projection and privacy behavior."
     files:
       - config.example.yaml
       - internal/api/middleware/request_logging.go
@@ -429,7 +429,7 @@ patches:
   - id: codex-model-not-found-request-scope
     reason: An OpenAI-style 404 with error.type invalid_request_error and error.param model is a request/model routing failure, not evidence of unhealthy Codex credentials; retrying every auth or applying the generic 12-hour model cooldown can suspend the entire model pool.
     introduced_in: ded0314d23dc38656e2fb02220504bd98373813c
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); fe28d582/b148af80 improve unknown-route model errors and c1d69e7b/579f5e30 generalize client-fault handling, but v7.2.130 regular Codex execution still does not recognize the OpenAI-style invalid_request_error model 404. The 579f5e30 generic classifier removed this narrower LTS case and failed the listed cooldown regression until restored, so the patch remains required.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); ec105dac correctly scopes ordinary compact request faults, but regular Codex execution still does not recognize the OpenAI-style invalid_request_error model 404. The narrower LTS request-scope classifier and its cooldown regression therefore remain required.
     files:
       - sdk/cliproxy/auth/conductor.go
       - sdk/cliproxy/auth/conductor_overrides_test.go
@@ -445,7 +445,7 @@ patches:
   - id: codex-websocket-reader-generation
     reason: Reusable Codex WebSocket sessions need generation ownership so a stale reader or shutdown race cannot deliver to, clear, close, or deadlock a newer request.
     introduced_in: 0877a26d333a3be918f5e48aadf0e4d71709ab2f
-    affected_upstream_range: "through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); b08fe3b4 and 133047de add per-connection Multi-Agent optimization state and clear it on namespace conflicts, but upstream still has only raw-connection ownership. LTS integrates that state into its generation-safe connection lifecycle and clears it on replacement, detach, invalidation, and session close while retaining atomic reader/request ownership, request-owned cancellation, retry rebinding, and stale-reader protection."
+    affected_upstream_range: "through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); 4b9d404f adds WebSocket bootstrap buffering on top of upstream raw-connection ownership, but it does not add generation-safe reader/request ownership. LTS composes the bootstrap path with replacement, detach, invalidation, session-close, request-owned cancellation, retry-rebinding, and stale-reader guards, so the patch remains required."
     files:
       - internal/runtime/executor/codex_websockets_executor.go
       - internal/runtime/executor/codex_websockets_executor_test.go
@@ -469,7 +469,7 @@ patches:
   - id: codex-spark-reasoning-summary-compat
     reason: GPT-5.3-Codex-Spark needs reasoning effort enabled but its upstream rejects reasoning.summary, so Core must remove only that unsupported field after final payload shaping across HTTP and WebSocket transports.
     introduced_in: 37e306f939e8ef363254a49cdc7f924a6ceceff5
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); f43aad76 and 2ab25eae normalize headers and unsupported cache options, while 6710a5af forwards sequential-cutoff summaries, but upstream still forwards reasoning.summary for gpt-5.3-codex-spark and has no equivalent post-override HTTP/WebSocket sanitization. LTS applies the sanitizer after optimized model mutation on every transport.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); f43aad76 and 2ab25eae normalize headers and unsupported cache options, while 6710a5af forwards sequential-cutoff summaries, but upstream still forwards reasoning.summary for gpt-5.3-codex-spark and has no equivalent post-override HTTP/WebSocket sanitization. LTS applies the sanitizer after optimized model mutation on every transport.
     files:
       - internal/runtime/executor/codex_executor.go
       - internal/runtime/executor/codex_websockets_executor.go
@@ -493,7 +493,7 @@ patches:
   - id: xai-explicit-tool-choice-none
     reason: xAI request preparation must not grant native x_search when the client declared no tools or a restricted allowlist; explicit tool_choice none must remain intact, an orphaned restriction must fail closed instead of reverting to auto, parallel_tool_calls must be removed when no tools survive, and custom declarations and choices must be canonicalized together before orphan pruning.
     introduced_in: ad7244752d324a5b179c3e30a628acf976fa995c
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); a6825fe9 correctly rewrites an explicitly forced web_search choice into xAI's allowed_tools shape, but the v7.2.130 changes do not alter xAI authorization. Upstream still injects x_search without explicit client authorization; LTS preserves only client-declared tools, explicit none, fail-closed allowlists, and canonicalized choices.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); a6825fe9 correctly rewrites an explicitly forced web_search choice into xAI's allowed_tools shape, but the v7.2.130 changes do not alter xAI authorization. Upstream still injects x_search without explicit client authorization; LTS preserves only client-declared tools, explicit none, fail-closed allowlists, and canonicalized choices.
     files:
       - internal/runtime/executor/xai_executor.go
       - internal/runtime/executor/xai_executor_test.go
@@ -511,7 +511,7 @@ patches:
   - id: kimi-claude-delegated-auth-immutability
     reason: Kimi delegates Claude-format requests to the Claude executor, but the selected Auth attributes are shared immutable credential configuration and must not be mutated per request to install the Kimi messages base URL.
     introduced_in: 772915acb699d8c6b6f6d8f9c51c1b4f3a61cf34
-    affected_upstream_range: 'introduced by 70c4bd78b2bc347bf988f74f2d2d7da85de5aa13 and still required through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); a2337beb correctly chooses the Kimi source format from the delegated path, but it does not make the selected credential request-local. Upstream still writes auth.Attributes["base_url"] directly in Execute, ExecuteStream, and CountTokens, which can panic for a nil map, race across concurrent requests, and persist a request-local route into shared auth state. LTS absorbs the source-format fix on top of its cloned auth view.'
+    affected_upstream_range: 'introduced by 70c4bd78b2bc347bf988f74f2d2d7da85de5aa13 and still required through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); a2337beb correctly chooses the Kimi source format from the delegated path, but it does not make the selected credential request-local. Upstream still writes auth.Attributes["base_url"] directly in Execute, ExecuteStream, and CountTokens, which can panic for a nil map, race across concurrent requests, and persist a request-local route into shared auth state. LTS absorbs the source-format fix on top of its cloned auth view.'
     files:
       - internal/runtime/executor/kimi_executor.go
       - internal/runtime/executor/kimi_executor_test.go
@@ -524,7 +524,7 @@ patches:
   - id: request-body-panic-tempfile-cleanup
     reason: This historical patch originally closed a panic-path temporary-file leak in error-only request logging. CPA-Core-LTS now removes that request-body tempfile spool entirely, keeps only bounded in-memory request/response/upstream previews, and still requires middleware-owned unwind cleanup so panic and http.ErrAbortHandler paths close the original body and release retained buffers.
     introduced_in: ad7244752d324a5b179c3e30a628acf976fa995c
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); the v7.2.130 stream, WebSocket, translator, proxy, and provider changes do not alter request-log body ownership; upstream still spools large error-only bodies to temporary files, retains larger deferred upstream bodies, and performs cleanup only from the response finalizer.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); the v7.2.130 stream, WebSocket, translator, proxy, and provider changes do not alter request-log body ownership; upstream still spools large error-only bodies to temporary files, retains larger deferred upstream bodies, and performs cleanup only from the response finalizer.
     files:
       - internal/api/middleware/request_logging.go
       - internal/api/middleware/request_logging_test.go
@@ -546,7 +546,7 @@ patches:
   - id: api-request-body-size-limit
     reason: Public Claude, Gemini, OpenAI, Responses, image, and video JSON handlers previously used unbounded body reads and unbounded zstd expansion, so a small number of concurrent oversized requests could consume container memory before provider routing or normal validation ran.
     introduced_in: b2b593fad3f18bfe700fe5f11d4e88e10bbc7f16
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); the no-copy work in 34364fff/c30e60a1/b7a44152 and the v7.2.130 Responses handler refactor reduce amplification but are not a decoded-body limit. Upstream handlers still use unbounded GetRawData/io.ReadAll behavior and do not enforce the same limit on every decoded Content-Encoding layer.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); the no-copy work in 34364fff/c30e60a1/b7a44152 and the v7.2.130 Responses handler refactor reduce amplification but are not a decoded-body limit. Upstream handlers still use unbounded GetRawData/io.ReadAll behavior and do not enforce the same limit on every decoded Content-Encoding layer.
     files:
       - sdk/api/handlers/request_body.go
       - sdk/api/handlers/request_body_test.go
@@ -568,7 +568,7 @@ patches:
   - id: object-store-auth-path-containment
     reason: Object-store auth persistence must never create, overwrite, upload, delete, or render credential files outside its managed private roots, including traversal, sibling-prefix, absolute-path, pre-existing or dangling symlinks, junctions, initialized-root replacement, check/write path-swap races, and crash-persistent global-temp copies.
     introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); the v7.2.130 changes do not touch object-store path handling. Upstream still accepts caller-provided absolute auth paths and computes object keys from unchecked filepath.Rel results, so paths outside the mirror can reach local file and remote object operations.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); the v7.2.130 changes do not touch object-store path handling. Upstream still accepts caller-provided absolute auth paths and computes object keys from unchecked filepath.Rel results, so paths outside the mirror can reach local file and remote object operations.
     files:
       - .github/workflows/pr-test-build.yml
       - internal/store/objectstore.go
@@ -614,7 +614,7 @@ patches:
   - id: auth-token-private-file-permissions
     reason: OAuth tokens and service-account credentials must be created with owner-only permissions and must tighten pre-existing wider files before replacing their contents.
     introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); the v7.2.130 provider changes do not alter token persistence. Claude, Codex, Kimi, Vertex, and xAI token writers still use os.Create, which follows umask for new files and preserves wider permissions on existing files.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); the v7.2.130 provider changes do not alter token persistence. Claude, Codex, Kimi, Vertex, and xAI token writers still use os.Create, which follows umask for new files and preserves wider permissions on existing files.
     files:
       - .github/workflows/pr-test-build.yml
       - internal/misc/credential_file.go
@@ -642,7 +642,7 @@ patches:
   - id: auth-store-list-error-propagation
     reason: A damaged or unreadable auth JSON file must fail Store.List instead of silently removing that credential from routing, fallback, and usage attribution while startup reports success.
     introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); the v7.2.130 changes do not touch FileTokenStore.List. Upstream still expects it to silently skip an invalid persisted plugin source; LTS keeps fail-closed list error propagation so damaged JSON, parser failures, and invalid weights cannot silently remove credentials from routing and attribution.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); the v7.2.130 changes do not touch FileTokenStore.List. Upstream still expects it to silently skip an invalid persisted plugin source; LTS keeps fail-closed list error propagation so damaged JSON, parser failures, and invalid weights cannot silently remove credentials from routing and attribution.
     files:
       - internal/store/gitstore.go
       - internal/store/gitstore_test.go
@@ -665,7 +665,7 @@ patches:
   - id: auth-store-metadata-hydration
     reason: Initial File, Git, Object, and Postgres store loading must hydrate the same normalized auth prefix, custom headers, and disabled state as watcher synthesis so prefixed model routing and Management auth-file output do not change after a reload event.
     introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); the request-scoped Management proxy addition does not change auth metadata hydration. Upstream initial Store.List paths still apply partial metadata and the Management auth-file response omits Auth.Prefix.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); the request-scoped Management proxy addition does not change auth metadata hydration. Upstream initial Store.List paths still apply partial metadata and the Management auth-file response omits Auth.Prefix.
     files:
       - sdk/cliproxy/auth/metadata_hydrate.go
       - sdk/cliproxy/auth/metadata_hydrate_test.go
@@ -698,7 +698,7 @@ patches:
   - id: panel-release-token-isolation
     reason: Management panel release lookups must authorize only exact HTTPS GitHub release URLs and should use a dedicated panel token while retaining a guarded legacy GitStore fallback.
     introduced_in: 177978c4a9fbaf3669c6b2f0c2d5faad19682bf8
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); the v7.2.130 changes do not touch panel asset retrieval. Upstream still decides whether to attach GITSTORE_GIT_TOKEN from the GitStore URL rather than the actual release URL and has no dedicated panel release token.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); the v7.2.130 changes do not touch panel asset retrieval. Upstream still decides whether to attach GITSTORE_GIT_TOKEN from the GitStore URL rather than the actual release URL and has no dedicated panel release token.
     files:
       - .env.example
       - internal/managementasset/updater.go
@@ -715,7 +715,7 @@ patches:
   - id: gemini-unknown-method-not-found
     reason: Gemini-compatible routes must reject unknown RPC method suffixes with a stable 404 invalid_request_error before reading the request body, instead of consuming the body and falling through to generateContent behavior.
     introduced_in: 6b0f185939f914983514d6a5e62378a8d91164e7
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); the v7.2.130 changes do not touch Gemini route dispatch. Upstream still sends every non-stream and non-count suffix through generateContent and has no method allowlist before body decoding.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); the v7.2.130 changes do not touch Gemini route dispatch. Upstream still sends every non-stream and non-count suffix through generateContent and has no method allowlist before body decoding.
     files:
       - sdk/api/handlers/gemini/gemini_handlers.go
       - sdk/api/handlers/gemini/gemini_handlers_test.go
@@ -728,7 +728,7 @@ patches:
   - id: count-tokens-not-found-no-cooldown
     reason: A provider-specific count_tokens endpoint can be absent even when normal generation works, so its 404 must still record the failed request and publish hooks while remaining request-scoped and allowing another credential to serve the count request.
     introduced_in: 6b0f185939f914983514d6a5e62378a8d91164e7
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); 36ed0ca5/issue #4410 and c1d69e7b/579f5e30 remain only partial equivalents. The v7.2.130 changes do not add the LTS count_tokens generic-route-404 versus explicit-model-miss scope, failure publication, and credential-fallback combination, so genuine model availability errors remain distinct.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); 36ed0ca5/issue #4410 and c1d69e7b/579f5e30 remain only partial equivalents. The v7.2.130 changes do not add the LTS count_tokens generic-route-404 versus explicit-model-miss scope, failure publication, and credential-fallback combination, so genuine model availability errors remain distinct.
     files:
       - sdk/cliproxy/auth/conductor.go
       - sdk/cliproxy/auth/conductor_overrides_test.go
@@ -744,7 +744,7 @@ patches:
   - id: management-logs-bounded-response
     reason: Management log reads need a bounded default and maximum response size without breaking Panel and TUI limits or silently skipping legacy after deltas that exceed one page.
     introduced_in: 6b0f185939f914983514d6a5e62378a8d91164e7
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); 17a479a8 adds an APICall proxy override but does not change log reads. Upstream still leaves an omitted limit unbounded and does not clamp oversized limits or provide lossless bounded pagination for legacy after reads.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); 17a479a8 adds an APICall proxy override but does not change log reads. Upstream still leaves an omitted limit unbounded and does not clamp oversized limits or provide lossless bounded pagination for legacy after reads.
     files:
       - internal/api/handlers/management/logs.go
       - internal/api/handlers/management/logs_test.go
@@ -761,7 +761,7 @@ patches:
   - id: transient-eof-cooldown
     reason: Transport EOF and unexpected EOF failures before successful completion indicate a transient upstream path failure and need a bounded 502 cooldown, including stream bootstrap, post-payload accounting, and wsrelay errors that have lost the standard-library sentinel identity.
     introduced_in: 6b0f185939f914983514d6a5e62378a8d91164e7
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); 522b4de5 improves premature SSE termination emission but does not replace auth cooldown classification, while 8392b180 still conflicts by skipping cooldown for terminal EOF/UnexpectedEOF. LTS keeps context cancellation and normal closes cooldown-free while preserving transient 502 cooldown for terminal EOF paths.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); 4b9d404f improves opt-in Codex bootstrap failure delivery but does not replace auth cooldown classification for terminal EOF/UnexpectedEOF across transports. LTS keeps context cancellation and normal closes cooldown-free while preserving transient 502 cooldown for terminal EOF paths.
     files:
       - internal/runtime/executor/aistudio_executor.go
       - sdk/cliproxy/auth/conductor.go
@@ -777,7 +777,7 @@ patches:
   - id: expired-availability-pruning
     reason: Expired auth and model cooldown state must be pruned before Management availability is displayed so runtime routing, registry state, scheduler state, and persisted cooldown snapshots converge, while future, zero-deadline, disabled, Cloudflare, and independent auth-level warnings remain intact.
     introduced_in: 6b0f185939f914983514d6a5e62378a8d91164e7
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); 17a479a8 adds an APICall proxy override but no expired-availability pruning. Upstream still does not reconcile manager, model registry, scheduler, and cooldown-store state while separating independent auth-level warnings from model aggregates.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); 17a479a8 adds an APICall proxy override but no expired-availability pruning. Upstream still does not reconcile manager, model registry, scheduler, and cooldown-store state while separating independent auth-level warnings from model aggregates.
     files:
       - internal/api/handlers/management/auth_files.go
       - internal/api/handlers/management/auth_files_recent_requests_test.go
@@ -798,7 +798,7 @@ patches:
   - id: responses-chat-tool-call-turn-grouping
     reason: Reasoning, assistant text, or omitted assistant-side Responses items interleaved between consecutive function_call/custom_tool_call items must not split one assistant turn into adjacent assistant(tool_calls) messages. Kimi-style strict Chat Completions upstreams reject that shape with HTTP 400 ("assistant message with 'tool_calls' must be followed by tool messages"), permanently blocking affected Codex multi-agent histories routed through those upstreams. The related closed report focused on id pairing while the remaining defect is turn grouping, so LTS keeps the fix as a downstream patch.
     introduced_in: 12b542a201b1f8d083ada591cdb7687a7281b0a8
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); c845ce15 refactors downstream Responses WebSocket transcript repair and 522b4de5 improves terminal streaming errors, but neither changes the Responses-to-Chat request converter. Upstream still splits calls separated by reasoning, assistant text, or ignored assistant-side items, so LTS retains output-boundary grouping and user/developer turn boundaries.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); c845ce15 refactors downstream Responses WebSocket transcript repair and 522b4de5 improves terminal streaming errors, but neither changes the Responses-to-Chat request converter. Upstream still splits calls separated by reasoning, assistant text, or ignored assistant-side items, so LTS retains output-boundary grouping and user/developer turn boundaries.
     files:
       - docs/lts/downstream-patches.yaml
       - internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -819,7 +819,7 @@ patches:
   - id: codex-desktop-tool-overlay
     reason: Codex Desktop registers deferred codex_app handlers that are not present in the Direct tool surface sent to third-party Responses models, so those models cannot read or coordinate existing Desktop tasks even though the app already owns the handlers. LTS therefore provides a default-off, fixed-version projection that adds only explicitly configured codex_app children after auth selection, only for provable root Desktop turns on non-GPT models, and preserves the existing provider namespace round trip without executing any app operation inside CPA.
     introduced_in: b052097362ef63bd35329c8b18d73c651078e85d
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); b08fe3b4 and 133047de improve collaboration namespace continuity but do not project missing codex_app children into eligible third-party Direct requests. LTS still needs its model, UA, root-turn, tool-surface, configuration, GPT, and subagent isolation gates.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); b08fe3b4 and 133047de improve collaboration namespace continuity but do not project missing codex_app children into eligible third-party Direct requests. LTS still needs its model, UA, root-turn, tool-surface, configuration, GPT, and subagent isolation gates.
     files:
       - config.example.yaml
       - docs/lts/downstream-patches.yaml
@@ -868,7 +868,7 @@ patches:
   - id: codex-multi-agent-plaintext-contract
     reason: Codex Multi-Agent history and message-tool schemas carry plaintext provenance that must not be inferred from an encrypted_content string or an unqualified short tool name. LTS therefore converts agent_message only when every content part is a non-empty string input_text, preserves opaque or mixed history on native Codex and provider paths, and removes only a JSON boolean-true message.encrypted marker from positively identified collaboration, collaboration-optimize, or complete agents namespaces.
     introduced_in: 798ad1854064361461225fe766db9b2f54a7653d
-    affected_upstream_range: "through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); b08fe3b4 and 133047de preserve the optimized namespace across incremental WebSocket turns and correctly clear that connection state when a request defines the reserved namespace. They improve transport continuity but do not change plaintext provenance: upstream still treats string encrypted_content as portable, recursively matches unrelated short tool names, and removes message.encrypted without requiring JSON boolean true. LTS adapts the new connection-state behavior while retaining proven-plaintext, confirmed-namespace, boolean-marker, and opaque/mixed-content fail-closed rules."
+    affected_upstream_range: "through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); b08fe3b4 and 133047de preserve the optimized namespace across incremental WebSocket turns and correctly clear that connection state when a request defines the reserved namespace. They improve transport continuity but do not change plaintext provenance: upstream still treats string encrypted_content as portable, recursively matches unrelated short tool names, and removes message.encrypted without requiring JSON boolean true. LTS adapts the new connection-state behavior while retaining proven-plaintext, confirmed-namespace, boolean-marker, and opaque/mixed-content fail-closed rules."
     files:
       - config.example.yaml
       - docs/lts/downstream-patches.yaml
@@ -902,7 +902,7 @@ patches:
   - id: xai-multi-agent-plaintext-provenance
     reason: xAI requires namespace tools to be flattened and cannot consume the Codex message.encrypted schema marker, while the returning Codex client needs encrypted_function_args to distinguish a plaintext Multi-Agent call. LTS therefore records the exact root or additional_tools function declarations whose boolean-true marker was removed, restores namespace and short name first, then adds encrypted_function_args as an empty array only for response calls matching that request provenance across HTTP non-stream, SSE, and WebSocket.
     introduced_in: 23caefe8b2495856c2c8df50b63823846ad6b910
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); b08fe3b4 and 133047de improve Codex WebSocket namespace continuity, not xAI response provenance. Upstream xAI handling still does not derive before/after plaintext provenance from the Multi-Agent schema rewrite or restore encrypted_function_args on HTTP, SSE, and WebSocket responses.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); b08fe3b4 and 133047de improve Codex WebSocket namespace continuity, not xAI response provenance. Upstream xAI handling still does not derive before/after plaintext provenance from the Multi-Agent schema rewrite or restore encrypted_function_args on HTTP, SSE, and WebSocket responses.
     files:
       - docs/lts/downstream-patches.yaml
       - internal/runtime/executor/xai_executor_execute.go
@@ -926,7 +926,7 @@ patches:
   - id: provider-runtime-state-isolation
     reason: Runtime state belongs to one concrete auth provider generation and must not leak across same-ID provider replacement. Codex transient rate limits must remain distinct from quota exhaustion, non-buffering streams must not fail after delivering visible deltas merely because optional completion reconstruction exceeds its cap, and thinking-suffix cooldown reconciliation must restore only the intended concrete registry IDs without racing a newer success.
     introduced_in: e97ccfb8b41e0874745d807d6c1434bcf572840f
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); 522b4de5 improves terminal stream errors but does not isolate provider generations or rate-limit state. Upstream still caps non-buffering reconstruction, treats raw Codex rate_limit_error/rate_limit_exceeded 429s as quota, restores canonicalized cooldowns to the wrong concrete registry ID, and inherits state across same-ID provider replacement; LTS keeps exact suffix keys and generation-aware reconciliation.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); 4b9d404f handles opt-in pre-delivery bootstrap overloads, but it does not protect non-buffering delivered streams, distinguish transient rate limits from quota, or isolate runtime state across same-ID provider replacement. LTS composes bootstrap buffering with exact suffix keys, bounded reconstruction, and generation-aware reconciliation, so the patch remains required.
     files:
       - docs/lts/downstream-patches.yaml
       - internal/runtime/executor/codex_abnormal_reasoning_retry_test.go
@@ -970,7 +970,7 @@ patches:
   - id: auth-provider-generation-fence
     reason: Auth IDs are stable across watcher refreshes and can be reused after provider replacement or remove-and-register. An execution, stream, token count, request-auth preparation, or credential refresh that started on the previous lifecycle could therefore write quota, health, token, runtime, scheduler, registry, or persisted cooldown state into the replacement auth. LTS assigns a process-local, non-persisted generation to each auth lifecycle, carries it through every managed request path, and accepts writebacks only when both generation and provider still match.
     introduced_in: 7db4a30d3c7b489503873df855146ad911bec117
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); the request-scoped proxy, Kimi format, stream, namespace, and header fixes do not carry a per-auth lifecycle generation through execution or reject stale provider writebacks. Upstream still keys asynchronous result, preparation, and refresh writebacks only by auth ID and accepts persisted or refreshed state from a same-ID replacement provider.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); 601ca430/0a14eb70 add execution, stream, and Home retry-round paths, but still carry no per-auth lifecycle generation and reject no stale provider writeback. LTS threads the existing generation fence through the adapted retry paths, so the patch remains required.
     files:
       - docs/lts/downstream-patches.yaml
       - sdk/cliproxy/auth/conductor.go
@@ -1004,7 +1004,7 @@ patches:
   - id: codex-live-bootstrap-accounting-and-egress
     reason: Codex Live bootstrap SDP carries short-lived ICE credentials that must never enter request logs, while every actual bootstrap dispatch still needs zero-token usage attribution and local auth outcome tracking. Live and sideband also require model-scoped OAuth selection for models intentionally absent from the general proxy catalog, confirm/mark/abandon lifecycle coverage, Home retry attempt accounting without duplicate 401 records, in-memory config validation parity, and fail-closed sideband proxy handling.
     introduced_in: 4534eed92ef5cd639b377a17dd56dad2d9e41f70
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); v7.2.130 does not touch the Realtime live client. The bd34ceca direct WebSocket and hangup paths therefore still rely on the LTS adaptation for uncatalogued-model continuity, confirm/mark/abandon lifecycle, zero-token usage reporting, SDP-safe logging, Home retry accounting, config validation parity, and fail-closed proxy behavior.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); v7.2.130 does not touch the Realtime live client. The bd34ceca direct WebSocket and hangup paths therefore still rely on the LTS adaptation for uncatalogued-model continuity, confirm/mark/abandon lifecycle, zero-token usage reporting, SDP-safe logging, Home retry accounting, config validation parity, and fail-closed proxy behavior.
     files:
       - docs/lts/downstream-patches.yaml
       - internal/client/codex/live/live.go
@@ -1035,7 +1035,7 @@ patches:
   - id: xai-implicit-responses-message-token-accounting
     reason: OpenAI Responses permits message-shaped input items with role/content and no explicit type, and xAI local token estimation must include their content instead of silently undercounting the request.
     introduced_in: 4534eed92ef5cd639b377a17dd56dad2d9e41f70
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); the v7.2.130 changes do not touch xAI token collection, which still dispatches only on an explicit input item type and ignores ordinary untyped role/content messages.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); the v7.2.130 changes do not touch xAI token collection, which still dispatches only on an explicit input item type and ignores ordinary untyped role/content messages.
     files:
       - docs/lts/downstream-patches.yaml
       - internal/runtime/executor/xai_executor_test.go
@@ -1049,7 +1049,7 @@ patches:
   - id: xai-websocket-saturated-reader-invalidation
     reason: A terminal xAI WebSocket reader cannot enqueue its error when the active request channel is full; invalidation must cancel the active reader before the terminal sender waits, otherwise the reader and request can deadlock indefinitely.
     introduced_in: 4534eed92ef5cd639b377a17dd56dad2d9e41f70
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); the Codex Multi-Agent WebSocket changes do not modify xAI reader invalidation. Upstream still does not cancel the active read lifecycle when invalidating a saturated shared xAI WebSocket connection.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); the Codex Multi-Agent WebSocket changes do not modify xAI reader invalidation. Upstream still does not cancel the active read lifecycle when invalidating a saturated shared xAI WebSocket connection.
     files:
       - docs/lts/downstream-patches.yaml
       - internal/runtime/executor/codex_websockets_session.go
@@ -1064,7 +1064,7 @@ patches:
   - id: xai-model-bad-credentials-auth-normalization
     reason: xAI model-scoped 403 bad-credentials failures normalize the model error to unauthorized, and the auth-level LastError snapshot must use the same code so refresh and availability decisions do not continue treating the credential as an ordinary 403.
     introduced_in: 4534eed92ef5cd639b377a17dd56dad2d9e41f70
-    affected_upstream_range: through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); dd67f56f remains a partial equivalent that remaps xAI HTTP/WebSocket bad-credentials 403 responses, while v7.2.130 still does not guarantee that the auth-level LastError snapshot uses the same normalized code as the model state.
+    affected_upstream_range: through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); dd67f56f remains a partial equivalent that remaps xAI HTTP/WebSocket bad-credentials 403 responses, while v7.2.130 still does not guarantee that the auth-level LastError snapshot uses the same normalized code as the model state.
     files:
       - docs/lts/downstream-patches.yaml
       - sdk/cliproxy/auth/conductor_cooldown.go
@@ -1079,7 +1079,7 @@ patches:
   - id: dynamic-custom-header-transport-coverage
     reason: Configured custom header values that reference downstream headers must resolve on every documented transport; otherwise Claude caller-owned requests and Codex direct image requests silently omit the configured header while other Claude and Codex paths forward it.
     introduced_in: 49c4771ff6404c20678979a3a7d76730c38a4434
-    affected_upstream_range: introduced by e424bfad00a6a2c3c8a501cf4951d9849fd1c10c and still required through 55397bf68d01a99dc8fd523fe56719857afd579c (post-v7.2.136, 2026-08-19); upstream main omits incoming headers in the Claude caller-owned branch and from both Codex direct image call sites. Upstream dev commit 5fef17e2ecd1b68a94e297cfc24f4ac3859e2593 fixes only the Claude branch and is not part of the protected main baseline.
+    affected_upstream_range: introduced by e424bfad00a6a2c3c8a501cf4951d9849fd1c10c and still required through a834917e871d85d7fd9e49eaa590d1dfd4159f2a (post-v7.2.139, 2026-08-22); 5fef17e2 is now in the protected baseline and provides the Claude caller-owned half of the fix. Both Codex direct image call sites still omit incoming headers, so this is only a partial upstream equivalent and the patch cannot become removable or retired.
     files:
       - docs/lts/downstream-patches.yaml
       - internal/runtime/executor/claude_executor_request.go

--- a/internal/api/handlers/management/config_apikey_disable.go
+++ b/internal/api/handlers/management/config_apikey_disable.go
@@ -43,7 +43,14 @@ func toggleConfigAPIKeyExcludedAll(cfg *config.Config, auth *coreauth.Auth, disa
 
 	for i := range cfg.GeminiKey {
 		entry := &cfg.GeminiKey[i]
-		id, _ := idGen.Next("gemini:apikey", entry.APIKey, entry.BaseURL)
+		key := strings.TrimSpace(entry.APIKey)
+		base := strings.TrimSpace(entry.BaseURL)
+		proxyURL := strings.TrimSpace(entry.ProxyURL)
+		prefix := strings.TrimSpace(entry.Prefix)
+		if key == "" && base == "" {
+			continue
+		}
+		id, _ := idGen.Next("gemini:apikey", key, base, proxyURL, prefix, config.FormatSortedHeaders(entry.Headers))
 		if id == authID {
 			entry.ExcludedModels = setConfigAPIKeyExcludedAll(entry.ExcludedModels, disable)
 			return true, nil
@@ -51,7 +58,14 @@ func toggleConfigAPIKeyExcludedAll(cfg *config.Config, auth *coreauth.Auth, disa
 	}
 	for i := range cfg.InteractionsKey {
 		entry := &cfg.InteractionsKey[i]
-		id, _ := idGen.Next("gemini-interactions:apikey", entry.APIKey, entry.BaseURL)
+		key := strings.TrimSpace(entry.APIKey)
+		base := strings.TrimSpace(entry.BaseURL)
+		proxyURL := strings.TrimSpace(entry.ProxyURL)
+		prefix := strings.TrimSpace(entry.Prefix)
+		if key == "" && base == "" {
+			continue
+		}
+		id, _ := idGen.Next("gemini-interactions:apikey", key, base, proxyURL, prefix, config.FormatSortedHeaders(entry.Headers))
 		if id == authID {
 			entry.ExcludedModels = setConfigAPIKeyExcludedAll(entry.ExcludedModels, disable)
 			return true, nil
@@ -59,7 +73,14 @@ func toggleConfigAPIKeyExcludedAll(cfg *config.Config, auth *coreauth.Auth, disa
 	}
 	for i := range cfg.ClaudeKey {
 		entry := &cfg.ClaudeKey[i]
-		id, _ := idGen.Next("claude:apikey", entry.APIKey, entry.BaseURL)
+		key := strings.TrimSpace(entry.APIKey)
+		base := strings.TrimSpace(entry.BaseURL)
+		proxyURL := strings.TrimSpace(entry.ProxyURL)
+		prefix := strings.TrimSpace(entry.Prefix)
+		if key == "" && base == "" {
+			continue
+		}
+		id, _ := idGen.Next("claude:apikey", key, base, proxyURL, prefix, config.FormatSortedHeaders(entry.Headers))
 		if id == authID {
 			entry.ExcludedModels = setConfigAPIKeyExcludedAll(entry.ExcludedModels, disable)
 			return true, nil
@@ -67,7 +88,14 @@ func toggleConfigAPIKeyExcludedAll(cfg *config.Config, auth *coreauth.Auth, disa
 	}
 	for i := range cfg.CodexKey {
 		entry := &cfg.CodexKey[i]
-		id, _ := idGen.Next("codex:apikey", entry.APIKey, entry.BaseURL)
+		key := strings.TrimSpace(entry.APIKey)
+		base := strings.TrimSpace(entry.BaseURL)
+		proxyURL := strings.TrimSpace(entry.ProxyURL)
+		prefix := strings.TrimSpace(entry.Prefix)
+		if key == "" && base == "" {
+			continue
+		}
+		id, _ := idGen.Next("codex:apikey", key, base, proxyURL, prefix, config.FormatSortedHeaders(entry.Headers))
 		if id == authID {
 			entry.ExcludedModels = setConfigAPIKeyExcludedAll(entry.ExcludedModels, disable)
 			return true, nil
@@ -75,7 +103,14 @@ func toggleConfigAPIKeyExcludedAll(cfg *config.Config, auth *coreauth.Auth, disa
 	}
 	for i := range cfg.XAIKey {
 		entry := &cfg.XAIKey[i]
-		id, _ := idGen.Next("xai:apikey", entry.APIKey, entry.BaseURL)
+		key := strings.TrimSpace(entry.APIKey)
+		base := strings.TrimSpace(entry.BaseURL)
+		proxyURL := strings.TrimSpace(entry.ProxyURL)
+		prefix := strings.TrimSpace(entry.Prefix)
+		if key == "" && base == "" {
+			continue
+		}
+		id, _ := idGen.Next("xai:apikey", key, base, proxyURL, prefix, config.FormatSortedHeaders(entry.Headers))
 		if id == authID {
 			entry.ExcludedModels = setConfigAPIKeyExcludedAll(entry.ExcludedModels, disable)
 			return true, nil
@@ -83,7 +118,10 @@ func toggleConfigAPIKeyExcludedAll(cfg *config.Config, auth *coreauth.Auth, disa
 	}
 	for i := range cfg.VertexCompatAPIKey {
 		entry := &cfg.VertexCompatAPIKey[i]
-		id, _ := idGen.Next("vertex:apikey", entry.APIKey, entry.BaseURL, entry.ProxyURL)
+		key := strings.TrimSpace(entry.APIKey)
+		base := strings.TrimSpace(entry.BaseURL)
+		proxy := strings.TrimSpace(entry.ProxyURL)
+		id, _ := idGen.Next("vertex:apikey", key, base, proxy)
 		if id == authID {
 			entry.ExcludedModels = setConfigAPIKeyExcludedAll(entry.ExcludedModels, disable)
 			return true, nil

--- a/internal/api/handlers/management/config_apikey_disable_test.go
+++ b/internal/api/handlers/management/config_apikey_disable_test.go
@@ -27,7 +27,7 @@ func TestToggleConfigAPIKeyExcludedAll_XAI(t *testing.T) {
 		}},
 	}
 	idGen := synthesizer.NewStableIDGenerator()
-	authID, _ := idGen.Next("xai:apikey", "xai-test", "https://api.x.ai/v1")
+	authID, _ := idGen.Next("xai:apikey", "xai-test", "https://api.x.ai/v1", "", "", "")
 	auth := &coreauth.Auth{
 		ID:       authID,
 		Provider: "xai",
@@ -55,7 +55,7 @@ func TestToggleConfigAPIKeyExcludedAll_Codex(t *testing.T) {
 		}},
 	}
 	idGen := synthesizer.NewStableIDGenerator()
-	authID, _ := idGen.Next("codex:apikey", "sk-test", "https://example.com/v1")
+	authID, _ := idGen.Next("codex:apikey", "sk-test", "https://example.com/v1", "", "", "")
 	auth := &coreauth.Auth{
 		ID:       authID,
 		Provider: "codex",
@@ -80,5 +80,83 @@ func TestToggleConfigAPIKeyExcludedAll_Codex(t *testing.T) {
 	}
 	if len(cfg.CodexKey[0].ExcludedModels) != 0 {
 		t.Fatalf("expected excluded-models cleared, got %#v", cfg.CodexKey[0].ExcludedModels)
+	}
+}
+
+func TestToggleConfigAPIKeyExcludedAll_Vertex_NoBaseURL(t *testing.T) {
+	cfg := &config.Config{
+		VertexCompatAPIKey: []config.VertexCompatKey{{
+			APIKey: "vertex-key-only",
+		}},
+	}
+	idGen := synthesizer.NewStableIDGenerator()
+	authID, _ := idGen.Next("vertex:apikey", "vertex-key-only", "", "")
+	auth := &coreauth.Auth{
+		ID:       authID,
+		Provider: "vertex",
+		Attributes: map[string]string{
+			"auth_kind": "apikey",
+			"api_key":   "vertex-key-only",
+			"source":    "config:vertex[xyz]",
+		},
+	}
+
+	handled, errToggle := toggleConfigAPIKeyExcludedAll(cfg, auth, true)
+	if errToggle != nil || !handled {
+		t.Fatalf("toggle disable: handled=%v err=%v", handled, errToggle)
+	}
+	if len(cfg.VertexCompatAPIKey[0].ExcludedModels) != 1 || cfg.VertexCompatAPIKey[0].ExcludedModels[0] != "*" {
+		t.Fatalf("excluded-models = %#v, want [*]", cfg.VertexCompatAPIKey[0].ExcludedModels)
+	}
+}
+
+func TestToggleConfigAPIKeyExcludedAll_EmptyKeyWithBaseURL(t *testing.T) {
+	cfg := &config.Config{
+		ClaudeKey: []config.ClaudeKey{{
+			APIKey:  "",
+			BaseURL: "https://custom-claude.example.com",
+		}},
+		GeminiKey: []config.GeminiKey{{
+			APIKey:  "   ",
+			BaseURL: "https://custom-gemini.example.com",
+		}},
+	}
+	idGen := synthesizer.NewStableIDGenerator()
+	claudeID, _ := idGen.Next("claude:apikey", "", "https://custom-claude.example.com", "", "", "")
+	geminiID, _ := idGen.Next("gemini:apikey", "", "https://custom-gemini.example.com", "", "", "")
+
+	claudeAuth := &coreauth.Auth{
+		ID:       claudeID,
+		Provider: "claude",
+		Attributes: map[string]string{
+			"auth_kind": "apikey",
+			"base_url":  "https://custom-claude.example.com",
+			"source":    "config:claude[abc]",
+		},
+	}
+	geminiAuth := &coreauth.Auth{
+		ID:       geminiID,
+		Provider: "gemini",
+		Attributes: map[string]string{
+			"auth_kind": "apikey",
+			"base_url":  "https://custom-gemini.example.com",
+			"source":    "config:gemini[def]",
+		},
+	}
+
+	handled, err := toggleConfigAPIKeyExcludedAll(cfg, claudeAuth, true)
+	if err != nil || !handled {
+		t.Fatalf("toggle claude: handled=%v err=%v", handled, err)
+	}
+	if len(cfg.ClaudeKey[0].ExcludedModels) != 1 || cfg.ClaudeKey[0].ExcludedModels[0] != "*" {
+		t.Fatalf("claude excluded-models = %#v, want [*]", cfg.ClaudeKey[0].ExcludedModels)
+	}
+
+	handled, err = toggleConfigAPIKeyExcludedAll(cfg, geminiAuth, true)
+	if err != nil || !handled {
+		t.Fatalf("toggle gemini: handled=%v err=%v", handled, err)
+	}
+	if len(cfg.GeminiKey[0].ExcludedModels) != 1 || cfg.GeminiKey[0].ExcludedModels[0] != "*" {
+		t.Fatalf("gemini excluded-models = %#v, want [*]", cfg.GeminiKey[0].ExcludedModels)
 	}
 }

--- a/internal/api/handlers/management/config_auth_index.go
+++ b/internal/api/handlers/management/config_auth_index.go
@@ -103,8 +103,12 @@ func (h *Handler) geminiKeysWithAuthIndex() []geminiKeyWithAuthIndex {
 	for i := range h.cfg.GeminiKey {
 		entry := h.cfg.GeminiKey[i]
 		authIndex := ""
-		if key := strings.TrimSpace(entry.APIKey); key != "" {
-			id, _ := idGen.Next("gemini:apikey", key, entry.BaseURL)
+		key := strings.TrimSpace(entry.APIKey)
+		base := strings.TrimSpace(entry.BaseURL)
+		proxyURL := strings.TrimSpace(entry.ProxyURL)
+		prefix := strings.TrimSpace(entry.Prefix)
+		if key != "" || base != "" {
+			id, _ := idGen.Next("gemini:apikey", key, base, proxyURL, prefix, config.FormatSortedHeaders(entry.Headers))
 			authIndex = liveIndexByID[id]
 		}
 		out[i] = geminiKeyWithAuthIndex{
@@ -132,8 +136,12 @@ func (h *Handler) interactionsKeysWithAuthIndex() []geminiKeyWithAuthIndex {
 	for i := range h.cfg.InteractionsKey {
 		entry := h.cfg.InteractionsKey[i]
 		authIndex := ""
-		if key := strings.TrimSpace(entry.APIKey); key != "" {
-			id, _ := idGen.Next("gemini-interactions:apikey", key, entry.BaseURL)
+		key := strings.TrimSpace(entry.APIKey)
+		base := strings.TrimSpace(entry.BaseURL)
+		proxyURL := strings.TrimSpace(entry.ProxyURL)
+		prefix := strings.TrimSpace(entry.Prefix)
+		if key != "" || base != "" {
+			id, _ := idGen.Next("gemini-interactions:apikey", key, base, proxyURL, prefix, config.FormatSortedHeaders(entry.Headers))
 			authIndex = liveIndexByID[id]
 		}
 		out[i] = geminiKeyWithAuthIndex{
@@ -161,8 +169,12 @@ func (h *Handler) claudeKeysWithAuthIndex() []claudeKeyWithAuthIndex {
 	for i := range h.cfg.ClaudeKey {
 		entry := h.cfg.ClaudeKey[i]
 		authIndex := ""
-		if key := strings.TrimSpace(entry.APIKey); key != "" {
-			id, _ := idGen.Next("claude:apikey", key, entry.BaseURL)
+		key := strings.TrimSpace(entry.APIKey)
+		base := strings.TrimSpace(entry.BaseURL)
+		proxyURL := strings.TrimSpace(entry.ProxyURL)
+		prefix := strings.TrimSpace(entry.Prefix)
+		if key != "" || base != "" {
+			id, _ := idGen.Next("claude:apikey", key, base, proxyURL, prefix, config.FormatSortedHeaders(entry.Headers))
 			authIndex = liveIndexByID[id]
 		}
 		out[i] = claudeKeyWithAuthIndex{
@@ -190,8 +202,12 @@ func (h *Handler) codexKeysWithAuthIndex() []codexKeyWithAuthIndex {
 	for i := range h.cfg.CodexKey {
 		entry := h.cfg.CodexKey[i]
 		authIndex := ""
-		if key := strings.TrimSpace(entry.APIKey); key != "" {
-			id, _ := idGen.Next("codex:apikey", key, entry.BaseURL)
+		key := strings.TrimSpace(entry.APIKey)
+		base := strings.TrimSpace(entry.BaseURL)
+		proxyURL := strings.TrimSpace(entry.ProxyURL)
+		prefix := strings.TrimSpace(entry.Prefix)
+		if key != "" || base != "" {
+			id, _ := idGen.Next("codex:apikey", key, base, proxyURL, prefix, config.FormatSortedHeaders(entry.Headers))
 			authIndex = liveIndexByID[id]
 		}
 		out[i] = codexKeyWithAuthIndex{
@@ -219,8 +235,12 @@ func (h *Handler) xaiKeysWithAuthIndex() []xaiKeyWithAuthIndex {
 	for i := range h.cfg.XAIKey {
 		entry := h.cfg.XAIKey[i]
 		authIndex := ""
-		if key := strings.TrimSpace(entry.APIKey); key != "" {
-			id, _ := idGen.Next("xai:apikey", key, entry.BaseURL)
+		key := strings.TrimSpace(entry.APIKey)
+		base := strings.TrimSpace(entry.BaseURL)
+		proxyURL := strings.TrimSpace(entry.ProxyURL)
+		prefix := strings.TrimSpace(entry.Prefix)
+		if key != "" || base != "" {
+			id, _ := idGen.Next("xai:apikey", key, base, proxyURL, prefix, config.FormatSortedHeaders(entry.Headers))
 			authIndex = liveIndexByID[id]
 		}
 		out[i] = xaiKeyWithAuthIndex{

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -1254,6 +1254,103 @@ func (h *Handler) DeleteOAuthModelAlias(c *gin.Context) {
 	h.persist(c)
 }
 
+// oauth-request-scoped-errors: map[string][]RequestScopedErrorRule
+func (h *Handler) GetOAuthRequestScopedErrors(c *gin.Context) {
+	c.JSON(200, gin.H{"oauth-request-scoped-errors": sanitizedOAuthRequestScopedErrors(h.cfg.OAuthRequestScopedErrors)})
+}
+
+func (h *Handler) PutOAuthRequestScopedErrors(c *gin.Context) {
+	data, err := c.GetRawData()
+	if err != nil {
+		c.JSON(400, gin.H{"error": "failed to read body"})
+		return
+	}
+	var entries map[string][]config.RequestScopedErrorRule
+	if err = json.Unmarshal(data, &entries); err != nil {
+		var wrapper struct {
+			Items map[string][]config.RequestScopedErrorRule `json:"items"`
+		}
+		if err2 := json.Unmarshal(data, &wrapper); err2 != nil {
+			c.JSON(400, gin.H{"error": "invalid body"})
+			return
+		}
+		entries = wrapper.Items
+	}
+	h.cfg.OAuthRequestScopedErrors = sanitizedOAuthRequestScopedErrors(entries)
+	h.persist(c)
+}
+
+func (h *Handler) PatchOAuthRequestScopedErrors(c *gin.Context) {
+	var body struct {
+		Provider *string                         `json:"provider"`
+		Channel  *string                         `json:"channel"`
+		Rules    []config.RequestScopedErrorRule `json:"rules"`
+	}
+	if errBindJSON := c.ShouldBindJSON(&body); errBindJSON != nil {
+		c.JSON(400, gin.H{"error": "invalid body"})
+		return
+	}
+	channelRaw := ""
+	if body.Channel != nil {
+		channelRaw = *body.Channel
+	} else if body.Provider != nil {
+		channelRaw = *body.Provider
+	}
+	channel := strings.ToLower(strings.TrimSpace(channelRaw))
+	if channel == "" {
+		c.JSON(400, gin.H{"error": "invalid channel"})
+		return
+	}
+
+	normalizedMap := sanitizedOAuthRequestScopedErrors(map[string][]config.RequestScopedErrorRule{channel: body.Rules})
+	normalized := normalizedMap[channel]
+	if len(normalized) == 0 {
+		if h.cfg.OAuthRequestScopedErrors == nil {
+			c.JSON(404, gin.H{"error": "channel not found"})
+			return
+		}
+		if _, ok := h.cfg.OAuthRequestScopedErrors[channel]; !ok {
+			c.JSON(404, gin.H{"error": "channel not found"})
+			return
+		}
+		delete(h.cfg.OAuthRequestScopedErrors, channel)
+		if len(h.cfg.OAuthRequestScopedErrors) == 0 {
+			h.cfg.OAuthRequestScopedErrors = nil
+		}
+		h.persist(c)
+		return
+	}
+	if h.cfg.OAuthRequestScopedErrors == nil {
+		h.cfg.OAuthRequestScopedErrors = make(map[string][]config.RequestScopedErrorRule)
+	}
+	h.cfg.OAuthRequestScopedErrors[channel] = normalized
+	h.persist(c)
+}
+
+func (h *Handler) DeleteOAuthRequestScopedErrors(c *gin.Context) {
+	channel := strings.ToLower(strings.TrimSpace(c.Query("channel")))
+	if channel == "" {
+		channel = strings.ToLower(strings.TrimSpace(c.Query("provider")))
+	}
+	if channel == "" {
+		c.JSON(400, gin.H{"error": "missing channel"})
+		return
+	}
+	if h.cfg.OAuthRequestScopedErrors == nil {
+		c.JSON(404, gin.H{"error": "channel not found"})
+		return
+	}
+	if _, ok := h.cfg.OAuthRequestScopedErrors[channel]; !ok {
+		c.JSON(404, gin.H{"error": "channel not found"})
+		return
+	}
+	delete(h.cfg.OAuthRequestScopedErrors, channel)
+	if len(h.cfg.OAuthRequestScopedErrors) == 0 {
+		h.cfg.OAuthRequestScopedErrors = nil
+	}
+	h.persist(c)
+}
+
 // codex-api-key: []CodexKey
 func (h *Handler) GetCodexKeys(c *gin.Context) {
 	c.JSON(200, gin.H{"codex-api-key": h.codexKeysWithAuthIndex()})
@@ -1800,4 +1897,26 @@ func sanitizedOAuthModelAlias(entries map[string][]config.OAuthModelAlias) map[s
 		return nil
 	}
 	return cfg.OAuthModelAlias
+}
+
+func sanitizedOAuthRequestScopedErrors(entries map[string][]config.RequestScopedErrorRule) map[string][]config.RequestScopedErrorRule {
+	if len(entries) == 0 {
+		return nil
+	}
+	copied := make(map[string][]config.RequestScopedErrorRule, len(entries))
+	for channel, rules := range entries {
+		if len(rules) == 0 {
+			continue
+		}
+		copied[channel] = append([]config.RequestScopedErrorRule(nil), rules...)
+	}
+	if len(copied) == 0 {
+		return nil
+	}
+	cfg := config.Config{OAuthRequestScopedErrors: copied}
+	cfg.SanitizeOAuthRequestScopedErrors()
+	if len(cfg.OAuthRequestScopedErrors) == 0 {
+		return nil
+	}
+	return cfg.OAuthRequestScopedErrors
 }

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -235,14 +235,7 @@ func (h *Handler) PatchGeminiKey(c *gin.Context) {
 
 	entry := h.cfg.GeminiKey[targetIndex]
 	if body.Value.APIKey != nil {
-		trimmed := strings.TrimSpace(*body.Value.APIKey)
-		if trimmed == "" {
-			h.cfg.GeminiKey = append(h.cfg.GeminiKey[:targetIndex], h.cfg.GeminiKey[targetIndex+1:]...)
-			h.cfg.SanitizeGeminiKeys()
-			h.persistLocked(c)
-			return
-		}
-		entry.APIKey = trimmed
+		entry.APIKey = strings.TrimSpace(*body.Value.APIKey)
 	}
 	if len(body.Value.Weight) > 0 {
 		weight, errWeight := parseCredentialWeightPatch(body.Value.Weight)
@@ -275,6 +268,12 @@ func (h *Handler) PatchGeminiKey(c *gin.Context) {
 	}
 	if body.Value.RequestScopedErrors != nil {
 		entry.RequestScopedErrors = append([]config.RequestScopedErrorRule(nil), *body.Value.RequestScopedErrors...)
+	}
+	if entry.APIKey == "" && entry.BaseURL == "" {
+		h.cfg.GeminiKey = append(h.cfg.GeminiKey[:targetIndex], h.cfg.GeminiKey[targetIndex+1:]...)
+		h.cfg.SanitizeGeminiKeys()
+		h.persistLocked(c)
+		return
 	}
 	h.cfg.GeminiKey[targetIndex] = entry
 	h.cfg.SanitizeGeminiKeys()
@@ -421,14 +420,7 @@ func (h *Handler) PatchInteractionsKey(c *gin.Context) {
 
 	entry := h.cfg.InteractionsKey[targetIndex]
 	if body.Value.APIKey != nil {
-		trimmed := strings.TrimSpace(*body.Value.APIKey)
-		if trimmed == "" {
-			h.cfg.InteractionsKey = append(h.cfg.InteractionsKey[:targetIndex], h.cfg.InteractionsKey[targetIndex+1:]...)
-			h.cfg.SanitizeInteractionsKeys()
-			h.persistLocked(c)
-			return
-		}
-		entry.APIKey = trimmed
+		entry.APIKey = strings.TrimSpace(*body.Value.APIKey)
 	}
 	if len(body.Value.Weight) > 0 {
 		weight, errWeight := parseCredentialWeightPatch(body.Value.Weight)
@@ -461,6 +453,12 @@ func (h *Handler) PatchInteractionsKey(c *gin.Context) {
 	}
 	if body.Value.RequestScopedErrors != nil {
 		entry.RequestScopedErrors = append([]config.RequestScopedErrorRule(nil), *body.Value.RequestScopedErrors...)
+	}
+	if entry.APIKey == "" && entry.BaseURL == "" {
+		h.cfg.InteractionsKey = append(h.cfg.InteractionsKey[:targetIndex], h.cfg.InteractionsKey[targetIndex+1:]...)
+		h.cfg.SanitizeInteractionsKeys()
+		h.persistLocked(c)
+		return
 	}
 	h.cfg.InteractionsKey[targetIndex] = entry
 	h.cfg.SanitizeInteractionsKeys()
@@ -986,14 +984,7 @@ func (h *Handler) PatchVertexCompatKey(c *gin.Context) {
 		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
 	}
 	if body.Value.BaseURL != nil {
-		trimmed := strings.TrimSpace(*body.Value.BaseURL)
-		if trimmed == "" {
-			h.cfg.VertexCompatAPIKey = append(h.cfg.VertexCompatAPIKey[:targetIndex], h.cfg.VertexCompatAPIKey[targetIndex+1:]...)
-			h.cfg.SanitizeVertexCompatKeys()
-			h.persistLocked(c)
-			return
-		}
-		entry.BaseURL = trimmed
+		entry.BaseURL = strings.TrimSpace(*body.Value.BaseURL)
 	}
 	if body.Value.ProxyURL != nil {
 		entry.ProxyURL = strings.TrimSpace(*body.Value.ProxyURL)

--- a/internal/api/handlers/management/config_lists.go
+++ b/internal/api/handlers/management/config_lists.go
@@ -235,14 +235,7 @@ func (h *Handler) PatchGeminiKey(c *gin.Context) {
 
 	entry := h.cfg.GeminiKey[targetIndex]
 	if body.Value.APIKey != nil {
-		trimmed := strings.TrimSpace(*body.Value.APIKey)
-		if trimmed == "" {
-			h.cfg.GeminiKey = append(h.cfg.GeminiKey[:targetIndex], h.cfg.GeminiKey[targetIndex+1:]...)
-			h.cfg.SanitizeGeminiKeys()
-			h.persistLocked(c)
-			return
-		}
-		entry.APIKey = trimmed
+		entry.APIKey = strings.TrimSpace(*body.Value.APIKey)
 	}
 	if len(body.Value.Weight) > 0 {
 		weight, errWeight := parseCredentialWeightPatch(body.Value.Weight)
@@ -275,6 +268,12 @@ func (h *Handler) PatchGeminiKey(c *gin.Context) {
 	}
 	if body.Value.RequestScopedErrors != nil {
 		entry.RequestScopedErrors = append([]config.RequestScopedErrorRule(nil), *body.Value.RequestScopedErrors...)
+	}
+	if entry.APIKey == "" && entry.BaseURL == "" {
+		h.cfg.GeminiKey = append(h.cfg.GeminiKey[:targetIndex], h.cfg.GeminiKey[targetIndex+1:]...)
+		h.cfg.SanitizeGeminiKeys()
+		h.persistLocked(c)
+		return
 	}
 	h.cfg.GeminiKey[targetIndex] = entry
 	h.cfg.SanitizeGeminiKeys()
@@ -421,14 +420,7 @@ func (h *Handler) PatchInteractionsKey(c *gin.Context) {
 
 	entry := h.cfg.InteractionsKey[targetIndex]
 	if body.Value.APIKey != nil {
-		trimmed := strings.TrimSpace(*body.Value.APIKey)
-		if trimmed == "" {
-			h.cfg.InteractionsKey = append(h.cfg.InteractionsKey[:targetIndex], h.cfg.InteractionsKey[targetIndex+1:]...)
-			h.cfg.SanitizeInteractionsKeys()
-			h.persistLocked(c)
-			return
-		}
-		entry.APIKey = trimmed
+		entry.APIKey = strings.TrimSpace(*body.Value.APIKey)
 	}
 	if len(body.Value.Weight) > 0 {
 		weight, errWeight := parseCredentialWeightPatch(body.Value.Weight)
@@ -461,6 +453,12 @@ func (h *Handler) PatchInteractionsKey(c *gin.Context) {
 	}
 	if body.Value.RequestScopedErrors != nil {
 		entry.RequestScopedErrors = append([]config.RequestScopedErrorRule(nil), *body.Value.RequestScopedErrors...)
+	}
+	if entry.APIKey == "" && entry.BaseURL == "" {
+		h.cfg.InteractionsKey = append(h.cfg.InteractionsKey[:targetIndex], h.cfg.InteractionsKey[targetIndex+1:]...)
+		h.cfg.SanitizeInteractionsKeys()
+		h.persistLocked(c)
+		return
 	}
 	h.cfg.InteractionsKey[targetIndex] = entry
 	h.cfg.SanitizeInteractionsKeys()
@@ -986,14 +984,7 @@ func (h *Handler) PatchVertexCompatKey(c *gin.Context) {
 		entry.Prefix = strings.TrimSpace(*body.Value.Prefix)
 	}
 	if body.Value.BaseURL != nil {
-		trimmed := strings.TrimSpace(*body.Value.BaseURL)
-		if trimmed == "" {
-			h.cfg.VertexCompatAPIKey = append(h.cfg.VertexCompatAPIKey[:targetIndex], h.cfg.VertexCompatAPIKey[targetIndex+1:]...)
-			h.cfg.SanitizeVertexCompatKeys()
-			h.persistLocked(c)
-			return
-		}
-		entry.BaseURL = trimmed
+		entry.BaseURL = strings.TrimSpace(*body.Value.BaseURL)
 	}
 	if body.Value.ProxyURL != nil {
 		entry.ProxyURL = strings.TrimSpace(*body.Value.ProxyURL)
@@ -1250,6 +1241,103 @@ func (h *Handler) DeleteOAuthModelAlias(c *gin.Context) {
 	delete(h.cfg.OAuthModelAlias, channel)
 	if len(h.cfg.OAuthModelAlias) == 0 {
 		h.cfg.OAuthModelAlias = nil
+	}
+	h.persist(c)
+}
+
+// oauth-request-scoped-errors: map[string][]RequestScopedErrorRule
+func (h *Handler) GetOAuthRequestScopedErrors(c *gin.Context) {
+	c.JSON(200, gin.H{"oauth-request-scoped-errors": sanitizedOAuthRequestScopedErrors(h.cfg.OAuthRequestScopedErrors)})
+}
+
+func (h *Handler) PutOAuthRequestScopedErrors(c *gin.Context) {
+	data, err := c.GetRawData()
+	if err != nil {
+		c.JSON(400, gin.H{"error": "failed to read body"})
+		return
+	}
+	var entries map[string][]config.RequestScopedErrorRule
+	if err = json.Unmarshal(data, &entries); err != nil {
+		var wrapper struct {
+			Items map[string][]config.RequestScopedErrorRule `json:"items"`
+		}
+		if err2 := json.Unmarshal(data, &wrapper); err2 != nil {
+			c.JSON(400, gin.H{"error": "invalid body"})
+			return
+		}
+		entries = wrapper.Items
+	}
+	h.cfg.OAuthRequestScopedErrors = sanitizedOAuthRequestScopedErrors(entries)
+	h.persist(c)
+}
+
+func (h *Handler) PatchOAuthRequestScopedErrors(c *gin.Context) {
+	var body struct {
+		Provider *string                         `json:"provider"`
+		Channel  *string                         `json:"channel"`
+		Rules    []config.RequestScopedErrorRule `json:"rules"`
+	}
+	if errBindJSON := c.ShouldBindJSON(&body); errBindJSON != nil {
+		c.JSON(400, gin.H{"error": "invalid body"})
+		return
+	}
+	channelRaw := ""
+	if body.Channel != nil {
+		channelRaw = *body.Channel
+	} else if body.Provider != nil {
+		channelRaw = *body.Provider
+	}
+	channel := strings.ToLower(strings.TrimSpace(channelRaw))
+	if channel == "" {
+		c.JSON(400, gin.H{"error": "invalid channel"})
+		return
+	}
+
+	normalizedMap := sanitizedOAuthRequestScopedErrors(map[string][]config.RequestScopedErrorRule{channel: body.Rules})
+	normalized := normalizedMap[channel]
+	if len(normalized) == 0 {
+		if h.cfg.OAuthRequestScopedErrors == nil {
+			c.JSON(404, gin.H{"error": "channel not found"})
+			return
+		}
+		if _, ok := h.cfg.OAuthRequestScopedErrors[channel]; !ok {
+			c.JSON(404, gin.H{"error": "channel not found"})
+			return
+		}
+		delete(h.cfg.OAuthRequestScopedErrors, channel)
+		if len(h.cfg.OAuthRequestScopedErrors) == 0 {
+			h.cfg.OAuthRequestScopedErrors = nil
+		}
+		h.persist(c)
+		return
+	}
+	if h.cfg.OAuthRequestScopedErrors == nil {
+		h.cfg.OAuthRequestScopedErrors = make(map[string][]config.RequestScopedErrorRule)
+	}
+	h.cfg.OAuthRequestScopedErrors[channel] = normalized
+	h.persist(c)
+}
+
+func (h *Handler) DeleteOAuthRequestScopedErrors(c *gin.Context) {
+	channel := strings.ToLower(strings.TrimSpace(c.Query("channel")))
+	if channel == "" {
+		channel = strings.ToLower(strings.TrimSpace(c.Query("provider")))
+	}
+	if channel == "" {
+		c.JSON(400, gin.H{"error": "missing channel"})
+		return
+	}
+	if h.cfg.OAuthRequestScopedErrors == nil {
+		c.JSON(404, gin.H{"error": "channel not found"})
+		return
+	}
+	if _, ok := h.cfg.OAuthRequestScopedErrors[channel]; !ok {
+		c.JSON(404, gin.H{"error": "channel not found"})
+		return
+	}
+	delete(h.cfg.OAuthRequestScopedErrors, channel)
+	if len(h.cfg.OAuthRequestScopedErrors) == 0 {
+		h.cfg.OAuthRequestScopedErrors = nil
 	}
 	h.persist(c)
 }
@@ -2082,6 +2170,30 @@ func normalizeAmpUpstreamAPIKeyEntries(entries []config.AmpUpstreamAPIKeyEntry) 
 		return nil
 	}
 	return out
+}
+
+// sanitizedOAuthRequestScopedErrors normalizes OAuth request-scoped error rules
+// using the LTS config sanitization pipeline before persisting.
+func sanitizedOAuthRequestScopedErrors(entries map[string][]config.RequestScopedErrorRule) map[string][]config.RequestScopedErrorRule {
+	if len(entries) == 0 {
+		return nil
+	}
+	copied := make(map[string][]config.RequestScopedErrorRule, len(entries))
+	for channel, rules := range entries {
+		if len(rules) == 0 {
+			continue
+		}
+		copied[channel] = append([]config.RequestScopedErrorRule(nil), rules...)
+	}
+	if len(copied) == 0 {
+		return nil
+	}
+	cfg := config.Config{OAuthRequestScopedErrors: copied}
+	cfg.SanitizeOAuthRequestScopedErrors()
+	if len(cfg.OAuthRequestScopedErrors) == 0 {
+		return nil
+	}
+	return cfg.OAuthRequestScopedErrors
 }
 
 // normalizeAPIKeysList trims and filters empty strings from a list of API keys.

--- a/internal/api/middleware/request_logging_test.go
+++ b/internal/api/middleware/request_logging_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/klauspost/compress/zstd"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/clienterror"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
@@ -379,4 +380,128 @@ func TestCaptureRequestInfoDecodesZstdRequestBodyForLog(t *testing.T) {
 	if !bytes.Equal(restoredBody, compressedBytes) {
 		t.Fatal("request body was not restored with the original compressed bytes")
 	}
+}
+
+func TestRequestLoggingMiddleware_ClientCancellationExclusion(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("499 status does not create error log when request-log is false", func(t *testing.T) {
+		logsDir := t.TempDir()
+		logger := logging.NewFileRequestLogger(false, logsDir, "", 10)
+
+		router := gin.New()
+		router.Use(RequestLoggingMiddleware(logger))
+		router.POST("/v1/responses", func(c *gin.Context) {
+			c.AbortWithStatus(clienterror.StatusClientClosedRequest)
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-4"}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+
+		if resp.Code != clienterror.StatusClientClosedRequest {
+			t.Fatalf("status = %d, want %d", resp.Code, clienterror.StatusClientClosedRequest)
+		}
+
+		entries, errRead := os.ReadDir(logsDir)
+		if errRead != nil {
+			t.Fatalf("read logs dir: %v", errRead)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("expected 0 log files for 499 cancellation in error-only mode, got %d files", len(entries))
+		}
+	})
+
+	t.Run("context canceled does not create error log when request-log is false", func(t *testing.T) {
+		logsDir := t.TempDir()
+		logger := logging.NewFileRequestLogger(false, logsDir, "", 10)
+
+		router := gin.New()
+		router.Use(RequestLoggingMiddleware(logger))
+		router.POST("/v1/responses", func(c *gin.Context) {
+			// Simulate client closing connection mid-flight
+			ctx, cancel := context.WithCancel(c.Request.Context())
+			cancel()
+			c.Request = c.Request.WithContext(ctx)
+			c.Status(http.StatusOK)
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-4"}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+
+		entries, errRead := os.ReadDir(logsDir)
+		if errRead != nil {
+			t.Fatalf("read logs dir: %v", errRead)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("expected 0 log files for canceled context in error-only mode, got %d files", len(entries))
+		}
+	})
+
+	t.Run("400 bad request creates error log when request-log is false", func(t *testing.T) {
+		logsDir := t.TempDir()
+		logger := logging.NewFileRequestLogger(false, logsDir, "", 10)
+
+		router := gin.New()
+		router.Use(RequestLoggingMiddleware(logger))
+		router.POST("/v1/responses", func(c *gin.Context) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid parameter"})
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"bad":"param"}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+
+		if resp.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", resp.Code, http.StatusBadRequest)
+		}
+
+		entries, errRead := os.ReadDir(logsDir)
+		if errRead != nil {
+			t.Fatalf("read logs dir: %v", errRead)
+		}
+		var errorLogCount int
+		for _, entry := range entries {
+			if strings.HasPrefix(entry.Name(), "error-") && strings.HasSuffix(entry.Name(), ".log") {
+				errorLogCount++
+			}
+		}
+		if errorLogCount != 1 {
+			t.Fatalf("expected 1 error log file for 400 Bad Request, got %d", errorLogCount)
+		}
+	})
+
+	t.Run("499 status logs standard request when request-log is true", func(t *testing.T) {
+		logsDir := t.TempDir()
+		logger := logging.NewFileRequestLogger(true, logsDir, "", 10)
+
+		router := gin.New()
+		router.Use(RequestLoggingMiddleware(logger))
+		router.POST("/v1/responses", func(c *gin.Context) {
+			c.AbortWithStatus(clienterror.StatusClientClosedRequest)
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-4"}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+
+		entries, errRead := os.ReadDir(logsDir)
+		if errRead != nil {
+			t.Fatalf("read logs dir: %v", errRead)
+		}
+		var standardLogCount int
+		for _, entry := range entries {
+			if !strings.HasPrefix(entry.Name(), "error-") && strings.HasSuffix(entry.Name(), ".log") {
+				standardLogCount++
+			}
+		}
+		if standardLogCount != 1 {
+			t.Fatalf("expected 1 standard request log file when request-log=true, got %d", standardLogCount)
+		}
+	})
 }

--- a/internal/api/middleware/request_logging_test.go
+++ b/internal/api/middleware/request_logging_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/klauspost/compress/zstd"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/clienterror"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
@@ -541,4 +542,128 @@ func TestCaptureRequestInfoDecodesZstdRequestBodyForLog(t *testing.T) {
 	if !bytes.Equal(restoredBody, compressedBytes) {
 		t.Fatal("request body was not restored with the original compressed bytes")
 	}
+}
+
+func TestRequestLoggingMiddleware_ClientCancellationExclusion(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("499 status does not create error log when request-log is false", func(t *testing.T) {
+		logsDir := t.TempDir()
+		logger := logging.NewFileRequestLogger(false, logsDir, "", 10)
+
+		router := gin.New()
+		router.Use(RequestLoggingMiddleware(logger))
+		router.POST("/v1/responses", func(c *gin.Context) {
+			c.AbortWithStatus(clienterror.StatusClientClosedRequest)
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-4"}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+
+		if resp.Code != clienterror.StatusClientClosedRequest {
+			t.Fatalf("status = %d, want %d", resp.Code, clienterror.StatusClientClosedRequest)
+		}
+
+		entries, errRead := os.ReadDir(logsDir)
+		if errRead != nil {
+			t.Fatalf("read logs dir: %v", errRead)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("expected 0 log files for 499 cancellation in error-only mode, got %d files", len(entries))
+		}
+	})
+
+	t.Run("context canceled does not create error log when request-log is false", func(t *testing.T) {
+		logsDir := t.TempDir()
+		logger := logging.NewFileRequestLogger(false, logsDir, "", 10)
+
+		router := gin.New()
+		router.Use(RequestLoggingMiddleware(logger))
+		router.POST("/v1/responses", func(c *gin.Context) {
+			// Simulate client closing connection mid-flight
+			ctx, cancel := context.WithCancel(c.Request.Context())
+			cancel()
+			c.Request = c.Request.WithContext(ctx)
+			c.Status(http.StatusOK)
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-4"}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+
+		entries, errRead := os.ReadDir(logsDir)
+		if errRead != nil {
+			t.Fatalf("read logs dir: %v", errRead)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("expected 0 log files for canceled context in error-only mode, got %d files", len(entries))
+		}
+	})
+
+	t.Run("400 bad request creates error log when request-log is false", func(t *testing.T) {
+		logsDir := t.TempDir()
+		logger := logging.NewFileRequestLogger(false, logsDir, "", 10)
+
+		router := gin.New()
+		router.Use(RequestLoggingMiddleware(logger))
+		router.POST("/v1/responses", func(c *gin.Context) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid parameter"})
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"bad":"param"}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+
+		if resp.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", resp.Code, http.StatusBadRequest)
+		}
+
+		entries, errRead := os.ReadDir(logsDir)
+		if errRead != nil {
+			t.Fatalf("read logs dir: %v", errRead)
+		}
+		var errorLogCount int
+		for _, entry := range entries {
+			if strings.HasPrefix(entry.Name(), "error-") && strings.HasSuffix(entry.Name(), ".log") {
+				errorLogCount++
+			}
+		}
+		if errorLogCount != 1 {
+			t.Fatalf("expected 1 error log file for 400 Bad Request, got %d", errorLogCount)
+		}
+	})
+
+	t.Run("499 status logs standard request when request-log is true", func(t *testing.T) {
+		logsDir := t.TempDir()
+		logger := logging.NewFileRequestLogger(true, logsDir, "", 10)
+
+		router := gin.New()
+		router.Use(RequestLoggingMiddleware(logger))
+		router.POST("/v1/responses", func(c *gin.Context) {
+			c.AbortWithStatus(clienterror.StatusClientClosedRequest)
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-4"}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+
+		entries, errRead := os.ReadDir(logsDir)
+		if errRead != nil {
+			t.Fatalf("read logs dir: %v", errRead)
+		}
+		var standardLogCount int
+		for _, entry := range entries {
+			if !strings.HasPrefix(entry.Name(), "error-") && strings.HasSuffix(entry.Name(), ".log") {
+				standardLogCount++
+			}
+		}
+		if standardLogCount != 1 {
+			t.Fatalf("expected 1 standard request log file when request-log=true, got %d", standardLogCount)
+		}
+	})
 }

--- a/internal/api/middleware/response_writer.go
+++ b/internal/api/middleware/response_writer.go
@@ -5,11 +5,14 @@ package middleware
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/clienterror"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	log "github.com/sirupsen/logrus"
@@ -116,7 +119,7 @@ func (w *ResponseWriterWrapper) shouldBufferResponseBody() bool {
 			status = http.StatusOK
 		}
 	}
-	return status >= http.StatusBadRequest
+	return status >= http.StatusBadRequest && status != clienterror.StatusClientClosedRequest
 }
 
 // WriteString wraps the underlying ResponseWriter's WriteString method to capture response data.
@@ -283,7 +286,7 @@ func (w *ResponseWriterWrapper) Finalize(c *gin.Context) error {
 		}
 	}
 
-	hasAPIError := len(slicesAPIResponseError) > 0 || finalStatusCode >= http.StatusBadRequest
+	hasAPIError := hasActionableError(c, finalStatusCode, slicesAPIResponseError)
 	forceLog := w.logOnErrorOnly && hasAPIError && !w.logger.IsEnabled()
 	websocketTimelineSource := w.extractWebsocketTimelineSource(c)
 	apiRequestSource := w.extractAPIRequestSource(c)
@@ -718,4 +721,41 @@ func cleanupFileBodySources(sources ...*logging.FileBodySource) {
 			log.WithError(errCleanup).Warn("failed to clean up log part files")
 		}
 	}
+}
+
+func isClientCancellationErrorMessage(errMsg *interfaces.ErrorMessage) bool {
+	if errMsg == nil {
+		return true
+	}
+	return clienterror.IsClientCancellation(errMsg.StatusCode, errMsg.Error)
+}
+
+func hasActionableAPIResponseErrors(apiErrors []*interfaces.ErrorMessage) bool {
+	for _, err := range apiErrors {
+		if !isClientCancellationErrorMessage(err) {
+			return true
+		}
+	}
+	return false
+}
+
+func isContextCanceled(c *gin.Context) bool {
+	if c == nil || c.Request == nil {
+		return false
+	}
+	ctx := c.Request.Context()
+	return ctx != nil && errors.Is(ctx.Err(), context.Canceled)
+}
+
+func hasActionableError(c *gin.Context, statusCode int, apiErrors []*interfaces.ErrorMessage) bool {
+	if hasActionableAPIResponseErrors(apiErrors) {
+		return true
+	}
+	if statusCode == clienterror.StatusClientClosedRequest {
+		return false
+	}
+	if isContextCanceled(c) && statusCode < http.StatusBadRequest {
+		return false
+	}
+	return statusCode >= http.StatusBadRequest
 }

--- a/internal/api/middleware/response_writer.go
+++ b/internal/api/middleware/response_writer.go
@@ -5,11 +5,14 @@ package middleware
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/clienterror"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	log "github.com/sirupsen/logrus"
@@ -119,7 +122,7 @@ func (w *ResponseWriterWrapper) shouldBufferResponseBody() bool {
 			status = http.StatusOK
 		}
 	}
-	return status >= http.StatusBadRequest
+	return status >= http.StatusBadRequest && status != clienterror.StatusClientClosedRequest
 }
 
 // WriteString wraps the underlying ResponseWriter's WriteString method to capture response data.
@@ -307,7 +310,7 @@ func (w *ResponseWriterWrapper) Finalize(c *gin.Context) error {
 		}
 	}
 
-	hasAPIError := len(slicesAPIResponseError) > 0 || finalStatusCode >= http.StatusBadRequest
+	hasAPIError := hasActionableError(c, finalStatusCode, slicesAPIResponseError)
 	forceLog := w.logOnErrorOnly && hasAPIError && !w.logger.IsEnabled()
 	websocketTimelineSource := w.extractWebsocketTimelineSource(c)
 	apiRequestSource := w.extractAPIRequestSource(c)
@@ -758,4 +761,41 @@ func cleanupFileBodySources(sources ...*logging.FileBodySource) {
 			log.WithError(errCleanup).Warn("failed to clean up log part files")
 		}
 	}
+}
+
+func isClientCancellationErrorMessage(errMsg *interfaces.ErrorMessage) bool {
+	if errMsg == nil {
+		return true
+	}
+	return clienterror.IsClientCancellation(errMsg.StatusCode, errMsg.Error)
+}
+
+func hasActionableAPIResponseErrors(apiErrors []*interfaces.ErrorMessage) bool {
+	for _, err := range apiErrors {
+		if !isClientCancellationErrorMessage(err) {
+			return true
+		}
+	}
+	return false
+}
+
+func isContextCanceled(c *gin.Context) bool {
+	if c == nil || c.Request == nil {
+		return false
+	}
+	ctx := c.Request.Context()
+	return ctx != nil && errors.Is(ctx.Err(), context.Canceled)
+}
+
+func hasActionableError(c *gin.Context, statusCode int, apiErrors []*interfaces.ErrorMessage) bool {
+	if hasActionableAPIResponseErrors(apiErrors) {
+		return true
+	}
+	if statusCode == clienterror.StatusClientClosedRequest {
+		return false
+	}
+	if isContextCanceled(c) && statusCode < http.StatusBadRequest {
+		return false
+	}
+	return statusCode >= http.StatusBadRequest
 }

--- a/internal/api/middleware/response_writer_test.go
+++ b/internal/api/middleware/response_writer_test.go
@@ -2,11 +2,16 @@ package middleware
 
 import (
 	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/clienterror"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 )
@@ -199,4 +204,177 @@ func (w *testStreamingLogWriter) SetFirstChunkTimestamp(time.Time) {}
 func (w *testStreamingLogWriter) Close() error {
 	w.closed = true
 	return nil
+}
+
+func TestHasActionableError(t *testing.T) {
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		ctx        context.Context
+		apiErrors  []*interfaces.ErrorMessage
+		want       bool
+	}{
+		{
+			name:       "200 ok without errors",
+			statusCode: http.StatusOK,
+			want:       false,
+		},
+		{
+			name:       "499 client closed request",
+			statusCode: clienterror.StatusClientClosedRequest,
+			want:       false,
+		},
+		{
+			name:       "499 with context canceled api error",
+			statusCode: clienterror.StatusClientClosedRequest,
+			apiErrors:  []*interfaces.ErrorMessage{{StatusCode: clienterror.StatusClientClosedRequest, Error: context.Canceled}},
+			want:       false,
+		},
+		{
+			name:       "200 with canceled context",
+			statusCode: http.StatusOK,
+			ctx:        canceledCtx,
+			want:       false,
+		},
+		{
+			name:       "0 with canceled context",
+			statusCode: 0,
+			ctx:        canceledCtx,
+			want:       false,
+		},
+		{
+			name:       "400 bad request",
+			statusCode: http.StatusBadRequest,
+			want:       true,
+		},
+		{
+			name:       "429 rate limit",
+			statusCode: http.StatusTooManyRequests,
+			want:       true,
+		},
+		{
+			name:       "500 internal server error",
+			statusCode: http.StatusInternalServerError,
+			want:       true,
+		},
+		{
+			name:       "503 with canceled context",
+			statusCode: http.StatusServiceUnavailable,
+			ctx:        canceledCtx,
+			want:       true,
+		},
+		{
+			name:       "200 with actionable upstream api error",
+			statusCode: http.StatusOK,
+			apiErrors:  []*interfaces.ErrorMessage{{StatusCode: http.StatusBadGateway, Error: errors.New("upstream failed")}},
+			want:       true,
+		},
+		{
+			name:       "200 with non-actionable cancellation api error",
+			statusCode: http.StatusOK,
+			apiErrors:  []*interfaces.ErrorMessage{{StatusCode: 0, Error: fmt.Errorf("read: %w", context.Canceled)}},
+			want:       false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			req := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+			if tc.ctx != nil {
+				req = req.WithContext(tc.ctx)
+			}
+			c.Request = req
+
+			got := hasActionableError(c, tc.statusCode, tc.apiErrors)
+			if got != tc.want {
+				t.Fatalf("hasActionableError(status=%d, errors=%v) = %t, want %t", tc.statusCode, tc.apiErrors, got, tc.want)
+			}
+		})
+	}
+}
+
+type recordingRequestLogger struct {
+	loggedCalls []int
+	enabled     bool
+}
+
+func (l *recordingRequestLogger) LogRequest(url, method string, requestHeaders map[string][]string, body []byte, statusCode int, responseHeaders map[string][]string, response, websocketTimeline, apiRequest, apiResponse, apiWebsocketTimeline []byte, apiResponseErrors []*interfaces.ErrorMessage, requestID string, requestTimestamp, apiResponseTimestamp time.Time) error {
+	l.loggedCalls = append(l.loggedCalls, statusCode)
+	return nil
+}
+
+func (l *recordingRequestLogger) LogStreamingRequest(string, string, map[string][]string, []byte, string) (logging.StreamingLogWriter, error) {
+	return &testStreamingLogWriter{}, nil
+}
+
+func (l *recordingRequestLogger) IsEnabled() bool {
+	return l.enabled
+}
+
+func (l *recordingRequestLogger) LogRequestWithOptions(url, method string, requestHeaders map[string][]string, body []byte, statusCode int, responseHeaders map[string][]string, response, websocketTimeline, apiRequest, apiResponse, apiWebsocketTimeline []byte, apiResponseErrors []*interfaces.ErrorMessage, force bool, requestID string, requestTimestamp, apiResponseTimestamp time.Time) error {
+	if force || l.enabled {
+		l.loggedCalls = append(l.loggedCalls, statusCode)
+	}
+	return nil
+}
+
+func TestFinalizeExcludes499FromForceLog(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	logger := &recordingRequestLogger{enabled: false}
+	wrapper := &ResponseWriterWrapper{
+		ResponseWriter: c.Writer,
+		logger:         logger,
+		logOnErrorOnly: true,
+		statusCode:     clienterror.StatusClientClosedRequest,
+		requestInfo: &RequestInfo{
+			URL:       "/v1/responses",
+			Method:    "POST",
+			RequestID: "req-499",
+			Timestamp: time.Now(),
+		},
+	}
+
+	if err := wrapper.Finalize(c); err != nil {
+		t.Fatalf("Finalize error: %v", err)
+	}
+	if len(logger.loggedCalls) != 0 {
+		t.Fatalf("expected 0 logged calls for 499 cancellation, got %d: %v", len(logger.loggedCalls), logger.loggedCalls)
+	}
+}
+
+func TestFinalizeIncludes500InForceLog(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	logger := &recordingRequestLogger{enabled: false}
+	wrapper := &ResponseWriterWrapper{
+		ResponseWriter: c.Writer,
+		logger:         logger,
+		logOnErrorOnly: true,
+		statusCode:     http.StatusInternalServerError,
+		requestInfo: &RequestInfo{
+			URL:       "/v1/responses",
+			Method:    "POST",
+			RequestID: "req-500",
+			Timestamp: time.Now(),
+		},
+	}
+
+	if err := wrapper.Finalize(c); err != nil {
+		t.Fatalf("Finalize error: %v", err)
+	}
+	if len(logger.loggedCalls) != 1 || logger.loggedCalls[0] != http.StatusInternalServerError {
+		t.Fatalf("expected 1 logged call for 500 status, got: %v", logger.loggedCalls)
+	}
 }

--- a/internal/api/middleware/response_writer_test.go
+++ b/internal/api/middleware/response_writer_test.go
@@ -2,11 +2,16 @@ package middleware
 
 import (
 	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/clienterror"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 )
@@ -212,4 +217,177 @@ func (w *testStreamingLogWriter) SetFirstChunkTimestamp(time.Time) {}
 func (w *testStreamingLogWriter) Close() error {
 	w.closed = true
 	return nil
+}
+
+func TestHasActionableError(t *testing.T) {
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		ctx        context.Context
+		apiErrors  []*interfaces.ErrorMessage
+		want       bool
+	}{
+		{
+			name:       "200 ok without errors",
+			statusCode: http.StatusOK,
+			want:       false,
+		},
+		{
+			name:       "499 client closed request",
+			statusCode: clienterror.StatusClientClosedRequest,
+			want:       false,
+		},
+		{
+			name:       "499 with context canceled api error",
+			statusCode: clienterror.StatusClientClosedRequest,
+			apiErrors:  []*interfaces.ErrorMessage{{StatusCode: clienterror.StatusClientClosedRequest, Error: context.Canceled}},
+			want:       false,
+		},
+		{
+			name:       "200 with canceled context",
+			statusCode: http.StatusOK,
+			ctx:        canceledCtx,
+			want:       false,
+		},
+		{
+			name:       "0 with canceled context",
+			statusCode: 0,
+			ctx:        canceledCtx,
+			want:       false,
+		},
+		{
+			name:       "400 bad request",
+			statusCode: http.StatusBadRequest,
+			want:       true,
+		},
+		{
+			name:       "429 rate limit",
+			statusCode: http.StatusTooManyRequests,
+			want:       true,
+		},
+		{
+			name:       "500 internal server error",
+			statusCode: http.StatusInternalServerError,
+			want:       true,
+		},
+		{
+			name:       "503 with canceled context",
+			statusCode: http.StatusServiceUnavailable,
+			ctx:        canceledCtx,
+			want:       true,
+		},
+		{
+			name:       "200 with actionable upstream api error",
+			statusCode: http.StatusOK,
+			apiErrors:  []*interfaces.ErrorMessage{{StatusCode: http.StatusBadGateway, Error: errors.New("upstream failed")}},
+			want:       true,
+		},
+		{
+			name:       "200 with non-actionable cancellation api error",
+			statusCode: http.StatusOK,
+			apiErrors:  []*interfaces.ErrorMessage{{StatusCode: 0, Error: fmt.Errorf("read: %w", context.Canceled)}},
+			want:       false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			req := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+			if tc.ctx != nil {
+				req = req.WithContext(tc.ctx)
+			}
+			c.Request = req
+
+			got := hasActionableError(c, tc.statusCode, tc.apiErrors)
+			if got != tc.want {
+				t.Fatalf("hasActionableError(status=%d, errors=%v) = %t, want %t", tc.statusCode, tc.apiErrors, got, tc.want)
+			}
+		})
+	}
+}
+
+type recordingRequestLogger struct {
+	loggedCalls []int
+	enabled     bool
+}
+
+func (l *recordingRequestLogger) LogRequest(url, method string, requestHeaders map[string][]string, body []byte, statusCode int, responseHeaders map[string][]string, response, websocketTimeline, apiRequest, apiResponse, apiWebsocketTimeline []byte, apiResponseErrors []*interfaces.ErrorMessage, requestID string, requestTimestamp, apiResponseTimestamp time.Time) error {
+	l.loggedCalls = append(l.loggedCalls, statusCode)
+	return nil
+}
+
+func (l *recordingRequestLogger) LogStreamingRequest(string, string, map[string][]string, []byte, string) (logging.StreamingLogWriter, error) {
+	return &testStreamingLogWriter{}, nil
+}
+
+func (l *recordingRequestLogger) IsEnabled() bool {
+	return l.enabled
+}
+
+func (l *recordingRequestLogger) LogRequestWithOptions(url, method string, requestHeaders map[string][]string, body []byte, statusCode int, responseHeaders map[string][]string, response, websocketTimeline, apiRequest, apiResponse, apiWebsocketTimeline []byte, apiResponseErrors []*interfaces.ErrorMessage, force bool, requestID string, requestTimestamp, apiResponseTimestamp time.Time) error {
+	if force || l.enabled {
+		l.loggedCalls = append(l.loggedCalls, statusCode)
+	}
+	return nil
+}
+
+func TestFinalizeExcludes499FromForceLog(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	logger := &recordingRequestLogger{enabled: false}
+	wrapper := &ResponseWriterWrapper{
+		ResponseWriter: c.Writer,
+		logger:         logger,
+		logOnErrorOnly: true,
+		statusCode:     clienterror.StatusClientClosedRequest,
+		requestInfo: &RequestInfo{
+			URL:       "/v1/responses",
+			Method:    "POST",
+			RequestID: "req-499",
+			Timestamp: time.Now(),
+		},
+	}
+
+	if err := wrapper.Finalize(c); err != nil {
+		t.Fatalf("Finalize error: %v", err)
+	}
+	if len(logger.loggedCalls) != 0 {
+		t.Fatalf("expected 0 logged calls for 499 cancellation, got %d: %v", len(logger.loggedCalls), logger.loggedCalls)
+	}
+}
+
+func TestFinalizeIncludes500InForceLog(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	logger := &recordingRequestLogger{enabled: false}
+	wrapper := &ResponseWriterWrapper{
+		ResponseWriter: c.Writer,
+		logger:         logger,
+		logOnErrorOnly: true,
+		statusCode:     http.StatusInternalServerError,
+		requestInfo: &RequestInfo{
+			URL:       "/v1/responses",
+			Method:    "POST",
+			RequestID: "req-500",
+			Timestamp: time.Now(),
+		},
+	}
+
+	if err := wrapper.Finalize(c); err != nil {
+		t.Fatalf("Finalize error: %v", err)
+	}
+	if len(logger.loggedCalls) != 1 || logger.loggedCalls[0] != http.StatusInternalServerError {
+		t.Fatalf("expected 1 logged call for 500 status, got: %v", logger.loggedCalls)
+	}
 }

--- a/internal/api/server_management.go
+++ b/internal/api/server_management.go
@@ -155,6 +155,11 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.PATCH("/oauth-model-alias", s.mgmt.PatchOAuthModelAlias)
 		mgmt.DELETE("/oauth-model-alias", s.mgmt.DeleteOAuthModelAlias)
 
+		mgmt.GET("/oauth-request-scoped-errors", s.mgmt.GetOAuthRequestScopedErrors)
+		mgmt.PUT("/oauth-request-scoped-errors", s.mgmt.PutOAuthRequestScopedErrors)
+		mgmt.PATCH("/oauth-request-scoped-errors", s.mgmt.PatchOAuthRequestScopedErrors)
+		mgmt.DELETE("/oauth-request-scoped-errors", s.mgmt.DeleteOAuthRequestScopedErrors)
+
 		mgmt.GET("/auth-files", s.mgmt.ListAuthFiles)
 		mgmt.GET("/auth-files/models", s.mgmt.GetAuthFileModels)
 		mgmt.GET("/model-definitions/:channel", s.mgmt.GetStaticModelDefinitions)

--- a/internal/api/server_management.go
+++ b/internal/api/server_management.go
@@ -182,6 +182,11 @@ func (s *Server) registerManagementRoutes() {
 		mgmt.PATCH("/oauth-model-alias", s.mgmt.PatchOAuthModelAlias)
 		mgmt.DELETE("/oauth-model-alias", s.mgmt.DeleteOAuthModelAlias)
 
+		mgmt.GET("/oauth-request-scoped-errors", s.mgmt.GetOAuthRequestScopedErrors)
+		mgmt.PUT("/oauth-request-scoped-errors", s.mgmt.PutOAuthRequestScopedErrors)
+		mgmt.PATCH("/oauth-request-scoped-errors", s.mgmt.PatchOAuthRequestScopedErrors)
+		mgmt.DELETE("/oauth-request-scoped-errors", s.mgmt.DeleteOAuthRequestScopedErrors)
+
 		mgmt.GET("/auth-files", s.mgmt.ListAuthFiles)
 		mgmt.GET("/auth-files/models", s.mgmt.GetAuthFileModels)
 		mgmt.GET("/model-definitions/:channel", s.mgmt.GetStaticModelDefinitions)

--- a/internal/clienterror/client_error.go
+++ b/internal/clienterror/client_error.go
@@ -162,3 +162,28 @@ func hasRequestFaultBody(err error) bool {
 	}
 	return false
 }
+
+// IsClientCancellation reports whether an HTTP status code or error represents
+// a client-initiated cancellation (HTTP 499 StatusClientClosedRequest or context.Canceled).
+func IsClientCancellation(status int, err error) bool {
+	if status == StatusClientClosedRequest {
+		return true
+	}
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return true
+		}
+		type statusCoder interface {
+			StatusCode() int
+		}
+		var sc statusCoder
+		if errors.As(err, &sc) && sc != nil && sc.StatusCode() == StatusClientClosedRequest {
+			return true
+		}
+		lower := strings.ToLower(err.Error())
+		if strings.Contains(lower, "context canceled") || strings.Contains(lower, "client closed request") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/clienterror/client_error_test.go
+++ b/internal/clienterror/client_error_test.go
@@ -223,3 +223,33 @@ func TestIsRequestFault(t *testing.T) {
 		})
 	}
 }
+
+func TestIsClientCancellation(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		err    error
+		want   bool
+	}{
+		{name: "status 499", status: StatusClientClosedRequest, want: true},
+		{name: "context canceled error", status: 0, err: context.Canceled, want: true},
+		{name: "fmt wrapped context canceled", status: 0, err: fmt.Errorf("read: %w", context.Canceled), want: true},
+		{name: "context canceled string in error", status: 0, err: errors.New("upstream failed: context canceled"), want: true},
+		{name: "client closed request string in error", status: 0, err: errors.New("client closed request"), want: true},
+		{name: "statusCoder with 499", status: 0, err: statusError{status: StatusClientClosedRequest, body: "aborted"}, want: true},
+		{name: "status 200 without error", status: http.StatusOK, err: nil, want: false},
+		{name: "status 400 bad request", status: http.StatusBadRequest, err: errors.New("bad request"), want: false},
+		{name: "status 429 rate limit", status: http.StatusTooManyRequests, err: errors.New("rate limited"), want: false},
+		{name: "status 500 internal error", status: http.StatusInternalServerError, err: errors.New("internal error"), want: false},
+		{name: "plain unrelated error", status: 0, err: errors.New("connection reset by peer"), want: false},
+		{name: "nil error and 0 status", status: 0, err: nil, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsClientCancellation(tc.status, tc.err); got != tc.want {
+				t.Fatalf("IsClientCancellation(%d, %v) = %t, want %t", tc.status, tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -158,6 +158,12 @@ type Config struct {
 	// gemini-api-key, interactions-api-key, codex-api-key, xai-api-key, claude-api-key, openai-compatibility, and vertex-api-key.
 	OAuthModelAlias map[string][]OAuthModelAlias `yaml:"oauth-model-alias,omitempty" json:"oauth-model-alias,omitempty"`
 
+	// OAuthRequestScopedErrors defines per-provider request-scoped error rules applied to OAuth/file-backed auth entries.
+	// Supported channels include: vertex, aistudio, antigravity, claude, codex, kimi, xai, and OAuth plugin provider keys.
+	//
+	// NOTE: This applies only to OAuth credentials and does not affect per-credential request-scoped-errors under *-api-key.
+	OAuthRequestScopedErrors map[string][]RequestScopedErrorRule `yaml:"oauth-request-scoped-errors,omitempty" json:"oauth-request-scoped-errors,omitempty"`
+
 	// Payload defines default and override rules for provider payload parameters.
 	Payload PayloadConfig `yaml:"payload" json:"payload"`
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,12 +76,17 @@ type Config struct {
 	// When <= 0, the default worker count is used.
 	AuthAutoRefreshWorkers int `yaml:"auth-auto-refresh-workers" json:"auth-auto-refresh-workers"`
 
-	// RequestRetry defines the retry times when the request failed.
+	// RequestRetry defines the number of additional credential retry rounds after
+	// the first round has exhausted its eligible credentials.
 	RequestRetry int `yaml:"request-retry" json:"request-retry"`
-	// MaxRetryCredentials defines the maximum number of credentials to try for a failed request.
+	// MaxRetryCredentials defines the maximum number of different credentials to
+	// try in each credential retry round.
 	// Set to 0 or a negative value to keep trying all available credentials (legacy behavior).
 	MaxRetryCredentials int `yaml:"max-retry-credentials" json:"max-retry-credentials"`
-	// MaxRetryInterval defines the maximum wait time in seconds before retrying a cooled-down credential.
+	// MaxRetryInterval defines the maximum positive cooldown wait, in seconds,
+	// allowed before starting another credential retry round. A non-positive value
+	// forbids positive cooldown waits; it does not disable same-round credential
+	// failover or immediate additional rounds allowed by RequestRetry.
 	MaxRetryInterval int `yaml:"max-retry-interval" json:"max-retry-interval"`
 
 	// QuotaExceeded defines the behavior when a quota is exceeded.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,12 +76,17 @@ type Config struct {
 	// When <= 0, the default worker count is used.
 	AuthAutoRefreshWorkers int `yaml:"auth-auto-refresh-workers" json:"auth-auto-refresh-workers"`
 
-	// RequestRetry defines the retry times when the request failed.
+	// RequestRetry defines the number of additional credential retry rounds after
+	// the first round has exhausted its eligible credentials.
 	RequestRetry int `yaml:"request-retry" json:"request-retry"`
-	// MaxRetryCredentials defines the maximum number of credentials to try for a failed request.
+	// MaxRetryCredentials defines the maximum number of different credentials to
+	// try in each credential retry round.
 	// Set to 0 or a negative value to keep trying all available credentials (legacy behavior).
 	MaxRetryCredentials int `yaml:"max-retry-credentials" json:"max-retry-credentials"`
-	// MaxRetryInterval defines the maximum wait time in seconds before retrying a cooled-down credential.
+	// MaxRetryInterval defines the maximum positive cooldown wait, in seconds,
+	// allowed before starting another credential retry round. A non-positive value
+	// forbids positive cooldown waits; it does not disable same-round credential
+	// failover or immediate additional rounds allowed by RequestRetry.
 	MaxRetryInterval int `yaml:"max-retry-interval" json:"max-retry-interval"`
 
 	// QuotaExceeded defines the behavior when a quota is exceeded.
@@ -160,6 +165,12 @@ type Config struct {
 	// NOTE: This does not apply to existing per-credential model alias features under:
 	// gemini-api-key, interactions-api-key, codex-api-key, xai-api-key, claude-api-key, openai-compatibility, and vertex-api-key.
 	OAuthModelAlias map[string][]OAuthModelAlias `yaml:"oauth-model-alias,omitempty" json:"oauth-model-alias,omitempty"`
+
+	// OAuthRequestScopedErrors defines per-provider request-scoped error rules applied to OAuth/file-backed auth entries.
+	// Supported channels include: vertex, aistudio, antigravity, claude, codex, kimi, xai, and OAuth plugin provider keys.
+	//
+	// NOTE: This applies only to OAuth credentials and does not affect per-credential request-scoped-errors under *-api-key.
+	OAuthRequestScopedErrors map[string][]RequestScopedErrorRule `yaml:"oauth-request-scoped-errors,omitempty" json:"oauth-request-scoped-errors,omitempty"`
 
 	// Payload defines default and override rules for provider payload parameters.
 	Payload PayloadConfig `yaml:"payload" json:"payload"`

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -180,6 +180,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	// Normalize global OAuth model name aliases.
 	cfg.SanitizeOAuthModelAlias()
 
+	// Normalize global OAuth request-scoped error rules.
+	cfg.SanitizeOAuthRequestScopedErrors()
+
 	// Validate raw payload rules and drop invalid entries.
 	cfg.SanitizePayloadRules()
 

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -186,6 +186,9 @@ func LoadConfigOptional(configFile string, optional bool) (*Config, error) {
 	// Normalize global OAuth model name aliases.
 	cfg.SanitizeOAuthModelAlias()
 
+	// Normalize global OAuth request-scoped error rules.
+	cfg.SanitizeOAuthRequestScopedErrors()
+
 	// Validate raw payload rules and drop invalid entries.
 	cfg.SanitizePayloadRules()
 

--- a/internal/config/config_normalization.go
+++ b/internal/config/config_normalization.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"sort"
 	"strings"
 
 	sdkpluginstore "github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginstore"
@@ -101,6 +102,54 @@ func (cfg *Config) SanitizeOAuthModelAlias() {
 	cfg.OAuthModelAlias = out
 }
 
+// SanitizeOAuthRequestScopedErrors normalizes and validates global OAuth request-scoped error rules.
+// It trims whitespace, normalizes channel keys to lower-case, validates status/action, and drops invalid rules.
+func (cfg *Config) SanitizeOAuthRequestScopedErrors() {
+	if cfg == nil || len(cfg.OAuthRequestScopedErrors) == 0 {
+		return
+	}
+	out := make(map[string][]RequestScopedErrorRule, len(cfg.OAuthRequestScopedErrors))
+	for rawChannel, rules := range cfg.OAuthRequestScopedErrors {
+		channel := strings.ToLower(strings.TrimSpace(rawChannel))
+		if channel == "" || len(rules) == 0 {
+			continue
+		}
+		clean := make([]RequestScopedErrorRule, 0, len(rules))
+		for _, r := range rules {
+			action := strings.ToLower(strings.TrimSpace(r.Action))
+			match := make([]string, 0, len(r.Match))
+			for _, m := range r.Match {
+				if tm := strings.TrimSpace(m); tm != "" {
+					match = append(match, tm)
+				}
+			}
+			matchRegexr := make([]string, 0, len(r.MatchRegexr))
+			for _, re := range r.MatchRegexr {
+				if tre := strings.TrimSpace(re); tre != "" {
+					matchRegexr = append(matchRegexr, tre)
+				}
+			}
+			if r.Status <= 0 || (len(match) == 0 && len(matchRegexr) == 0) || action == "" {
+				continue
+			}
+			clean = append(clean, RequestScopedErrorRule{
+				Status:      r.Status,
+				Match:       match,
+				MatchRegexr: matchRegexr,
+				Action:      action,
+			})
+		}
+		if len(clean) > 0 {
+			out[channel] = clean
+		}
+	}
+	if len(out) == 0 {
+		cfg.OAuthRequestScopedErrors = nil
+		return
+	}
+	cfg.OAuthRequestScopedErrors = out
+}
+
 // SanitizeOpenAICompatibility removes OpenAI-compatibility provider entries that are
 // not actionable, specifically those missing a BaseURL. It trims whitespace before
 // evaluation and preserves the relative order of remaining entries.
@@ -191,15 +240,15 @@ func sanitizeGeminiKeyEntries(entries []GeminiKey) []GeminiKey {
 	for i := range entries {
 		entry := entries[i]
 		entry.APIKey = strings.TrimSpace(entry.APIKey)
-		if entry.APIKey == "" {
+		entry.BaseURL = strings.TrimSpace(entry.BaseURL)
+		if entry.APIKey == "" && entry.BaseURL == "" {
 			continue
 		}
 		entry.Prefix = normalizeModelPrefix(entry.Prefix)
-		entry.BaseURL = strings.TrimSpace(entry.BaseURL)
 		entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
 		entry.Headers = NormalizeHeaders(entry.Headers)
 		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
-		uniqueKey := entry.APIKey + "|" + entry.BaseURL
+		uniqueKey := formatGeminiKeyDedupID(entry)
 		if _, exists := seen[uniqueKey]; exists {
 			continue
 		}
@@ -209,8 +258,42 @@ func sanitizeGeminiKeyEntries(entries []GeminiKey) []GeminiKey {
 	return out
 }
 
+func formatGeminiKeyDedupID(entry GeminiKey) string {
+	var b strings.Builder
+	b.WriteString(entry.APIKey)
+	b.WriteByte(0)
+	b.WriteString(entry.BaseURL)
+	b.WriteByte(0)
+	b.WriteString(entry.ProxyURL)
+	b.WriteByte(0)
+	b.WriteString(entry.Prefix)
+	b.WriteByte(0)
+	b.WriteString(FormatSortedHeaders(entry.Headers))
+	return b.String()
+}
+
+// FormatSortedHeaders serializes headers deterministically with null byte separators.
+func FormatSortedHeaders(headers map[string]string) string {
+	if len(headers) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(headers))
+	for k := range headers {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteByte(0)
+		b.WriteString(headers[k])
+		b.WriteByte(0)
+	}
+	return b.String()
+}
+
 // SanitizeGeminiKeys deduplicates and normalizes Gemini credentials.
-// It uses API key + base URL as the uniqueness key.
+// It uses API key, base URL, proxy URL, prefix, and custom headers as the uniqueness key.
 func (cfg *Config) SanitizeGeminiKeys() {
 	if cfg == nil {
 		return
@@ -219,7 +302,7 @@ func (cfg *Config) SanitizeGeminiKeys() {
 }
 
 // SanitizeInteractionsKeys deduplicates and normalizes native Interactions credentials.
-// It uses API key + base URL as the uniqueness key.
+// It uses API key, base URL, proxy URL, prefix, and custom headers as the uniqueness key.
 func (cfg *Config) SanitizeInteractionsKeys() {
 	if cfg == nil {
 		return

--- a/internal/config/config_normalization.go
+++ b/internal/config/config_normalization.go
@@ -101,6 +101,54 @@ func (cfg *Config) SanitizeOAuthModelAlias() {
 	cfg.OAuthModelAlias = out
 }
 
+// SanitizeOAuthRequestScopedErrors normalizes and validates global OAuth request-scoped error rules.
+// It trims whitespace, normalizes channel keys to lower-case, validates status/action, and drops invalid rules.
+func (cfg *Config) SanitizeOAuthRequestScopedErrors() {
+	if cfg == nil || len(cfg.OAuthRequestScopedErrors) == 0 {
+		return
+	}
+	out := make(map[string][]RequestScopedErrorRule, len(cfg.OAuthRequestScopedErrors))
+	for rawChannel, rules := range cfg.OAuthRequestScopedErrors {
+		channel := strings.ToLower(strings.TrimSpace(rawChannel))
+		if channel == "" || len(rules) == 0 {
+			continue
+		}
+		clean := make([]RequestScopedErrorRule, 0, len(rules))
+		for _, r := range rules {
+			action := strings.ToLower(strings.TrimSpace(r.Action))
+			match := make([]string, 0, len(r.Match))
+			for _, m := range r.Match {
+				if tm := strings.TrimSpace(m); tm != "" {
+					match = append(match, tm)
+				}
+			}
+			matchRegexr := make([]string, 0, len(r.MatchRegexr))
+			for _, re := range r.MatchRegexr {
+				if tre := strings.TrimSpace(re); tre != "" {
+					matchRegexr = append(matchRegexr, tre)
+				}
+			}
+			if r.Status <= 0 || (len(match) == 0 && len(matchRegexr) == 0) || action == "" {
+				continue
+			}
+			clean = append(clean, RequestScopedErrorRule{
+				Status:      r.Status,
+				Match:       match,
+				MatchRegexr: matchRegexr,
+				Action:      action,
+			})
+		}
+		if len(clean) > 0 {
+			out[channel] = clean
+		}
+	}
+	if len(out) == 0 {
+		cfg.OAuthRequestScopedErrors = nil
+		return
+	}
+	cfg.OAuthRequestScopedErrors = out
+}
+
 // SanitizeOpenAICompatibility removes OpenAI-compatibility provider entries that are
 // not actionable, specifically those missing a BaseURL. It trims whitespace before
 // evaluation and preserves the relative order of remaining entries.

--- a/internal/config/config_normalization.go
+++ b/internal/config/config_normalization.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"sort"
 	"strings"
 
 	sdkpluginstore "github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginstore"
@@ -239,15 +240,15 @@ func sanitizeGeminiKeyEntries(entries []GeminiKey) []GeminiKey {
 	for i := range entries {
 		entry := entries[i]
 		entry.APIKey = strings.TrimSpace(entry.APIKey)
-		if entry.APIKey == "" {
+		entry.BaseURL = strings.TrimSpace(entry.BaseURL)
+		if entry.APIKey == "" && entry.BaseURL == "" {
 			continue
 		}
 		entry.Prefix = normalizeModelPrefix(entry.Prefix)
-		entry.BaseURL = strings.TrimSpace(entry.BaseURL)
 		entry.ProxyURL = strings.TrimSpace(entry.ProxyURL)
 		entry.Headers = NormalizeHeaders(entry.Headers)
 		entry.ExcludedModels = NormalizeExcludedModels(entry.ExcludedModels)
-		uniqueKey := entry.APIKey + "|" + entry.BaseURL
+		uniqueKey := formatGeminiKeyDedupID(entry)
 		if _, exists := seen[uniqueKey]; exists {
 			continue
 		}
@@ -257,8 +258,42 @@ func sanitizeGeminiKeyEntries(entries []GeminiKey) []GeminiKey {
 	return out
 }
 
+func formatGeminiKeyDedupID(entry GeminiKey) string {
+	var b strings.Builder
+	b.WriteString(entry.APIKey)
+	b.WriteByte(0)
+	b.WriteString(entry.BaseURL)
+	b.WriteByte(0)
+	b.WriteString(entry.ProxyURL)
+	b.WriteByte(0)
+	b.WriteString(entry.Prefix)
+	b.WriteByte(0)
+	b.WriteString(FormatSortedHeaders(entry.Headers))
+	return b.String()
+}
+
+// FormatSortedHeaders serializes headers deterministically with null byte separators.
+func FormatSortedHeaders(headers map[string]string) string {
+	if len(headers) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(headers))
+	for k := range headers {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteByte(0)
+		b.WriteString(headers[k])
+		b.WriteByte(0)
+	}
+	return b.String()
+}
+
 // SanitizeGeminiKeys deduplicates and normalizes Gemini credentials.
-// It uses API key + base URL as the uniqueness key.
+// It uses API key, base URL, proxy URL, prefix, and custom headers as the uniqueness key.
 func (cfg *Config) SanitizeGeminiKeys() {
 	if cfg == nil {
 		return
@@ -267,7 +302,7 @@ func (cfg *Config) SanitizeGeminiKeys() {
 }
 
 // SanitizeInteractionsKeys deduplicates and normalizes native Interactions credentials.
-// It uses API key + base URL as the uniqueness key.
+// It uses API key, base URL, proxy URL, prefix, and custom headers as the uniqueness key.
 func (cfg *Config) SanitizeInteractionsKeys() {
 	if cfg == nil {
 		return

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -378,7 +378,7 @@ type ClaudeKey struct {
 	DisableCooling *bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`
 
 	// RequestRetry optionally overrides the global request-retry for this credential.
-	// Nil or a negative value means "use the global request-retry". 0 disables retries.
+	// Nil or a negative value means "use the global request-retry". 0 disables additional retry rounds.
 	RequestRetry *int `yaml:"request-retry,omitempty" json:"request-retry,omitempty"`
 
 	// RequestScopedErrors configures custom classification rules for upstream errors.
@@ -496,7 +496,7 @@ type CodexKey struct {
 	DisableCooling *bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`
 
 	// RequestRetry optionally overrides the global request-retry for this credential.
-	// Nil or a negative value means "use the global request-retry". 0 disables retries.
+	// Nil or a negative value means "use the global request-retry". 0 disables additional retry rounds.
 	RequestRetry *int `yaml:"request-retry,omitempty" json:"request-retry,omitempty"`
 
 	// RequestScopedErrors configures custom classification rules for upstream errors.
@@ -593,7 +593,7 @@ type GeminiKey struct {
 	DisableCooling *bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`
 
 	// RequestRetry optionally overrides the global request-retry for this credential.
-	// Nil or a negative value means "use the global request-retry". 0 disables retries.
+	// Nil or a negative value means "use the global request-retry". 0 disables additional retry rounds.
 	RequestRetry *int `yaml:"request-retry,omitempty" json:"request-retry,omitempty"`
 
 	// RequestScopedErrors configures custom classification rules for upstream errors.
@@ -680,7 +680,7 @@ type OpenAICompatibility struct {
 	DisableCooling *bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`
 
 	// RequestRetry optionally overrides the global request-retry for this provider.
-	// Nil or a negative value means "use the global request-retry". 0 disables retries.
+	// Nil or a negative value means "use the global request-retry". 0 disables additional retry rounds.
 	RequestRetry *int `yaml:"request-retry,omitempty" json:"request-retry,omitempty"`
 
 	// RequestScopedErrors configures custom classification rules for upstream errors.

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -148,6 +148,14 @@ type CodexConfig struct {
 	IdentityConfuse bool `yaml:"identity-confuse" json:"identity-confuse"`
 	// DisableCodexCloaking disables forcing the official Codex identity headers on HTTP/SSE and WebSocket requests.
 	DisableCodexCloaking bool `yaml:"disable-codex-cloaking" json:"disable-codex-cloaking"`
+	// StreamBootstrapBuffering holds back initial handshake events (response.created,
+	// response.in_progress and the websocket metadata frames) until the first generated event
+	// arrives. The upstream delivers server_is_overloaded rejections inside an HTTP 200 stream
+	// right after those handshake events instead of returning 503 on the wire, so buffering them
+	// keeps the downstream response headers uncommitted long enough to retry on another credential.
+	// Trade-off: the response headers are delayed until the upstream starts generating, which can
+	// trip client or reverse-proxy read timeouts. Default is false.
+	StreamBootstrapBuffering bool `yaml:"stream-bootstrap-buffering" json:"stream-bootstrap-buffering"`
 	// OptimizeMultiAgentV2 optimizes official Codex multi-agent requests.
 	OptimizeMultiAgentV2 bool `yaml:"optimize-multi-agent-v2" json:"optimize-multi-agent-v2"`
 	// LiveMediaRelay terminates and relays Codex Live WebRTC media in this process.

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -174,6 +174,14 @@ type CodexConfig struct {
 	AbnormalReasoningRetry CodexAbnormalReasoningRetryConfig `yaml:"abnormal-reasoning-retry" json:"abnormal-reasoning-retry"`
 	// DisableCodexCloaking disables forcing the official Codex identity headers on HTTP/SSE and WebSocket requests.
 	DisableCodexCloaking bool `yaml:"disable-codex-cloaking" json:"disable-codex-cloaking"`
+	// StreamBootstrapBuffering holds back initial handshake events (response.created,
+	// response.in_progress and the websocket metadata frames) until the first generated event
+	// arrives. The upstream delivers server_is_overloaded rejections inside an HTTP 200 stream
+	// right after those handshake events instead of returning 503 on the wire, so buffering them
+	// keeps the downstream response headers uncommitted long enough to retry on another credential.
+	// Trade-off: the response headers are delayed until the upstream starts generating, which can
+	// trip client or reverse-proxy read timeouts. Default is false.
+	StreamBootstrapBuffering bool `yaml:"stream-bootstrap-buffering" json:"stream-bootstrap-buffering"`
 	// OptimizeMultiAgentV2 optimizes official Codex multi-agent requests.
 	OptimizeMultiAgentV2 bool `yaml:"optimize-multi-agent-v2" json:"optimize-multi-agent-v2"`
 	// LiveMediaRelay terminates and relays Codex Live WebRTC media in this process.
@@ -405,7 +413,7 @@ type ClaudeKey struct {
 	DisableCooling *bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`
 
 	// RequestRetry optionally overrides the global request-retry for this credential.
-	// Nil uses the global request-retry. 0 or a negative value disables retries.
+	// Nil or a negative value means "use the global request-retry". 0 disables additional retry rounds.
 	RequestRetry *int `yaml:"request-retry,omitempty" json:"request-retry,omitempty"`
 
 	// RequestScopedErrors configures custom classification rules for upstream errors.
@@ -523,7 +531,7 @@ type CodexKey struct {
 	DisableCooling *bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`
 
 	// RequestRetry optionally overrides the global request-retry for this credential.
-	// Nil uses the global request-retry. 0 or a negative value disables retries.
+	// Nil or a negative value means "use the global request-retry". 0 disables additional retry rounds.
 	RequestRetry *int `yaml:"request-retry,omitempty" json:"request-retry,omitempty"`
 
 	// RequestScopedErrors configures custom classification rules for upstream errors.
@@ -620,7 +628,7 @@ type GeminiKey struct {
 	DisableCooling *bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`
 
 	// RequestRetry optionally overrides the global request-retry for this credential.
-	// Nil uses the global request-retry. 0 or a negative value disables retries.
+	// Nil or a negative value means "use the global request-retry". 0 disables additional retry rounds.
 	RequestRetry *int `yaml:"request-retry,omitempty" json:"request-retry,omitempty"`
 
 	// RequestScopedErrors configures custom classification rules for upstream errors.
@@ -707,7 +715,7 @@ type OpenAICompatibility struct {
 	DisableCooling *bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`
 
 	// RequestRetry optionally overrides the global request-retry for this provider.
-	// Nil uses the global request-retry. 0 or a negative value disables retries.
+	// Nil or a negative value means "use the global request-retry". 0 disables additional retry rounds.
 	RequestRetry *int `yaml:"request-retry,omitempty" json:"request-retry,omitempty"`
 
 	// RequestScopedErrors configures custom classification rules for upstream errors.

--- a/internal/config/config_yaml.go
+++ b/internal/config/config_yaml.go
@@ -54,6 +54,7 @@ func SaveConfigPreserveComments(configFile string, cfg *Config) error {
 
 	pruneMappingToGeneratedKeys(original.Content[0], generated.Content[0], "oauth-excluded-models")
 	pruneMappingToGeneratedKeys(original.Content[0], generated.Content[0], "oauth-model-alias")
+	pruneMappingToGeneratedKeys(original.Content[0], generated.Content[0], "oauth-request-scoped-errors")
 	pruneMappingToGeneratedKeys(original.Content[0], generated.Content[0], "plugins", "configs")
 
 	// Merge generated into original in-place, preserving comments/order of existing nodes.
@@ -687,10 +688,10 @@ func pruneMappingToGeneratedKeys(dstRoot, srcRoot *yaml.Node, keyPath ...string)
 	}
 	srcIdx := findMapKeyIndex(srcRoot, key)
 	if srcIdx < 0 {
-		// Keep an explicit empty mapping for oauth-model-alias when it was previously present.
-		// When users delete the last channel from oauth-model-alias via the management API,
+		// Keep an explicit empty mapping for oauth-model-alias and oauth-request-scoped-errors when previously present.
+		// When users delete the last channel via the management API,
 		// we want that deletion to persist across hot reloads and restarts.
-		if key == "oauth-model-alias" {
+		if key == "oauth-model-alias" || key == "oauth-request-scoped-errors" {
 			dstRoot.Content[dstIdx+1] = &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
 			return
 		}

--- a/internal/config/gemini_keys_normalization_test.go
+++ b/internal/config/gemini_keys_normalization_test.go
@@ -1,0 +1,35 @@
+package config
+
+import "testing"
+
+func TestSanitizeGeminiKeys_AllowsEmptyAPIKeyWithBaseURL(t *testing.T) {
+	cfg := &Config{
+		GeminiKey: []GeminiKey{
+			{APIKey: ""},   // empty key without base URL, should be dropped
+			{APIKey: "  "}, // whitespace key without base URL, should be dropped
+			{APIKey: "", BaseURL: "https://custom-gemini.example.com", Headers: map[string]string{"Header-A": "1"}},
+			{APIKey: "", BaseURL: "https://custom-gemini.example.com", Headers: map[string]string{"Header-B": "2"}},
+			{APIKey: "key-1", BaseURL: "https://custom-gemini.example.com"},
+		},
+		InteractionsKey: []GeminiKey{
+			{APIKey: ""},   // empty key without base URL, should be dropped
+			{APIKey: "  "}, // whitespace key without base URL, should be dropped
+			{APIKey: "", BaseURL: "https://custom-interactions.example.com"},
+		},
+	}
+	cfg.SanitizeGeminiKeys()
+	cfg.SanitizeInteractionsKeys()
+
+	if len(cfg.GeminiKey) != 3 {
+		t.Fatalf("expected 3 GeminiKey entries, got %d", len(cfg.GeminiKey))
+	}
+	if cfg.GeminiKey[0].BaseURL != "https://custom-gemini.example.com" {
+		t.Fatalf("expected BaseURL https://custom-gemini.example.com, got %s", cfg.GeminiKey[0].BaseURL)
+	}
+	if len(cfg.InteractionsKey) != 1 {
+		t.Fatalf("expected 1 InteractionsKey entry, got %d", len(cfg.InteractionsKey))
+	}
+	if cfg.InteractionsKey[0].BaseURL != "https://custom-interactions.example.com" {
+		t.Fatalf("expected BaseURL https://custom-interactions.example.com, got %s", cfg.InteractionsKey[0].BaseURL)
+	}
+}

--- a/internal/config/oauth_request_scoped_errors_test.go
+++ b/internal/config/oauth_request_scoped_errors_test.go
@@ -1,0 +1,115 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestParseConfigOAuthRequestScopedErrors(t *testing.T) {
+	const yamlConfig = `
+oauth-request-scoped-errors:
+  vertex:
+    - status: 400
+      match:
+        - "maximum_context_length"
+        - "context_length_exceeded"
+      match-regexr:
+        - "maximum_context_length$"
+        - "^context_length_exceeded"
+      action: "stop"
+  aistudio:
+    - status: 400
+      match:
+        - "invalid_argument"
+      action: "continue"
+  antigravity:
+    - status: 500
+      match:
+        - "internal_server_error"
+      action: "stop-and-cooldown"
+  claude:
+    - status: 429
+      match:
+        - "rate_limit"
+      action: "continue-and-cooldown"
+  codex:
+    - status: 400
+      match:
+        - "context_window_exceeded"
+      action: "stop"
+  kimi:
+    - status: 400
+      match:
+        - "length_limit"
+      action: "stop"
+  xai:
+    - status: 400
+      match:
+        - "max_tokens_exceeded"
+      action: "stop"
+`
+
+	cfg, err := ParseConfigBytes([]byte(yamlConfig))
+	if err != nil {
+		t.Fatalf("ParseConfigFromBytes failed: %v", err)
+	}
+
+	if len(cfg.OAuthRequestScopedErrors) != 7 {
+		t.Fatalf("cfg.OAuthRequestScopedErrors len = %d, want 7", len(cfg.OAuthRequestScopedErrors))
+	}
+
+	vertexRules, ok := cfg.OAuthRequestScopedErrors["vertex"]
+	if !ok || len(vertexRules) != 1 {
+		t.Fatalf("vertex rules missing or len != 1: %#v", vertexRules)
+	}
+	rule := vertexRules[0]
+	if rule.Status != 400 || rule.Action != "stop" {
+		t.Errorf("unexpected vertex rule: %+v", rule)
+	}
+	if len(rule.Match) != 2 || len(rule.MatchRegexr) != 2 {
+		t.Errorf("unexpected vertex match len: %+v", rule)
+	}
+}
+
+func TestSanitizeOAuthRequestScopedErrors(t *testing.T) {
+	cfg := &Config{
+		OAuthRequestScopedErrors: map[string][]RequestScopedErrorRule{
+			" Vertex ": {
+				{
+					Status:      400,
+					Match:       []string{"  context_length  ", ""},
+					MatchRegexr: []string{"  ^error.*  ", ""},
+					Action:      " STOP ",
+				},
+				{
+					Status: 0, // invalid status
+					Match:  []string{"foo"},
+					Action: "stop",
+				},
+				{
+					Status: 400, // missing match / action
+				},
+			},
+			" empty-channel ": {},
+		},
+	}
+
+	cfg.SanitizeOAuthRequestScopedErrors()
+
+	if len(cfg.OAuthRequestScopedErrors) != 1 {
+		t.Fatalf("expected 1 sanitized channel, got %d", len(cfg.OAuthRequestScopedErrors))
+	}
+
+	rules := cfg.OAuthRequestScopedErrors["vertex"]
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule for vertex, got %d", len(rules))
+	}
+	if rules[0].Status != 400 || rules[0].Action != "stop" {
+		t.Errorf("unexpected sanitized rule: %+v", rules[0])
+	}
+	if len(rules[0].Match) != 1 || rules[0].Match[0] != "context_length" {
+		t.Errorf("unexpected sanitized match: %+v", rules[0].Match)
+	}
+	if len(rules[0].MatchRegexr) != 1 || rules[0].MatchRegexr[0] != "^error.*" {
+		t.Errorf("unexpected sanitized regexr: %+v", rules[0].MatchRegexr)
+	}
+}

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -105,6 +105,7 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 	cfg.SanitizeOpenAICompatibility()
 	cfg.OAuthExcludedModels = NormalizeOAuthExcludedModels(cfg.OAuthExcludedModels)
 	cfg.SanitizeOAuthModelAlias()
+	cfg.SanitizeOAuthRequestScopedErrors()
 	cfg.SanitizePayloadRules()
 
 	return &cfg, nil

--- a/internal/config/parse.go
+++ b/internal/config/parse.go
@@ -114,6 +114,7 @@ func ParseConfigBytes(data []byte) (*Config, error) {
 	cfg.SanitizeOpenAICompatibility()
 	cfg.OAuthExcludedModels = NormalizeOAuthExcludedModels(cfg.OAuthExcludedModels)
 	cfg.SanitizeOAuthModelAlias()
+	cfg.SanitizeOAuthRequestScopedErrors()
 	cfg.SanitizePayloadRules()
 
 	return &cfg, nil

--- a/internal/config/vertex_compat.go
+++ b/internal/config/vertex_compat.go
@@ -51,7 +51,7 @@ type VertexCompatKey struct {
 	DisableCooling *bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`
 
 	// RequestRetry optionally overrides the global request-retry for this credential.
-	// Nil or a negative value means "use the global request-retry". 0 disables retries.
+	// Nil or a negative value means "use the global request-retry". 0 disables additional retry rounds.
 	RequestRetry *int `yaml:"request-retry,omitempty" json:"request-retry,omitempty"`
 }
 

--- a/internal/config/vertex_compat.go
+++ b/internal/config/vertex_compat.go
@@ -51,7 +51,7 @@ type VertexCompatKey struct {
 	DisableCooling *bool `yaml:"disable-cooling,omitempty" json:"disable-cooling,omitempty"`
 
 	// RequestRetry optionally overrides the global request-retry for this credential.
-	// Nil uses the global request-retry. 0 or a negative value disables retries.
+	// Nil or a negative value means "use the global request-retry". 0 disables additional retry rounds.
 	RequestRetry *int `yaml:"request-retry,omitempty" json:"request-retry,omitempty"`
 }
 

--- a/internal/home/client.go
+++ b/internal/home/client.go
@@ -1249,9 +1249,18 @@ func queryToLowerMap(query url.Values) map[string]string {
 	return out
 }
 
-func newAuthDispatchRequest(requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string) authDispatchRequest {
+func newAuthDispatchRequest(requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string, excludedAuthIDs *[]string, pinnedAuthID string) authDispatchRequest {
 	if count <= 0 {
 		count = 1
+	}
+	var excludedAuthIDsCopy *[]string
+	if excludedAuthIDs != nil {
+		// Keep count at one so older Home servers that ignore excluded_auth_ids do
+		// not apply their legacy count-based retry cap before CPA can rotate
+		// credentials. New Home servers apply retry_round eligibility remotely.
+		count = 1
+		values := append([]string{}, (*excludedAuthIDs)...)
+		excludedAuthIDsCopy = &values
 	}
 	return authDispatchRequest{
 		Type:                "auth",
@@ -1261,19 +1270,54 @@ func newAuthDispatchRequest(requestedModel string, sessionID string, headers htt
 		SessionID:           strings.TrimSpace(sessionID),
 		Headers:             headersToLowerMap(headers),
 		CredentialPolicy:    strings.TrimSpace(credentialPolicy),
+		ExcludedAuthIDs:     excludedAuthIDsCopy,
+		PinnedAuthID:        strings.TrimSpace(pinnedAuthID),
 	}
 }
 
+func newAuthDispatchRequestWithRetryRound(requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string, retryRound int, excludedAuthIDs *[]string, pinnedAuthID string) authDispatchRequest {
+	req := newAuthDispatchRequest(requestedModel, sessionID, headers, count, credentialPolicy, excludedAuthIDs, pinnedAuthID)
+	if retryRound < 0 {
+		retryRound = 0
+	}
+	req.RetryRound = &retryRound
+	return req
+}
+
 func (c *Client) RPopAuth(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int) ([]byte, error) {
-	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, "")
+	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, "", nil, nil, "")
 }
 
 // RPopAuthWithPolicy requests a Home credential constrained by the supplied fixed policy.
 func (c *Client) RPopAuthWithPolicy(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string) ([]byte, error) {
-	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, credentialPolicy)
+	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, credentialPolicy, nil, nil, "")
 }
 
-func (c *Client) rPopAuth(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string) ([]byte, error) {
+// RPopAuthWithConstraints requests a credential using the current retry-round
+// exclusions and optional pinned credential constraint.
+func (c *Client) RPopAuthWithConstraints(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, excludedAuthIDs []string, pinnedAuthID string) ([]byte, error) {
+	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, "", nil, &excludedAuthIDs, pinnedAuthID)
+}
+
+// RPopAuthWithPolicyAndConstraints combines a fixed credential policy with the
+// current retry-round exclusions and optional pinned credential constraint.
+func (c *Client) RPopAuthWithPolicyAndConstraints(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string, excludedAuthIDs []string, pinnedAuthID string) ([]byte, error) {
+	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, credentialPolicy, nil, &excludedAuthIDs, pinnedAuthID)
+}
+
+// RPopAuthWithRetryRoundConstraints requests a credential with the retry round,
+// current-round exclusions, and optional pinned credential constraint.
+func (c *Client) RPopAuthWithRetryRoundConstraints(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, retryRound int, excludedAuthIDs []string, pinnedAuthID string) ([]byte, error) {
+	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, "", &retryRound, &excludedAuthIDs, pinnedAuthID)
+}
+
+// RPopAuthWithPolicyAndRetryRoundConstraints combines a credential policy with
+// the retry round, current-round exclusions, and optional pin.
+func (c *Client) RPopAuthWithPolicyAndRetryRoundConstraints(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string, retryRound int, excludedAuthIDs []string, pinnedAuthID string) ([]byte, error) {
+	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, credentialPolicy, &retryRound, &excludedAuthIDs, pinnedAuthID)
+}
+
+func (c *Client) rPopAuth(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string, retryRound *int, excludedAuthIDs *[]string, pinnedAuthID string) ([]byte, error) {
 	if c == nil || c.dispatchFenced.Load() {
 		return nil, ErrDispatchFenced
 	}
@@ -1287,7 +1331,12 @@ func (c *Client) rPopAuth(ctx context.Context, requestedModel string, sessionID 
 	if requestedModel == "" {
 		return nil, fmt.Errorf("home: requested model is empty")
 	}
-	req := newAuthDispatchRequest(requestedModel, sessionID, headers, count, credentialPolicy)
+	var req authDispatchRequest
+	if retryRound == nil {
+		req = newAuthDispatchRequest(requestedModel, sessionID, headers, count, credentialPolicy, excludedAuthIDs, pinnedAuthID)
+	} else {
+		req = newAuthDispatchRequestWithRetryRound(requestedModel, sessionID, headers, count, credentialPolicy, *retryRound, excludedAuthIDs, pinnedAuthID)
+	}
 	keyBytes, errMarshal := json.Marshal(&req)
 	if errMarshal != nil {
 		return nil, errMarshal

--- a/internal/home/client.go
+++ b/internal/home/client.go
@@ -1255,9 +1255,9 @@ func newAuthDispatchRequest(requestedModel string, sessionID string, headers htt
 	}
 	var excludedAuthIDsCopy *[]string
 	if excludedAuthIDs != nil {
-		// CPA enforces the new retry-round contract locally. Keep count at one so
-		// older Home servers that ignore excluded_auth_ids do not apply their
-		// legacy count-based retry cap before CPA can rotate credentials.
+		// Keep count at one so older Home servers that ignore excluded_auth_ids do
+		// not apply their legacy count-based retry cap before CPA can rotate
+		// credentials. New Home servers apply retry_round eligibility remotely.
 		count = 1
 		values := append([]string{}, (*excludedAuthIDs)...)
 		excludedAuthIDsCopy = &values
@@ -1275,28 +1275,49 @@ func newAuthDispatchRequest(requestedModel string, sessionID string, headers htt
 	}
 }
 
+func newAuthDispatchRequestWithRetryRound(requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string, retryRound int, excludedAuthIDs *[]string, pinnedAuthID string) authDispatchRequest {
+	req := newAuthDispatchRequest(requestedModel, sessionID, headers, count, credentialPolicy, excludedAuthIDs, pinnedAuthID)
+	if retryRound < 0 {
+		retryRound = 0
+	}
+	req.RetryRound = &retryRound
+	return req
+}
+
 func (c *Client) RPopAuth(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int) ([]byte, error) {
-	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, "", nil, "")
+	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, "", nil, nil, "")
 }
 
 // RPopAuthWithPolicy requests a Home credential constrained by the supplied fixed policy.
 func (c *Client) RPopAuthWithPolicy(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string) ([]byte, error) {
-	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, credentialPolicy, nil, "")
+	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, credentialPolicy, nil, nil, "")
 }
 
 // RPopAuthWithConstraints requests a credential using the current retry-round
 // exclusions and optional pinned credential constraint.
 func (c *Client) RPopAuthWithConstraints(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, excludedAuthIDs []string, pinnedAuthID string) ([]byte, error) {
-	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, "", &excludedAuthIDs, pinnedAuthID)
+	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, "", nil, &excludedAuthIDs, pinnedAuthID)
 }
 
 // RPopAuthWithPolicyAndConstraints combines a fixed credential policy with the
 // current retry-round exclusions and optional pinned credential constraint.
 func (c *Client) RPopAuthWithPolicyAndConstraints(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string, excludedAuthIDs []string, pinnedAuthID string) ([]byte, error) {
-	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, credentialPolicy, &excludedAuthIDs, pinnedAuthID)
+	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, credentialPolicy, nil, &excludedAuthIDs, pinnedAuthID)
 }
 
-func (c *Client) rPopAuth(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string, excludedAuthIDs *[]string, pinnedAuthID string) ([]byte, error) {
+// RPopAuthWithRetryRoundConstraints requests a credential with the retry round,
+// current-round exclusions, and optional pinned credential constraint.
+func (c *Client) RPopAuthWithRetryRoundConstraints(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, retryRound int, excludedAuthIDs []string, pinnedAuthID string) ([]byte, error) {
+	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, "", &retryRound, &excludedAuthIDs, pinnedAuthID)
+}
+
+// RPopAuthWithPolicyAndRetryRoundConstraints combines a credential policy with
+// the retry round, current-round exclusions, and optional pin.
+func (c *Client) RPopAuthWithPolicyAndRetryRoundConstraints(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string, retryRound int, excludedAuthIDs []string, pinnedAuthID string) ([]byte, error) {
+	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, credentialPolicy, &retryRound, &excludedAuthIDs, pinnedAuthID)
+}
+
+func (c *Client) rPopAuth(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string, retryRound *int, excludedAuthIDs *[]string, pinnedAuthID string) ([]byte, error) {
 	if c == nil || c.dispatchFenced.Load() {
 		return nil, ErrDispatchFenced
 	}
@@ -1310,7 +1331,12 @@ func (c *Client) rPopAuth(ctx context.Context, requestedModel string, sessionID 
 	if requestedModel == "" {
 		return nil, fmt.Errorf("home: requested model is empty")
 	}
-	req := newAuthDispatchRequest(requestedModel, sessionID, headers, count, credentialPolicy, excludedAuthIDs, pinnedAuthID)
+	var req authDispatchRequest
+	if retryRound == nil {
+		req = newAuthDispatchRequest(requestedModel, sessionID, headers, count, credentialPolicy, excludedAuthIDs, pinnedAuthID)
+	} else {
+		req = newAuthDispatchRequestWithRetryRound(requestedModel, sessionID, headers, count, credentialPolicy, *retryRound, excludedAuthIDs, pinnedAuthID)
+	}
 	keyBytes, errMarshal := json.Marshal(&req)
 	if errMarshal != nil {
 		return nil, errMarshal

--- a/internal/home/client.go
+++ b/internal/home/client.go
@@ -1249,9 +1249,18 @@ func queryToLowerMap(query url.Values) map[string]string {
 	return out
 }
 
-func newAuthDispatchRequest(requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string) authDispatchRequest {
+func newAuthDispatchRequest(requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string, excludedAuthIDs *[]string, pinnedAuthID string) authDispatchRequest {
 	if count <= 0 {
 		count = 1
+	}
+	var excludedAuthIDsCopy *[]string
+	if excludedAuthIDs != nil {
+		// CPA enforces the new retry-round contract locally. Keep count at one so
+		// older Home servers that ignore excluded_auth_ids do not apply their
+		// legacy count-based retry cap before CPA can rotate credentials.
+		count = 1
+		values := append([]string{}, (*excludedAuthIDs)...)
+		excludedAuthIDsCopy = &values
 	}
 	return authDispatchRequest{
 		Type:                "auth",
@@ -1261,19 +1270,33 @@ func newAuthDispatchRequest(requestedModel string, sessionID string, headers htt
 		SessionID:           strings.TrimSpace(sessionID),
 		Headers:             headersToLowerMap(headers),
 		CredentialPolicy:    strings.TrimSpace(credentialPolicy),
+		ExcludedAuthIDs:     excludedAuthIDsCopy,
+		PinnedAuthID:        strings.TrimSpace(pinnedAuthID),
 	}
 }
 
 func (c *Client) RPopAuth(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int) ([]byte, error) {
-	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, "")
+	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, "", nil, "")
 }
 
 // RPopAuthWithPolicy requests a Home credential constrained by the supplied fixed policy.
 func (c *Client) RPopAuthWithPolicy(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string) ([]byte, error) {
-	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, credentialPolicy)
+	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, credentialPolicy, nil, "")
 }
 
-func (c *Client) rPopAuth(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string) ([]byte, error) {
+// RPopAuthWithConstraints requests a credential using the current retry-round
+// exclusions and optional pinned credential constraint.
+func (c *Client) RPopAuthWithConstraints(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, excludedAuthIDs []string, pinnedAuthID string) ([]byte, error) {
+	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, "", &excludedAuthIDs, pinnedAuthID)
+}
+
+// RPopAuthWithPolicyAndConstraints combines a fixed credential policy with the
+// current retry-round exclusions and optional pinned credential constraint.
+func (c *Client) RPopAuthWithPolicyAndConstraints(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string, excludedAuthIDs []string, pinnedAuthID string) ([]byte, error) {
+	return c.rPopAuth(ctx, requestedModel, sessionID, headers, count, credentialPolicy, &excludedAuthIDs, pinnedAuthID)
+}
+
+func (c *Client) rPopAuth(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string, excludedAuthIDs *[]string, pinnedAuthID string) ([]byte, error) {
 	if c == nil || c.dispatchFenced.Load() {
 		return nil, ErrDispatchFenced
 	}
@@ -1287,7 +1310,7 @@ func (c *Client) rPopAuth(ctx context.Context, requestedModel string, sessionID 
 	if requestedModel == "" {
 		return nil, fmt.Errorf("home: requested model is empty")
 	}
-	req := newAuthDispatchRequest(requestedModel, sessionID, headers, count, credentialPolicy)
+	req := newAuthDispatchRequest(requestedModel, sessionID, headers, count, credentialPolicy, excludedAuthIDs, pinnedAuthID)
 	keyBytes, errMarshal := json.Marshal(&req)
 	if errMarshal != nil {
 		return nil, errMarshal

--- a/internal/home/client_test.go
+++ b/internal/home/client_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestAuthDispatchRequestIncludesCount(t *testing.T) {
-	req := newAuthDispatchRequest("gpt-5.4", "session-1", http.Header{"Authorization": {"Bearer test"}}, 2, "")
+	req := newAuthDispatchRequest("gpt-5.4", "session-1", http.Header{"Authorization": {"Bearer test"}}, 2, "", nil, "")
 
 	raw, err := json.Marshal(&req)
 	if err != nil {
@@ -43,10 +43,13 @@ func TestAuthDispatchRequestIncludesCount(t *testing.T) {
 	if got := int(payload["concurrency_protocol"].(float64)); got != 1 {
 		t.Fatalf("concurrency_protocol = %d, want 1", got)
 	}
+	if _, present := payload["excluded_auth_ids"]; present {
+		t.Fatalf("legacy request unexpectedly included excluded_auth_ids: %#v", payload["excluded_auth_ids"])
+	}
 }
 
 func TestAuthDispatchRequestDefaultsCountToOne(t *testing.T) {
-	req := newAuthDispatchRequest("gpt-5.4", "", nil, 0, "")
+	req := newAuthDispatchRequest("gpt-5.4", "", nil, 0, "", nil, "")
 
 	if req.Count != 1 {
 		t.Fatalf("count = %d, want 1", req.Count)
@@ -57,7 +60,7 @@ func TestAuthDispatchRequestDefaultsCountToOne(t *testing.T) {
 }
 
 func TestAuthDispatchRequestIncludesCredentialPolicy(t *testing.T) {
-	req := newAuthDispatchRequest("gpt-5.4", "", nil, 1, "codex_alpha_search_v1")
+	req := newAuthDispatchRequest("gpt-5.4", "", nil, 1, "codex_alpha_search_v1", nil, "")
 	raw, errMarshal := json.Marshal(&req)
 	if errMarshal != nil {
 		t.Fatalf("marshal auth dispatch request: %v", errMarshal)
@@ -68,6 +71,111 @@ func TestAuthDispatchRequestIncludesCredentialPolicy(t *testing.T) {
 	}
 	if got := payload["credential_policy"]; got != "codex_alpha_search_v1" {
 		t.Fatalf("credential_policy = %#v, want codex_alpha_search_v1", got)
+	}
+}
+
+func TestAuthDispatchRequestIncludesExcludedAuthIDs(t *testing.T) {
+	excludedAuthIDs := []string{"auth-a", "auth-b"}
+	req := newAuthDispatchRequest("gpt-5.4", "", nil, 2, "", &excludedAuthIDs, "")
+	if req.Count != 1 {
+		t.Fatalf("new retry-contract count = %d, want 1 for legacy Home compatibility", req.Count)
+	}
+	raw, errMarshal := json.Marshal(&req)
+	if errMarshal != nil {
+		t.Fatalf("marshal auth dispatch request: %v", errMarshal)
+	}
+	var payload map[string]any
+	if errUnmarshal := json.Unmarshal(raw, &payload); errUnmarshal != nil {
+		t.Fatalf("unmarshal auth dispatch request: %v", errUnmarshal)
+	}
+	got, ok := payload["excluded_auth_ids"].([]any)
+	if !ok || len(got) != 2 || got[0] != "auth-a" || got[1] != "auth-b" {
+		t.Fatalf("excluded_auth_ids = %#v, want [auth-a auth-b]", payload["excluded_auth_ids"])
+	}
+}
+
+func TestAuthDispatchRequestIncludesEmptyExcludedAuthIDs(t *testing.T) {
+	excludedAuthIDs := []string{}
+	req := newAuthDispatchRequest("gpt-5.4", "", nil, 2, "", &excludedAuthIDs, "")
+	if req.Count != 1 {
+		t.Fatalf("new retry-contract count = %d, want 1 for legacy Home compatibility", req.Count)
+	}
+	raw, errMarshal := json.Marshal(&req)
+	if errMarshal != nil {
+		t.Fatalf("marshal auth dispatch request: %v", errMarshal)
+	}
+	var payload map[string]any
+	if errUnmarshal := json.Unmarshal(raw, &payload); errUnmarshal != nil {
+		t.Fatalf("unmarshal auth dispatch request: %v", errUnmarshal)
+	}
+	got, ok := payload["excluded_auth_ids"].([]any)
+	if !ok || len(got) != 0 {
+		t.Fatalf("excluded_auth_ids = %#v, want []", payload["excluded_auth_ids"])
+	}
+}
+
+func TestAuthDispatchRequestIncludesPinnedAuthID(t *testing.T) {
+	excludedAuthIDs := []string{}
+	req := newAuthDispatchRequest("gpt-5.4", "", nil, 2, "", &excludedAuthIDs, " auth-pinned ")
+
+	raw, errMarshal := json.Marshal(&req)
+	if errMarshal != nil {
+		t.Fatalf("marshal auth dispatch request: %v", errMarshal)
+	}
+	var payload map[string]any
+	if errUnmarshal := json.Unmarshal(raw, &payload); errUnmarshal != nil {
+		t.Fatalf("unmarshal auth dispatch request: %v", errUnmarshal)
+	}
+	if got := payload["pinned_auth_id"]; got != "auth-pinned" {
+		t.Fatalf("pinned_auth_id = %#v, want auth-pinned", got)
+	}
+}
+
+func TestAuthDispatchRequestDistinguishesLegacyAndRetryRoundProtocol(t *testing.T) {
+	excludedAuthIDs := []string{"auth-a"}
+	legacy := newAuthDispatchRequest("gpt-5.4", "", nil, 3, "", &excludedAuthIDs, "")
+	legacyRaw, errMarshal := json.Marshal(&legacy)
+	if errMarshal != nil {
+		t.Fatalf("marshal legacy auth dispatch request: %v", errMarshal)
+	}
+	var legacyPayload map[string]any
+	if errUnmarshal := json.Unmarshal(legacyRaw, &legacyPayload); errUnmarshal != nil {
+		t.Fatalf("unmarshal legacy auth dispatch request: %v", errUnmarshal)
+	}
+	if _, present := legacyPayload["retry_round"]; present {
+		t.Fatalf("legacy request unexpectedly included retry_round: %#v", legacyPayload["retry_round"])
+	}
+
+	initial := newAuthDispatchRequestWithRetryRound("gpt-5.4", "", nil, 3, "", 0, &excludedAuthIDs, "")
+	initialRaw, errMarshal := json.Marshal(&initial)
+	if errMarshal != nil {
+		t.Fatalf("marshal initial auth dispatch request: %v", errMarshal)
+	}
+	var initialPayload map[string]any
+	if errUnmarshal := json.Unmarshal(initialRaw, &initialPayload); errUnmarshal != nil {
+		t.Fatalf("unmarshal initial auth dispatch request: %v", errUnmarshal)
+	}
+	if got := int(initialPayload["retry_round"].(float64)); got != 0 {
+		t.Fatalf("initial retry_round = %d, want explicit 0", got)
+	}
+	if got := int(initialPayload["count"].(float64)); got != 1 {
+		t.Fatalf("initial retry-contract count = %d, want 1", got)
+	}
+
+	additional := newAuthDispatchRequestWithRetryRound("gpt-5.4", "", nil, 3, "", 2, &excludedAuthIDs, "")
+	additionalRaw, errMarshal := json.Marshal(&additional)
+	if errMarshal != nil {
+		t.Fatalf("marshal additional auth dispatch request: %v", errMarshal)
+	}
+	var additionalPayload map[string]any
+	if errUnmarshal := json.Unmarshal(additionalRaw, &additionalPayload); errUnmarshal != nil {
+		t.Fatalf("unmarshal additional auth dispatch request: %v", errUnmarshal)
+	}
+	if got := int(additionalPayload["retry_round"].(float64)); got != 2 {
+		t.Fatalf("retry_round = %d, want 2", got)
+	}
+	if got := additionalPayload["excluded_auth_ids"].([]any); len(got) != 1 || got[0] != "auth-a" {
+		t.Fatalf("excluded_auth_ids = %#v, want [auth-a]", additionalPayload["excluded_auth_ids"])
 	}
 }
 

--- a/internal/home/client_test.go
+++ b/internal/home/client_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestAuthDispatchRequestIncludesCount(t *testing.T) {
-	req := newAuthDispatchRequest("gpt-5.4", "session-1", http.Header{"Authorization": {"Bearer test"}}, 2, "")
+	req := newAuthDispatchRequest("gpt-5.4", "session-1", http.Header{"Authorization": {"Bearer test"}}, 2, "", nil, "")
 
 	raw, err := json.Marshal(&req)
 	if err != nil {
@@ -43,10 +43,13 @@ func TestAuthDispatchRequestIncludesCount(t *testing.T) {
 	if got := int(payload["concurrency_protocol"].(float64)); got != 1 {
 		t.Fatalf("concurrency_protocol = %d, want 1", got)
 	}
+	if _, present := payload["excluded_auth_ids"]; present {
+		t.Fatalf("legacy request unexpectedly included excluded_auth_ids: %#v", payload["excluded_auth_ids"])
+	}
 }
 
 func TestAuthDispatchRequestDefaultsCountToOne(t *testing.T) {
-	req := newAuthDispatchRequest("gpt-5.4", "", nil, 0, "")
+	req := newAuthDispatchRequest("gpt-5.4", "", nil, 0, "", nil, "")
 
 	if req.Count != 1 {
 		t.Fatalf("count = %d, want 1", req.Count)
@@ -57,7 +60,7 @@ func TestAuthDispatchRequestDefaultsCountToOne(t *testing.T) {
 }
 
 func TestAuthDispatchRequestIncludesCredentialPolicy(t *testing.T) {
-	req := newAuthDispatchRequest("gpt-5.4", "", nil, 1, "codex_alpha_search_v1")
+	req := newAuthDispatchRequest("gpt-5.4", "", nil, 1, "codex_alpha_search_v1", nil, "")
 	raw, errMarshal := json.Marshal(&req)
 	if errMarshal != nil {
 		t.Fatalf("marshal auth dispatch request: %v", errMarshal)
@@ -68,6 +71,63 @@ func TestAuthDispatchRequestIncludesCredentialPolicy(t *testing.T) {
 	}
 	if got := payload["credential_policy"]; got != "codex_alpha_search_v1" {
 		t.Fatalf("credential_policy = %#v, want codex_alpha_search_v1", got)
+	}
+}
+
+func TestAuthDispatchRequestIncludesExcludedAuthIDs(t *testing.T) {
+	excludedAuthIDs := []string{"auth-a", "auth-b"}
+	req := newAuthDispatchRequest("gpt-5.4", "", nil, 2, "", &excludedAuthIDs, "")
+	if req.Count != 1 {
+		t.Fatalf("new retry-contract count = %d, want 1 for legacy Home compatibility", req.Count)
+	}
+	raw, errMarshal := json.Marshal(&req)
+	if errMarshal != nil {
+		t.Fatalf("marshal auth dispatch request: %v", errMarshal)
+	}
+	var payload map[string]any
+	if errUnmarshal := json.Unmarshal(raw, &payload); errUnmarshal != nil {
+		t.Fatalf("unmarshal auth dispatch request: %v", errUnmarshal)
+	}
+	got, ok := payload["excluded_auth_ids"].([]any)
+	if !ok || len(got) != 2 || got[0] != "auth-a" || got[1] != "auth-b" {
+		t.Fatalf("excluded_auth_ids = %#v, want [auth-a auth-b]", payload["excluded_auth_ids"])
+	}
+}
+
+func TestAuthDispatchRequestIncludesEmptyExcludedAuthIDs(t *testing.T) {
+	excludedAuthIDs := []string{}
+	req := newAuthDispatchRequest("gpt-5.4", "", nil, 2, "", &excludedAuthIDs, "")
+	if req.Count != 1 {
+		t.Fatalf("new retry-contract count = %d, want 1 for legacy Home compatibility", req.Count)
+	}
+	raw, errMarshal := json.Marshal(&req)
+	if errMarshal != nil {
+		t.Fatalf("marshal auth dispatch request: %v", errMarshal)
+	}
+	var payload map[string]any
+	if errUnmarshal := json.Unmarshal(raw, &payload); errUnmarshal != nil {
+		t.Fatalf("unmarshal auth dispatch request: %v", errUnmarshal)
+	}
+	got, ok := payload["excluded_auth_ids"].([]any)
+	if !ok || len(got) != 0 {
+		t.Fatalf("excluded_auth_ids = %#v, want []", payload["excluded_auth_ids"])
+	}
+}
+
+func TestAuthDispatchRequestIncludesPinnedAuthID(t *testing.T) {
+	excludedAuthIDs := []string{}
+	req := newAuthDispatchRequest("gpt-5.4", "", nil, 2, "", &excludedAuthIDs, " auth-pinned ")
+
+	raw, errMarshal := json.Marshal(&req)
+	if errMarshal != nil {
+		t.Fatalf("marshal auth dispatch request: %v", errMarshal)
+	}
+	var payload map[string]any
+	if errUnmarshal := json.Unmarshal(raw, &payload); errUnmarshal != nil {
+		t.Fatalf("unmarshal auth dispatch request: %v", errUnmarshal)
+	}
+	if got := payload["pinned_auth_id"]; got != "auth-pinned" {
+		t.Fatalf("pinned_auth_id = %#v, want auth-pinned", got)
 	}
 }
 

--- a/internal/home/client_test.go
+++ b/internal/home/client_test.go
@@ -131,6 +131,54 @@ func TestAuthDispatchRequestIncludesPinnedAuthID(t *testing.T) {
 	}
 }
 
+func TestAuthDispatchRequestDistinguishesLegacyAndRetryRoundProtocol(t *testing.T) {
+	excludedAuthIDs := []string{"auth-a"}
+	legacy := newAuthDispatchRequest("gpt-5.4", "", nil, 3, "", &excludedAuthIDs, "")
+	legacyRaw, errMarshal := json.Marshal(&legacy)
+	if errMarshal != nil {
+		t.Fatalf("marshal legacy auth dispatch request: %v", errMarshal)
+	}
+	var legacyPayload map[string]any
+	if errUnmarshal := json.Unmarshal(legacyRaw, &legacyPayload); errUnmarshal != nil {
+		t.Fatalf("unmarshal legacy auth dispatch request: %v", errUnmarshal)
+	}
+	if _, present := legacyPayload["retry_round"]; present {
+		t.Fatalf("legacy request unexpectedly included retry_round: %#v", legacyPayload["retry_round"])
+	}
+
+	initial := newAuthDispatchRequestWithRetryRound("gpt-5.4", "", nil, 3, "", 0, &excludedAuthIDs, "")
+	initialRaw, errMarshal := json.Marshal(&initial)
+	if errMarshal != nil {
+		t.Fatalf("marshal initial auth dispatch request: %v", errMarshal)
+	}
+	var initialPayload map[string]any
+	if errUnmarshal := json.Unmarshal(initialRaw, &initialPayload); errUnmarshal != nil {
+		t.Fatalf("unmarshal initial auth dispatch request: %v", errUnmarshal)
+	}
+	if got := int(initialPayload["retry_round"].(float64)); got != 0 {
+		t.Fatalf("initial retry_round = %d, want explicit 0", got)
+	}
+	if got := int(initialPayload["count"].(float64)); got != 1 {
+		t.Fatalf("initial retry-contract count = %d, want 1", got)
+	}
+
+	additional := newAuthDispatchRequestWithRetryRound("gpt-5.4", "", nil, 3, "", 2, &excludedAuthIDs, "")
+	additionalRaw, errMarshal := json.Marshal(&additional)
+	if errMarshal != nil {
+		t.Fatalf("marshal additional auth dispatch request: %v", errMarshal)
+	}
+	var additionalPayload map[string]any
+	if errUnmarshal := json.Unmarshal(additionalRaw, &additionalPayload); errUnmarshal != nil {
+		t.Fatalf("unmarshal additional auth dispatch request: %v", errUnmarshal)
+	}
+	if got := int(additionalPayload["retry_round"].(float64)); got != 2 {
+		t.Fatalf("retry_round = %d, want 2", got)
+	}
+	if got := additionalPayload["excluded_auth_ids"].([]any); len(got) != 1 || got[0] != "auth-a" {
+		t.Fatalf("excluded_auth_ids = %#v, want [auth-a]", additionalPayload["excluded_auth_ids"])
+	}
+}
+
 func TestRedisOptionsHomeTLSDisabled(t *testing.T) {
 	client := New(config.HomeConfig{
 		Enabled: true,

--- a/internal/home/requests.go
+++ b/internal/home/requests.go
@@ -10,6 +10,9 @@ type authDispatchRequest struct {
 	SessionID           string            `json:"session_id,omitempty"`
 	Headers             map[string]string `json:"headers,omitempty"`
 	CredentialPolicy    string            `json:"credential_policy,omitempty"`
+	RetryRound          *int              `json:"retry_round,omitempty"`
+	ExcludedAuthIDs     *[]string         `json:"excluded_auth_ids,omitempty"`
+	PinnedAuthID        string            `json:"pinned_auth_id,omitempty"`
 }
 
 type modelsRequest struct {

--- a/internal/home/requests.go
+++ b/internal/home/requests.go
@@ -10,6 +10,7 @@ type authDispatchRequest struct {
 	SessionID           string            `json:"session_id,omitempty"`
 	Headers             map[string]string `json:"headers,omitempty"`
 	CredentialPolicy    string            `json:"credential_policy,omitempty"`
+	RetryRound          *int              `json:"retry_round,omitempty"`
 	ExcludedAuthIDs     *[]string         `json:"excluded_auth_ids,omitempty"`
 	PinnedAuthID        string            `json:"pinned_auth_id,omitempty"`
 }

--- a/internal/home/requests.go
+++ b/internal/home/requests.go
@@ -10,6 +10,8 @@ type authDispatchRequest struct {
 	SessionID           string            `json:"session_id,omitempty"`
 	Headers             map[string]string `json:"headers,omitempty"`
 	CredentialPolicy    string            `json:"credential_policy,omitempty"`
+	ExcludedAuthIDs     *[]string         `json:"excluded_auth_ids,omitempty"`
+	PinnedAuthID        string            `json:"pinned_auth_id,omitempty"`
 }
 
 type modelsRequest struct {

--- a/internal/misc/antigravity_version.go
+++ b/internal/misc/antigravity_version.go
@@ -16,7 +16,11 @@ import (
 )
 
 const (
-	antigravityFallbackVersion = "2.2.1"
+	// antigravityFallbackVersion is the client version reported when the hub
+	// manifest has not been fetched yet or cannot be reached. Cloud Code rejects
+	// newer models for clients below 2.9.0, so this floor must stay at or above
+	// that version.
+	antigravityFallbackVersion = "2.9.1"
 	antigravityHubPlatform     = "darwin/arm64"
 	antigravityVersionCacheTTL = 6 * time.Hour
 	antigravityFetchTimeout    = 10 * time.Second

--- a/internal/misc/antigravity_version_test.go
+++ b/internal/misc/antigravity_version_test.go
@@ -2,6 +2,7 @@ package misc
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -42,8 +43,22 @@ func TestAntigravityLatestVersionUsesCurrentHubFallback(t *testing.T) {
 	defer restore()
 
 	version := AntigravityLatestVersion()
-	if version != "2.2.1" {
-		t.Fatalf("AntigravityLatestVersion() = %q, want %q", version, "2.2.1")
+	if version != antigravityFallbackVersion {
+		t.Fatalf("AntigravityLatestVersion() = %q, want %q", version, antigravityFallbackVersion)
+	}
+}
+
+// Cloud Code resolves newer models only for clients reporting at least 2.9.0;
+// older versions get 404 Requested entity was not found.
+func TestAntigravityFallbackVersionMeetsBackendFloor(t *testing.T) {
+	const floorMajor, floorMinor = 2, 9
+
+	var major, minor, patch int
+	if _, err := fmt.Sscanf(antigravityFallbackVersion, "%d.%d.%d", &major, &minor, &patch); err != nil {
+		t.Fatalf("antigravityFallbackVersion = %q is not a dotted version: %v", antigravityFallbackVersion, err)
+	}
+	if major < floorMajor || (major == floorMajor && minor < floorMinor) {
+		t.Fatalf("antigravityFallbackVersion = %q, want at least %d.%d.0", antigravityFallbackVersion, floorMajor, floorMinor)
 	}
 }
 

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -806,6 +806,38 @@
       "supportedOutputModalities": [
         "text"
       ]
+    },
+    {
+      "id": "gemini-3.7-flash",
+      "object": "model",
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini 3.7 Flash",
+      "name": "models/gemini-3.7-flash",
+      "version": "3.7",
+      "description": "Gemini 3.7 Flash",
+      "context_length": 1048576,
+      "max_completion_tokens": 65536,
+      "thinking": {
+        "min": 128,
+        "max": 65535,
+        "dynamic_allowed": true,
+        "levels": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
     }
   ],
   "vertex": [
@@ -1402,6 +1434,37 @@
       "thinking": {
         "min": 128,
         "max": 32768,
+        "dynamic_allowed": true,
+        "levels": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
+    },
+    {
+      "id": "gemini-3.7-flash",
+      "object": "model",
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini 3.7 Flash",
+      "name": "gemini-3.7-flash",
+      "description": "Gemini 3.7 Flash",
+      "context_length": 1048576,
+      "max_completion_tokens": 65536,
+      "thinking": {
+        "min": 128,
+        "max": 65535,
         "dynamic_allowed": true,
         "levels": [
           "minimal",
@@ -2139,6 +2202,38 @@
       "thinking": {
         "min": 128,
         "max": 32768,
+        "dynamic_allowed": true,
+        "levels": [
+          "minimal",
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      "supportedInputModalities": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "supportedOutputModalities": [
+        "text"
+      ]
+    },
+    {
+      "id": "gemini-3.7-flash",
+      "object": "model",
+      "owned_by": "google",
+      "type": "gemini",
+      "display_name": "Gemini 3.7 Flash",
+      "name": "models/gemini-3.7-flash",
+      "version": "3.7",
+      "description": "Gemini 3.7 Flash",
+      "context_length": 1048576,
+      "max_completion_tokens": 65536,
+      "thinking": {
+        "min": 128,
+        "max": 65535,
         "dynamic_allowed": true,
         "levels": [
           "minimal",

--- a/internal/runtime/executor/aistudio_executor.go
+++ b/internal/runtime/executor/aistudio_executor.go
@@ -487,6 +487,7 @@ func (e *AIStudioExecutor) translateRequest(ctx context.Context, req cliproxyexe
 		action = "streamGenerateContent"
 	}
 	payload, _ = sjson.DeleteBytes(payload, "session_id")
+	payload = helps.EnsureGeminiLeadingUserContent(payload, "contents")
 	return payload, translatedPayload{payload: payload, action: action, toFormat: to}, nil
 }
 

--- a/internal/runtime/executor/aistudio_executor_test.go
+++ b/internal/runtime/executor/aistudio_executor_test.go
@@ -39,6 +39,18 @@ func TestAIStudioTranslateRequestPreservesSummaryFromOriginalRequest(t *testing.
 	}
 }
 
+func TestAIStudioTranslateRequestPrependsLeadingUserForIssue4959ResponsesHistory(t *testing.T) {
+	executor := NewAIStudioExecutor(&config.Config{}, "aistudio", nil)
+	_, body, err := executor.translateRequest(context.Background(), cliproxyexecutor.Request{
+		Model:   "gemini-3.7-flash-high",
+		Payload: issue4959ResponsesModelFirstPayload(),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse}, false)
+	if err != nil {
+		t.Fatalf("translateRequest() error = %v", err)
+	}
+	assertIssue4959LeadingUserContents(t, gjson.GetBytes(body.payload, "contents").Array())
+}
+
 func TestAIStudioExecutorExecuteStartsTTFTBeforeRelayWait(t *testing.T) {
 	const authID = "aistudio-ttft-auth"
 	delay := 40 * time.Millisecond

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -345,6 +345,16 @@ func sanitizeAntigravityGeminiRequestSignatures(modelName string, rawJSON []byte
 	return normalizeAntigravityGeminiFunctionResponseRoles(rawJSON)
 }
 
+// ensureAntigravityGeminiLeadingUserContent prepends a synthetic empty user turn
+// after every contents rewrite, including reasoning replay. Claude targets are
+// left unchanged because the adapter rejects empty text parts.
+func ensureAntigravityGeminiLeadingUserContent(modelName string, payload []byte) []byte {
+	if strings.Contains(strings.ToLower(modelName), "claude") {
+		return payload
+	}
+	return helps.EnsureGeminiLeadingUserContent(payload, "request.contents")
+}
+
 type antigravityContentEdit struct {
 	index       int64
 	start       int

--- a/internal/runtime/executor/antigravity_executor_credits.go
+++ b/internal/runtime/executor/antigravity_executor_credits.go
@@ -525,26 +525,6 @@ func (e *AntigravityExecutor) updateAntigravityCreditsBalance(ctx context.Contex
 		return
 	}
 }
-func antigravityRetryAttempts(auth *cliproxyauth.Auth, cfg *config.Config) int {
-	retry := 0
-	if cfg != nil {
-		retry = cfg.RequestRetry
-	}
-	if auth != nil {
-		if override, ok := auth.RequestRetryOverride(); ok {
-			retry = override
-		}
-	}
-	if retry < 0 {
-		retry = 0
-	}
-	attempts := retry + 1
-	if attempts < 1 {
-		return 1
-	}
-	return attempts
-}
-
 func antigravityShouldRetryNoCapacity(statusCode int, body []byte) bool {
 	if statusCode != http.StatusServiceUnavailable {
 		return false

--- a/internal/runtime/executor/antigravity_executor_credits_test.go
+++ b/internal/runtime/executor/antigravity_executor_credits_test.go
@@ -278,27 +278,19 @@ func TestParseRetryDelay_HumanReadableDuration(t *testing.T) {
 	}
 }
 
-func TestAntigravityExecute_RetriesTransient429ResourceExhausted(t *testing.T) {
+func TestAntigravityExecute_DoesNotUseRequestRetryForInternalRetries(t *testing.T) {
 	resetAntigravityCreditsRetryState()
 	t.Cleanup(resetAntigravityCreditsRetryState)
 
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCount++
-		switch requestCount {
-		case 1:
-			w.WriteHeader(http.StatusTooManyRequests)
-			_, _ = w.Write([]byte(`{"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}`))
-		case 2:
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]}}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}}`))
-		default:
-			t.Fatalf("unexpected request count %d", requestCount)
-		}
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}`))
 	}))
 	defer server.Close()
 
-	exec := NewAntigravityExecutor(&config.Config{RequestRetry: 1})
+	exec := NewAntigravityExecutor(&config.Config{RequestRetry: 3})
 	auth := &cliproxyauth.Auth{
 		ID: "auth-transient-429",
 		Attributes: map[string]string{
@@ -317,14 +309,14 @@ func TestAntigravityExecute_RetriesTransient429ResourceExhausted(t *testing.T) {
 	}, cliproxyexecutor.Options{
 		SourceFormat: sdktranslator.FormatAntigravity,
 	})
-	if err != nil {
-		t.Fatalf("Execute() error = %v", err)
+	if err == nil {
+		t.Fatalf("Execute() error = nil, want upstream 429")
 	}
-	if len(resp.Payload) == 0 {
-		t.Fatal("Execute() returned empty payload")
+	if len(resp.Payload) != 0 {
+		t.Fatalf("Execute() returned payload %q, want empty payload", resp.Payload)
 	}
-	if requestCount != 2 {
-		t.Fatalf("request count = %d, want 2", requestCount)
+	if requestCount != 1 {
+		t.Fatalf("request count = %d, want 1", requestCount)
 	}
 }
 

--- a/internal/runtime/executor/antigravity_executor_execute.go
+++ b/internal/runtime/executor/antigravity_executor_execute.go
@@ -85,7 +85,9 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	attempts := antigravityRetryAttempts(auth, e.cfg)
+	// Credential retry rounds are owned by the conductor. Keep one upstream
+	// attempt per credential so request-retry is not consumed twice.
+	attempts := 1
 
 attemptLoop:
 	for attempt := 0; attempt < attempts; attempt++ {
@@ -110,6 +112,7 @@ attemptLoop:
 					return resp, err
 				}
 			}
+			requestPayload = ensureAntigravityGeminiLeadingUserContent(baseModel, requestPayload)
 
 			httpReq, errReq := e.buildRequest(ctx, auth, token, baseModel, requestPayload, false, opts.Alt, baseURL, helps.DerivedAntigravitySessionID(opts.Metadata, req.Metadata))
 			if errReq != nil {
@@ -312,7 +315,9 @@ func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
 
-	attempts := antigravityRetryAttempts(auth, e.cfg)
+	// Credential retry rounds are owned by the conductor. Keep one upstream
+	// attempt per credential so request-retry is not consumed twice.
+	attempts := 1
 
 attemptLoop:
 	for attempt := 0; attempt < attempts; attempt++ {
@@ -337,6 +342,7 @@ attemptLoop:
 					return resp, err
 				}
 			}
+			requestPayload = ensureAntigravityGeminiLeadingUserContent(baseModel, requestPayload)
 			httpReq, errReq := e.buildRequest(ctx, auth, token, baseModel, requestPayload, true, opts.Alt, baseURL, helps.DerivedAntigravitySessionID(opts.Metadata, req.Metadata))
 			if errReq != nil {
 				err = errReq

--- a/internal/runtime/executor/antigravity_executor_execute.go
+++ b/internal/runtime/executor/antigravity_executor_execute.go
@@ -85,7 +85,9 @@ func (e *AntigravityExecutor) Execute(ctx context.Context, auth *cliproxyauth.Au
 	baseURLs := antigravityBaseURLFallbackOrder(auth)
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
-	attempts := antigravityRetryAttempts(auth, e.cfg)
+	// Credential retry rounds are owned by the conductor. Keep one upstream
+	// attempt per credential so request-retry is not consumed twice.
+	attempts := 1
 
 attemptLoop:
 	for attempt := 0; attempt < attempts; attempt++ {
@@ -313,7 +315,9 @@ func (e *AntigravityExecutor) executeClaudeNonStream(ctx context.Context, auth *
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
 
-	attempts := antigravityRetryAttempts(auth, e.cfg)
+	// Credential retry rounds are owned by the conductor. Keep one upstream
+	// attempt per credential so request-retry is not consumed twice.
+	attempts := 1
 
 attemptLoop:
 	for attempt := 0; attempt < attempts; attempt++ {

--- a/internal/runtime/executor/antigravity_executor_execute.go
+++ b/internal/runtime/executor/antigravity_executor_execute.go
@@ -110,6 +110,7 @@ attemptLoop:
 					return resp, err
 				}
 			}
+			requestPayload = ensureAntigravityGeminiLeadingUserContent(baseModel, requestPayload)
 
 			httpReq, errReq := e.buildRequest(ctx, auth, token, baseModel, requestPayload, false, opts.Alt, baseURL, helps.DerivedAntigravitySessionID(opts.Metadata, req.Metadata))
 			if errReq != nil {
@@ -337,6 +338,7 @@ attemptLoop:
 					return resp, err
 				}
 			}
+			requestPayload = ensureAntigravityGeminiLeadingUserContent(baseModel, requestPayload)
 			httpReq, errReq := e.buildRequest(ctx, auth, token, baseModel, requestPayload, true, opts.Alt, baseURL, helps.DerivedAntigravitySessionID(opts.Metadata, req.Metadata))
 			if errReq != nil {
 				err = errReq

--- a/internal/runtime/executor/antigravity_executor_signature_test.go
+++ b/internal/runtime/executor/antigravity_executor_signature_test.go
@@ -39,6 +39,50 @@ func testFakeClaudeSignature() string {
 	return base64.StdEncoding.EncodeToString([]byte{0x12, 0xFF, 0xFE, 0xFD})
 }
 
+func issue4959GeminiThoughtSignature() string {
+	return "EjQKMgEMOdbHO0Gd+c9Mxk4ELwPGbpCEcp2mFfYYLix2UVtBH3fL8GECc4+JITVnHF4qZDsA"
+}
+
+// issue4959ResponsesModelFirstPayload is the #4959 Responses history: a
+// next:function reasoning carrier, then function_call / function_call_output,
+// then trailing assistant turns. Trailing model turns are left for a follow-up.
+func issue4959ResponsesModelFirstPayload() []byte {
+	carrier := "cpa-gemini-responses-carrier-v1:next:function:" + base64.RawStdEncoding.EncodeToString([]byte(issue4959GeminiThoughtSignature()))
+	return []byte(`{"model":"gemini-3.7-flash-high","input":[` +
+		`{"type":"reasoning","id":"rs_resp_test_detached_before_0","summary":[],"encrypted_content":"` + carrier + `"},` +
+		`{"type":"function_call","call_id":"call_bash_1","name":"Bash","arguments":"{\"command\":\"true\"}"},` +
+		`{"type":"function_call_output","call_id":"call_bash_1","output":"ok"},` +
+		`{"role":"assistant","content":[{"type":"output_text","text":"first"}]},` +
+		`{"role":"assistant","content":[{"type":"output_text","text":"second"}]}` +
+		`]}`)
+}
+
+func contentHasNamedPart(content gjson.Result, partKind, name string) bool {
+	for _, part := range content.Get("parts").Array() {
+		if part.Get(partKind+".name").String() == name {
+			return true
+		}
+	}
+	return false
+}
+
+func assertIssue4959LeadingUserContents(t *testing.T, contents []gjson.Result) {
+	t.Helper()
+	if len(contents) < 3 {
+		t.Fatalf("contents too short: %d", len(contents))
+	}
+	leadingText := contents[0].Get("parts.0.text")
+	if contents[0].Get("role").String() != "user" || !leadingText.Exists() || leadingText.String() != "" {
+		t.Fatalf("synthetic leading user missing: %s", contents[0].Raw)
+	}
+	if contents[1].Get("role").String() != "model" || !contentHasNamedPart(contents[1], "functionCall", "Bash") {
+		t.Fatalf("function call is not immediately after the synthetic user: %s", contents[1].Raw)
+	}
+	if !contentHasNamedPart(contents[2], "functionResponse", "Bash") {
+		t.Fatalf("function response missing or moved: %s", contents[2].Raw)
+	}
+}
+
 func testAntigravityAuth(baseURL string) *cliproxyauth.Auth {
 	return &cliproxyauth.Auth{
 		Attributes: map[string]string{
@@ -210,6 +254,338 @@ func TestAntigravityStreamObfuscatesSensitiveSystemInstruction(t *testing.T) {
 	}
 }
 
+func TestAntigravityStreamPrependsLeadingUserForGemini(t *testing.T) {
+	assertLeadingFunctionHistory := func(t *testing.T, body []byte) {
+		t.Helper()
+		contents := gjson.GetBytes(body, "request.contents").Array()
+		if len(contents) != 3 || contents[0].Get("role").String() != "user" {
+			t.Fatalf("upstream roles malformed: %s", body)
+		}
+		leadingText := contents[0].Get("parts.0.text")
+		if !leadingText.Exists() || leadingText.String() != "" {
+			t.Fatalf("synthetic leading user missing: %s", body)
+		}
+		if !contents[1].Get("parts.0.functionCall").Exists() || !contents[2].Get("parts.0.functionResponse").Exists() {
+			t.Fatalf("function history changed: %s", body)
+		}
+	}
+
+	tests := []struct {
+		name    string
+		format  sdktranslator.Format
+		payload string
+		assert  func(*testing.T, []byte)
+	}{
+		{
+			name:   "Gemini prepends user before leading function call",
+			format: sdktranslator.FormatGemini,
+			payload: `{"contents":[` +
+				`{"role":"model","parts":[{"functionCall":{"name":"run","args":{}}}]},` +
+				`{"role":"user","parts":[{"functionResponse":{"name":"run","response":{"result":"ok"}}}]}` +
+				`]}`,
+			assert: assertLeadingFunctionHistory,
+		},
+		{
+			name:   "OpenAI Chat prepends user before leading tool call",
+			format: sdktranslator.FormatOpenAI,
+			payload: `{"messages":[` +
+				`{"role":"assistant","tool_calls":[{"id":"call-1","type":"function","function":{"name":"run","arguments":"{}"}}]},` +
+				`{"role":"tool","tool_call_id":"call-1","content":"ok"}` +
+				`]}`,
+			assert: assertLeadingFunctionHistory,
+		},
+		{
+			name:   "OpenAI Responses prepends user before leading function call",
+			format: sdktranslator.FormatOpenAIResponse,
+			payload: `{"input":[` +
+				`{"type":"function_call","call_id":"call-1","name":"run","arguments":"{}"},` +
+				`{"type":"function_call_output","call_id":"call-1","output":"ok"}` +
+				`]}`,
+			assert: assertLeadingFunctionHistory,
+		},
+		{
+			name:   "Claude prepends user before leading tool use",
+			format: sdktranslator.FormatClaude,
+			payload: `{"messages":[` +
+				`{"role":"assistant","content":[{"type":"tool_use","id":"run-call-1","name":"run","input":{}}]},` +
+				`{"role":"user","content":[{"type":"tool_result","tool_use_id":"run-call-1","content":"ok"}]}` +
+				`]}`,
+			assert: assertLeadingFunctionHistory,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			captured := make(chan []byte, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, errRead := io.ReadAll(r.Body)
+				if errRead != nil {
+					t.Errorf("read request body: %v", errRead)
+					return
+				}
+				captured <- body
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = w.Write([]byte("data: {\"response\":{\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"ok\"}]},\"finishReason\":\"STOP\"}]}}\n\n"))
+			}))
+			defer server.Close()
+
+			executor := NewAntigravityExecutor(&config.Config{RequestRetry: 1})
+			auth := testAntigravityAuth(server.URL)
+			auth.Metadata["project_id"] = "project-1"
+			result, errExecute := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+				Model:   "gemini-3.6-flash-high",
+				Payload: []byte(tt.payload),
+			}, cliproxyexecutor.Options{
+				SourceFormat:   tt.format,
+				ResponseFormat: tt.format,
+				Stream:         true,
+			})
+			if errExecute != nil {
+				t.Fatalf("ExecuteStream() error = %v", errExecute)
+			}
+			for chunk := range result.Chunks {
+				if chunk.Err != nil {
+					t.Fatalf("stream chunk error = %v", chunk.Err)
+				}
+			}
+			tt.assert(t, <-captured)
+		})
+	}
+}
+
+func TestAntigravityStreamPrependsLeadingUserForIssue4959ResponsesHistory(t *testing.T) {
+	captured := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		captured <- body
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"response\":{\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"ok\"}]},\"finishReason\":\"STOP\"}]}}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewAntigravityExecutor(&config.Config{RequestRetry: 1})
+	auth := testAntigravityAuth(server.URL)
+	auth.Metadata["project_id"] = "project-1"
+	result, errExecute := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gemini-3.7-flash-high",
+		Payload: issue4959ResponsesModelFirstPayload(),
+	}, cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FormatOpenAIResponse,
+		ResponseFormat: sdktranslator.FormatOpenAIResponse,
+		Stream:         true,
+	})
+	if errExecute != nil {
+		t.Fatalf("ExecuteStream() error = %v", errExecute)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v", chunk.Err)
+		}
+	}
+	assertIssue4959LeadingUserContents(t, gjson.GetBytes(<-captured, "request.contents").Array())
+}
+
+func TestAntigravityStreamPrependsLeadingUserAfterReplayInsertsFunctionCall(t *testing.T) {
+	cache.ClearAntigravityReasoningReplayCache()
+	t.Cleanup(cache.ClearAntigravityReasoningReplayCache)
+
+	const sessionID = "replay-insert-at-zero"
+	const nativeID = "call-1"
+	const nativeArgs = `{}`
+	clientID := util.GeminiClaudeToolUseID(nativeID, "run", nativeArgs)
+	item := []byte(`{"type":"function_call_part","contentIndex":0,"partIndex":0,"call_id":"` + nativeID + `","name":"run","args":` + nativeArgs + `,"thoughtSignature":"replay-inserted-call-signature-123456"}`)
+	if !cache.CacheAntigravityReasoningReplayItems("gemini-3.6-flash-high", "responses:"+sessionID, [][]byte{item}) {
+		t.Fatal("failed to cache omitted function call")
+	}
+
+	captured := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Errorf("read request body: %v", errRead)
+			return
+		}
+		captured <- body
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"response\":{\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"ok\"}]},\"finishReason\":\"STOP\"}]}}\n\n"))
+	}))
+	defer server.Close()
+
+	payload := []byte(`{"model":"gemini-3.6-flash-high","session_id":"` + sessionID + `","messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"` + clientID + `","content":"ok"}]}],"tools":[{"name":"run","input_schema":{"type":"object"}}]}`)
+	executor := NewAntigravityExecutor(&config.Config{RequestRetry: 1})
+	auth := testAntigravityAuth(server.URL)
+	auth.Metadata["project_id"] = "project-1"
+	result, errExecute := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gemini-3.6-flash-high",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat:    sdktranslator.FormatClaude,
+		ResponseFormat:  sdktranslator.FormatClaude,
+		Stream:          true,
+		OriginalRequest: payload,
+	})
+	if errExecute != nil {
+		t.Fatalf("ExecuteStream() error = %v", errExecute)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v", chunk.Err)
+		}
+	}
+
+	body := <-captured
+	contents := gjson.GetBytes(body, "request.contents").Array()
+	if len(contents) != 3 {
+		t.Fatalf("contents len = %d, want 3; body=%s", len(contents), body)
+	}
+	leadingText := contents[0].Get("parts.0.text")
+	if contents[0].Get("role").String() != "user" || !leadingText.Exists() || leadingText.String() != "" {
+		t.Fatalf("synthetic leading user missing after replay insert: %s", contents[0].Raw)
+	}
+	if contents[1].Get("role").String() != "model" || contents[1].Get("parts.0.functionCall.id").String() != "call-1" {
+		t.Fatalf("replayed functionCall is not immediately after the synthetic user: %s", contents[1].Raw)
+	}
+	if !contentHasNamedPart(contents[2], "functionResponse", "run") {
+		t.Fatalf("functionResponse missing or moved: %s", contents[2].Raw)
+	}
+}
+
+func TestAntigravityStreamDoesNotPrependLeadingUserForClaudeTarget(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  sdktranslator.Format
+		payload string
+	}{
+		{
+			name:   "Gemini model-first history",
+			format: sdktranslator.FormatGemini,
+			payload: `{"contents":[` +
+				`{"role":"model","parts":[{"text":"prior answer"}]},` +
+				`{"role":"user","parts":[{"text":"continue"}]}` +
+				`]}`,
+		},
+		{
+			name:   "OpenAI Responses assistant-first history",
+			format: sdktranslator.FormatOpenAIResponse,
+			payload: `{"input":[` +
+				`{"type":"message","role":"assistant","content":[{"type":"output_text","text":"prior answer"}]},` +
+				`{"type":"message","role":"user","content":[{"type":"input_text","text":"continue"}]}` +
+				`]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			captured := make(chan []byte, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, errRead := io.ReadAll(r.Body)
+				if errRead != nil {
+					t.Errorf("read request body: %v", errRead)
+					return
+				}
+				captured <- body
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = w.Write([]byte("data: {\"response\":{\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"ok\"}]},\"finishReason\":\"STOP\"}]}}\n\n"))
+			}))
+			defer server.Close()
+
+			executor := NewAntigravityExecutor(&config.Config{RequestRetry: 1})
+			auth := testAntigravityAuth(server.URL)
+			auth.Metadata["project_id"] = "project-1"
+			result, errExecute := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+				Model:   "claude-sonnet-4-6",
+				Payload: []byte(tt.payload),
+			}, cliproxyexecutor.Options{
+				SourceFormat:   tt.format,
+				ResponseFormat: tt.format,
+				Stream:         true,
+			})
+			if errExecute != nil {
+				t.Fatalf("ExecuteStream() error = %v", errExecute)
+			}
+			for chunk := range result.Chunks {
+				if chunk.Err != nil {
+					t.Fatalf("stream chunk error = %v", chunk.Err)
+				}
+			}
+
+			body := <-captured
+			contents := gjson.GetBytes(body, "request.contents").Array()
+			if len(contents) != 2 || contents[0].Get("role").String() != "model" || contents[1].Get("role").String() != "user" {
+				t.Fatalf("Claude target history changed: %s", body)
+			}
+			if got := contents[0].Get("parts.0.text").String(); got != "prior answer" {
+				t.Fatalf("first Claude model turn = %q, want prior answer; body=%s", got, body)
+			}
+		})
+	}
+}
+
+func TestAntigravityCountTokensMatchesTargetLeadingUserPolicy(t *testing.T) {
+	tests := []struct {
+		name      string
+		model     string
+		wantRoles string
+	}{
+		{name: "Gemini target prepends user", model: "gemini-3.6-flash-high", wantRoles: "user,model,user"},
+		{name: "Claude target preserves history", model: "claude-sonnet-4-6", wantRoles: "model,user"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var upstreamBody []byte
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != antigravityCountTokensPath {
+					t.Fatalf("path = %q, want %q", r.URL.Path, antigravityCountTokensPath)
+				}
+				body, errRead := io.ReadAll(r.Body)
+				if errRead != nil {
+					t.Fatalf("read countTokens body: %v", errRead)
+				}
+				upstreamBody = append([]byte(nil), body...)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"totalTokens":42}`))
+			}))
+			defer server.Close()
+
+			executor := NewAntigravityExecutor(&config.Config{RequestRetry: 1})
+			payload := []byte(`{"contents":[` +
+				`{"role":"model","parts":[{"text":"prior output"}]},` +
+				`{"role":"user","parts":[{"text":"continue"}]}` +
+				`]}`)
+			_, errCount := executor.CountTokens(context.Background(), testAntigravityAuth(server.URL), cliproxyexecutor.Request{
+				Model:   tt.model,
+				Payload: payload,
+			}, cliproxyexecutor.Options{
+				SourceFormat:   sdktranslator.FormatGemini,
+				ResponseFormat: sdktranslator.FormatGemini,
+			})
+			if errCount != nil {
+				t.Fatalf("CountTokens() error = %v", errCount)
+			}
+
+			contents := gjson.GetBytes(upstreamBody, "request.contents").Array()
+			roles := make([]string, 0, len(contents))
+			for _, content := range contents {
+				roles = append(roles, content.Get("role").String())
+			}
+			if got := strings.Join(roles, ","); got != tt.wantRoles {
+				t.Fatalf("countTokens roles = %q, want %q; body=%s", got, tt.wantRoles, upstreamBody)
+			}
+			if strings.HasPrefix(tt.wantRoles, "user,") {
+				text := contents[0].Get("parts.0.text")
+				if !text.Exists() || text.String() != "" {
+					t.Fatalf("synthetic countTokens user missing: %s", upstreamBody)
+				}
+			}
+		})
+	}
+}
+
 func TestAntigravityExecutorCountTokensSanitizesGeminiToolHistory(t *testing.T) {
 	inner := protowire.AppendTag(nil, 1, protowire.BytesType)
 	inner = protowire.AppendBytes(inner, []byte{0x01, 0x0c, 0x39, 0xd6, 0xc7, 0x34})
@@ -248,16 +624,16 @@ func TestAntigravityExecutorCountTokensSanitizesGeminiToolHistory(t *testing.T) 
 	if len(upstreamBody) == 0 {
 		t.Fatal("countTokens upstream body was not captured")
 	}
-	if got := gjson.GetBytes(upstreamBody, "request.contents.0.parts.0.thoughtSignature").String(); got != nativeSignature {
+	if got := gjson.GetBytes(upstreamBody, "request.contents.1.parts.0.thoughtSignature").String(); got != nativeSignature {
 		t.Fatalf("first call signature = %q, want native signature; body=%s", got, upstreamBody)
 	}
-	if signature := gjson.GetBytes(upstreamBody, "request.contents.0.parts.1.thoughtSignature"); signature.Exists() {
+	if signature := gjson.GetBytes(upstreamBody, "request.contents.1.parts.1.thoughtSignature"); signature.Exists() {
 		t.Fatalf("second sibling bypass was not removed: %s", upstreamBody)
 	}
-	if got := gjson.GetBytes(upstreamBody, "request.contents.1.role").String(); got != "model" {
+	if got := gjson.GetBytes(upstreamBody, "request.contents.2.role").String(); got != "model" {
 		t.Fatalf("functionResponse role = %q, want model; body=%s", got, upstreamBody)
 	}
-	if got := gjson.GetBytes(upstreamBody, "request.contents.1.parts.0.functionResponse.id").String(); got != "call-1" {
+	if got := gjson.GetBytes(upstreamBody, "request.contents.2.parts.0.functionResponse.id").String(); got != "call-1" {
 		t.Fatalf("first functionResponse.id = %q, want call-1; body=%s", got, upstreamBody)
 	}
 	if errPairing := internalsignature.ValidateGeminiFunctionCallPairing(upstreamBody); errPairing != nil {
@@ -310,11 +686,15 @@ func TestAntigravityExecutorCountTokensReconstructsCompactedClaudeToolCall(t *te
 	if len(upstreamBody) == 0 {
 		t.Fatal("countTokens upstream body was not captured")
 	}
-	call := gjson.GetBytes(upstreamBody, "request.contents.0.parts.0")
+	leadingText := gjson.GetBytes(upstreamBody, "request.contents.0.parts.0.text")
+	if gjson.GetBytes(upstreamBody, "request.contents.0.role").String() != "user" || !leadingText.Exists() || leadingText.String() != "" {
+		t.Fatalf("synthetic leading user missing after replay insert: %s", upstreamBody)
+	}
+	call := gjson.GetBytes(upstreamBody, "request.contents.1.parts.0")
 	if call.Get("functionCall.id").String() != nativeID || call.Get("functionCall.name").String() != "Bash" || call.Get("thoughtSignature").String() != nativeSignature {
 		t.Fatalf("native function call provenance was not reconstructed: %s", upstreamBody)
 	}
-	response := gjson.GetBytes(upstreamBody, "request.contents.1.parts.0.functionResponse")
+	response := gjson.GetBytes(upstreamBody, "request.contents.2.parts.0.functionResponse")
 	if response.Get("id").String() != nativeID || response.Get("name").String() != "Bash" {
 		t.Fatalf("native function response provenance was not reconstructed: %s", upstreamBody)
 	}

--- a/internal/runtime/executor/antigravity_executor_stream.go
+++ b/internal/runtime/executor/antigravity_executor_stream.go
@@ -82,7 +82,9 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
 
-	attempts := antigravityRetryAttempts(auth, e.cfg)
+	// Credential retry rounds are owned by the conductor. Keep one upstream
+	// attempt per credential so request-retry is not consumed twice.
+	attempts := 1
 
 attemptLoop:
 	for attempt := 0; attempt < attempts; attempt++ {

--- a/internal/runtime/executor/antigravity_executor_stream.go
+++ b/internal/runtime/executor/antigravity_executor_stream.go
@@ -107,6 +107,7 @@ attemptLoop:
 					return nil, err
 				}
 			}
+			requestPayload = ensureAntigravityGeminiLeadingUserContent(baseModel, requestPayload)
 			httpReq, errReq := e.buildRequest(ctx, auth, token, baseModel, requestPayload, true, opts.Alt, baseURL, helps.DerivedAntigravitySessionID(opts.Metadata, req.Metadata))
 			if errReq != nil {
 				err = errReq

--- a/internal/runtime/executor/antigravity_executor_stream.go
+++ b/internal/runtime/executor/antigravity_executor_stream.go
@@ -82,7 +82,9 @@ func (e *AntigravityExecutor) ExecuteStream(ctx context.Context, auth *cliproxya
 	httpClient := newAntigravityHTTPClient(ctx, e.cfg, auth, 0)
 	httpClient = reporter.TrackHTTPClient(httpClient)
 
-	attempts := antigravityRetryAttempts(auth, e.cfg)
+	// Credential retry rounds are owned by the conductor. Keep one upstream
+	// attempt per credential so request-retry is not consumed twice.
+	attempts := 1
 
 attemptLoop:
 	for attempt := 0; attempt < attempts; attempt++ {
@@ -107,6 +109,7 @@ attemptLoop:
 					return nil, err
 				}
 			}
+			requestPayload = ensureAntigravityGeminiLeadingUserContent(baseModel, requestPayload)
 			httpReq, errReq := e.buildRequest(ctx, auth, token, baseModel, requestPayload, true, opts.Alt, baseURL, helps.DerivedAntigravitySessionID(opts.Metadata, req.Metadata))
 			if errReq != nil {
 				err = errReq

--- a/internal/runtime/executor/antigravity_executor_tokens.go
+++ b/internal/runtime/executor/antigravity_executor_tokens.go
@@ -61,7 +61,7 @@ func (e *AntigravityExecutor) CountTokens(ctx context.Context, auth *cliproxyaut
 	if errReplay != nil {
 		return cliproxyexecutor.Response{}, errReplay
 	}
-	payload = preparedPayload
+	payload = ensureAntigravityGeminiLeadingUserContent(baseModel, preparedPayload)
 
 	payload = helps.DeleteJSONField(payload, "project")
 	payload = helps.DeleteJSONField(payload, "model")

--- a/internal/runtime/executor/antigravity_schema_sanitize_test.go
+++ b/internal/runtime/executor/antigravity_schema_sanitize_test.go
@@ -592,3 +592,24 @@ func TestAntigravityBuildRequestStripsPropertyNamesFromOutboundBody(t *testing.T
 		}
 	}
 }
+
+// TestSanitizeAntigravityRequestSchemasStripsEncryptedMetadata covers Codex client tool parameters
+// that carry "encrypted": true or "encrypted": false markers.
+func TestSanitizeAntigravityRequestSchemasStripsEncryptedMetadata(t *testing.T) {
+	encryptedSchema := `{"type":"object","properties":{"key":{"type":"string","encrypted":true},"timeout":{"type":"integer","encrypted":false}},"required":["key"]}`
+
+	for _, declContainer := range []string{"functionDeclarations", "function_declarations"} {
+		payload := `{"request":{"tools":[{"` + declContainer + `":[{"name":"test_tool","parameters":` + encryptedSchema + `}]}]}}`
+
+		for _, useAntigravitySchema := range []bool{false, true} {
+			got := sanitizeAntigravityRequestSchemas(payload, useAntigravitySchema)
+			if strings.Contains(got, `"encrypted"`) {
+				t.Errorf("declContainer=%s antigravity=%v: 'encrypted' marker survived sanitization: %s", declContainer, useAntigravitySchema, got)
+			}
+			schema := gjson.Get(got, "request.tools.0."+declContainer+".0.parameters")
+			if !schema.Get("properties.key.type").Exists() || schema.Get("properties.key.type").String() != "string" {
+				t.Errorf("declContainer=%s antigravity=%v: key property was corrupted: %s", declContainer, useAntigravitySchema, schema.Raw)
+			}
+		}
+	}
+}

--- a/internal/runtime/executor/claude_executor.go
+++ b/internal/runtime/executor/claude_executor.go
@@ -212,17 +212,19 @@ func (e *ClaudeExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Au
 		return nil
 	}
 	apiKey, _ := claudeCreds(auth)
-	if strings.TrimSpace(apiKey) == "" {
-		return nil
-	}
-	useAPIKey := auth != nil && auth.Attributes != nil && strings.TrimSpace(auth.Attributes["api_key"]) != ""
+	useAPIKey := auth != nil && (auth.AuthKind() == cliproxyauth.AuthKindAPIKey || (auth.Attributes != nil && strings.TrimSpace(auth.Attributes["api_key"]) != ""))
 	isAnthropicBase := isAnthropicUpstreamURL(req.URL)
-	if isAnthropicBase && useAPIKey {
-		req.Header.Del("Authorization")
-		req.Header.Set("x-api-key", apiKey)
+	if strings.TrimSpace(apiKey) != "" {
+		if isAnthropicBase && useAPIKey {
+			req.Header.Del("Authorization")
+			req.Header.Set("x-api-key", apiKey)
+		} else {
+			req.Header.Del("x-api-key")
+			req.Header.Set("Authorization", "Bearer "+apiKey)
+		}
 	} else {
+		req.Header.Del("Authorization")
 		req.Header.Del("x-api-key")
-		req.Header.Set("Authorization", "Bearer "+apiKey)
 	}
 	var attrs map[string]string
 	if auth != nil {

--- a/internal/runtime/executor/claude_executor_auth.go
+++ b/internal/runtime/executor/claude_executor_auth.go
@@ -30,6 +30,48 @@ func (e *ClaudeExecutor) ShouldPrepareRequestAuth(auth *cliproxyauth.Auth) bool 
 	return helps.ClaudeCredentialAccountUUID(auth) == ""
 }
 
+func isClaudeSetupToken(auth *cliproxyauth.Auth, apiKey string) bool {
+	if !isClaudeOAuthToken(apiKey) || auth == nil {
+		return false
+	}
+	if skip, _ := auth.Metadata["skip_account_profile"].(bool); skip {
+		return true
+	}
+	if isSetup, _ := auth.Metadata["is_setup_token"].(bool); isSetup {
+		return true
+	}
+	if isSetup, _ := auth.Metadata["setup_token"].(bool); isSetup {
+		return true
+	}
+	if kind := strings.ToLower(auth.Attributes["auth_kind"]); kind == "setup_token" || kind == "setup-token" {
+		return true
+	}
+	scopes := strings.ToLower(claudeauth.ReadMetadataString(&auth.Metadata, "scopes"))
+	if scopes == "" {
+		scopes = strings.ToLower(claudeauth.ReadMetadataString(&auth.Metadata, "scope"))
+	}
+	if scopes != "" && !strings.Contains(scopes, "user:profile") && !strings.Contains(scopes, "user:office") {
+		return true
+	}
+	return false
+}
+
+func isClaudeOAuthScope403(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "status 403") ||
+		strings.Contains(msg, "403 forbidden") ||
+		strings.Contains(msg, "403") ||
+		strings.Contains(msg, "forbidden") ||
+		strings.Contains(msg, "permission_error") ||
+		strings.Contains(msg, "scope requirement") ||
+		strings.Contains(msg, "insufficient_scope") ||
+		strings.Contains(msg, "user:profile") ||
+		strings.Contains(msg, "user:office")
+}
+
 func (e *ClaudeExecutor) PrepareRequestAuth(ctx context.Context, auth *cliproxyauth.Auth) (*cliproxyauth.Auth, error) {
 	if auth == nil || !e.ShouldPrepareRequestAuth(auth) {
 		return auth, nil
@@ -43,15 +85,42 @@ func (e *ClaudeExecutor) PrepareRequestAuth(ctx context.Context, auth *cliproxya
 		return auth, nil
 	}
 
+	if isClaudeSetupToken(auth, apiKey) {
+		seed := helps.ClaudeCLIAuthIdentitySeed(auth)
+		if seed == "" {
+			seed = "claude-setup-token|" + apiKey
+		}
+		claudeauth.StoreMetadataString(&auth.Metadata, "account_uuid", helps.StableClaudeCLIAccountUUID(seed))
+		claudeauth.StoreMetadataString(&auth.Metadata, claudeAccountProfileCheckedAtKey, time.Now().UTC().Format(time.RFC3339))
+		return auth, nil
+	}
+
 	profile, errProfile := e.fetchClaudeOAuthProfile(ctx, auth, apiKey)
 	if errProfile != nil {
 		if errContext := ctx.Err(); errContext != nil {
 			return nil, errContext
 		}
+		if isClaudeOAuthScope403(errProfile) {
+			log.Debugf("Claude OAuth account profile lookup returned 403 for auth %s: %v (falling back to stable credential identity)", auth.ID, errProfile)
+			seed := helps.ClaudeCLIAuthIdentitySeed(auth)
+			if seed == "" {
+				seed = "claude-oauth-fallback|" + apiKey
+			}
+			claudeauth.StoreMetadataString(&auth.Metadata, "account_uuid", helps.StableClaudeCLIAccountUUID(seed))
+			claudeauth.StoreMetadataString(&auth.Metadata, claudeAccountProfileCheckedAtKey, time.Now().UTC().Format(time.RFC3339))
+			return auth, nil
+		}
 		return nil, fmt.Errorf("populate Claude OAuth account profile: %w", errProfile)
 	}
 	if profile == nil || strings.TrimSpace(profile.Account.UUID) == "" {
-		return nil, fmt.Errorf("populate Claude OAuth account profile: account UUID is empty")
+		log.Debugf("Claude OAuth account profile lookup returned empty account UUID for auth %s (falling back to stable credential identity)", auth.ID)
+		seed := helps.ClaudeCLIAuthIdentitySeed(auth)
+		if seed == "" {
+			seed = "claude-oauth-fallback|" + apiKey
+		}
+		claudeauth.StoreMetadataString(&auth.Metadata, "account_uuid", helps.StableClaudeCLIAccountUUID(seed))
+		claudeauth.StoreMetadataString(&auth.Metadata, claudeAccountProfileCheckedAtKey, time.Now().UTC().Format(time.RFC3339))
+		return auth, nil
 	}
 	claudeauth.StoreMetadataString(&auth.Metadata, "account_uuid", profile.Account.UUID)
 	claudeauth.StoreMetadataString(&auth.Metadata, "email", profile.Account.Email)
@@ -86,6 +155,9 @@ func (e *ClaudeExecutor) Refresh(ctx context.Context, auth *cliproxyauth.Auth) (
 		return nil, fmt.Errorf("claude executor: auth is nil")
 	}
 	refreshToken := claudeauth.ReadMetadataString(&auth.Metadata, "refresh_token")
+	if refreshToken == "" {
+		refreshToken = claudeauth.ReadMetadataString(&auth.Metadata, "refreshToken")
+	}
 	if refreshToken == "" {
 		return auth, nil
 	}

--- a/internal/runtime/executor/claude_executor_auth_test.go
+++ b/internal/runtime/executor/claude_executor_auth_test.go
@@ -192,3 +192,155 @@ func TestClaudeExecutorPrepareRequestAuthIgnoresFreshTimestampWithoutIdentity(t 
 		t.Fatalf("profile checked timestamp = %q, want prior value preserved without suppressing retry", got)
 	}
 }
+
+func TestClaudeExecutorPrepareRequestAuthSetupTokenBypassesProfile(t *testing.T) {
+	executor := NewClaudeExecutor(&config.Config{})
+	executor.oauthProfileFetcher = func(context.Context, *cliproxyauth.Auth, string) (*claudeauth.OAuthProfile, error) {
+		t.Fatal("profile fetcher should NOT be called for setup-tokens")
+		return nil, nil
+	}
+	auth := &cliproxyauth.Auth{
+		ID: "claude-setuptoken.json",
+		Attributes: map[string]string{
+			"api_key": "sk-ant-oat01-test-setup-token-value",
+		},
+		Metadata: map[string]any{
+			"type":   "claude",
+			"scopes": "user:inference user:ccr_inference user:file_upload",
+		},
+	}
+
+	if !executor.ShouldPrepareRequestAuth(auth) {
+		t.Fatal("ShouldPrepareRequestAuth() = false for missing setup-token identity")
+	}
+	prepared, errPrepare := executor.PrepareRequestAuth(context.Background(), auth)
+	if errPrepare != nil {
+		t.Fatalf("PrepareRequestAuth() error = %v", errPrepare)
+	}
+	if prepared == nil {
+		t.Fatal("prepared auth is nil")
+	}
+	accountUUID := claudeauth.ReadMetadataString(&prepared.Metadata, "account_uuid")
+	if accountUUID == "" {
+		t.Fatal("account_uuid is empty after setup-token preparation")
+	}
+	deviceIDs := claudeauth.NormalizeDeviceIDPool(prepared.Metadata[claudeauth.ClaudeDeviceIDsMetadataKey])
+	if len(deviceIDs) != 1 {
+		t.Fatalf("device pool length = %d, want 1", len(deviceIDs))
+	}
+	if executor.ShouldPrepareRequestAuth(prepared) {
+		t.Fatal("ShouldPrepareRequestAuth() = true after setup-token identity was populated")
+	}
+}
+
+func TestClaudeExecutorPrepareRequestAuth403ScopeFallback(t *testing.T) {
+	executor := NewClaudeExecutor(&config.Config{})
+	fetchCalls := 0
+	executor.oauthProfileFetcher = func(context.Context, *cliproxyauth.Auth, string) (*claudeauth.OAuthProfile, error) {
+		fetchCalls++
+		return nil, fmt.Errorf("fetch Claude OAuth profile failed with status 403: permission_error: OAuth token does not meet scope requirement any_of(user:profile, user:office)")
+	}
+	auth := &cliproxyauth.Auth{
+		ID: "claude-scope-restricted-credential",
+		Attributes: map[string]string{
+			"api_key": "sk-ant-oat01-scope-restricted",
+		},
+		Metadata: map[string]any{
+			"type":          "claude",
+			"refresh_token": "dummy-refresh-token",
+		},
+	}
+
+	if !executor.ShouldPrepareRequestAuth(auth) {
+		t.Fatal("ShouldPrepareRequestAuth() = false for missing identity")
+	}
+	prepared, errPrepare := executor.PrepareRequestAuth(context.Background(), auth)
+	if errPrepare != nil {
+		t.Fatalf("PrepareRequestAuth() with 403 error = %v, want fallback success", errPrepare)
+	}
+	if prepared == nil {
+		t.Fatal("prepared auth is nil")
+	}
+	if fetchCalls != 1 {
+		t.Fatalf("fetchCalls = %d, want 1", fetchCalls)
+	}
+	accountUUID := claudeauth.ReadMetadataString(&prepared.Metadata, "account_uuid")
+	if accountUUID == "" {
+		t.Fatal("account_uuid is empty after 403 fallback")
+	}
+	if executor.ShouldPrepareRequestAuth(prepared) {
+		t.Fatal("ShouldPrepareRequestAuth() = true after 403 identity was populated")
+	}
+}
+
+func TestClaudeExecutorPrepareRequestAuthSkipAccountProfileConfig(t *testing.T) {
+	executor := NewClaudeExecutor(&config.Config{})
+	executor.oauthProfileFetcher = func(context.Context, *cliproxyauth.Auth, string) (*claudeauth.OAuthProfile, error) {
+		t.Fatal("profile fetcher should NOT be called when skip_account_profile is true")
+		return nil, nil
+	}
+	auth := &cliproxyauth.Auth{
+		ID: "claude-skip-profile.json",
+		Attributes: map[string]string{
+			"api_key": "sk-ant-oat01-skip-profile",
+		},
+		Metadata: map[string]any{
+			"type":                 "claude",
+			"skip_account_profile": true,
+		},
+	}
+
+	if !executor.ShouldPrepareRequestAuth(auth) {
+		t.Fatal("ShouldPrepareRequestAuth() = false for missing identity")
+	}
+	prepared, errPrepare := executor.PrepareRequestAuth(context.Background(), auth)
+	if errPrepare != nil {
+		t.Fatalf("PrepareRequestAuth() error = %v", errPrepare)
+	}
+	if prepared == nil {
+		t.Fatal("prepared auth is nil")
+	}
+	accountUUID := claudeauth.ReadMetadataString(&prepared.Metadata, "account_uuid")
+	if accountUUID == "" {
+		t.Fatal("account_uuid is empty after skip_account_profile preparation")
+	}
+	if executor.ShouldPrepareRequestAuth(prepared) {
+		t.Fatal("ShouldPrepareRequestAuth() = true after identity was populated")
+	}
+}
+
+func TestClaudeExecutorPrepareRequestAuthEmptyAccountUUIDInProfileFallback(t *testing.T) {
+	executor := NewClaudeExecutor(&config.Config{})
+	fetchCalls := 0
+	executor.oauthProfileFetcher = func(context.Context, *cliproxyauth.Auth, string) (*claudeauth.OAuthProfile, error) {
+		fetchCalls++
+		return &claudeauth.OAuthProfile{}, nil
+	}
+	auth := &cliproxyauth.Auth{
+		ID: "claude-empty-uuid-in-profile",
+		Attributes: map[string]string{
+			"api_key": "sk-ant-oat01-empty-uuid",
+		},
+		Metadata: map[string]any{
+			"type": "claude",
+		},
+	}
+
+	prepared, errPrepare := executor.PrepareRequestAuth(context.Background(), auth)
+	if errPrepare != nil {
+		t.Fatalf("PrepareRequestAuth() error = %v, want fallback on empty UUID", errPrepare)
+	}
+	if prepared == nil {
+		t.Fatal("prepared auth is nil")
+	}
+	if fetchCalls != 1 {
+		t.Fatalf("fetchCalls = %d, want 1", fetchCalls)
+	}
+	accountUUID := claudeauth.ReadMetadataString(&prepared.Metadata, "account_uuid")
+	if accountUUID == "" {
+		t.Fatal("account_uuid is empty after fallback")
+	}
+	if executor.ShouldPrepareRequestAuth(prepared) {
+		t.Fatal("ShouldPrepareRequestAuth() = true after identity was populated")
+	}
+}

--- a/internal/runtime/executor/claude_executor_fable_ratelimit_test.go
+++ b/internal/runtime/executor/claude_executor_fable_ratelimit_test.go
@@ -95,58 +95,49 @@ func TestClassifyClaudeUpstreamError_SharedOrAmbiguousRejectionRemainsCredential
 	}
 }
 
-func TestClassifyClaudeUpstreamError_FableRetryDurationRemainsAvailable(t *testing.T) {
-	tests := []struct {
-		name     string
-		headers  http.Header
-		min, max time.Duration
-	}{
-		{
-			name: "7d_oi reset",
-			headers: http.Header{
-				"Anthropic-Ratelimit-Unified-Status":       []string{"rejected"},
-				"Anthropic-Ratelimit-Unified-5h-Status":    []string{"allowed"},
-				"Anthropic-Ratelimit-Unified-7d-Status":    []string{"allowed"},
-				"Anthropic-Ratelimit-Unified-7d_oi-Status": []string{"rejected"},
-				"Anthropic-Ratelimit-Unified-7d_oi-Reset":  []string{strconv.FormatInt(time.Now().Add(2*time.Hour).Unix(), 10)},
-			},
-			min: 2*time.Hour - 5*time.Second,
-			max: 2*time.Hour + 35*time.Second,
-		},
-		{
-			name: "retry-after",
-			headers: http.Header{
-				"Anthropic-Ratelimit-Unified-Status":       []string{"rejected"},
-				"Anthropic-Ratelimit-Unified-5h-Status":    []string{"allowed"},
-				"Anthropic-Ratelimit-Unified-7d-Status":    []string{"allowed"},
-				"Anthropic-Ratelimit-Unified-7d_oi-Status": []string{"rejected"},
-				"Retry-After": []string{"120"},
-			},
-			min: 2 * time.Minute,
-			max: 2*time.Minute + 30*time.Second,
-		},
-	}
+func TestClassifyClaudeUpstreamError_FableRetryDuration(t *testing.T) {
+	t.Run("retry-after header is respected", func(t *testing.T) {
+		headers := http.Header{
+			"Anthropic-Ratelimit-Unified-Status":       []string{"rejected"},
+			"Anthropic-Ratelimit-Unified-5h-Status":    []string{"allowed"},
+			"Anthropic-Ratelimit-Unified-7d-Status":    []string{"allowed"},
+			"Anthropic-Ratelimit-Unified-7d_oi-Status": []string{"rejected"},
+			"Anthropic-Ratelimit-Unified-7d_oi-Reset":  []string{strconv.FormatInt(time.Now().Add(7*24*time.Hour).Unix(), 10)},
+			"Retry-After": []string{"120"},
+		}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// When
-			err := classifyClaudeUpstreamError(http.StatusTooManyRequests, tt.headers, []byte(`{"type":"error","error":{"type":"rate_limit_error","message":"Fable usage window rejected."}}`))
+		err := classifyClaudeUpstreamError(http.StatusTooManyRequests, headers, []byte(`{"type":"error","error":{"type":"rate_limit_error","message":"Fable usage window rejected."}}`))
 
-			// Then
-			var retry retryAfterProvider
-			if !errors.As(err, &retry) || retry == nil || retry.RetryAfter() == nil {
-				t.Fatalf("expected Fable rate-limit error to retain a retry duration, got %v", err)
-			}
-			if got := *retry.RetryAfter(); got < tt.min || got > tt.max {
-				t.Fatalf("RetryAfter = %v, want between %v and %v", got, tt.min, tt.max)
-			}
-		})
-	}
+		var retry retryAfterProvider
+		if !errors.As(err, &retry) || retry == nil || retry.RetryAfter() == nil {
+			t.Fatalf("expected Fable rate-limit error to retain a retry duration, got %v", err)
+		}
+		if got := *retry.RetryAfter(); got < 2*time.Minute || got > 2*time.Minute+30*time.Second {
+			t.Fatalf("RetryAfter = %v, want ~120s with fuzz, but not 7d", got)
+		}
+	})
+
+	t.Run("7d_oi reset only does not set week-long retry duration", func(t *testing.T) {
+		headers := http.Header{
+			"Anthropic-Ratelimit-Unified-Status":       []string{"rejected"},
+			"Anthropic-Ratelimit-Unified-5h-Status":    []string{"allowed"},
+			"Anthropic-Ratelimit-Unified-7d-Status":    []string{"allowed"},
+			"Anthropic-Ratelimit-Unified-7d_oi-Status": []string{"rejected"},
+			"Anthropic-Ratelimit-Unified-7d_oi-Reset":  []string{strconv.FormatInt(time.Now().Add(7*24*time.Hour).Unix(), 10)},
+		}
+
+		err := classifyClaudeUpstreamError(http.StatusTooManyRequests, headers, []byte(`{"type":"error","error":{"type":"rate_limit_error","message":"Fable usage window rejected."}}`))
+
+		var retry retryAfterProvider
+		if errors.As(err, &retry) && retry != nil && retry.RetryAfter() != nil {
+			t.Fatalf("expected Fable 7d_oi-only reset to yield nil RetryAfter, got %v", *retry.RetryAfter())
+		}
+	})
 }
 
 func TestClaudeExecutor_AuthManager_FableOnlyRejectionDoesNotBlockOpus(t *testing.T) {
 	var fableAttempts, opusAttempts atomic.Int32
-	reset := time.Now().Add(2 * time.Hour).Unix()
+	reset := time.Now().Add(7 * 24 * time.Hour).Unix()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, errRead := io.ReadAll(r.Body)
 		if errRead != nil {
@@ -205,6 +196,19 @@ func TestClaudeExecutor_AuthManager_FableOnlyRejectionDoesNotBlockOpus(t *testin
 	}
 	if got := fableAttempts.Load(); got != 1 {
 		t.Fatalf("Fable upstream attempts = %d, want 1", got)
+	}
+
+	// Verify that Fable model state cooldown is driven by Retry-After (~120s) and not 7 days.
+	updatedAuth, ok := manager.GetByID(auth.ID)
+	if !ok || updatedAuth == nil {
+		t.Fatal("auth not found")
+	}
+	fableState := updatedAuth.ModelStates["claude-fable-5"]
+	if fableState == nil {
+		t.Fatal("fable model state not found")
+	}
+	if fableState.Quota.NextRecoverAt.After(time.Now().Add(5 * time.Minute)) {
+		t.Fatalf("fable model state cooldown too long: NextRecoverAt = %v (want ~120s, not 7 days)", fableState.Quota.NextRecoverAt)
 	}
 
 	payloadOpus := []byte(`{"model":"claude-opus-5","messages":[{"role":"user","content":[{"type":"text","text":"test"}]}]}`)

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -610,8 +610,14 @@ func isZlibHeader(header []byte) bool {
 // single authority for every decision that has to agree with the OAuth beta
 // profile, including the extended-cache-ttl beta and the matching body cache ttl.
 func claudeCredentialUsesOAuth(auth *cliproxyauth.Auth, apiKey string) bool {
+	if isClaudeOAuthToken(apiKey) {
+		return true
+	}
+	if auth != nil && auth.AuthKind() == cliproxyauth.AuthKindAPIKey {
+		return false
+	}
 	hasAPIKeyAttr := auth != nil && auth.Attributes != nil && strings.TrimSpace(auth.Attributes["api_key"]) != ""
-	return isClaudeOAuthToken(apiKey) || !hasAPIKeyAttr
+	return !hasAPIKeyAttr
 }
 
 func copyClaudeCallerFingerprintHeaders(dst, src http.Header) {
@@ -692,11 +698,17 @@ func applyClaudeHeadersWithNativeProfile(
 	preserveCallerFingerprint := !applyCLIFingerprint && !confirmedClaudeCode
 	useOAuthBetas := fp.UseOAuthBetas
 	isAnthropicBase := isAnthropicUpstreamURL(r.URL)
-	if isAnthropicBase && useAPIKey {
-		r.Header.Del("Authorization")
-		r.Header.Set("x-api-key", apiKey)
+	if strings.TrimSpace(apiKey) != "" {
+		if isAnthropicBase && useAPIKey {
+			r.Header.Del("Authorization")
+			r.Header.Set("x-api-key", apiKey)
+		} else {
+			r.Header.Del("x-api-key")
+			r.Header.Set("Authorization", "Bearer "+apiKey)
+		}
 	} else {
-		r.Header.Set("Authorization", "Bearer "+apiKey)
+		r.Header.Del("Authorization")
+		r.Header.Del("x-api-key")
 	}
 	r.Header.Set("Content-Type", "application/json")
 

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -1392,6 +1392,25 @@ func remapOAuthToolNamesWithBatchedEdits(body []byte, mcpAliases claudeMCPAliasO
 							return true
 						})
 					}
+				case "tool_search_tool_result":
+					toolRefs := part.Get("content.tool_references")
+					if toolRefs.Exists() && toolRefs.IsArray() {
+						toolRefs.ForEach(func(_, refPart gjson.Result) bool {
+							if refPart.Get("type").String() != "tool_reference" {
+								return true
+							}
+							nameResult := refPart.Get("tool_name")
+							refToolName := nameResult.String()
+							if newName, renamed := rewriteName(refToolName); renamed {
+								if !appendStringEdit(nameResult, newName) {
+									validOffsets = false
+									return false
+								}
+								recordRename(refToolName, newName)
+							}
+							return true
+						})
+					}
 				}
 				return validOffsets
 			})
@@ -1620,6 +1639,21 @@ func remapOAuthToolNamesWithOptionsLegacy(body []byte, mcpAliases claudeMCPAlias
 							return true
 						})
 					}
+				case "tool_search_tool_result":
+					toolRefs := part.Get("content.tool_references")
+					if toolRefs.Exists() && toolRefs.IsArray() {
+						toolRefs.ForEach(func(refIndex, refPart gjson.Result) bool {
+							if refPart.Get("type").String() == "tool_reference" {
+								refToolName := refPart.Get("tool_name").String()
+								if newName, renamed := rewriteName(refToolName); renamed {
+									refPath := fmt.Sprintf("messages.%d.content.%d.content.tool_references.%d.tool_name", msgIndex.Int(), contentIndex.Int(), refIndex.Int())
+									body, _ = sjson.SetBytes(body, refPath, newName)
+									recordRename(refToolName, newName)
+								}
+							}
+							return true
+						})
+					}
 				}
 				return true
 			})
@@ -1646,6 +1680,18 @@ type claudeMCPAliasResolver struct {
 	exact   map[string]string
 	aliases []claudeMCPAliasEntry
 	servers map[string]struct{}
+}
+
+type claudeMCPAliasRestoreError struct {
+	error
+}
+
+func (e claudeMCPAliasRestoreError) Unwrap() error {
+	return e.error
+}
+
+func (claudeMCPAliasRestoreError) IsRequestScoped() bool {
+	return true
 }
 
 func newClaudeMCPAliasResolver(reverseMap map[string]string) claudeMCPAliasResolver {
@@ -1761,7 +1807,7 @@ func (resolver claudeMCPAliasResolver) resolve(name string) (string, bool, error
 		return matchedOriginal, true, nil
 	}
 	if matchCount > 1 {
-		return "", false, fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: matched multiple declared aliases", name)
+		return "", false, claudeMCPAliasRestoreError{fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: matched multiple declared aliases", name)}
 	}
 
 	parts, validAlias := parseClaudeMCPAlias(normalizedName)
@@ -1816,10 +1862,10 @@ func (resolver claudeMCPAliasResolver) resolve(name string) (string, bool, error
 		return matchedOriginal, true, nil
 	}
 	if matchCount > 1 {
-		return "", false, fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: semantic suffix matches multiple declared tools", name)
+		return "", false, claudeMCPAliasRestoreError{fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: semantic suffix matches multiple declared tools", name)}
 	}
 
-	return "", false, fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: no unique request-local match", name)
+	return "", false, claudeMCPAliasRestoreError{fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: no unique request-local match", name)}
 }
 
 // reverseRemapOAuthToolNames reverses the tool name mapping for non-stream responses
@@ -1880,6 +1926,26 @@ func reverseRemapOAuthToolNames(body []byte, reverseMap map[string]string) ([]by
 					return true
 				})
 			}
+		case "tool_search_tool_result":
+			toolRefs := part.Get("content.tool_references")
+			if toolRefs.Exists() && toolRefs.IsArray() {
+				toolRefs.ForEach(func(refIndex, refPart gjson.Result) bool {
+					if refPart.Get("type").String() != "tool_reference" {
+						return true
+					}
+					toolName := refPart.Get("tool_name").String()
+					origName, matched, errResolve := resolver.resolve(toolName)
+					if errResolve != nil {
+						resolveErr = errResolve
+						return false
+					}
+					if matched {
+						path := fmt.Sprintf("content.%d.content.tool_references.%d.tool_name", index.Int(), refIndex.Int())
+						body, _ = sjson.SetBytes(body, path, origName)
+					}
+					return true
+				})
+			}
 		}
 		return resolveErr == nil
 	})
@@ -1928,6 +1994,44 @@ func reverseRemapOAuthToolNamesFromStreamLine(line []byte, reverseMap map[string
 			return line, nil
 		}
 		updated, err = sjson.SetBytes(payload, "content_block.tool_name", origName)
+	case "tool_search_tool_result":
+		toolRefs := contentBlock.Get("content.tool_references")
+		if !toolRefs.Exists() || !toolRefs.IsArray() {
+			return line, nil
+		}
+		updatedPayload := payload
+		var resolveErr error
+		hasChange := false
+		toolRefs.ForEach(func(refIndex, refPart gjson.Result) bool {
+			if refPart.Get("type").String() != "tool_reference" {
+				return true
+			}
+			toolName := refPart.Get("tool_name").String()
+			origName, matched, errResolve := resolver.resolve(toolName)
+			if errResolve != nil {
+				resolveErr = errResolve
+				return false
+			}
+			if matched {
+				path := fmt.Sprintf("content_block.content.tool_references.%d.tool_name", refIndex.Int())
+				updatedPayload, err = sjson.SetBytes(updatedPayload, path, origName)
+				if err != nil {
+					return false
+				}
+				hasChange = true
+			}
+			return true
+		})
+		if resolveErr != nil {
+			return line, resolveErr
+		}
+		if err != nil {
+			return line, fmt.Errorf("rewrite Claude OAuth MCP tool alias: %w", err)
+		}
+		if !hasChange {
+			return line, nil
+		}
+		updated = updatedPayload
 	default:
 		return line, nil
 	}

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -624,7 +624,10 @@ func copyClaudeCallerFingerprintHeaders(dst, src http.Header) {
 			lowerName != "x-app" && lowerName != "x-client-request-id" &&
 			!strings.HasPrefix(lowerName, "anthropic-") &&
 			!strings.HasPrefix(lowerName, "x-stainless-") &&
-			!strings.HasPrefix(lowerName, "x-claude-code-") {
+			!strings.HasPrefix(lowerName, "x-claude-code-") &&
+			!strings.HasPrefix(lowerName, "x-claude-remote-") &&
+			lowerName != "x-client-app" &&
+			lowerName != "x-anthropic-additional-protection" {
 			continue
 		}
 		dst.Del(name)
@@ -879,6 +882,19 @@ func applyClaudeHeadersWithNativeProfile(
 			return errSessionID
 		}
 		identityHeader("X-Claude-Code-Session-Id", sessionID)
+	}
+	// Preserve native Claude Code subagent and environment headers when present in the incoming request.
+	for _, hdr := range []string{
+		"X-Claude-Code-Agent-Id",
+		"X-Claude-Code-Parent-Agent-Id",
+		"X-Claude-Remote-Container-Id",
+		"X-Claude-Remote-Session-Id",
+		"X-Client-App",
+		"X-Anthropic-Additional-Protection",
+	} {
+		if val := helps.HeaderValueCaseInsensitive(incomingHeaders, hdr); val != "" {
+			r.Header.Set(hdr, val)
+		}
 	}
 	// Per-request UUID, matches Claude Code's x-client-request-id for first-party API.
 	// identityHeader prefers the incoming value for a confirmed client, so a confirmed

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -805,7 +805,7 @@ func applyClaudeHeadersWithNativeProfile(
 		if auth != nil {
 			attrs = auth.Attributes
 		}
-		util.ApplyCustomHeadersFromAttrs(r, attrs)
+		util.ApplyCustomHeadersFromAttrs(r, attrs, incomingHeaders)
 		// Scope the custom-header escape hatch exactly like the CLI path below, which
 		// claws overrides back on api.anthropic.com (an operator Anthropic-Beta reaches
 		// a first-party API that rejects unknown values) and on any streaming request

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -610,8 +610,14 @@ func isZlibHeader(header []byte) bool {
 // single authority for every decision that has to agree with the OAuth beta
 // profile, including the extended-cache-ttl beta and the matching body cache ttl.
 func claudeCredentialUsesOAuth(auth *cliproxyauth.Auth, apiKey string) bool {
+	if isClaudeOAuthToken(apiKey) {
+		return true
+	}
+	if auth != nil && auth.AuthKind() == cliproxyauth.AuthKindAPIKey {
+		return false
+	}
 	hasAPIKeyAttr := auth != nil && auth.Attributes != nil && strings.TrimSpace(auth.Attributes["api_key"]) != ""
-	return isClaudeOAuthToken(apiKey) || !hasAPIKeyAttr
+	return !hasAPIKeyAttr
 }
 
 func copyClaudeCallerFingerprintHeaders(dst, src http.Header) {
@@ -624,7 +630,10 @@ func copyClaudeCallerFingerprintHeaders(dst, src http.Header) {
 			lowerName != "x-app" && lowerName != "x-client-request-id" &&
 			!strings.HasPrefix(lowerName, "anthropic-") &&
 			!strings.HasPrefix(lowerName, "x-stainless-") &&
-			!strings.HasPrefix(lowerName, "x-claude-code-") {
+			!strings.HasPrefix(lowerName, "x-claude-code-") &&
+			!strings.HasPrefix(lowerName, "x-claude-remote-") &&
+			lowerName != "x-client-app" &&
+			lowerName != "x-anthropic-additional-protection" {
 			continue
 		}
 		dst.Del(name)
@@ -689,11 +698,17 @@ func applyClaudeHeadersWithNativeProfile(
 	preserveCallerFingerprint := !applyCLIFingerprint && !confirmedClaudeCode
 	useOAuthBetas := fp.UseOAuthBetas
 	isAnthropicBase := isAnthropicUpstreamURL(r.URL)
-	if isAnthropicBase && useAPIKey {
-		r.Header.Del("Authorization")
-		r.Header.Set("x-api-key", apiKey)
+	if strings.TrimSpace(apiKey) != "" {
+		if isAnthropicBase && useAPIKey {
+			r.Header.Del("Authorization")
+			r.Header.Set("x-api-key", apiKey)
+		} else {
+			r.Header.Del("x-api-key")
+			r.Header.Set("Authorization", "Bearer "+apiKey)
+		}
 	} else {
-		r.Header.Set("Authorization", "Bearer "+apiKey)
+		r.Header.Del("Authorization")
+		r.Header.Del("x-api-key")
 	}
 	r.Header.Set("Content-Type", "application/json")
 
@@ -879,6 +894,19 @@ func applyClaudeHeadersWithNativeProfile(
 			return errSessionID
 		}
 		identityHeader("X-Claude-Code-Session-Id", sessionID)
+	}
+	// Preserve native Claude Code subagent and environment headers when present in the incoming request.
+	for _, hdr := range []string{
+		"X-Claude-Code-Agent-Id",
+		"X-Claude-Code-Parent-Agent-Id",
+		"X-Claude-Remote-Container-Id",
+		"X-Claude-Remote-Session-Id",
+		"X-Client-App",
+		"X-Anthropic-Additional-Protection",
+	} {
+		if val := helps.HeaderValueCaseInsensitive(incomingHeaders, hdr); val != "" {
+			r.Header.Set(hdr, val)
+		}
 	}
 	// Per-request UUID, matches Claude Code's x-client-request-id for first-party API.
 	// identityHeader prefers the incoming value for a confirmed client, so a confirmed
@@ -1392,6 +1420,25 @@ func remapOAuthToolNamesWithBatchedEdits(body []byte, mcpAliases claudeMCPAliasO
 							return true
 						})
 					}
+				case "tool_search_tool_result":
+					toolRefs := part.Get("content.tool_references")
+					if toolRefs.Exists() && toolRefs.IsArray() {
+						toolRefs.ForEach(func(_, refPart gjson.Result) bool {
+							if refPart.Get("type").String() != "tool_reference" {
+								return true
+							}
+							nameResult := refPart.Get("tool_name")
+							refToolName := nameResult.String()
+							if newName, renamed := rewriteName(refToolName); renamed {
+								if !appendStringEdit(nameResult, newName) {
+									validOffsets = false
+									return false
+								}
+								recordRename(refToolName, newName)
+							}
+							return true
+						})
+					}
 				}
 				return validOffsets
 			})
@@ -1620,6 +1667,21 @@ func remapOAuthToolNamesWithOptionsLegacy(body []byte, mcpAliases claudeMCPAlias
 							return true
 						})
 					}
+				case "tool_search_tool_result":
+					toolRefs := part.Get("content.tool_references")
+					if toolRefs.Exists() && toolRefs.IsArray() {
+						toolRefs.ForEach(func(refIndex, refPart gjson.Result) bool {
+							if refPart.Get("type").String() == "tool_reference" {
+								refToolName := refPart.Get("tool_name").String()
+								if newName, renamed := rewriteName(refToolName); renamed {
+									refPath := fmt.Sprintf("messages.%d.content.%d.content.tool_references.%d.tool_name", msgIndex.Int(), contentIndex.Int(), refIndex.Int())
+									body, _ = sjson.SetBytes(body, refPath, newName)
+									recordRename(refToolName, newName)
+								}
+							}
+							return true
+						})
+					}
 				}
 				return true
 			})
@@ -1646,6 +1708,18 @@ type claudeMCPAliasResolver struct {
 	exact   map[string]string
 	aliases []claudeMCPAliasEntry
 	servers map[string]struct{}
+}
+
+type claudeMCPAliasRestoreError struct {
+	error
+}
+
+func (e claudeMCPAliasRestoreError) Unwrap() error {
+	return e.error
+}
+
+func (claudeMCPAliasRestoreError) IsRequestScoped() bool {
+	return true
 }
 
 func newClaudeMCPAliasResolver(reverseMap map[string]string) claudeMCPAliasResolver {
@@ -1761,7 +1835,7 @@ func (resolver claudeMCPAliasResolver) resolve(name string) (string, bool, error
 		return matchedOriginal, true, nil
 	}
 	if matchCount > 1 {
-		return "", false, fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: matched multiple declared aliases", name)
+		return "", false, claudeMCPAliasRestoreError{fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: matched multiple declared aliases", name)}
 	}
 
 	parts, validAlias := parseClaudeMCPAlias(normalizedName)
@@ -1816,10 +1890,10 @@ func (resolver claudeMCPAliasResolver) resolve(name string) (string, bool, error
 		return matchedOriginal, true, nil
 	}
 	if matchCount > 1 {
-		return "", false, fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: semantic suffix matches multiple declared tools", name)
+		return "", false, claudeMCPAliasRestoreError{fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: semantic suffix matches multiple declared tools", name)}
 	}
 
-	return "", false, fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: no unique request-local match", name)
+	return "", false, claudeMCPAliasRestoreError{fmt.Errorf("cannot restore Claude OAuth MCP tool alias %q: no unique request-local match", name)}
 }
 
 // reverseRemapOAuthToolNames reverses the tool name mapping for non-stream responses
@@ -1880,6 +1954,26 @@ func reverseRemapOAuthToolNames(body []byte, reverseMap map[string]string) ([]by
 					return true
 				})
 			}
+		case "tool_search_tool_result":
+			toolRefs := part.Get("content.tool_references")
+			if toolRefs.Exists() && toolRefs.IsArray() {
+				toolRefs.ForEach(func(refIndex, refPart gjson.Result) bool {
+					if refPart.Get("type").String() != "tool_reference" {
+						return true
+					}
+					toolName := refPart.Get("tool_name").String()
+					origName, matched, errResolve := resolver.resolve(toolName)
+					if errResolve != nil {
+						resolveErr = errResolve
+						return false
+					}
+					if matched {
+						path := fmt.Sprintf("content.%d.content.tool_references.%d.tool_name", index.Int(), refIndex.Int())
+						body, _ = sjson.SetBytes(body, path, origName)
+					}
+					return true
+				})
+			}
 		}
 		return resolveErr == nil
 	})
@@ -1928,6 +2022,44 @@ func reverseRemapOAuthToolNamesFromStreamLine(line []byte, reverseMap map[string
 			return line, nil
 		}
 		updated, err = sjson.SetBytes(payload, "content_block.tool_name", origName)
+	case "tool_search_tool_result":
+		toolRefs := contentBlock.Get("content.tool_references")
+		if !toolRefs.Exists() || !toolRefs.IsArray() {
+			return line, nil
+		}
+		updatedPayload := payload
+		var resolveErr error
+		hasChange := false
+		toolRefs.ForEach(func(refIndex, refPart gjson.Result) bool {
+			if refPart.Get("type").String() != "tool_reference" {
+				return true
+			}
+			toolName := refPart.Get("tool_name").String()
+			origName, matched, errResolve := resolver.resolve(toolName)
+			if errResolve != nil {
+				resolveErr = errResolve
+				return false
+			}
+			if matched {
+				path := fmt.Sprintf("content_block.content.tool_references.%d.tool_name", refIndex.Int())
+				updatedPayload, err = sjson.SetBytes(updatedPayload, path, origName)
+				if err != nil {
+					return false
+				}
+				hasChange = true
+			}
+			return true
+		})
+		if resolveErr != nil {
+			return line, resolveErr
+		}
+		if err != nil {
+			return line, fmt.Errorf("rewrite Claude OAuth MCP tool alias: %w", err)
+		}
+		if !hasChange {
+			return line, nil
+		}
+		updated = updatedPayload
 	default:
 		return line, nil
 	}

--- a/internal/runtime/executor/claude_executor_request_remap_test.go
+++ b/internal/runtime/executor/claude_executor_request_remap_test.go
@@ -2,12 +2,14 @@ package executor
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"maps"
 	"strings"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/tidwall/gjson"
 )
 
@@ -343,13 +345,23 @@ func TestReverseRemapOAuthToolNamesRejectsUnsafeMangledAliases(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			response := []byte(fmt.Sprintf(`{"content":[{"type":"tool_use","id":"toolu_1","name":%q,"input":{}}]}`, test.alias))
-			if _, errReverse := reverseRemapOAuthToolNames(response, reverseMap); errReverse == nil || !strings.Contains(errReverse.Error(), test.wantError) {
+			_, errReverse := reverseRemapOAuthToolNames(response, reverseMap)
+			if errReverse == nil || !strings.Contains(errReverse.Error(), test.wantError) {
 				t.Fatalf("reverseRemapOAuthToolNames() error = %v, want %q", errReverse, test.wantError)
+			}
+			var requestErr cliproxyexecutor.RequestScopedError
+			if !errors.As(errReverse, &requestErr) || !requestErr.IsRequestScoped() {
+				t.Fatalf("reverseRemapOAuthToolNames() error = %T %v, want request-scoped", errReverse, errReverse)
 			}
 
 			line := []byte(fmt.Sprintf(`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":%q,"input":{}}}`, test.alias))
-			if _, errStream := reverseRemapOAuthToolNamesFromStreamLine(line, reverseMap); errStream == nil || !strings.Contains(errStream.Error(), test.wantError) {
+			_, errStream := reverseRemapOAuthToolNamesFromStreamLine(line, reverseMap)
+			if errStream == nil || !strings.Contains(errStream.Error(), test.wantError) {
 				t.Fatalf("reverseRemapOAuthToolNamesFromStreamLine() error = %v, want %q", errStream, test.wantError)
+			}
+			requestErr = nil
+			if !errors.As(errStream, &requestErr) || !requestErr.IsRequestScoped() {
+				t.Fatalf("reverseRemapOAuthToolNamesFromStreamLine() error = %T %v, want request-scoped", errStream, errStream)
 			}
 		})
 	}
@@ -541,4 +553,195 @@ func TestRemapKeepsReverseMapEmptyWhenOnlyCallerMCPToolsArePresent(t *testing.T)
 	if !bytes.Equal(out, body) {
 		t.Fatalf("body = %s, want unchanged %s", out, body)
 	}
+}
+
+func TestReverseRemapOAuthToolNamesMarksTrailingMarkupFailureRequestScoped(t *testing.T) {
+	const alias = "mcp__hmzqrngkulqv__xuo7jlxlpzee_clear_thinking"
+	malformedAlias := alias + "</parameter>\n<parameter name=\"merge\""
+	reverseMap := map[string]string{alias: "clear_thinking"}
+
+	response := []byte(fmt.Sprintf(`{"content":[{"type":"tool_use","id":"toolu_1","name":%q,"input":{}}]}`, malformedAlias))
+	restored, errReverse := reverseRemapOAuthToolNames(response, reverseMap)
+	if errReverse == nil {
+		t.Fatal("reverseRemapOAuthToolNames() error = nil, want fail-closed alias error")
+	}
+	if !bytes.Equal(restored, response) {
+		t.Fatalf("reverseRemapOAuthToolNames() returned modified response: %s", restored)
+	}
+	var requestErr cliproxyexecutor.RequestScopedError
+	if !errors.As(errReverse, &requestErr) || !requestErr.IsRequestScoped() {
+		t.Fatalf("reverseRemapOAuthToolNames() error = %T %v, want request-scoped", errReverse, errReverse)
+	}
+
+	line := []byte(fmt.Sprintf(`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":%q,"input":{}}}`, malformedAlias))
+	restoredLine, errStream := reverseRemapOAuthToolNamesFromStreamLine(line, reverseMap)
+	if errStream == nil {
+		t.Fatal("reverseRemapOAuthToolNamesFromStreamLine() error = nil, want fail-closed alias error")
+	}
+	if !bytes.Equal(restoredLine, line) {
+		t.Fatalf("reverseRemapOAuthToolNamesFromStreamLine() returned modified line: %s", restoredLine)
+	}
+	requestErr = nil
+	if !errors.As(errStream, &requestErr) || !requestErr.IsRequestScoped() {
+		t.Fatalf("reverseRemapOAuthToolNamesFromStreamLine() error = %T %v, want request-scoped", errStream, errStream)
+	}
+}
+
+func TestReverseRemapOAuthToolNames_ToolSearchResult_NonStream(t *testing.T) {
+	body := []byte(`{"tools":[{"name":"task_list","input_schema":{"type":"object"}},{"name":"fetch_url","input_schema":{"type":"object"}}]}`)
+	remapped, reverseMap := remapOAuthToolNamesWithOptions(body, claudeMCPAliasOptions{secret: "tool-search-caller"})
+	taskAlias := gjson.GetBytes(remapped, "tools.0.name").String()
+	fetchAlias := gjson.GetBytes(remapped, "tools.1.name").String()
+
+	if taskAlias == "task_list" || fetchAlias == "fetch_url" {
+		t.Fatalf("tools were not aliased: task=%q, fetch=%q", taskAlias, fetchAlias)
+	}
+
+	// 1. Successful search result with multiple tool_references
+	resp := []byte(fmt.Sprintf(`{
+		"id": "msg_01HczuyKgD1KCUuVzvZEH3WN",
+		"type": "message",
+		"role": "assistant",
+		"content": [
+			{
+				"type": "tool_search_tool_result",
+				"tool_use_id": "srvtoolu_01HczuyKgD1KCUuVzvZEH3WN",
+				"content": {
+					"type": "tool_search_tool_search_result",
+					"tool_references": [
+						{"type": "tool_reference", "tool_name": %q},
+						{"type": "tool_reference", "tool_name": %q}
+					]
+				}
+			},
+			{
+				"type": "tool_use",
+				"id": "toolu_01",
+				"name": %q,
+				"input": {"action": "list"}
+			}
+		]
+	}`, taskAlias, fetchAlias, taskAlias))
+
+	restored, err := reverseRemapOAuthToolNames(resp, reverseMap)
+	if err != nil {
+		t.Fatalf("reverseRemapOAuthToolNames() error = %v", err)
+	}
+
+	ref0 := gjson.GetBytes(restored, "content.0.content.tool_references.0.tool_name").String()
+	ref1 := gjson.GetBytes(restored, "content.0.content.tool_references.1.tool_name").String()
+	toolUseName := gjson.GetBytes(restored, "content.1.name").String()
+
+	if ref0 != "task_list" {
+		t.Errorf("ref0 = %q, want task_list", ref0)
+	}
+	if ref1 != "fetch_url" {
+		t.Errorf("ref1 = %q, want fetch_url", ref1)
+	}
+	if toolUseName != "task_list" {
+		t.Errorf("toolUseName = %q, want task_list", toolUseName)
+	}
+
+	// 2. Error variant (tool_search_tool_result_error) without tool_references should pass cleanly
+	errorResp := []byte(`{
+		"id": "msg_02",
+		"type": "message",
+		"role": "assistant",
+		"content": [
+			{
+				"type": "tool_search_tool_result",
+				"tool_use_id": "srvtoolu_02",
+				"content": {
+					"type": "tool_search_tool_result_error",
+					"error_code": "regex_compilation_failed"
+				}
+			}
+		]
+	}`)
+
+	restoredErr, err := reverseRemapOAuthToolNames(errorResp, reverseMap)
+	if err != nil {
+		t.Fatalf("reverseRemapOAuthToolNames(errorResp) error = %v", err)
+	}
+	if !bytes.Equal(restoredErr, errorResp) {
+		t.Fatalf("errorResp altered: %s", string(restoredErr))
+	}
+}
+
+func TestReverseRemapOAuthToolNamesFromStreamLine_ToolSearchResult_Stream(t *testing.T) {
+	body := []byte(`{"tools":[{"name":"task_list","input_schema":{"type":"object"}}]}`)
+	remapped, reverseMap := remapOAuthToolNamesWithOptions(body, claudeMCPAliasOptions{secret: "tool-search-stream-caller"})
+	taskAlias := gjson.GetBytes(remapped, "tools.0.name").String()
+
+	line := []byte(fmt.Sprintf(`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_search_tool_result","tool_use_id":"srvtoolu_01","content":{"type":"tool_search_tool_search_result","tool_references":[{"type":"tool_reference","tool_name":%q}]}}}`, taskAlias))
+
+	restoredLine, err := reverseRemapOAuthToolNamesFromStreamLine(line, reverseMap)
+	if err != nil {
+		t.Fatalf("reverseRemapOAuthToolNamesFromStreamLine() error = %v", err)
+	}
+
+	if !bytes.HasPrefix(restoredLine, []byte("data: ")) {
+		t.Fatalf("restoredLine lost data: prefix: %s", string(restoredLine))
+	}
+	gotToolName := gjson.GetBytes(helps.JSONPayload(restoredLine), "content_block.content.tool_references.0.tool_name").String()
+	if gotToolName != "task_list" {
+		t.Fatalf("stream restored tool_name = %q, want task_list", gotToolName)
+	}
+}
+
+func TestRemapOAuthToolNames_ToolSearchResultInMessageHistory(t *testing.T) {
+	body := []byte(`{
+		"tools": [
+			{"name": "task_list", "input_schema": {"type": "object"}},
+			{"type": "advisor_20260301", "name": "advisor", "model": "claude-haiku-4-5-20251001"},
+			{"type": "agent_toolset_20260401"}
+		],
+		"messages": [
+			{
+				"role": "assistant",
+				"content": [
+					{
+						"type": "tool_search_tool_result",
+						"tool_use_id": "srvtoolu_01",
+						"content": {
+							"type": "tool_search_tool_search_result",
+							"tool_references": [
+								{"type": "tool_reference", "tool_name": "task_list"}
+							]
+						}
+					}
+				]
+			}
+		]
+	}`)
+
+	remapped, reverseMap := remapOAuthToolNamesWithOptions(body, claudeMCPAliasOptions{secret: "history-caller"})
+	taskAlias := reverseMapKeyFor(reverseMap, "task_list")
+	if taskAlias == "" {
+		t.Fatal("task_list was not aliased")
+	}
+
+	// Verify server tools were preserved
+	tools := gjson.GetBytes(remapped, "tools")
+	if tools.Get("1.type").String() != "advisor_20260301" || tools.Get("1.name").String() != "advisor" {
+		t.Fatalf("advisor server tool was altered: %s", tools.Get("1").Raw)
+	}
+	if tools.Get("2.type").String() != "agent_toolset_20260401" {
+		t.Fatalf("agent_toolset was altered: %s", tools.Get("2").Raw)
+	}
+
+	// Verify tool_search_tool_result in messages was remapped
+	gotHistoryToolName := gjson.GetBytes(remapped, "messages.0.content.0.content.tool_references.0.tool_name").String()
+	if gotHistoryToolName != taskAlias {
+		t.Fatalf("history tool_name = %q, want aliased %q", gotHistoryToolName, taskAlias)
+	}
+}
+
+func reverseMapKeyFor(m map[string]string, val string) string {
+	for k, v := range m {
+		if v == val && k != val {
+			return k
+		}
+	}
+	return ""
 }

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -740,6 +740,55 @@ func TestApplyClaudeHeaders_UsesOAuthAuthorizationAndBrowserFingerprint(t *testi
 	}
 }
 
+func TestApplyClaudeHeaders_EmptyAPIKey_OmitsAuthHeaders(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Provider: "claude",
+		Attributes: map[string]string{
+			"auth_kind":           "apikey",
+			"base_url":            "https://custom-claude.example.com",
+			"header:Custom-Token": "custom-secret",
+		},
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://custom-claude.example.com/v1/messages", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	// Preset preexisting client headers to ensure they get stripped for empty API key
+	req.Header.Set("Authorization", "Bearer preexisting-bearer")
+	req.Header.Set("x-api-key", "preexisting-key")
+
+	if errHeaders := applyClaudeHeaders(req, auth, "", false, nil, nil, &config.Config{}, nil, false); errHeaders != nil {
+		t.Fatalf("applyClaudeHeaders() error = %v", errHeaders)
+	}
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization = %q, want empty for empty API key", got)
+	}
+	if got := req.Header.Get("x-api-key"); got != "" {
+		t.Fatalf("x-api-key = %q, want empty for empty API key", got)
+	}
+	if got := req.Header.Get("Custom-Token"); got != "custom-secret" {
+		t.Fatalf("Custom-Token = %q, want custom-secret", got)
+	}
+
+	// Also verify PrepareRequest
+	req2, _ := http.NewRequest(http.MethodPost, "https://custom-claude.example.com/v1/messages", nil)
+	req2.Header.Set("Authorization", "Bearer preexisting-bearer")
+	req2.Header.Set("x-api-key", "preexisting-key")
+	exec := &ClaudeExecutor{}
+	if errPrep := exec.PrepareRequest(req2, auth); errPrep != nil {
+		t.Fatalf("PrepareRequest() error = %v", errPrep)
+	}
+	if got := req2.Header.Get("Authorization"); got != "" {
+		t.Fatalf("PrepareRequest Authorization = %q, want empty", got)
+	}
+	if got := req2.Header.Get("x-api-key"); got != "" {
+		t.Fatalf("PrepareRequest x-api-key = %q, want empty", got)
+	}
+	if got := req2.Header.Get("Custom-Token"); got != "custom-secret" {
+		t.Fatalf("PrepareRequest Custom-Token = %q, want custom-secret", got)
+	}
+}
+
 func TestClaudeExecutor_NonClaudeRequestUsesClaudeCode220CLIFingerprint(t *testing.T) {
 	var seenBody []byte
 	var seenHeaders http.Header

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -6319,3 +6319,100 @@ func TestClaudeExecutor_CacheTTLIsPairedWithExtendedCacheTTLBeta(t *testing.T) {
 		})
 	}
 }
+
+func TestClaudeExecutor_PreservesNativeAgentAndEnvironmentHeaders(t *testing.T) {
+	tests := []struct {
+		name            string
+		incomingHeaders http.Header
+		wantHeaders     map[string]string
+		wantAbsent      []string
+	}{
+		{
+			name: "preserves canonical agent and parent agent headers",
+			incomingHeaders: http.Header{
+				"X-Claude-Code-Agent-Id":        {"subagent-001"},
+				"X-Claude-Code-Parent-Agent-Id": {"parent-agent-root"},
+			},
+			wantHeaders: map[string]string{
+				"X-Claude-Code-Agent-Id":        "subagent-001",
+				"X-Claude-Code-Parent-Agent-Id": "parent-agent-root",
+			},
+		},
+		{
+			name: "preserves lowercased agent and environment headers",
+			incomingHeaders: http.Header{
+				"x-claude-code-agent-id":            {"agent-xyz"},
+				"x-claude-remote-container-id":      {"container-123"},
+				"x-claude-remote-session-id":        {"remote-sess-456"},
+				"x-client-app":                      {"custom-sdk"},
+				"x-anthropic-additional-protection": {"true"},
+			},
+			wantHeaders: map[string]string{
+				"X-Claude-Code-Agent-Id":            "agent-xyz",
+				"X-Claude-Remote-Container-Id":      "container-123",
+				"X-Claude-Remote-Session-Id":        "remote-sess-456",
+				"X-Client-App":                      "custom-sdk",
+				"X-Anthropic-Additional-Protection": "true",
+			},
+		},
+		{
+			name: "does not fabricate agent header when absent",
+			incomingHeaders: http.Header{
+				"User-Agent": {"test-client"},
+			},
+			wantAbsent: []string{
+				"X-Claude-Code-Agent-Id",
+				"X-Claude-Code-Parent-Agent-Id",
+				"X-Claude-Remote-Container-Id",
+				"X-Claude-Remote-Session-Id",
+				"X-Client-App",
+				"X-Anthropic-Additional-Protection",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var seenHeaders http.Header
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				seenHeaders = r.Header.Clone()
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"id":"msg_agent","type":"message","model":"claude-opus-4-6","role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+			}))
+			defer server.Close()
+
+			executor := NewClaudeExecutor(&config.Config{})
+			auth := &cliproxyauth.Auth{
+				ID: "agent-header-test",
+				Attributes: map[string]string{
+					"api_key":    "sk-ant-test-key",
+					"base_url":   server.URL,
+					"cloak_mode": "always",
+				},
+				Metadata: claudeOAuthTestMetadata(),
+			}
+
+			_, errExecute := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+				Model:   "claude-opus-4-6",
+				Payload: []byte(`{"model":"claude-opus-4-6","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`),
+			}, cliproxyexecutor.Options{
+				SourceFormat: sdktranslator.FormatClaude,
+				Headers:      tt.incomingHeaders,
+			})
+			if errExecute != nil {
+				t.Fatalf("Execute() error = %v", errExecute)
+			}
+
+			for wantKey, wantVal := range tt.wantHeaders {
+				if got := seenHeaders.Get(wantKey); got != wantVal {
+					t.Errorf("header %s = %q, want %q", wantKey, got, wantVal)
+				}
+			}
+			for _, absentKey := range tt.wantAbsent {
+				if got := seenHeaders.Get(absentKey); got != "" {
+					t.Errorf("header %s = %q, want absent", absentKey, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -740,6 +740,55 @@ func TestApplyClaudeHeaders_UsesOAuthAuthorizationAndBrowserFingerprint(t *testi
 	}
 }
 
+func TestApplyClaudeHeaders_EmptyAPIKey_OmitsAuthHeaders(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Provider: "claude",
+		Attributes: map[string]string{
+			"auth_kind":           "apikey",
+			"base_url":            "https://custom-claude.example.com",
+			"header:Custom-Token": "custom-secret",
+		},
+	}
+	req, err := http.NewRequest(http.MethodPost, "https://custom-claude.example.com/v1/messages", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	// Preset preexisting client headers to ensure they get stripped for empty API key
+	req.Header.Set("Authorization", "Bearer preexisting-bearer")
+	req.Header.Set("x-api-key", "preexisting-key")
+
+	if errHeaders := applyClaudeHeaders(req, auth, "", false, nil, nil, &config.Config{}, nil, false); errHeaders != nil {
+		t.Fatalf("applyClaudeHeaders() error = %v", errHeaders)
+	}
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization = %q, want empty for empty API key", got)
+	}
+	if got := req.Header.Get("x-api-key"); got != "" {
+		t.Fatalf("x-api-key = %q, want empty for empty API key", got)
+	}
+	if got := req.Header.Get("Custom-Token"); got != "custom-secret" {
+		t.Fatalf("Custom-Token = %q, want custom-secret", got)
+	}
+
+	// Also verify PrepareRequest
+	req2, _ := http.NewRequest(http.MethodPost, "https://custom-claude.example.com/v1/messages", nil)
+	req2.Header.Set("Authorization", "Bearer preexisting-bearer")
+	req2.Header.Set("x-api-key", "preexisting-key")
+	exec := &ClaudeExecutor{}
+	if errPrep := exec.PrepareRequest(req2, auth); errPrep != nil {
+		t.Fatalf("PrepareRequest() error = %v", errPrep)
+	}
+	if got := req2.Header.Get("Authorization"); got != "" {
+		t.Fatalf("PrepareRequest Authorization = %q, want empty", got)
+	}
+	if got := req2.Header.Get("x-api-key"); got != "" {
+		t.Fatalf("PrepareRequest x-api-key = %q, want empty", got)
+	}
+	if got := req2.Header.Get("Custom-Token"); got != "custom-secret" {
+		t.Fatalf("PrepareRequest Custom-Token = %q, want custom-secret", got)
+	}
+}
+
 func TestClaudeExecutor_NonClaudeRequestUsesClaudeCode220CLIFingerprint(t *testing.T) {
 	var seenBody []byte
 	var seenHeaders http.Header
@@ -6315,6 +6364,103 @@ func TestClaudeExecutor_CacheTTLIsPairedWithExtendedCacheTTLBeta(t *testing.T) {
 			// without a 1h body ttl, is a combination native never produces.
 			if (gotTTL == "1h") != gotBeta {
 				t.Fatalf("body ttl %q and extended-cache-ttl beta %v disagree", gotTTL, gotBeta)
+			}
+		})
+	}
+}
+
+func TestClaudeExecutor_PreservesNativeAgentAndEnvironmentHeaders(t *testing.T) {
+	tests := []struct {
+		name            string
+		incomingHeaders http.Header
+		wantHeaders     map[string]string
+		wantAbsent      []string
+	}{
+		{
+			name: "preserves canonical agent and parent agent headers",
+			incomingHeaders: http.Header{
+				"X-Claude-Code-Agent-Id":        {"subagent-001"},
+				"X-Claude-Code-Parent-Agent-Id": {"parent-agent-root"},
+			},
+			wantHeaders: map[string]string{
+				"X-Claude-Code-Agent-Id":        "subagent-001",
+				"X-Claude-Code-Parent-Agent-Id": "parent-agent-root",
+			},
+		},
+		{
+			name: "preserves lowercased agent and environment headers",
+			incomingHeaders: http.Header{
+				"x-claude-code-agent-id":            {"agent-xyz"},
+				"x-claude-remote-container-id":      {"container-123"},
+				"x-claude-remote-session-id":        {"remote-sess-456"},
+				"x-client-app":                      {"custom-sdk"},
+				"x-anthropic-additional-protection": {"true"},
+			},
+			wantHeaders: map[string]string{
+				"X-Claude-Code-Agent-Id":            "agent-xyz",
+				"X-Claude-Remote-Container-Id":      "container-123",
+				"X-Claude-Remote-Session-Id":        "remote-sess-456",
+				"X-Client-App":                      "custom-sdk",
+				"X-Anthropic-Additional-Protection": "true",
+			},
+		},
+		{
+			name: "does not fabricate agent header when absent",
+			incomingHeaders: http.Header{
+				"User-Agent": {"test-client"},
+			},
+			wantAbsent: []string{
+				"X-Claude-Code-Agent-Id",
+				"X-Claude-Code-Parent-Agent-Id",
+				"X-Claude-Remote-Container-Id",
+				"X-Claude-Remote-Session-Id",
+				"X-Client-App",
+				"X-Anthropic-Additional-Protection",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var seenHeaders http.Header
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				seenHeaders = r.Header.Clone()
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"id":"msg_agent","type":"message","model":"claude-opus-4-6","role":"assistant","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1}}`))
+			}))
+			defer server.Close()
+
+			executor := NewClaudeExecutor(&config.Config{})
+			auth := &cliproxyauth.Auth{
+				ID: "agent-header-test",
+				Attributes: map[string]string{
+					"api_key":    "sk-ant-test-key",
+					"base_url":   server.URL,
+					"cloak_mode": "always",
+				},
+				Metadata: claudeOAuthTestMetadata(),
+			}
+
+			_, errExecute := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+				Model:   "claude-opus-4-6",
+				Payload: []byte(`{"model":"claude-opus-4-6","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`),
+			}, cliproxyexecutor.Options{
+				SourceFormat: sdktranslator.FormatClaude,
+				Headers:      tt.incomingHeaders,
+			})
+			if errExecute != nil {
+				t.Fatalf("Execute() error = %v", errExecute)
+			}
+
+			for wantKey, wantVal := range tt.wantHeaders {
+				if got := seenHeaders.Get(wantKey); got != wantVal {
+					t.Errorf("header %s = %q, want %q", wantKey, got, wantVal)
+				}
+			}
+			for _, absentKey := range tt.wantAbsent {
+				if got := seenHeaders.Get(absentKey); got != "" {
+					t.Errorf("header %s = %q, want absent", absentKey, got)
+				}
 			}
 		})
 	}

--- a/internal/runtime/executor/codex_executor_request.go
+++ b/internal/runtime/executor/codex_executor_request.go
@@ -57,6 +57,8 @@ func (e *CodexExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Aut
 	apiKey, _ := codexCreds(auth)
 	if strings.TrimSpace(apiKey) != "" {
 		req.Header.Set("Authorization", "Bearer "+apiKey)
+	} else {
+		req.Header.Del("Authorization")
 	}
 	var attrs map[string]string
 	if auth != nil {
@@ -319,7 +321,11 @@ func applyCodexDirectImageHeaders(r *http.Request, auth *cliproxyauth.Auth, toke
 
 func applyCodexHeadersFromSources(r *http.Request, auth *cliproxyauth.Auth, token string, stream bool, cfg *config.Config, ginHeaders http.Header) {
 	r.Header.Set("Content-Type", "application/json")
-	r.Header.Set("Authorization", "Bearer "+token)
+	if strings.TrimSpace(token) != "" {
+		r.Header.Set("Authorization", "Bearer "+token)
+	} else {
+		r.Header.Del("Authorization")
+	}
 
 	if ginHeaders != nil && ginHeaders.Get("X-Codex-Beta-Features") != "" {
 		r.Header.Set("X-Codex-Beta-Features", ginHeaders.Get("X-Codex-Beta-Features"))
@@ -342,12 +348,7 @@ func applyCodexHeadersFromSources(r *http.Request, auth *cliproxyauth.Auth, toke
 	}
 	r.Header.Set("Connection", "Keep-Alive")
 
-	isAPIKey := false
-	if auth != nil && auth.Attributes != nil {
-		if v := strings.TrimSpace(auth.Attributes["api_key"]); v != "" {
-			isAPIKey = true
-		}
-	}
+	isAPIKey := codexAuthUsesAPIKey(auth)
 	if originator := strings.TrimSpace(ginHeaders.Get("Originator")); originator != "" {
 		r.Header.Set("Originator", originator)
 	} else if !isAPIKey {

--- a/internal/runtime/executor/codex_executor_request.go
+++ b/internal/runtime/executor/codex_executor_request.go
@@ -58,6 +58,8 @@ func (e *CodexExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Aut
 	apiKey, _ := codexCreds(auth)
 	if strings.TrimSpace(apiKey) != "" {
 		req.Header.Set("Authorization", "Bearer "+apiKey)
+	} else {
+		req.Header.Del("Authorization")
 	}
 	var attrs map[string]string
 	if auth != nil {
@@ -327,7 +329,11 @@ func applyCodexDirectImageHeaders(r *http.Request, auth *cliproxyauth.Auth, toke
 
 func applyCodexHeadersFromSources(r *http.Request, auth *cliproxyauth.Auth, token string, stream bool, cfg *config.Config, ginHeaders http.Header) {
 	r.Header.Set("Content-Type", "application/json")
-	r.Header.Set("Authorization", "Bearer "+token)
+	if strings.TrimSpace(token) != "" {
+		r.Header.Set("Authorization", "Bearer "+token)
+	} else {
+		r.Header.Del("Authorization")
+	}
 
 	if ginHeaders != nil && ginHeaders.Get("X-Codex-Beta-Features") != "" {
 		r.Header.Set("X-Codex-Beta-Features", ginHeaders.Get("X-Codex-Beta-Features"))
@@ -350,12 +356,7 @@ func applyCodexHeadersFromSources(r *http.Request, auth *cliproxyauth.Auth, toke
 	}
 	r.Header.Set("Connection", "Keep-Alive")
 
-	isAPIKey := false
-	if auth != nil && auth.Attributes != nil {
-		if v := strings.TrimSpace(auth.Attributes["api_key"]); v != "" {
-			isAPIKey = true
-		}
-	}
+	isAPIKey := codexAuthUsesAPIKey(auth)
 	if originator := strings.TrimSpace(ginHeaders.Get("Originator")); originator != "" {
 		r.Header.Set("Originator", originator)
 	} else if !isAPIKey {

--- a/internal/runtime/executor/codex_executor_stream.go
+++ b/internal/runtime/executor/codex_executor_stream.go
@@ -130,7 +130,150 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		err = newCodexStatusErr(httpResp.StatusCode, data)
 		return nil, err
 	}
-	out := make(chan cliproxyexecutor.StreamChunk)
+
+	buffering := e.cfg != nil && e.cfg.Codex.StreamBootstrapBuffering
+
+	scanner := bufio.NewScanner(httpResp.Body)
+	scanner.Buffer(nil, 52_428_800) // 50MB
+	claudeInputTokens := helps.NewClaudeInputTokenState(from, to, responseFormat, originalPayload)
+	var param any
+	outputItemsByIndex := make(map[int64][]byte)
+	var outputItemsFallback [][]byte
+
+	var bufferedChunks [][]byte
+	var initialChunks [][]byte
+	streamStarted := false
+	immediateTerminal := false
+	// bootstrapTerminalErr holds a non-overload terminal failure seen while buffering. It is
+	// delivered as an in-stream chunk after the buffered handshake so downstream behaviour stays
+	// identical to the unbuffered path instead of silently turning into a credential failover.
+	var bootstrapTerminalErr error
+
+	closeBootstrapBody := func() {
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("codex executor: close response body error: %v", errClose)
+		}
+	}
+
+	if buffering {
+		for scanner.Scan() {
+			line := applyCodexIdentityConfuseResponsePayload(scanner.Bytes(), identityState)
+			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
+			translatedLine := bytes.Clone(line)
+			isHandshake := false
+			terminalSuccess := false
+
+			if bytes.HasPrefix(line, dataTag) {
+				data := bytes.TrimSpace(line[5:])
+				data = helps.RestoreCodexMultiAgentV2Response(data, optimizeMultiAgentV2)
+				translatedLine = append([]byte("data: "), data...)
+				eventType := gjson.GetBytes(data, "type").String()
+				if streamErr, terminalBody, ok := codexTerminalFailureErr(data); ok {
+					closeBootstrapBody()
+					if errClearReplay := clearCodexReasoningReplayOnInvalidSignature(ctx, replayScope, streamErr.StatusCode(), terminalBody); errClearReplay != nil {
+						helps.RecordAPIResponseError(ctx, e.cfg, errClearReplay)
+						reporter.PublishFailure(ctx, errClearReplay)
+						return nil, errClearReplay
+					}
+					helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
+					reporter.PublishFailure(ctx, streamErr)
+					if isCodexOverloadBootstrapFailure(terminalBody) {
+						// Transient capacity rejection smuggled into an HTTP 200 stream. Fail the
+						// attempt before the downstream headers are committed so the conductor can
+						// transparently retry on another credential, and report the status the
+						// upstream refused to put on the wire.
+						helps.LogWithRequestID(ctx).Debugf("codex executor: bootstrap overload rejection after %d buffered handshake events, failing over", len(bufferedChunks))
+						return nil, newCodexBootstrapOverloadErr(terminalBody)
+					}
+					bootstrapTerminalErr = streamErr
+					break
+				}
+				if isCodexHandshakeMetadataEvent(eventType) {
+					isHandshake = true
+				}
+				switch eventType {
+				case "response.output_item.done":
+					collectCodexOutputItemDone(data, outputItemsByIndex, &outputItemsFallback)
+				case "response.completed", "response.incomplete":
+					terminalSuccess = true
+					if detail, ok := helps.ParseCodexUsage(data); ok {
+						reporter.Publish(ctx, detail)
+					}
+					publishCodexImageToolUsage(ctx, reporter, body, data)
+					data = patchCodexCompletedOutput(data, outputItemsByIndex, outputItemsFallback)
+					if eventType == "response.completed" {
+						cacheCodexReasoningReplayFromCompleted(replayScope, data)
+					}
+					translatedLine = append([]byte("data: "), data...)
+				}
+			} else {
+				isHandshake = true
+			}
+
+			translatedLine = applyCodexIdentityExposeResponsePayload(translatedLine, identityState)
+			chunks := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, originalPayload, body, translatedLine, &param, claudeInputTokens)
+			if isHandshake && !terminalSuccess {
+				if len(bufferedChunks) < codexBootstrapMaxBufferedEvents {
+					bufferedChunks = append(bufferedChunks, chunks...)
+					continue
+				}
+				helps.LogWithRequestID(ctx).Debugf("codex executor: bootstrap buffer limit %d reached, releasing stream without overload probing", codexBootstrapMaxBufferedEvents)
+			}
+
+			initialChunks = chunks
+			streamStarted = true
+			if terminalSuccess {
+				immediateTerminal = true
+			}
+			break
+		}
+
+		if !streamStarted && bootstrapTerminalErr == nil {
+			closeBootstrapBody()
+			if errScan := scanner.Err(); errScan != nil {
+				// A cancelled downstream request must not be recorded as an upstream failure or
+				// penalise the credential; mirror the unbuffered goroutine's guard.
+				if ctx.Err() != nil {
+					return nil, ctx.Err()
+				}
+				helps.RecordAPIResponseError(ctx, e.cfg, errScan)
+				reporter.PublishFailure(ctx, errScan)
+				return nil, errScan
+			}
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			streamErr := newCodexIncompleteStreamError()
+			helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
+			reporter.PublishFailure(ctx, streamErr)
+			return nil, streamErr
+		}
+	}
+
+	chanCapacity := len(bufferedChunks) + len(initialChunks)
+	if bootstrapTerminalErr != nil {
+		chanCapacity++
+	}
+	out := make(chan cliproxyexecutor.StreamChunk, chanCapacity)
+	for _, chunk := range bufferedChunks {
+		out <- cliproxyexecutor.StreamChunk{Payload: chunk}
+	}
+	for _, chunk := range initialChunks {
+		out <- cliproxyexecutor.StreamChunk{Payload: chunk}
+	}
+	if bootstrapTerminalErr != nil {
+		// Buffered handshake payloads are flushed first so the conductor observes a committed
+		// stream and delivers this failure in-stream, exactly as the unbuffered path would.
+		out <- cliproxyexecutor.StreamChunk{Err: bootstrapTerminalErr}
+		close(out)
+		return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+	}
+	if immediateTerminal {
+		closeBootstrapBody()
+		close(out)
+		return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+	}
+
 	go func() {
 		defer close(out)
 		defer func() {
@@ -138,12 +281,6 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 				log.Errorf("codex executor: close response body error: %v", errClose)
 			}
 		}()
-		scanner := bufio.NewScanner(httpResp.Body)
-		scanner.Buffer(nil, 52_428_800) // 50MB
-		claudeInputTokens := helps.NewClaudeInputTokenState(from, to, responseFormat, originalPayload)
-		var param any
-		outputItemsByIndex := make(map[int64][]byte)
-		var outputItemsFallback [][]byte
 		for scanner.Scan() {
 			line := applyCodexIdentityConfuseResponsePayload(scanner.Bytes(), identityState)
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)

--- a/internal/runtime/executor/codex_executor_stream.go
+++ b/internal/runtime/executor/codex_executor_stream.go
@@ -153,11 +153,95 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		err = newCodexStatusErr(httpResp.StatusCode, data)
 		return nil, err
 	}
+	abnormalStreamBuffering := abnormalRetry.StreamBuffer()
+	bufferMaxBytes := abnormalRetry.StreamBufferMaxBytes()
+	scannerMaxTokenBytes := int64(52_428_800) // 50 MiB compatibility ceiling.
+	if abnormalStreamBuffering && bufferMaxBytes > 0 && bufferMaxBytes < scannerMaxTokenBytes {
+		scannerMaxTokenBytes = bufferMaxBytes + 1
+		if scannerMaxTokenBytes < 64<<10 {
+			scannerMaxTokenBytes = 64 << 10
+		}
+	}
+	scanner := bufio.NewScanner(httpResp.Body)
+	scanner.Buffer(nil, int(scannerMaxTokenBytes))
+	closeResponseBody := func() {
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("codex executor: close response body error: %v", errClose)
+		}
+	}
+
+	var bootstrapLines [][]byte
+	if e.cfg != nil && e.cfg.Codex.StreamBootstrapBuffering {
+		bootstrapReleased := false
+		handshakeEvents := 0
+		for scanner.Scan() {
+			rawLine := bytes.Clone(scanner.Bytes())
+			bootstrapLines = append(bootstrapLines, rawLine)
+			line := applyCodexIdentityConfuseResponsePayload(rawLine, identityState)
+			if !bytes.HasPrefix(line, dataTag) {
+				continue
+			}
+
+			data := bytes.TrimSpace(line[5:])
+			data = helps.RestoreCodexMultiAgentV2Response(data, optimizeMultiAgentV2)
+			if streamErr, terminalBody, ok := codexTerminalFailureErr(data); ok {
+				if isCodexOverloadBootstrapFailure(terminalBody) {
+					for _, bufferedLine := range bootstrapLines {
+						helpersLine := applyCodexIdentityConfuseResponsePayload(bufferedLine, identityState)
+						helps.AppendAPIResponseChunk(ctx, e.cfg, helpersLine)
+					}
+					closeResponseBody()
+					if errClearReplay := clearCodexReasoningReplayOnInvalidSignature(ctx, replayScope, streamErr.StatusCode(), terminalBody); errClearReplay != nil {
+						helps.RecordAPIResponseError(ctx, e.cfg, errClearReplay)
+						reporter.PublishFailure(ctx, errClearReplay)
+						return nil, errClearReplay
+					}
+					overloadErr := newCodexBootstrapOverloadErr(terminalBody)
+					helps.RecordAPIResponseError(ctx, e.cfg, overloadErr)
+					reporter.PublishFailure(ctx, overloadErr)
+					helps.LogWithRequestID(ctx).Debugf("codex executor: bootstrap overload rejection after %d buffered handshake events, failing over", handshakeEvents)
+					return nil, overloadErr
+				}
+				bootstrapReleased = true
+				break
+			}
+
+			eventType := gjson.GetBytes(data, "type").String()
+			if !isCodexHandshakeMetadataEvent(eventType) {
+				bootstrapReleased = true
+				break
+			}
+			handshakeEvents++
+			if handshakeEvents >= codexBootstrapMaxBufferedEvents {
+				helps.LogWithRequestID(ctx).Debugf("codex executor: bootstrap buffer limit %d reached, releasing stream without overload probing", codexBootstrapMaxBufferedEvents)
+				bootstrapReleased = true
+				break
+			}
+		}
+		if !bootstrapReleased {
+			closeResponseBody()
+			if errScan := scanner.Err(); errScan != nil {
+				if ctx.Err() != nil {
+					return nil, ctx.Err()
+				}
+				helps.RecordAPIResponseError(ctx, e.cfg, errScan)
+				reporter.PublishFailure(ctx, errScan)
+				return nil, errScan
+			}
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			streamErr := newCodexIncompleteStreamError()
+			helps.RecordAPIResponseError(ctx, e.cfg, streamErr)
+			reporter.PublishFailure(ctx, streamErr)
+			return nil, streamErr
+		}
+	}
 	out := make(chan cliproxyexecutor.StreamChunk)
 	streamUsage := &cliproxyexecutor.RetryWithoutPenaltyStreamUsage{}
 	var qualityRecorder *codexAbnormalReasoningRetryStreamRecorder
-	if abnormalRetry.StreamBuffer() {
-		qualityRecorder = newCodexAbnormalReasoningRetryStreamRecorder(abnormalRetry.StreamBufferMaxBytes())
+	if abnormalStreamBuffering {
+		qualityRecorder = newCodexAbnormalReasoningRetryStreamRecorder(bufferMaxBytes)
 	}
 	streamFinalizer := cliproxyexecutor.RetryWithoutPenaltyStreamFinalizer(func(headers http.Header, chunks []cliproxyexecutor.StreamChunk, previous cliproxyexecutor.RetryWithoutPenaltyUsageSnapshot) *cliproxyexecutor.StreamResult {
 		if result := finalizeCodexAbnormalReasoningRetryStreamFromRaw(ctx, to, responseFormat, req.Model, originalPayload, body, identityState, qualityRecorder, headers, previous, abnormalRetry.clientUsageAggregation); result != nil {
@@ -167,22 +251,8 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 	})
 	go func() {
 		defer close(out)
-		defer func() {
-			if errClose := httpResp.Body.Close(); errClose != nil {
-				log.Errorf("codex executor: close response body error: %v", errClose)
-			}
-		}()
-		buffering := abnormalRetry.StreamBuffer()
-		bufferMaxBytes := abnormalRetry.StreamBufferMaxBytes()
-		scannerMaxTokenBytes := int64(52_428_800) // 50 MiB compatibility ceiling.
-		if buffering && bufferMaxBytes > 0 && bufferMaxBytes < scannerMaxTokenBytes {
-			scannerMaxTokenBytes = bufferMaxBytes + 1
-			if scannerMaxTokenBytes < 64<<10 {
-				scannerMaxTokenBytes = 64 << 10
-			}
-		}
-		scanner := bufio.NewScanner(httpResp.Body)
-		scanner.Buffer(nil, int(scannerMaxTokenBytes))
+		defer closeResponseBody()
+		buffering := abnormalStreamBuffering
 		claudeInputTokens := helps.NewClaudeInputTokenState(from, to, responseFormat, originalPayload)
 		var param any
 		outputItemsByIndex := make(map[int64][]byte)
@@ -253,8 +323,24 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 			case <-ctx.Done():
 			}
 		}
-		for scanner.Scan() {
-			line := applyCodexIdentityConfuseResponsePayload(scanner.Bytes(), identityState)
+		bootstrapLineIndex := 0
+		nextLine := func() ([]byte, bool) {
+			if bootstrapLineIndex < len(bootstrapLines) {
+				line := bootstrapLines[bootstrapLineIndex]
+				bootstrapLineIndex++
+				return line, true
+			}
+			if scanner.Scan() {
+				return scanner.Bytes(), true
+			}
+			return nil, false
+		}
+		for {
+			rawLine, ok := nextLine()
+			if !ok {
+				break
+			}
+			line := applyCodexIdentityConfuseResponsePayload(rawLine, identityState)
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
 			translatedLine := bytes.Clone(line)
 			flushAfterLine := false

--- a/internal/runtime/executor/codex_executor_stream_output_test.go
+++ b/internal/runtime/executor/codex_executor_stream_output_test.go
@@ -576,6 +576,13 @@ func TestCodexTerminalFailureErrClassifiesStatus(t *testing.T) {
 			event:      `{"type":"response.failed","response":{"error":{"type":"upstream_error","code":"unknown","message":"Upstream failed."}}}`,
 			wantStatus: http.StatusBadGateway,
 		},
+		// Overload rejections keep falling through to 502 here. The 503 restoration is scoped to
+		// the opt-in bootstrap buffering path so this shared mapping stays unchanged.
+		{
+			name:       "overload stays a bad gateway without buffering",
+			event:      `{"type":"error","error":{"type":"service_unavailable_error","code":"server_is_overloaded","message":"Our servers are currently overloaded. Please try again later."}}`,
+			wantStatus: http.StatusBadGateway,
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/runtime/executor/codex_executor_terminal.go
+++ b/internal/runtime/executor/codex_executor_terminal.go
@@ -405,3 +405,51 @@ func parseCodexRetryAfter(statusCode int, errorBody []byte, now time.Time) *time
 	}
 	return nil
 }
+
+// codexBootstrapMaxBufferedEvents bounds how many handshake metadata events may be held
+// back while probing for an upstream rejection embedded in an HTTP 200 stream. The websocket
+// transport prefixes response events with codex.response.metadata and codex.rate_limits frames,
+// so the limit must comfortably exceed the four handshake frames observed in practice. Once the
+// limit is reached the stream is released and the original unbuffered semantics apply.
+const codexBootstrapMaxBufferedEvents = 16
+
+// isCodexHandshakeMetadataEvent reports whether an event carries no generated output and is
+// therefore safe to hold back before the downstream response headers are committed. Keeping a type
+// allow-list rather than a fixed event count matters for the websocket transport, where the
+// handshake frames arrive before response.created and would otherwise exhaust a small counter
+// before the rejection event is seen.
+func isCodexHandshakeMetadataEvent(eventType string) bool {
+	switch eventType {
+	case "response.created", "response.in_progress", "codex.rate_limits", "codex.response.metadata":
+		return true
+	default:
+		return false
+	}
+}
+
+// newCodexBootstrapOverloadErr reports a buffered overload rejection with its real status.
+//
+// The status is deliberately produced here instead of in codexTerminalFailureStatus: that mapping
+// is shared with the unbuffered path, where the rejection is delivered in-stream and a status
+// change would alter cooldown classification and retry-after parsing for everyone. Keeping 503
+// scoped to this path means disabling the feature restores the previous behaviour exactly.
+func newCodexBootstrapOverloadErr(body []byte) statusErr {
+	return newCodexStatusErr(http.StatusServiceUnavailable, body)
+}
+
+// isCodexOverloadBootstrapFailure reports whether a terminal failure delivered inside an HTTP 200
+// stream is a transient capacity rejection that a different credential may be able to serve.
+// Only these failures justify replacing the whole attempt during bootstrap; every other terminal
+// failure keeps the original in-stream delivery semantics so downstream behaviour is unchanged.
+func isCodexOverloadBootstrapFailure(body []byte) bool {
+	errorType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.type").String()))
+	errorCode := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.code").String()))
+	switch {
+	case errorType == "service_unavailable_error", errorCode == "server_is_overloaded":
+		return true
+	case errorType == "rate_limit_error", errorCode == "rate_limit_exceeded":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/runtime/executor/codex_executor_terminal.go
+++ b/internal/runtime/executor/codex_executor_terminal.go
@@ -428,3 +428,51 @@ func parseCodexRetryAfter(statusCode int, errorBody []byte, now time.Time) *time
 	}
 	return nil
 }
+
+// codexBootstrapMaxBufferedEvents bounds how many handshake metadata events may be held
+// back while probing for an upstream rejection embedded in an HTTP 200 stream. The websocket
+// transport prefixes response events with codex.response.metadata and codex.rate_limits frames,
+// so the limit must comfortably exceed the four handshake frames observed in practice. Once the
+// limit is reached the stream is released and the original unbuffered semantics apply.
+const codexBootstrapMaxBufferedEvents = 16
+
+// isCodexHandshakeMetadataEvent reports whether an event carries no generated output and is
+// therefore safe to hold back before the downstream response headers are committed. Keeping a type
+// allow-list rather than a fixed event count matters for the websocket transport, where the
+// handshake frames arrive before response.created and would otherwise exhaust a small counter
+// before the rejection event is seen.
+func isCodexHandshakeMetadataEvent(eventType string) bool {
+	switch eventType {
+	case "response.created", "response.in_progress", "codex.rate_limits", "codex.response.metadata":
+		return true
+	default:
+		return false
+	}
+}
+
+// newCodexBootstrapOverloadErr reports a buffered overload rejection with its real status.
+//
+// The status is deliberately produced here instead of in codexTerminalFailureStatus: that mapping
+// is shared with the unbuffered path, where the rejection is delivered in-stream and a status
+// change would alter cooldown classification and retry-after parsing for everyone. Keeping 503
+// scoped to this path means disabling the feature restores the previous behaviour exactly.
+func newCodexBootstrapOverloadErr(body []byte) statusErr {
+	return newCodexStatusErr(http.StatusServiceUnavailable, body)
+}
+
+// isCodexOverloadBootstrapFailure reports whether a terminal failure delivered inside an HTTP 200
+// stream is a transient capacity rejection that a different credential may be able to serve.
+// Only these failures justify replacing the whole attempt during bootstrap; every other terminal
+// failure keeps the original in-stream delivery semantics so downstream behaviour is unchanged.
+func isCodexOverloadBootstrapFailure(body []byte) bool {
+	errorType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.type").String()))
+	errorCode := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, "error.code").String()))
+	switch {
+	case errorType == "service_unavailable_error", errorCode == "server_is_overloaded":
+		return true
+	case errorType == "rate_limit_error", errorCode == "rate_limit_exceeded":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/runtime/executor/codex_stream_bootstrap_buffering_test.go
+++ b/internal/runtime/executor/codex_stream_bootstrap_buffering_test.go
@@ -1,0 +1,478 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+const (
+	codexOverloadEvent      = `{"type":"error","error":{"type":"service_unavailable_error","code":"server_is_overloaded","message":"Our servers are currently overloaded. Please try again later.","param":null},"sequence_number":2}`
+	codexInvalidEvent       = `{"type":"error","error":{"type":"invalid_request_error","code":"invalid_value","message":"Invalid input."},"sequence_number":2}`
+	codexCreatedEvent       = `{"type":"response.created","response":{"id":"resp_1","model":"gpt-5.6-terra"}}`
+	codexInProgressEvent    = `{"type":"response.in_progress","response":{"id":"resp_1"}}`
+	codexOutputAddedEvent   = `{"type":"response.output_item.added","item":{"id":"msg_1","type":"message","role":"assistant","content":[]},"output_index":0}`
+	codexCompletedEventBody = `{"type":"response.completed","response":{"id":"resp_1","status":"completed","output":[{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`
+)
+
+func codexBufferingConfig(enabled bool) *config.Config {
+	return &config.Config{Codex: config.CodexConfig{StreamBootstrapBuffering: enabled}}
+}
+
+func codexTestAuth(baseURL string) *cliproxyauth.Auth {
+	return &cliproxyauth.Auth{Attributes: map[string]string{"base_url": baseURL, "api_key": "test"}}
+}
+
+func codexTestRequest() (cliproxyexecutor.Request, cliproxyexecutor.Options) {
+	return cliproxyexecutor.Request{
+			Model:   "gpt-5.6-terra",
+			Payload: []byte(`{"model":"gpt-5.6-terra","input":"hello"}`),
+		}, cliproxyexecutor.Options{
+			SourceFormat: sdktranslator.FromString("openai-response"),
+			Stream:       true,
+		}
+}
+
+// codexSSEServer streams the supplied event payloads as an HTTP 200 SSE response.
+func codexSSEServer(events ...string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		for _, event := range events {
+			eventType := "message"
+			if parsed := strings.SplitN(event, `"type":"`, 2); len(parsed) == 2 {
+				eventType = strings.SplitN(parsed[1], `"`, 2)[0]
+			}
+			_, _ = w.Write([]byte("event: " + eventType + "\n"))
+			_, _ = w.Write([]byte("data: " + event + "\n\n"))
+		}
+	}))
+}
+
+// codexWebsocketServer echoes the supplied frames after receiving the client request frame.
+func codexWebsocketServer(t *testing.T, frames ...string) *httptest.Server {
+	t.Helper()
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		if _, _, errRead := conn.ReadMessage(); errRead != nil {
+			t.Errorf("read websocket message: %v", errRead)
+			return
+		}
+		for _, frame := range frames {
+			_ = conn.WriteMessage(websocket.TextMessage, []byte(frame))
+		}
+	}))
+}
+
+func codexWebsocketRequest() (cliproxyexecutor.Request, cliproxyexecutor.Options) {
+	return cliproxyexecutor.Request{
+			Model:   "gpt-5.6-terra",
+			Payload: []byte(`{"model":"gpt-5.6-terra","input":[{"type":"message","role":"user","content":"hello"}]}`),
+		}, cliproxyexecutor.Options{
+			SourceFormat: sdktranslator.FromString("openai-response"),
+		}
+}
+
+// drainChunks collects every payload and the first error from a stream result.
+func drainChunks(result *cliproxyexecutor.StreamResult) (string, error) {
+	var payloads [][]byte
+	var streamErr error
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			if streamErr == nil {
+				streamErr = chunk.Err
+			}
+			continue
+		}
+		payloads = append(payloads, chunk.Payload)
+	}
+	return string(bytes.Join(payloads, []byte("\n"))), streamErr
+}
+
+// An overload rejection smuggled into an HTTP 200 stream must fail the whole attempt before any
+// downstream chunk escapes, so the conductor can retry on another credential. A nil StreamResult
+// is the invariant: with no channel there is no way for the buffered handshake to reach the client.
+func TestCodexExecutor_BootstrapBuffering_OverloadFailsAttemptWithoutLeakingHandshake(t *testing.T) {
+	server := codexSSEServer(codexCreatedEvent, codexInProgressEvent, codexOverloadEvent)
+	defer server.Close()
+
+	req, opts := codexTestRequest()
+	result, err := NewCodexExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+
+	if err == nil {
+		t.Fatal("expected ExecuteStream to fail the attempt on an overload rejection")
+	}
+	if result != nil {
+		t.Fatal("expected nil result so no buffered handshake chunk can reach the client")
+	}
+	if got := statusCodeFromTestError(t, err); got != http.StatusServiceUnavailable {
+		t.Fatalf("status code = %d, want %d (upstream hides 503 behind HTTP 200)", got, http.StatusServiceUnavailable)
+	}
+}
+
+// A non-overload terminal failure must keep the original in-stream delivery semantics: the
+// buffered handshake is flushed first and the error arrives as a stream chunk, so the conductor
+// sees a committed stream and does not burn another credential on a request-level fault.
+func TestCodexExecutor_BootstrapBuffering_NonOverloadStaysInStream(t *testing.T) {
+	server := codexSSEServer(codexCreatedEvent, codexInProgressEvent, codexInvalidEvent)
+	defer server.Close()
+
+	req, opts := codexTestRequest()
+	result, err := NewCodexExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+
+	if err != nil {
+		t.Fatalf("non-overload failure must not fail the attempt synchronously: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a stream result for in-stream error delivery")
+	}
+	combined, streamErr := drainChunks(result)
+	if streamErr == nil {
+		t.Fatal("expected the invalid-request failure to arrive as an in-stream chunk error")
+	}
+	if !strings.Contains(combined, "response.created") {
+		t.Fatalf("buffered handshake must be flushed before the in-stream error: %s", combined)
+	}
+	if got := statusCodeFromTestError(t, streamErr); got != http.StatusBadRequest {
+		t.Fatalf("status code = %d, want %d", got, http.StatusBadRequest)
+	}
+}
+
+// Once the buffer limit is exceeded the stream is released and overload probing stops, which
+// bounds how long the downstream response headers can stay uncommitted.
+func TestCodexExecutor_BootstrapBuffering_BufferLimitReleasesStream(t *testing.T) {
+	events := make([]string, 0, codexBootstrapMaxBufferedEvents+2)
+	for i := 0; i < codexBootstrapMaxBufferedEvents+1; i++ {
+		events = append(events, fmt.Sprintf(`{"type":"response.in_progress","response":{"id":"resp_%d"}}`, i))
+	}
+	events = append(events, codexOverloadEvent)
+	server := codexSSEServer(events...)
+	defer server.Close()
+
+	req, opts := codexTestRequest()
+	result, err := NewCodexExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+
+	if err != nil {
+		t.Fatalf("expected the stream to be released once the buffer limit is hit: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a stream result after the buffer limit released the stream")
+	}
+	_, streamErr := drainChunks(result)
+	if streamErr == nil {
+		t.Fatal("expected the overload error to be delivered in-stream after the limit was hit")
+	}
+}
+
+// Buffered handshake events must be replayed in upstream order ahead of the first generated event.
+func TestCodexExecutor_BootstrapBuffering_FlushesInOrderOnFirstOutput(t *testing.T) {
+	server := codexSSEServer(codexCreatedEvent, codexInProgressEvent, codexOutputAddedEvent, codexCompletedEventBody)
+	defer server.Close()
+
+	req, opts := codexTestRequest()
+	result, err := NewCodexExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+	if err != nil {
+		t.Fatalf("unexpected ExecuteStream error: %v", err)
+	}
+
+	combined, streamErr := drainChunks(result)
+	if streamErr != nil {
+		t.Fatalf("unexpected chunk error: %v", streamErr)
+	}
+	createdAt := strings.Index(combined, "response.created")
+	addedAt := strings.Index(combined, "response.output_item.added")
+	if createdAt < 0 || addedAt < 0 {
+		t.Fatalf("missing handshake or first generated event: %s", combined)
+	}
+	if createdAt > addedAt {
+		t.Fatalf("buffered handshake must be replayed before the first generated event: %s", combined)
+	}
+}
+
+// With the feature disabled the overload rejection keeps its legacy in-stream delivery.
+func TestCodexExecutor_BootstrapBuffering_DefaultDisabledPassthrough(t *testing.T) {
+	server := codexSSEServer(codexCreatedEvent, codexOverloadEvent)
+	defer server.Close()
+
+	req, opts := codexTestRequest()
+	result, err := NewCodexExecutor(&config.Config{}).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+	if err != nil {
+		t.Fatalf("default unbuffered ExecuteStream returned error at call time: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result in default unbuffered mode")
+	}
+	_, streamErr := drainChunks(result)
+	if streamErr == nil {
+		t.Fatal("expected stream error in chunks for default unbuffered mode")
+	}
+	// Disabling the feature must restore the previous behaviour exactly, status classification
+	// included: the 503 restoration is scoped to the buffered failover path, so an unbuffered
+	// overload still classifies as a bad gateway and keeps its old cooldown treatment.
+	if got := statusCodeFromTestError(t, streamErr); got != http.StatusBadGateway {
+		t.Fatalf("status code = %d, want %d while buffering is disabled", got, http.StatusBadGateway)
+	}
+}
+
+// A cancelled downstream request must surface the context error rather than being recorded as an
+// upstream failure that penalises the credential.
+func TestCodexExecutor_BootstrapBuffering_ContextCancelDuringBootstrap(t *testing.T) {
+	server := codexSSEServer(codexCreatedEvent)
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	req, opts := codexTestRequest()
+	_, err := NewCodexExecutor(codexBufferingConfig(true)).ExecuteStream(ctx, codexTestAuth(server.URL), req, opts)
+	if err == nil {
+		t.Fatal("expected an error for a cancelled bootstrap")
+	}
+	if !strings.Contains(err.Error(), context.Canceled.Error()) {
+		t.Fatalf("expected the context cancellation to surface, got: %v", err)
+	}
+}
+
+func TestCodexWebsocketsExecutor_BootstrapBuffering_OverloadFailsAttempt(t *testing.T) {
+	server := codexWebsocketServer(t, codexCreatedEvent, codexInProgressEvent, codexOverloadEvent)
+	defer server.Close()
+
+	req, opts := codexWebsocketRequest()
+	result, err := NewCodexWebsocketsExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+
+	if err == nil {
+		t.Fatal("expected ExecuteStream to fail the attempt on a websocket overload rejection")
+	}
+	if result != nil {
+		t.Fatal("expected nil result so no buffered handshake frame can reach the client")
+	}
+	if got := statusCodeFromTestError(t, err); got != http.StatusServiceUnavailable {
+		t.Fatalf("status code = %d, want %d", got, http.StatusServiceUnavailable)
+	}
+}
+
+// The websocket transport prefixes response events with private metadata frames. Frame order
+// below matches live wire capture: codex.rate_limits and codex.response.metadata both arrive
+// *before* response.created, making the first generated event the fifth frame. They must be
+// treated as handshake events, otherwise a fixed 3-event window would release the stream at
+// response.created and never observe the rejection.
+func TestCodexWebsocketsExecutor_BootstrapBuffering_PrivateHandshakeFramesDoNotExhaustWindow(t *testing.T) {
+	server := codexWebsocketServer(t,
+		`{"type":"codex.rate_limits","rate_limits":{"primary":{"used_percent":1}}}`,
+		`{"type":"codex.response.metadata","metadata":{"conversation_id":"conv_1"}}`,
+		codexCreatedEvent,
+		codexInProgressEvent,
+		codexOverloadEvent,
+	)
+	defer server.Close()
+
+	req, opts := codexWebsocketRequest()
+	result, err := NewCodexWebsocketsExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+
+	if err == nil {
+		t.Fatal("expected the overload rejection to be caught past the private handshake frames")
+	}
+	if result != nil {
+		t.Fatal("expected nil result so no buffered frame can reach the client")
+	}
+	if got := statusCodeFromTestError(t, err); got != http.StatusServiceUnavailable {
+		t.Fatalf("status code = %d, want %d", got, http.StatusServiceUnavailable)
+	}
+}
+
+func TestCodexWebsocketsExecutor_BootstrapBuffering_NonOverloadStaysInStream(t *testing.T) {
+	server := codexWebsocketServer(t, codexCreatedEvent, codexInProgressEvent, codexInvalidEvent)
+	defer server.Close()
+
+	req, opts := codexWebsocketRequest()
+	result, err := NewCodexWebsocketsExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+
+	if err != nil {
+		t.Fatalf("non-overload failure must not fail the attempt synchronously: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a stream result for in-stream error delivery")
+	}
+	combined, streamErr := drainChunks(result)
+	if streamErr == nil {
+		t.Fatal("expected the invalid-request failure to arrive as an in-stream chunk error")
+	}
+	if !strings.Contains(combined, "response.created") {
+		t.Fatalf("buffered handshake must be flushed before the in-stream error: %s", combined)
+	}
+}
+
+func TestCodexWebsocketsExecutor_BootstrapBuffering_FlushesInOrderOnFirstOutput(t *testing.T) {
+	server := codexWebsocketServer(t,
+		codexCreatedEvent,
+		codexInProgressEvent,
+		codexOutputAddedEvent,
+		`{"type":"response.completed","response":{"id":"resp_1","output":[],"usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0}}}`,
+	)
+	defer server.Close()
+
+	req, opts := codexWebsocketRequest()
+	result, err := NewCodexWebsocketsExecutor(codexBufferingConfig(true)).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+	if err != nil {
+		t.Fatalf("unexpected ExecuteStream error: %v", err)
+	}
+
+	combined, streamErr := drainChunks(result)
+	if streamErr != nil {
+		t.Fatalf("unexpected chunk error: %v", streamErr)
+	}
+	createdAt := strings.Index(combined, "response.created")
+	addedAt := strings.Index(combined, "response.output_item.added")
+	if createdAt < 0 || addedAt < 0 {
+		t.Fatalf("missing handshake or first generated event: %s", combined)
+	}
+	if createdAt > addedAt {
+		t.Fatalf("buffered handshake must be replayed before the first generated event: %s", combined)
+	}
+}
+
+func TestCodexWebsocketsExecutor_BootstrapBuffering_DefaultDisabledPassthrough(t *testing.T) {
+	server := codexWebsocketServer(t, codexCreatedEvent, codexOverloadEvent)
+	defer server.Close()
+
+	req, opts := codexWebsocketRequest()
+	result, err := NewCodexWebsocketsExecutor(&config.Config{}).ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+	if err != nil {
+		t.Fatalf("default unbuffered ExecuteStream returned error at call time: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result in default unbuffered mode")
+	}
+	_, streamErr := drainChunks(result)
+	if streamErr == nil {
+		t.Fatal("expected stream error in chunks for default unbuffered mode")
+	}
+	if got := statusCodeFromTestError(t, streamErr); got != http.StatusBadGateway {
+		t.Fatalf("status code = %d, want %d while buffering is disabled", got, http.StatusBadGateway)
+	}
+}
+
+// The 503 restoration is scoped to the buffered failover path, so this only covers which
+// rejections are eligible to replace the whole attempt.
+func TestIsCodexOverloadBootstrapFailureRejectsRequestFaults(t *testing.T) {
+	notOverload := []string{
+		`{"error":{"type":"invalid_request_error","code":"invalid_value"}}`,
+		`{"error":{"type":"authentication_error","code":"invalid_api_key"}}`,
+		`{"error":{"type":"upstream_error","code":"unknown"}}`,
+	}
+	for _, body := range notOverload {
+		if isCodexOverloadBootstrapFailure([]byte(body)) {
+			t.Fatalf("request-level fault must not trigger bootstrap failover: %s", body)
+		}
+	}
+	if !isCodexOverloadBootstrapFailure([]byte(`{"error":{"type":"rate_limit_error","code":"rate_limit_exceeded"}}`)) {
+		t.Fatal("rate limit rejections should be eligible for bootstrap failover")
+	}
+}
+
+// codexWebsocketServerHoldingConnection behaves like codexWebsocketServer but keeps the upstream
+// connection open after writing the frames, so the executor's own teardown path is the only
+// source of session invalidation. With the plain helper the connection closes immediately, the
+// reader goroutine observes EOF first and reports upstream_disconnected, which both masks the
+// path under test and can make a disconnect assertion pass for the wrong reason.
+func codexWebsocketServerHoldingConnection(t *testing.T, frames ...string) *httptest.Server {
+	t.Helper()
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		if _, _, errRead := conn.ReadMessage(); errRead != nil {
+			t.Errorf("read websocket message: %v", errRead)
+			return
+		}
+		for _, frame := range frames {
+			_ = conn.WriteMessage(websocket.TextMessage, []byte(frame))
+		}
+		for {
+			if _, _, errRead := conn.ReadMessage(); errRead != nil {
+				return
+			}
+		}
+	}))
+}
+
+// executeWebsocketStreamInSession runs ExecuteStream bound to a named execution session and
+// reports whether the upstream teardown was signalled to the downstream handler.
+//
+// The downstream Responses WebSocket handler subscribes to UpstreamDisconnectChan and closes
+// the client connection as soon as a disconnect is published. A bootstrap overload is retried
+// on another credential, so publishing there would tear down the client connection before the
+// retry can deliver anything, and the client would observe an abnormal close with zero frames.
+func executeWebsocketStreamInSession(t *testing.T, frames ...string) (notified bool, err error) {
+	t.Helper()
+
+	server := codexWebsocketServerHoldingConnection(t, frames...)
+	defer server.Close()
+
+	exec := NewCodexWebsocketsExecutor(codexBufferingConfig(true))
+	exec.store = &codexWebsocketSessionStore{sessions: make(map[string]*codexWebsocketSession)}
+
+	const sessionID = "bootstrap-session"
+	disconnectCh := exec.UpstreamDisconnectChan(sessionID)
+	if disconnectCh == nil {
+		t.Fatal("expected a disconnect channel")
+	}
+
+	req, opts := codexWebsocketRequest()
+	opts.Metadata = map[string]any{cliproxyexecutor.ExecutionSessionMetadataKey: sessionID}
+	_, err = exec.ExecuteStream(context.Background(), codexTestAuth(server.URL), req, opts)
+
+	select {
+	case <-disconnectCh:
+		notified = true
+	default:
+	}
+	return notified, err
+}
+
+func TestCodexWebsocketsExecutor_BootstrapOverload_DoesNotNotifyDownstreamDisconnect(t *testing.T) {
+	notified, err := executeWebsocketStreamInSession(t, codexCreatedEvent, codexInProgressEvent, codexOverloadEvent)
+
+	if err == nil {
+		t.Fatal("expected the overload rejection to fail the attempt")
+	}
+	if got := statusCodeFromTestError(t, err); got != http.StatusServiceUnavailable {
+		t.Fatalf("status code = %d, want %d", got, http.StatusServiceUnavailable)
+	}
+	if notified {
+		t.Fatal("bootstrap overload must not signal a downstream disconnect: the conductor still has to retry on another credential, and signalling closes the client connection with zero frames delivered")
+	}
+}
+
+// A non-overload terminal failure is delivered in-stream and genuinely ends the session, so it
+// must keep signalling the disconnect exactly as it did before buffering existed.
+func TestCodexWebsocketsExecutor_BootstrapNonOverload_StillNotifiesDownstreamDisconnect(t *testing.T) {
+	notified, err := executeWebsocketStreamInSession(t, codexCreatedEvent, codexInProgressEvent, codexInvalidEvent)
+
+	if err != nil {
+		t.Fatalf("non-overload failures stay in-stream, got err = %v", err)
+	}
+	if !notified {
+		t.Fatal("a terminal failure that is delivered in-stream must still signal the downstream disconnect")
+	}
+}

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -1641,6 +1641,83 @@ func TestApplyCodexHeadersDefaultsToCodexCloaking(t *testing.T) {
 	}
 }
 
+func TestApplyCodexHeaders_EmptyAPIKey_OmitsAuthorizationAndOAuthHeaders(t *testing.T) {
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/responses", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Attributes: map[string]string{
+			"auth_kind": "apikey",
+			"base_url":  "https://custom-codex.example.com",
+		},
+		Metadata: map[string]any{
+			"account_id": "acc-12345",
+		},
+	}
+	cfg := &config.Config{
+		Codex: config.CodexConfig{
+			DisableCodexCloaking: true,
+		},
+		CodexHeaderDefaults: config.CodexHeaderDefaults{
+			UserAgent: "oauth-default-ua",
+		},
+	}
+	applyCodexHeaders(req, auth, "", false, cfg)
+
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization = %q, want empty for empty API key", got)
+	}
+	if got := req.Header.Get("Chatgpt-Account-Id"); got != "" {
+		t.Fatalf("Chatgpt-Account-Id = %q, want empty for API key auth_kind", got)
+	}
+	if got := req.Header.Get("Originator"); got != "" {
+		t.Fatalf("Originator = %q, want empty for API key auth_kind when client originator omitted", got)
+	}
+	if got := req.Header.Get("User-Agent"); got == "oauth-default-ua" {
+		t.Fatalf("User-Agent unexpectedly used OAuth default UA %q for API key auth_kind", got)
+	}
+}
+
+func TestApplyCodexWebsocketHeaders_EmptyAPIKey_OmitsAuthorizationAndOAuthHeaders(t *testing.T) {
+	auth := &cliproxyauth.Auth{
+		Provider: "codex",
+		Attributes: map[string]string{
+			"auth_kind": "apikey",
+			"base_url":  "https://custom-codex.example.com",
+		},
+		Metadata: map[string]any{
+			"account_id": "acc-ws-123",
+		},
+	}
+	cfg := &config.Config{
+		Codex: config.CodexConfig{
+			DisableCodexCloaking: true,
+		},
+		CodexHeaderDefaults: config.CodexHeaderDefaults{
+			UserAgent:    "oauth-default-ua",
+			BetaFeatures: "oauth-beta",
+		},
+	}
+	headers := applyCodexWebsocketHeaders(context.Background(), nil, auth, "", cfg)
+	if got := headers.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization = %q, want empty for empty API key", got)
+	}
+	if got := headers.Get("ChatGPT-Account-ID"); got != "" {
+		t.Fatalf("ChatGPT-Account-ID = %q, want empty for API key auth_kind", got)
+	}
+	if got := headers.Get("Originator"); got != "" {
+		t.Fatalf("Originator = %q, want empty for API key auth_kind", got)
+	}
+	if got := headers.Get("x-codex-beta-features"); got != "" {
+		t.Fatalf("x-codex-beta-features = %q, want empty for API key auth_kind", got)
+	}
+	if got := headers.Get("User-Agent"); got == "oauth-default-ua" {
+		t.Fatalf("User-Agent unexpectedly used OAuth default UA %q for API key auth_kind", got)
+	}
+}
+
 func TestApplyModelHeaderOverridesFromModelConfig(t *testing.T) {
 	const wantUA = "codex-tui/0.144.0 (Mac OS 26.5.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.144.0)"
 	req, err := http.NewRequest(http.MethodPost, "https://example.com/responses", nil)

--- a/internal/runtime/executor/codex_websockets_request.go
+++ b/internal/runtime/executor/codex_websockets_request.go
@@ -70,6 +70,8 @@ func applyCodexWebsocketHeaders(ctx context.Context, headers http.Header, auth *
 	}
 	if strings.TrimSpace(token) != "" {
 		headers.Set("Authorization", "Bearer "+token)
+	} else {
+		headers.Del("Authorization")
 	}
 
 	var ginHeaders http.Header
@@ -158,10 +160,16 @@ func codexSessionHeaderValue(headers http.Header) string {
 }
 
 func codexAuthUsesAPIKey(auth *cliproxyauth.Auth) bool {
-	if auth == nil || auth.Attributes == nil {
+	if auth == nil {
 		return false
 	}
-	return strings.TrimSpace(auth.Attributes["api_key"]) != ""
+	if auth.AuthKind() == cliproxyauth.AuthKindAPIKey {
+		return true
+	}
+	if auth.Attributes != nil {
+		return strings.TrimSpace(auth.Attributes["api_key"]) != ""
+	}
+	return false
 }
 
 func ensureHeaderCasePreserved(target http.Header, source http.Header, key, configValue, fallbackValue string) {
@@ -270,13 +278,8 @@ func deleteHeaderCaseInsensitive(headers http.Header, key string) {
 }
 
 func codexHeaderDefaults(cfg *config.Config, auth *cliproxyauth.Auth) (string, string) {
-	if cfg == nil || auth == nil {
+	if cfg == nil || auth == nil || codexAuthUsesAPIKey(auth) {
 		return "", ""
-	}
-	if auth.Attributes != nil {
-		if v := strings.TrimSpace(auth.Attributes["api_key"]); v != "" {
-			return "", ""
-		}
 	}
 	return strings.TrimSpace(cfg.CodexHeaderDefaults.UserAgent), strings.TrimSpace(cfg.CodexHeaderDefaults.BetaFeatures)
 }

--- a/internal/runtime/executor/codex_websockets_request.go
+++ b/internal/runtime/executor/codex_websockets_request.go
@@ -76,6 +76,8 @@ func applyCodexWebsocketHeaders(ctx context.Context, headers http.Header, auth *
 	}
 	if strings.TrimSpace(token) != "" {
 		headers.Set("Authorization", "Bearer "+token)
+	} else {
+		headers.Del("Authorization")
 	}
 
 	var ginHeaders http.Header
@@ -168,10 +170,16 @@ func codexSessionHeaderValue(headers http.Header) string {
 }
 
 func codexAuthUsesAPIKey(auth *cliproxyauth.Auth) bool {
-	if auth == nil || auth.Attributes == nil {
+	if auth == nil {
 		return false
 	}
-	return strings.TrimSpace(auth.Attributes["api_key"]) != ""
+	if auth.AuthKind() == cliproxyauth.AuthKindAPIKey {
+		return true
+	}
+	if auth.Attributes != nil {
+		return strings.TrimSpace(auth.Attributes["api_key"]) != ""
+	}
+	return false
 }
 
 func ensureHeaderCasePreserved(target http.Header, source http.Header, key, configValue, fallbackValue string) {
@@ -280,13 +288,8 @@ func deleteHeaderCaseInsensitive(headers http.Header, key string) {
 }
 
 func codexHeaderDefaults(cfg *config.Config, auth *cliproxyauth.Auth) (string, string) {
-	if cfg == nil || auth == nil {
+	if cfg == nil || auth == nil || codexAuthUsesAPIKey(auth) {
 		return "", ""
-	}
-	if auth.Attributes != nil {
-		if v := strings.TrimSpace(auth.Attributes["api_key"]); v != "" {
-			return "", ""
-		}
 	}
 	return strings.TrimSpace(cfg.CodexHeaderDefaults.UserAgent), strings.TrimSpace(cfg.CodexHeaderDefaults.BetaFeatures)
 }

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -262,7 +262,207 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		sess.setMultiAgentV2Optimized(conn, optimizeMultiAgentV2 && !multiAgentV2Conflict)
 	}
 
-	out := make(chan cliproxyexecutor.StreamChunk)
+	buffering := e.cfg != nil && e.cfg.Codex.StreamBootstrapBuffering
+
+	claudeInputTokens := helps.NewClaudeInputTokenState(from, to, responseFormat, originalPayload)
+	var param any
+	outputItemsByIndex := make(map[int64][]byte)
+	var outputItemsFallback [][]byte
+
+	var bufferedChunks [][]byte
+	var initialChunks [][]byte
+	immediateTerminal := false
+	// bootstrapTerminalErr holds a non-overload terminal failure seen while buffering. It is
+	// delivered as an in-stream chunk after the buffered handshake so downstream behaviour stays
+	// identical to the unbuffered path instead of silently turning into a credential failover.
+	var bootstrapTerminalErr error
+
+	if buffering {
+		for {
+			if ctx != nil && ctx.Err() != nil {
+				if sess != nil {
+					sess.clearActive(conn, readCh)
+					unlockStreamSession()
+				} else {
+					_ = closer.Close()
+				}
+				return nil, ctx.Err()
+			}
+			msgType, payload, errRead := readCodexWebsocketMessage(ctx, sess, conn, readCh)
+			if errRead != nil {
+				mappedErr := mapCodexWebsocketReadError(errRead)
+				if sess != nil {
+					e.invalidateUpstreamConn(sess, conn, "read_error", mappedErr)
+					sess.clearActive(conn, readCh)
+					unlockStreamSession()
+				} else {
+					logCodexWebsocketDisconnected(executionSessionID, authID, wsURL, "read_error", mappedErr)
+					_ = closer.Close()
+				}
+				helps.RecordAPIWebsocketError(ctx, e.cfg, "read", mappedErr)
+				reporter.PublishFailure(ctx, mappedErr)
+				return nil, mappedErr
+			}
+			if msgType != websocket.TextMessage {
+				if msgType == websocket.BinaryMessage {
+					errBinary := fmt.Errorf("codex websockets executor: unexpected binary message")
+					if sess != nil {
+						e.invalidateUpstreamConn(sess, conn, "unexpected_binary", errBinary)
+						sess.clearActive(conn, readCh)
+						unlockStreamSession()
+					} else {
+						logCodexWebsocketDisconnected(executionSessionID, authID, wsURL, "unexpected_binary", errBinary)
+						_ = closer.Close()
+					}
+					helps.RecordAPIWebsocketError(ctx, e.cfg, "unexpected_binary", errBinary)
+					reporter.PublishFailure(ctx, errBinary)
+					return nil, errBinary
+				}
+				continue
+			}
+
+			payload = bytes.TrimSpace(payload)
+			if len(payload) == 0 {
+				continue
+			}
+			reporter.MarkFirstResponseByte()
+			payload = applyCodexIdentityConfuseResponsePayload(payload, identityState)
+			helps.AppendAPIWebsocketResponse(ctx, e.cfg, payload)
+			payload = helps.RestoreCodexMultiAgentV2Response(payload, restoreMultiAgentV2)
+
+			if wsErr, ok := parseCodexWebsocketError(payload); ok {
+				if sess != nil {
+					e.invalidateUpstreamConn(sess, conn, "upstream_error", wsErr)
+					sess.clearActive(conn, readCh)
+					unlockStreamSession()
+				} else {
+					logCodexWebsocketDisconnected(executionSessionID, authID, wsURL, "upstream_error", wsErr)
+					_ = closer.Close()
+				}
+				if errClearReplay := clearCodexReasoningReplayOnWebsocketError(ctx, replayScope, payload); errClearReplay != nil {
+					helps.RecordAPIWebsocketError(ctx, e.cfg, "replay_clear_error", errClearReplay)
+					reporter.PublishFailure(ctx, errClearReplay)
+					return nil, errClearReplay
+				}
+				helps.RecordAPIWebsocketError(ctx, e.cfg, "upstream_error", wsErr)
+				reporter.PublishFailure(ctx, wsErr)
+				return nil, wsErr
+			}
+			if streamErr, terminalBody, ok := codexTerminalFailureErr(payload); ok {
+				// A transient capacity rejection is retried on another credential, so the
+				// downstream websocket session must survive this upstream teardown. Notifying
+				// the disconnect here would close the client connection before the retry can
+				// deliver anything. Every other terminal failure is forwarded in-stream and
+				// legitimately terminates the session, so it keeps the notifying variant.
+				failoverPending := isCodexOverloadBootstrapFailure(terminalBody)
+				if sess != nil {
+					unlockStreamSession()
+					if failoverPending {
+						e.invalidateUpstreamConnWithoutDisconnectNotify(sess, conn, "terminal_failure", streamErr)
+					} else {
+						e.invalidateUpstreamConn(sess, conn, "terminal_failure", streamErr)
+					}
+					sess.clearActive(conn, readCh)
+				} else {
+					logCodexWebsocketDisconnected(executionSessionID, authID, wsURL, "terminal_failure", streamErr)
+					_ = closer.Close()
+				}
+				if errClearReplay := clearCodexReasoningReplayOnInvalidSignature(ctx, replayScope, streamErr.StatusCode(), terminalBody); errClearReplay != nil {
+					helps.RecordAPIWebsocketError(ctx, e.cfg, "replay_clear_error", errClearReplay)
+					reporter.PublishFailure(ctx, errClearReplay)
+					return nil, errClearReplay
+				}
+				helps.RecordAPIWebsocketError(ctx, e.cfg, "upstream_error", streamErr)
+				reporter.PublishFailure(ctx, streamErr)
+				if failoverPending {
+					// Fail the attempt before the downstream headers are committed so the
+					// conductor can transparently retry on another credential, and report the
+					// status the upstream refused to put on the wire.
+					helps.LogWithRequestID(ctx).Debugf("codex websockets executor: bootstrap overload rejection after %d buffered handshake events, failing over", len(bufferedChunks))
+					return nil, newCodexBootstrapOverloadErr(terminalBody)
+				}
+				bootstrapTerminalErr = streamErr
+				break
+			}
+
+			eventType := gjson.GetBytes(payload, "type").String()
+			isTerminalEvent := eventType == "response.completed" || eventType == "response.done" || eventType == "error"
+			if eventType == "response.output_item.done" {
+				collectCodexOutputItemDone(payload, outputItemsByIndex, &outputItemsFallback)
+			}
+			completedPayload := payload
+			if eventType == "response.completed" || eventType == "response.done" {
+				completedPayload = normalizeCodexWebsocketCompletion(completedPayload)
+				completedPayload = patchCodexCompletedOutput(completedPayload, outputItemsByIndex, outputItemsFallback)
+				cacheCodexReasoningReplayFromCompleted(replayScope, completedPayload)
+				if detail, ok := helps.ParseCodexUsage(completedPayload); ok {
+					reporter.Publish(ctx, detail)
+				}
+			}
+
+			var currentChunks [][]byte
+			if cliproxyexecutor.DownstreamWebsocket(ctx) {
+				clientPayload := applyCodexIdentityExposeResponsePayload(payload, identityState)
+				downstreamPayload := helps.EnsureResponsesUsageDetails(clientPayload)
+				currentChunks = [][]byte{downstreamPayload}
+			} else {
+				payload = normalizeCodexWebsocketCompletion(payload)
+				if eventType == "response.completed" || eventType == "response.done" {
+					payload = completedPayload
+				}
+				clientPayload := applyCodexIdentityExposeResponsePayload(payload, identityState)
+				line := encodeCodexWebsocketAsSSE(clientPayload)
+				currentChunks = helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, originalPayload, clientBody, line, &param, claudeInputTokens)
+			}
+
+			if isCodexHandshakeMetadataEvent(eventType) && !isTerminalEvent {
+				if len(bufferedChunks) < codexBootstrapMaxBufferedEvents {
+					bufferedChunks = append(bufferedChunks, currentChunks...)
+					continue
+				}
+				helps.LogWithRequestID(ctx).Debugf("codex websockets executor: bootstrap buffer limit %d reached, releasing stream without overload probing", codexBootstrapMaxBufferedEvents)
+			}
+
+			initialChunks = currentChunks
+			if isTerminalEvent {
+				immediateTerminal = true
+			}
+			break
+		}
+	}
+
+	chanCapacity := len(bufferedChunks) + len(initialChunks)
+	if bootstrapTerminalErr != nil {
+		chanCapacity++
+	}
+	out := make(chan cliproxyexecutor.StreamChunk, chanCapacity)
+	for _, chunk := range bufferedChunks {
+		out <- cliproxyexecutor.StreamChunk{Payload: chunk}
+	}
+	for _, chunk := range initialChunks {
+		out <- cliproxyexecutor.StreamChunk{Payload: chunk}
+	}
+	if bootstrapTerminalErr != nil {
+		// The upstream connection was already invalidated and released in the terminal-failure
+		// branch above, so only the buffered payloads plus the in-stream error remain to emit.
+		out <- cliproxyexecutor.StreamChunk{Err: bootstrapTerminalErr}
+		close(out)
+		return &cliproxyexecutor.StreamResult{Headers: upstreamHeaders, Chunks: out}, nil
+	}
+	if immediateTerminal {
+		if sess != nil {
+			sess.clearActive(conn, readCh)
+			unlockStreamSession()
+		} else {
+			logCodexWebsocketDisconnected(executionSessionID, authID, wsURL, "completed", nil)
+			if errClose := closer.Close(); errClose != nil {
+				log.Errorf("codex websockets executor: close websocket error: %v", errClose)
+			}
+		}
+		close(out)
+		return &cliproxyexecutor.StreamResult{Headers: upstreamHeaders, Chunks: out}, nil
+	}
+
 	go func() {
 		terminateReason := "completed"
 		var terminateErr error
@@ -293,10 +493,6 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			}
 		}
 
-		claudeInputTokens := helps.NewClaudeInputTokenState(from, to, responseFormat, originalPayload)
-		var param any
-		outputItemsByIndex := make(map[int64][]byte)
-		var outputItemsFallback [][]byte
 		for {
 			if ctx != nil && ctx.Err() != nil {
 				terminateReason = "context_done"

--- a/internal/runtime/executor/codex_websockets_stream.go
+++ b/internal/runtime/executor/codex_websockets_stream.go
@@ -283,7 +283,207 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 		sess.setMultiAgentV2Optimized(connection, optimizeMultiAgentV2 && !multiAgentV2Conflict)
 	}
 
-	out := make(chan cliproxyexecutor.StreamChunk)
+	buffering := e.cfg != nil && e.cfg.Codex.StreamBootstrapBuffering
+
+	claudeInputTokens := helps.NewClaudeInputTokenState(from, to, responseFormat, originalPayload)
+	var param any
+	outputItemsByIndex := make(map[int64][]byte)
+	var outputItemsFallback [][]byte
+
+	var bufferedChunks [][]byte
+	var initialChunks [][]byte
+	immediateTerminal := false
+	// bootstrapTerminalErr holds a non-overload terminal failure seen while buffering. It is
+	// delivered as an in-stream chunk after the buffered handshake so downstream behaviour stays
+	// identical to the unbuffered path instead of silently turning into a credential failover.
+	var bootstrapTerminalErr error
+
+	if buffering {
+		for {
+			if ctx != nil && ctx.Err() != nil {
+				if sess != nil {
+					sess.clearActiveConnection(connection, readCh)
+					unlockStreamSession()
+				} else {
+					_ = closer.Close()
+				}
+				return nil, ctx.Err()
+			}
+			msgType, payload, errRead := readCodexWebsocketMessage(ctx, sess, connection, readCh, requestSignal)
+			if errRead != nil {
+				mappedErr := mapCodexWebsocketReadError(errRead)
+				if sess != nil {
+					e.invalidateUpstreamConn(sess, connection, "read_error", mappedErr)
+					sess.clearActiveConnection(connection, readCh)
+					unlockStreamSession()
+				} else {
+					logCodexWebsocketDisconnected(executionSessionID, authID, wsURL, "read_error", mappedErr)
+					_ = closer.Close()
+				}
+				helps.RecordAPIWebsocketError(ctx, e.cfg, "read", mappedErr)
+				reporter.PublishFailure(ctx, mappedErr)
+				return nil, mappedErr
+			}
+			if msgType != websocket.TextMessage {
+				if msgType == websocket.BinaryMessage {
+					errBinary := fmt.Errorf("codex websockets executor: unexpected binary message")
+					if sess != nil {
+						e.invalidateUpstreamConn(sess, connection, "unexpected_binary", errBinary)
+						sess.clearActiveConnection(connection, readCh)
+						unlockStreamSession()
+					} else {
+						logCodexWebsocketDisconnected(executionSessionID, authID, wsURL, "unexpected_binary", errBinary)
+						_ = closer.Close()
+					}
+					helps.RecordAPIWebsocketError(ctx, e.cfg, "unexpected_binary", errBinary)
+					reporter.PublishFailure(ctx, errBinary)
+					return nil, errBinary
+				}
+				continue
+			}
+
+			payload = bytes.TrimSpace(payload)
+			if len(payload) == 0 {
+				continue
+			}
+			reporter.MarkFirstResponseByte()
+			payload = applyCodexIdentityConfuseResponsePayload(payload, identityState)
+			helps.AppendAPIWebsocketResponse(ctx, e.cfg, payload)
+			payload = helps.RestoreCodexMultiAgentV2Response(payload, restoreMultiAgentV2)
+
+			if wsErr, ok := parseCodexWebsocketError(payload); ok {
+				if sess != nil {
+					e.invalidateUpstreamConn(sess, connection, "upstream_error", wsErr)
+					sess.clearActiveConnection(connection, readCh)
+					unlockStreamSession()
+				} else {
+					logCodexWebsocketDisconnected(executionSessionID, authID, wsURL, "upstream_error", wsErr)
+					_ = closer.Close()
+				}
+				if errClearReplay := clearCodexReasoningReplayOnWebsocketError(ctx, replayScope, payload); errClearReplay != nil {
+					helps.RecordAPIWebsocketError(ctx, e.cfg, "replay_clear_error", errClearReplay)
+					reporter.PublishFailure(ctx, errClearReplay)
+					return nil, errClearReplay
+				}
+				helps.RecordAPIWebsocketError(ctx, e.cfg, "upstream_error", wsErr)
+				reporter.PublishFailure(ctx, wsErr)
+				return nil, wsErr
+			}
+			if streamErr, terminalBody, ok := codexTerminalFailureErr(payload); ok {
+				// A transient capacity rejection is retried on another credential, so the
+				// downstream websocket session must survive this upstream teardown. Notifying
+				// the disconnect here would close the client connection before the retry can
+				// deliver anything. Every other terminal failure is forwarded in-stream and
+				// legitimately terminates the session, so it keeps the notifying variant.
+				failoverPending := isCodexOverloadBootstrapFailure(terminalBody)
+				if sess != nil {
+					unlockStreamSession()
+					if failoverPending {
+						e.invalidateUpstreamConnWithoutDisconnectNotify(sess, connection, "terminal_failure", streamErr)
+					} else {
+						e.invalidateUpstreamConn(sess, connection, "terminal_failure", streamErr)
+					}
+					sess.clearActiveConnection(connection, readCh)
+				} else {
+					logCodexWebsocketDisconnected(executionSessionID, authID, wsURL, "terminal_failure", streamErr)
+					_ = closer.Close()
+				}
+				if errClearReplay := clearCodexReasoningReplayOnInvalidSignature(ctx, replayScope, streamErr.StatusCode(), terminalBody); errClearReplay != nil {
+					helps.RecordAPIWebsocketError(ctx, e.cfg, "replay_clear_error", errClearReplay)
+					reporter.PublishFailure(ctx, errClearReplay)
+					return nil, errClearReplay
+				}
+				helps.RecordAPIWebsocketError(ctx, e.cfg, "upstream_error", streamErr)
+				reporter.PublishFailure(ctx, streamErr)
+				if failoverPending {
+					// Fail the attempt before the downstream headers are committed so the
+					// conductor can transparently retry on another credential, and report the
+					// status the upstream refused to put on the wire.
+					helps.LogWithRequestID(ctx).Debugf("codex websockets executor: bootstrap overload rejection after %d buffered handshake events, failing over", len(bufferedChunks))
+					return nil, newCodexBootstrapOverloadErr(terminalBody)
+				}
+				bootstrapTerminalErr = streamErr
+				break
+			}
+
+			eventType := gjson.GetBytes(payload, "type").String()
+			isTerminalEvent := eventType == "response.completed" || eventType == "response.done" || eventType == "error"
+			if eventType == "response.output_item.done" {
+				collectCodexOutputItemDone(payload, outputItemsByIndex, &outputItemsFallback)
+			}
+			completedPayload := payload
+			if eventType == "response.completed" || eventType == "response.done" {
+				completedPayload = normalizeCodexWebsocketCompletion(completedPayload)
+				completedPayload = patchCodexCompletedOutput(completedPayload, outputItemsByIndex, outputItemsFallback)
+				cacheCodexReasoningReplayFromCompleted(replayScope, completedPayload)
+				if detail, ok := helps.ParseCodexUsage(completedPayload); ok {
+					reporter.Publish(ctx, detail)
+				}
+			}
+
+			var currentChunks [][]byte
+			if cliproxyexecutor.DownstreamWebsocket(ctx) {
+				clientPayload := applyCodexIdentityExposeResponsePayload(payload, identityState)
+				downstreamPayload := helps.EnsureResponsesUsageDetails(clientPayload)
+				currentChunks = [][]byte{downstreamPayload}
+			} else {
+				payload = normalizeCodexWebsocketCompletion(payload)
+				if eventType == "response.completed" || eventType == "response.done" {
+					payload = completedPayload
+				}
+				clientPayload := applyCodexIdentityExposeResponsePayload(payload, identityState)
+				line := encodeCodexWebsocketAsSSE(clientPayload)
+				currentChunks = helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, originalPayload, clientBody, line, &param, claudeInputTokens)
+			}
+
+			if isCodexHandshakeMetadataEvent(eventType) && !isTerminalEvent {
+				if len(bufferedChunks) < codexBootstrapMaxBufferedEvents {
+					bufferedChunks = append(bufferedChunks, currentChunks...)
+					continue
+				}
+				helps.LogWithRequestID(ctx).Debugf("codex websockets executor: bootstrap buffer limit %d reached, releasing stream without overload probing", codexBootstrapMaxBufferedEvents)
+			}
+
+			initialChunks = currentChunks
+			if isTerminalEvent {
+				immediateTerminal = true
+			}
+			break
+		}
+	}
+
+	chanCapacity := len(bufferedChunks) + len(initialChunks)
+	if bootstrapTerminalErr != nil {
+		chanCapacity++
+	}
+	out := make(chan cliproxyexecutor.StreamChunk, chanCapacity)
+	for _, chunk := range bufferedChunks {
+		out <- cliproxyexecutor.StreamChunk{Payload: chunk}
+	}
+	for _, chunk := range initialChunks {
+		out <- cliproxyexecutor.StreamChunk{Payload: chunk}
+	}
+	if bootstrapTerminalErr != nil {
+		// The upstream connection was already invalidated and released in the terminal-failure
+		// branch above, so only the buffered payloads plus the in-stream error remain to emit.
+		out <- cliproxyexecutor.StreamChunk{Err: bootstrapTerminalErr}
+		close(out)
+		return &cliproxyexecutor.StreamResult{Headers: upstreamHeaders, Chunks: out}, nil
+	}
+	if immediateTerminal {
+		if sess != nil {
+			sess.clearActiveConnection(connection, readCh)
+			unlockStreamSession()
+		} else {
+			logCodexWebsocketDisconnected(executionSessionID, authID, wsURL, "completed", nil)
+			if errClose := closer.Close(); errClose != nil {
+				log.Errorf("codex websockets executor: close websocket error: %v", errClose)
+			}
+		}
+		close(out)
+		return &cliproxyexecutor.StreamResult{Headers: upstreamHeaders, Chunks: out}, nil
+	}
+
 	go func() {
 		terminateReason := "completed"
 		var terminateErr error
@@ -317,10 +517,6 @@ func (e *CodexWebsocketsExecutor) ExecuteStream(ctx context.Context, auth *clipr
 			}
 		}
 
-		claudeInputTokens := helps.NewClaudeInputTokenState(from, to, responseFormat, originalPayload)
-		var param any
-		outputItemsByIndex := make(map[int64][]byte)
-		var outputItemsFallback [][]byte
 		for {
 			if ctx != nil && ctx.Err() != nil {
 				terminateReason = "context_done"

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -166,6 +166,7 @@ func (e *GeminiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 			action = "countTokens"
 		}
 	}
+	body = helps.EnsureGeminiLeadingUserContent(body, "contents")
 	baseURL := resolveGeminiBaseURL(auth)
 	url := fmt.Sprintf("%s/%s/models/%s:%s", baseURL, glAPIVersion, baseModel, action)
 	if opts.Alt != "" && action != "countTokens" {
@@ -275,6 +276,7 @@ func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body = helps.SetStringIfDifferent(body, "model", baseModel)
 	body = capGeminiMaxOutputTokens(body, baseModel)
+	body = helps.EnsureGeminiLeadingUserContent(body, "contents")
 
 	baseURL := resolveGeminiBaseURL(auth)
 	url := fmt.Sprintf("%s/%s/models/%s:%s", baseURL, glAPIVersion, baseModel, "streamGenerateContent")
@@ -640,6 +642,7 @@ func (e *GeminiExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "generationConfig")
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "safetySettings")
 	translatedReq = helps.SetStringIfDifferent(translatedReq, "model", baseModel)
+	translatedReq = helps.EnsureGeminiLeadingUserContent(translatedReq, "contents")
 
 	baseURL := resolveGeminiBaseURL(auth)
 	url := fmt.Sprintf("%s/%s/models/%s:%s", baseURL, glAPIVersion, baseModel, "countTokens")

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	internalsignature "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -88,6 +89,9 @@ func (e *GeminiExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Au
 	if apiKey != "" {
 		req.Header.Set("x-goog-api-key", apiKey)
 		req.Header.Del("Authorization")
+	} else {
+		req.Header.Del("x-goog-api-key")
+		req.Header.Del("Authorization")
 	}
 	applyGeminiHeaders(req, auth)
 	return nil
@@ -159,6 +163,7 @@ func (e *GeminiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body = helps.SetStringIfDifferent(body, "model", baseModel)
 	body = capGeminiMaxOutputTokens(body, baseModel)
+	body = internalsignature.SanitizeGeminiRequestThoughtSignatures(body, "contents")
 
 	action := "generateContent"
 	if req.Metadata != nil {
@@ -166,6 +171,7 @@ func (e *GeminiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 			action = "countTokens"
 		}
 	}
+	body = helps.EnsureGeminiLeadingUserContent(body, "contents")
 	baseURL := resolveGeminiBaseURL(auth)
 	url := fmt.Sprintf("%s/%s/models/%s:%s", baseURL, glAPIVersion, baseModel, action)
 	if opts.Alt != "" && action != "countTokens" {
@@ -275,6 +281,8 @@ func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body = helps.SetStringIfDifferent(body, "model", baseModel)
 	body = capGeminiMaxOutputTokens(body, baseModel)
+	body = internalsignature.SanitizeGeminiRequestThoughtSignatures(body, "contents")
+	body = helps.EnsureGeminiLeadingUserContent(body, "contents")
 
 	baseURL := resolveGeminiBaseURL(auth)
 	url := fmt.Sprintf("%s/%s/models/%s:%s", baseURL, glAPIVersion, baseModel, "streamGenerateContent")
@@ -640,6 +648,8 @@ func (e *GeminiExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "generationConfig")
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "safetySettings")
 	translatedReq = helps.SetStringIfDifferent(translatedReq, "model", baseModel)
+	translatedReq = internalsignature.SanitizeGeminiRequestThoughtSignatures(translatedReq, "contents")
+	translatedReq = helps.EnsureGeminiLeadingUserContent(translatedReq, "contents")
 
 	baseURL := resolveGeminiBaseURL(auth)
 	url := fmt.Sprintf("%s/%s/models/%s:%s", baseURL, glAPIVersion, baseModel, "countTokens")

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -88,6 +88,9 @@ func (e *GeminiExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Au
 	if apiKey != "" {
 		req.Header.Set("x-goog-api-key", apiKey)
 		req.Header.Del("Authorization")
+	} else {
+		req.Header.Del("x-goog-api-key")
+		req.Header.Del("Authorization")
 	}
 	applyGeminiHeaders(req, auth)
 	return nil

--- a/internal/runtime/executor/gemini_executor.go
+++ b/internal/runtime/executor/gemini_executor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	internalsignature "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -162,6 +163,7 @@ func (e *GeminiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body = helps.SetStringIfDifferent(body, "model", baseModel)
 	body = capGeminiMaxOutputTokens(body, baseModel)
+	body = internalsignature.SanitizeGeminiRequestThoughtSignatures(body, "contents")
 
 	action := "generateContent"
 	if req.Metadata != nil {
@@ -279,6 +281,7 @@ func (e *GeminiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body = helps.SetStringIfDifferent(body, "model", baseModel)
 	body = capGeminiMaxOutputTokens(body, baseModel)
+	body = internalsignature.SanitizeGeminiRequestThoughtSignatures(body, "contents")
 	body = helps.EnsureGeminiLeadingUserContent(body, "contents")
 
 	baseURL := resolveGeminiBaseURL(auth)
@@ -645,6 +648,7 @@ func (e *GeminiExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Aut
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "generationConfig")
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "safetySettings")
 	translatedReq = helps.SetStringIfDifferent(translatedReq, "model", baseModel)
+	translatedReq = internalsignature.SanitizeGeminiRequestThoughtSignatures(translatedReq, "contents")
 	translatedReq = helps.EnsureGeminiLeadingUserContent(translatedReq, "contents")
 
 	baseURL := resolveGeminiBaseURL(auth)

--- a/internal/runtime/executor/gemini_executor_signature_test.go
+++ b/internal/runtime/executor/gemini_executor_signature_test.go
@@ -1,0 +1,601 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	internalsignature "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+	"github.com/tidwall/gjson"
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+const testClaudeCAISSample = "CAISqwIKiAEIEBgCKkBHRlRBsNiptQUWfPoOhuQKwi5LnncZVO9bB5jqOs76D7uBtgktML0zqJtNmLHXHHcgD6lk4MQu4QBXzFd1lbC3Mg5jbGF1ZGUtZmFibGUtNTgBQgh0aGlua2luZ1okZDk3NDM5NzUtNGJiMC00OTM2LTllMjgtZDViMGQyMWJkYzQ4EgxCGh+XVFFFeySAjtAaDL/A1LltGu6MMJ+eXSIwsN0oBpDrqLv22UBfkMnTotnIbkvkOyb9xZHgigG6OZVHaI3gThm+maLKmgO5PrFLKlDFYp+YZksy/wKwszJlnLTPzAK+NUlfzagOE1ymtZTXhAYK260XyFYmg/te/C231+Fr/hoX+EJoUBnrn0gD7hqMISOT+TaFEuOXYsN517GfaxgB"
+
+func testNativeGemini3ThoughtSignature() string {
+	inner := protowire.AppendTag(nil, 1, protowire.BytesType)
+	inner = protowire.AppendBytes(inner, []byte{0x01, 0x0c, 0x39, 0xd6, 0xc7, 0x34})
+	encoded := protowire.AppendTag(nil, 2, protowire.BytesType)
+	encoded = protowire.AppendBytes(encoded, inner)
+	return base64.StdEncoding.EncodeToString(encoded)
+}
+
+func claudeRequestWithThinkingSignature(sig string) (cliproxyexecutor.Request, cliproxyexecutor.Options) {
+	req := cliproxyexecutor.Request{
+		Model: "gemini-2.5-flash",
+		Payload: []byte(`{
+		"model": "claude-3-7-sonnet-20250219",
+		"messages": [
+			{
+				"role": "assistant",
+				"content": [
+					{"type": "thinking", "thinking": "Let me think...", "signature": "` + sig + `"},
+					{"type": "text", "text": "Here is the response."}
+				]
+			},
+			{
+				"role": "user",
+				"content": [
+					{"type": "text", "text": "Follow up question."}
+				]
+			}
+		]
+	}`),
+		Metadata: map[string]any{
+			"cliproxy.resolved_api_key_model_info": &registry.ModelInfo{IsCompat: true},
+		},
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatClaude,
+	}
+	return req, opts
+}
+
+func TestGeminiExecutorExecute_SanitizesClaudeCAISSignature(t *testing.T) {
+	var upstreamBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read request body: %v", errRead)
+		}
+		upstreamBody = append([]byte(nil), body...)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}`))
+	}))
+	defer server.Close()
+
+	executor := NewGeminiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"api_key":  "test-api-key",
+			"base_url": server.URL,
+		},
+	}
+
+	req, opts := claudeRequestWithThinkingSignature(testClaudeCAISSample)
+
+	_, err := executor.Execute(context.Background(), auth, req, opts)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if bytes.Contains(upstreamBody, []byte(testClaudeCAISSample)) {
+		t.Fatalf("upstream request leaked raw Claude CAIS signature: %s", upstreamBody)
+	}
+
+	contents := gjson.GetBytes(upstreamBody, "contents").Array()
+	for _, content := range contents {
+		if content.Get("role").String() == "model" {
+			for _, part := range content.Get("parts").Array() {
+				if sig := part.Get("thoughtSignature").String(); sig == testClaudeCAISSample {
+					t.Fatalf("model part thoughtSignature contains raw Claude CAIS signature: %s", upstreamBody)
+				}
+			}
+		}
+	}
+}
+
+func TestGeminiExecutorExecuteStream_SanitizesClaudeCAISSignature(t *testing.T) {
+	var upstreamBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read request body: %v", errRead)
+		}
+		upstreamBody = append([]byte(nil), body...)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"chunk\"}]}}]}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewGeminiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"api_key":  "test-api-key",
+			"base_url": server.URL,
+		},
+	}
+
+	req, opts := claudeRequestWithThinkingSignature(testClaudeCAISSample)
+
+	res, err := executor.ExecuteStream(context.Background(), auth, req, opts)
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	for range res.Chunks {
+	}
+
+	if bytes.Contains(upstreamBody, []byte(testClaudeCAISSample)) {
+		t.Fatalf("upstream stream request leaked raw Claude CAIS signature: %s", upstreamBody)
+	}
+}
+
+func TestGeminiExecutorCountTokens_SanitizesClaudeCAISSignature(t *testing.T) {
+	var upstreamBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read request body: %v", errRead)
+		}
+		upstreamBody = append([]byte(nil), body...)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"totalTokens": 42}`))
+	}))
+	defer server.Close()
+
+	executor := NewGeminiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"api_key":  "test-api-key",
+			"base_url": server.URL,
+		},
+	}
+
+	req, opts := claudeRequestWithThinkingSignature(testClaudeCAISSample)
+
+	_, err := executor.CountTokens(context.Background(), auth, req, opts)
+	if err != nil {
+		t.Fatalf("CountTokens() error = %v", err)
+	}
+
+	if bytes.Contains(upstreamBody, []byte(testClaudeCAISSample)) {
+		t.Fatalf("upstream countTokens request leaked raw Claude CAIS signature: %s", upstreamBody)
+	}
+}
+
+func TestGeminiExecutorExecute_FunctionCall_ReplacesClaudeSignatureWithBypass(t *testing.T) {
+	var upstreamBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read request body: %v", errRead)
+		}
+		upstreamBody = append([]byte(nil), body...)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`))
+	}))
+	defer server.Close()
+
+	executor := NewGeminiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"api_key":  "test-api-key",
+			"base_url": server.URL,
+		},
+	}
+
+	reqPayload := []byte(`{
+		"contents": [
+			{
+				"role": "model",
+				"parts": [
+					{
+						"functionCall": {"name": "search", "args": {"q": "go"}},
+						"thoughtSignature": "` + testClaudeCAISSample + `"
+					}
+				]
+			},
+			{
+				"role": "user",
+				"parts": [
+					{
+						"functionResponse": {"name": "search", "response": {"result": "found"}}
+					}
+				]
+			}
+		]
+	}`)
+
+	req := cliproxyexecutor.Request{
+		Model:   "gemini-2.5-flash",
+		Payload: reqPayload,
+	}
+
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatGemini,
+	}
+
+	_, err := executor.Execute(context.Background(), auth, req, opts)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	gotSig := gjson.GetBytes(upstreamBody, "contents.1.parts.0.thoughtSignature").String()
+	if gotSig != internalsignature.GeminiSkipThoughtSignatureValidator {
+		t.Fatalf("first functionCall thoughtSignature = %q, want bypass sentinel %q; upstreamBody=%s",
+			gotSig, internalsignature.GeminiSkipThoughtSignatureValidator, upstreamBody)
+	}
+}
+
+func TestGeminiExecutorExecute_PreservesNativeGeminiSignature(t *testing.T) {
+	var upstreamBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read request body: %v", errRead)
+		}
+		upstreamBody = append([]byte(nil), body...)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`))
+	}))
+	defer server.Close()
+
+	nativeSig := testNativeGemini3ThoughtSignature()
+	executor := NewGeminiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"api_key":  "test-api-key",
+			"base_url": server.URL,
+		},
+	}
+
+	reqPayload := []byte(`{
+		"contents": [
+			{
+				"role": "model",
+				"parts": [
+					{
+						"functionCall": {"name": "search", "args": {"q": "go"}},
+						"thoughtSignature": "` + nativeSig + `"
+					}
+				]
+			},
+			{
+				"role": "user",
+				"parts": [
+					{
+						"functionResponse": {"name": "search", "response": {"result": "found"}}
+					}
+				]
+			}
+		]
+	}`)
+
+	req := cliproxyexecutor.Request{
+		Model:   "gemini-2.5-flash",
+		Payload: reqPayload,
+	}
+
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatGemini,
+	}
+
+	_, err := executor.Execute(context.Background(), auth, req, opts)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	gotSig := gjson.GetBytes(upstreamBody, "contents.1.parts.0.thoughtSignature").String()
+	if gotSig != nativeSig {
+		t.Fatalf("thoughtSignature = %q, want preserved native signature %q; upstreamBody=%s",
+			gotSig, nativeSig, upstreamBody)
+	}
+}
+
+func TestGeminiExecutorExecute_UnsignedRequestNotCorrupted(t *testing.T) {
+	var upstreamBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read request body: %v", errRead)
+		}
+		upstreamBody = append([]byte(nil), body...)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`))
+	}))
+	defer server.Close()
+
+	executor := NewGeminiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{
+			"api_key":  "test-api-key",
+			"base_url": server.URL,
+		},
+	}
+
+	reqPayload := []byte(`{
+		"contents": [
+			{
+				"role": "user",
+				"parts": [{"text": "Hello world"}]
+			}
+		]
+	}`)
+
+	req := cliproxyexecutor.Request{
+		Model:   "gemini-2.5-flash",
+		Payload: reqPayload,
+	}
+
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatGemini,
+	}
+
+	_, err := executor.Execute(context.Background(), auth, req, opts)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	text := gjson.GetBytes(upstreamBody, "contents.0.parts.0.text").String()
+	if text != "Hello world" {
+		t.Fatalf("text = %q, want 'Hello world'; upstreamBody=%s", text, upstreamBody)
+	}
+}
+
+func geminiRequestWithThinkingSignature(sig string) (cliproxyexecutor.Request, cliproxyexecutor.Options) {
+	req := cliproxyexecutor.Request{
+		Model: "gemini-2.5-flash",
+		Payload: []byte(`{
+		"contents": [
+			{
+				"role": "model",
+				"parts": [
+					{"text": "Let me think...", "thought": true, "thoughtSignature": "` + sig + `"},
+					{"text": "Here is the response."}
+				]
+			},
+			{
+				"role": "user",
+				"parts": [
+					{"text": "Follow up question."}
+				]
+			}
+		]
+	}`),
+	}
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatGemini,
+	}
+	return req, opts
+}
+
+func TestGeminiVertexExecutorExecute_GeminiPayload_SanitizesClaudeCAISSignature(t *testing.T) {
+	var upstreamBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read request body: %v", errRead)
+		}
+		upstreamBody = append([]byte(nil), body...)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`))
+	}))
+	defer server.Close()
+
+	executor := NewGeminiVertexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider: "vertex",
+		Attributes: map[string]string{
+			"api_key":  "test-vertex-key",
+			"base_url": server.URL,
+		},
+	}
+
+	req, opts := geminiRequestWithThinkingSignature(testClaudeCAISSample)
+
+	_, err := executor.Execute(context.Background(), auth, req, opts)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if bytes.Contains(upstreamBody, []byte(testClaudeCAISSample)) {
+		t.Fatalf("vertex upstream request leaked raw Claude CAIS signature: %s", upstreamBody)
+	}
+}
+
+func TestGeminiVertexExecutorExecuteStream_GeminiPayload_SanitizesClaudeCAISSignature(t *testing.T) {
+	var upstreamBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read request body: %v", errRead)
+		}
+		upstreamBody = append([]byte(nil), body...)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"chunk\"}]}}]}\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewGeminiVertexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider: "vertex",
+		Attributes: map[string]string{
+			"api_key":  "test-vertex-key",
+			"base_url": server.URL,
+		},
+	}
+
+	req, opts := geminiRequestWithThinkingSignature(testClaudeCAISSample)
+
+	res, err := executor.ExecuteStream(context.Background(), auth, req, opts)
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	for range res.Chunks {
+	}
+
+	if bytes.Contains(upstreamBody, []byte(testClaudeCAISSample)) {
+		t.Fatalf("vertex stream upstream request leaked raw Claude CAIS signature: %s", upstreamBody)
+	}
+}
+
+func TestGeminiVertexExecutorCountTokens_GeminiPayload_SanitizesClaudeCAISSignature(t *testing.T) {
+	var upstreamBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read request body: %v", errRead)
+		}
+		upstreamBody = append([]byte(nil), body...)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"totalTokens": 42}`))
+	}))
+	defer server.Close()
+
+	executor := NewGeminiVertexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider: "vertex",
+		Attributes: map[string]string{
+			"api_key":  "test-vertex-key",
+			"base_url": server.URL,
+		},
+	}
+
+	req, opts := geminiRequestWithThinkingSignature(testClaudeCAISSample)
+
+	_, err := executor.CountTokens(context.Background(), auth, req, opts)
+	if err != nil {
+		t.Fatalf("CountTokens() error = %v", err)
+	}
+
+	if bytes.Contains(upstreamBody, []byte(testClaudeCAISSample)) {
+		t.Fatalf("vertex countTokens upstream request leaked raw Claude CAIS signature: %s", upstreamBody)
+	}
+}
+
+func TestGeminiVertexExecutorExecute_PreservesNativeGeminiSignature(t *testing.T) {
+	var upstreamBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read request body: %v", errRead)
+		}
+		upstreamBody = append([]byte(nil), body...)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`))
+	}))
+	defer server.Close()
+
+	nativeSig := testNativeGemini3ThoughtSignature()
+	executor := NewGeminiVertexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider: "vertex",
+		Attributes: map[string]string{
+			"api_key":  "test-vertex-key",
+			"base_url": server.URL,
+		},
+	}
+
+	reqPayload := []byte(`{
+		"contents": [
+			{
+				"role": "model",
+				"parts": [
+					{
+						"functionCall": {"name": "search", "args": {"q": "go"}},
+						"thoughtSignature": "` + nativeSig + `"
+					}
+				]
+			},
+			{
+				"role": "user",
+				"parts": [
+					{
+						"functionResponse": {"name": "search", "response": {"result": "found"}}
+					}
+				]
+			}
+		]
+	}`)
+
+	req := cliproxyexecutor.Request{
+		Model:   "gemini-2.5-flash",
+		Payload: reqPayload,
+	}
+
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatGemini,
+	}
+
+	_, err := executor.Execute(context.Background(), auth, req, opts)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	gotSig := gjson.GetBytes(upstreamBody, "contents.1.parts.0.thoughtSignature").String()
+	if gotSig != nativeSig {
+		t.Fatalf("thoughtSignature = %q, want preserved native signature %q; upstreamBody=%s",
+			gotSig, nativeSig, upstreamBody)
+	}
+}
+
+func TestGeminiVertexExecutorExecute_UnsignedRequestNotCorrupted(t *testing.T) {
+	var upstreamBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read request body: %v", errRead)
+		}
+		upstreamBody = append([]byte(nil), body...)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`))
+	}))
+	defer server.Close()
+
+	executor := NewGeminiVertexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider: "vertex",
+		Attributes: map[string]string{
+			"api_key":  "test-vertex-key",
+			"base_url": server.URL,
+		},
+	}
+
+	reqPayload := []byte(`{
+		"contents": [
+			{
+				"role": "user",
+				"parts": [{"text": "Hello world"}]
+			}
+		]
+	}`)
+
+	req := cliproxyexecutor.Request{
+		Model:   "gemini-2.5-flash",
+		Payload: reqPayload,
+	}
+
+	opts := cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatGemini,
+	}
+
+	_, err := executor.Execute(context.Background(), auth, req, opts)
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	text := gjson.GetBytes(upstreamBody, "contents.0.parts.0.text").String()
+	if text != "Hello world" {
+		t.Fatalf("text = %q, want 'Hello world'; upstreamBody=%s", text, upstreamBody)
+	}
+}

--- a/internal/runtime/executor/gemini_executor_test.go
+++ b/internal/runtime/executor/gemini_executor_test.go
@@ -1148,3 +1148,34 @@ func TestGeminiExecutorNativeInteractionsResponsesStreamEmitsDone(t *testing.T) 
 		t.Fatal("Responses [DONE] chunk not found")
 	}
 }
+
+func TestGeminiExecutor_PrepareRequest_EmptyAPIKey_OmitsAuthHeaders(t *testing.T) {
+	req, err := http.NewRequest(http.MethodPost, "https://custom-gemini.example.com/v1beta/models", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer preexisting-bearer")
+	req.Header.Set("x-goog-api-key", "preexisting-key")
+
+	auth := &cliproxyauth.Auth{
+		Provider: "gemini",
+		Attributes: map[string]string{
+			"auth_kind":           "apikey",
+			"base_url":            "https://custom-gemini.example.com",
+			"header:Custom-Token": "gemini-secret",
+		},
+	}
+	exec := &GeminiExecutor{}
+	if errPrep := exec.PrepareRequest(req, auth); errPrep != nil {
+		t.Fatalf("PrepareRequest() error = %v", errPrep)
+	}
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization = %q, want empty", got)
+	}
+	if got := req.Header.Get("x-goog-api-key"); got != "" {
+		t.Fatalf("x-goog-api-key = %q, want empty", got)
+	}
+	if got := req.Header.Get("Custom-Token"); got != "gemini-secret" {
+		t.Fatalf("Custom-Token = %q, want gemini-secret", got)
+	}
+}

--- a/internal/runtime/executor/gemini_executor_test.go
+++ b/internal/runtime/executor/gemini_executor_test.go
@@ -91,6 +91,162 @@ func TestGeminiExecutorExecuteCapsMaxOutputTokensBeforeUpstream(t *testing.T) {
 	}
 }
 
+func TestGeminiExecutorExecutePrependsLeadingUser(t *testing.T) {
+	var upstreamBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read request body: %v", errRead)
+		}
+		upstreamBody = append([]byte(nil), body...)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}`))
+	}))
+	defer server.Close()
+
+	executor := NewGeminiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "test-key",
+		"base_url": server.URL,
+	}}
+	request := cliproxyexecutor.Request{
+		Model: "gemini-3.7-flash",
+		Payload: []byte(`{"contents":[` +
+			`{"role":"model","parts":[{"functionCall":{"name":"lookup","args":{"key":"value"}}}]},` +
+			`{"role":"user","parts":[{"functionResponse":{"name":"lookup","response":{"result":"ok"}}}]}` +
+			`]}`),
+	}
+
+	if _, errExecute := executor.Execute(context.Background(), auth, request, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatGemini}); errExecute != nil {
+		t.Fatalf("Execute() error = %v", errExecute)
+	}
+	contents := gjson.GetBytes(upstreamBody, "contents").Array()
+	if len(contents) != 3 || contents[0].Get("role").String() != "user" || contents[1].Get("role").String() != "model" || contents[2].Get("role").String() != "user" {
+		t.Fatalf("upstream roles malformed: %s", upstreamBody)
+	}
+	if got := contents[0].Get("parts.0.text").String(); got != "" {
+		t.Fatalf("leading user prompt = %q, want empty string; body=%s", got, upstreamBody)
+	}
+}
+
+func TestGeminiExecutorExecutePrependsLeadingUserForIssue4959ResponsesHistory(t *testing.T) {
+	var upstreamBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read request body: %v", errRead)
+		}
+		upstreamBody = append([]byte(nil), body...)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}`))
+	}))
+	defer server.Close()
+
+	executor := NewGeminiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "test-key",
+		"base_url": server.URL,
+	}}
+	if _, errExecute := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gemini-3.7-flash",
+		Payload: issue4959ResponsesModelFirstPayload(),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse}); errExecute != nil {
+		t.Fatalf("Execute() error = %v", errExecute)
+	}
+	assertIssue4959LeadingUserContents(t, gjson.GetBytes(upstreamBody, "contents").Array())
+}
+
+func TestGeminiExecutorCountTokensPrependsLeadingUser(t *testing.T) {
+	var upstreamBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read request body: %v", errRead)
+		}
+		upstreamBody = append([]byte(nil), body...)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"totalTokens":7}`))
+	}))
+	defer server.Close()
+
+	executor := NewGeminiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "test-key",
+		"base_url": server.URL,
+	}}
+	request := cliproxyexecutor.Request{
+		Model:   "gemini-3.7-flash",
+		Payload: []byte(`{"contents":[{"role":"model","parts":[{"text":"prior output"}]}]}`),
+	}
+
+	if _, errCount := executor.CountTokens(context.Background(), auth, request, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatGemini}); errCount != nil {
+		t.Fatalf("CountTokens() error = %v", errCount)
+	}
+	contents := gjson.GetBytes(upstreamBody, "contents").Array()
+	if len(contents) != 2 || contents[0].Get("role").String() != "user" || contents[1].Get("role").String() != "model" {
+		t.Fatalf("countTokens roles malformed: %s", upstreamBody)
+	}
+	if text := contents[0].Get("parts.0.text"); !text.Exists() || text.String() != "" {
+		t.Fatalf("countTokens synthetic user missing: %s", upstreamBody)
+	}
+	if got := contents[1].Get("parts.0.text").String(); got != "prior output" {
+		t.Fatalf("countTokens model text = %q, want prior output; body=%s", got, upstreamBody)
+	}
+
+	request.Metadata = map[string]any{"action": "countTokens"}
+	if _, errExecute := executor.Execute(context.Background(), auth, request, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatGemini}); errExecute != nil {
+		t.Fatalf("Execute(countTokens) error = %v", errExecute)
+	}
+	contents = gjson.GetBytes(upstreamBody, "contents").Array()
+	if len(contents) != 2 || contents[0].Get("role").String() != "user" || contents[1].Get("role").String() != "model" {
+		t.Fatalf("Execute(countTokens) roles malformed: %s", upstreamBody)
+	}
+}
+
+func TestGeminiExecutorAppliesPayloadRulesBeforeLeadingUserNormalization(t *testing.T) {
+	var upstreamBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read request body: %v", errRead)
+		}
+		upstreamBody = append([]byte(nil), body...)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`))
+	}))
+	defer server.Close()
+
+	executor := NewGeminiExecutor(&config.Config{Payload: config.PayloadConfig{Override: []config.PayloadRule{{
+		Models: []config.PayloadModelRule{{Name: "gemini-3.7-flash", Protocol: "gemini"}},
+		Params: map[string]any{"contents.0.parts.0.text": "payload override"},
+	}}}})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "test-key",
+		"base_url": server.URL,
+	}}
+	request := cliproxyexecutor.Request{
+		Model: "gemini-3.7-flash",
+		Payload: []byte(`{"contents":[` +
+			`{"role":"model","parts":[{"text":"prior output"}]},` +
+			`{"role":"user","parts":[{"text":"continue"}]}` +
+			`]}`),
+	}
+
+	if _, errExecute := executor.Execute(context.Background(), auth, request, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatGemini}); errExecute != nil {
+		t.Fatalf("Execute() error = %v", errExecute)
+	}
+	contents := gjson.GetBytes(upstreamBody, "contents").Array()
+	if len(contents) != 3 || contents[0].Get("role").String() != "user" || contents[1].Get("role").String() != "model" {
+		t.Fatalf("upstream roles malformed: %s", upstreamBody)
+	}
+	if text := contents[0].Get("parts.0.text"); !text.Exists() || text.String() != "" {
+		t.Fatalf("synthetic leading user changed: %s", upstreamBody)
+	}
+	if got := contents[1].Get("parts.0.text").String(); got != "payload override" {
+		t.Fatalf("payload rule applied to %q, want original first model turn; body=%s", got, upstreamBody)
+	}
+}
+
 func TestGeminiExecutorInteractionsWithGeminiAPIKeyUsesGeminiEndpoint(t *testing.T) {
 	var gotPath string
 	var gotRevision string

--- a/internal/runtime/executor/gemini_executor_test.go
+++ b/internal/runtime/executor/gemini_executor_test.go
@@ -91,6 +91,162 @@ func TestGeminiExecutorExecuteCapsMaxOutputTokensBeforeUpstream(t *testing.T) {
 	}
 }
 
+func TestGeminiExecutorExecutePrependsLeadingUser(t *testing.T) {
+	var upstreamBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read request body: %v", errRead)
+		}
+		upstreamBody = append([]byte(nil), body...)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}`))
+	}))
+	defer server.Close()
+
+	executor := NewGeminiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "test-key",
+		"base_url": server.URL,
+	}}
+	request := cliproxyexecutor.Request{
+		Model: "gemini-3.7-flash",
+		Payload: []byte(`{"contents":[` +
+			`{"role":"model","parts":[{"functionCall":{"name":"lookup","args":{"key":"value"}}}]},` +
+			`{"role":"user","parts":[{"functionResponse":{"name":"lookup","response":{"result":"ok"}}}]}` +
+			`]}`),
+	}
+
+	if _, errExecute := executor.Execute(context.Background(), auth, request, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatGemini}); errExecute != nil {
+		t.Fatalf("Execute() error = %v", errExecute)
+	}
+	contents := gjson.GetBytes(upstreamBody, "contents").Array()
+	if len(contents) != 3 || contents[0].Get("role").String() != "user" || contents[1].Get("role").String() != "model" || contents[2].Get("role").String() != "user" {
+		t.Fatalf("upstream roles malformed: %s", upstreamBody)
+	}
+	if got := contents[0].Get("parts.0.text").String(); got != "" {
+		t.Fatalf("leading user prompt = %q, want empty string; body=%s", got, upstreamBody)
+	}
+}
+
+func TestGeminiExecutorExecutePrependsLeadingUserForIssue4959ResponsesHistory(t *testing.T) {
+	var upstreamBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read request body: %v", errRead)
+		}
+		upstreamBody = append([]byte(nil), body...)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}`))
+	}))
+	defer server.Close()
+
+	executor := NewGeminiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "test-key",
+		"base_url": server.URL,
+	}}
+	if _, errExecute := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gemini-3.7-flash",
+		Payload: issue4959ResponsesModelFirstPayload(),
+	}, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatOpenAIResponse}); errExecute != nil {
+		t.Fatalf("Execute() error = %v", errExecute)
+	}
+	assertIssue4959LeadingUserContents(t, gjson.GetBytes(upstreamBody, "contents").Array())
+}
+
+func TestGeminiExecutorCountTokensPrependsLeadingUser(t *testing.T) {
+	var upstreamBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read request body: %v", errRead)
+		}
+		upstreamBody = append([]byte(nil), body...)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"totalTokens":7}`))
+	}))
+	defer server.Close()
+
+	executor := NewGeminiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "test-key",
+		"base_url": server.URL,
+	}}
+	request := cliproxyexecutor.Request{
+		Model:   "gemini-3.7-flash",
+		Payload: []byte(`{"contents":[{"role":"model","parts":[{"text":"prior output"}]}]}`),
+	}
+
+	if _, errCount := executor.CountTokens(context.Background(), auth, request, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatGemini}); errCount != nil {
+		t.Fatalf("CountTokens() error = %v", errCount)
+	}
+	contents := gjson.GetBytes(upstreamBody, "contents").Array()
+	if len(contents) != 2 || contents[0].Get("role").String() != "user" || contents[1].Get("role").String() != "model" {
+		t.Fatalf("countTokens roles malformed: %s", upstreamBody)
+	}
+	if text := contents[0].Get("parts.0.text"); !text.Exists() || text.String() != "" {
+		t.Fatalf("countTokens synthetic user missing: %s", upstreamBody)
+	}
+	if got := contents[1].Get("parts.0.text").String(); got != "prior output" {
+		t.Fatalf("countTokens model text = %q, want prior output; body=%s", got, upstreamBody)
+	}
+
+	request.Metadata = map[string]any{"action": "countTokens"}
+	if _, errExecute := executor.Execute(context.Background(), auth, request, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatGemini}); errExecute != nil {
+		t.Fatalf("Execute(countTokens) error = %v", errExecute)
+	}
+	contents = gjson.GetBytes(upstreamBody, "contents").Array()
+	if len(contents) != 2 || contents[0].Get("role").String() != "user" || contents[1].Get("role").String() != "model" {
+		t.Fatalf("Execute(countTokens) roles malformed: %s", upstreamBody)
+	}
+}
+
+func TestGeminiExecutorAppliesPayloadRulesBeforeLeadingUserNormalization(t *testing.T) {
+	var upstreamBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, errRead := io.ReadAll(r.Body)
+		if errRead != nil {
+			t.Fatalf("read request body: %v", errRead)
+		}
+		upstreamBody = append([]byte(nil), body...)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`))
+	}))
+	defer server.Close()
+
+	executor := NewGeminiExecutor(&config.Config{Payload: config.PayloadConfig{Override: []config.PayloadRule{{
+		Models: []config.PayloadModelRule{{Name: "gemini-3.7-flash", Protocol: "gemini"}},
+		Params: map[string]any{"contents.0.parts.0.text": "payload override"},
+	}}}})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "test-key",
+		"base_url": server.URL,
+	}}
+	request := cliproxyexecutor.Request{
+		Model: "gemini-3.7-flash",
+		Payload: []byte(`{"contents":[` +
+			`{"role":"model","parts":[{"text":"prior output"}]},` +
+			`{"role":"user","parts":[{"text":"continue"}]}` +
+			`]}`),
+	}
+
+	if _, errExecute := executor.Execute(context.Background(), auth, request, cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatGemini}); errExecute != nil {
+		t.Fatalf("Execute() error = %v", errExecute)
+	}
+	contents := gjson.GetBytes(upstreamBody, "contents").Array()
+	if len(contents) != 3 || contents[0].Get("role").String() != "user" || contents[1].Get("role").String() != "model" {
+		t.Fatalf("upstream roles malformed: %s", upstreamBody)
+	}
+	if text := contents[0].Get("parts.0.text"); !text.Exists() || text.String() != "" {
+		t.Fatalf("synthetic leading user changed: %s", upstreamBody)
+	}
+	if got := contents[1].Get("parts.0.text").String(); got != "payload override" {
+		t.Fatalf("payload rule applied to %q, want original first model turn; body=%s", got, upstreamBody)
+	}
+}
+
 func TestGeminiExecutorInteractionsWithGeminiAPIKeyUsesGeminiEndpoint(t *testing.T) {
 	var gotPath string
 	var gotRevision string
@@ -990,5 +1146,36 @@ func TestGeminiExecutorNativeInteractionsResponsesStreamEmitsDone(t *testing.T) 
 	}
 	if !done {
 		t.Fatal("Responses [DONE] chunk not found")
+	}
+}
+
+func TestGeminiExecutor_PrepareRequest_EmptyAPIKey_OmitsAuthHeaders(t *testing.T) {
+	req, err := http.NewRequest(http.MethodPost, "https://custom-gemini.example.com/v1beta/models", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer preexisting-bearer")
+	req.Header.Set("x-goog-api-key", "preexisting-key")
+
+	auth := &cliproxyauth.Auth{
+		Provider: "gemini",
+		Attributes: map[string]string{
+			"auth_kind":           "apikey",
+			"base_url":            "https://custom-gemini.example.com",
+			"header:Custom-Token": "gemini-secret",
+		},
+	}
+	exec := &GeminiExecutor{}
+	if errPrep := exec.PrepareRequest(req, auth); errPrep != nil {
+		t.Fatalf("PrepareRequest() error = %v", errPrep)
+	}
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization = %q, want empty", got)
+	}
+	if got := req.Header.Get("x-goog-api-key"); got != "" {
+		t.Fatalf("x-goog-api-key = %q, want empty", got)
+	}
+	if got := req.Header.Get("Custom-Token"); got != "gemini-secret" {
+		t.Fatalf("Custom-Token = %q, want gemini-secret", got)
 	}
 }

--- a/internal/runtime/executor/gemini_vertex_executor.go
+++ b/internal/runtime/executor/gemini_vertex_executor.go
@@ -17,6 +17,7 @@ import (
 	vertexauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/vertex"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	internalsignature "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -342,6 +343,7 @@ func (e *GeminiVertexExecutor) executeWithServiceAccount(ctx context.Context, au
 		body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 		body = helps.SetStringIfDifferent(body, "model", baseModel)
 		body = helps.StripVertexOpenAIResponsesToolCallIDs(body, from.String())
+		body = internalsignature.SanitizeGeminiRequestThoughtSignatures(body, "contents")
 	}
 
 	action := getVertexAction(baseModel, false)
@@ -471,6 +473,7 @@ func (e *GeminiVertexExecutor) executeWithAPIKey(ctx context.Context, auth *clip
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body = helps.SetStringIfDifferent(body, "model", baseModel)
 	body = helps.StripVertexOpenAIResponsesToolCallIDs(body, from.String())
+	body = internalsignature.SanitizeGeminiRequestThoughtSignatures(body, "contents")
 
 	action := getVertexAction(baseModel, false)
 	if req.Metadata != nil {
@@ -590,6 +593,7 @@ func (e *GeminiVertexExecutor) executeStreamWithServiceAccount(ctx context.Conte
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body = helps.SetStringIfDifferent(body, "model", baseModel)
 	body = helps.StripVertexOpenAIResponsesToolCallIDs(body, from.String())
+	body = internalsignature.SanitizeGeminiRequestThoughtSignatures(body, "contents")
 
 	action := getVertexAction(baseModel, true)
 	body = helps.EnsureGeminiLeadingUserContent(body, "contents")
@@ -738,6 +742,7 @@ func (e *GeminiVertexExecutor) executeStreamWithAPIKey(ctx context.Context, auth
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body = helps.SetStringIfDifferent(body, "model", baseModel)
 	body = helps.StripVertexOpenAIResponsesToolCallIDs(body, from.String())
+	body = internalsignature.SanitizeGeminiRequestThoughtSignatures(body, "contents")
 
 	action := getVertexAction(baseModel, true)
 	body = helps.EnsureGeminiLeadingUserContent(body, "contents")
@@ -878,6 +883,7 @@ func (e *GeminiVertexExecutor) countTokensWithServiceAccount(ctx context.Context
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "tools")
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "generationConfig")
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "safetySettings")
+	translatedReq = internalsignature.SanitizeGeminiRequestThoughtSignatures(translatedReq, "contents")
 	translatedReq = helps.EnsureGeminiLeadingUserContent(translatedReq, "contents")
 
 	baseURL := vertexBaseURL(location)
@@ -970,6 +976,7 @@ func (e *GeminiVertexExecutor) countTokensWithAPIKey(ctx context.Context, auth *
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "tools")
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "generationConfig")
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "safetySettings")
+	translatedReq = internalsignature.SanitizeGeminiRequestThoughtSignatures(translatedReq, "contents")
 	translatedReq = helps.EnsureGeminiLeadingUserContent(translatedReq, "contents")
 
 	// For API key auth, use simpler URL format without project/location

--- a/internal/runtime/executor/gemini_vertex_executor.go
+++ b/internal/runtime/executor/gemini_vertex_executor.go
@@ -17,6 +17,7 @@ import (
 	vertexauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/vertex"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	internalsignature "github.com/router-for-me/CLIProxyAPI/v7/internal/signature"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
@@ -342,6 +343,7 @@ func (e *GeminiVertexExecutor) executeWithServiceAccount(ctx context.Context, au
 		body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 		body = helps.SetStringIfDifferent(body, "model", baseModel)
 		body = helps.StripVertexOpenAIResponsesToolCallIDs(body, from.String())
+		body = internalsignature.SanitizeGeminiRequestThoughtSignatures(body, "contents")
 	}
 
 	action := getVertexAction(baseModel, false)
@@ -350,6 +352,7 @@ func (e *GeminiVertexExecutor) executeWithServiceAccount(ctx context.Context, au
 			action = "countTokens"
 		}
 	}
+	body = helps.EnsureGeminiLeadingUserContent(body, "contents")
 	baseURL := vertexBaseURL(location)
 	url := fmt.Sprintf("%s/%s/projects/%s/locations/%s/publishers/google/models/%s:%s", baseURL, vertexAPIVersion, projectID, location, baseModel, action)
 	if opts.Alt != "" && action != "countTokens" {
@@ -470,6 +473,7 @@ func (e *GeminiVertexExecutor) executeWithAPIKey(ctx context.Context, auth *clip
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body = helps.SetStringIfDifferent(body, "model", baseModel)
 	body = helps.StripVertexOpenAIResponsesToolCallIDs(body, from.String())
+	body = internalsignature.SanitizeGeminiRequestThoughtSignatures(body, "contents")
 
 	action := getVertexAction(baseModel, false)
 	if req.Metadata != nil {
@@ -477,6 +481,7 @@ func (e *GeminiVertexExecutor) executeWithAPIKey(ctx context.Context, auth *clip
 			action = "countTokens"
 		}
 	}
+	body = helps.EnsureGeminiLeadingUserContent(body, "contents")
 
 	// For API key auth, use simpler URL format without project/location
 	if baseURL == "" {
@@ -588,8 +593,10 @@ func (e *GeminiVertexExecutor) executeStreamWithServiceAccount(ctx context.Conte
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body = helps.SetStringIfDifferent(body, "model", baseModel)
 	body = helps.StripVertexOpenAIResponsesToolCallIDs(body, from.String())
+	body = internalsignature.SanitizeGeminiRequestThoughtSignatures(body, "contents")
 
 	action := getVertexAction(baseModel, true)
+	body = helps.EnsureGeminiLeadingUserContent(body, "contents")
 	baseURL := vertexBaseURL(location)
 	url := fmt.Sprintf("%s/%s/projects/%s/locations/%s/publishers/google/models/%s:%s", baseURL, vertexAPIVersion, projectID, location, baseModel, action)
 	// Imagen models don't support streaming, skip SSE params
@@ -735,8 +742,10 @@ func (e *GeminiVertexExecutor) executeStreamWithAPIKey(ctx context.Context, auth
 	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, to.String(), from.String(), "", body, originalTranslated, requestedModel, requestPath, opts.Headers)
 	body = helps.SetStringIfDifferent(body, "model", baseModel)
 	body = helps.StripVertexOpenAIResponsesToolCallIDs(body, from.String())
+	body = internalsignature.SanitizeGeminiRequestThoughtSignatures(body, "contents")
 
 	action := getVertexAction(baseModel, true)
+	body = helps.EnsureGeminiLeadingUserContent(body, "contents")
 	// For API key auth, use simpler URL format without project/location
 	if baseURL == "" {
 		baseURL = "https://aiplatform.googleapis.com"
@@ -874,6 +883,8 @@ func (e *GeminiVertexExecutor) countTokensWithServiceAccount(ctx context.Context
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "tools")
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "generationConfig")
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "safetySettings")
+	translatedReq = internalsignature.SanitizeGeminiRequestThoughtSignatures(translatedReq, "contents")
+	translatedReq = helps.EnsureGeminiLeadingUserContent(translatedReq, "contents")
 
 	baseURL := vertexBaseURL(location)
 	url := fmt.Sprintf("%s/%s/projects/%s/locations/%s/publishers/google/models/%s:%s", baseURL, vertexAPIVersion, projectID, location, baseModel, "countTokens")
@@ -965,6 +976,8 @@ func (e *GeminiVertexExecutor) countTokensWithAPIKey(ctx context.Context, auth *
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "tools")
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "generationConfig")
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "safetySettings")
+	translatedReq = internalsignature.SanitizeGeminiRequestThoughtSignatures(translatedReq, "contents")
+	translatedReq = helps.EnsureGeminiLeadingUserContent(translatedReq, "contents")
 
 	// For API key auth, use simpler URL format without project/location
 	if baseURL == "" {

--- a/internal/runtime/executor/gemini_vertex_executor.go
+++ b/internal/runtime/executor/gemini_vertex_executor.go
@@ -350,6 +350,7 @@ func (e *GeminiVertexExecutor) executeWithServiceAccount(ctx context.Context, au
 			action = "countTokens"
 		}
 	}
+	body = helps.EnsureGeminiLeadingUserContent(body, "contents")
 	baseURL := vertexBaseURL(location)
 	url := fmt.Sprintf("%s/%s/projects/%s/locations/%s/publishers/google/models/%s:%s", baseURL, vertexAPIVersion, projectID, location, baseModel, action)
 	if opts.Alt != "" && action != "countTokens" {
@@ -477,6 +478,7 @@ func (e *GeminiVertexExecutor) executeWithAPIKey(ctx context.Context, auth *clip
 			action = "countTokens"
 		}
 	}
+	body = helps.EnsureGeminiLeadingUserContent(body, "contents")
 
 	// For API key auth, use simpler URL format without project/location
 	if baseURL == "" {
@@ -590,6 +592,7 @@ func (e *GeminiVertexExecutor) executeStreamWithServiceAccount(ctx context.Conte
 	body = helps.StripVertexOpenAIResponsesToolCallIDs(body, from.String())
 
 	action := getVertexAction(baseModel, true)
+	body = helps.EnsureGeminiLeadingUserContent(body, "contents")
 	baseURL := vertexBaseURL(location)
 	url := fmt.Sprintf("%s/%s/projects/%s/locations/%s/publishers/google/models/%s:%s", baseURL, vertexAPIVersion, projectID, location, baseModel, action)
 	// Imagen models don't support streaming, skip SSE params
@@ -737,6 +740,7 @@ func (e *GeminiVertexExecutor) executeStreamWithAPIKey(ctx context.Context, auth
 	body = helps.StripVertexOpenAIResponsesToolCallIDs(body, from.String())
 
 	action := getVertexAction(baseModel, true)
+	body = helps.EnsureGeminiLeadingUserContent(body, "contents")
 	// For API key auth, use simpler URL format without project/location
 	if baseURL == "" {
 		baseURL = "https://aiplatform.googleapis.com"
@@ -874,6 +878,7 @@ func (e *GeminiVertexExecutor) countTokensWithServiceAccount(ctx context.Context
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "tools")
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "generationConfig")
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "safetySettings")
+	translatedReq = helps.EnsureGeminiLeadingUserContent(translatedReq, "contents")
 
 	baseURL := vertexBaseURL(location)
 	url := fmt.Sprintf("%s/%s/projects/%s/locations/%s/publishers/google/models/%s:%s", baseURL, vertexAPIVersion, projectID, location, baseModel, "countTokens")
@@ -965,6 +970,7 @@ func (e *GeminiVertexExecutor) countTokensWithAPIKey(ctx context.Context, auth *
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "tools")
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "generationConfig")
 	translatedReq, _ = sjson.DeleteBytes(translatedReq, "safetySettings")
+	translatedReq = helps.EnsureGeminiLeadingUserContent(translatedReq, "contents")
 
 	// For API key auth, use simpler URL format without project/location
 	if baseURL == "" {

--- a/internal/runtime/executor/helps/claude_builtin_tools.go
+++ b/internal/runtime/executor/helps/claude_builtin_tools.go
@@ -27,6 +27,8 @@ func newClaudeBuiltinToolRegistry() map[string]bool {
 func IsClaudeServerToolType(toolType string) bool {
 	toolType = strings.ToLower(strings.TrimSpace(toolType))
 	for _, prefix := range []string{
+		"advisor_",
+		"agent_toolset_",
 		"bash_",
 		"code_execution_",
 		"computer_",

--- a/internal/runtime/executor/helps/claude_builtin_tools_test.go
+++ b/internal/runtime/executor/helps/claude_builtin_tools_test.go
@@ -32,7 +32,18 @@ func TestClaudeBuiltinToolRegistry_AugmentsKnownTypedBuiltinsFromBody(t *testing
 }
 
 func TestIsClaudeServerToolType(t *testing.T) {
-	for _, toolType := range []string{"web_search_20250305", "code_execution_20250522", "tool_search_tool_regex_20251119"} {
+	for _, toolType := range []string{
+		"web_search_20250305",
+		"code_execution_20250522",
+		"tool_search_tool_regex_20251119",
+		"advisor_20260301",
+		"agent_toolset_20260401",
+		"bash_20250124",
+		"text_editor_20250728",
+		"memory_20250818",
+		"computer_20241022",
+		"web_fetch_20260209",
+	} {
 		if !IsClaudeServerToolType(toolType) {
 			t.Fatalf("IsClaudeServerToolType(%q) = false, want true", toolType)
 		}

--- a/internal/runtime/executor/helps/claude_cli_identity_seed.go
+++ b/internal/runtime/executor/helps/claude_cli_identity_seed.go
@@ -21,8 +21,18 @@ func stableClaudeCLIDeviceID(seed string) string {
 	return hex.EncodeToString(sum[:])
 }
 
+// StableClaudeCLIDeviceID returns a deterministic device ID derived from a seed.
+func StableClaudeCLIDeviceID(seed string) string {
+	return stableClaudeCLIDeviceID(seed)
+}
+
 func stableClaudeCLIAccountUUID(seed string) string {
 	return uuid.NewSHA1(claudeCLIIdentityNamespace, []byte("cpa-claude-code-cli-account|"+seed)).String()
+}
+
+// StableClaudeCLIAccountUUID returns a deterministic UUIDv5 account ID derived from a seed.
+func StableClaudeCLIAccountUUID(seed string) string {
+	return stableClaudeCLIAccountUUID(seed)
 }
 
 // ClaudeCLIAuthIdentitySeed returns a stable credential identity that does not

--- a/internal/runtime/executor/helps/claude_code_session.go
+++ b/internal/runtime/executor/helps/claude_code_session.go
@@ -56,6 +56,11 @@ func claudeCodeHeader(ctx context.Context, headers http.Header, name string) str
 	return ""
 }
 
+// HeaderValueCaseInsensitive returns the first non-empty header value matching name case-insensitively.
+func HeaderValueCaseInsensitive(headers http.Header, name string) string {
+	return headerValueCaseInsensitive(headers, name)
+}
+
 func headerValueCaseInsensitive(headers http.Header, name string) string {
 	if headers == nil {
 		return ""

--- a/internal/runtime/executor/helps/claude_code_session.go
+++ b/internal/runtime/executor/helps/claude_code_session.go
@@ -32,6 +32,28 @@ func ClaudeCodeExecutionScope(ctx context.Context, payload []byte, headers http.
 }
 
 // ClaudeCodePromptCache maps one Claude Code agent execution scope to a stable upstream prompt_cache_key.
+
+// HeaderValueCaseInsensitive returns the first non-empty header value matching name case-insensitively.
+func HeaderValueCaseInsensitive(headers http.Header, name string) string {
+	if headers == nil {
+		return ""
+	}
+	if value := strings.TrimSpace(headers.Get(name)); value != "" {
+		return value
+	}
+	for key, values := range headers {
+		if !strings.EqualFold(key, name) {
+			continue
+		}
+		for _, value := range values {
+			if value = strings.TrimSpace(value); value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
 func ClaudeCodePromptCache(ctx context.Context, modelName string, payload []byte, headers http.Header) (CodexCache, bool, error) {
 	modelName = strings.TrimSpace(modelName)
 	executionScope, ok := ClaudeCodeExecutionScope(ctx, payload, headers)

--- a/internal/runtime/executor/helps/claude_ratelimit.go
+++ b/internal/runtime/executor/helps/claude_ratelimit.go
@@ -36,8 +36,11 @@ func ClaudeHeadersIndicateUnifiedRateLimitRejection(headers http.Header) bool {
 		return false
 	}
 	status7dOI := strings.ToLower(strings.TrimSpace(getHeaderCaseInsensitive(headers, "Anthropic-Ratelimit-Unified-7d_oi-Status")))
-	fableOnlyRejection := status5h == "allowed" && status7d == "allowed" && status7dOI == "rejected"
-	return !fableOnlyRejection
+	return !isFableOnlyRejection(status5h, status7d, status7dOI)
+}
+
+func isFableOnlyRejection(status5h, status7d, status7dOI string) bool {
+	return status5h == "allowed" && status7d == "allowed" && status7dOI == "rejected"
 }
 
 // ParseClaudeRateLimitReset inspects Anthropic response headers for shared and Fable-specific
@@ -57,6 +60,7 @@ func parseClaudeRateLimitResetWithFuzz(headers http.Header, now time.Time, minFu
 	status5h := strings.ToLower(strings.TrimSpace(getHeaderCaseInsensitive(headers, "Anthropic-Ratelimit-Unified-5h-Status")))
 	status7d := strings.ToLower(strings.TrimSpace(getHeaderCaseInsensitive(headers, "Anthropic-Ratelimit-Unified-7d-Status")))
 	status7dOI := strings.ToLower(strings.TrimSpace(getHeaderCaseInsensitive(headers, "Anthropic-Ratelimit-Unified-7d_oi-Status")))
+	fableOnlyRejection := isFableOnlyRejection(status5h, status7d, status7dOI)
 
 	var candidateDeadlines []time.Time
 	var rejectedWindows []string
@@ -102,8 +106,8 @@ func parseClaudeRateLimitResetWithFuzz(headers http.Header, now time.Time, minFu
 		}
 	}
 
-	// 4. Fable-specific 7-day window reset (only when rejected)
-	if status7dOI == "rejected" {
+	// 4. Fable-specific 7-day window reset (only when rejected and not a Fable-only rejection)
+	if status7dOI == "rejected" && !fableOnlyRejection {
 		if raw := getHeaderCaseInsensitive(headers, "Anthropic-Ratelimit-Unified-7d_oi-Reset"); raw != "" {
 			if t, ok := parseUnixOrTimestamp(raw); ok && t.After(now) {
 				candidateDeadlines = append(candidateDeadlines, t)
@@ -112,8 +116,8 @@ func parseClaudeRateLimitResetWithFuzz(headers http.Header, now time.Time, minFu
 	}
 
 	// 5. Unified reset header:
-	unifiedRejected := unifiedStatus == "rejected" || status5h == "rejected" || status7d == "rejected" || status7dOI == "rejected" ||
-		(unifiedStatus == "" && status5h != "allowed" && status7d != "allowed")
+	unifiedRejected := !fableOnlyRejection && (unifiedStatus == "rejected" || status5h == "rejected" || status7d == "rejected" || status7dOI == "rejected" ||
+		(unifiedStatus == "" && status5h != "allowed" && status7d != "allowed"))
 
 	if unifiedRejected {
 		if raw := getHeaderCaseInsensitive(headers, "Anthropic-Ratelimit-Unified-Reset"); raw != "" {

--- a/internal/runtime/executor/helps/claude_ratelimit_test.go
+++ b/internal/runtime/executor/helps/claude_ratelimit_test.go
@@ -113,6 +113,58 @@ func TestParseClaudeRateLimitReset_AllCases(t *testing.T) {
 		}
 	})
 
+	t.Run("fable-only rejection with 7d_oi reset and retry-after uses retry-after only", func(t *testing.T) {
+		h := make(http.Header)
+		h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+		h.Set("Anthropic-Ratelimit-Unified-5h-Status", "allowed")
+		h.Set("Anthropic-Ratelimit-Unified-7d-Status", "allowed")
+		h.Set("Anthropic-Ratelimit-Unified-7d_oi-Status", "rejected")
+		h.Set("Anthropic-Ratelimit-Unified-7d_oi-Reset", strconv.FormatInt(now.Add(7*24*time.Hour).Unix(), 10))
+		h.Set("Anthropic-Ratelimit-Unified-Reset", strconv.FormatInt(now.Add(7*24*time.Hour).Unix(), 10))
+		h.Set("Retry-After", "60")
+
+		got := parseClaudeRateLimitResetWithFuzz(h, now, 0, 0)
+		if got == nil {
+			t.Fatal("expected non-nil RetryAfter")
+		}
+		if *got != 60*time.Second {
+			t.Fatalf("expected 60s from Retry-After, got %v", *got)
+		}
+	})
+
+	t.Run("fable-only rejection with 7d_oi reset only returns nil for exponential backoff", func(t *testing.T) {
+		h := make(http.Header)
+		h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+		h.Set("Anthropic-Ratelimit-Unified-5h-Status", "allowed")
+		h.Set("Anthropic-Ratelimit-Unified-7d-Status", "allowed")
+		h.Set("Anthropic-Ratelimit-Unified-7d_oi-Status", "rejected")
+		h.Set("Anthropic-Ratelimit-Unified-7d_oi-Reset", strconv.FormatInt(now.Add(7*24*time.Hour).Unix(), 10))
+		h.Set("Anthropic-Ratelimit-Unified-Reset", strconv.FormatInt(now.Add(7*24*time.Hour).Unix(), 10))
+
+		got := ParseClaudeRateLimitReset(h, now)
+		if got != nil {
+			t.Fatalf("expected nil for fable-only rejection without retry-after, got %v", *got)
+		}
+	})
+
+	t.Run("non-fable combined rejection with 7d_oi reset keeps longer duration", func(t *testing.T) {
+		h := make(http.Header)
+		h.Set("Anthropic-Ratelimit-Unified-Status", "rejected")
+		h.Set("Anthropic-Ratelimit-Unified-5h-Status", "rejected")
+		h.Set("Anthropic-Ratelimit-Unified-5h-Reset", strconv.FormatInt(now.Add(5*time.Hour).Unix(), 10))
+		h.Set("Anthropic-Ratelimit-Unified-7d-Status", "allowed")
+		h.Set("Anthropic-Ratelimit-Unified-7d_oi-Status", "rejected")
+		h.Set("Anthropic-Ratelimit-Unified-7d_oi-Reset", strconv.FormatInt(now.Add(7*24*time.Hour).Unix(), 10))
+
+		got := parseClaudeRateLimitResetWithFuzz(h, now, 0, 0)
+		if got == nil {
+			t.Fatal("expected non-nil RetryAfter")
+		}
+		if *got < 7*24*time.Hour-5*time.Second || *got > 7*24*time.Hour+5*time.Second {
+			t.Fatalf("expected ~7d, got %v", *got)
+		}
+	})
+
 	t.Run("past timestamp returns nil", func(t *testing.T) {
 		h := make(http.Header)
 		h.Set("Anthropic-Ratelimit-Unified-5h-Status", "rejected")

--- a/internal/runtime/executor/helps/gemini_content_turns.go
+++ b/internal/runtime/executor/helps/gemini_content_turns.go
@@ -1,0 +1,39 @@
+package helps
+
+import (
+	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+var emptyGeminiUserTurnJSON = []byte(`{"role":"user","parts":[{"text":""}]}`)
+
+// EnsureGeminiLeadingUserContent ensures that the contents array at the given path
+// starts with a user turn when sending to Gemini/Antigravity upstreams.
+func EnsureGeminiLeadingUserContent(payload []byte, path string) []byte {
+	firstRole := gjson.GetBytes(payload, path+".0.role")
+	if firstRole.String() != "model" {
+		return payload
+	}
+	contents := util.GetGJSONBytesNoCopy(payload, path)
+	if !contents.IsArray() {
+		return payload
+	}
+	contentArray := contents.Array()
+	if len(contentArray) == 0 {
+		return payload
+	}
+
+	contentItems := make([][]byte, 0, len(contentArray)+1)
+	contentItems = append(contentItems, emptyGeminiUserTurnJSON)
+	for _, content := range contentArray {
+		contentItems = append(contentItems, []byte(content.Raw))
+	}
+
+	out, errSet := sjson.SetRawBytes(payload, path, translatorcommon.JoinRawArray(contentItems))
+	if errSet != nil {
+		return payload
+	}
+	return out
+}

--- a/internal/runtime/executor/helps/gemini_content_turns_test.go
+++ b/internal/runtime/executor/helps/gemini_content_turns_test.go
@@ -1,0 +1,99 @@
+package helps
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+var leadingGeminiUserContentOutput []byte
+
+func TestEnsureGeminiLeadingUserContentReusesLargeValidPayload(t *testing.T) {
+	input := []byte(`{"contents":[{"role":"user","parts":[{"inlineData":{"mimeType":"video/mp4","data":"` + strings.Repeat("A", 4<<20) + `"}}]}]}`)
+
+	output := EnsureGeminiLeadingUserContent(input, "contents")
+	if &output[0] != &input[0] {
+		t.Fatal("valid request should reuse the input payload")
+	}
+
+	result := testing.Benchmark(func(b *testing.B) {
+		for b.Loop() {
+			leadingGeminiUserContentOutput = EnsureGeminiLeadingUserContent(input, "contents")
+		}
+	})
+	if allocated := result.AllocedBytesPerOp(); allocated >= 1<<20 {
+		t.Fatalf("valid 4 MiB request allocated %d bytes/op, want less than 1 MiB", allocated)
+	}
+}
+
+func TestEnsureGeminiLeadingUserContent(t *testing.T) {
+	tests := []struct {
+		name             string
+		inputJSON        string
+		path             string
+		wantRoles        string
+		wantLeadingEmpty bool
+	}{
+		{
+			name:      "user first is unchanged",
+			inputJSON: `{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}`,
+			path:      "contents",
+			wantRoles: "user",
+		},
+		{
+			name:             "leading model functionCall gets empty user",
+			inputJSON:        `{"contents":[{"role":"model","parts":[{"functionCall":{"name":"run"}}]},{"role":"user","parts":[{"functionResponse":{"name":"run"}}]}]}`,
+			path:             "contents",
+			wantRoles:        "user,model,user",
+			wantLeadingEmpty: true,
+		},
+		{
+			name:             "leading model text gets empty user and preserves following turns",
+			inputJSON:        `{"contents":[{"role":"model","parts":[{"text":"answer"}]},{"role":"user","parts":[{"text":"continue"}]}]}`,
+			path:             "contents",
+			wantRoles:        "user,model,user",
+			wantLeadingEmpty: true,
+		},
+		{
+			name:             "nested contents are normalized",
+			inputJSON:        `{"request":{"contents":[{"role":"model","parts":[{"text":"answer"}]},{"role":"user","parts":[{"text":"continue"}]}]}}`,
+			path:             "request.contents",
+			wantRoles:        "request.user,model,user",
+			wantLeadingEmpty: true,
+		},
+		{
+			name:      "empty contents are unchanged",
+			inputJSON: `{"contents":[]}`,
+			path:      "contents",
+			wantRoles: "",
+		},
+		{
+			name:      "missing contents are unchanged",
+			inputJSON: `{"model":"test"}`,
+			path:      "contents",
+			wantRoles: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := EnsureGeminiLeadingUserContent([]byte(tt.inputJSON), tt.path)
+			contents := gjson.GetBytes(out, tt.path).Array()
+			roles := make([]string, 0, len(contents))
+			for _, content := range contents {
+				roles = append(roles, content.Get("role").String())
+			}
+			expectedRoles := strings.TrimPrefix(tt.wantRoles, "request.")
+			if got := strings.Join(roles, ","); got != expectedRoles {
+				t.Fatalf("roles = %q, want %q; output=%s", got, expectedRoles, out)
+			}
+			if tt.wantLeadingEmpty {
+				text := gjson.GetBytes(out, tt.path+".0.parts.0.text")
+				if !text.Exists() || text.String() != "" {
+					t.Fatalf("leading empty user part missing; output=%s", out)
+				}
+			}
+		})
+	}
+}

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -210,6 +210,10 @@ func (r *UsageReporter) PublishFailure(ctx context.Context, errs ...error) {
 	r.publishWithOutcome(ctx, usage.Detail{}, true, failFromErrors(errs...))
 }
 
+func (r *UsageReporter) PublishFailureWithDetail(ctx context.Context, detail usage.Detail, errs ...error) {
+	r.publishWithOutcome(ctx, detail, true, failFromErrors(errs...))
+}
+
 func (r *UsageReporter) TrackFailure(ctx context.Context, errPtr *error) {
 	if r == nil || errPtr == nil {
 		return
@@ -522,6 +526,15 @@ func (b *StreamUsageBuffer) Publish(ctx context.Context, reporter *UsageReporter
 		return false
 	}
 	reporter.Publish(ctx, b.detail)
+	return true
+}
+
+// PublishFailure emits the latest observed usage detail together with failure details.
+func (b *StreamUsageBuffer) PublishFailure(ctx context.Context, reporter *UsageReporter, errs ...error) bool {
+	if b == nil || reporter == nil {
+		return false
+	}
+	reporter.PublishFailureWithDetail(ctx, b.detail, errs...)
 	return true
 }
 

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -599,6 +599,15 @@ func (b *StreamUsageBuffer) Publish(ctx context.Context, reporter *UsageReporter
 	return true
 }
 
+// PublishFailure emits the latest observed usage detail together with failure details.
+func (b *StreamUsageBuffer) PublishFailure(ctx context.Context, reporter *UsageReporter, errs ...error) bool {
+	if b == nil || reporter == nil {
+		return false
+	}
+	reporter.PublishFailureWithDetail(ctx, b.detail, errs...)
+	return true
+}
+
 // Detail returns the latest observed usage detail.
 func (b *StreamUsageBuffer) Detail() (usage.Detail, bool) {
 	if b == nil || !b.ok {

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -719,6 +719,27 @@ func TestFailFromErrorsMapsContextStatuses(t *testing.T) {
 	}
 }
 
+func TestStreamUsageBufferPublishFailure(t *testing.T) {
+	var buffer StreamUsageBuffer
+	buffer.Observe(usage.Detail{InputTokens: 10, OutputTokens: 5, TotalTokens: 15}, true)
+
+	reporter := &UsageReporter{
+		provider: "openai",
+		model:    "gpt-5.4",
+	}
+
+	record := reporter.buildRecord(buffer.detail, true, failFromErrors(context.Canceled))
+	if !record.Failed {
+		t.Fatal("expected record to be marked failed")
+	}
+	if record.Fail.StatusCode != clienterror.StatusClientClosedRequest {
+		t.Fatalf("Fail.StatusCode = %d, want %d", record.Fail.StatusCode, clienterror.StatusClientClosedRequest)
+	}
+	if record.Detail.TotalTokens != 15 {
+		t.Fatalf("Detail.TotalTokens = %d, want 15", record.Detail.TotalTokens)
+	}
+}
+
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -991,6 +991,27 @@ func TestFailFromErrorsMapsContextStatuses(t *testing.T) {
 	}
 }
 
+func TestStreamUsageBufferPublishFailure(t *testing.T) {
+	var buffer StreamUsageBuffer
+	buffer.Observe(usage.Detail{InputTokens: 10, OutputTokens: 5, TotalTokens: 15}, true)
+
+	reporter := &UsageReporter{
+		provider: "openai",
+		model:    "gpt-5.4",
+	}
+
+	record := reporter.buildRecord(buffer.detail, true, failFromErrors(context.Canceled))
+	if !record.Failed {
+		t.Fatal("expected record to be marked failed")
+	}
+	if record.Fail.StatusCode != clienterror.StatusClientClosedRequest {
+		t.Fatalf("Fail.StatusCode = %d, want %d", record.Fail.StatusCode, clienterror.StatusClientClosedRequest)
+	}
+	if record.Detail.TotalTokens != 15 {
+		t.Fatalf("Detail.TotalTokens = %d, want 15", record.Detail.TotalTokens)
+	}
+}
+
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -83,6 +83,8 @@ func (e *XAIExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Auth)
 	token, _ := xaiCreds(auth)
 	if strings.TrimSpace(token) != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
+	} else {
+		req.Header.Del("Authorization")
 	}
 	var attrs map[string]string
 	if auth != nil {

--- a/internal/runtime/executor/xai_executor.go
+++ b/internal/runtime/executor/xai_executor.go
@@ -84,6 +84,8 @@ func (e *XAIExecutor) PrepareRequest(req *http.Request, auth *cliproxyauth.Auth)
 	token, _ := xaiCreds(auth)
 	if strings.TrimSpace(token) != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
+	} else {
+		req.Header.Del("Authorization")
 	}
 	var attrs map[string]string
 	if auth != nil {

--- a/internal/runtime/executor/xai_executor_execute.go
+++ b/internal/runtime/executor/xai_executor_execute.go
@@ -94,16 +94,21 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 		if len(eventData) == 0 {
 			continue
 		}
-		switch gjson.GetBytes(eventData, "type").String() {
+		eventType := gjson.GetBytes(eventData, "type").String()
+		switch eventType {
 		case "response.output_item.done":
 			xaiCollectOutputItemDone(eventData, outputItemsByIndex, &outputItemsFallback)
-		case "response.completed":
+		case "response.completed", "response.incomplete":
 			if detail, ok := helps.ParseCodexUsage(eventData); ok {
 				reporter.Publish(ctx, detail)
 			}
 			completedData := xaiPatchCompletedOutput(eventData, outputItemsByIndex, outputItemsFallback)
 			completedData = xaiNormalizeReasoningSummaryData(completedData)
-			cacheXAIReasoningReplayFromCompleted(ctx, prepared.replayScope, completedData)
+			if eventType == "response.completed" {
+				// A truncated turn carries no replayable terminal state, so only a
+				// completed response may refresh the reasoning replay cache.
+				cacheXAIReasoningReplayFromCompleted(ctx, prepared.replayScope, completedData)
+			}
 			var param any
 			out := sdktranslator.TranslateNonStream(ctx, prepared.to, prepared.responseFormat, req.Model, prepared.originalPayload, prepared.body, completedData, &param)
 			if prepared.responseFormat == sdktranslator.FormatOpenAIResponse {
@@ -113,7 +118,7 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 		}
 	}
 
-	return resp, statusErr{code: http.StatusRequestTimeout, msg: "xai stream error: stream disconnected before response.completed"}
+	return resp, statusErr{code: http.StatusRequestTimeout, msg: "xai stream error: stream disconnected before response.completed or response.incomplete"}
 }
 
 func (e *XAIExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {

--- a/internal/runtime/executor/xai_executor_execute.go
+++ b/internal/runtime/executor/xai_executor_execute.go
@@ -95,16 +95,21 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 		if len(eventData) == 0 {
 			continue
 		}
-		switch gjson.GetBytes(eventData, "type").String() {
+		eventType := gjson.GetBytes(eventData, "type").String()
+		switch eventType {
 		case "response.output_item.done":
 			xaiCollectOutputItemDone(eventData, outputItemsByIndex, &outputItemsFallback)
-		case "response.completed":
+		case "response.completed", "response.incomplete":
 			if detail, ok := helps.ParseCodexUsage(eventData); ok {
 				reporter.Publish(ctx, detail)
 			}
 			completedData := xaiPatchCompletedOutput(eventData, outputItemsByIndex, outputItemsFallback)
 			completedData = xaiNormalizeReasoningSummaryData(completedData)
-			cacheXAIReasoningReplayFromCompleted(ctx, prepared.replayScope, completedData)
+			if eventType == "response.completed" {
+				// A truncated turn carries no replayable terminal state, so only a
+				// completed response may refresh the reasoning replay cache.
+				cacheXAIReasoningReplayFromCompleted(ctx, prepared.replayScope, completedData)
+			}
 			var param any
 			out := sdktranslator.TranslateNonStream(ctx, prepared.to, prepared.responseFormat, req.Model, prepared.originalPayload, prepared.body, completedData, &param)
 			if prepared.responseFormat == sdktranslator.FormatOpenAIResponse {
@@ -114,7 +119,7 @@ func (e *XAIExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req 
 		}
 	}
 
-	return resp, statusErr{code: http.StatusRequestTimeout, msg: "xai stream error: stream disconnected before response.completed"}
+	return resp, statusErr{code: http.StatusRequestTimeout, msg: "xai stream error: stream disconnected before response.completed or response.incomplete"}
 }
 
 func (e *XAIExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {

--- a/internal/runtime/executor/xai_executor_request.go
+++ b/internal/runtime/executor/xai_executor_request.go
@@ -285,6 +285,8 @@ func applyXAIDefaultHeaders(r *http.Request, token string, stream bool, sessionI
 	r.Header.Set("Content-Type", "application/json")
 	if strings.TrimSpace(token) != "" {
 		r.Header.Set("Authorization", "Bearer "+token)
+	} else {
+		r.Header.Del("Authorization")
 	}
 	if stream {
 		r.Header.Set("Accept", "text/event-stream")

--- a/internal/runtime/executor/xai_executor_request.go
+++ b/internal/runtime/executor/xai_executor_request.go
@@ -290,6 +290,8 @@ func applyXAIDefaultHeaders(r *http.Request, token string, stream bool, sessionI
 	r.Header.Set("Content-Type", "application/json")
 	if strings.TrimSpace(token) != "" {
 		r.Header.Set("Authorization", "Bearer "+token)
+	} else {
+		r.Header.Del("Authorization")
 	}
 	if stream {
 		r.Header.Set("Accept", "text/event-stream")

--- a/internal/runtime/executor/xai_executor_stream.go
+++ b/internal/runtime/executor/xai_executor_stream.go
@@ -121,13 +121,17 @@ func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth
 					switch normalizedEventName {
 					case "response.output_item.done":
 						xaiCollectOutputItemDone(eventData, outputItemsByIndex, &outputItemsFallback)
-					case "response.completed":
+					case "response.completed", "response.incomplete":
 						if detail, ok := helps.ParseCodexUsage(eventData); ok {
 							reporter.Publish(ctx, detail)
 						}
 						eventData = xaiPatchCompletedOutput(eventData, outputItemsByIndex, outputItemsFallback)
 						eventData = xaiNormalizeReasoningSummaryData(eventData)
-						cacheXAIReasoningReplayFromCompleted(ctx, prepared.replayScope, eventData)
+						if normalizedEventName == "response.completed" {
+							// A truncated turn carries no replayable terminal state, so only a
+							// completed response may refresh the reasoning replay cache.
+							cacheXAIReasoningReplayFromCompleted(ctx, prepared.replayScope, eventData)
+						}
 						normalizedEventName = gjson.GetBytes(eventData, "type").String()
 					}
 

--- a/internal/runtime/executor/xai_executor_stream.go
+++ b/internal/runtime/executor/xai_executor_stream.go
@@ -122,13 +122,17 @@ func (e *XAIExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth
 					switch normalizedEventName {
 					case "response.output_item.done":
 						xaiCollectOutputItemDone(eventData, outputItemsByIndex, &outputItemsFallback)
-					case "response.completed":
+					case "response.completed", "response.incomplete":
 						if detail, ok := helps.ParseCodexUsage(eventData); ok {
 							reporter.Publish(ctx, detail)
 						}
 						eventData = xaiPatchCompletedOutput(eventData, outputItemsByIndex, outputItemsFallback)
 						eventData = xaiNormalizeReasoningSummaryData(eventData)
-						cacheXAIReasoningReplayFromCompleted(ctx, prepared.replayScope, eventData)
+						if normalizedEventName == "response.completed" {
+							// A truncated turn carries no replayable terminal state, so only a
+							// completed response may refresh the reasoning replay cache.
+							cacheXAIReasoningReplayFromCompleted(ctx, prepared.replayScope, eventData)
+						}
 						normalizedEventName = gjson.GetBytes(eventData, "type").String()
 					}
 

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -656,6 +656,96 @@ func TestXAIExecutorExecuteFiltersInternalXSearchCalls(t *testing.T) {
 	}
 }
 
+func TestXAIExecutorExecuteAcceptsResponseIncomplete(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"rs_1\",\"type\":\"reasoning\",\"summary\":[]}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.incomplete\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"status\":\"incomplete\",\"incomplete_details\":{\"reason\":\"max_output_tokens\"},\"output\":[],\"usage\":{\"input_tokens\":8,\"output_tokens\":1,\"total_tokens\":9}}}\n\n"))
+	}))
+	defer server.Close()
+
+	exec := NewXAIExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider:   "xai",
+		Attributes: map[string]string{"base_url": server.URL},
+		Metadata:   map[string]any{"access_token": "xai-token"},
+	}
+	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "grok-4.5",
+		Payload: []byte(`{"model":"grok-4.5","input":"hi","max_output_tokens":1}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := gjson.GetBytes(resp.Payload, "status").String(); got != "incomplete" {
+		t.Fatalf("status = %q, want incomplete; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "incomplete_details.reason").String(); got != "max_output_tokens" {
+		t.Fatalf("incomplete reason = %q, want max_output_tokens; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "output.#").Int(); got != 1 {
+		t.Fatalf("output length = %d, want 1; payload=%s", got, resp.Payload)
+	}
+}
+
+func TestXAIExecutorExecuteStreamAcceptsResponseIncomplete(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"rs_1\",\"type\":\"reasoning\",\"summary\":[]}}\n\n")
+		_, _ = fmt.Fprint(w, "event: response.incomplete\ndata: {\"type\":\"response.incomplete\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"status\":\"incomplete\",\"incomplete_details\":{\"reason\":\"max_output_tokens\"},\"output\":[],\"usage\":{\"input_tokens\":8,\"output_tokens\":1,\"total_tokens\":9}}}\n\n")
+	}))
+	defer server.Close()
+
+	exec := NewXAIExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider:   "xai",
+		Attributes: map[string]string{"base_url": server.URL},
+		Metadata:   map[string]any{"access_token": "xai-token"},
+	}
+	result, err := exec.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "grok-4.5",
+		Payload: []byte(`{"model":"grok-4.5","input":"hi","max_output_tokens":1}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+
+	var stream bytes.Buffer
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v", chunk.Err)
+		}
+		stream.Write(chunk.Payload)
+		stream.WriteByte('\n')
+	}
+
+	var incomplete gjson.Result
+	for _, line := range strings.Split(stream.String(), "\n") {
+		line = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if !gjson.Valid(line) {
+			continue
+		}
+		if event := gjson.Parse(line); event.Get("type").String() == "response.incomplete" {
+			incomplete = event
+		}
+	}
+	if !incomplete.Exists() {
+		t.Fatalf("no response.incomplete chunk forwarded: %s", stream.String())
+	}
+	if got := incomplete.Get("response.output.#").Int(); got != 1 {
+		t.Fatalf("incomplete output length = %d, want 1; event=%s", got, incomplete.Raw)
+	}
+	if got := incomplete.Get("response.usage.total_tokens").Int(); got != 9 {
+		t.Fatalf("incomplete usage total_tokens = %d, want 9; event=%s", got, incomplete.Raw)
+	}
+}
+
 func TestXAIExecutorPrepareHonorsInjectXSearchConfig(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -3843,6 +3843,47 @@ func TestXAIExecutorComposerReusesClaudeCodeSession(t *testing.T) {
 	}
 }
 
+func TestApplyXAIHeaders_EmptyAPIKey_OmitsAuthorization(t *testing.T) {
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/v1/chat/completions", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer preexisting-bearer")
+	auth := &cliproxyauth.Auth{
+		Provider: "xai",
+		Attributes: map[string]string{
+			"auth_kind":           "apikey",
+			"base_url":            "https://custom-xai.example.com",
+			"header:Custom-Token": "xai-custom",
+		},
+	}
+	applyXAIHeaders(req, auth, "", false, "session-123")
+
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization = %q, want empty for empty API key", got)
+	}
+	if got := req.Header.Get("x-grok-conv-id"); got != "session-123" {
+		t.Fatalf("x-grok-conv-id = %q, want session-123", got)
+	}
+	if got := req.Header.Get("Custom-Token"); got != "xai-custom" {
+		t.Fatalf("Custom-Token = %q, want xai-custom", got)
+	}
+
+	// Also verify PrepareRequest
+	req2, _ := http.NewRequest(http.MethodPost, "https://example.com/v1/chat/completions", nil)
+	req2.Header.Set("Authorization", "Bearer preexisting-bearer")
+	exec := &XAIExecutor{}
+	if errPrep := exec.PrepareRequest(req2, auth); errPrep != nil {
+		t.Fatalf("PrepareRequest() error = %v", errPrep)
+	}
+	if got := req2.Header.Get("Authorization"); got != "" {
+		t.Fatalf("PrepareRequest Authorization = %q, want empty", got)
+	}
+	if got := req2.Header.Get("Custom-Token"); got != "xai-custom" {
+		t.Fatalf("PrepareRequest Custom-Token = %q, want xai-custom", got)
+	}
+}
+
 func TestSanitizeXAIInputEncryptedContent_DropsInvalidReasoningBlob(t *testing.T) {
 	body := []byte(`{"model":"grok-4.3","input":[{"type":"reasoning","summary":[],"encrypted_content":"bad"},{"type":"reasoning","summary":[],"encrypted_content":"gAAAAABinvalid-gpt-shape"},{"role":"user","content":"hi"}]}`)
 	got := sanitizeXAIInputEncryptedContent(body)

--- a/internal/runtime/executor/xai_executor_test.go
+++ b/internal/runtime/executor/xai_executor_test.go
@@ -933,6 +933,96 @@ func TestXAIExecutorExecuteFiltersInternalXSearchCalls(t *testing.T) {
 	}
 }
 
+func TestXAIExecutorExecuteAcceptsResponseIncomplete(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"rs_1\",\"type\":\"reasoning\",\"summary\":[]}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"type\":\"response.incomplete\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"status\":\"incomplete\",\"incomplete_details\":{\"reason\":\"max_output_tokens\"},\"output\":[],\"usage\":{\"input_tokens\":8,\"output_tokens\":1,\"total_tokens\":9}}}\n\n"))
+	}))
+	defer server.Close()
+
+	exec := NewXAIExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider:   "xai",
+		Attributes: map[string]string{"base_url": server.URL},
+		Metadata:   map[string]any{"access_token": "xai-token"},
+	}
+	resp, err := exec.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "grok-4.5",
+		Payload: []byte(`{"model":"grok-4.5","input":"hi","max_output_tokens":1}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Stream:       false,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := gjson.GetBytes(resp.Payload, "status").String(); got != "incomplete" {
+		t.Fatalf("status = %q, want incomplete; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "incomplete_details.reason").String(); got != "max_output_tokens" {
+		t.Fatalf("incomplete reason = %q, want max_output_tokens; payload=%s", got, resp.Payload)
+	}
+	if got := gjson.GetBytes(resp.Payload, "output.#").Int(); got != 1 {
+		t.Fatalf("output length = %d, want 1; payload=%s", got, resp.Payload)
+	}
+}
+
+func TestXAIExecutorExecuteStreamAcceptsResponseIncomplete(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"rs_1\",\"type\":\"reasoning\",\"summary\":[]}}\n\n")
+		_, _ = fmt.Fprint(w, "event: response.incomplete\ndata: {\"type\":\"response.incomplete\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"status\":\"incomplete\",\"incomplete_details\":{\"reason\":\"max_output_tokens\"},\"output\":[],\"usage\":{\"input_tokens\":8,\"output_tokens\":1,\"total_tokens\":9}}}\n\n")
+	}))
+	defer server.Close()
+
+	exec := NewXAIExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Provider:   "xai",
+		Attributes: map[string]string{"base_url": server.URL},
+		Metadata:   map[string]any{"access_token": "xai-token"},
+	}
+	result, err := exec.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "grok-4.5",
+		Payload: []byte(`{"model":"grok-4.5","input":"hi","max_output_tokens":1}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+
+	var stream bytes.Buffer
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v", chunk.Err)
+		}
+		stream.Write(chunk.Payload)
+		stream.WriteByte('\n')
+	}
+
+	var incomplete gjson.Result
+	for _, line := range strings.Split(stream.String(), "\n") {
+		line = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if !gjson.Valid(line) {
+			continue
+		}
+		if event := gjson.Parse(line); event.Get("type").String() == "response.incomplete" {
+			incomplete = event
+		}
+	}
+	if !incomplete.Exists() {
+		t.Fatalf("no response.incomplete chunk forwarded: %s", stream.String())
+	}
+	if got := incomplete.Get("response.output.#").Int(); got != 1 {
+		t.Fatalf("incomplete output length = %d, want 1; event=%s", got, incomplete.Raw)
+	}
+	if got := incomplete.Get("response.usage.total_tokens").Int(); got != 9 {
+		t.Fatalf("incomplete usage total_tokens = %d, want 9; event=%s", got, incomplete.Raw)
+	}
+}
+
 func TestXAIExecutorPrepareHonorsInjectXSearchConfig(t *testing.T) {
 	t.Parallel()
 
@@ -4117,6 +4207,47 @@ func TestXAIExecutorComposerReusesClaudeCodeSession(t *testing.T) {
 	applyXAIHeaders(httpReq, auth, "xai-token", true, first.sessionID)
 	if got := httpReq.Header.Get("x-grok-conv-id"); got != firstKey {
 		t.Fatalf("x-grok-conv-id = %q, want %q", got, firstKey)
+	}
+}
+
+func TestApplyXAIHeaders_EmptyAPIKey_OmitsAuthorization(t *testing.T) {
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/v1/chat/completions", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer preexisting-bearer")
+	auth := &cliproxyauth.Auth{
+		Provider: "xai",
+		Attributes: map[string]string{
+			"auth_kind":           "apikey",
+			"base_url":            "https://custom-xai.example.com",
+			"header:Custom-Token": "xai-custom",
+		},
+	}
+	applyXAIHeaders(req, auth, "", false, "session-123")
+
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Fatalf("Authorization = %q, want empty for empty API key", got)
+	}
+	if got := req.Header.Get("x-grok-conv-id"); got != "session-123" {
+		t.Fatalf("x-grok-conv-id = %q, want session-123", got)
+	}
+	if got := req.Header.Get("Custom-Token"); got != "xai-custom" {
+		t.Fatalf("Custom-Token = %q, want xai-custom", got)
+	}
+
+	// Also verify PrepareRequest
+	req2, _ := http.NewRequest(http.MethodPost, "https://example.com/v1/chat/completions", nil)
+	req2.Header.Set("Authorization", "Bearer preexisting-bearer")
+	exec := &XAIExecutor{}
+	if errPrep := exec.PrepareRequest(req2, auth); errPrep != nil {
+		t.Fatalf("PrepareRequest() error = %v", errPrep)
+	}
+	if got := req2.Header.Get("Authorization"); got != "" {
+		t.Fatalf("PrepareRequest Authorization = %q, want empty", got)
+	}
+	if got := req2.Header.Get("Custom-Token"); got != "xai-custom" {
+		t.Fatalf("PrepareRequest Custom-Token = %q, want xai-custom", got)
 	}
 }
 

--- a/internal/runtime/executor/xai_websockets_executor.go
+++ b/internal/runtime/executor/xai_websockets_executor.go
@@ -1449,6 +1449,8 @@ func applyXAIWebsocketHeaders(headers http.Header, auth *cliproxyauth.Auth, toke
 	headers.Set("Content-Type", "application/json")
 	if strings.TrimSpace(token) != "" {
 		headers.Set("Authorization", "Bearer "+token)
+	} else {
+		headers.Del("Authorization")
 	}
 	if sessionID != "" {
 		headers.Set("x-grok-conv-id", sessionID)

--- a/internal/runtime/executor/xai_websockets_executor.go
+++ b/internal/runtime/executor/xai_websockets_executor.go
@@ -1453,6 +1453,8 @@ func applyXAIWebsocketHeaders(headers http.Header, auth *cliproxyauth.Auth, toke
 	headers.Set("Content-Type", "application/json")
 	if strings.TrimSpace(token) != "" {
 		headers.Set("Authorization", "Bearer "+token)
+	} else {
+		headers.Del("Authorization")
 	}
 	if sessionID != "" {
 		headers.Set("x-grok-conv-id", sessionID)

--- a/internal/translator/antigravity/gemini/antigravity_gemini_request.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request.go
@@ -639,6 +639,74 @@ type FunctionCallGroup struct {
 	CallNames       []string // ordered function call names for backfilling empty response names
 }
 
+func normalizeAntigravityInlineDataPart(part gjson.Result) ([]byte, bool) {
+	inline := part.Get("inlineData")
+	if !inline.Exists() {
+		inline = part.Get("inline_data")
+	}
+	if !inline.Exists() {
+		return nil, false
+	}
+	data := inline.Get("data").String()
+	if data == "" {
+		return nil, false
+	}
+	mimeType := inline.Get("mimeType").String()
+	if mimeType == "" {
+		mimeType = inline.Get("mime_type").String()
+	}
+	if mimeType == "" {
+		// Cloud Code Assist ignores inlineData without mimeType.
+		mimeType = "image/png"
+	}
+	out := []byte(`{"inlineData":{"mimeType":"","data":""}}`)
+	out, _ = sjson.SetBytes(out, "inlineData.mimeType", mimeType)
+	out, _ = sjson.SetBytes(out, "inlineData.data", data)
+	return out, true
+}
+
+func attachInlineDataToFunctionResponse(response gjson.Result, images [][]byte) gjson.Result {
+	if len(images) == 0 {
+		return response
+	}
+	target := []byte(response.Raw)
+	for _, img := range images {
+		target, _ = sjson.SetRawBytes(target, "functionResponse.parts.-1", img)
+	}
+	return gjson.ParseBytes(target)
+}
+
+// collectFunctionResponsesWithSiblingInlineData keeps functionResponse parts and
+// moves sibling inline_data/inlineData onto the nearest preceding functionResponse.
+// Leading images before the first functionResponse attach to that first response.
+func collectFunctionResponsesWithSiblingInlineData(parts gjson.Result) []gjson.Result {
+	responses := make([]gjson.Result, 0)
+	leadingImages := make([][]byte, 0)
+	current := -1
+	parts.ForEach(func(_, part gjson.Result) bool {
+		if part.Get("functionResponse").Exists() {
+			responses = append(responses, part)
+			current = len(responses) - 1
+			if len(leadingImages) > 0 {
+				responses[current] = attachInlineDataToFunctionResponse(responses[current], leadingImages)
+				leadingImages = nil
+			}
+			return true
+		}
+		imagePart, ok := normalizeAntigravityInlineDataPart(part)
+		if !ok {
+			return true
+		}
+		if current >= 0 {
+			responses[current] = attachInlineDataToFunctionResponse(responses[current], [][]byte{imagePart})
+			return true
+		}
+		leadingImages = append(leadingImages, imagePart)
+		return true
+	})
+	return responses
+}
+
 // parseFunctionResponseRaw attempts to normalize a function response part into a JSON object string.
 // Falls back to a minimal "functionResponse" object when parsing fails.
 // fallbackName is used when the response's own name is empty.
@@ -749,14 +817,8 @@ func fixCLIToolResponse(input []byte) ([]byte, error) {
 		role := value.Get("role").String()
 		parts := value.Get("parts")
 
-		// Check if this content has function responses
-		var responsePartsInThisContent []gjson.Result
-		parts.ForEach(func(_, part gjson.Result) bool {
-			if part.Get("functionResponse").Exists() {
-				responsePartsInThisContent = append(responsePartsInThisContent, part)
-			}
-			return true
-		})
+		// Collect function responses and attach sibling inlineData to the nearest one.
+		responsePartsInThisContent := collectFunctionResponsesWithSiblingInlineData(parts)
 
 		// If this content has function responses, collect them
 		if len(responsePartsInThisContent) > 0 {

--- a/internal/translator/antigravity/gemini/antigravity_gemini_request_test.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request_test.go
@@ -954,3 +954,190 @@ func TestSanitizeAntigravityClaudeGeminiRequestSignatures_LargeNumberDoesNotHalt
 		t.Fatalf("expected hidden thoughtSignature to be stripped despite large number, got %s", fcSig.Raw)
 	}
 }
+
+func TestFixCLIToolResponse_AttachesSiblingInlineDataToNearestFunctionResponse(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts string
+		want  []struct {
+			id   string
+			mime string
+			data string
+		}
+	}{
+		{
+			name: "snake_case sibling after single response",
+			parts: `{"functionResponse":{"name":"read","response":{"result":"Read image file [image/png]"},"id":"call_1"}},` +
+				`{"inline_data":{"mime_type":"image/png","data":"QUJD"}}`,
+			want: []struct {
+				id   string
+				mime string
+				data string
+			}{{id: "call_1", mime: "image/png", data: "QUJD"}},
+		},
+		{
+			name: "camelCase sibling after single response",
+			parts: `{"functionResponse":{"name":"read","response":{"result":"ok"},"id":"call_1"}},` +
+				`{"inlineData":{"mimeType":"image/webp","data":"NEW"}}`,
+			want: []struct {
+				id   string
+				mime string
+				data string
+			}{{id: "call_1", mime: "image/webp", data: "NEW"}},
+		},
+		{
+			name: "append sibling onto existing functionResponse.parts",
+			parts: `{"functionResponse":{"name":"read","response":{"result":"ok"},"id":"call_1","parts":[{"inlineData":{"mimeType":"image/gif","data":"OLD"}}]}},` +
+				`{"inlineData":{"mimeType":"image/webp","data":"NEW"}}`,
+			want: []struct {
+				id   string
+				mime string
+				data string
+			}{
+				{id: "call_1", mime: "image/gif", data: "OLD"},
+			},
+		},
+		{
+			name: "interleaved siblings attach to nearest response",
+			parts: `{"functionResponse":{"name":"read","response":{"result":"A"},"id":"call_a"}},` +
+				`{"inline_data":{"mime_type":"image/png","data":"AAA"}},` +
+				`{"functionResponse":{"name":"read","response":{"result":"B"},"id":"call_b"}},` +
+				`{"inline_data":{"mime_type":"image/jpeg","data":"BBB"}}`,
+			want: []struct {
+				id   string
+				mime string
+				data string
+			}{
+				{id: "call_a", mime: "image/png", data: "AAA"},
+				{id: "call_b", mime: "image/jpeg", data: "BBB"},
+			},
+		},
+		{
+			name: "leading sibling attaches to first response",
+			parts: `{"inline_data":{"mime_type":"image/png","data":"LEAD"}},` +
+				`{"functionResponse":{"name":"read","response":{"result":"A"},"id":"call_a"}},` +
+				`{"functionResponse":{"name":"read","response":{"result":"B"},"id":"call_b"}}`,
+			want: []struct {
+				id   string
+				mime string
+				data string
+			}{
+				{id: "call_a", mime: "image/png", data: "LEAD"},
+			},
+		},
+		{
+			name: "missing mimeType defaults to image/png",
+			parts: `{"functionResponse":{"name":"read","response":{"result":"ok"},"id":"call_1"}},` +
+				`{"inlineData":{"data":"QUJD"}}`,
+			want: []struct {
+				id   string
+				mime string
+				data string
+			}{{id: "call_1", mime: "image/png", data: "QUJD"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			modelParts := `{"functionCall":{"name":"read","id":"call_1"}}`
+			if tt.name == "interleaved siblings attach to nearest response" || tt.name == "leading sibling attaches to first response" {
+				modelParts = `{"functionCall":{"name":"read","id":"call_a"}},{"functionCall":{"name":"read","id":"call_b"}}`
+			}
+			input := `{"request":{"contents":[` +
+				`{"role":"model","parts":[` + modelParts + `]},` +
+				`{"role":"user","parts":[` + tt.parts + `]}` +
+				`]}}`
+			result, err := fixCLIToolResponse([]byte(input))
+			if err != nil {
+				t.Fatalf("fixCLIToolResponse failed: %v", err)
+			}
+			contents := gjson.GetBytes(result, "request.contents").Array()
+			if len(contents) != 2 {
+				t.Fatalf("contents = %d, want 2. Output: %s", len(contents), result)
+			}
+			funcParts := contents[1].Get("parts").Array()
+			gotByID := map[string][]gjson.Result{}
+			for _, part := range funcParts {
+				fr := part.Get("functionResponse")
+				gotByID[fr.Get("id").String()] = fr.Get("parts").Array()
+			}
+			for _, want := range tt.want {
+				images := gotByID[want.id]
+				found := false
+				for _, img := range images {
+					if img.Get("inlineData.data").String() == want.data && img.Get("inlineData.mimeType").String() == want.mime {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("id=%s missing inlineData mime=%s data=%s. Output: %s", want.id, want.mime, want.data, result)
+				}
+			}
+			if tt.name == "interleaved siblings attach to nearest response" {
+				if len(gotByID["call_a"]) != 1 || len(gotByID["call_b"]) != 1 {
+					t.Fatalf("nearest attribution failed: A=%d B=%d. Output: %s", len(gotByID["call_a"]), len(gotByID["call_b"]), result)
+				}
+			}
+			if tt.name == "leading sibling attaches to first response" {
+				if len(gotByID["call_b"]) != 0 {
+					t.Fatalf("leading image leaked onto call_b. Output: %s", result)
+				}
+			}
+			if tt.name == "append sibling onto existing functionResponse.parts" {
+				images := gotByID["call_1"]
+				if len(images) != 2 {
+					t.Fatalf("existing+sibling parts = %d, want 2. Output: %s", len(images), result)
+				}
+				if images[1].Get("inlineData.data").String() != "NEW" {
+					t.Fatalf("appended sibling data = %q, want NEW. Output: %s", images[1].Get("inlineData.data").String(), result)
+				}
+			}
+		})
+	}
+}
+
+func TestConvertGeminiRequestToAntigravity_PreservesSiblingToolImageOnUserRole(t *testing.T) {
+	input := []byte(`{
+		"contents": [
+			{"role":"user","parts":[{"text":"read file"}]},
+			{"role":"model","parts":[{"functionCall":{"name":"read","args":{},"id":"call_1"}}]},
+			{"role":"user","parts":[
+				{"functionResponse":{"name":"read","response":{"result":"Read image file [image/png]"},"id":"call_1"}},
+				{"inline_data":{"mime_type":"image/png","data":"QUJD"}}
+			]}
+		]
+	}`)
+	out := ConvertGeminiRequestToAntigravity("gemini-3-flash", input, false)
+	contents := gjson.GetBytes(out, "request.contents").Array()
+	if len(contents) != 3 {
+		t.Fatalf("contents = %d, want 3. Output: %s", len(contents), out)
+	}
+	funcContent := contents[2]
+	if got := funcContent.Get("role").String(); got != "user" {
+		t.Fatalf("role = %q, want user after Antigravity normalization. Output: %s", got, out)
+	}
+	funcResp := funcContent.Get("parts.0.functionResponse")
+	if !funcResp.Exists() {
+		t.Fatalf("functionResponse missing. Output: %s", out)
+	}
+	if got := funcResp.Get("id").String(); got != "call_1" {
+		t.Fatalf("id = %q, want call_1", got)
+	}
+	if got := funcResp.Get("response.result").String(); got != "Read image file [image/png]" {
+		t.Fatalf("result = %q", got)
+	}
+	inlineData := funcResp.Get("parts.0.inlineData")
+	if !inlineData.Exists() {
+		t.Fatalf("functionResponse.parts.0.inlineData missing. Output: %s", out)
+	}
+	if got := inlineData.Get("mimeType").String(); got != "image/png" {
+		t.Fatalf("mimeType = %q, want image/png", got)
+	}
+	if got := inlineData.Get("data").String(); got != "QUJD" {
+		t.Fatalf("data = %q, want QUJD", got)
+	}
+	if funcContent.Get("parts.1.inline_data").Exists() || funcContent.Get("parts.1.inlineData").Exists() {
+		t.Fatalf("sibling inline data should be absorbed into functionResponse.parts. Output: %s", out)
+	}
+}

--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request.go
@@ -59,7 +59,7 @@ func ConvertOpenAIRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 	}
 	out = applyOpenAIThinkingCompatibilityToAntigravity(out, rawJSON)
 
-	// Temperature/top_p/top_k/max_tokens
+	// Temperature/top_p/top_k/max_tokens/max_completion_tokens
 	if tr := gjson.GetBytes(rawJSON, "temperature"); tr.Exists() && tr.Type == gjson.Number {
 		out, _ = sjson.SetBytes(out, "request.generationConfig.temperature", tr.Num)
 	}
@@ -71,6 +71,8 @@ func ConvertOpenAIRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 	}
 	if maxTok := gjson.GetBytes(rawJSON, "max_tokens"); maxTok.Exists() && maxTok.Type == gjson.Number {
 		out, _ = sjson.SetBytes(out, "request.generationConfig.maxOutputTokens", maxTok.Num)
+	} else if mct := gjson.GetBytes(rawJSON, "max_completion_tokens"); mct.Exists() && mct.Type == gjson.Number {
+		out, _ = sjson.SetBytes(out, "request.generationConfig.maxOutputTokens", mct.Num)
 	}
 
 	// Map OpenAI response_format to Antigravity structured output settings.

--- a/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request_test.go
+++ b/internal/translator/antigravity/openai/chat-completions/antigravity_openai_request_test.go
@@ -455,3 +455,40 @@ func TestConvertOpenAIRequestToAntigravityTranslatesVideoURL(t *testing.T) {
 		t.Fatalf("inlineData.data = %q, want AAAAIGZ0eXBtcDQy. Output: %s", got, out)
 	}
 }
+
+func TestConvertOpenAIRequestToAntigravity_MaxCompletionTokens(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		expected float64
+	}{
+		{
+			name:     "only max_tokens",
+			body:     `{"model":"gemini-2.5-flash","messages":[{"role":"user","content":"hi"}],"max_tokens":100}`,
+			expected: 100,
+		},
+		{
+			name:     "only max_completion_tokens",
+			body:     `{"model":"gemini-2.5-flash","messages":[{"role":"user","content":"hi"}],"max_completion_tokens":200}`,
+			expected: 200,
+		},
+		{
+			name:     "max_tokens preferred over max_completion_tokens",
+			body:     `{"model":"gemini-2.5-flash","messages":[{"role":"user","content":"hi"}],"max_tokens":100,"max_completion_tokens":200}`,
+			expected: 100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := ConvertOpenAIRequestToAntigravity("gemini-2.5-flash", []byte(tt.body), false)
+			got := gjson.GetBytes(out, "request.generationConfig.maxOutputTokens")
+			if !got.Exists() {
+				t.Fatalf("request.generationConfig.maxOutputTokens missing. Output: %s", out)
+			}
+			if got.Float() != tt.expected {
+				t.Fatalf("maxOutputTokens = %v, want %v. Output: %s", got.Float(), tt.expected, out)
+			}
+		})
+	}
+}

--- a/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request_test.go
+++ b/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request_test.go
@@ -265,3 +265,139 @@ func TestConvertOpenAIResponsesRequestToAntigravity_GeminiReasoningUsesNativeTho
 		t.Fatalf("parts[0].thoughtSignature = %q, want preserved Gemini signature. Output: %s", got, out)
 	}
 }
+
+func TestConvertOpenAIResponsesRequestToAntigravity_PreservesToolResultImage(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3-flash",
+		"input": [
+			{"role": "user", "content": [{"type": "input_text", "text": "请帮我读取分析这张图片"}]},
+			{"type": "function_call", "id": "fc_read", "call_id": "call_read_1", "name": "read", "arguments": "{\"path\":\"/path/to/image.png\"}"},
+			{
+				"type": "function_call_output",
+				"call_id": "call_read_1",
+				"output": [
+					{"type": "input_text", "text": "Read image file [image/png]"},
+					{"type": "input_image", "detail": "auto", "image_url": "data:image/png;base64,QUJD"}
+				]
+			}
+		]
+	}`
+	out := ConvertOpenAIResponsesRequestToAntigravity("gemini-3-flash", []byte(inputJSON), false)
+	contents := gjson.GetBytes(out, "request.contents").Array()
+	if len(contents) != 3 {
+		t.Fatalf("expected 3 contents, got %d. Output: %s", len(contents), out)
+	}
+	funcContent := contents[2]
+	if got := funcContent.Get("role").String(); got != "user" {
+		t.Fatalf("role = %q, want user. Output: %s", got, out)
+	}
+	funcResp := funcContent.Get("parts.0.functionResponse")
+	if !funcResp.Exists() {
+		t.Fatalf("functionResponse should exist. Output: %s", out)
+	}
+	if got := funcResp.Get("id").String(); got != "call_read_1" {
+		t.Fatalf("id = %q, want call_read_1", got)
+	}
+	if got := funcResp.Get("name").String(); got != "read" {
+		t.Fatalf("name = %q, want read", got)
+	}
+	inlineData := funcResp.Get("parts.0.inlineData")
+	if !inlineData.Exists() {
+		t.Fatalf("expected functionResponse.parts.0.inlineData to exist, got: %s", out)
+	}
+	if got := inlineData.Get("mimeType").String(); got != "image/png" {
+		t.Errorf("expected mimeType image/png, got %q", got)
+	}
+	if got := inlineData.Get("data").String(); got != "QUJD" {
+		t.Errorf("expected data QUJD, got %q", got)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToAntigravity_AttachesParallelToolImagesToNearestResponse(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3-flash",
+		"input": [
+			{"role": "user", "content": [{"type": "input_text", "text": "read both"}]},
+			{"type": "function_call", "id": "fc_a", "call_id": "call_a", "name": "read", "arguments": "{\"path\":\"/tmp/a.png\"}"},
+			{"type": "function_call", "id": "fc_b", "call_id": "call_b", "name": "read", "arguments": "{\"path\":\"/tmp/b.png\"}"},
+			{
+				"type": "function_call_output",
+				"call_id": "call_a",
+				"output": [
+					{"type": "input_text", "text": "file A"},
+					{"type": "input_image", "image_url": "data:image/png;base64,AAA"}
+				]
+			},
+			{
+				"type": "function_call_output",
+				"call_id": "call_b",
+				"output": [
+					{"type": "input_text", "text": "file B"},
+					{"type": "input_image", "image_url": "data:image/jpeg;base64,BBB"}
+				]
+			}
+		]
+	}`
+	out := ConvertOpenAIResponsesRequestToAntigravity("gemini-3-flash", []byte(inputJSON), false)
+	parts := gjson.GetBytes(out, "request.contents.2.parts").Array()
+	if len(parts) != 2 {
+		t.Fatalf("function parts = %d, want 2. Output: %s", len(parts), out)
+	}
+	got := map[string]string{}
+	for _, part := range parts {
+		fr := part.Get("functionResponse")
+		got[fr.Get("id").String()] = fr.Get("parts.0.inlineData.data").String()
+	}
+	if got["call_a"] != "AAA" {
+		t.Fatalf("call_a image = %q, want AAA. Output: %s", got["call_a"], out)
+	}
+	if got["call_b"] != "BBB" {
+		t.Fatalf("call_b image = %q, want BBB. Output: %s", got["call_b"], out)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToAntigravity_PreservesAdditionalToolsAndToolConfig(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3-flash",
+		"input": [
+			{
+				"type": "additional_tools",
+				"tools": [
+					{
+						"type": "namespace",
+						"name": "functions",
+						"tools": [
+							{"type": "custom", "name": "exec", "description": "Execute a command"},
+							{"type": "function", "name": "continuity_probe", "description": "Probe", "parameters": {"type": "object", "properties": {"value": {"type": "string"}}, "required": ["value"]}}
+						]
+					}
+				]
+			},
+			{"role": "user", "content": [{"type": "input_text", "text": "test"}]}
+		],
+		"tool_choice": {
+			"type": "function",
+			"name": "continuity_probe",
+			"namespace": "functions"
+		}
+	}`
+
+	out := ConvertOpenAIResponsesRequestToAntigravity("gemini-3-flash", []byte(inputJSON), false)
+	if !gjson.ValidBytes(out) {
+		t.Fatalf("invalid JSON output: %s", out)
+	}
+
+	decls := gjson.GetBytes(out, "request.tools.0.functionDeclarations").Array()
+	if len(decls) != 2 {
+		t.Fatalf("expected 2 functionDeclarations in request.tools, got %d; raw: %s", len(decls), out)
+	}
+
+	mode := gjson.GetBytes(out, "request.toolConfig.functionCallingConfig.mode").String()
+	if mode != "ANY" {
+		t.Fatalf("mode = %q, want ANY", mode)
+	}
+	allowed := gjson.GetBytes(out, "request.toolConfig.functionCallingConfig.allowedFunctionNames.0").String()
+	if allowed != "functions__continuity_probe" {
+		t.Fatalf("allowedFunctionNames.0 = %q, want functions__continuity_probe", allowed)
+	}
+}

--- a/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request_test.go
+++ b/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request_test.go
@@ -265,3 +265,93 @@ func TestConvertOpenAIResponsesRequestToAntigravity_GeminiReasoningUsesNativeTho
 		t.Fatalf("parts[0].thoughtSignature = %q, want preserved Gemini signature. Output: %s", got, out)
 	}
 }
+
+func TestConvertOpenAIResponsesRequestToAntigravity_PreservesToolResultImage(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3-flash",
+		"input": [
+			{"role": "user", "content": [{"type": "input_text", "text": "请帮我读取分析这张图片"}]},
+			{"type": "function_call", "id": "fc_read", "call_id": "call_read_1", "name": "read", "arguments": "{\"path\":\"/path/to/image.png\"}"},
+			{
+				"type": "function_call_output",
+				"call_id": "call_read_1",
+				"output": [
+					{"type": "input_text", "text": "Read image file [image/png]"},
+					{"type": "input_image", "detail": "auto", "image_url": "data:image/png;base64,QUJD"}
+				]
+			}
+		]
+	}`
+	out := ConvertOpenAIResponsesRequestToAntigravity("gemini-3-flash", []byte(inputJSON), false)
+	contents := gjson.GetBytes(out, "request.contents").Array()
+	if len(contents) != 3 {
+		t.Fatalf("expected 3 contents, got %d. Output: %s", len(contents), out)
+	}
+	funcContent := contents[2]
+	if got := funcContent.Get("role").String(); got != "user" {
+		t.Fatalf("role = %q, want user. Output: %s", got, out)
+	}
+	funcResp := funcContent.Get("parts.0.functionResponse")
+	if !funcResp.Exists() {
+		t.Fatalf("functionResponse should exist. Output: %s", out)
+	}
+	if got := funcResp.Get("id").String(); got != "call_read_1" {
+		t.Fatalf("id = %q, want call_read_1", got)
+	}
+	if got := funcResp.Get("name").String(); got != "read" {
+		t.Fatalf("name = %q, want read", got)
+	}
+	inlineData := funcResp.Get("parts.0.inlineData")
+	if !inlineData.Exists() {
+		t.Fatalf("expected functionResponse.parts.0.inlineData to exist, got: %s", out)
+	}
+	if got := inlineData.Get("mimeType").String(); got != "image/png" {
+		t.Errorf("expected mimeType image/png, got %q", got)
+	}
+	if got := inlineData.Get("data").String(); got != "QUJD" {
+		t.Errorf("expected data QUJD, got %q", got)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToAntigravity_AttachesParallelToolImagesToNearestResponse(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3-flash",
+		"input": [
+			{"role": "user", "content": [{"type": "input_text", "text": "read both"}]},
+			{"type": "function_call", "id": "fc_a", "call_id": "call_a", "name": "read", "arguments": "{\"path\":\"/tmp/a.png\"}"},
+			{"type": "function_call", "id": "fc_b", "call_id": "call_b", "name": "read", "arguments": "{\"path\":\"/tmp/b.png\"}"},
+			{
+				"type": "function_call_output",
+				"call_id": "call_a",
+				"output": [
+					{"type": "input_text", "text": "file A"},
+					{"type": "input_image", "image_url": "data:image/png;base64,AAA"}
+				]
+			},
+			{
+				"type": "function_call_output",
+				"call_id": "call_b",
+				"output": [
+					{"type": "input_text", "text": "file B"},
+					{"type": "input_image", "image_url": "data:image/jpeg;base64,BBB"}
+				]
+			}
+		]
+	}`
+	out := ConvertOpenAIResponsesRequestToAntigravity("gemini-3-flash", []byte(inputJSON), false)
+	parts := gjson.GetBytes(out, "request.contents.2.parts").Array()
+	if len(parts) != 2 {
+		t.Fatalf("function parts = %d, want 2. Output: %s", len(parts), out)
+	}
+	got := map[string]string{}
+	for _, part := range parts {
+		fr := part.Get("functionResponse")
+		got[fr.Get("id").String()] = fr.Get("parts.0.inlineData.data").String()
+	}
+	if got["call_a"] != "AAA" {
+		t.Fatalf("call_a image = %q, want AAA. Output: %s", got["call_a"], out)
+	}
+	if got["call_b"] != "BBB" {
+		t.Fatalf("call_b image = %q, want BBB. Output: %s", got["call_b"], out)
+	}
+}

--- a/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request_test.go
+++ b/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request_test.go
@@ -355,3 +355,49 @@ func TestConvertOpenAIResponsesRequestToAntigravity_AttachesParallelToolImagesTo
 		t.Fatalf("call_b image = %q, want BBB. Output: %s", got["call_b"], out)
 	}
 }
+
+func TestConvertOpenAIResponsesRequestToAntigravity_PreservesAdditionalToolsAndToolConfig(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3-flash",
+		"input": [
+			{
+				"type": "additional_tools",
+				"tools": [
+					{
+						"type": "namespace",
+						"name": "functions",
+						"tools": [
+							{"type": "custom", "name": "exec", "description": "Execute a command"},
+							{"type": "function", "name": "continuity_probe", "description": "Probe", "parameters": {"type": "object", "properties": {"value": {"type": "string"}}, "required": ["value"]}}
+						]
+					}
+				]
+			},
+			{"role": "user", "content": [{"type": "input_text", "text": "test"}]}
+		],
+		"tool_choice": {
+			"type": "function",
+			"name": "continuity_probe",
+			"namespace": "functions"
+		}
+	}`
+
+	out := ConvertOpenAIResponsesRequestToAntigravity("gemini-3-flash", []byte(inputJSON), false)
+	if !gjson.ValidBytes(out) {
+		t.Fatalf("invalid JSON output: %s", out)
+	}
+
+	decls := gjson.GetBytes(out, "request.tools.0.functionDeclarations").Array()
+	if len(decls) != 2 {
+		t.Fatalf("expected 2 functionDeclarations in request.tools, got %d; raw: %s", len(decls), out)
+	}
+
+	mode := gjson.GetBytes(out, "request.toolConfig.functionCallingConfig.mode").String()
+	if mode != "ANY" {
+		t.Fatalf("mode = %q, want ANY", mode)
+	}
+	allowed := gjson.GetBytes(out, "request.toolConfig.functionCallingConfig.allowedFunctionNames.0").String()
+	if allowed != "functions__continuity_probe" {
+		t.Fatalf("allowedFunctionNames.0 = %q, want functions__continuity_probe", allowed)
+	}
+}

--- a/internal/translator/antigravity/openai/responses/antigravity_openai-responses_response_test.go
+++ b/internal/translator/antigravity/openai/responses/antigravity_openai-responses_response_test.go
@@ -85,3 +85,58 @@ func TestConvertAntigravityResponseToOpenAIResponsesNonStream_PreservesOpenAIToo
 		t.Fatalf("output.0.arguments = %q, want JSON arguments with city Tokyo; output=%s", arguments, output)
 	}
 }
+
+func TestConvertAntigravityResponseToOpenAIResponses_RestoresAdditionalNamespaceCustomToolCall(t *testing.T) {
+	originalRequest := []byte(`{
+		"model": "gemini-3.5-flash-low",
+		"input": [{
+			"type": "additional_tools",
+			"tools": [{
+				"type": "namespace",
+				"name": "functions",
+				"tools": [{"type": "custom", "name": "exec"}]
+			}]
+		}]
+	}`)
+	rawResponse := []byte(`{
+		"response": {
+			"responseId": "antigravity-custom-response",
+			"candidates": [{
+				"content": {
+					"parts": [{
+						"functionCall": {
+							"name": "functions__exec",
+							"args": {"input": "pwd"}
+						}
+					}]
+				},
+				"finishReason": "STOP"
+			}]
+		}
+	}`)
+
+	output := ConvertAntigravityResponseToOpenAIResponsesNonStream(
+		context.Background(),
+		"gemini-3.5-flash-low",
+		originalRequest,
+		nil,
+		rawResponse,
+		nil,
+	)
+
+	if !gjson.ValidBytes(output) {
+		t.Fatalf("invalid JSON output: %s", output)
+	}
+	if got := gjson.GetBytes(output, "output.0.type").String(); got != "custom_tool_call" {
+		t.Fatalf("output.0.type = %q, want custom_tool_call; output=%s", got, output)
+	}
+	if got := gjson.GetBytes(output, "output.0.name").String(); got != "exec" {
+		t.Fatalf("output.0.name = %q, want exec", got)
+	}
+	if got := gjson.GetBytes(output, "output.0.namespace").String(); got != "functions" {
+		t.Fatalf("output.0.namespace = %q, want functions", got)
+	}
+	if got := gjson.GetBytes(output, "output.0.input").String(); got != "pwd" {
+		t.Fatalf("output.0.input = %q, want pwd", got)
+	}
+}

--- a/internal/translator/claude/gemini/claude_gemini_request.go
+++ b/internal/translator/claude/gemini/claude_gemini_request.go
@@ -91,6 +91,7 @@ func ConvertGeminiRequestToClaude(modelName string, inputRawJSON []byte, stream 
 	// functionCalls, so we keep a FIFO queue of generated tool IDs and
 	// consume them in order when functionResponses arrive.
 	var pendingToolIDs []string
+	toolCallCounter := 0
 
 	// Model mapping to specify which Claude Code model to use
 	out, _ = sjson.SetBytes(out, "model", modelName)
@@ -272,7 +273,8 @@ func ConvertGeminiRequestToClaude(modelName string, inputRawJSON []byte, stream 
 						// Reuse gateway-provided IDs when present, otherwise generate one for pairing.
 						toolID := getGeminiToolID(fc)
 						if toolID == "" {
-							toolID = translatorcommon.GenerateClaudeToolCallID()
+							toolCallCounter++
+							toolID = fmt.Sprintf("toolu_gemini_%016d", toolCallCounter)
 						}
 						pendingToolIDs = append(pendingToolIDs, toolID)
 						toolUse, _ = sjson.SetBytes(toolUse, "id", toolID)
@@ -303,7 +305,8 @@ func ConvertGeminiRequestToClaude(modelName string, inputRawJSON []byte, stream 
 							pendingToolIDs = pendingToolIDs[1:]
 						} else {
 							// Fallback: generate new ID if no pending tool_use found
-							toolID = translatorcommon.GenerateClaudeToolCallID()
+							toolCallCounter++
+							toolID = fmt.Sprintf("toolu_gemini_%016d", toolCallCounter)
 						}
 						toolResult, _ = sjson.SetBytes(toolResult, "tool_use_id", toolID)
 

--- a/internal/translator/claude/gemini/claude_gemini_request_test.go
+++ b/internal/translator/claude/gemini/claude_gemini_request_test.go
@@ -200,3 +200,56 @@ func TestConvertGeminiRequestToClaude_DropsHiddenThoughtParts(t *testing.T) {
 		}
 	})
 }
+
+func TestConvertGeminiRequestToClaude_DeterministicToolIDs(t *testing.T) {
+	raw := []byte(`{
+		"contents": [
+			{
+				"role": "model",
+				"parts": [
+					{"functionCall": {"name": "first_tool", "args": {"q": "one"}}}
+				]
+			},
+			{
+				"role": "user",
+				"parts": [
+					{"functionResponse": {"name": "first_tool", "response": {"result": "ok1"}}}
+				]
+			},
+			{
+				"role": "model",
+				"parts": [
+					{"functionCall": {"name": "second_tool", "args": {"q": "two"}}}
+				]
+			},
+			{
+				"role": "user",
+				"parts": [
+					{"functionResponse": {"name": "second_tool", "response": {"result": "ok2"}}}
+				]
+			}
+		]
+	}`)
+
+	out1 := ConvertGeminiRequestToClaude("claude-sonnet-4", raw, false)
+	out2 := ConvertGeminiRequestToClaude("claude-sonnet-4", raw, false)
+
+	if string(out1) != string(out2) {
+		t.Fatalf("expected deterministic output across multiple conversions, got different outputs:\nout1=%s\nout2=%s", string(out1), string(out2))
+	}
+
+	wantID1 := "toolu_gemini_0000000000000001"
+	wantID2 := "toolu_gemini_0000000000000002"
+
+	gotCall1 := gjson.GetBytes(out1, "messages.0.content.0.id").String()
+	gotResp1 := gjson.GetBytes(out1, "messages.1.content.0.tool_use_id").String()
+	gotCall2 := gjson.GetBytes(out1, "messages.2.content.0.id").String()
+	gotResp2 := gjson.GetBytes(out1, "messages.3.content.0.tool_use_id").String()
+
+	if gotCall1 != wantID1 || gotResp1 != wantID1 {
+		t.Fatalf("expected first tool pair to have id %q, got call=%q, resp=%q", wantID1, gotCall1, gotResp1)
+	}
+	if gotCall2 != wantID2 || gotResp2 != wantID2 {
+		t.Fatalf("expected second tool pair to have id %q, got call=%q, resp=%q", wantID2, gotCall2, gotResp2)
+	}
+}

--- a/internal/translator/claude/openai/chat-completions/claude_openai_response.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_response.go
@@ -430,7 +430,7 @@ func ConvertClaudeResponseToOpenAINonStream(_ context.Context, _ string, origina
 	if len(reasoningParts) > 0 {
 		reasoningContent := strings.Join(reasoningParts, "")
 		// Add reasoning as a separate field in the message
-		out, _ = sjson.SetBytes(out, "choices.0.message.reasoning", reasoningContent)
+		out, _ = sjson.SetBytes(out, "choices.0.message.reasoning_content", reasoningContent)
 	}
 
 	// Set tool calls if any were accumulated during processing

--- a/internal/translator/claude/openai/chat-completions/claude_openai_response.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_response.go
@@ -441,7 +441,7 @@ func ConvertClaudeResponseToOpenAINonStream(_ context.Context, _ string, origina
 	if len(reasoningParts) > 0 {
 		reasoningContent := strings.Join(reasoningParts, "")
 		// Add reasoning as a separate field in the message
-		out, _ = sjson.SetBytes(out, "choices.0.message.reasoning", reasoningContent)
+		out, _ = sjson.SetBytes(out, "choices.0.message.reasoning_content", reasoningContent)
 	}
 
 	// Set tool calls if any were accumulated during processing

--- a/internal/translator/claude/openai/chat-completions/claude_openai_response_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_response_test.go
@@ -206,3 +206,26 @@ func TestConvertClaudeResponseToOpenAINonStream_RefusalStopReason(t *testing.T) 
 		})
 	}
 }
+
+func TestConvertClaudeResponseToOpenAINonStream_ReasoningContent(t *testing.T) {
+	rawJSON := []byte("data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_123\",\"model\":\"claude-opus-4-6\"}}\n" +
+		"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"Let me think... \"}}\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"Done thinking.\"}}\n" +
+		"data: {\"type\":\"content_block_stop\",\"index\":0}\n" +
+		"data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello world\"}}\n" +
+		"data: {\"type\":\"content_block_stop\",\"index\":1}\n" +
+		"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":10,\"output_tokens\":20}}\n")
+
+	out := ConvertClaudeResponseToOpenAINonStream(context.Background(), "", nil, nil, rawJSON, nil)
+
+	gotReasoningContent := gjson.GetBytes(out, "choices.0.message.reasoning_content").String()
+	wantReasoningContent := "Let me think... Done thinking."
+	if gotReasoningContent != wantReasoningContent {
+		t.Fatalf("expected reasoning_content %q, got %q, payload=%s", wantReasoningContent, gotReasoningContent, string(out))
+	}
+	if gotLegacyReasoning := gjson.GetBytes(out, "choices.0.message.reasoning"); gotLegacyReasoning.Exists() {
+		t.Fatalf("expected reasoning to not exist, got %q, payload=%s", gotLegacyReasoning.String(), string(out))
+	}
+}

--- a/internal/translator/claude/openai/chat-completions/claude_openai_response_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_response_test.go
@@ -210,22 +210,173 @@ func TestConvertClaudeResponseToOpenAINonStream_RefusalStopReason(t *testing.T) 
 func TestConvertClaudeResponseToOpenAINonStream_ReasoningContent(t *testing.T) {
 	rawJSON := []byte("data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_123\",\"model\":\"claude-opus-4-6\"}}\n" +
 		"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}\n" +
-		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"Let me think... \"}}\n" +
-		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"Done thinking.\"}}\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"Let me analyze the problem.\"}}\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\" Step 2 is clear.\"}}\n" +
 		"data: {\"type\":\"content_block_stop\",\"index\":0}\n" +
 		"data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n" +
-		"data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello world\"}}\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"Here is the solution.\"}}\n" +
 		"data: {\"type\":\"content_block_stop\",\"index\":1}\n" +
 		"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":10,\"output_tokens\":20}}\n")
 
 	out := ConvertClaudeResponseToOpenAINonStream(context.Background(), "", nil, nil, rawJSON, nil)
 
-	gotReasoningContent := gjson.GetBytes(out, "choices.0.message.reasoning_content").String()
-	wantReasoningContent := "Let me think... Done thinking."
-	if gotReasoningContent != wantReasoningContent {
-		t.Fatalf("expected reasoning_content %q, got %q, payload=%s", wantReasoningContent, gotReasoningContent, string(out))
+	gotRC := gjson.GetBytes(out, "choices.0.message.reasoning_content")
+	if !gotRC.Exists() {
+		t.Fatalf("expected choices.0.message.reasoning_content to exist, payload=%s", string(out))
 	}
-	if gotLegacyReasoning := gjson.GetBytes(out, "choices.0.message.reasoning"); gotLegacyReasoning.Exists() {
-		t.Fatalf("expected reasoning to not exist, got %q, payload=%s", gotLegacyReasoning.String(), string(out))
+	wantRC := "Let me analyze the problem. Step 2 is clear."
+	if gotRC.String() != wantRC {
+		t.Fatalf("reasoning_content = %q, want %q", gotRC.String(), wantRC)
+	}
+
+	if gotOldReasoning := gjson.GetBytes(out, "choices.0.message.reasoning"); gotOldReasoning.Exists() {
+		t.Fatalf("choices.0.message.reasoning should not exist, got %q", gotOldReasoning.String())
+	}
+
+	gotContent := gjson.GetBytes(out, "choices.0.message.content").String()
+	wantContent := "Here is the solution."
+	if gotContent != wantContent {
+		t.Fatalf("content = %q, want %q", gotContent, wantContent)
+	}
+}
+
+func TestConvertClaudeResponseToOpenAINonStream_OmitsReasoningContentWhenAbsent(t *testing.T) {
+	rawJSON := []byte("data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_123\",\"model\":\"claude-opus-4-6\"}}\n" +
+		"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Just plain text.\"}}\n" +
+		"data: {\"type\":\"content_block_stop\",\"index\":0}\n" +
+		"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":10,\"output_tokens\":20}}\n")
+
+	out := ConvertClaudeResponseToOpenAINonStream(context.Background(), "", nil, nil, rawJSON, nil)
+
+	if gotRC := gjson.GetBytes(out, "choices.0.message.reasoning_content"); gotRC.Exists() {
+		t.Fatalf("choices.0.message.reasoning_content should be omitted when absent, got %q", gotRC.String())
+	}
+	if gotReasoning := gjson.GetBytes(out, "choices.0.message.reasoning"); gotReasoning.Exists() {
+		t.Fatalf("choices.0.message.reasoning should not exist, got %q", gotReasoning.String())
+	}
+	if gotContent := gjson.GetBytes(out, "choices.0.message.content").String(); gotContent != "Just plain text." {
+		t.Fatalf("content = %q, want %q", gotContent, "Just plain text.")
+	}
+}
+
+func TestConvertClaudeResponseToOpenAI_StreamAndNonStreamParity(t *testing.T) {
+	events := [][]byte{
+		[]byte(`data: {"type":"message_start","message":{"id":"msg_123","model":"claude-opus-4-6","usage":{"input_tokens":15,"output_tokens":1}}}`),
+		[]byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`),
+		[]byte(`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"First thought. "}}`),
+		[]byte(`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Second thought."}}`),
+		[]byte(`data: {"type":"content_block_stop","index":0}`),
+		[]byte(`data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`),
+		[]byte(`data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Final "}}`),
+		[]byte(`data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"answer."}}`),
+		[]byte(`data: {"type":"content_block_stop","index":1}`),
+		[]byte(`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":25}}`),
+		[]byte(`data: {"type":"message_stop"}`),
+	}
+
+	// 1. Process via streaming
+	ctx := context.Background()
+	var param any
+	var streamReasoning string
+	var streamContent string
+	var streamFinishReason string
+
+	for _, ev := range events {
+		chunks := ConvertClaudeResponseToOpenAI(ctx, "claude-opus-4-6", nil, nil, ev, &param)
+		for _, chunk := range chunks {
+			if rc := gjson.GetBytes(chunk, "choices.0.delta.reasoning_content"); rc.Exists() {
+				streamReasoning += rc.String()
+			}
+			if c := gjson.GetBytes(chunk, "choices.0.delta.content"); c.Exists() {
+				streamContent += c.String()
+			}
+			if fr := gjson.GetBytes(chunk, "choices.0.finish_reason"); fr.Exists() && fr.String() != "" {
+				streamFinishReason = fr.String()
+			}
+		}
+	}
+
+	// 2. Process via non-stream
+	var rawBuffer []byte
+	for _, ev := range events {
+		rawBuffer = append(rawBuffer, ev...)
+		rawBuffer = append(rawBuffer, '\n')
+	}
+
+	nonStreamOut := ConvertClaudeResponseToOpenAINonStream(ctx, "", nil, nil, rawBuffer, nil)
+	nonStreamRC := gjson.GetBytes(nonStreamOut, "choices.0.message.reasoning_content").String()
+	nonStreamContent := gjson.GetBytes(nonStreamOut, "choices.0.message.content").String()
+	nonStreamFinishReason := gjson.GetBytes(nonStreamOut, "choices.0.finish_reason").String()
+
+	if streamReasoning != "First thought. Second thought." {
+		t.Fatalf("streamReasoning = %q, want %q", streamReasoning, "First thought. Second thought.")
+	}
+	if nonStreamRC != streamReasoning {
+		t.Fatalf("parity mismatch for reasoning_content: nonStream=%q, stream=%q", nonStreamRC, streamReasoning)
+	}
+	if streamContent != "Final answer." {
+		t.Fatalf("streamContent = %q, want %q", streamContent, "Final answer.")
+	}
+	if nonStreamContent != streamContent {
+		t.Fatalf("parity mismatch for content: nonStream=%q, stream=%q", nonStreamContent, streamContent)
+	}
+	if streamFinishReason != "stop" {
+		t.Fatalf("streamFinishReason = %q, want %q", streamFinishReason, "stop")
+	}
+	if nonStreamFinishReason != streamFinishReason {
+		t.Fatalf("parity mismatch for finish_reason: nonStream=%q, stream=%q", nonStreamFinishReason, streamFinishReason)
+	}
+}
+
+func TestConvertClaudeResponseToOpenAI_RedactedThinkingIgnored(t *testing.T) {
+	events := [][]byte{
+		[]byte(`data: {"type":"message_start","message":{"id":"msg_123","model":"claude-opus-4-6"}}`),
+		[]byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"redacted_thinking","data":"encrypted_blob"}}`),
+		[]byte(`data: {"type":"content_block_stop","index":0}`),
+		[]byte(`data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`),
+		[]byte(`data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Visible reply."}}`),
+		[]byte(`data: {"type":"content_block_stop","index":1}`),
+		[]byte(`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":10,"output_tokens":20}}`),
+	}
+
+	// Non-stream check
+	var rawJSON []byte
+	for _, ev := range events {
+		rawJSON = append(rawJSON, ev...)
+		rawJSON = append(rawJSON, '\n')
+	}
+
+	outNonStream := ConvertClaudeResponseToOpenAINonStream(context.Background(), "", nil, nil, rawJSON, nil)
+	if gotRC := gjson.GetBytes(outNonStream, "choices.0.message.reasoning_content"); gotRC.Exists() {
+		t.Fatalf("redacted_thinking must never map to reasoning_content in non-stream, got %q", gotRC.String())
+	}
+	if gotReasoning := gjson.GetBytes(outNonStream, "choices.0.message.reasoning"); gotReasoning.Exists() {
+		t.Fatalf("redacted_thinking must not produce reasoning field in non-stream, got %q", gotReasoning.String())
+	}
+	if gotContent := gjson.GetBytes(outNonStream, "choices.0.message.content").String(); gotContent != "Visible reply." {
+		t.Fatalf("content = %q, want %q", gotContent, "Visible reply.")
+	}
+
+	// Stream check
+	ctx := context.Background()
+	var param any
+	var streamContent string
+	for _, line := range events {
+		chunks := ConvertClaudeResponseToOpenAI(ctx, "claude-opus-4-6", nil, nil, line, &param)
+		for _, chunk := range chunks {
+			if gotRC := gjson.GetBytes(chunk, "choices.0.delta.reasoning_content"); gotRC.Exists() {
+				t.Fatalf("redacted_thinking must never map to reasoning_content in stream, got %q", gotRC.String())
+			}
+			if gotReasoning := gjson.GetBytes(chunk, "choices.0.delta.reasoning"); gotReasoning.Exists() {
+				t.Fatalf("redacted_thinking must not produce delta.reasoning field in stream, got %q", gotReasoning.String())
+			}
+			if c := gjson.GetBytes(chunk, "choices.0.delta.content"); c.Exists() {
+				streamContent += c.String()
+			}
+		}
+	}
+	if streamContent != "Visible reply." {
+		t.Fatalf("stream content = %q, want %q", streamContent, "Visible reply.")
 	}
 }

--- a/internal/translator/claude/openai/chat-completions/claude_openai_response_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_response_test.go
@@ -228,3 +228,177 @@ func TestConvertClaudeResponseToOpenAINonStream_RefusalStopReason(t *testing.T) 
 		})
 	}
 }
+
+func TestConvertClaudeResponseToOpenAINonStream_ReasoningContent(t *testing.T) {
+	rawJSON := []byte("data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_123\",\"model\":\"claude-opus-4-6\"}}\n" +
+		"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"Let me analyze the problem.\"}}\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\" Step 2 is clear.\"}}\n" +
+		"data: {\"type\":\"content_block_stop\",\"index\":0}\n" +
+		"data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"Here is the solution.\"}}\n" +
+		"data: {\"type\":\"content_block_stop\",\"index\":1}\n" +
+		"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":10,\"output_tokens\":20}}\n")
+
+	out := ConvertClaudeResponseToOpenAINonStream(context.Background(), "", nil, nil, rawJSON, nil)
+
+	gotRC := gjson.GetBytes(out, "choices.0.message.reasoning_content")
+	if !gotRC.Exists() {
+		t.Fatalf("expected choices.0.message.reasoning_content to exist, payload=%s", string(out))
+	}
+	wantRC := "Let me analyze the problem. Step 2 is clear."
+	if gotRC.String() != wantRC {
+		t.Fatalf("reasoning_content = %q, want %q", gotRC.String(), wantRC)
+	}
+
+	if gotOldReasoning := gjson.GetBytes(out, "choices.0.message.reasoning"); gotOldReasoning.Exists() {
+		t.Fatalf("choices.0.message.reasoning should not exist, got %q", gotOldReasoning.String())
+	}
+
+	gotContent := gjson.GetBytes(out, "choices.0.message.content").String()
+	wantContent := "Here is the solution."
+	if gotContent != wantContent {
+		t.Fatalf("content = %q, want %q", gotContent, wantContent)
+	}
+}
+
+func TestConvertClaudeResponseToOpenAINonStream_OmitsReasoningContentWhenAbsent(t *testing.T) {
+	rawJSON := []byte("data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_123\",\"model\":\"claude-opus-4-6\"}}\n" +
+		"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n" +
+		"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Just plain text.\"}}\n" +
+		"data: {\"type\":\"content_block_stop\",\"index\":0}\n" +
+		"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":10,\"output_tokens\":20}}\n")
+
+	out := ConvertClaudeResponseToOpenAINonStream(context.Background(), "", nil, nil, rawJSON, nil)
+
+	if gotRC := gjson.GetBytes(out, "choices.0.message.reasoning_content"); gotRC.Exists() {
+		t.Fatalf("choices.0.message.reasoning_content should be omitted when absent, got %q", gotRC.String())
+	}
+	if gotReasoning := gjson.GetBytes(out, "choices.0.message.reasoning"); gotReasoning.Exists() {
+		t.Fatalf("choices.0.message.reasoning should not exist, got %q", gotReasoning.String())
+	}
+	if gotContent := gjson.GetBytes(out, "choices.0.message.content").String(); gotContent != "Just plain text." {
+		t.Fatalf("content = %q, want %q", gotContent, "Just plain text.")
+	}
+}
+
+func TestConvertClaudeResponseToOpenAI_StreamAndNonStreamParity(t *testing.T) {
+	events := [][]byte{
+		[]byte(`data: {"type":"message_start","message":{"id":"msg_123","model":"claude-opus-4-6","usage":{"input_tokens":15,"output_tokens":1}}}`),
+		[]byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`),
+		[]byte(`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"First thought. "}}`),
+		[]byte(`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Second thought."}}`),
+		[]byte(`data: {"type":"content_block_stop","index":0}`),
+		[]byte(`data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`),
+		[]byte(`data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Final "}}`),
+		[]byte(`data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"answer."}}`),
+		[]byte(`data: {"type":"content_block_stop","index":1}`),
+		[]byte(`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":25}}`),
+		[]byte(`data: {"type":"message_stop"}`),
+	}
+
+	// 1. Process via streaming
+	ctx := context.Background()
+	var param any
+	var streamReasoning string
+	var streamContent string
+	var streamFinishReason string
+
+	for _, ev := range events {
+		chunks := ConvertClaudeResponseToOpenAI(ctx, "claude-opus-4-6", nil, nil, ev, &param)
+		for _, chunk := range chunks {
+			if rc := gjson.GetBytes(chunk, "choices.0.delta.reasoning_content"); rc.Exists() {
+				streamReasoning += rc.String()
+			}
+			if c := gjson.GetBytes(chunk, "choices.0.delta.content"); c.Exists() {
+				streamContent += c.String()
+			}
+			if fr := gjson.GetBytes(chunk, "choices.0.finish_reason"); fr.Exists() && fr.String() != "" {
+				streamFinishReason = fr.String()
+			}
+		}
+	}
+
+	// 2. Process via non-stream
+	var rawBuffer []byte
+	for _, ev := range events {
+		rawBuffer = append(rawBuffer, ev...)
+		rawBuffer = append(rawBuffer, '\n')
+	}
+
+	nonStreamOut := ConvertClaudeResponseToOpenAINonStream(ctx, "", nil, nil, rawBuffer, nil)
+	nonStreamRC := gjson.GetBytes(nonStreamOut, "choices.0.message.reasoning_content").String()
+	nonStreamContent := gjson.GetBytes(nonStreamOut, "choices.0.message.content").String()
+	nonStreamFinishReason := gjson.GetBytes(nonStreamOut, "choices.0.finish_reason").String()
+
+	if streamReasoning != "First thought. Second thought." {
+		t.Fatalf("streamReasoning = %q, want %q", streamReasoning, "First thought. Second thought.")
+	}
+	if nonStreamRC != streamReasoning {
+		t.Fatalf("parity mismatch for reasoning_content: nonStream=%q, stream=%q", nonStreamRC, streamReasoning)
+	}
+	if streamContent != "Final answer." {
+		t.Fatalf("streamContent = %q, want %q", streamContent, "Final answer.")
+	}
+	if nonStreamContent != streamContent {
+		t.Fatalf("parity mismatch for content: nonStream=%q, stream=%q", nonStreamContent, streamContent)
+	}
+	if streamFinishReason != "stop" {
+		t.Fatalf("streamFinishReason = %q, want %q", streamFinishReason, "stop")
+	}
+	if nonStreamFinishReason != streamFinishReason {
+		t.Fatalf("parity mismatch for finish_reason: nonStream=%q, stream=%q", nonStreamFinishReason, streamFinishReason)
+	}
+}
+
+func TestConvertClaudeResponseToOpenAI_RedactedThinkingIgnored(t *testing.T) {
+	events := [][]byte{
+		[]byte(`data: {"type":"message_start","message":{"id":"msg_123","model":"claude-opus-4-6"}}`),
+		[]byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"redacted_thinking","data":"encrypted_blob"}}`),
+		[]byte(`data: {"type":"content_block_stop","index":0}`),
+		[]byte(`data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`),
+		[]byte(`data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Visible reply."}}`),
+		[]byte(`data: {"type":"content_block_stop","index":1}`),
+		[]byte(`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":10,"output_tokens":20}}`),
+	}
+
+	// Non-stream check
+	var rawJSON []byte
+	for _, ev := range events {
+		rawJSON = append(rawJSON, ev...)
+		rawJSON = append(rawJSON, '\n')
+	}
+
+	outNonStream := ConvertClaudeResponseToOpenAINonStream(context.Background(), "", nil, nil, rawJSON, nil)
+	if gotRC := gjson.GetBytes(outNonStream, "choices.0.message.reasoning_content"); gotRC.Exists() {
+		t.Fatalf("redacted_thinking must never map to reasoning_content in non-stream, got %q", gotRC.String())
+	}
+	if gotReasoning := gjson.GetBytes(outNonStream, "choices.0.message.reasoning"); gotReasoning.Exists() {
+		t.Fatalf("redacted_thinking must not produce reasoning field in non-stream, got %q", gotReasoning.String())
+	}
+	if gotContent := gjson.GetBytes(outNonStream, "choices.0.message.content").String(); gotContent != "Visible reply." {
+		t.Fatalf("content = %q, want %q", gotContent, "Visible reply.")
+	}
+
+	// Stream check
+	ctx := context.Background()
+	var param any
+	var streamContent string
+	for _, line := range events {
+		chunks := ConvertClaudeResponseToOpenAI(ctx, "claude-opus-4-6", nil, nil, line, &param)
+		for _, chunk := range chunks {
+			if gotRC := gjson.GetBytes(chunk, "choices.0.delta.reasoning_content"); gotRC.Exists() {
+				t.Fatalf("redacted_thinking must never map to reasoning_content in stream, got %q", gotRC.String())
+			}
+			if gotReasoning := gjson.GetBytes(chunk, "choices.0.delta.reasoning"); gotReasoning.Exists() {
+				t.Fatalf("redacted_thinking must not produce delta.reasoning field in stream, got %q", gotReasoning.String())
+			}
+			if c := gjson.GetBytes(chunk, "choices.0.delta.content"); c.Exists() {
+				streamContent += c.String()
+			}
+		}
+	}
+	if streamContent != "Visible reply." {
+		t.Fatalf("stream content = %q, want %q", streamContent, "Visible reply.")
+	}
+}

--- a/internal/translator/codex/gemini/codex_gemini_request.go
+++ b/internal/translator/codex/gemini/codex_gemini_request.go
@@ -6,9 +6,7 @@
 package gemini
 
 import (
-	"crypto/rand"
 	"fmt"
-	"math/big"
 	"strconv"
 	"strings"
 
@@ -65,23 +63,12 @@ func ConvertGeminiRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 		}
 	}
 
-	// helper for generating paired call IDs in the form: call_<alphanum>
+	// helper for generating paired call IDs in the form: call_gemini_<seq>
 	// Gemini uses sequential pairing across possibly multiple in-flight
 	// functionCalls, so we keep a FIFO queue of generated call IDs and
 	// consume them in order when functionResponses arrive.
 	var pendingCallIDs []string
-
-	// genCallID creates a random call id like: call_<8chars>
-	genCallID := func() string {
-		const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-		var b strings.Builder
-		// 8 chars random suffix
-		for i := 0; i < 24; i++ {
-			n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(letters))))
-			b.WriteByte(letters[n.Int64()])
-		}
-		return "call_" + b.String()
-	}
+	callCounter := 0
 
 	getGeminiCallID := func(value gjson.Result) string {
 		if callID := strings.TrimSpace(value.Get("id").String()); callID != "" {
@@ -198,7 +185,8 @@ func ConvertGeminiRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 					// Reuse gateway-provided IDs when present, otherwise generate one for pairing.
 					id := getGeminiCallID(fc)
 					if id == "" {
-						id = genCallID()
+						callCounter++
+						id = fmt.Sprintf("call_gemini_%016d", callCounter)
 					}
 					fn, _ = sjson.SetBytes(fn, "call_id", id)
 					pendingCallIDs = append(pendingCallIDs, id)
@@ -227,7 +215,8 @@ func ConvertGeminiRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 						// pop the first element
 						pendingCallIDs = pendingCallIDs[1:]
 					} else {
-						id = genCallID()
+						callCounter++
+						id = fmt.Sprintf("call_gemini_%016d", callCounter)
 					}
 					fno, _ = sjson.SetBytes(fno, "call_id", id)
 					inputItems = append(inputItems, fno)

--- a/internal/translator/codex/gemini/codex_gemini_request_test.go
+++ b/internal/translator/codex/gemini/codex_gemini_request_test.go
@@ -115,3 +115,56 @@ func TestConvertGeminiRequestToCodex_DropsHiddenThoughtParts(t *testing.T) {
 		}
 	})
 }
+
+func TestConvertGeminiRequestToCodex_DeterministicCallIDs(t *testing.T) {
+	raw := []byte(`{
+		"contents": [
+			{
+				"role": "model",
+				"parts": [
+					{"functionCall": {"name": "first_tool", "args": {"q": "one"}}}
+				]
+			},
+			{
+				"role": "user",
+				"parts": [
+					{"functionResponse": {"name": "first_tool", "response": {"result": "ok1"}}}
+				]
+			},
+			{
+				"role": "model",
+				"parts": [
+					{"functionCall": {"name": "second_tool", "args": {"q": "two"}}}
+				]
+			},
+			{
+				"role": "user",
+				"parts": [
+					{"functionResponse": {"name": "second_tool", "response": {"result": "ok2"}}}
+				]
+			}
+		]
+	}`)
+
+	out1 := ConvertGeminiRequestToCodex("gpt-5.1-codex", raw, false)
+	out2 := ConvertGeminiRequestToCodex("gpt-5.1-codex", raw, false)
+
+	if string(out1) != string(out2) {
+		t.Fatalf("expected deterministic output across multiple conversions, got different outputs:\nout1=%s\nout2=%s", string(out1), string(out2))
+	}
+
+	wantID1 := "call_gemini_0000000000000001"
+	wantID2 := "call_gemini_0000000000000002"
+
+	gotCall1 := gjson.GetBytes(out1, "input.0.call_id").String()
+	gotResp1 := gjson.GetBytes(out1, "input.1.call_id").String()
+	gotCall2 := gjson.GetBytes(out1, "input.2.call_id").String()
+	gotResp2 := gjson.GetBytes(out1, "input.3.call_id").String()
+
+	if gotCall1 != wantID1 || gotResp1 != wantID1 {
+		t.Fatalf("expected first tool pair to have id %q, got call=%q, resp=%q", wantID1, gotCall1, gotResp1)
+	}
+	if gotCall2 != wantID2 || gotResp2 != wantID2 {
+		t.Fatalf("expected second tool pair to have id %q, got call=%q, resp=%q", wantID2, gotCall2, gotResp2)
+	}
+}

--- a/internal/translator/codex/openai/responses/codex_openai-responses_request.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request.go
@@ -31,7 +31,7 @@ func ConvertOpenAIResponsesRequestToCodex(modelName string, inputRawJSON []byte,
 		rawJSON = deleteCodexRequestFields(rawJSON, "service_tier")
 	}
 
-	rawJSON = deleteCodexRequestFields(rawJSON, "truncation", "prompt_cache_options")
+	rawJSON = deleteCodexRequestFields(rawJSON, "truncation", "prompt_cache_options", "prompt_cache_retention")
 	rawJSON = stripCodexResponsesCacheBreakpoints(rawJSON)
 	rawJSON = applyResponsesCompactionCompatibility(rawJSON)
 

--- a/internal/translator/codex/openai/responses/codex_openai-responses_request_test.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request_test.go
@@ -253,6 +253,7 @@ func TestConvertOpenAIResponsesRequestToCodexNormalizesRequiredFields(t *testing
 		"service_tier":"standard",
 		"truncation":"auto",
 		"prompt_cache_options":{"mode":"implicit"},
+		"prompt_cache_retention":"24h",
 		"user":"request-owner",
 		"input":[{"type":"message","role":"system","content":"hello"}]
 	}`)
@@ -283,11 +284,36 @@ func TestConvertOpenAIResponsesRequestToCodexNormalizesRequiredFields(t *testing
 		"service_tier",
 		"truncation",
 		"prompt_cache_options",
+		"prompt_cache_retention",
 		"user",
 	} {
 		if gjson.GetBytes(output, path).Exists() {
 			t.Fatalf("%s should be removed: %s", path, output)
 		}
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToCodex_FiltersPromptCacheRetention(t *testing.T) {
+	inputJSON := []byte(`{
+		"model": "gpt-5.6-terra",
+		"prompt_cache_retention": "24h",
+		"input": [
+			{
+				"type": "message",
+				"role": "user",
+				"content": [
+					{
+						"type": "input_text",
+						"text": "hello"
+					}
+				]
+			}
+		]
+	}`)
+
+	output := ConvertOpenAIResponsesRequestToCodex("gpt-5.6-terra", inputJSON, true)
+	if gjson.GetBytes(output, "prompt_cache_retention").Exists() {
+		t.Fatalf("prompt_cache_retention should be removed: %s", string(output))
 	}
 }
 

--- a/internal/translator/codex/openai/responses/codex_openai-responses_request_test.go
+++ b/internal/translator/codex/openai/responses/codex_openai-responses_request_test.go
@@ -273,6 +273,7 @@ func TestConvertOpenAIResponsesRequestToCodexNormalizesRequiredFields(t *testing
 		"service_tier":"standard",
 		"truncation":"auto",
 		"prompt_cache_options":{"mode":"implicit"},
+		"prompt_cache_retention":"24h",
 		"user":"request-owner",
 		"input":[{"type":"message","role":"system","content":"hello"}]
 	}`)
@@ -303,11 +304,36 @@ func TestConvertOpenAIResponsesRequestToCodexNormalizesRequiredFields(t *testing
 		"service_tier",
 		"truncation",
 		"prompt_cache_options",
+		"prompt_cache_retention",
 		"user",
 	} {
 		if gjson.GetBytes(output, path).Exists() {
 			t.Fatalf("%s should be removed: %s", path, output)
 		}
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToCodex_FiltersPromptCacheRetention(t *testing.T) {
+	inputJSON := []byte(`{
+		"model": "gpt-5.6-terra",
+		"prompt_cache_retention": "24h",
+		"input": [
+			{
+				"type": "message",
+				"role": "user",
+				"content": [
+					{
+						"type": "input_text",
+						"text": "hello"
+					}
+				]
+			}
+		]
+	}`)
+
+	output := ConvertOpenAIResponsesRequestToCodex("gpt-5.6-terra", inputJSON, true)
+	if gjson.GetBytes(output, "prompt_cache_retention").Exists() {
+		t.Fatalf("prompt_cache_retention should be removed: %s", string(output))
 	}
 }
 

--- a/internal/translator/gemini/claude/gemini_claude_response.go
+++ b/internal/translator/gemini/claude/gemini_claude_response.go
@@ -304,6 +304,7 @@ func ConvertGeminiResponseToClaudeNonStream(_ context.Context, _ string, origina
 	parts := root.Get("candidates.0.content.parts")
 	textBuilder := strings.Builder{}
 	thinkingBuilder := strings.Builder{}
+	var thinkingSignature string
 	toolIDCounter := 0
 	hasToolCall := false
 	var blocks [][]byte
@@ -319,19 +320,39 @@ func ConvertGeminiResponseToClaudeNonStream(_ context.Context, _ string, origina
 	}
 
 	flushThinking := func() {
-		if thinkingBuilder.Len() == 0 {
+		if thinkingBuilder.Len() == 0 && thinkingSignature == "" {
 			return
 		}
 		block := []byte(`{"type":"thinking","thinking":""}`)
 		block, _ = sjson.SetBytes(block, "thinking", thinkingBuilder.String())
+		if thinkingSignature != "" {
+			block, _ = sjson.SetBytes(block, "signature", thinkingSignature)
+		}
 		blocks = append(blocks, block)
 		thinkingBuilder.Reset()
+		thinkingSignature = ""
 	}
 
 	if parts.IsArray() {
 		for _, part := range parts.Array() {
-			if text := part.Get("text"); text.Exists() && text.String() != "" {
-				if part.Get("thought").Bool() {
+			thoughtSignatureResult := part.Get("thoughtSignature")
+			if !thoughtSignatureResult.Exists() {
+				thoughtSignatureResult = part.Get("thought_signature")
+			}
+			hasThoughtSignature := thoughtSignatureResult.Exists() && thoughtSignatureResult.String() != ""
+			if hasThoughtSignature {
+				thinkingSignature = thoughtSignatureResult.String()
+			}
+
+			text := part.Get("text")
+			functionCall := part.Get("functionCall")
+
+			if hasThoughtSignature && (!text.Exists() || text.String() == "") && !functionCall.Exists() {
+				continue
+			}
+
+			if text.Exists() && text.String() != "" {
+				if part.Get("thought").Bool() || hasThoughtSignature {
 					flushText()
 					thinkingBuilder.WriteString(text.String())
 					continue
@@ -341,7 +362,7 @@ func ConvertGeminiResponseToClaudeNonStream(_ context.Context, _ string, origina
 				continue
 			}
 
-			if functionCall := part.Get("functionCall"); functionCall.Exists() {
+			if functionCall.Exists() {
 				flushThinking()
 				flushText()
 				hasToolCall = true

--- a/internal/translator/gemini/claude/gemini_claude_response_test.go
+++ b/internal/translator/gemini/claude/gemini_claude_response_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"github.com/tidwall/gjson"
 )
 
 func TestConvertGeminiResponseToClaude_SignatureOnlyPartDoesNotOpenEmptyTextBlock(t *testing.T) {
@@ -58,5 +60,145 @@ func TestConvertGeminiResponseToClaude_SignatureOnlyPartDoesNotOpenEmptyTextBloc
 	}
 	if !strings.Contains(outputText, `"type":"message_stop"`) {
 		t.Fatalf("DONE chunk must still emit message_stop after final events: %s", outputText)
+	}
+}
+
+func TestConvertGeminiResponseToClaudeNonStream_PreservesThoughtSignature(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-2.5-pro","messages":[{"role":"user","content":"hi"}]}`)
+	geminiResponse := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [
+					{"text": "thinking step 1\n", "thought": true},
+					{"text": "thinking step 2", "thought": true, "thoughtSignature": "sig-xyz-123"},
+					{"text": "visible answer"}
+				]
+			},
+			"finishReason": "STOP"
+		}],
+		"usageMetadata": {
+			"promptTokenCount": 10,
+			"candidatesTokenCount": 5
+		},
+		"modelVersion": "gemini-2.5-pro",
+		"responseId": "resp-non-stream"
+	}`)
+
+	ctx := context.Background()
+	output := ConvertGeminiResponseToClaudeNonStream(ctx, "gemini-2.5-pro", requestJSON, requestJSON, geminiResponse, nil)
+	outputJSON := gjson.ParseBytes(output)
+
+	blocks := outputJSON.Get("content").Array()
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 content blocks (thinking + text), got %d: %s", len(blocks), string(output))
+	}
+
+	thinkingBlock := blocks[0]
+	if thinkingBlock.Get("type").String() != "thinking" {
+		t.Fatalf("expected first block to be thinking, got %s", thinkingBlock.Get("type").String())
+	}
+	if thinkingBlock.Get("thinking").String() != "thinking step 1\nthinking step 2" {
+		t.Fatalf("unexpected thinking content: %s", thinkingBlock.Get("thinking").String())
+	}
+	if thinkingBlock.Get("signature").String() != "sig-xyz-123" {
+		t.Fatalf("expected signature 'sig-xyz-123', got %q. Output: %s", thinkingBlock.Get("signature").String(), string(output))
+	}
+
+	textBlock := blocks[1]
+	if textBlock.Get("type").String() != "text" || textBlock.Get("text").String() != "visible answer" {
+		t.Fatalf("unexpected text block: %s", textBlock.Raw)
+	}
+}
+
+func TestConvertGeminiResponseToClaudeNonStream_PartWithThoughtSignatureWithoutThoughtBool(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-2.5-pro","messages":[{"role":"user","content":"hi"}]}`)
+	geminiResponse := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [
+					{"text": "inferred reasoning", "thought_signature": "sig-snake-case"},
+					{"text": "final answer"}
+				]
+			},
+			"finishReason": "STOP"
+		}],
+		"usageMetadata": {
+			"promptTokenCount": 10,
+			"candidatesTokenCount": 5
+		},
+		"modelVersion": "gemini-2.5-pro",
+		"responseId": "resp-non-stream-2"
+	}`)
+
+	ctx := context.Background()
+	output := ConvertGeminiResponseToClaudeNonStream(ctx, "gemini-2.5-pro", requestJSON, requestJSON, geminiResponse, nil)
+	outputJSON := gjson.ParseBytes(output)
+
+	blocks := outputJSON.Get("content").Array()
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 content blocks (thinking + text), got %d: %s", len(blocks), string(output))
+	}
+
+	thinkingBlock := blocks[0]
+	if thinkingBlock.Get("type").String() != "thinking" {
+		t.Fatalf("expected first block to be thinking, got %s", thinkingBlock.Get("type").String())
+	}
+	if thinkingBlock.Get("thinking").String() != "inferred reasoning" {
+		t.Fatalf("unexpected thinking content: %s", thinkingBlock.Get("thinking").String())
+	}
+	if thinkingBlock.Get("signature").String() != "sig-snake-case" {
+		t.Fatalf("expected signature 'sig-snake-case', got %q. Output: %s", thinkingBlock.Get("signature").String(), string(output))
+	}
+
+	textBlock := blocks[1]
+	if textBlock.Get("type").String() != "text" || textBlock.Get("text").String() != "final answer" {
+		t.Fatalf("unexpected text block: %s", textBlock.Raw)
+	}
+}
+
+func TestConvertGeminiResponseToClaudeNonStream_TrailingSignatureOnlyPart(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-2.5-pro","messages":[{"role":"user","content":"hi"}]}`)
+	geminiResponse := []byte(`{
+		"candidates": [{
+			"content": {
+				"parts": [
+					{"text": "thinking step 1\n", "thought": true},
+					{"text": "", "thoughtSignature": "sig-trailing"},
+					{"text": "visible answer"}
+				]
+			},
+			"finishReason": "STOP"
+		}],
+		"usageMetadata": {
+			"promptTokenCount": 10,
+			"candidatesTokenCount": 5
+		},
+		"modelVersion": "gemini-2.5-pro",
+		"responseId": "resp-non-stream-trailing"
+	}`)
+
+	ctx := context.Background()
+	output := ConvertGeminiResponseToClaudeNonStream(ctx, "gemini-2.5-pro", requestJSON, requestJSON, geminiResponse, nil)
+	outputJSON := gjson.ParseBytes(output)
+
+	blocks := outputJSON.Get("content").Array()
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 content blocks (thinking + text), got %d: %s", len(blocks), string(output))
+	}
+
+	thinkingBlock := blocks[0]
+	if thinkingBlock.Get("type").String() != "thinking" {
+		t.Fatalf("expected first block to be thinking, got %s", thinkingBlock.Get("type").String())
+	}
+	if thinkingBlock.Get("thinking").String() != "thinking step 1\n" {
+		t.Fatalf("unexpected thinking content: %s", thinkingBlock.Get("thinking").String())
+	}
+	if thinkingBlock.Get("signature").String() != "sig-trailing" {
+		t.Fatalf("expected signature 'sig-trailing', got %q. Output: %s", thinkingBlock.Get("signature").String(), string(output))
+	}
+
+	textBlock := blocks[1]
+	if textBlock.Get("type").String() != "text" || textBlock.Get("text").String() != "visible answer" {
+		t.Fatalf("unexpected text block: %s", textBlock.Raw)
 	}
 }

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
@@ -26,6 +26,21 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 
 	root := gjson.ParseBytes(rawJSON)
 
+	// Extract tools and forward map early so request contents and toolDeclarations use the exact same forward map
+	functionDeclarations, forwardMap, _ := util.BuildGeminiFunctionDeclarations(root)
+	if len(functionDeclarations) > 0 {
+		geminiTools := []byte(`[{"functionDeclarations":[]}]`)
+		geminiTools, _ = sjson.SetRawBytes(geminiTools, "0.functionDeclarations", translatorcommon.JoinRawArray(functionDeclarations))
+		out, _ = sjson.SetRawBytes(out, "tools", geminiTools)
+	}
+
+	// Handle tool_choice if present
+	if toolChoice := root.Get("tool_choice"); toolChoice.Exists() {
+		if toolConfig, ok := util.ConvertResponsesToolChoiceToGemini(toolChoice, forwardMap); ok {
+			out, _ = sjson.SetRawBytes(out, "toolConfig.functionCallingConfig", toolConfig)
+		}
+	}
+
 	// Extract system instruction from OpenAI "instructions" field.
 	systemParts := make([][]byte, 0, 2)
 	if instructions := root.Get("instructions"); instructions.Exists() {
@@ -45,10 +60,15 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 		functionNamesByCallID := make(map[string]string)
 		pendingFunctionCallIDs := make([]string, 0)
 		for _, item := range items {
-			if item.Get("type").String() == "function_call" {
+			itemType := item.Get("type").String()
+			if itemType == "function_call" || itemType == "custom_tool_call" {
 				callID := item.Get("call_id").String()
 				if _, exists := functionNamesByCallID[callID]; !exists {
-					functionNamesByCallID[callID] = item.Get("name").String()
+					name := item.Get("name").String()
+					if ns := item.Get("namespace").String(); ns != "" {
+						name = util.QualifyResponsesNamespaceToolName(ns, name)
+					}
+					functionNamesByCallID[callID] = util.MapResponsesToolName(forwardMap, name)
 				}
 			}
 		}
@@ -211,23 +231,23 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 					contentItems = append(contentItems, geminiContent(effRole, [][]byte{part}))
 				}
 
-			case "function_call":
+			case "function_call", "custom_tool_call":
 				signature := geminiResponsesThoughtSignature
 				if rawSignature := strings.TrimSpace(item.Get("_cpa_reasoning_signature").String()); rawSignature != "" {
 					signature = openAIResponsesGeminiThoughtSignature(rawSignature)
 				}
 				if thoughtText := item.Get("_cpa_reasoning_summary").String(); thoughtText != "" {
-					contentItems = append(contentItems, buildOpenAIResponsesReasoningFunctionCallModelContent(thoughtText, item, signature))
+					contentItems = append(contentItems, buildOpenAIResponsesReasoningFunctionCallModelContent(thoughtText, item, signature, forwardMap))
 				} else if !useGeminiNativeReasoningLayout && strings.TrimSpace(item.Get("_cpa_reasoning_signature").String()) != "" {
-					contentItems = append(contentItems, buildOpenAIResponsesEmptyReasoningFunctionCallModelContent(item, signature))
+					contentItems = append(contentItems, buildOpenAIResponsesEmptyReasoningFunctionCallModelContent(item, signature, forwardMap))
 				} else {
-					contentItems = append(contentItems, buildOpenAIResponsesFunctionCallModelContent(item, signature))
+					contentItems = append(contentItems, buildOpenAIResponsesFunctionCallModelContent(item, signature, forwardMap))
 				}
 				if callID := strings.TrimSpace(item.Get("call_id").String()); callID != "" {
 					pendingFunctionCallIDs = append(pendingFunctionCallIDs, callID)
 				}
 
-			case "function_call_output":
+			case "function_call_output", "custom_tool_call_output":
 				orderedOutputs, consumedIndexes, remainingPending := collectOpenAIResponsesFunctionCallOutputs(normalized, i, pendingFunctionCallIDs)
 				pendingFunctionCallIDs = remainingPending
 				for consumedIndex := range consumedIndexes {
@@ -263,8 +283,8 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 					if visible, ok := openAIResponsesAssistantVisibleText(next); ok && canBindText {
 						visibleText = visible
 						i++
-					} else if next.Get("type").String() == "function_call" && canBindFunction && strings.TrimSpace(next.Get("_cpa_reasoning_signature").String()) == "" && signature != geminiResponsesThoughtSignature {
-						contentItems = append(contentItems, buildOpenAIResponsesReasoningFunctionCallModelContent(thoughtText, next, signature))
+					} else if (next.Get("type").String() == "function_call" || next.Get("type").String() == "custom_tool_call") && canBindFunction && strings.TrimSpace(next.Get("_cpa_reasoning_signature").String()) == "" && signature != geminiResponsesThoughtSignature {
+						contentItems = append(contentItems, buildOpenAIResponsesReasoningFunctionCallModelContent(thoughtText, next, signature, forwardMap))
 						if callID := strings.TrimSpace(next.Get("call_id").String()); callID != "" {
 							pendingFunctionCallIDs = append(pendingFunctionCallIDs, callID)
 						}
@@ -288,36 +308,6 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 	}
 	if len(systemParts) > 0 {
 		out, _ = sjson.SetRawBytes(out, "systemInstruction", geminiSystemInstruction(systemParts))
-	}
-
-	// Convert tools to Gemini functionDeclarations format
-	if tools := root.Get("tools"); tools.Exists() && tools.IsArray() {
-		var functionDeclarations [][]byte
-		tools.ForEach(func(_, tool gjson.Result) bool {
-			if tool.Get("type").String() == "function" {
-				funcDecl := []byte(`{"name":"","description":"","parametersJsonSchema":{}}`)
-
-				if name := tool.Get("name"); name.Exists() {
-					funcDecl, _ = sjson.SetBytes(funcDecl, "name", util.SanitizeFunctionName(name.String()))
-				}
-				if desc := tool.Get("description"); desc.Exists() {
-					funcDecl, _ = sjson.SetBytes(funcDecl, "description", desc.String())
-				}
-				if params := tool.Get("parameters"); params.Exists() {
-					funcDecl, _ = sjson.SetRawBytes(funcDecl, "parametersJsonSchema", []byte(util.CleanJSONSchemaForGemini(params.Raw)))
-				}
-
-				functionDeclarations = append(functionDeclarations, funcDecl)
-			}
-			return true
-		})
-
-		// Only add tools if there are function declarations.
-		if len(functionDeclarations) > 0 {
-			geminiTools := []byte(`[{"functionDeclarations":[]}]`)
-			geminiTools, _ = sjson.SetRawBytes(geminiTools, "0.functionDeclarations", translatorcommon.JoinRawArray(functionDeclarations))
-			out, _ = sjson.SetRawBytes(out, "tools", geminiTools)
-		}
 	}
 
 	// Handle generation config from OpenAI format
@@ -473,7 +463,7 @@ func isTrailingOpenAIResponsesAssistantPrefill(items []gjson.Result, assistantIn
 			itemType = "message"
 		}
 		switch itemType {
-		case "reasoning", "function_call", "function_call_output":
+		case "reasoning", "function_call", "custom_tool_call", "function_call_output", "custom_tool_call_output":
 			return false
 		case "message":
 			if strings.EqualFold(itemRole, "system") || strings.EqualFold(itemRole, "developer") {
@@ -533,37 +523,47 @@ func openAIResponsesAssistantVisibleText(item gjson.Result) (string, bool) {
 	return strings.Join(textParts, "\n"), true
 }
 
+func isOpenAIResponsesToolCall(item gjson.Result) bool {
+	t := item.Get("type").String()
+	return t == "function_call" || t == "custom_tool_call"
+}
+
+func isOpenAIResponsesToolOutput(item gjson.Result) bool {
+	t := item.Get("type").String()
+	return t == "function_call_output" || t == "custom_tool_call_output"
+}
+
 func pairOpenAIResponsesReasoningWithFunctionCalls(items []gjson.Result) []gjson.Result {
 	isDetachedCarrier := isOpenAIResponsesDetachedCarrier
 	postCallSignature := make(map[int]string)
 	postCallCarrier := make(map[int]bool)
 	consumedPostCallCarrier := make(map[int]bool)
 	for groupStart := 0; groupStart < len(items); {
-		if items[groupStart].Get("type").String() != "function_call" && !isDetachedCarrier(items[groupStart]) {
+		if !isOpenAIResponsesToolCall(items[groupStart]) && !isDetachedCarrier(items[groupStart]) {
 			groupStart++
 			continue
 		}
 		groupEnd := groupStart
 		hasFunctionCall := false
-		for groupEnd < len(items) && (items[groupEnd].Get("type").String() == "function_call" || isDetachedCarrier(items[groupEnd])) {
-			hasFunctionCall = hasFunctionCall || items[groupEnd].Get("type").String() == "function_call"
+		for groupEnd < len(items) && (isOpenAIResponsesToolCall(items[groupEnd]) || isDetachedCarrier(items[groupEnd])) {
+			hasFunctionCall = hasFunctionCall || isOpenAIResponsesToolCall(items[groupEnd])
 			groupEnd++
 		}
-		if !hasFunctionCall || groupEnd >= len(items) || items[groupEnd].Get("type").String() != "function_call_output" {
+		if !hasFunctionCall || groupEnd >= len(items) || !isOpenAIResponsesToolOutput(items[groupEnd]) {
 			groupStart = groupEnd
 			continue
 		}
 		outputEnd := groupEnd
-		for outputEnd < len(items) && items[outputEnd].Get("type").String() == "function_call_output" {
+		for outputEnd < len(items) && isOpenAIResponsesToolOutput(items[outputEnd]) {
 			outputEnd++
 		}
 		// A run beginning with a carrier uses leading-carrier semantics. A run
 		// beginning with a call uses post-call semantics. This preserves both
 		// carrier,call,carrier,call and call,carrier,call,carrier histories.
-		if items[groupStart].Get("type").String() == "function_call" {
+		if isOpenAIResponsesToolCall(items[groupStart]) {
 			for callIndex := groupStart; callIndex < groupEnd; callIndex++ {
 				item := items[callIndex]
-				if item.Get("type").String() != "function_call" || strings.TrimSpace(item.Get("_cpa_reasoning_signature").String()) != "" || callIndex+1 >= groupEnd || !isDetachedCarrier(items[callIndex+1]) {
+				if !isOpenAIResponsesToolCall(item) || strings.TrimSpace(item.Get("_cpa_reasoning_signature").String()) != "" || callIndex+1 >= groupEnd || !isDetachedCarrier(items[callIndex+1]) {
 					continue
 				}
 				carrierDirection := geminiResponsesCarrierDirection(items[callIndex+1])
@@ -607,7 +607,7 @@ func pairOpenAIResponsesReasoningWithFunctionCalls(items []gjson.Result) []gjson
 		carrierDirection := geminiResponsesCarrierDirection(item)
 		carrierTarget := geminiResponsesCarrierTarget(item)
 		canBindFollowingCall := carrierDirection == "" || (carrierDirection == geminiResponsesCarrierNext && (carrierTarget == geminiResponsesCarrierFunction || carrierTarget == geminiResponsesCarrierAny))
-		if item.Get("type").String() == "reasoning" && !postCallCarrier[index] && canBindFollowingCall && !strings.Contains(item.Get("id").String(), "_detached_after_") && index+1 < len(items) && items[index+1].Get("type").String() == "function_call" {
+		if item.Get("type").String() == "reasoning" && !postCallCarrier[index] && canBindFollowingCall && !strings.Contains(item.Get("id").String(), "_detached_after_") && index+1 < len(items) && isOpenAIResponsesToolCall(items[index+1]) {
 			rawSignature := strings.TrimSpace(item.Get("encrypted_content").String())
 			if rawSignature != "" {
 				functionCall := []byte(items[index+1].Raw)
@@ -655,7 +655,7 @@ func reorderOpenAIResponsesDetachedReasoning(items []gjson.Result) []gjson.Resul
 					alreadyPairedFunction = priorBindsFollowing && (priorTarget == geminiResponsesCarrierFunction || priorTarget == geminiResponsesCarrierAny)
 				}
 				bindPreviousMessage := direction == geminiResponsesCarrierPrevious && (targetKind == geminiResponsesCarrierText || targetKind == geminiResponsesCarrierAny) && isAssistantMessage && !alreadyPairedText
-				bindPreviousFunction := direction == geminiResponsesCarrierPrevious && (targetKind == geminiResponsesCarrierFunction || targetKind == geminiResponsesCarrierAny) && previousType == "function_call" && strings.TrimSpace(previous.Get("_cpa_reasoning_signature").String()) == "" && !alreadyPairedFunction
+				bindPreviousFunction := direction == geminiResponsesCarrierPrevious && (targetKind == geminiResponsesCarrierFunction || targetKind == geminiResponsesCarrierAny) && (previousType == "function_call" || previousType == "custom_tool_call") && strings.TrimSpace(previous.Get("_cpa_reasoning_signature").String()) == "" && !alreadyPairedFunction
 				if bindPreviousMessage || bindPreviousFunction {
 					movedItemJSON, _ := sjson.SetBytes([]byte(item.Raw), geminiResponsesCarrierDirectionField, geminiResponsesCarrierNext)
 					reordered[len(reordered)-1] = gjson.ParseBytes(movedItemJSON)
@@ -675,7 +675,7 @@ func reorderOpenAIResponsesDetachedReasoning(items []gjson.Result) []gjson.Resul
 				prior := reordered[len(reordered)-2]
 				alreadyPaired = isOpenAIResponsesDetachedCarrier(prior) && strings.Contains(prior.Get("id").String(), "_detached_after_")
 			}
-			if !alreadyPaired && (isAssistantMessage || (markedDetached && previousType == "function_call" && strings.TrimSpace(previous.Get("_cpa_reasoning_signature").String()) == "")) {
+			if !alreadyPaired && (isAssistantMessage || (markedDetached && (previousType == "function_call" || previousType == "custom_tool_call") && strings.TrimSpace(previous.Get("_cpa_reasoning_signature").String()) == "")) {
 				reordered[len(reordered)-1] = item
 				reordered = append(reordered, previous)
 				continue
@@ -686,16 +686,38 @@ func reorderOpenAIResponsesDetachedReasoning(items []gjson.Result) []gjson.Resul
 	return reordered
 }
 
-func buildOpenAIResponsesFunctionCallPart(item gjson.Result, signature string) []byte {
-	name := util.SanitizeFunctionName(item.Get("name").String())
-	arguments := item.Get("arguments").String()
+func buildOpenAIResponsesFunctionCallPart(item gjson.Result, signature string, forwardMap map[string]string) []byte {
+	name := item.Get("name").String()
+	if ns := item.Get("namespace").String(); ns != "" {
+		name = util.QualifyResponsesNamespaceToolName(ns, name)
+	}
+	name = util.MapResponsesToolName(forwardMap, name)
 	functionCall := []byte(`{"functionCall":{"name":"","args":{}}}`)
 	functionCall, _ = sjson.SetBytes(functionCall, "functionCall.name", name)
 	functionCall, _ = sjson.SetBytes(functionCall, "thoughtSignature", signature)
 	functionCall, _ = sjson.SetBytes(functionCall, "functionCall.id", item.Get("call_id").String())
-	if arguments != "" {
-		argsResult := gjson.Parse(arguments)
-		functionCall, _ = sjson.SetRawBytes(functionCall, "functionCall.args", []byte(argsResult.Raw))
+
+	if item.Get("type").String() == "custom_tool_call" {
+		inputVal := item.Get("input")
+		if inputVal.Exists() {
+			if inputVal.Type == gjson.String {
+				functionCall, _ = sjson.SetBytes(functionCall, "functionCall.args.input", inputVal.String())
+			} else {
+				functionCall, _ = sjson.SetRawBytes(functionCall, "functionCall.args.input", []byte(inputVal.Raw))
+			}
+		} else {
+			functionCall, _ = sjson.SetBytes(functionCall, "functionCall.args.input", "")
+		}
+	} else {
+		arguments := item.Get("arguments").String()
+		if arguments != "" {
+			argsResult := gjson.Parse(arguments)
+			if argsResult.IsObject() || argsResult.IsArray() {
+				functionCall, _ = sjson.SetRawBytes(functionCall, "functionCall.args", []byte(argsResult.Raw))
+			} else {
+				functionCall, _ = sjson.SetBytes(functionCall, "functionCall.args.arguments", arguments)
+			}
+		}
 	}
 	return functionCall
 }
@@ -887,7 +909,7 @@ func buildOpenAIResponsesFunctionResponseParts(item gjson.Result, functionNamesB
 
 func collectOpenAIResponsesFunctionCallOutputs(items []gjson.Result, start int, pendingCallIDs []string) ([]gjson.Result, map[int]bool, []string) {
 	end := start + 1
-	for end < len(items) && items[end].Get("type").String() == "function_call_output" {
+	for end < len(items) && (items[end].Get("type").String() == "function_call_output" || items[end].Get("type").String() == "custom_tool_call_output") {
 		end++
 	}
 	outputs := items[start:end]
@@ -926,29 +948,29 @@ func orderOpenAIResponsesFunctionCallOutputs(outputs []gjson.Result, pendingCall
 	return ordered, remainingPending
 }
 
-func buildOpenAIResponsesFunctionCallModelContent(item gjson.Result, signature string) []byte {
+func buildOpenAIResponsesFunctionCallModelContent(item gjson.Result, signature string, forwardMap map[string]string) []byte {
 	modelContent := []byte(`{"role":"model","parts":[]}`)
-	modelContent, _ = sjson.SetRawBytes(modelContent, "parts", translatorcommon.JoinRawArray([][]byte{buildOpenAIResponsesFunctionCallPart(item, signature)}))
+	modelContent, _ = sjson.SetRawBytes(modelContent, "parts", translatorcommon.JoinRawArray([][]byte{buildOpenAIResponsesFunctionCallPart(item, signature, forwardMap)}))
 	return modelContent
 }
 
-func buildOpenAIResponsesEmptyReasoningFunctionCallModelContent(item gjson.Result, signature string) []byte {
+func buildOpenAIResponsesEmptyReasoningFunctionCallModelContent(item gjson.Result, signature string, forwardMap map[string]string) []byte {
 	thought := []byte(`{"text":"","thought":true,"thoughtSignature":""}`)
 	thought, _ = sjson.SetBytes(thought, "thoughtSignature", signature)
-	parts := [][]byte{thought, buildOpenAIResponsesFunctionCallPart(item, signature)}
+	parts := [][]byte{thought, buildOpenAIResponsesFunctionCallPart(item, signature, forwardMap)}
 	modelContent := []byte(`{"role":"model","parts":[]}`)
 	modelContent, _ = sjson.SetRawBytes(modelContent, "parts", translatorcommon.JoinRawArray(parts))
 	return modelContent
 }
 
-func buildOpenAIResponsesReasoningFunctionCallModelContent(thoughtText string, item gjson.Result, signature string) []byte {
+func buildOpenAIResponsesReasoningFunctionCallModelContent(thoughtText string, item gjson.Result, signature string, forwardMap map[string]string) []byte {
 	parts := make([][]byte, 0, 2)
 	if thoughtText != "" {
 		thought := []byte(`{"text":"","thought":true}`)
 		thought, _ = sjson.SetBytes(thought, "text", thoughtText)
 		parts = append(parts, thought)
 	}
-	parts = append(parts, buildOpenAIResponsesFunctionCallPart(item, signature))
+	parts = append(parts, buildOpenAIResponsesFunctionCallPart(item, signature, forwardMap))
 	modelContent := []byte(`{"role":"model","parts":[]}`)
 	modelContent, _ = sjson.SetRawBytes(modelContent, "parts", translatorcommon.JoinRawArray(parts))
 	return modelContent

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
@@ -1357,3 +1357,205 @@ func TestConvertOpenAIResponsesRequestToGemini_FunctionCallOutputVariations(t *t
 		}
 	})
 }
+
+func TestConvertOpenAIResponsesRequestToGemini_AdditionalToolsNamespaceAndCustom(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-2.5-flash",
+		"input": [
+			{
+				"type": "additional_tools",
+				"role": "developer",
+				"tools": [
+					{
+						"type": "namespace",
+						"name": "functions",
+						"tools": [
+							{
+								"type": "custom",
+								"name": "exec",
+								"description": "Execute a command"
+							},
+							{
+								"type": "function",
+								"name": "continuity_probe",
+								"description": "Return a continuity probe",
+								"parameters": {
+									"type": "object",
+									"properties": {
+										"value": {"type": "string"}
+									},
+									"required": ["value"]
+								}
+							}
+						]
+					}
+				]
+			},
+			{
+				"role": "user",
+				"content": [
+					{
+						"type": "input_text",
+						"text": "Run probe"
+					}
+				]
+			}
+		],
+		"tool_choice": {
+			"type": "function",
+			"name": "continuity_probe",
+			"namespace": "functions"
+		}
+	}`
+
+	output := ConvertOpenAIResponsesRequestToGemini("gemini-2.5-flash", []byte(inputJSON), false)
+	decls := gjson.GetBytes(output, "tools.0.functionDeclarations").Array()
+	if len(decls) != 2 {
+		t.Fatalf("expected 2 functionDeclarations, got %d; raw: %s", len(decls), output)
+	}
+
+	execDecl := decls[0]
+	if got := execDecl.Get("name").String(); got != "functions__exec" {
+		t.Fatalf("decl 0 name = %q, want functions__exec", got)
+	}
+	if got := execDecl.Get("parametersJsonSchema.properties.input.type").String(); got != "string" {
+		t.Fatalf("decl 0 custom input schema missing: %s", execDecl.Raw)
+	}
+
+	probeDecl := decls[1]
+	if got := probeDecl.Get("name").String(); got != "functions__continuity_probe" {
+		t.Fatalf("decl 1 name = %q, want functions__continuity_probe", got)
+	}
+
+	mode := gjson.GetBytes(output, "toolConfig.functionCallingConfig.mode").String()
+	if mode != "ANY" {
+		t.Fatalf("toolConfig mode = %q, want ANY", mode)
+	}
+	allowed := gjson.GetBytes(output, "toolConfig.functionCallingConfig.allowedFunctionNames.0").String()
+	if allowed != "functions__continuity_probe" {
+		t.Fatalf("allowedFunctionNames = %q, want functions__continuity_probe", allowed)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToGemini_ReplaysCustomToolCallAndOutput(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-2.5-flash",
+		"input": [
+			{
+				"type": "additional_tools",
+				"tools": [
+					{
+						"type": "namespace",
+						"name": "functions",
+						"tools": [
+							{"type": "custom", "name": "exec"}
+						]
+					}
+				]
+			},
+			{
+				"type": "custom_tool_call",
+				"call_id": "call_1",
+				"name": "exec",
+				"namespace": "functions",
+				"input": "pwd"
+			},
+			{
+				"type": "custom_tool_call_output",
+				"call_id": "call_1",
+				"output": "/workspace"
+			}
+		]
+	}`
+
+	output := ConvertOpenAIResponsesRequestToGemini("gemini-2.5-flash", []byte(inputJSON), false)
+	contents := gjson.GetBytes(output, "contents").Array()
+	if len(contents) < 2 {
+		t.Fatalf("expected at least 2 contents, got %d; raw: %s", len(contents), output)
+	}
+
+	callPart := contents[0].Get("parts.0.functionCall")
+	if !callPart.Exists() {
+		t.Fatalf("missing functionCall in content 0: %s", contents[0].Raw)
+	}
+	if got := callPart.Get("name").String(); got != "functions__exec" {
+		t.Fatalf("functionCall name = %q, want functions__exec", got)
+	}
+	if got := callPart.Get("args.input").String(); got != "pwd" {
+		t.Fatalf("functionCall args.input = %q, want pwd", got)
+	}
+
+	respPart := contents[1].Get("parts.0.functionResponse")
+	if !respPart.Exists() {
+		t.Fatalf("missing functionResponse in content 1: %s", contents[1].Raw)
+	}
+	if got := respPart.Get("name").String(); got != "functions__exec" {
+		t.Fatalf("functionResponse name = %q, want functions__exec", got)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToGemini_TwoTurnCustomToolRoundtripWithReasoning(t *testing.T) {
+	// Turn 2 request: includes reasoning carrier before custom_tool_call, then custom_tool_call_output
+	inputJSON := `{
+		"model": "gemini-3.6-flash-high",
+		"input": [
+			{
+				"type": "additional_tools",
+				"tools": [
+					{
+						"type": "namespace",
+						"name": "functions",
+						"tools": [
+							{"type": "custom", "name": "exec"}
+						]
+					}
+				]
+			},
+			{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "Run pwd"}]},
+			{"type": "reasoning", "encrypted_content": "` + testResponsesGeminiThoughtSignature + `", "summary": [{"type": "summary_text", "text": "executing pwd"}]},
+			{
+				"type": "custom_tool_call",
+				"call_id": "call_1",
+				"name": "exec",
+				"namespace": "functions",
+				"input": "pwd"
+			},
+			{
+				"type": "custom_tool_call_output",
+				"call_id": "call_1",
+				"output": "/workspace"
+			}
+		]
+	}`
+
+	output := ConvertOpenAIResponsesRequestToGemini("gemini-3.6-flash-high", []byte(inputJSON), false)
+	contents := gjson.GetBytes(output, "contents").Array()
+	if len(contents) != 3 {
+		t.Fatalf("expected 3 contents (user, model, user), got %d; raw: %s", len(contents), output)
+	}
+
+	modelParts := contents[1].Get("parts").Array()
+	if len(modelParts) != 2 {
+		t.Fatalf("expected 2 parts in model content (thought + functionCall), got %d; raw: %s", len(modelParts), contents[1].Raw)
+	}
+	if !modelParts[0].Get("thought").Bool() || modelParts[0].Get("text").String() != "executing pwd" {
+		t.Fatalf("expected thought part with 'executing pwd', got: %s", modelParts[0].Raw)
+	}
+	if modelParts[1].Get("functionCall.name").String() != "functions__exec" {
+		t.Fatalf("expected functionCall name 'functions__exec', got: %s", modelParts[1].Raw)
+	}
+	if modelParts[1].Get("thoughtSignature").String() != testResponsesGeminiThoughtSignature {
+		t.Fatalf("expected thoughtSignature on functionCall, got: %s", modelParts[1].Raw)
+	}
+
+	userRespParts := contents[2].Get("parts").Array()
+	if len(userRespParts) != 1 {
+		t.Fatalf("expected 1 part in user tool response, got %d; raw: %s", len(userRespParts), contents[2].Raw)
+	}
+	if userRespParts[0].Get("functionResponse.name").String() != "functions__exec" {
+		t.Fatalf("expected functionResponse name 'functions__exec', got: %s", userRespParts[0].Raw)
+	}
+	if userRespParts[0].Get("functionResponse.response.result").String() != "/workspace" {
+		t.Fatalf("expected functionResponse result '/workspace', got: %s", userRespParts[0].Raw)
+	}
+}

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_response.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_response.go
@@ -65,10 +65,14 @@ type geminiToResponsesState struct {
 	// function call aggregation (keyed by output_index)
 	NextIndex        int
 	FuncArgsBuf      map[int]*strings.Builder
+	FuncInputBuf     map[int]string
+	FuncCustom       map[int]bool
 	FuncNames        map[int]string
+	FuncNamespaces   map[int]string
 	FuncCallIDs      map[int]string
 	FuncDone         map[int]bool
 	SanitizedNameMap map[string]string
+	ToolIdentityMap  map[string]util.ResponsesToolIdentity
 }
 
 // responseIDCounter provides a process-wide unique counter for synthesized response identifiers.
@@ -116,10 +120,14 @@ func emitEvent(event string, payload []byte) []byte {
 
 // ConvertGeminiResponseToOpenAIResponses converts Gemini SSE chunks into OpenAI Responses SSE events.
 func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, param *any) [][]byte {
+	reqJSON := pickRequestJSON(originalRequestRawJSON, requestRawJSON)
 	if *param == nil {
 		*param = &geminiToResponsesState{
 			FuncArgsBuf:             make(map[int]*strings.Builder),
+			FuncInputBuf:            make(map[int]string),
+			FuncCustom:              make(map[int]bool),
 			FuncNames:               make(map[int]string),
+			FuncNamespaces:          make(map[int]string),
 			FuncCallIDs:             make(map[int]string),
 			FuncDone:                make(map[int]bool),
 			DetachedReasoning:       make(map[int]geminiDetachedReasoningItem),
@@ -127,14 +135,24 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 			CompletedReasoning:      make(map[int]geminiCompletedReasoningItem),
 			SeenReasoningSignatures: make(map[string]bool),
 			SanitizedNameMap:        util.SanitizedToolNameMap(originalRequestRawJSON),
+			ToolIdentityMap:         util.ResponsesToolReverseIdentityMap(reqJSON),
 		}
 	}
 	st := (*param).(*geminiToResponsesState)
 	if st.FuncArgsBuf == nil {
 		st.FuncArgsBuf = make(map[int]*strings.Builder)
 	}
+	if st.FuncInputBuf == nil {
+		st.FuncInputBuf = make(map[int]string)
+	}
+	if st.FuncCustom == nil {
+		st.FuncCustom = make(map[int]bool)
+	}
 	if st.FuncNames == nil {
 		st.FuncNames = make(map[int]string)
+	}
+	if st.FuncNamespaces == nil {
+		st.FuncNamespaces = make(map[int]string)
 	}
 	if st.FuncCallIDs == nil {
 		st.FuncCallIDs = make(map[int]string)
@@ -156,6 +174,9 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 	}
 	if st.SanitizedNameMap == nil {
 		st.SanitizedNameMap = util.SanitizedToolNameMap(originalRequestRawJSON)
+	}
+	if st.ToolIdentityMap == nil {
+		st.ToolIdentityMap = util.ResponsesToolReverseIdentityMap(reqJSON)
 	}
 
 	if bytes.HasPrefix(rawJSON, []byte("data:")) {
@@ -289,7 +310,7 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 		partDone, _ = sjson.SetBytes(partDone, "output_index", st.MsgIndex)
 		partDone, _ = sjson.SetBytes(partDone, "part.text", fullText)
 		out = append(out, emitEvent("response.content_part.done", partDone))
-		final := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"message","status":"completed","content":[{"type":"output_text","text":""}],"role":"assistant"}}`)
+		final := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":""}],"role":"assistant"}}`)
 		final, _ = sjson.SetBytes(final, "sequence_number", nextSeq())
 		final, _ = sjson.SetBytes(final, "output_index", st.MsgIndex)
 		final, _ = sjson.SetBytes(final, "item.id", st.CurrentMsgID)
@@ -571,7 +592,17 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 				finalizeReasoning()
 				finalizeMessage()
 				st.LastSemanticKind = geminiResponsesCarrierFunction
-				name := util.RestoreSanitizedToolName(st.SanitizedNameMap, fc.Get("name").String())
+
+				rawName := fc.Get("name").String()
+				identity, hasIdentity := st.ToolIdentityMap[rawName]
+				if !hasIdentity {
+					restored := util.RestoreSanitizedToolName(st.SanitizedNameMap, rawName)
+					identity = util.ResponsesToolIdentity{Name: restored}
+				}
+				name := identity.Name
+				namespace := identity.Namespace
+				isCustom := identity.Custom
+
 				idx := st.NextIndex
 				st.NextIndex++
 				// Ensure buffers
@@ -582,6 +613,8 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 					st.FuncCallIDs[idx] = fmt.Sprintf("call_%d_%d", time.Now().UnixNano(), atomic.AddUint64(&funcCallIDCounter, 1))
 				}
 				st.FuncNames[idx] = name
+				st.FuncNamespaces[idx] = namespace
+				st.FuncCustom[idx] = isCustom
 
 				argsJSON := "{}"
 				if args := fc.Get("args"); args.Exists() {
@@ -591,45 +624,80 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 					st.FuncArgsBuf[idx].WriteString(argsJSON)
 				}
 
-				// Emit item.added for function call
-				item := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"in_progress","arguments":"","call_id":"","name":""}}`)
-				item, _ = sjson.SetBytes(item, "sequence_number", nextSeq())
-				item, _ = sjson.SetBytes(item, "output_index", idx)
-				item, _ = sjson.SetBytes(item, "item.id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
-				item, _ = sjson.SetBytes(item, "item.call_id", st.FuncCallIDs[idx])
-				item, _ = sjson.SetBytes(item, "item.name", name)
-				out = append(out, emitEvent("response.output_item.added", item))
+				if isCustom {
+					inputStr := util.UnwrapResponsesCustomToolInput(argsJSON)
+					st.FuncInputBuf[idx] = inputStr
 
-				// Emit arguments delta (full args in one chunk).
-				// When Gemini omits args, emit "{}" to keep Responses streaming event order consistent.
-				if argsJSON != "" {
-					ad := []byte(`{"type":"response.function_call_arguments.delta","sequence_number":0,"item_id":"","output_index":0,"delta":""}`)
-					ad, _ = sjson.SetBytes(ad, "sequence_number", nextSeq())
-					ad, _ = sjson.SetBytes(ad, "item_id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
-					ad, _ = sjson.SetBytes(ad, "output_index", idx)
-					ad, _ = sjson.SetBytes(ad, "delta", argsJSON)
-					out = append(out, emitEvent("response.function_call_arguments.delta", ad))
-				}
+					// Emit item.added for custom tool call
+					item := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"custom_tool_call","status":"in_progress","input":"","call_id":"","name":""}}`)
+					item, _ = sjson.SetBytes(item, "sequence_number", nextSeq())
+					item, _ = sjson.SetBytes(item, "output_index", idx)
+					item, _ = sjson.SetBytes(item, "item.id", fmt.Sprintf("ctc_%s", st.FuncCallIDs[idx]))
+					item, _ = sjson.SetBytes(item, "item.call_id", st.FuncCallIDs[idx])
+					item = translatorcommon.SetResponsesToolCallIdentity(item, name, namespace, "item")
+					out = append(out, emitEvent("response.output_item.added", item))
 
-				// Gemini emits the full function call payload at once, so we can finalize it immediately.
-				if !st.FuncDone[idx] {
-					fcDone := []byte(`{"type":"response.function_call_arguments.done","sequence_number":0,"item_id":"","output_index":0,"arguments":""}`)
-					fcDone, _ = sjson.SetBytes(fcDone, "sequence_number", nextSeq())
-					fcDone, _ = sjson.SetBytes(fcDone, "item_id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
-					fcDone, _ = sjson.SetBytes(fcDone, "output_index", idx)
-					fcDone, _ = sjson.SetBytes(fcDone, "arguments", argsJSON)
-					out = append(out, emitEvent("response.function_call_arguments.done", fcDone))
+					// Emit custom tool call input.done
+					if !st.FuncDone[idx] {
+						inputDone := []byte(`{"type":"response.custom_tool_call_input.done","sequence_number":0,"item_id":"","output_index":0,"input":""}`)
+						inputDone, _ = sjson.SetBytes(inputDone, "sequence_number", nextSeq())
+						inputDone, _ = sjson.SetBytes(inputDone, "item_id", fmt.Sprintf("ctc_%s", st.FuncCallIDs[idx]))
+						inputDone, _ = sjson.SetBytes(inputDone, "output_index", idx)
+						inputDone, _ = sjson.SetBytes(inputDone, "input", inputStr)
+						out = append(out, emitEvent("response.custom_tool_call_input.done", inputDone))
 
-					itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}}`)
-					itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
-					itemDone, _ = sjson.SetBytes(itemDone, "output_index", idx)
-					itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
-					itemDone, _ = sjson.SetBytes(itemDone, "item.arguments", argsJSON)
-					itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", st.FuncCallIDs[idx])
-					itemDone, _ = sjson.SetBytes(itemDone, "item.name", st.FuncNames[idx])
-					out = append(out, emitEvent("response.output_item.done", itemDone))
+						itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"custom_tool_call","status":"completed","input":"","call_id":"","name":""}}`)
+						itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
+						itemDone, _ = sjson.SetBytes(itemDone, "output_index", idx)
+						itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("ctc_%s", st.FuncCallIDs[idx]))
+						itemDone, _ = sjson.SetBytes(itemDone, "item.input", inputStr)
+						itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", st.FuncCallIDs[idx])
+						itemDone = translatorcommon.SetResponsesToolCallIdentity(itemDone, name, namespace, "item")
+						out = append(out, emitEvent("response.output_item.done", itemDone))
 
-					st.FuncDone[idx] = true
+						st.FuncDone[idx] = true
+					}
+				} else {
+					// Emit item.added for function call
+					item := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"in_progress","arguments":"","call_id":"","name":""}}`)
+					item, _ = sjson.SetBytes(item, "sequence_number", nextSeq())
+					item, _ = sjson.SetBytes(item, "output_index", idx)
+					item, _ = sjson.SetBytes(item, "item.id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
+					item, _ = sjson.SetBytes(item, "item.call_id", st.FuncCallIDs[idx])
+					item = translatorcommon.SetResponsesToolCallIdentity(item, name, namespace, "item")
+					out = append(out, emitEvent("response.output_item.added", item))
+
+					// Emit arguments delta (full args in one chunk).
+					// When Gemini omits args, emit "{}" to keep Responses streaming event order consistent.
+					if argsJSON != "" {
+						ad := []byte(`{"type":"response.function_call_arguments.delta","sequence_number":0,"item_id":"","output_index":0,"delta":""}`)
+						ad, _ = sjson.SetBytes(ad, "sequence_number", nextSeq())
+						ad, _ = sjson.SetBytes(ad, "item_id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
+						ad, _ = sjson.SetBytes(ad, "output_index", idx)
+						ad, _ = sjson.SetBytes(ad, "delta", argsJSON)
+						out = append(out, emitEvent("response.function_call_arguments.delta", ad))
+					}
+
+					// Gemini emits the full function call payload at once, so we can finalize it immediately.
+					if !st.FuncDone[idx] {
+						fcDone := []byte(`{"type":"response.function_call_arguments.done","sequence_number":0,"item_id":"","output_index":0,"arguments":""}`)
+						fcDone, _ = sjson.SetBytes(fcDone, "sequence_number", nextSeq())
+						fcDone, _ = sjson.SetBytes(fcDone, "item_id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
+						fcDone, _ = sjson.SetBytes(fcDone, "output_index", idx)
+						fcDone, _ = sjson.SetBytes(fcDone, "arguments", argsJSON)
+						out = append(out, emitEvent("response.function_call_arguments.done", fcDone))
+
+						itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}}`)
+						itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
+						itemDone, _ = sjson.SetBytes(itemDone, "output_index", idx)
+						itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
+						itemDone, _ = sjson.SetBytes(itemDone, "item.arguments", argsJSON)
+						itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", st.FuncCallIDs[idx])
+						itemDone = translatorcommon.SetResponsesToolCallIdentity(itemDone, name, namespace, "item")
+						out = append(out, emitEvent("response.output_item.done", itemDone))
+
+						st.FuncDone[idx] = true
+					}
 				}
 
 				return true
@@ -667,26 +735,44 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 				if st.FuncDone[idx] {
 					continue
 				}
-				args := "{}"
-				if b := st.FuncArgsBuf[idx]; b != nil && b.Len() > 0 {
-					args = b.String()
+				if st.FuncCustom[idx] {
+					inputStr := st.FuncInputBuf[idx]
+					inputDone := []byte(`{"type":"response.custom_tool_call_input.done","sequence_number":0,"item_id":"","output_index":0,"input":""}`)
+					inputDone, _ = sjson.SetBytes(inputDone, "sequence_number", nextSeq())
+					inputDone, _ = sjson.SetBytes(inputDone, "item_id", fmt.Sprintf("ctc_%s", st.FuncCallIDs[idx]))
+					inputDone, _ = sjson.SetBytes(inputDone, "output_index", idx)
+					inputDone, _ = sjson.SetBytes(inputDone, "input", inputStr)
+					out = append(out, emitEvent("response.custom_tool_call_input.done", inputDone))
+
+					itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"custom_tool_call","status":"completed","input":"","call_id":"","name":""}}`)
+					itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
+					itemDone, _ = sjson.SetBytes(itemDone, "output_index", idx)
+					itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("ctc_%s", st.FuncCallIDs[idx]))
+					itemDone, _ = sjson.SetBytes(itemDone, "item.input", inputStr)
+					itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", st.FuncCallIDs[idx])
+					itemDone = translatorcommon.SetResponsesToolCallIdentity(itemDone, st.FuncNames[idx], st.FuncNamespaces[idx], "item")
+					out = append(out, emitEvent("response.output_item.done", itemDone))
+				} else {
+					args := "{}"
+					if b := st.FuncArgsBuf[idx]; b != nil && b.Len() > 0 {
+						args = b.String()
+					}
+					fcDone := []byte(`{"type":"response.function_call_arguments.done","sequence_number":0,"item_id":"","output_index":0,"arguments":""}`)
+					fcDone, _ = sjson.SetBytes(fcDone, "sequence_number", nextSeq())
+					fcDone, _ = sjson.SetBytes(fcDone, "item_id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
+					fcDone, _ = sjson.SetBytes(fcDone, "output_index", idx)
+					fcDone, _ = sjson.SetBytes(fcDone, "arguments", args)
+					out = append(out, emitEvent("response.function_call_arguments.done", fcDone))
+
+					itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}}`)
+					itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
+					itemDone, _ = sjson.SetBytes(itemDone, "output_index", idx)
+					itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
+					itemDone, _ = sjson.SetBytes(itemDone, "item.arguments", args)
+					itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", st.FuncCallIDs[idx])
+					itemDone = translatorcommon.SetResponsesToolCallIdentity(itemDone, st.FuncNames[idx], st.FuncNamespaces[idx], "item")
+					out = append(out, emitEvent("response.output_item.done", itemDone))
 				}
-				fcDone := []byte(`{"type":"response.function_call_arguments.done","sequence_number":0,"item_id":"","output_index":0,"arguments":""}`)
-				fcDone, _ = sjson.SetBytes(fcDone, "sequence_number", nextSeq())
-				fcDone, _ = sjson.SetBytes(fcDone, "item_id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
-				fcDone, _ = sjson.SetBytes(fcDone, "output_index", idx)
-				fcDone, _ = sjson.SetBytes(fcDone, "arguments", args)
-				out = append(out, emitEvent("response.function_call_arguments.done", fcDone))
-
-				itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}}`)
-				itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
-				itemDone, _ = sjson.SetBytes(itemDone, "output_index", idx)
-				itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
-				itemDone, _ = sjson.SetBytes(itemDone, "item.arguments", args)
-				itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", st.FuncCallIDs[idx])
-				itemDone, _ = sjson.SetBytes(itemDone, "item.name", st.FuncNames[idx])
-				out = append(out, emitEvent("response.output_item.done", itemDone))
-
 				st.FuncDone[idx] = true
 			}
 		}
@@ -790,16 +876,26 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 			}
 
 			if callID, ok := st.FuncCallIDs[idx]; ok && callID != "" {
-				args := "{}"
-				if b := st.FuncArgsBuf[idx]; b != nil && b.Len() > 0 {
-					args = b.String()
+				if st.FuncCustom[idx] {
+					inputStr := st.FuncInputBuf[idx]
+					item := []byte(`{"id":"","type":"custom_tool_call","status":"completed","input":"","call_id":"","name":""}`)
+					item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("ctc_%s", callID))
+					item, _ = sjson.SetBytes(item, "input", inputStr)
+					item, _ = sjson.SetBytes(item, "call_id", callID)
+					item = translatorcommon.SetResponsesToolCallIdentity(item, st.FuncNames[idx], st.FuncNamespaces[idx], "")
+					outputs = append(outputs, item)
+				} else {
+					args := "{}"
+					if b := st.FuncArgsBuf[idx]; b != nil && b.Len() > 0 {
+						args = b.String()
+					}
+					item := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
+					item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("fc_%s", callID))
+					item, _ = sjson.SetBytes(item, "arguments", args)
+					item, _ = sjson.SetBytes(item, "call_id", callID)
+					item = translatorcommon.SetResponsesToolCallIdentity(item, st.FuncNames[idx], st.FuncNamespaces[idx], "")
+					outputs = append(outputs, item)
 				}
-				item := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
-				item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("fc_%s", callID))
-				item, _ = sjson.SetBytes(item, "arguments", args)
-				item, _ = sjson.SetBytes(item, "call_id", callID)
-				item, _ = sjson.SetBytes(item, "name", st.FuncNames[idx])
-				outputs = append(outputs, item)
 			}
 		}
 		if len(outputs) > 0 {
@@ -842,7 +938,9 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 func ConvertGeminiResponseToOpenAIResponsesNonStream(_ context.Context, _ string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, _ *any) []byte {
 	root := gjson.ParseBytes(rawJSON)
 	root = unwrapGeminiResponseRoot(root)
+	reqJSON := pickRequestJSON(originalRequestRawJSON, requestRawJSON)
 	sanitizedNameMap := util.SanitizedToolNameMap(originalRequestRawJSON)
+	toolIdentityMap := util.ResponsesToolReverseIdentityMap(reqJSON)
 
 	// Base response scaffold
 	resp := []byte(`{"id":"","object":"response","created_at":0,"status":"completed","background":false,"error":null,"incomplete_details":null}`)
@@ -1071,18 +1169,38 @@ func ConvertGeminiResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 				}
 				flushReasoningOutput()
 				flushMessageOutput()
-				name := util.RestoreSanitizedToolName(sanitizedNameMap, fc.Get("name").String())
+
+				rawName := fc.Get("name").String()
+				identity, hasIdentity := toolIdentityMap[rawName]
+				if !hasIdentity {
+					restored := util.RestoreSanitizedToolName(sanitizedNameMap, rawName)
+					identity = util.ResponsesToolIdentity{Name: restored}
+				}
+				name := identity.Name
+				namespace := identity.Namespace
+				isCustom := identity.Custom
+
 				args := fc.Get("args")
-				callID := fmt.Sprintf("call_%x_%d", time.Now().UnixNano(), atomic.AddUint64(&funcCallIDCounter, 1))
-				itemJSON := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
-				itemJSON, _ = sjson.SetBytes(itemJSON, "id", fmt.Sprintf("fc_%s", callID))
-				itemJSON, _ = sjson.SetBytes(itemJSON, "call_id", callID)
-				itemJSON, _ = sjson.SetBytes(itemJSON, "name", name)
 				argsStr := ""
 				if args.Exists() {
 					argsStr = args.Raw
 				}
-				itemJSON, _ = sjson.SetBytes(itemJSON, "arguments", argsStr)
+				callID := fmt.Sprintf("call_%x_%d", time.Now().UnixNano(), atomic.AddUint64(&funcCallIDCounter, 1))
+				var itemJSON []byte
+				if isCustom {
+					inputStr := util.UnwrapResponsesCustomToolInput(argsStr)
+					itemJSON = []byte(`{"id":"","type":"custom_tool_call","status":"completed","input":"","call_id":"","name":""}`)
+					itemJSON, _ = sjson.SetBytes(itemJSON, "id", fmt.Sprintf("ctc_%s", callID))
+					itemJSON, _ = sjson.SetBytes(itemJSON, "call_id", callID)
+					itemJSON, _ = sjson.SetBytes(itemJSON, "input", inputStr)
+					itemJSON = translatorcommon.SetResponsesToolCallIdentity(itemJSON, name, namespace, "")
+				} else {
+					itemJSON = []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
+					itemJSON, _ = sjson.SetBytes(itemJSON, "id", fmt.Sprintf("fc_%s", callID))
+					itemJSON, _ = sjson.SetBytes(itemJSON, "call_id", callID)
+					itemJSON, _ = sjson.SetBytes(itemJSON, "arguments", argsStr)
+					itemJSON = translatorcommon.SetResponsesToolCallIdentity(itemJSON, name, namespace, "")
+				}
 				functionIndex := len(functionOutputs)
 				functionOutputs = append(functionOutputs, nonStreamFunctionOutput{item: itemJSON, signature: signature})
 				outputOrder = append(outputOrder, nonStreamOutputOrder{kind: "function", index: functionIndex})

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_response.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_response.go
@@ -65,10 +65,14 @@ type geminiToResponsesState struct {
 	// function call aggregation (keyed by output_index)
 	NextIndex        int
 	FuncArgsBuf      map[int]*strings.Builder
+	FuncInputBuf     map[int]string
+	FuncCustom       map[int]bool
 	FuncNames        map[int]string
+	FuncNamespaces   map[int]string
 	FuncCallIDs      map[int]string
 	FuncDone         map[int]bool
 	SanitizedNameMap map[string]string
+	ToolIdentityMap  map[string]util.ResponsesToolIdentity
 }
 
 // responseIDCounter provides a process-wide unique counter for synthesized response identifiers.
@@ -116,10 +120,14 @@ func emitEvent(event string, payload []byte) []byte {
 
 // ConvertGeminiResponseToOpenAIResponses converts Gemini SSE chunks into OpenAI Responses SSE events.
 func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, param *any) [][]byte {
+	reqJSON := pickRequestJSON(originalRequestRawJSON, requestRawJSON)
 	if *param == nil {
 		*param = &geminiToResponsesState{
 			FuncArgsBuf:             make(map[int]*strings.Builder),
+			FuncInputBuf:            make(map[int]string),
+			FuncCustom:              make(map[int]bool),
 			FuncNames:               make(map[int]string),
+			FuncNamespaces:          make(map[int]string),
 			FuncCallIDs:             make(map[int]string),
 			FuncDone:                make(map[int]bool),
 			DetachedReasoning:       make(map[int]geminiDetachedReasoningItem),
@@ -127,14 +135,24 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 			CompletedReasoning:      make(map[int]geminiCompletedReasoningItem),
 			SeenReasoningSignatures: make(map[string]bool),
 			SanitizedNameMap:        util.SanitizedToolNameMap(originalRequestRawJSON),
+			ToolIdentityMap:         util.ResponsesToolReverseIdentityMap(reqJSON),
 		}
 	}
 	st := (*param).(*geminiToResponsesState)
 	if st.FuncArgsBuf == nil {
 		st.FuncArgsBuf = make(map[int]*strings.Builder)
 	}
+	if st.FuncInputBuf == nil {
+		st.FuncInputBuf = make(map[int]string)
+	}
+	if st.FuncCustom == nil {
+		st.FuncCustom = make(map[int]bool)
+	}
 	if st.FuncNames == nil {
 		st.FuncNames = make(map[int]string)
+	}
+	if st.FuncNamespaces == nil {
+		st.FuncNamespaces = make(map[int]string)
 	}
 	if st.FuncCallIDs == nil {
 		st.FuncCallIDs = make(map[int]string)
@@ -156,6 +174,9 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 	}
 	if st.SanitizedNameMap == nil {
 		st.SanitizedNameMap = util.SanitizedToolNameMap(originalRequestRawJSON)
+	}
+	if st.ToolIdentityMap == nil {
+		st.ToolIdentityMap = util.ResponsesToolReverseIdentityMap(reqJSON)
 	}
 
 	if bytes.HasPrefix(rawJSON, []byte("data:")) {
@@ -571,7 +592,17 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 				finalizeReasoning()
 				finalizeMessage()
 				st.LastSemanticKind = geminiResponsesCarrierFunction
-				name := util.RestoreSanitizedToolName(st.SanitizedNameMap, fc.Get("name").String())
+
+				rawName := fc.Get("name").String()
+				identity, hasIdentity := st.ToolIdentityMap[rawName]
+				if !hasIdentity {
+					restored := util.RestoreSanitizedToolName(st.SanitizedNameMap, rawName)
+					identity = util.ResponsesToolIdentity{Name: restored}
+				}
+				name := identity.Name
+				namespace := identity.Namespace
+				isCustom := identity.Custom
+
 				idx := st.NextIndex
 				st.NextIndex++
 				// Ensure buffers
@@ -582,6 +613,8 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 					st.FuncCallIDs[idx] = fmt.Sprintf("call_%d_%d", time.Now().UnixNano(), atomic.AddUint64(&funcCallIDCounter, 1))
 				}
 				st.FuncNames[idx] = name
+				st.FuncNamespaces[idx] = namespace
+				st.FuncCustom[idx] = isCustom
 
 				argsJSON := "{}"
 				if args := fc.Get("args"); args.Exists() {
@@ -591,45 +624,80 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 					st.FuncArgsBuf[idx].WriteString(argsJSON)
 				}
 
-				// Emit item.added for function call
-				item := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"in_progress","arguments":"","call_id":"","name":""}}`)
-				item, _ = sjson.SetBytes(item, "sequence_number", nextSeq())
-				item, _ = sjson.SetBytes(item, "output_index", idx)
-				item, _ = sjson.SetBytes(item, "item.id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
-				item, _ = sjson.SetBytes(item, "item.call_id", st.FuncCallIDs[idx])
-				item, _ = sjson.SetBytes(item, "item.name", name)
-				out = append(out, emitEvent("response.output_item.added", item))
+				if isCustom {
+					inputStr := util.UnwrapResponsesCustomToolInput(argsJSON)
+					st.FuncInputBuf[idx] = inputStr
 
-				// Emit arguments delta (full args in one chunk).
-				// When Gemini omits args, emit "{}" to keep Responses streaming event order consistent.
-				if argsJSON != "" {
-					ad := []byte(`{"type":"response.function_call_arguments.delta","sequence_number":0,"item_id":"","output_index":0,"delta":""}`)
-					ad, _ = sjson.SetBytes(ad, "sequence_number", nextSeq())
-					ad, _ = sjson.SetBytes(ad, "item_id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
-					ad, _ = sjson.SetBytes(ad, "output_index", idx)
-					ad, _ = sjson.SetBytes(ad, "delta", argsJSON)
-					out = append(out, emitEvent("response.function_call_arguments.delta", ad))
-				}
+					// Emit item.added for custom tool call
+					item := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"custom_tool_call","status":"in_progress","input":"","call_id":"","name":""}}`)
+					item, _ = sjson.SetBytes(item, "sequence_number", nextSeq())
+					item, _ = sjson.SetBytes(item, "output_index", idx)
+					item, _ = sjson.SetBytes(item, "item.id", fmt.Sprintf("ctc_%s", st.FuncCallIDs[idx]))
+					item, _ = sjson.SetBytes(item, "item.call_id", st.FuncCallIDs[idx])
+					item = translatorcommon.SetResponsesToolCallIdentity(item, name, namespace, "item")
+					out = append(out, emitEvent("response.output_item.added", item))
 
-				// Gemini emits the full function call payload at once, so we can finalize it immediately.
-				if !st.FuncDone[idx] {
-					fcDone := []byte(`{"type":"response.function_call_arguments.done","sequence_number":0,"item_id":"","output_index":0,"arguments":""}`)
-					fcDone, _ = sjson.SetBytes(fcDone, "sequence_number", nextSeq())
-					fcDone, _ = sjson.SetBytes(fcDone, "item_id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
-					fcDone, _ = sjson.SetBytes(fcDone, "output_index", idx)
-					fcDone, _ = sjson.SetBytes(fcDone, "arguments", argsJSON)
-					out = append(out, emitEvent("response.function_call_arguments.done", fcDone))
+					// Emit custom tool call input.done
+					if !st.FuncDone[idx] {
+						inputDone := []byte(`{"type":"response.custom_tool_call_input.done","sequence_number":0,"item_id":"","output_index":0,"input":""}`)
+						inputDone, _ = sjson.SetBytes(inputDone, "sequence_number", nextSeq())
+						inputDone, _ = sjson.SetBytes(inputDone, "item_id", fmt.Sprintf("ctc_%s", st.FuncCallIDs[idx]))
+						inputDone, _ = sjson.SetBytes(inputDone, "output_index", idx)
+						inputDone, _ = sjson.SetBytes(inputDone, "input", inputStr)
+						out = append(out, emitEvent("response.custom_tool_call_input.done", inputDone))
 
-					itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}}`)
-					itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
-					itemDone, _ = sjson.SetBytes(itemDone, "output_index", idx)
-					itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
-					itemDone, _ = sjson.SetBytes(itemDone, "item.arguments", argsJSON)
-					itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", st.FuncCallIDs[idx])
-					itemDone, _ = sjson.SetBytes(itemDone, "item.name", st.FuncNames[idx])
-					out = append(out, emitEvent("response.output_item.done", itemDone))
+						itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"custom_tool_call","status":"completed","input":"","call_id":"","name":""}}`)
+						itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
+						itemDone, _ = sjson.SetBytes(itemDone, "output_index", idx)
+						itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("ctc_%s", st.FuncCallIDs[idx]))
+						itemDone, _ = sjson.SetBytes(itemDone, "item.input", inputStr)
+						itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", st.FuncCallIDs[idx])
+						itemDone = translatorcommon.SetResponsesToolCallIdentity(itemDone, name, namespace, "item")
+						out = append(out, emitEvent("response.output_item.done", itemDone))
 
-					st.FuncDone[idx] = true
+						st.FuncDone[idx] = true
+					}
+				} else {
+					// Emit item.added for function call
+					item := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"in_progress","arguments":"","call_id":"","name":""}}`)
+					item, _ = sjson.SetBytes(item, "sequence_number", nextSeq())
+					item, _ = sjson.SetBytes(item, "output_index", idx)
+					item, _ = sjson.SetBytes(item, "item.id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
+					item, _ = sjson.SetBytes(item, "item.call_id", st.FuncCallIDs[idx])
+					item = translatorcommon.SetResponsesToolCallIdentity(item, name, namespace, "item")
+					out = append(out, emitEvent("response.output_item.added", item))
+
+					// Emit arguments delta (full args in one chunk).
+					// When Gemini omits args, emit "{}" to keep Responses streaming event order consistent.
+					if argsJSON != "" {
+						ad := []byte(`{"type":"response.function_call_arguments.delta","sequence_number":0,"item_id":"","output_index":0,"delta":""}`)
+						ad, _ = sjson.SetBytes(ad, "sequence_number", nextSeq())
+						ad, _ = sjson.SetBytes(ad, "item_id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
+						ad, _ = sjson.SetBytes(ad, "output_index", idx)
+						ad, _ = sjson.SetBytes(ad, "delta", argsJSON)
+						out = append(out, emitEvent("response.function_call_arguments.delta", ad))
+					}
+
+					// Gemini emits the full function call payload at once, so we can finalize it immediately.
+					if !st.FuncDone[idx] {
+						fcDone := []byte(`{"type":"response.function_call_arguments.done","sequence_number":0,"item_id":"","output_index":0,"arguments":""}`)
+						fcDone, _ = sjson.SetBytes(fcDone, "sequence_number", nextSeq())
+						fcDone, _ = sjson.SetBytes(fcDone, "item_id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
+						fcDone, _ = sjson.SetBytes(fcDone, "output_index", idx)
+						fcDone, _ = sjson.SetBytes(fcDone, "arguments", argsJSON)
+						out = append(out, emitEvent("response.function_call_arguments.done", fcDone))
+
+						itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}}`)
+						itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
+						itemDone, _ = sjson.SetBytes(itemDone, "output_index", idx)
+						itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
+						itemDone, _ = sjson.SetBytes(itemDone, "item.arguments", argsJSON)
+						itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", st.FuncCallIDs[idx])
+						itemDone = translatorcommon.SetResponsesToolCallIdentity(itemDone, name, namespace, "item")
+						out = append(out, emitEvent("response.output_item.done", itemDone))
+
+						st.FuncDone[idx] = true
+					}
 				}
 
 				return true
@@ -667,26 +735,44 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 				if st.FuncDone[idx] {
 					continue
 				}
-				args := "{}"
-				if b := st.FuncArgsBuf[idx]; b != nil && b.Len() > 0 {
-					args = b.String()
+				if st.FuncCustom[idx] {
+					inputStr := st.FuncInputBuf[idx]
+					inputDone := []byte(`{"type":"response.custom_tool_call_input.done","sequence_number":0,"item_id":"","output_index":0,"input":""}`)
+					inputDone, _ = sjson.SetBytes(inputDone, "sequence_number", nextSeq())
+					inputDone, _ = sjson.SetBytes(inputDone, "item_id", fmt.Sprintf("ctc_%s", st.FuncCallIDs[idx]))
+					inputDone, _ = sjson.SetBytes(inputDone, "output_index", idx)
+					inputDone, _ = sjson.SetBytes(inputDone, "input", inputStr)
+					out = append(out, emitEvent("response.custom_tool_call_input.done", inputDone))
+
+					itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"custom_tool_call","status":"completed","input":"","call_id":"","name":""}}`)
+					itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
+					itemDone, _ = sjson.SetBytes(itemDone, "output_index", idx)
+					itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("ctc_%s", st.FuncCallIDs[idx]))
+					itemDone, _ = sjson.SetBytes(itemDone, "item.input", inputStr)
+					itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", st.FuncCallIDs[idx])
+					itemDone = translatorcommon.SetResponsesToolCallIdentity(itemDone, st.FuncNames[idx], st.FuncNamespaces[idx], "item")
+					out = append(out, emitEvent("response.output_item.done", itemDone))
+				} else {
+					args := "{}"
+					if b := st.FuncArgsBuf[idx]; b != nil && b.Len() > 0 {
+						args = b.String()
+					}
+					fcDone := []byte(`{"type":"response.function_call_arguments.done","sequence_number":0,"item_id":"","output_index":0,"arguments":""}`)
+					fcDone, _ = sjson.SetBytes(fcDone, "sequence_number", nextSeq())
+					fcDone, _ = sjson.SetBytes(fcDone, "item_id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
+					fcDone, _ = sjson.SetBytes(fcDone, "output_index", idx)
+					fcDone, _ = sjson.SetBytes(fcDone, "arguments", args)
+					out = append(out, emitEvent("response.function_call_arguments.done", fcDone))
+
+					itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}}`)
+					itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
+					itemDone, _ = sjson.SetBytes(itemDone, "output_index", idx)
+					itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
+					itemDone, _ = sjson.SetBytes(itemDone, "item.arguments", args)
+					itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", st.FuncCallIDs[idx])
+					itemDone = translatorcommon.SetResponsesToolCallIdentity(itemDone, st.FuncNames[idx], st.FuncNamespaces[idx], "item")
+					out = append(out, emitEvent("response.output_item.done", itemDone))
 				}
-				fcDone := []byte(`{"type":"response.function_call_arguments.done","sequence_number":0,"item_id":"","output_index":0,"arguments":""}`)
-				fcDone, _ = sjson.SetBytes(fcDone, "sequence_number", nextSeq())
-				fcDone, _ = sjson.SetBytes(fcDone, "item_id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
-				fcDone, _ = sjson.SetBytes(fcDone, "output_index", idx)
-				fcDone, _ = sjson.SetBytes(fcDone, "arguments", args)
-				out = append(out, emitEvent("response.function_call_arguments.done", fcDone))
-
-				itemDone := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}}`)
-				itemDone, _ = sjson.SetBytes(itemDone, "sequence_number", nextSeq())
-				itemDone, _ = sjson.SetBytes(itemDone, "output_index", idx)
-				itemDone, _ = sjson.SetBytes(itemDone, "item.id", fmt.Sprintf("fc_%s", st.FuncCallIDs[idx]))
-				itemDone, _ = sjson.SetBytes(itemDone, "item.arguments", args)
-				itemDone, _ = sjson.SetBytes(itemDone, "item.call_id", st.FuncCallIDs[idx])
-				itemDone, _ = sjson.SetBytes(itemDone, "item.name", st.FuncNames[idx])
-				out = append(out, emitEvent("response.output_item.done", itemDone))
-
 				st.FuncDone[idx] = true
 			}
 		}
@@ -790,16 +876,26 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 			}
 
 			if callID, ok := st.FuncCallIDs[idx]; ok && callID != "" {
-				args := "{}"
-				if b := st.FuncArgsBuf[idx]; b != nil && b.Len() > 0 {
-					args = b.String()
+				if st.FuncCustom[idx] {
+					inputStr := st.FuncInputBuf[idx]
+					item := []byte(`{"id":"","type":"custom_tool_call","status":"completed","input":"","call_id":"","name":""}`)
+					item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("ctc_%s", callID))
+					item, _ = sjson.SetBytes(item, "input", inputStr)
+					item, _ = sjson.SetBytes(item, "call_id", callID)
+					item = translatorcommon.SetResponsesToolCallIdentity(item, st.FuncNames[idx], st.FuncNamespaces[idx], "")
+					outputs = append(outputs, item)
+				} else {
+					args := "{}"
+					if b := st.FuncArgsBuf[idx]; b != nil && b.Len() > 0 {
+						args = b.String()
+					}
+					item := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
+					item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("fc_%s", callID))
+					item, _ = sjson.SetBytes(item, "arguments", args)
+					item, _ = sjson.SetBytes(item, "call_id", callID)
+					item = translatorcommon.SetResponsesToolCallIdentity(item, st.FuncNames[idx], st.FuncNamespaces[idx], "")
+					outputs = append(outputs, item)
 				}
-				item := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
-				item, _ = sjson.SetBytes(item, "id", fmt.Sprintf("fc_%s", callID))
-				item, _ = sjson.SetBytes(item, "arguments", args)
-				item, _ = sjson.SetBytes(item, "call_id", callID)
-				item, _ = sjson.SetBytes(item, "name", st.FuncNames[idx])
-				outputs = append(outputs, item)
 			}
 		}
 		if len(outputs) > 0 {
@@ -842,7 +938,9 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 func ConvertGeminiResponseToOpenAIResponsesNonStream(_ context.Context, _ string, originalRequestRawJSON, requestRawJSON, rawJSON []byte, _ *any) []byte {
 	root := gjson.ParseBytes(rawJSON)
 	root = unwrapGeminiResponseRoot(root)
+	reqJSON := pickRequestJSON(originalRequestRawJSON, requestRawJSON)
 	sanitizedNameMap := util.SanitizedToolNameMap(originalRequestRawJSON)
+	toolIdentityMap := util.ResponsesToolReverseIdentityMap(reqJSON)
 
 	// Base response scaffold
 	resp := []byte(`{"id":"","object":"response","created_at":0,"status":"completed","background":false,"error":null,"incomplete_details":null}`)
@@ -1071,18 +1169,38 @@ func ConvertGeminiResponseToOpenAIResponsesNonStream(_ context.Context, _ string
 				}
 				flushReasoningOutput()
 				flushMessageOutput()
-				name := util.RestoreSanitizedToolName(sanitizedNameMap, fc.Get("name").String())
+
+				rawName := fc.Get("name").String()
+				identity, hasIdentity := toolIdentityMap[rawName]
+				if !hasIdentity {
+					restored := util.RestoreSanitizedToolName(sanitizedNameMap, rawName)
+					identity = util.ResponsesToolIdentity{Name: restored}
+				}
+				name := identity.Name
+				namespace := identity.Namespace
+				isCustom := identity.Custom
+
 				args := fc.Get("args")
-				callID := fmt.Sprintf("call_%x_%d", time.Now().UnixNano(), atomic.AddUint64(&funcCallIDCounter, 1))
-				itemJSON := []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
-				itemJSON, _ = sjson.SetBytes(itemJSON, "id", fmt.Sprintf("fc_%s", callID))
-				itemJSON, _ = sjson.SetBytes(itemJSON, "call_id", callID)
-				itemJSON, _ = sjson.SetBytes(itemJSON, "name", name)
 				argsStr := ""
 				if args.Exists() {
 					argsStr = args.Raw
 				}
-				itemJSON, _ = sjson.SetBytes(itemJSON, "arguments", argsStr)
+				callID := fmt.Sprintf("call_%x_%d", time.Now().UnixNano(), atomic.AddUint64(&funcCallIDCounter, 1))
+				var itemJSON []byte
+				if isCustom {
+					inputStr := util.UnwrapResponsesCustomToolInput(argsStr)
+					itemJSON = []byte(`{"id":"","type":"custom_tool_call","status":"completed","input":"","call_id":"","name":""}`)
+					itemJSON, _ = sjson.SetBytes(itemJSON, "id", fmt.Sprintf("ctc_%s", callID))
+					itemJSON, _ = sjson.SetBytes(itemJSON, "call_id", callID)
+					itemJSON, _ = sjson.SetBytes(itemJSON, "input", inputStr)
+					itemJSON = translatorcommon.SetResponsesToolCallIdentity(itemJSON, name, namespace, "")
+				} else {
+					itemJSON = []byte(`{"id":"","type":"function_call","status":"completed","arguments":"","call_id":"","name":""}`)
+					itemJSON, _ = sjson.SetBytes(itemJSON, "id", fmt.Sprintf("fc_%s", callID))
+					itemJSON, _ = sjson.SetBytes(itemJSON, "call_id", callID)
+					itemJSON, _ = sjson.SetBytes(itemJSON, "arguments", argsStr)
+					itemJSON = translatorcommon.SetResponsesToolCallIdentity(itemJSON, name, namespace, "")
+				}
 				functionIndex := len(functionOutputs)
 				functionOutputs = append(functionOutputs, nonStreamFunctionOutput{item: itemJSON, signature: signature})
 				outputOrder = append(outputOrder, nonStreamOutputOrder{kind: "function", index: functionIndex})

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_response.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_response.go
@@ -310,7 +310,7 @@ func ConvertGeminiResponseToOpenAIResponses(_ context.Context, modelName string,
 		partDone, _ = sjson.SetBytes(partDone, "output_index", st.MsgIndex)
 		partDone, _ = sjson.SetBytes(partDone, "part.text", fullText)
 		out = append(out, emitEvent("response.content_part.done", partDone))
-		final := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"message","status":"completed","content":[{"type":"output_text","text":""}],"role":"assistant"}}`)
+		final := []byte(`{"type":"response.output_item.done","sequence_number":0,"output_index":0,"item":{"id":"","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":""}],"role":"assistant"}}`)
 		final, _ = sjson.SetBytes(final, "sequence_number", nextSeq())
 		final, _ = sjson.SetBytes(final, "output_index", st.MsgIndex)
 		final, _ = sjson.SetBytes(final, "item.id", st.CurrentMsgID)

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_response_test.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_response_test.go
@@ -1319,3 +1319,219 @@ func TestConvertGeminiResponseToOpenAIResponses_ResponseOutputOrdering(t *testin
 		t.Fatalf("expected response.completed after message added: msgAdded=%d completed=%d", posMsgAdded, posCompleted)
 	}
 }
+
+func TestConvertGeminiResponseToOpenAIResponses_RestoresAdditionalNamespaceCustomToolCall(t *testing.T) {
+	originalRequest := []byte(`{
+		"model":"gemini-2.5-flash",
+		"input":[{"type":"additional_tools","role":"developer","tools":[
+			{"type":"namespace","name":"functions","tools":[{"type":"custom","name":"exec"}]}
+		]}]
+	}`)
+	chunks := [][]byte{
+		[]byte(`data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"functions__exec","args":{"input":"pwd"}}}]},"finishReason":"STOP"}],"modelVersion":"gemini-2.5-flash","responseId":"resp_custom_stream"}`),
+	}
+
+	var param any
+	var added, inputDone, done, completed gjson.Result
+	functionEvents := 0
+	for _, chunk := range chunks {
+		for _, output := range ConvertGeminiResponseToOpenAIResponses(context.Background(), "gemini-2.5-flash", originalRequest, nil, chunk, &param) {
+			event, data := parseSSEEvent(t, output)
+			switch event {
+			case "response.output_item.added":
+				if data.Get("item.type").String() == "custom_tool_call" {
+					added = data
+				}
+			case "response.custom_tool_call_input.done":
+				inputDone = data
+			case "response.output_item.done":
+				if data.Get("item.type").String() == "custom_tool_call" {
+					done = data
+				}
+			case "response.function_call_arguments.delta", "response.function_call_arguments.done":
+				functionEvents++
+			case "response.completed":
+				completed = data
+			}
+		}
+	}
+
+	if !added.Exists() || !inputDone.Exists() || !done.Exists() || !completed.Exists() {
+		t.Fatalf("missing custom tool lifecycle events: added=%v input_done=%v done=%v completed=%v", added.Exists(), inputDone.Exists(), done.Exists(), completed.Exists())
+	}
+	if functionEvents != 0 {
+		t.Fatalf("function call events = %d, want 0", functionEvents)
+	}
+	for _, test := range []struct {
+		label string
+		item  gjson.Result
+	}{
+		{label: "added", item: added.Get("item")},
+		{label: "done", item: done.Get("item")},
+		{label: "completed", item: completed.Get("response.output.0")},
+	} {
+		if got := test.item.Get("name").String(); got != "exec" {
+			t.Fatalf("%s name = %q, want exec", test.label, got)
+		}
+		if got := test.item.Get("namespace").String(); got != "functions" {
+			t.Fatalf("%s namespace = %q, want functions", test.label, got)
+		}
+	}
+	if got := inputDone.Get("input").String(); got != "pwd" {
+		t.Fatalf("custom input.done input = %q, want pwd", got)
+	}
+	if got := done.Get("item.input").String(); got != "pwd" {
+		t.Fatalf("done input = %q, want pwd", got)
+	}
+	if got := completed.Get("response.output.0.type").String(); got != "custom_tool_call" {
+		t.Fatalf("completed output type = %q, want custom_tool_call", got)
+	}
+	if got := completed.Get("response.output.0.input").String(); got != "pwd" {
+		t.Fatalf("completed input = %q, want pwd", got)
+	}
+}
+
+func TestConvertGeminiResponseToOpenAIResponsesNonStream_RestoresAdditionalNamespaceCustomToolCall(t *testing.T) {
+	originalRequest := []byte(`{
+		"model":"gemini-2.5-flash",
+		"input":[{"type":"additional_tools","role":"developer","tools":[
+			{"type":"namespace","name":"functions","tools":[{"type":"custom","name":"exec"}]}
+		]}]
+	}`)
+	raw := []byte(`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"functions__exec","args":{"input":"pwd"}}}]}}],"modelVersion":"gemini-2.5-flash","responseId":"resp_custom_nonstream"}`)
+
+	out := ConvertGeminiResponseToOpenAIResponsesNonStream(context.Background(), "gemini-2.5-flash", originalRequest, nil, raw, nil)
+	root := gjson.ParseBytes(out)
+
+	if got := root.Get("output.0.type").String(); got != "custom_tool_call" {
+		t.Fatalf("non-stream output type = %q, want custom_tool_call; raw: %s", got, out)
+	}
+	if got := root.Get("output.0.name").String(); got != "exec" {
+		t.Fatalf("non-stream output name = %q, want exec", got)
+	}
+	if got := root.Get("output.0.namespace").String(); got != "functions" {
+		t.Fatalf("non-stream output namespace = %q, want functions", got)
+	}
+	if got := root.Get("output.0.input").String(); got != "pwd" {
+		t.Fatalf("non-stream output input = %q, want pwd", got)
+	}
+}
+
+func TestConvertGeminiResponseToOpenAIResponses_RestoresAdditionalNamespaceFunctionCall(t *testing.T) {
+	originalRequest := []byte(`{
+		"model":"gemini-2.5-flash",
+		"input":[{"type":"additional_tools","role":"developer","tools":[
+			{"type":"namespace","name":"functions","tools":[{"type":"function","name":"continuity_probe","parameters":{"type":"object","properties":{"value":{"type":"string"}}}}]}]
+		}]
+	}`)
+	chunks := [][]byte{
+		[]byte(`data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"functions__continuity_probe","args":{"value":"PROBE"}}}]},"finishReason":"STOP"}],"modelVersion":"gemini-2.5-flash","responseId":"resp_func_stream"}`),
+	}
+
+	var param any
+	var added, argDone, done, completed gjson.Result
+	for _, chunk := range chunks {
+		for _, output := range ConvertGeminiResponseToOpenAIResponses(context.Background(), "gemini-2.5-flash", originalRequest, nil, chunk, &param) {
+			event, data := parseSSEEvent(t, output)
+			switch event {
+			case "response.output_item.added":
+				if data.Get("item.type").String() == "function_call" {
+					added = data
+				}
+			case "response.function_call_arguments.done":
+				argDone = data
+			case "response.output_item.done":
+				if data.Get("item.type").String() == "function_call" {
+					done = data
+				}
+			case "response.completed":
+				completed = data
+			}
+		}
+	}
+
+	if !added.Exists() || !argDone.Exists() || !done.Exists() || !completed.Exists() {
+		t.Fatalf("missing function tool lifecycle events: added=%v arg_done=%v done=%v completed=%v", added.Exists(), argDone.Exists(), done.Exists(), completed.Exists())
+	}
+	for _, test := range []struct {
+		label string
+		item  gjson.Result
+	}{
+		{label: "added", item: added.Get("item")},
+		{label: "done", item: done.Get("item")},
+		{label: "completed", item: completed.Get("response.output.0")},
+	} {
+		if got := test.item.Get("name").String(); got != "continuity_probe" {
+			t.Fatalf("%s name = %q, want continuity_probe", test.label, got)
+		}
+		if got := test.item.Get("namespace").String(); got != "functions" {
+			t.Fatalf("%s namespace = %q, want functions", test.label, got)
+		}
+	}
+	if got := completed.Get("response.output.0.type").String(); got != "function_call" {
+		t.Fatalf("completed output type = %q, want function_call", got)
+	}
+	if got := gjson.Get(completed.Get("response.output.0.arguments").String(), "value").String(); got != "PROBE" {
+		t.Fatalf("completed value = %q, want PROBE", got)
+	}
+}
+
+func TestConvertGeminiResponseToOpenAIResponsesNonStream_RestoresAdditionalNamespaceFunctionCall(t *testing.T) {
+	originalRequest := []byte(`{
+		"model":"gemini-2.5-flash",
+		"input":[{"type":"additional_tools","role":"developer","tools":[
+			{"type":"namespace","name":"functions","tools":[{"type":"function","name":"continuity_probe","parameters":{"type":"object","properties":{"value":{"type":"string"}}}}]}]
+		}]
+	}`)
+	raw := []byte(`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"functions__continuity_probe","args":{"value":"PROBE"}}}]}}],"modelVersion":"gemini-2.5-flash","responseId":"resp_func_nonstream"}`)
+
+	out := ConvertGeminiResponseToOpenAIResponsesNonStream(context.Background(), "gemini-2.5-flash", originalRequest, nil, raw, nil)
+	root := gjson.ParseBytes(out)
+
+	if got := root.Get("output.0.type").String(); got != "function_call" {
+		t.Fatalf("non-stream output type = %q, want function_call; raw: %s", got, out)
+	}
+	if got := root.Get("output.0.name").String(); got != "continuity_probe" {
+		t.Fatalf("non-stream output name = %q, want continuity_probe", got)
+	}
+	if got := root.Get("output.0.namespace").String(); got != "functions" {
+		t.Fatalf("non-stream output namespace = %q, want functions", got)
+	}
+	if got := gjson.Get(root.Get("output.0.arguments").String(), "value").String(); got != "PROBE" {
+		t.Fatalf("non-stream output value = %q, want PROBE", got)
+	}
+}
+
+func TestConvertGeminiResponseToOpenAIResponses_MessageOutputItemDoneFields(t *testing.T) {
+	chunks := [][]byte{
+		[]byte(`data: {"candidates":[{"content":{"role":"model","parts":[{"text":"hello"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":2,"totalTokenCount":7},"modelVersion":"gemini-2.5-flash","responseId":"resp_item_done_test"}`),
+	}
+	originalReq := []byte(`{"model":"gemini-2.5-flash","input":"Reply with exactly: hello"}`)
+
+	var param any
+	var gotItemDone bool
+	for _, chunk := range chunks {
+		for _, output := range ConvertGeminiResponseToOpenAIResponses(context.Background(), "gemini-2.5-flash", originalReq, nil, chunk, &param) {
+			event, data := parseSSEEvent(t, output)
+			if event == "response.output_item.done" && data.Get("item.type").String() == "message" {
+				gotItemDone = true
+				if !data.Get("item.content.0.annotations").Exists() {
+					t.Fatalf("missing item.content.0.annotations in response.output_item.done: %s", data.Raw)
+				}
+				if !data.Get("item.content.0.annotations").IsArray() {
+					t.Fatalf("item.content.0.annotations should be an array: %s", data.Raw)
+				}
+				if !data.Get("item.content.0.logprobs").Exists() {
+					t.Fatalf("missing item.content.0.logprobs in response.output_item.done: %s", data.Raw)
+				}
+				if !data.Get("item.content.0.logprobs").IsArray() {
+					t.Fatalf("item.content.0.logprobs should be an array: %s", data.Raw)
+				}
+			}
+		}
+	}
+
+	if !gotItemDone {
+		t.Fatalf("missing message response.output_item.done event")
+	}
+}

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_response_test.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_response_test.go
@@ -1319,3 +1319,185 @@ func TestConvertGeminiResponseToOpenAIResponses_ResponseOutputOrdering(t *testin
 		t.Fatalf("expected response.completed after message added: msgAdded=%d completed=%d", posMsgAdded, posCompleted)
 	}
 }
+
+func TestConvertGeminiResponseToOpenAIResponses_RestoresAdditionalNamespaceCustomToolCall(t *testing.T) {
+	originalRequest := []byte(`{
+		"model":"gemini-2.5-flash",
+		"input":[{"type":"additional_tools","role":"developer","tools":[
+			{"type":"namespace","name":"functions","tools":[{"type":"custom","name":"exec"}]}
+		]}]
+	}`)
+	chunks := [][]byte{
+		[]byte(`data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"functions__exec","args":{"input":"pwd"}}}]},"finishReason":"STOP"}],"modelVersion":"gemini-2.5-flash","responseId":"resp_custom_stream"}`),
+	}
+
+	var param any
+	var added, inputDone, done, completed gjson.Result
+	functionEvents := 0
+	for _, chunk := range chunks {
+		for _, output := range ConvertGeminiResponseToOpenAIResponses(context.Background(), "gemini-2.5-flash", originalRequest, nil, chunk, &param) {
+			event, data := parseSSEEvent(t, output)
+			switch event {
+			case "response.output_item.added":
+				if data.Get("item.type").String() == "custom_tool_call" {
+					added = data
+				}
+			case "response.custom_tool_call_input.done":
+				inputDone = data
+			case "response.output_item.done":
+				if data.Get("item.type").String() == "custom_tool_call" {
+					done = data
+				}
+			case "response.function_call_arguments.delta", "response.function_call_arguments.done":
+				functionEvents++
+			case "response.completed":
+				completed = data
+			}
+		}
+	}
+
+	if !added.Exists() || !inputDone.Exists() || !done.Exists() || !completed.Exists() {
+		t.Fatalf("missing custom tool lifecycle events: added=%v input_done=%v done=%v completed=%v", added.Exists(), inputDone.Exists(), done.Exists(), completed.Exists())
+	}
+	if functionEvents != 0 {
+		t.Fatalf("function call events = %d, want 0", functionEvents)
+	}
+	for _, test := range []struct {
+		label string
+		item  gjson.Result
+	}{
+		{label: "added", item: added.Get("item")},
+		{label: "done", item: done.Get("item")},
+		{label: "completed", item: completed.Get("response.output.0")},
+	} {
+		if got := test.item.Get("name").String(); got != "exec" {
+			t.Fatalf("%s name = %q, want exec", test.label, got)
+		}
+		if got := test.item.Get("namespace").String(); got != "functions" {
+			t.Fatalf("%s namespace = %q, want functions", test.label, got)
+		}
+	}
+	if got := inputDone.Get("input").String(); got != "pwd" {
+		t.Fatalf("custom input.done input = %q, want pwd", got)
+	}
+	if got := done.Get("item.input").String(); got != "pwd" {
+		t.Fatalf("done input = %q, want pwd", got)
+	}
+	if got := completed.Get("response.output.0.type").String(); got != "custom_tool_call" {
+		t.Fatalf("completed output type = %q, want custom_tool_call", got)
+	}
+	if got := completed.Get("response.output.0.input").String(); got != "pwd" {
+		t.Fatalf("completed input = %q, want pwd", got)
+	}
+}
+
+func TestConvertGeminiResponseToOpenAIResponsesNonStream_RestoresAdditionalNamespaceCustomToolCall(t *testing.T) {
+	originalRequest := []byte(`{
+		"model":"gemini-2.5-flash",
+		"input":[{"type":"additional_tools","role":"developer","tools":[
+			{"type":"namespace","name":"functions","tools":[{"type":"custom","name":"exec"}]}
+		]}]
+	}`)
+	raw := []byte(`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"functions__exec","args":{"input":"pwd"}}}]}}],"modelVersion":"gemini-2.5-flash","responseId":"resp_custom_nonstream"}`)
+
+	out := ConvertGeminiResponseToOpenAIResponsesNonStream(context.Background(), "gemini-2.5-flash", originalRequest, nil, raw, nil)
+	root := gjson.ParseBytes(out)
+
+	if got := root.Get("output.0.type").String(); got != "custom_tool_call" {
+		t.Fatalf("non-stream output type = %q, want custom_tool_call; raw: %s", got, out)
+	}
+	if got := root.Get("output.0.name").String(); got != "exec" {
+		t.Fatalf("non-stream output name = %q, want exec", got)
+	}
+	if got := root.Get("output.0.namespace").String(); got != "functions" {
+		t.Fatalf("non-stream output namespace = %q, want functions", got)
+	}
+	if got := root.Get("output.0.input").String(); got != "pwd" {
+		t.Fatalf("non-stream output input = %q, want pwd", got)
+	}
+}
+
+func TestConvertGeminiResponseToOpenAIResponses_RestoresAdditionalNamespaceFunctionCall(t *testing.T) {
+	originalRequest := []byte(`{
+		"model":"gemini-2.5-flash",
+		"input":[{"type":"additional_tools","role":"developer","tools":[
+			{"type":"namespace","name":"functions","tools":[{"type":"function","name":"continuity_probe","parameters":{"type":"object","properties":{"value":{"type":"string"}}}}]}]
+		}]
+	}`)
+	chunks := [][]byte{
+		[]byte(`data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"functions__continuity_probe","args":{"value":"PROBE"}}}]},"finishReason":"STOP"}],"modelVersion":"gemini-2.5-flash","responseId":"resp_func_stream"}`),
+	}
+
+	var param any
+	var added, argDone, done, completed gjson.Result
+	for _, chunk := range chunks {
+		for _, output := range ConvertGeminiResponseToOpenAIResponses(context.Background(), "gemini-2.5-flash", originalRequest, nil, chunk, &param) {
+			event, data := parseSSEEvent(t, output)
+			switch event {
+			case "response.output_item.added":
+				if data.Get("item.type").String() == "function_call" {
+					added = data
+				}
+			case "response.function_call_arguments.done":
+				argDone = data
+			case "response.output_item.done":
+				if data.Get("item.type").String() == "function_call" {
+					done = data
+				}
+			case "response.completed":
+				completed = data
+			}
+		}
+	}
+
+	if !added.Exists() || !argDone.Exists() || !done.Exists() || !completed.Exists() {
+		t.Fatalf("missing function tool lifecycle events: added=%v arg_done=%v done=%v completed=%v", added.Exists(), argDone.Exists(), done.Exists(), completed.Exists())
+	}
+	for _, test := range []struct {
+		label string
+		item  gjson.Result
+	}{
+		{label: "added", item: added.Get("item")},
+		{label: "done", item: done.Get("item")},
+		{label: "completed", item: completed.Get("response.output.0")},
+	} {
+		if got := test.item.Get("name").String(); got != "continuity_probe" {
+			t.Fatalf("%s name = %q, want continuity_probe", test.label, got)
+		}
+		if got := test.item.Get("namespace").String(); got != "functions" {
+			t.Fatalf("%s namespace = %q, want functions", test.label, got)
+		}
+	}
+	if got := completed.Get("response.output.0.type").String(); got != "function_call" {
+		t.Fatalf("completed output type = %q, want function_call", got)
+	}
+	if got := gjson.Get(completed.Get("response.output.0.arguments").String(), "value").String(); got != "PROBE" {
+		t.Fatalf("completed value = %q, want PROBE", got)
+	}
+}
+
+func TestConvertGeminiResponseToOpenAIResponsesNonStream_RestoresAdditionalNamespaceFunctionCall(t *testing.T) {
+	originalRequest := []byte(`{
+		"model":"gemini-2.5-flash",
+		"input":[{"type":"additional_tools","role":"developer","tools":[
+			{"type":"namespace","name":"functions","tools":[{"type":"function","name":"continuity_probe","parameters":{"type":"object","properties":{"value":{"type":"string"}}}}]}]
+		}]
+	}`)
+	raw := []byte(`{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"functions__continuity_probe","args":{"value":"PROBE"}}}]}}],"modelVersion":"gemini-2.5-flash","responseId":"resp_func_nonstream"}`)
+
+	out := ConvertGeminiResponseToOpenAIResponsesNonStream(context.Background(), "gemini-2.5-flash", originalRequest, nil, raw, nil)
+	root := gjson.ParseBytes(out)
+
+	if got := root.Get("output.0.type").String(); got != "function_call" {
+		t.Fatalf("non-stream output type = %q, want function_call; raw: %s", got, out)
+	}
+	if got := root.Get("output.0.name").String(); got != "continuity_probe" {
+		t.Fatalf("non-stream output name = %q, want continuity_probe", got)
+	}
+	if got := root.Get("output.0.namespace").String(); got != "functions" {
+		t.Fatalf("non-stream output namespace = %q, want functions", got)
+	}
+	if got := gjson.Get(root.Get("output.0.arguments").String(), "value").String(); got != "PROBE" {
+		t.Fatalf("non-stream output value = %q, want PROBE", got)
+	}
+}

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_response_test.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_response_test.go
@@ -1501,3 +1501,37 @@ func TestConvertGeminiResponseToOpenAIResponsesNonStream_RestoresAdditionalNames
 		t.Fatalf("non-stream output value = %q, want PROBE", got)
 	}
 }
+
+func TestConvertGeminiResponseToOpenAIResponses_MessageOutputItemDoneFields(t *testing.T) {
+	chunks := [][]byte{
+		[]byte(`data: {"candidates":[{"content":{"role":"model","parts":[{"text":"hello"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":2,"totalTokenCount":7},"modelVersion":"gemini-2.5-flash","responseId":"resp_item_done_test"}`),
+	}
+	originalReq := []byte(`{"model":"gemini-2.5-flash","input":"Reply with exactly: hello"}`)
+
+	var param any
+	var gotItemDone bool
+	for _, chunk := range chunks {
+		for _, output := range ConvertGeminiResponseToOpenAIResponses(context.Background(), "gemini-2.5-flash", originalReq, nil, chunk, &param) {
+			event, data := parseSSEEvent(t, output)
+			if event == "response.output_item.done" && data.Get("item.type").String() == "message" {
+				gotItemDone = true
+				if !data.Get("item.content.0.annotations").Exists() {
+					t.Fatalf("missing item.content.0.annotations in response.output_item.done: %s", data.Raw)
+				}
+				if !data.Get("item.content.0.annotations").IsArray() {
+					t.Fatalf("item.content.0.annotations should be an array: %s", data.Raw)
+				}
+				if !data.Get("item.content.0.logprobs").Exists() {
+					t.Fatalf("missing item.content.0.logprobs in response.output_item.done: %s", data.Raw)
+				}
+				if !data.Get("item.content.0.logprobs").IsArray() {
+					t.Fatalf("item.content.0.logprobs should be an array: %s", data.Raw)
+				}
+			}
+		}
+	}
+
+	if !gotItemDone {
+		t.Fatalf("missing message response.output_item.done event")
+	}
+}

--- a/internal/translator/gemini/openai/responses/signature_carrier.go
+++ b/internal/translator/gemini/openai/responses/signature_carrier.go
@@ -78,7 +78,7 @@ func compatibleGeminiResponsesCarrierSignature(rawSignature, targetKind string) 
 
 func geminiResponsesCarrierSemanticTarget(item gjson.Result) string {
 	switch item.Get("type").String() {
-	case "function_call":
+	case "function_call", "custom_tool_call":
 		return geminiResponsesCarrierFunction
 	case "reasoning":
 		if strings.TrimSpace(item.Get("summary.0.text").String()) != "" {

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -886,8 +886,12 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(_ context.Co
 
 	// Build output list from choices[...]
 	var outputItems [][]byte
-	// Detect and capture reasoning content if present
-	rcText := gjson.GetBytes(rawJSON, "choices.0.message.reasoning_content").String()
+	// Detect and capture reasoning content if present (with fallback to reasoning)
+	rc := gjson.GetBytes(rawJSON, "choices.0.message.reasoning_content")
+	if !rc.Exists() || rc.String() == "" {
+		rc = gjson.GetBytes(rawJSON, "choices.0.message.reasoning")
+	}
+	rcText := rc.String()
 	includeReasoning := rcText != ""
 	if !includeReasoning && len(requestRawJSON) > 0 {
 		includeReasoning = gjson.GetBytes(requestRawJSON, "reasoning").Exists()

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
@@ -1259,3 +1259,93 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_FinishRe
 		t.Fatalf("output.0.status = %q, want incomplete; out=%s", got, out)
 	}
 }
+
+func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback(t *testing.T) {
+	tests := []struct {
+		name          string
+		rawJSON       string
+		requestJSON   string
+		wantReasoning bool
+		wantText      string
+	}{
+		{
+			name:          "reasoning_content field present",
+			rawJSON:       `{"id":"chatcmpl_rc","object":"chat.completion","created":1773896263,"model":"o3-mini","choices":[{"index":0,"message":{"role":"assistant","content":"hello","reasoning_content":"thought from reasoning_content"},"finish_reason":"stop"}]}`,
+			wantReasoning: true,
+			wantText:      "thought from reasoning_content",
+		},
+		{
+			name:          "reasoning fallback field present",
+			rawJSON:       `{"id":"chatcmpl_r","object":"chat.completion","created":1773896263,"model":"o3-mini","choices":[{"index":0,"message":{"role":"assistant","content":"hello","reasoning":"thought from reasoning"},"finish_reason":"stop"}]}`,
+			wantReasoning: true,
+			wantText:      "thought from reasoning",
+		},
+		{
+			name:          "both reasoning_content and reasoning present (reasoning_content priority)",
+			rawJSON:       `{"id":"chatcmpl_both","object":"chat.completion","created":1773896263,"model":"o3-mini","choices":[{"index":0,"message":{"role":"assistant","content":"hello","reasoning_content":"priority thought","reasoning":"ignored thought"},"finish_reason":"stop"}]}`,
+			wantReasoning: true,
+			wantText:      "priority thought",
+		},
+		{
+			name:          "empty reasoning_content falls back to reasoning",
+			rawJSON:       `{"id":"chatcmpl_empty_rc","object":"chat.completion","created":1773896263,"model":"o3-mini","choices":[{"index":0,"message":{"role":"assistant","content":"hello","reasoning_content":"","reasoning":"fallback thought"},"finish_reason":"stop"}]}`,
+			wantReasoning: true,
+			wantText:      "fallback thought",
+		},
+		{
+			name:          "neither field present without request reasoning",
+			rawJSON:       `{"id":"chatcmpl_none","object":"chat.completion","created":1773896263,"model":"gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]}`,
+			wantReasoning: false,
+		},
+		{
+			name:          "neither field present with request reasoning produces empty summary",
+			rawJSON:       `{"id":"chatcmpl_req_only","object":"chat.completion","created":1773896263,"model":"gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]}`,
+			requestJSON:   `{"model":"gpt-4o","reasoning":{"effort":"medium"}}`,
+			wantReasoning: true,
+			wantText:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var reqBytes []byte
+			if tt.requestJSON != "" {
+				reqBytes = []byte(tt.requestJSON)
+			}
+			out := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(context.Background(), "o3-mini", reqBytes, reqBytes, []byte(tt.rawJSON), nil)
+			data := gjson.ParseBytes(out)
+
+			var reasoningItem gjson.Result
+			found := false
+			data.Get("output").ForEach(func(_, item gjson.Result) bool {
+				if item.Get("type").String() == "reasoning" {
+					found = true
+					reasoningItem = item
+					return false
+				}
+				return true
+			})
+
+			if tt.wantReasoning != found {
+				t.Fatalf("reasoning found = %v, want %v; out=%s", found, tt.wantReasoning, out)
+			}
+
+			if tt.wantReasoning {
+				if tt.wantText != "" {
+					gotText := reasoningItem.Get("summary.0.text").String()
+					if gotText != tt.wantText {
+						t.Fatalf("summary.0.text = %q, want %q; out=%s", gotText, tt.wantText, out)
+					}
+					gotType := reasoningItem.Get("summary.0.type").String()
+					if gotType != "summary_text" {
+						t.Fatalf("summary.0.type = %q, want summary_text; out=%s", gotType, out)
+					}
+				} else {
+					if len(reasoningItem.Get("summary").Array()) != 0 {
+						t.Fatalf("summary = %s, want empty array; out=%s", reasoningItem.Get("summary").Raw, out)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
@@ -1262,40 +1262,89 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_FinishRe
 
 func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback(t *testing.T) {
 	tests := []struct {
-		name string
-		raw  string
+		name          string
+		rawJSON       string
+		requestJSON   string
+		wantReasoning bool
+		wantText      string
 	}{
 		{
-			name: "missing reasoning_content",
-			raw:  `{"id":"chatcmpl_reasoning_fallback","object":"chat.completion","created":1773896263,"model":"grok-3","choices":[{"index":0,"message":{"role":"assistant","content":"42","reasoning":"step by step thought"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+			name:          "reasoning_content field present",
+			rawJSON:       `{"id":"chatcmpl_rc","object":"chat.completion","created":1773896263,"model":"o3-mini","choices":[{"index":0,"message":{"role":"assistant","content":"hello","reasoning_content":"thought from reasoning_content"},"finish_reason":"stop"}]}`,
+			wantReasoning: true,
+			wantText:      "thought from reasoning_content",
 		},
 		{
-			name: "empty reasoning_content",
-			raw:  `{"id":"chatcmpl_reasoning_fallback","object":"chat.completion","created":1773896263,"model":"grok-3","choices":[{"index":0,"message":{"role":"assistant","content":"42","reasoning_content":"","reasoning":"step by step thought"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+			name:          "reasoning fallback field present",
+			rawJSON:       `{"id":"chatcmpl_r","object":"chat.completion","created":1773896263,"model":"o3-mini","choices":[{"index":0,"message":{"role":"assistant","content":"hello","reasoning":"thought from reasoning"},"finish_reason":"stop"}]}`,
+			wantReasoning: true,
+			wantText:      "thought from reasoning",
+		},
+		{
+			name:          "both reasoning_content and reasoning present (reasoning_content priority)",
+			rawJSON:       `{"id":"chatcmpl_both","object":"chat.completion","created":1773896263,"model":"o3-mini","choices":[{"index":0,"message":{"role":"assistant","content":"hello","reasoning_content":"priority thought","reasoning":"ignored thought"},"finish_reason":"stop"}]}`,
+			wantReasoning: true,
+			wantText:      "priority thought",
+		},
+		{
+			name:          "empty reasoning_content falls back to reasoning",
+			rawJSON:       `{"id":"chatcmpl_empty_rc","object":"chat.completion","created":1773896263,"model":"o3-mini","choices":[{"index":0,"message":{"role":"assistant","content":"hello","reasoning_content":"","reasoning":"fallback thought"},"finish_reason":"stop"}]}`,
+			wantReasoning: true,
+			wantText:      "fallback thought",
+		},
+		{
+			name:          "neither field present without request reasoning",
+			rawJSON:       `{"id":"chatcmpl_none","object":"chat.completion","created":1773896263,"model":"gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]}`,
+			wantReasoning: false,
+		},
+		{
+			name:          "neither field present with request reasoning produces empty summary",
+			rawJSON:       `{"id":"chatcmpl_req_only","object":"chat.completion","created":1773896263,"model":"gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]}`,
+			requestJSON:   `{"model":"gpt-4o","reasoning":{"effort":"medium"}}`,
+			wantReasoning: true,
+			wantText:      "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			out := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(context.Background(), "grok-3", nil, nil, []byte(tt.raw), nil)
+			var reqBytes []byte
+			if tt.requestJSON != "" {
+				reqBytes = []byte(tt.requestJSON)
+			}
+			out := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(context.Background(), "o3-mini", reqBytes, reqBytes, []byte(tt.rawJSON), nil)
 			data := gjson.ParseBytes(out)
 
-			reasoningType := data.Get("output.0.type").String()
-			if reasoningType != "reasoning" {
-				t.Fatalf("output.0.type = %q, want reasoning; out=%s", reasoningType, out)
-			}
-			reasoningText := data.Get("output.0.summary.0.text").String()
-			if reasoningText != "step by step thought" {
-				t.Fatalf("output.0.summary.0.text = %q, want %q; out=%s", reasoningText, "step by step thought", out)
+			var reasoningItem gjson.Result
+			found := false
+			data.Get("output").ForEach(func(_, item gjson.Result) bool {
+				if item.Get("type").String() == "reasoning" {
+					found = true
+					reasoningItem = item
+					return false
+				}
+				return true
+			})
+
+			if tt.wantReasoning != found {
+				t.Fatalf("reasoning found = %v, want %v; out=%s", found, tt.wantReasoning, out)
 			}
 
-			msgType := data.Get("output.1.type").String()
-			if msgType != "message" {
-				t.Fatalf("output.1.type = %q, want message; out=%s", msgType, out)
-			}
-			msgText := data.Get("output.1.content.0.text").String()
-			if msgText != "42" {
-				t.Fatalf("output.1.content.0.text = %q, want %q; out=%s", msgText, "42", out)
+			if tt.wantReasoning {
+				if tt.wantText != "" {
+					gotText := reasoningItem.Get("summary.0.text").String()
+					if gotText != tt.wantText {
+						t.Fatalf("summary.0.text = %q, want %q; out=%s", gotText, tt.wantText, out)
+					}
+					gotType := reasoningItem.Get("summary.0.type").String()
+					if gotType != "summary_text" {
+						t.Fatalf("summary.0.type = %q, want summary_text; out=%s", gotType, out)
+					}
+				} else {
+					if len(reasoningItem.Get("summary").Array()) != 0 {
+						t.Fatalf("summary = %s, want empty array; out=%s", reasoningItem.Get("summary").Raw, out)
+					}
+				}
 			}
 		})
 	}

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
@@ -1259,3 +1259,44 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_FinishRe
 		t.Fatalf("output.0.status = %q, want incomplete; out=%s", got, out)
 	}
 }
+
+func TestConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream_ReasoningFallback(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "missing reasoning_content",
+			raw:  `{"id":"chatcmpl_reasoning_fallback","object":"chat.completion","created":1773896263,"model":"grok-3","choices":[{"index":0,"message":{"role":"assistant","content":"42","reasoning":"step by step thought"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+		},
+		{
+			name: "empty reasoning_content",
+			raw:  `{"id":"chatcmpl_reasoning_fallback","object":"chat.completion","created":1773896263,"model":"grok-3","choices":[{"index":0,"message":{"role":"assistant","content":"42","reasoning_content":"","reasoning":"step by step thought"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := ConvertOpenAIChatCompletionsResponseToOpenAIResponsesNonStream(context.Background(), "grok-3", nil, nil, []byte(tt.raw), nil)
+			data := gjson.ParseBytes(out)
+
+			reasoningType := data.Get("output.0.type").String()
+			if reasoningType != "reasoning" {
+				t.Fatalf("output.0.type = %q, want reasoning; out=%s", reasoningType, out)
+			}
+			reasoningText := data.Get("output.0.summary.0.text").String()
+			if reasoningText != "step by step thought" {
+				t.Fatalf("output.0.summary.0.text = %q, want %q; out=%s", reasoningText, "step by step thought", out)
+			}
+
+			msgType := data.Get("output.1.type").String()
+			if msgType != "message" {
+				t.Fatalf("output.1.type = %q, want message; out=%s", msgType, out)
+			}
+			msgText := data.Get("output.1.content.0.text").String()
+			if msgText != "42" {
+				t.Fatalf("output.1.content.0.text = %q, want %q; out=%s", msgText, "42", out)
+			}
+		})
+	}
+}

--- a/internal/util/gemini_schema.go
+++ b/internal/util/gemini_schema.go
@@ -766,7 +766,7 @@ func removeUnsupportedKeywords(jsonStr string, options jsonSchemaCleanOptions) s
 		"$schema", "$defs", "definitions", "const", "$ref", "$id", "additionalProperties",
 		"propertyNames", "patternProperties", // Gemini doesn't support these schema keywords
 		"if", "then", "else",
-		"$comment", "enumDescriptions", "enumTitles", "prefill", "deprecated", // Schema metadata fields unsupported by Gemini
+		"$comment", "enumDescriptions", "enumTitles", "prefill", "deprecated", "encrypted", // Schema metadata fields unsupported by Gemini
 	)
 	if options.antigravitySemantics {
 		keywords = append(keywords, "not")

--- a/internal/util/gemini_schema_test.go
+++ b/internal/util/gemini_schema_test.go
@@ -1532,3 +1532,89 @@ func TestSortByDepthUsesSegmentsAndIsStable(t *testing.T) {
 		t.Fatalf("sortByDepth() = %v, want %v", paths, want)
 	}
 }
+
+// TestCleanJSONSchemaStripsEncryptedMetadata covers Codex client tool definitions where
+// properties carry the Responses-only "encrypted" marker (e.g. "encrypted": true or "encrypted": false).
+// The Gemini backend strictly rejects unknown schema fields with an INVALID_ARGUMENT 400.
+func TestCleanJSONSchemaStripsEncryptedMetadata(t *testing.T) {
+	input := `{
+		"type": "object",
+		"properties": {
+			"api_key": {
+				"type": "string",
+				"description": "API credential",
+				"encrypted": true
+			},
+			"timeout": {
+				"type": "integer",
+				"encrypted": false
+			},
+			"nested": {
+				"type": "object",
+				"properties": {
+					"secret": {
+						"type": "string",
+						"encrypted": true
+					}
+				}
+			}
+		},
+		"required": ["api_key"]
+	}`
+
+	for cleaner, clean := range map[string]func(string) string{
+		"antigravity":         CleanJSONSchemaForAntigravity,
+		"gemini":              CleanJSONSchemaForGemini,
+		"antigravityTool":     func(s string) string { return CleanJSONSchemaForAntigravityTool(s, false) },
+		"antigravityResponse": CleanJSONSchemaForAntigravityResponse,
+	} {
+		got := clean(input)
+		if strings.Contains(got, `"encrypted"`) {
+			t.Errorf("%s: 'encrypted' marker survived cleaning: %s", cleaner, got)
+		}
+		parsed := gjson.Parse(got)
+		if !parsed.Get("properties.api_key.type").Exists() || parsed.Get("properties.api_key.description").String() != "API credential" {
+			t.Errorf("%s: api_key schema was corrupted: %s", cleaner, got)
+		}
+		if !parsed.Get("properties.nested.properties.secret.type").Exists() {
+			t.Errorf("%s: nested property secret was corrupted: %s", cleaner, got)
+		}
+	}
+}
+
+// TestCleanJSONSchemaKeepsPropertyNamedEncrypted guards the legitimate case where a tool
+// parameter itself is named "encrypted" (e.g. properties.encrypted: {"type": "boolean"}).
+func TestCleanJSONSchemaKeepsPropertyNamedEncrypted(t *testing.T) {
+	input := `{
+		"type": "object",
+		"properties": {
+			"encrypted": {
+				"type": "boolean",
+				"description": "Whether the payload is encrypted",
+				"encrypted": true
+			},
+			"data": {
+				"type": "string"
+			}
+		},
+		"required": ["encrypted"]
+	}`
+
+	for cleaner, clean := range map[string]func(string) string{
+		"antigravity": CleanJSONSchemaForAntigravity,
+		"gemini":      CleanJSONSchemaForGemini,
+	} {
+		got := clean(input)
+		parsed := gjson.Parse(got)
+		if !parsed.Get("properties.encrypted").Exists() {
+			t.Errorf("%s: property named 'encrypted' was removed: %s", cleaner, got)
+		}
+		if parsed.Get("properties.encrypted.type").String() != "boolean" {
+			t.Errorf("%s: property named 'encrypted' type corrupted: %s", cleaner, got)
+		}
+		// The inner attribute "encrypted": true must be stripped
+		if parsed.Get("properties.encrypted.encrypted").Exists() {
+			t.Errorf("%s: inner 'encrypted' attribute survived: %s", cleaner, got)
+		}
+	}
+}

--- a/internal/util/responses_tools.go
+++ b/internal/util/responses_tools.go
@@ -1,0 +1,418 @@
+package util
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// ResponsesToolIdentity represents the resolved identity of a tool in OpenAI Responses format.
+type ResponsesToolIdentity struct {
+	Name      string
+	Namespace string
+	Custom    bool
+}
+
+// ResponsesToolDescriptor is an internal representation of a tool declaration in a Responses request.
+type ResponsesToolDescriptor struct {
+	Name           string // Qualified name (e.g. "functions__exec" or "exec")
+	LocalName      string // Local name without namespace (e.g. "exec")
+	Namespace      string // Namespace if any (e.g. "functions")
+	ToolType       string // "function", "custom", etc.
+	Tool           gjson.Result
+	SourcePriority int  // 0 for top-level tools, 1 for additional_tools
+	Direct         bool // true if declared directly, false if declared as namespace child
+	Order          int  // original discovery order
+}
+
+// QualifyResponsesNamespaceToolName qualifies a child tool name with its namespace.
+func QualifyResponsesNamespaceToolName(namespaceName, childName string) string {
+	childName = strings.TrimSpace(childName)
+	namespaceName = strings.TrimSpace(namespaceName)
+	if childName == "" || namespaceName == "" || strings.HasPrefix(childName, "mcp__") {
+		return childName
+	}
+	if childName == namespaceName || strings.HasPrefix(childName, namespaceName+"__") {
+		return childName
+	}
+	if strings.HasSuffix(namespaceName, "__") {
+		return namespaceName + childName
+	}
+	return namespaceName + "__" + childName
+}
+
+func responsesToolSources(root gjson.Result) []struct {
+	tools    gjson.Result
+	priority int
+} {
+	var sources []struct {
+		tools    gjson.Result
+		priority int
+	}
+	appendSource := func(tools gjson.Result, priority int) {
+		if tools.Exists() && tools.IsArray() {
+			sources = append(sources, struct {
+				tools    gjson.Result
+				priority int
+			}{tools: tools, priority: priority})
+		}
+	}
+	appendSource(root.Get("tools"), 0)
+	if input := root.Get("input"); input.Exists() && input.IsArray() {
+		input.ForEach(func(_, item gjson.Result) bool {
+			if item.Get("type").String() == "additional_tools" {
+				appendSource(item.Get("tools"), 1)
+			}
+			return true
+		})
+	}
+	return sources
+}
+
+func responsesToolName(tool gjson.Result) string {
+	if name := strings.TrimSpace(tool.Get("name").String()); name != "" {
+		return name
+	}
+	return strings.TrimSpace(tool.Get("function.name").String())
+}
+
+func responsesToolDescription(tool gjson.Result) string {
+	if description := tool.Get("description").String(); description != "" {
+		return description
+	}
+	return tool.Get("function.description").String()
+}
+
+func responsesToolParameters(tool gjson.Result) gjson.Result {
+	for _, path := range []string{
+		"parameters",
+		"parametersJsonSchema",
+		"input_schema",
+		"function.parameters",
+		"function.parametersJsonSchema",
+	} {
+		if parameters := tool.Get(path); parameters.Exists() {
+			return parameters
+		}
+	}
+	return gjson.Result{}
+}
+
+// CollectResponsesToolDescriptors extracts all tool descriptors from a Responses request root.
+func CollectResponsesToolDescriptors(root gjson.Result) []ResponsesToolDescriptor {
+	var descriptors []ResponsesToolDescriptor
+	appendDescriptor := func(tool gjson.Result, name, localName, namespace string, toolType string, sourcePriority int, direct bool) {
+		if name == "" {
+			return
+		}
+		descriptors = append(descriptors, ResponsesToolDescriptor{
+			Name:           name,
+			LocalName:      localName,
+			Namespace:      namespace,
+			ToolType:       toolType,
+			Tool:           tool,
+			SourcePriority: sourcePriority,
+			Direct:         direct,
+			Order:          len(descriptors),
+		})
+	}
+	appendNamespaceChildren := func(namespaceTool gjson.Result, sourcePriority int) {
+		namespaceName := strings.TrimSpace(namespaceTool.Get("name").String())
+		children := namespaceTool.Get("tools")
+		if !children.Exists() || !children.IsArray() {
+			return
+		}
+		children.ForEach(func(_, child gjson.Result) bool {
+			childName := responsesToolName(child)
+			if childName == "" {
+				return true
+			}
+			qualifiedName := QualifyResponsesNamespaceToolName(namespaceName, childName)
+			switch strings.TrimSpace(child.Get("type").String()) {
+			case "", "function":
+				appendDescriptor(child, qualifiedName, childName, namespaceName, "function", sourcePriority, false)
+			case "custom":
+				appendDescriptor(child, qualifiedName, childName, namespaceName, "custom", sourcePriority, false)
+			}
+			return true
+		})
+	}
+	for _, source := range responsesToolSources(root) {
+		source.tools.ForEach(func(_, tool gjson.Result) bool {
+			toolType := strings.TrimSpace(tool.Get("type").String())
+			switch toolType {
+			case "", "function":
+				name := responsesToolName(tool)
+				appendDescriptor(tool, name, name, "", "function", source.priority, true)
+			case "custom":
+				name := responsesToolName(tool)
+				appendDescriptor(tool, name, name, "", "custom", source.priority, true)
+			case "namespace":
+				appendNamespaceChildren(tool, source.priority)
+			}
+			return true
+		})
+	}
+	return descriptors
+}
+
+func responsesToolDescriptorPrecedes(left, right ResponsesToolDescriptor) bool {
+	if left.SourcePriority != right.SourcePriority {
+		return left.SourcePriority < right.SourcePriority
+	}
+	if left.Direct != right.Direct {
+		return left.Direct
+	}
+	return left.Order < right.Order
+}
+
+// CollectResponsesToolWinners collects deduplicated winning descriptors for each qualified tool name.
+func CollectResponsesToolWinners(root gjson.Result) map[string]ResponsesToolDescriptor {
+	winners := map[string]ResponsesToolDescriptor{}
+	for _, descriptor := range CollectResponsesToolDescriptors(root) {
+		current, exists := winners[descriptor.Name]
+		if !exists || responsesToolDescriptorPrecedes(descriptor, current) {
+			winners[descriptor.Name] = descriptor
+		}
+	}
+	return winners
+}
+
+func sanitizeResponsesToolNames(names []string) map[string]string {
+	if len(names) == 0 {
+		return nil
+	}
+	uniqueNames := make(map[string]struct{}, len(names))
+	baseCounts := make(map[string]int, len(names))
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+		if _, exists := uniqueNames[name]; exists {
+			continue
+		}
+		uniqueNames[name] = struct{}{}
+		baseCounts[SanitizeFunctionName(name)]++
+	}
+
+	sortedNames := make([]string, 0, len(uniqueNames))
+	for name := range uniqueNames {
+		sortedNames = append(sortedNames, name)
+	}
+	sort.Strings(sortedNames)
+
+	out := make(map[string]string, len(sortedNames))
+	used := make(map[string]string, len(sortedNames))
+	for _, name := range sortedNames {
+		base := SanitizeFunctionName(name)
+		mapped := base
+		_, baseUsed := used[base]
+		if baseCounts[base] > 1 || baseUsed {
+			mapped = disambiguateResponsesSanitizedName(base, name, used)
+		}
+		out[name] = mapped
+		used[mapped] = name
+	}
+	return out
+}
+
+func disambiguateResponsesSanitizedName(base, original string, used map[string]string) string {
+	for attempt := 0; ; attempt++ {
+		digest := sha256.Sum256([]byte(fmt.Sprintf("%s\x00%d", original, attempt)))
+		suffix := "_" + hex.EncodeToString(digest[:6])
+		prefix := base
+		if maxPrefix := 64 - len(suffix); len(prefix) > maxPrefix {
+			prefix = prefix[:maxPrefix]
+		}
+		candidate := prefix + suffix
+		if _, exists := used[candidate]; !exists {
+			return candidate
+		}
+	}
+}
+
+// BuildGeminiFunctionDeclarations builds Gemini function declarations, forward name mapping, and reverse identity mapping.
+func BuildGeminiFunctionDeclarations(root gjson.Result) ([][]byte, map[string]string, map[string]ResponsesToolIdentity) {
+	descriptors := CollectResponsesToolDescriptors(root)
+	winners := CollectResponsesToolWinners(root)
+
+	seenNames := make(map[string]struct{})
+	var winningList []ResponsesToolDescriptor
+	for _, descriptor := range descriptors {
+		winner, ok := winners[descriptor.Name]
+		if !ok || winner.Order != descriptor.Order {
+			continue
+		}
+		if _, seen := seenNames[descriptor.Name]; seen {
+			continue
+		}
+		seenNames[descriptor.Name] = struct{}{}
+		winningList = append(winningList, descriptor)
+	}
+
+	if len(winningList) == 0 {
+		return nil, nil, nil
+	}
+
+	qualifiedNames := make([]string, 0, len(winningList))
+	for _, desc := range winningList {
+		qualifiedNames = append(qualifiedNames, desc.Name)
+	}
+	sanitizedMap := sanitizeResponsesToolNames(qualifiedNames)
+
+	forwardMap := make(map[string]string, len(winningList)*2)
+	reverseMap := make(map[string]ResponsesToolIdentity, len(winningList)*2)
+	var declarations [][]byte
+
+	for _, desc := range winningList {
+		geminiName := desc.Name
+		if mapped, ok := sanitizedMap[desc.Name]; ok && mapped != "" {
+			geminiName = mapped
+		} else {
+			geminiName = SanitizeFunctionName(desc.Name)
+		}
+
+		forwardMap[desc.Name] = geminiName
+		if desc.LocalName != "" && desc.LocalName != desc.Name {
+			if _, exists := forwardMap[desc.LocalName]; !exists {
+				forwardMap[desc.LocalName] = geminiName
+			}
+		}
+
+		identity := ResponsesToolIdentity{
+			Name:      desc.LocalName,
+			Namespace: desc.Namespace,
+			Custom:    desc.ToolType == "custom",
+		}
+		reverseMap[geminiName] = identity
+		if desc.Name != geminiName {
+			reverseMap[desc.Name] = identity
+		}
+
+		funcDecl := []byte(`{"name":"","description":"","parametersJsonSchema":{}}`)
+		funcDecl, _ = sjson.SetBytes(funcDecl, "name", geminiName)
+		if descStr := responsesToolDescription(desc.Tool); descStr != "" {
+			funcDecl, _ = sjson.SetBytes(funcDecl, "description", descStr)
+		}
+
+		if desc.ToolType == "custom" {
+			funcDecl, _ = sjson.SetRawBytes(funcDecl, "parametersJsonSchema", []byte(`{"type":"object","properties":{"input":{"type":"string"}},"required":["input"]}`))
+		} else {
+			params := responsesToolParameters(desc.Tool)
+			if params.Exists() {
+				funcDecl, _ = sjson.SetRawBytes(funcDecl, "parametersJsonSchema", []byte(CleanJSONSchemaForGemini(params.Raw)))
+			}
+		}
+		declarations = append(declarations, funcDecl)
+	}
+
+	return declarations, forwardMap, reverseMap
+}
+
+// ResponsesToolReverseIdentityMap builds a Gemini function name -> ResponsesToolIdentity map from a Responses request raw JSON.
+func ResponsesToolReverseIdentityMap(rawJSON []byte) map[string]ResponsesToolIdentity {
+	if len(rawJSON) == 0 || !gjson.ValidBytes(rawJSON) {
+		return nil
+	}
+	root := gjson.ParseBytes(rawJSON)
+	if req := root.Get("request"); req.Exists() && (req.Get("model").Exists() || req.Get("input").Exists() || req.Get("tools").Exists()) {
+		root = req
+	}
+	_, _, reverseMap := BuildGeminiFunctionDeclarations(root)
+	return reverseMap
+}
+
+// MapResponsesToolName returns the mapped Gemini function name if present in forwardMap, else sanitized name.
+func MapResponsesToolName(forwardMap map[string]string, name string) string {
+	if mapped, ok := forwardMap[name]; ok && mapped != "" {
+		return mapped
+	}
+	return SanitizeFunctionName(name)
+}
+
+// ConvertResponsesToolChoiceToGemini translates Responses tool_choice into Gemini functionCallingConfig JSON.
+func ConvertResponsesToolChoiceToGemini(toolChoice gjson.Result, forwardMap map[string]string) ([]byte, bool) {
+	if !toolChoice.Exists() {
+		return nil, false
+	}
+	mode := ""
+	var allowedNames []string
+	if toolChoice.Type == gjson.String {
+		switch strings.ToLower(strings.TrimSpace(toolChoice.String())) {
+		case "none":
+			mode = "NONE"
+		case "auto":
+			mode = "AUTO"
+		case "required", "any":
+			mode = "ANY"
+		}
+	} else if toolChoice.IsObject() {
+		toolType := strings.ToLower(strings.TrimSpace(toolChoice.Get("type").String()))
+		switch toolType {
+		case "none":
+			mode = "NONE"
+		case "auto":
+			mode = "AUTO"
+		case "required", "any":
+			mode = "ANY"
+		case "function", "custom", "tool", "":
+			mode = "ANY"
+			name := strings.TrimSpace(toolChoice.Get("name").String())
+			if name == "" {
+				name = strings.TrimSpace(toolChoice.Get("function.name").String())
+			}
+			if name == "" {
+				name = strings.TrimSpace(toolChoice.Get("custom.name").String())
+			}
+			namespace := strings.TrimSpace(toolChoice.Get("namespace").String())
+			if namespace == "" {
+				namespace = strings.TrimSpace(toolChoice.Get("function.namespace").String())
+			}
+			if namespace == "" {
+				namespace = strings.TrimSpace(toolChoice.Get("custom.namespace").String())
+			}
+			if namespace != "" {
+				name = QualifyResponsesNamespaceToolName(namespace, name)
+			}
+			if name != "" {
+				geminiName := MapResponsesToolName(forwardMap, name)
+				allowedNames = append(allowedNames, geminiName)
+			}
+		}
+	}
+	if mode == "" {
+		return nil, false
+	}
+	cfg := []byte(`{"mode":""}`)
+	cfg, _ = sjson.SetBytes(cfg, "mode", mode)
+	if len(allowedNames) > 0 {
+		cfg, _ = sjson.SetBytes(cfg, "allowedFunctionNames", allowedNames)
+	}
+	return cfg, true
+}
+
+// UnwrapResponsesCustomToolInput extracts the raw input string from custom tool arguments JSON or plain string.
+func UnwrapResponsesCustomToolInput(arguments string) string {
+	arguments = strings.TrimSpace(arguments)
+	if arguments == "" || arguments == "{}" {
+		return ""
+	}
+	if gjson.Valid(arguments) {
+		parsed := gjson.Parse(arguments)
+		if v := parsed.Get("input"); v.Exists() {
+			if v.Type == gjson.String {
+				return v.String()
+			}
+			return v.Raw
+		}
+		if parsed.Type == gjson.String {
+			return parsed.String()
+		}
+	}
+	return arguments
+}

--- a/internal/util/responses_tools_test.go
+++ b/internal/util/responses_tools_test.go
@@ -1,0 +1,228 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestCollectResponsesToolDescriptors_PriorityAndNamespace(t *testing.T) {
+	raw := `{
+		"tools": [
+			{"type": "function", "name": "top_fn", "description": "top function"}
+		],
+		"input": [
+			{
+				"type": "additional_tools",
+				"tools": [
+					{
+						"type": "namespace",
+						"name": "ns1",
+						"tools": [
+							{"type": "function", "name": "child_fn", "description": "child function"},
+							{"type": "custom", "name": "child_custom", "description": "child custom"}
+						]
+					},
+					{"type": "custom", "name": "direct_custom"}
+				]
+			}
+		]
+	}`
+
+	root := gjson.Parse(raw)
+	descriptors := CollectResponsesToolDescriptors(root)
+	if len(descriptors) != 4 {
+		t.Fatalf("expected 4 descriptors, got %d", len(descriptors))
+	}
+
+	decls, forwardMap, reverseMap := BuildGeminiFunctionDeclarations(root)
+	if len(decls) != 4 {
+		t.Fatalf("expected 4 declarations, got %d", len(decls))
+	}
+
+	if forwardMap["ns1__child_fn"] != "ns1__child_fn" {
+		t.Fatalf("forwardMap['ns1__child_fn'] = %q, want ns1__child_fn", forwardMap["ns1__child_fn"])
+	}
+
+	childCustomIdentity := reverseMap["ns1__child_custom"]
+	if childCustomIdentity.Name != "child_custom" || childCustomIdentity.Namespace != "ns1" || !childCustomIdentity.Custom {
+		t.Fatalf("unexpected reverseMap for ns1__child_custom: %+v", childCustomIdentity)
+	}
+
+	topFnIdentity := reverseMap["top_fn"]
+	if topFnIdentity.Name != "top_fn" || topFnIdentity.Namespace != "" || topFnIdentity.Custom {
+		t.Fatalf("unexpected reverseMap for top_fn: %+v", topFnIdentity)
+	}
+}
+
+func TestResponsesToolWinners_TopLevelBeatsAdditionalTools(t *testing.T) {
+	raw := `{
+		"tools": [
+			{"type": "function", "name": "shared_fn", "description": "top level"}
+		],
+		"input": [
+			{
+				"type": "additional_tools",
+				"tools": [
+					{"type": "function", "name": "shared_fn", "description": "additional"}
+				]
+			}
+		]
+	}`
+
+	root := gjson.Parse(raw)
+	winners := CollectResponsesToolWinners(root)
+	winner := winners["shared_fn"]
+	if winner.SourcePriority != 0 {
+		t.Fatalf("winner priority = %d, want 0", winner.SourcePriority)
+	}
+	if winner.Tool.Get("description").String() != "top level" {
+		t.Fatalf("winner description = %q, want 'top level'", winner.Tool.Get("description").String())
+	}
+}
+
+func TestResponsesToolWinners_DirectBeatsNamespaceChild(t *testing.T) {
+	raw := `{
+		"tools": [
+			{"type": "namespace", "name": "n", "tools": [{"type": "function", "name": "x", "description": "namespace child"}]},
+			{"type": "custom", "name": "n__x", "description": "direct"}
+		]
+	}`
+
+	root := gjson.Parse(raw)
+	winners := CollectResponsesToolWinners(root)
+	winner := winners["n__x"]
+	if !winner.Direct {
+		t.Fatalf("winner direct = %v, want true", winner.Direct)
+	}
+	if winner.ToolType != "custom" {
+		t.Fatalf("winner toolType = %q, want custom", winner.ToolType)
+	}
+}
+
+func TestConvertResponsesToolChoiceToGemini(t *testing.T) {
+	tests := []struct {
+		name       string
+		choiceJSON string
+		forwardMap map[string]string
+		wantMode   string
+		wantNames  []string
+	}{
+		{
+			name:       "auto string",
+			choiceJSON: `"auto"`,
+			wantMode:   "AUTO",
+		},
+		{
+			name:       "none string",
+			choiceJSON: `"none"`,
+			wantMode:   "NONE",
+		},
+		{
+			name:       "required string",
+			choiceJSON: `"required"`,
+			wantMode:   "ANY",
+		},
+		{
+			name:       "function object with namespace",
+			choiceJSON: `{"type": "function", "name": "my_fn", "namespace": "my_ns"}`,
+			forwardMap: map[string]string{"my_ns__my_fn": "my_ns__my_fn"},
+			wantMode:   "ANY",
+			wantNames:  []string{"my_ns__my_fn"},
+		},
+		{
+			name:       "custom object",
+			choiceJSON: `{"type": "custom", "name": "exec", "namespace": "functions"}`,
+			forwardMap: map[string]string{"functions__exec": "functions__exec"},
+			wantMode:   "ANY",
+			wantNames:  []string{"functions__exec"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			choice := gjson.Parse(tt.choiceJSON)
+			out, ok := ConvertResponsesToolChoiceToGemini(choice, tt.forwardMap)
+			if !ok {
+				t.Fatalf("ConvertResponsesToolChoiceToGemini returned false")
+			}
+			mode := gjson.GetBytes(out, "mode").String()
+			if mode != tt.wantMode {
+				t.Fatalf("mode = %q, want %q", mode, tt.wantMode)
+			}
+			if len(tt.wantNames) > 0 {
+				names := gjson.GetBytes(out, "allowedFunctionNames").Array()
+				if len(names) != len(tt.wantNames) {
+					t.Fatalf("allowedFunctionNames count = %d, want %d", len(names), len(tt.wantNames))
+				}
+				for i, want := range tt.wantNames {
+					if names[i].String() != want {
+						t.Fatalf("allowedFunctionNames[%d] = %q, want %q", i, names[i].String(), want)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestUnwrapResponsesCustomToolInput(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: `{"input":"pwd"}`, want: "pwd"},
+		{input: `{"input":{"cmd":"ls"}}`, want: `{"cmd":"ls"}`},
+		{input: `"direct text"`, want: "direct text"},
+		{input: `{}`, want: ""},
+		{input: ``, want: ""},
+	}
+
+	for _, tt := range tests {
+		got := UnwrapResponsesCustomToolInput(tt.input)
+		if got != tt.want {
+			t.Errorf("UnwrapResponsesCustomToolInput(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestBuildGeminiFunctionDeclarations_DisambiguationAndLongNames(t *testing.T) {
+	// Two tools that genuinely collide after sanitization (e.g. "read/file" vs "read_file"), and one > 64 chars
+	raw := `{
+		"tools": [
+			{"type": "function", "name": "read/file", "description": "tool with slash"},
+			{"type": "function", "name": "read_file", "description": "tool with underscore"},
+			{"type": "custom", "name": "mcp__very_very_very_very_very_very_long_namespace_name__very_very_very_long_custom_tool_name_that_exceeds_sixty_four_chars"}
+		]
+	}`
+
+	root := gjson.Parse(raw)
+	decls, forwardMap, reverseMap := BuildGeminiFunctionDeclarations(root)
+	if len(decls) != 3 {
+		t.Fatalf("expected 3 decls, got %d", len(decls))
+	}
+
+	name1 := forwardMap["read/file"]
+	name2 := forwardMap["read_file"]
+	if name1 == name2 {
+		t.Fatalf("colliding tools mapped to identical name: %q", name1)
+	}
+
+	identity1 := reverseMap[name1]
+	if identity1.Name != "read/file" {
+		t.Fatalf("reverseMap[%q].Name = %q, want read/file", name1, identity1.Name)
+	}
+	identity2 := reverseMap[name2]
+	if identity2.Name != "read_file" {
+		t.Fatalf("reverseMap[%q].Name = %q, want read_file", name2, identity2.Name)
+	}
+
+	longName := forwardMap["mcp__very_very_very_very_very_very_long_namespace_name__very_very_very_long_custom_tool_name_that_exceeds_sixty_four_chars"]
+	if len(longName) > 64 {
+		t.Fatalf("long tool name length = %d > 64: %q", len(longName), longName)
+	}
+
+	identityLong := reverseMap[longName]
+	if !identityLong.Custom || identityLong.Name != "mcp__very_very_very_very_very_very_long_namespace_name__very_very_very_long_custom_tool_name_that_exceeds_sixty_four_chars" {
+		t.Fatalf("unexpected reverse identity for long name: %+v", identityLong)
+	}
+}

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -115,6 +115,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.Codex.DisableCodexCloaking != newCfg.Codex.DisableCodexCloaking {
 		changes = append(changes, fmt.Sprintf("codex.disable-codex-cloaking: %t -> %t", oldCfg.Codex.DisableCodexCloaking, newCfg.Codex.DisableCodexCloaking))
 	}
+	if oldCfg.Codex.StreamBootstrapBuffering != newCfg.Codex.StreamBootstrapBuffering {
+		changes = append(changes, fmt.Sprintf("codex.stream-bootstrap-buffering: %t -> %t", oldCfg.Codex.StreamBootstrapBuffering, newCfg.Codex.StreamBootstrapBuffering))
+	}
 	if oldCfg.Codex.OptimizeMultiAgentV2 != newCfg.Codex.OptimizeMultiAgentV2 {
 		changes = append(changes, fmt.Sprintf("codex.optimize-multi-agent-v2: %t -> %t", oldCfg.Codex.OptimizeMultiAgentV2, newCfg.Codex.OptimizeMultiAgentV2))
 	}

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -375,6 +375,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if entries, _ := DiffOAuthModelAliasChanges(oldCfg.OAuthModelAlias, newCfg.OAuthModelAlias); len(entries) > 0 {
 		changes = append(changes, entries...)
 	}
+	if entries, _ := DiffOAuthRequestScopedErrorsChanges(oldCfg.OAuthRequestScopedErrors, newCfg.OAuthRequestScopedErrors); len(entries) > 0 {
+		changes = append(changes, entries...)
+	}
 
 	// Remote management (never print the key)
 	if oldCfg.RemoteManagement.AllowRemote != newCfg.RemoteManagement.AllowRemote {

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -119,6 +119,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.Codex.DisableCodexCloaking != newCfg.Codex.DisableCodexCloaking {
 		changes = append(changes, fmt.Sprintf("codex.disable-codex-cloaking: %t -> %t", oldCfg.Codex.DisableCodexCloaking, newCfg.Codex.DisableCodexCloaking))
 	}
+	if oldCfg.Codex.StreamBootstrapBuffering != newCfg.Codex.StreamBootstrapBuffering {
+		changes = append(changes, fmt.Sprintf("codex.stream-bootstrap-buffering: %t -> %t", oldCfg.Codex.StreamBootstrapBuffering, newCfg.Codex.StreamBootstrapBuffering))
+	}
 	if oldCfg.Codex.OptimizeMultiAgentV2 != newCfg.Codex.OptimizeMultiAgentV2 {
 		changes = append(changes, fmt.Sprintf("codex.optimize-multi-agent-v2: %t -> %t", oldCfg.Codex.OptimizeMultiAgentV2, newCfg.Codex.OptimizeMultiAgentV2))
 	}
@@ -422,6 +425,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 		changes = append(changes, entries...)
 	}
 	if entries, _ := DiffOAuthModelAliasChanges(oldCfg.OAuthModelAlias, newCfg.OAuthModelAlias); len(entries) > 0 {
+		changes = append(changes, entries...)
+	}
+	if entries, _ := DiffOAuthRequestScopedErrorsChanges(oldCfg.OAuthRequestScopedErrors, newCfg.OAuthRequestScopedErrors); len(entries) > 0 {
 		changes = append(changes, entries...)
 	}
 

--- a/internal/watcher/diff/oauth_request_scoped_errors.go
+++ b/internal/watcher/diff/oauth_request_scoped_errors.go
@@ -1,0 +1,91 @@
+package diff
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+type OAuthRequestScopedErrorsSummary struct {
+	hash  string
+	count int
+}
+
+// SummarizeOAuthRequestScopedErrors summarizes OAuth request-scoped errors per channel.
+func SummarizeOAuthRequestScopedErrors(entries map[string][]config.RequestScopedErrorRule) map[string]OAuthRequestScopedErrorsSummary {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make(map[string]OAuthRequestScopedErrorsSummary, len(entries))
+	for k, v := range entries {
+		key := strings.ToLower(strings.TrimSpace(k))
+		if key == "" {
+			continue
+		}
+		out[key] = summarizeOAuthRequestScopedErrorsList(v)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// DiffOAuthRequestScopedErrorsChanges compares OAuth request-scoped error maps.
+func DiffOAuthRequestScopedErrorsChanges(oldMap, newMap map[string][]config.RequestScopedErrorRule) ([]string, []string) {
+	oldSummary := SummarizeOAuthRequestScopedErrors(oldMap)
+	newSummary := SummarizeOAuthRequestScopedErrors(newMap)
+	keys := make(map[string]struct{}, len(oldSummary)+len(newSummary))
+	for k := range oldSummary {
+		keys[k] = struct{}{}
+	}
+	for k := range newSummary {
+		keys[k] = struct{}{}
+	}
+	changes := make([]string, 0, len(keys))
+	affected := make([]string, 0, len(keys))
+	for key := range keys {
+		oldInfo, okOld := oldSummary[key]
+		newInfo, okNew := newSummary[key]
+		switch {
+		case okOld && !okNew:
+			changes = append(changes, fmt.Sprintf("oauth-request-scoped-errors[%s]: removed", key))
+			affected = append(affected, key)
+		case !okOld && okNew:
+			changes = append(changes, fmt.Sprintf("oauth-request-scoped-errors[%s]: added (%d entries)", key, newInfo.count))
+			affected = append(affected, key)
+		case okOld && okNew && oldInfo.hash != newInfo.hash:
+			changes = append(changes, fmt.Sprintf("oauth-request-scoped-errors[%s]: updated (%d -> %d entries)", key, oldInfo.count, newInfo.count))
+			affected = append(affected, key)
+		}
+	}
+	sort.Strings(changes)
+	sort.Strings(affected)
+	return changes, affected
+}
+
+func summarizeOAuthRequestScopedErrorsList(list []config.RequestScopedErrorRule) OAuthRequestScopedErrorsSummary {
+	if len(list) == 0 {
+		return OAuthRequestScopedErrorsSummary{}
+	}
+	var b strings.Builder
+	valid := 0
+	for _, entry := range list {
+		if entry.Status <= 0 || (len(entry.Match) == 0 && len(entry.MatchRegexr) == 0) || entry.Action == "" {
+			continue
+		}
+		valid++
+		b.WriteString(fmt.Sprintf("%d|%s|%s|%s\n", entry.Status, strings.Join(entry.Match, ","), strings.Join(entry.MatchRegexr, ","), entry.Action))
+	}
+	if valid == 0 {
+		return OAuthRequestScopedErrorsSummary{}
+	}
+	sum := sha256.Sum256([]byte(b.String()))
+	return OAuthRequestScopedErrorsSummary{
+		hash:  hex.EncodeToString(sum[:]),
+		count: valid,
+	}
+}

--- a/internal/watcher/diff/oauth_request_scoped_errors_test.go
+++ b/internal/watcher/diff/oauth_request_scoped_errors_test.go
@@ -1,0 +1,57 @@
+package diff
+
+import (
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+)
+
+func TestSummarizeOAuthRequestScopedErrors_NormalizesKeys(t *testing.T) {
+	out := SummarizeOAuthRequestScopedErrors(map[string][]config.RequestScopedErrorRule{
+		" Vertex ": {
+			{Status: 400, Match: []string{"error"}, Action: "stop"},
+		},
+		"": {
+			{Status: 500, Match: []string{"err"}, Action: "continue"},
+		},
+	})
+	if len(out) != 1 {
+		t.Fatalf("expected 1 normalized entry, got %d", len(out))
+	}
+	if summary, ok := out["vertex"]; !ok || summary.count != 1 {
+		t.Fatalf("unexpected summary for vertex: %#v", summary)
+	}
+
+	if outEmpty := SummarizeOAuthRequestScopedErrors(nil); outEmpty != nil {
+		t.Fatalf("expected nil summary for nil map, got %#v", outEmpty)
+	}
+}
+
+func TestDiffOAuthRequestScopedErrorsChanges(t *testing.T) {
+	oldMap := map[string][]config.RequestScopedErrorRule{
+		"vertex": {
+			{Status: 400, Match: []string{"context_length"}, Action: "stop"},
+		},
+		"claude": {
+			{Status: 429, Match: []string{"rate_limit"}, Action: "continue"},
+		},
+	}
+	newMap := map[string][]config.RequestScopedErrorRule{
+		"vertex": {
+			{Status: 400, Match: []string{"context_length_updated"}, Action: "stop"},
+		},
+		"codex": {
+			{Status: 400, Match: []string{"window_exceeded"}, Action: "stop"},
+		},
+	}
+
+	changes, affected := DiffOAuthRequestScopedErrorsChanges(oldMap, newMap)
+
+	expectContains(t, changes, "oauth-request-scoped-errors[claude]: removed")
+	expectContains(t, changes, "oauth-request-scoped-errors[codex]: added (1 entries)")
+	expectContains(t, changes, "oauth-request-scoped-errors[vertex]: updated (1 -> 1 entries)")
+
+	expectContains(t, affected, "claude")
+	expectContains(t, affected, "codex")
+	expectContains(t, affected, "vertex")
+}

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -79,17 +79,19 @@ func (s *ConfigSynthesizer) synthesizeGeminiKeyEntries(ctx *SynthesisContext, en
 	for i := range entries {
 		entry := entries[i]
 		key := strings.TrimSpace(entry.APIKey)
-		if key == "" {
+		base := strings.TrimSpace(entry.BaseURL)
+		if key == "" && base == "" {
 			continue
 		}
 		prefix := strings.TrimSpace(entry.Prefix)
-		base := strings.TrimSpace(entry.BaseURL)
 		proxyURL := strings.TrimSpace(entry.ProxyURL)
-		id, token := idGen.Next(idKind, key, base)
+		id, token := idGen.Next(idKind, key, base, proxyURL, prefix, config.FormatSortedHeaders(entry.Headers))
 		attrs := map[string]string{
 			"source":       fmt.Sprintf("config:%s[%s]", sourceName, token),
-			"api_key":      key,
 			"config_index": strconv.Itoa(i),
+		}
+		if key != "" {
+			attrs["api_key"] = key
 		}
 		metadata := map[string]any{}
 		if entry.DisableCooling != nil {
@@ -139,16 +141,19 @@ func (s *ConfigSynthesizer) synthesizeClaudeKeys(ctx *SynthesisContext) []*corea
 	for i := range cfg.ClaudeKey {
 		ck := cfg.ClaudeKey[i]
 		key := strings.TrimSpace(ck.APIKey)
-		if key == "" {
+		base := strings.TrimSpace(ck.BaseURL)
+		if key == "" && base == "" {
 			continue
 		}
 		prefix := strings.TrimSpace(ck.Prefix)
-		base := strings.TrimSpace(ck.BaseURL)
-		id, token := idGen.Next("claude:apikey", key, base)
+		proxyURL := strings.TrimSpace(ck.ProxyURL)
+		id, token := idGen.Next("claude:apikey", key, base, proxyURL, prefix, config.FormatSortedHeaders(ck.Headers))
 		attrs := map[string]string{
 			"source":       fmt.Sprintf("config:claude[%s]", token),
-			"api_key":      key,
 			"config_index": strconv.Itoa(i),
+		}
+		if key != "" {
+			attrs["api_key"] = key
 		}
 		metadata := map[string]any{}
 		if ck.DisableCooling != nil {
@@ -173,7 +178,6 @@ func (s *ConfigSynthesizer) synthesizeClaudeKeys(ctx *SynthesisContext) []*corea
 			attrs["models_hash"] = hash
 		}
 		addConfigHeadersToAttrs(ck.Headers, attrs)
-		proxyURL := strings.TrimSpace(ck.ProxyURL)
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   "claude",
@@ -214,16 +218,19 @@ func (s *ConfigSynthesizer) synthesizeCodexStyleKeys(ctx *SynthesisContext, entr
 	for i := range entries {
 		entry := entries[i]
 		key := strings.TrimSpace(entry.APIKey)
-		if key == "" {
+		baseURL := strings.TrimSpace(entry.BaseURL)
+		if key == "" && baseURL == "" {
 			continue
 		}
 		prefix := strings.TrimSpace(entry.Prefix)
-		baseURL := strings.TrimSpace(entry.BaseURL)
-		id, token := idGen.Next(provider+":apikey", key, baseURL)
+		proxyURL := strings.TrimSpace(entry.ProxyURL)
+		id, token := idGen.Next(provider+":apikey", key, baseURL, proxyURL, prefix, config.FormatSortedHeaders(entry.Headers))
 		attrs := map[string]string{
 			"source":       fmt.Sprintf("config:%s[%s]", provider, token),
-			"api_key":      key,
 			"config_index": strconv.Itoa(i),
+		}
+		if key != "" {
+			attrs["api_key"] = key
 		}
 		metadata := map[string]any{}
 		if entry.DisableCooling != nil {

--- a/internal/watcher/synthesizer/config.go
+++ b/internal/watcher/synthesizer/config.go
@@ -79,17 +79,19 @@ func (s *ConfigSynthesizer) synthesizeGeminiKeyEntries(ctx *SynthesisContext, en
 	for i := range entries {
 		entry := entries[i]
 		key := strings.TrimSpace(entry.APIKey)
-		if key == "" {
+		base := strings.TrimSpace(entry.BaseURL)
+		if key == "" && base == "" {
 			continue
 		}
 		prefix := strings.TrimSpace(entry.Prefix)
-		base := strings.TrimSpace(entry.BaseURL)
 		proxyURL := strings.TrimSpace(entry.ProxyURL)
-		id, token := idGen.Next(idKind, key, base)
+		id, token := idGen.Next(idKind, key, base, proxyURL, prefix, config.FormatSortedHeaders(entry.Headers))
 		attrs := map[string]string{
 			"source":       fmt.Sprintf("config:%s[%s]", sourceName, token),
-			"api_key":      key,
 			"config_index": strconv.Itoa(i),
+		}
+		if key != "" {
+			attrs["api_key"] = key
 		}
 		metadata := map[string]any{}
 		if entry.DisableCooling != nil && *entry.DisableCooling {
@@ -139,16 +141,19 @@ func (s *ConfigSynthesizer) synthesizeClaudeKeys(ctx *SynthesisContext) []*corea
 	for i := range cfg.ClaudeKey {
 		ck := cfg.ClaudeKey[i]
 		key := strings.TrimSpace(ck.APIKey)
-		if key == "" {
+		base := strings.TrimSpace(ck.BaseURL)
+		if key == "" && base == "" {
 			continue
 		}
 		prefix := strings.TrimSpace(ck.Prefix)
-		base := strings.TrimSpace(ck.BaseURL)
-		id, token := idGen.Next("claude:apikey", key, base)
+		proxyURL := strings.TrimSpace(ck.ProxyURL)
+		id, token := idGen.Next("claude:apikey", key, base, proxyURL, prefix, config.FormatSortedHeaders(ck.Headers))
 		attrs := map[string]string{
 			"source":       fmt.Sprintf("config:claude[%s]", token),
-			"api_key":      key,
 			"config_index": strconv.Itoa(i),
+		}
+		if key != "" {
+			attrs["api_key"] = key
 		}
 		metadata := map[string]any{}
 		if ck.DisableCooling != nil && *ck.DisableCooling {
@@ -173,7 +178,6 @@ func (s *ConfigSynthesizer) synthesizeClaudeKeys(ctx *SynthesisContext) []*corea
 			attrs["models_hash"] = hash
 		}
 		addConfigHeadersToAttrs(ck.Headers, attrs)
-		proxyURL := strings.TrimSpace(ck.ProxyURL)
 		a := &coreauth.Auth{
 			ID:         id,
 			Provider:   "claude",
@@ -214,16 +218,19 @@ func (s *ConfigSynthesizer) synthesizeCodexStyleKeys(ctx *SynthesisContext, entr
 	for i := range entries {
 		entry := entries[i]
 		key := strings.TrimSpace(entry.APIKey)
-		if key == "" {
+		baseURL := strings.TrimSpace(entry.BaseURL)
+		if key == "" && baseURL == "" {
 			continue
 		}
 		prefix := strings.TrimSpace(entry.Prefix)
-		baseURL := strings.TrimSpace(entry.BaseURL)
-		id, token := idGen.Next(provider+":apikey", key, baseURL)
+		proxyURL := strings.TrimSpace(entry.ProxyURL)
+		id, token := idGen.Next(provider+":apikey", key, baseURL, proxyURL, prefix, config.FormatSortedHeaders(entry.Headers))
 		attrs := map[string]string{
 			"source":       fmt.Sprintf("config:%s[%s]", provider, token),
-			"api_key":      key,
 			"config_index": strconv.Itoa(i),
+		}
+		if key != "" {
+			attrs["api_key"] = key
 		}
 		metadata := map[string]any{}
 		if entry.DisableCooling != nil && *entry.DisableCooling {

--- a/internal/watcher/synthesizer/config_test.go
+++ b/internal/watcher/synthesizer/config_test.go
@@ -409,13 +409,141 @@ func TestConfigSynthesizer_XAIKeys(t *testing.T) {
 	}
 }
 
+func TestConfigSynthesizer_XAIKeys_AllowsEmptyAPIKeyWithBaseURL(t *testing.T) {
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{
+			XAIKey: []config.CodexKey{
+				{
+					APIKey:  "",
+					BaseURL: "https://custom-xai.example.com",
+					Headers: map[string]string{"Custom-Auth": "secret"},
+				},
+				{
+					APIKey:  "   ",
+					BaseURL: "https://custom-xai-2.example.com",
+				},
+			},
+		},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 2 {
+		t.Fatalf("expected 2 auths for empty API keys with base URL, got %d", len(auths))
+	}
+	if auths[0].Attributes["base_url"] != "https://custom-xai.example.com" {
+		t.Fatalf("expected base_url=https://custom-xai.example.com, got %s", auths[0].Attributes["base_url"])
+	}
+	if auths[0].Attributes["header:Custom-Auth"] != "secret" {
+		t.Fatalf("expected header:Custom-Auth=secret, got %s", auths[0].Attributes["header:Custom-Auth"])
+	}
+	if auths[0].Attributes["auth_kind"] != "apikey" {
+		t.Fatalf("expected auth_kind=apikey, got %s", auths[0].Attributes["auth_kind"])
+	}
+	if _, exists := auths[0].Attributes["api_key"]; exists {
+		t.Fatalf("expected no api_key attribute for empty key, got %s", auths[0].Attributes["api_key"])
+	}
+}
+
+func TestConfigSynthesizer_ClaudeKeys_AllowsEmptyAPIKeyWithBaseURL(t *testing.T) {
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{
+			ClaudeKey: []config.ClaudeKey{
+				{
+					APIKey:  "",
+					BaseURL: "https://custom-claude.example.com",
+					Headers: map[string]string{"Custom-Auth": "secret"},
+				},
+				{
+					APIKey:  "   ",
+					BaseURL: "https://custom-claude-2.example.com",
+				},
+			},
+		},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 2 {
+		t.Fatalf("expected 2 auths for empty API keys with base URL, got %d", len(auths))
+	}
+	if auths[0].Attributes["base_url"] != "https://custom-claude.example.com" {
+		t.Fatalf("expected base_url=https://custom-claude.example.com, got %s", auths[0].Attributes["base_url"])
+	}
+	if auths[0].Attributes["header:Custom-Auth"] != "secret" {
+		t.Fatalf("expected header:Custom-Auth=secret, got %s", auths[0].Attributes["header:Custom-Auth"])
+	}
+	if auths[0].Attributes["auth_kind"] != "apikey" {
+		t.Fatalf("expected auth_kind=apikey, got %s", auths[0].Attributes["auth_kind"])
+	}
+	if _, exists := auths[0].Attributes["api_key"]; exists {
+		t.Fatalf("expected no api_key attribute for empty key, got %s", auths[0].Attributes["api_key"])
+	}
+}
+
+func TestConfigSynthesizer_GeminiKeys_AllowsEmptyAPIKeyWithBaseURL(t *testing.T) {
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{
+			GeminiKey: []config.GeminiKey{
+				{
+					APIKey:  "",
+					BaseURL: "https://custom-gemini.example.com",
+					Headers: map[string]string{"Custom-Auth": "secret"},
+				},
+			},
+			InteractionsKey: []config.GeminiKey{
+				{
+					APIKey:  "",
+					BaseURL: "https://custom-interactions.example.com",
+				},
+			},
+		},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 2 {
+		t.Fatalf("expected 2 auths for empty API keys with base URL, got %d", len(auths))
+	}
+	if auths[0].Attributes["base_url"] != "https://custom-gemini.example.com" {
+		t.Fatalf("expected base_url=https://custom-gemini.example.com, got %s", auths[0].Attributes["base_url"])
+	}
+	if auths[0].Attributes["header:Custom-Auth"] != "secret" {
+		t.Fatalf("expected header:Custom-Auth=secret, got %s", auths[0].Attributes["header:Custom-Auth"])
+	}
+	if auths[0].Attributes["auth_kind"] != "apikey" {
+		t.Fatalf("expected auth_kind=apikey, got %s", auths[0].Attributes["auth_kind"])
+	}
+	if _, exists := auths[0].Attributes["api_key"]; exists {
+		t.Fatalf("expected no api_key attribute for empty key, got %s", auths[0].Attributes["api_key"])
+	}
+	if auths[1].Attributes["base_url"] != "https://custom-interactions.example.com" {
+		t.Fatalf("expected base_url=https://custom-interactions.example.com, got %s", auths[1].Attributes["base_url"])
+	}
+}
+
 func TestConfigSynthesizer_CodexKeys_SkipsEmptyAndHeaders(t *testing.T) {
 	synth := NewConfigSynthesizer()
 	ctx := &SynthesisContext{
 		Config: &config.Config{
 			CodexKey: []config.CodexKey{
-				{APIKey: ""},   // empty, should be skipped
-				{APIKey: "  "}, // whitespace, should be skipped
+				{APIKey: ""},   // empty key without base URL, should be skipped
+				{APIKey: "  "}, // whitespace key without base URL, should be skipped
 				{APIKey: "valid-key", Headers: map[string]string{"Authorization": "Bearer xyz"}},
 			},
 		},
@@ -435,6 +563,47 @@ func TestConfigSynthesizer_CodexKeys_SkipsEmptyAndHeaders(t *testing.T) {
 	}
 	if _, exists := auths[0].Attributes[coreauth.AttributeCodexAlphaSearch]; exists {
 		t.Fatal("default alpha-search=false unexpectedly generated codex_alpha_search")
+	}
+}
+
+func TestConfigSynthesizer_CodexKeys_AllowsEmptyAPIKeyWithBaseURL(t *testing.T) {
+	synth := NewConfigSynthesizer()
+	ctx := &SynthesisContext{
+		Config: &config.Config{
+			CodexKey: []config.CodexKey{
+				{
+					APIKey:  "",
+					BaseURL: "https://custom-codex.example.com",
+					Headers: map[string]string{"Custom-Auth": "secret"},
+				},
+				{
+					APIKey:  "   ",
+					BaseURL: "https://custom-codex-2.example.com",
+				},
+			},
+		},
+		Now:         time.Now(),
+		IDGenerator: NewStableIDGenerator(),
+	}
+
+	auths, err := synth.Synthesize(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(auths) != 2 {
+		t.Fatalf("expected 2 auths for empty API keys with base URL, got %d", len(auths))
+	}
+	if auths[0].Attributes["base_url"] != "https://custom-codex.example.com" {
+		t.Fatalf("expected base_url=https://custom-codex.example.com, got %s", auths[0].Attributes["base_url"])
+	}
+	if auths[0].Attributes["header:Custom-Auth"] != "secret" {
+		t.Fatalf("expected header:Custom-Auth=secret, got %s", auths[0].Attributes["header:Custom-Auth"])
+	}
+	if auths[0].Attributes["auth_kind"] != "apikey" {
+		t.Fatalf("expected auth_kind=apikey, got %s", auths[0].Attributes["auth_kind"])
+	}
+	if _, exists := auths[0].Attributes["api_key"]; exists {
+		t.Fatalf("expected no api_key attribute for empty key, got %s", auths[0].Attributes["api_key"])
 	}
 }
 

--- a/sdk/api/handlers/handlers_context.go
+++ b/sdk/api/handlers/handlers_context.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/gin-gonic/gin"
 	"golang.org/x/net/context"
@@ -18,6 +19,51 @@ type preparedModelRouteContextKey struct{}
 type executionSessionContextKey struct{}
 
 type disallowFreeAuthContextKey struct{}
+
+type nestedExecutionTrackerKey struct{}
+
+type nestedExecutionTracker struct {
+	mu     sync.Mutex
+	called bool
+}
+
+func (t *nestedExecutionTracker) mark() {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	t.called = true
+	t.mu.Unlock()
+}
+
+func (t *nestedExecutionTracker) hasNestedExecution() bool {
+	if t == nil {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.called
+}
+
+func withNestedExecutionTracker(ctx context.Context) (context.Context, *nestedExecutionTracker) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if existing, ok := ctx.Value(nestedExecutionTrackerKey{}).(*nestedExecutionTracker); ok && existing != nil {
+		return ctx, existing
+	}
+	tracker := &nestedExecutionTracker{}
+	return context.WithValue(ctx, nestedExecutionTrackerKey{}, tracker), tracker
+}
+
+func markNestedExecution(ctx context.Context) {
+	if ctx == nil {
+		return
+	}
+	if tracker, ok := ctx.Value(nestedExecutionTrackerKey{}).(*nestedExecutionTracker); ok && tracker != nil {
+		tracker.mark()
+	}
+}
 
 // WithPinnedAuthID returns a child context that requests execution on a specific auth ID.
 func WithPinnedAuthID(ctx context.Context, authID string) context.Context {

--- a/sdk/api/handlers/handlers_execution.go
+++ b/sdk/api/handlers/handlers_execution.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/clienterror"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
@@ -175,28 +176,42 @@ func (h *BaseAPIHandler) executeWithPluginExecutor(ctx context.Context, entryPro
 	if host == nil {
 		return nil, nil, &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("plugin executor host is unavailable")}
 	}
-	req, opts := h.pluginExecutorRequest(ctx, entryProtocol, responseProtocol, modelName, originalRequestedModel, rawJSON, alt, false, execOptions)
-	lifecycle := h.newRequestLifecycleTracker(ctx, entryProtocol, modelName, originalRequestedModel, false, opts.Metadata, execOptions.SkipInterceptorPluginID)
+	execCtx, nestedTracker := withNestedExecutionTracker(ctx)
+	req, opts := h.pluginExecutorRequest(execCtx, entryProtocol, responseProtocol, modelName, originalRequestedModel, rawJSON, alt, false, execOptions)
+	lifecycle := h.newRequestLifecycleTracker(execCtx, entryProtocol, modelName, originalRequestedModel, false, opts.Metadata, execOptions.SkipInterceptorPluginID)
 	var interceptErr *interfaces.ErrorMessage
-	req, opts, interceptErr = h.applyRequestInterceptorsBeforeAuth(ctx, entryProtocol, originalRequestedModel, lifecycle.requestID(), req, opts, execOptions.SkipInterceptorPluginID)
+	req, opts, interceptErr = h.applyRequestInterceptorsBeforeAuth(execCtx, entryProtocol, originalRequestedModel, lifecycle.requestID(), req, opts, execOptions.SkipInterceptorPluginID)
 	if interceptErr != nil {
-		lifecycle.completeError(ctx, interceptErr)
+		lifecycle.completeError(execCtx, interceptErr)
 		return nil, nil, interceptErr
 	}
-	req, opts, interceptErr = h.applyRequestInterceptorsAfterPluginExecutorRoute(ctx, host, executorPluginID, entryProtocol, originalRequestedModel, lifecycle.requestID(), req, opts, execOptions.SkipInterceptorPluginID)
+	req, opts, interceptErr = h.applyRequestInterceptorsAfterPluginExecutorRoute(execCtx, host, executorPluginID, entryProtocol, originalRequestedModel, lifecycle.requestID(), req, opts, execOptions.SkipInterceptorPluginID)
 	if interceptErr != nil {
-		lifecycle.completeError(ctx, interceptErr)
+		lifecycle.completeError(execCtx, interceptErr)
 		return nil, nil, interceptErr
 	}
-	resp, errExecute := host.ExecutePluginExecutor(ctx, executorPluginID, req, opts)
+	var reporter *helps.UsageReporter
+	if !execOptions.InternalSource {
+		reporter = helps.NewUsageReporter(execCtx, executorPluginID, modelName, nil)
+		reporter.SetTranslatedReasoningEffort(req.Payload, entryProtocol)
+	}
+	resp, errExecute := host.ExecutePluginExecutor(execCtx, executorPluginID, req, opts)
 	if errExecute != nil {
+		if reporter != nil && !nestedTracker.hasNestedExecution() {
+			reporter.PublishFailure(execCtx, errExecute)
+		}
 		errMsg := executionErrorMessage(errExecute)
-		lifecycle.completeError(ctx, errMsg)
+		lifecycle.completeError(execCtx, errMsg)
 		return nil, nil, errMsg
+	}
+	if reporter != nil && !nestedTracker.hasNestedExecution() {
+		detail := parsePluginExecutorResponseUsage(responseProtocol, resp.Payload)
+		reporter.Publish(execCtx, detail)
+		reporter.EnsurePublished(execCtx)
 	}
 	rawResponseHeaders := cloneHeader(resp.Headers)
 	responseHeaders := downstreamHeadersFromExecutor(rawResponseHeaders, PassthroughHeadersEnabled(h.Cfg))
-	body, responseHeaders := h.applyResponseInterceptors(ctx, lifecycle.requestID(), responseProtocol, modelName, originalRequestedModel, opts, rawResponseHeaders, responseHeaders, opts.OriginalRequest, req.Payload, resp.Payload, http.StatusOK, execOptions.SkipInterceptorPluginID)
+	body, responseHeaders := h.applyResponseInterceptors(execCtx, lifecycle.requestID(), responseProtocol, modelName, originalRequestedModel, opts, rawResponseHeaders, responseHeaders, opts.OriginalRequest, req.Payload, resp.Payload, http.StatusOK, execOptions.SkipInterceptorPluginID)
 	lifecycle.complete(pluginapi.RequestCompletionSucceeded, http.StatusOK, nil)
 	return body, responseHeaders, nil
 }

--- a/sdk/api/handlers/handlers_plugin_executor_usage.go
+++ b/sdk/api/handlers/handlers_plugin_executor_usage.go
@@ -1,0 +1,197 @@
+package handlers
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+	"github.com/tidwall/gjson"
+)
+
+func parsePluginExecutorResponseUsage(protocol string, payload []byte) usage.Detail {
+	if len(payload) == 0 {
+		return usage.Detail{}
+	}
+	switch strings.ToLower(strings.TrimSpace(protocol)) {
+	case "claude":
+		return parseClaudePayloadUsage(payload)
+	case "gemini":
+		return helps.ParseGeminiUsage(payload)
+	case "interactions", "interactions-response":
+		return helps.ParseInteractionsUsage(payload)
+	case "antigravity":
+		return helps.ParseAntigravityUsage(payload)
+	case "codex", "openai-response":
+		if detail, ok := helps.ParseCodexUsage(payload); ok {
+			return detail
+		}
+		return helps.ParseOpenAIUsage(payload)
+	default:
+		return helps.ParseOpenAIUsage(payload)
+	}
+}
+
+func observePluginExecutorStreamUsage(protocol string, payload []byte, buffer *helps.StreamUsageBuffer) {
+	if buffer == nil || len(payload) == 0 {
+		return
+	}
+	switch strings.ToLower(strings.TrimSpace(protocol)) {
+	case "claude":
+		iterateStreamLines(payload, func(line []byte) {
+			if detail, ok := parseClaudeStreamLine(line); ok {
+				observeMergedStreamUsage(buffer, detail)
+			}
+		})
+	case "gemini":
+		iterateStreamLines(payload, func(line []byte) {
+			if detail, ok := helps.ParseGeminiStreamUsage(line); ok {
+				buffer.Observe(detail, ok)
+			}
+		})
+	case "interactions", "interactions-response":
+		iterateStreamLines(payload, func(line []byte) {
+			if detail, ok := helps.ParseInteractionsStreamUsage(line); ok {
+				observeMergedStreamUsage(buffer, detail)
+			}
+		})
+	case "antigravity":
+		iterateStreamLines(payload, func(line []byte) {
+			if detail, ok := helps.ParseAntigravityStreamUsage(line); ok {
+				buffer.Observe(detail, ok)
+			}
+		})
+	case "codex", "openai-response":
+		iterateStreamLines(payload, func(line []byte) {
+			if jsonBytes := extractStreamJSONPayload(line); len(jsonBytes) > 0 {
+				if detail, ok := helps.ParseCodexUsage(jsonBytes); ok {
+					buffer.Observe(detail, ok)
+					return
+				}
+			}
+			buffer.ObserveOpenAIStream(line)
+		})
+	default:
+		iterateStreamLines(payload, func(line []byte) {
+			buffer.ObserveOpenAIStream(line)
+		})
+	}
+}
+
+func parseClaudePayloadUsage(payload []byte) usage.Detail {
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return usage.Detail{}
+	}
+	usageNode := gjson.GetBytes(payload, "usage")
+	if !usageNode.Exists() {
+		usageNode = gjson.GetBytes(payload, "message.usage")
+	}
+	if !usageNode.Exists() {
+		return usage.Detail{}
+	}
+	return helps.ParseClaudeUsage([]byte(`{"usage":` + usageNode.Raw + `}`))
+}
+
+func parseClaudeStreamLine(line []byte) (usage.Detail, bool) {
+	payload := extractStreamJSONPayload(line)
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return usage.Detail{}, false
+	}
+	usageNode := gjson.GetBytes(payload, "usage")
+	if !usageNode.Exists() {
+		usageNode = gjson.GetBytes(payload, "message.usage")
+	}
+	if !usageNode.Exists() {
+		return usage.Detail{}, false
+	}
+	detail := helps.ParseClaudeUsage([]byte(`{"usage":` + usageNode.Raw + `}`))
+	return detail, true
+}
+
+func observeMergedStreamUsage(buffer *helps.StreamUsageBuffer, update usage.Detail) {
+	if buffer == nil {
+		return
+	}
+	if existing, ok := buffer.Detail(); ok {
+		merged := mergeStreamUsageDetail(existing, update)
+		buffer.Observe(merged, true)
+		return
+	}
+	buffer.Observe(update, true)
+}
+
+func mergeStreamUsageDetail(existing, update usage.Detail) usage.Detail {
+	merged := update
+	if merged.InputTokens == 0 && existing.InputTokens > 0 {
+		merged.InputTokens = existing.InputTokens
+	}
+	if merged.CachedTokens == 0 && existing.CachedTokens > 0 {
+		merged.CachedTokens = existing.CachedTokens
+	}
+	if merged.CacheReadTokens == 0 && existing.CacheReadTokens > 0 {
+		merged.CacheReadTokens = existing.CacheReadTokens
+	}
+	if merged.CacheCreationTokens == 0 && existing.CacheCreationTokens > 0 {
+		merged.CacheCreationTokens = existing.CacheCreationTokens
+	}
+	if merged.OutputTokens == 0 && existing.OutputTokens > 0 {
+		merged.OutputTokens = existing.OutputTokens
+	}
+	if merged.ReasoningTokens == 0 && existing.ReasoningTokens > 0 {
+		merged.ReasoningTokens = existing.ReasoningTokens
+	}
+	if merged.ResponseServiceTier == "" {
+		merged.ResponseServiceTier = existing.ResponseServiceTier
+	}
+	cached := merged.CacheReadTokens + merged.CacheCreationTokens
+	if cached == 0 {
+		cached = merged.CachedTokens
+	}
+	calculatedTotal := merged.InputTokens + merged.OutputTokens + cached
+	if merged.TotalTokens == 0 || merged.TotalTokens < calculatedTotal {
+		merged.TotalTokens = calculatedTotal
+	}
+	nonReasoningOutput := merged.OutputTokens - merged.ReasoningTokens
+	if nonReasoningOutput < 0 {
+		nonReasoningOutput = 0
+	}
+	merged.TokenBreakdown = usage.NewIndependentTokenBreakdown(
+		merged.InputTokens,
+		merged.CacheReadTokens,
+		merged.CacheCreationTokens,
+		nonReasoningOutput,
+		merged.ReasoningTokens,
+		merged.TotalTokens,
+	)
+	return merged
+}
+
+func iterateStreamLines(payload []byte, fn func(line []byte)) {
+	for _, line := range bytes.Split(payload, []byte("\n")) {
+		trimmed := bytes.TrimSpace(line)
+		if len(trimmed) == 0 {
+			continue
+		}
+		fn(trimmed)
+	}
+}
+
+func extractStreamJSONPayload(line []byte) []byte {
+	trimmed := bytes.TrimSpace(line)
+	if len(trimmed) == 0 {
+		return nil
+	}
+	if bytes.Equal(trimmed, []byte("[DONE]")) {
+		return nil
+	}
+	if bytes.HasPrefix(trimmed, []byte("event:")) {
+		return nil
+	}
+	if bytes.HasPrefix(trimmed, []byte("data:")) {
+		trimmed = bytes.TrimSpace(bytes.TrimPrefix(trimmed, []byte("data:")))
+	}
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("[DONE]")) {
+		return nil
+	}
+	return trimmed
+}

--- a/sdk/api/handlers/handlers_plugin_executor_usage.go
+++ b/sdk/api/handlers/handlers_plugin_executor_usage.go
@@ -1,0 +1,215 @@
+package handlers
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+	"github.com/tidwall/gjson"
+)
+
+func parsePluginExecutorResponseUsage(protocol string, payload []byte) usage.Detail {
+	if len(payload) == 0 {
+		return usage.Detail{}
+	}
+	switch strings.ToLower(strings.TrimSpace(protocol)) {
+	case "claude":
+		return parseClaudePayloadUsage(payload)
+	case "gemini":
+		return helps.ParseGeminiUsage(payload)
+	case "interactions", "interactions-response":
+		return helps.ParseInteractionsUsage(payload)
+	case "antigravity":
+		return helps.ParseAntigravityUsage(payload)
+	case "codex", "openai-response":
+		if detail, ok := helps.ParseCodexUsage(payload); ok {
+			return detail
+		}
+		return helps.ParseOpenAIUsage(payload)
+	default:
+		return helps.ParseOpenAIUsage(payload)
+	}
+}
+
+func observePluginExecutorStreamUsage(protocol string, payload []byte, buffer *helps.StreamUsageBuffer) {
+	if buffer == nil || len(payload) == 0 {
+		return
+	}
+	switch strings.ToLower(strings.TrimSpace(protocol)) {
+	case "claude":
+		iterateStreamLines(payload, func(line []byte) {
+			if detail, ok := parseClaudeStreamLine(line); ok {
+				observeMergedStreamUsage(buffer, detail)
+			}
+		})
+	case "gemini":
+		iterateStreamLines(payload, func(line []byte) {
+			if detail, ok := helps.ParseGeminiStreamUsage(line); ok {
+				buffer.Observe(detail, ok)
+			}
+		})
+	case "interactions", "interactions-response":
+		iterateStreamLines(payload, func(line []byte) {
+			if detail, ok := helps.ParseInteractionsStreamUsage(line); ok {
+				observeMergedStreamUsage(buffer, detail)
+			}
+		})
+	case "antigravity":
+		iterateStreamLines(payload, func(line []byte) {
+			if detail, ok := helps.ParseAntigravityStreamUsage(line); ok {
+				buffer.Observe(detail, ok)
+			}
+		})
+	case "codex", "openai-response":
+		iterateStreamLines(payload, func(line []byte) {
+			if jsonBytes := extractStreamJSONPayload(line); len(jsonBytes) > 0 {
+				if detail, ok := helps.ParseCodexUsage(jsonBytes); ok {
+					buffer.Observe(detail, ok)
+					return
+				}
+			}
+			buffer.ObserveOpenAIStream(line)
+		})
+	default:
+		iterateStreamLines(payload, func(line []byte) {
+			buffer.ObserveOpenAIStream(line)
+		})
+	}
+}
+
+func parseClaudePayloadUsage(payload []byte) usage.Detail {
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return usage.Detail{}
+	}
+	usageNode := gjson.GetBytes(payload, "usage")
+	if !usageNode.Exists() {
+		usageNode = gjson.GetBytes(payload, "message.usage")
+	}
+	if !usageNode.Exists() {
+		return usage.Detail{}
+	}
+	return helps.ParseClaudeUsage([]byte(`{"usage":` + usageNode.Raw + `}`))
+}
+
+func parseClaudeStreamLine(line []byte) (usage.Detail, bool) {
+	payload := extractStreamJSONPayload(line)
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return usage.Detail{}, false
+	}
+	usageNode := gjson.GetBytes(payload, "usage")
+	if !usageNode.Exists() {
+		usageNode = gjson.GetBytes(payload, "message.usage")
+	}
+	if !usageNode.Exists() {
+		return usage.Detail{}, false
+	}
+	detail := helps.ParseClaudeUsage([]byte(`{"usage":` + usageNode.Raw + `}`))
+	return detail, true
+}
+
+func observeMergedStreamUsage(buffer *helps.StreamUsageBuffer, update usage.Detail) {
+	if buffer == nil {
+		return
+	}
+	if existing, ok := buffer.Detail(); ok {
+		merged := mergeStreamUsageDetail(existing, update)
+		buffer.Observe(merged, true)
+		return
+	}
+	buffer.Observe(update, true)
+}
+
+func mergeStreamUsageDetail(existing, update usage.Detail) usage.Detail {
+	merged := update
+	if merged.InputTokens == 0 && existing.InputTokens > 0 {
+		merged.InputTokens = existing.InputTokens
+	}
+	if merged.CachedTokens == 0 && existing.CachedTokens > 0 {
+		merged.CachedTokens = existing.CachedTokens
+	}
+	if merged.CacheReadTokens == 0 && existing.CacheReadTokens > 0 {
+		merged.CacheReadTokens = existing.CacheReadTokens
+	}
+	if merged.CacheCreationTokens == 0 && existing.CacheCreationTokens > 0 {
+		merged.CacheCreationTokens = existing.CacheCreationTokens
+	}
+	if merged.OutputTokens == 0 && existing.OutputTokens > 0 {
+		merged.OutputTokens = existing.OutputTokens
+	}
+	if merged.ReasoningTokens == 0 && existing.ReasoningTokens > 0 {
+		merged.ReasoningTokens = existing.ReasoningTokens
+	}
+	if merged.ResponseServiceTier == "" {
+		merged.ResponseServiceTier = existing.ResponseServiceTier
+	}
+
+	inputSource := update
+	if update.InputTokens == 0 && update.CacheReadTokens == 0 && update.CacheCreationTokens == 0 && update.CachedTokens == 0 {
+		inputSource = existing
+	}
+	outputSource := update
+	if update.OutputTokens == 0 && update.ReasoningTokens == 0 {
+		outputSource = existing
+	}
+	inputBreakdown := inputSource.TokenBreakdown
+	outputBreakdown := outputSource.TokenBreakdown
+	if inputBreakdown.Valid() && outputBreakdown.Valid() &&
+		inputBreakdown.Quality == usage.TokenAccountingQualityComplete &&
+		outputBreakdown.Quality == usage.TokenAccountingQualityComplete &&
+		inputBreakdown.UnclassifiedTokens == 0 && outputBreakdown.UnclassifiedTokens == 0 &&
+		inputBreakdown.Input.TotalTokens <= int64(^uint64(0)>>1)-outputBreakdown.Output.TotalTokens {
+		total := inputBreakdown.Input.TotalTokens + outputBreakdown.Output.TotalTokens
+		merged.InputTokens = inputBreakdown.Input.TotalTokens
+		merged.CachedTokens = inputBreakdown.Input.CacheReadTokens
+		merged.CacheReadTokens = inputBreakdown.Input.CacheReadTokens
+		merged.CacheCreationTokens = inputBreakdown.Input.CacheWriteTokens
+		merged.TotalTokens = total
+		merged.TokenBreakdown = usage.TokenBreakdown{
+			SchemaVersion: usage.TokenAccountingSchemaVersion,
+			Quality:       usage.TokenAccountingQualityComplete,
+			TotalTokens:   total,
+			Input:         inputBreakdown.Input,
+			Output:        outputBreakdown.Output,
+		}
+		return merged
+	}
+
+	// A malformed or unrepresentable partial update cannot safely preserve a
+	// protocol-specific overlap rule. Keep the legacy counters and classify only
+	// their non-overlapping lower bound instead of double-counting cache buckets.
+	merged.TotalTokens = 0
+	merged.TokenBreakdown = usage.TokenBreakdown{}
+	merged = usage.EnsureTokenBreakdown(merged)
+	return merged
+}
+
+func iterateStreamLines(payload []byte, fn func(line []byte)) {
+	for _, line := range bytes.Split(payload, []byte("\n")) {
+		trimmed := bytes.TrimSpace(line)
+		if len(trimmed) == 0 {
+			continue
+		}
+		fn(trimmed)
+	}
+}
+
+func extractStreamJSONPayload(line []byte) []byte {
+	trimmed := bytes.TrimSpace(line)
+	if len(trimmed) == 0 {
+		return nil
+	}
+	if bytes.Equal(trimmed, []byte("[DONE]")) {
+		return nil
+	}
+	if bytes.HasPrefix(trimmed, []byte("event:")) {
+		return nil
+	}
+	if bytes.HasPrefix(trimmed, []byte("data:")) {
+		trimmed = bytes.TrimSpace(bytes.TrimPrefix(trimmed, []byte("data:")))
+	}
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("[DONE]")) {
+		return nil
+	}
+	return trimmed
+}

--- a/sdk/api/handlers/handlers_plugin_executor_usage_test.go
+++ b/sdk/api/handlers/handlers_plugin_executor_usage_test.go
@@ -1,0 +1,718 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+type noopUsagePlugin struct{}
+
+func (noopUsagePlugin) HandleUsage(context.Context, usage.Record) {}
+
+type capturePluginExecutorUsagePlugin struct {
+	targetProvider string
+	records        chan usage.Record
+}
+
+func newCapturePluginExecutorUsagePlugin(targetProvider string) *capturePluginExecutorUsagePlugin {
+	return &capturePluginExecutorUsagePlugin{
+		targetProvider: targetProvider,
+		records:        make(chan usage.Record, 50),
+	}
+}
+
+func (p *capturePluginExecutorUsagePlugin) HandleUsage(_ context.Context, record usage.Record) {
+	if p.targetProvider != "" && record.Provider != p.targetProvider {
+		return
+	}
+	select {
+	case p.records <- record:
+	default:
+	}
+}
+
+func (p *capturePluginExecutorUsagePlugin) waitRecord(t *testing.T) usage.Record {
+	t.Helper()
+	select {
+	case rec := <-p.records:
+		return rec
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for usage record")
+		return usage.Record{}
+	}
+}
+
+func (p *capturePluginExecutorUsagePlugin) assertNoRecord(t *testing.T) {
+	t.Helper()
+	select {
+	case rec := <-p.records:
+		t.Fatalf("expected no usage record for %q, got %+v", p.targetProvider, rec)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func registerUsagePluginForTest(t *testing.T, name string, plugin usage.Plugin) {
+	t.Helper()
+	usage.RegisterNamedPlugin(name, plugin)
+	t.Cleanup(func() {
+		usage.RegisterNamedPlugin(name, noopUsagePlugin{})
+	})
+}
+
+func TestHandlerPluginExecutorPublishesUsageNonStreamOpenAI(t *testing.T) {
+	targetPluginID := "custom-openai-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-nonstream-openai", plugin)
+
+	originalModel := "gpt-4o"
+
+	openAIResponseBody := []byte(`{"id":"chatcmpl-1","choices":[{"message":{"role":"assistant","content":"hello"}}],"usage":{"prompt_tokens":12,"completion_tokens":34,"total_tokens":46}}`)
+
+	mockHost := &mockPluginUsageHost{
+		execResp: coreexecutor.Response{
+			Payload: openAIResponseBody,
+		},
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	body, _, errMsg := handler.ExecuteWithAuthManager(context.Background(), "openai", originalModel, []byte(fmt.Sprintf(`{"model":%q}`, originalModel)), "")
+	if errMsg != nil {
+		t.Fatalf("ExecuteWithAuthManager() error = %+v", errMsg)
+	}
+	if len(body) == 0 {
+		t.Fatal("empty response body")
+	}
+
+	record := plugin.waitRecord(t)
+	if record.Provider != targetPluginID {
+		t.Errorf("record.Provider = %q, want %q", record.Provider, targetPluginID)
+	}
+	if record.Detail.InputTokens != 12 || record.Detail.OutputTokens != 34 || record.Detail.TotalTokens != 46 {
+		t.Errorf("record.Detail = %+v, want prompt=12 completion=34 total=46", record.Detail)
+	}
+}
+
+func TestHandlerPluginExecutorPublishesUsageStreamOpenAI(t *testing.T) {
+	targetPluginID := "custom-stream-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-stream-openai", plugin)
+
+	originalModel := "gpt-4o"
+
+	chunks := make(chan coreexecutor.StreamChunk, 3)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n")}
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: {\"choices\":[],\"usage\":{\"prompt_tokens\":15,\"completion_tokens\":25,\"total_tokens\":40}}\n\n")}
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: [DONE]\n\n")}
+	close(chunks)
+
+	mockHost := &mockPluginUsageHost{
+		streamResult: &coreexecutor.StreamResult{Chunks: chunks},
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", originalModel, []byte(fmt.Sprintf(`{"model":%q,"stream":true}`, originalModel)), "")
+	for range dataChan {
+	}
+	for err := range errChan {
+		if err != nil {
+			t.Fatalf("stream error = %+v", err)
+		}
+	}
+
+	record := plugin.waitRecord(t)
+	if record.Provider != targetPluginID {
+		t.Errorf("record.Provider = %q, want %q", record.Provider, targetPluginID)
+	}
+	if record.Detail.InputTokens != 15 || record.Detail.OutputTokens != 25 || record.Detail.TotalTokens != 40 {
+		t.Errorf("record.Detail = %+v, want prompt=15 completion=25 total=40", record.Detail)
+	}
+}
+
+func TestHandlerPluginExecutorPublishesUsageStreamCodex(t *testing.T) {
+	targetPluginID := "custom-codex-stream-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-stream-codex", plugin)
+
+	originalModel := "codex-5.2"
+
+	chunks := make(chan coreexecutor.StreamChunk, 2)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":18,\"output_tokens\":22,\"total_tokens\":40}}}\n\n")}
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: [DONE]\n\n")}
+	close(chunks)
+
+	mockHost := &mockPluginUsageHost{
+		streamResult: &coreexecutor.StreamResult{Chunks: chunks},
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai-response", originalModel, []byte(fmt.Sprintf(`{"model":%q,"stream":true}`, originalModel)), "")
+	for range dataChan {
+	}
+	for err := range errChan {
+		if err != nil {
+			t.Fatalf("stream error = %+v", err)
+		}
+	}
+
+	record := plugin.waitRecord(t)
+	if record.Provider != targetPluginID {
+		t.Errorf("record.Provider = %q, want %q", record.Provider, targetPluginID)
+	}
+	if record.Detail.InputTokens != 18 || record.Detail.OutputTokens != 22 || record.Detail.TotalTokens != 40 {
+		t.Errorf("record.Detail = %+v, want input=18 output=22 total=40", record.Detail)
+	}
+}
+
+func TestHandlerPluginExecutorPublishesUsageNonStreamClaude(t *testing.T) {
+	targetPluginID := "custom-claude-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-nonstream-claude", plugin)
+
+	originalModel := "claude-3-5-sonnet"
+
+	claudeResponseBody := []byte(`{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"hello"}],"usage":{"input_tokens":50,"output_tokens":30,"output_tokens_details":{"thinking_tokens":10}}}`)
+
+	mockHost := &mockPluginUsageHost{
+		execResp: coreexecutor.Response{
+			Payload: claudeResponseBody,
+		},
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	body, _, errMsg := handler.ExecuteWithAuthManager(context.Background(), "claude", originalModel, []byte(fmt.Sprintf(`{"model":%q,"messages":[{"role":"user","content":"hi"}]}`, originalModel)), "")
+	if errMsg != nil {
+		t.Fatalf("ExecuteWithAuthManager() error = %+v", errMsg)
+	}
+	if len(body) == 0 {
+		t.Fatal("empty response body")
+	}
+
+	record := plugin.waitRecord(t)
+	if record.Provider != targetPluginID {
+		t.Errorf("record.Provider = %q, want %q", record.Provider, targetPluginID)
+	}
+	if record.Detail.InputTokens != 50 || record.Detail.OutputTokens != 30 || record.Detail.ReasoningTokens != 10 || record.Detail.TotalTokens != 80 {
+		t.Errorf("record.Detail = %+v, want input=50 output=30 reasoning=10 total=80", record.Detail)
+	}
+}
+
+func TestHandlerPluginExecutorPublishesUsageStreamClaude(t *testing.T) {
+	targetPluginID := "custom-claude-stream-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-stream-claude", plugin)
+
+	originalModel := "claude-3-5-sonnet"
+
+	// Claude streams split usage between message_start (input, cache) and message_delta (output, thinking)
+	chunks := make(chan coreexecutor.StreamChunk, 4)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"usage\":{\"input_tokens\":100,\"cache_read_input_tokens\":50,\"cache_creation_input_tokens\":20,\"output_tokens\":1}}}\n\n")}
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\n")}
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("event: message_delta\ndata: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":25,\"output_tokens_details\":{\"thinking_tokens\":5}}}\n\n")}
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")}
+	close(chunks)
+
+	mockHost := &mockPluginUsageHost{
+		streamResult: &coreexecutor.StreamResult{Chunks: chunks},
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "claude", originalModel, []byte(fmt.Sprintf(`{"model":%q,"stream":true}`, originalModel)), "")
+	for range dataChan {
+	}
+	for err := range errChan {
+		if err != nil {
+			t.Fatalf("stream error = %+v", err)
+		}
+	}
+
+	record := plugin.waitRecord(t)
+	if record.Provider != targetPluginID {
+		t.Errorf("record.Provider = %q, want %q", record.Provider, targetPluginID)
+	}
+	if record.Detail.InputTokens != 100 || record.Detail.CacheReadTokens != 50 || record.Detail.CacheCreationTokens != 20 || record.Detail.OutputTokens != 25 || record.Detail.ReasoningTokens != 5 || record.Detail.TotalTokens != 195 {
+		t.Errorf("record.Detail = %+v, want input=100 cache_read=50 cache_creation=20 output=25 reasoning=5 total=195", record.Detail)
+	}
+	tb := record.Detail.TokenBreakdown
+	if !tb.Valid() || tb.TotalTokens != 195 || tb.Input.TotalTokens != 170 || tb.Input.UncachedTokens != 100 || tb.Input.CacheReadTokens != 50 || tb.Input.CacheWriteTokens != 20 || tb.Output.TotalTokens != 25 || tb.Output.NonReasoningTokens != 20 || tb.Output.ReasoningTokens != 5 {
+		t.Errorf("record.Detail.TokenBreakdown = %+v, want valid independent breakdown with total=195 input=170 output=25", tb)
+	}
+}
+
+func TestHandlerPluginExecutorPublishesUsageGemini(t *testing.T) {
+	targetPluginID := "custom-gemini-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-gemini", plugin)
+
+	originalModel := "gemini-2.5-flash"
+
+	geminiResponseBody := []byte(`{"candidates":[{"content":{"parts":[{"text":"hello"}]}}],"usageMetadata":{"promptTokenCount":40,"candidatesTokenCount":60,"totalTokenCount":100}}`)
+
+	mockHost := &mockPluginUsageHost{
+		execResp: coreexecutor.Response{
+			Payload: geminiResponseBody,
+		},
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	body, _, errMsg := handler.ExecuteWithAuthManager(context.Background(), "gemini", originalModel, []byte(fmt.Sprintf(`{"contents":[{"parts":[{"text":"hi"}]}]}`)), "")
+	if errMsg != nil {
+		t.Fatalf("ExecuteWithAuthManager() error = %+v", errMsg)
+	}
+	if len(body) == 0 {
+		t.Fatal("empty response body")
+	}
+
+	record := plugin.waitRecord(t)
+	if record.Provider != targetPluginID {
+		t.Errorf("record.Provider = %q, want %q", record.Provider, targetPluginID)
+	}
+	if record.Detail.InputTokens != 40 || record.Detail.OutputTokens != 60 || record.Detail.TotalTokens != 100 {
+		t.Errorf("record.Detail = %+v, want prompt=40 candidates=60 total=100", record.Detail)
+	}
+}
+
+func TestHandlerPluginExecutorPublishesUsageStreamInteractions(t *testing.T) {
+	targetPluginID := "custom-interactions-stream-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-stream-interactions", plugin)
+
+	originalModel := "gemini-2.5-flash"
+
+	chunks := make(chan coreexecutor.StreamChunk, 2)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: {\"event_type\":\"finish\",\"metadata\":{\"total_usage\":{\"total_input_tokens\":30,\"total_output_tokens\":70,\"total_tokens\":100}}}\n\n")}
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: [DONE]\n\n")}
+	close(chunks)
+
+	mockHost := &mockPluginUsageHost{
+		streamResult: &coreexecutor.StreamResult{Chunks: chunks},
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "interactions", originalModel, []byte(fmt.Sprintf(`{"model":%q,"stream":true}`, originalModel)), "")
+	for range dataChan {
+	}
+	for err := range errChan {
+		if err != nil {
+			t.Fatalf("stream error = %+v", err)
+		}
+	}
+
+	record := plugin.waitRecord(t)
+	if record.Provider != targetPluginID {
+		t.Errorf("record.Provider = %q, want %q", record.Provider, targetPluginID)
+	}
+	if record.Detail.InputTokens != 30 || record.Detail.OutputTokens != 70 || record.Detail.TotalTokens != 100 {
+		t.Errorf("record.Detail = %+v, want input=30 output=70 total=100", record.Detail)
+	}
+}
+
+func TestHandlerPluginExecutorPublishesUsageStreamAntigravity(t *testing.T) {
+	targetPluginID := "custom-antigravity-stream-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-stream-antigravity", plugin)
+
+	originalModel := "claude-3-5-sonnet"
+
+	chunks := make(chan coreexecutor.StreamChunk, 2)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: {\"response\":{\"usageMetadata\":{\"promptTokenCount\":33,\"candidatesTokenCount\":67,\"totalTokenCount\":100}}}\n\n")}
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: [DONE]\n\n")}
+	close(chunks)
+
+	mockHost := &mockPluginUsageHost{
+		streamResult: &coreexecutor.StreamResult{Chunks: chunks},
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "antigravity", originalModel, []byte(fmt.Sprintf(`{"model":%q,"stream":true}`, originalModel)), "")
+	for range dataChan {
+	}
+	for err := range errChan {
+		if err != nil {
+			t.Fatalf("stream error = %+v", err)
+		}
+	}
+
+	record := plugin.waitRecord(t)
+	if record.Provider != targetPluginID {
+		t.Errorf("record.Provider = %q, want %q", record.Provider, targetPluginID)
+	}
+	if record.Detail.InputTokens != 33 || record.Detail.OutputTokens != 67 || record.Detail.TotalTokens != 100 {
+		t.Errorf("record.Detail = %+v, want prompt=33 candidates=67 total=100", record.Detail)
+	}
+}
+
+func TestHandlerPluginExecutorPublishesFailure(t *testing.T) {
+	targetPluginID := "failing-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-failure", plugin)
+
+	originalModel := "gpt-4o"
+
+	mockHost := &mockPluginUsageHost{
+		execErr: errors.New("upstream plugin failure"),
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	_, _, errMsg := handler.ExecuteWithAuthManager(context.Background(), "openai", originalModel, []byte(fmt.Sprintf(`{"model":%q}`, originalModel)), "")
+	if errMsg == nil {
+		t.Fatal("expected ExecuteWithAuthManager() to fail")
+	}
+
+	record := plugin.waitRecord(t)
+	if record.Provider != targetPluginID {
+		t.Errorf("record.Provider = %q, want %q", record.Provider, targetPluginID)
+	}
+	if !record.Failed {
+		t.Error("record.Failed = false, want true")
+	}
+	if record.Fail.Body != "upstream plugin failure" {
+		t.Errorf("record.Fail.Body = %q, want %q", record.Fail.Body, "upstream plugin failure")
+	}
+}
+
+func TestHandlerPluginExecutorPublishesStreamFailure(t *testing.T) {
+	targetPluginID := "failing-stream-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-stream-failure", plugin)
+
+	originalModel := "gpt-4o"
+
+	chunks := make(chan coreexecutor.StreamChunk, 2)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n")}
+	chunks <- coreexecutor.StreamChunk{Err: errors.New("upstream stream broke")}
+	close(chunks)
+
+	mockHost := &mockPluginUsageHost{
+		streamResult: &coreexecutor.StreamResult{Chunks: chunks},
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", originalModel, []byte(fmt.Sprintf(`{"model":%q,"stream":true}`, originalModel)), "")
+	for range dataChan {
+	}
+	seenErr := false
+	for err := range errChan {
+		if err != nil {
+			seenErr = true
+		}
+	}
+	if !seenErr {
+		t.Fatal("expected stream error")
+	}
+
+	record := plugin.waitRecord(t)
+	if record.Provider != targetPluginID {
+		t.Errorf("record.Provider = %q, want %q", record.Provider, targetPluginID)
+	}
+	if !record.Failed {
+		t.Error("record.Failed = false, want true")
+	}
+}
+
+func TestHandlerPluginExecutorPublishesStreamCancellation(t *testing.T) {
+	targetPluginID := "canceling-stream-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-stream-cancel", plugin)
+
+	originalModel := "gpt-4o"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	chunks := make(chan coreexecutor.StreamChunk, 5)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n")}
+
+	mockHost := &mockPluginUsageHost{
+		streamResult: &coreexecutor.StreamResult{Chunks: chunks},
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	dataChan, _, _ := handler.ExecuteStreamWithAuthManager(ctx, "openai", originalModel, []byte(fmt.Sprintf(`{"model":%q,"stream":true}`, originalModel)), "")
+	// Receive first chunk then cancel context
+	<-dataChan
+	cancel()
+	close(chunks)
+
+	record := plugin.waitRecord(t)
+	if record.Provider != targetPluginID {
+		t.Errorf("record.Provider = %q, want %q", record.Provider, targetPluginID)
+	}
+	if !record.Failed {
+		t.Error("record.Failed = false, want true for canceled stream")
+	}
+}
+
+func TestHandlerPluginExecutorSkipsUsageForNestedExecution(t *testing.T) {
+	targetPluginID := "nested-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-nested", plugin)
+
+	originalModel := "gpt-4o"
+
+	openAIResponseBody := []byte(`{"id":"chatcmpl-1","choices":[{"message":{"role":"assistant","content":"hello"}}],"usage":{"prompt_tokens":12,"completion_tokens":34,"total_tokens":46}}`)
+
+	mockHost := &mockPluginUsageHost{
+		execResp: coreexecutor.Response{
+			Payload: openAIResponseBody,
+		},
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	// ExecuteModel triggers execution with InternalSource = true (host.model.execute callback)
+	resp, errMsg := handler.ExecuteModel(context.Background(), ModelExecutionRequest{
+		EntryProtocol: "openai",
+		ExitProtocol:  "openai",
+		Model:         originalModel,
+		Body:          []byte(fmt.Sprintf(`{"model":%q}`, originalModel)),
+	})
+	if errMsg != nil {
+		t.Fatalf("ExecuteModel() error = %+v", errMsg)
+	}
+	if len(resp.Body) == 0 {
+		t.Fatal("empty response body")
+	}
+
+	plugin.assertNoRecord(t)
+}
+
+func TestHandlerPluginExecutorSkipsOuterUsageWhenPluginCallsHostModelExecute(t *testing.T) {
+	targetPluginID := "agent-wrapper-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-nested-callback", plugin)
+
+	outerModel := "agent-wrapper-model"
+	innerModel := "inner-model"
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	innerExecutor := &modelExecutionCaptureExecutor{
+		provider: "openai",
+		execute: func(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
+			return coreexecutor.Response{
+				Payload: []byte(`{"id":"chatcmpl-inner","choices":[{"message":{"role":"assistant","content":"inner"}}],"usage":{"prompt_tokens":5,"completion_tokens":5,"total_tokens":10}}`),
+			}, nil
+		},
+	}
+	manager.RegisterExecutor(innerExecutor)
+	auth := &coreauth.Auth{
+		ID:       "auth-" + innerModel,
+		Provider: innerExecutor.Identifier(),
+		Status:   coreauth.StatusActive,
+	}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("manager.Register(): %v", errRegister)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: innerModel}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+
+	mockHost := &mockPluginUsageHost{}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		if req.RequestedModel == outerModel {
+			return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+		}
+		return pluginapi.ModelRouteResponse{}, false
+	}
+	// When the plugin executor executes, it simulates calling back into the host via ExecuteModel
+	mockHost.execFunc = func(ctx context.Context, pluginID string, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
+		// Plugin calls back into host.model.execute using the provided ctx
+		innerResp, errInner := handler.ExecuteModel(ctx, ModelExecutionRequest{
+			EntryProtocol: "openai",
+			ExitProtocol:  "openai",
+			Model:         innerModel,
+			Body:          []byte(fmt.Sprintf(`{"model":%q}`, innerModel)),
+		})
+		if errInner != nil {
+			return coreexecutor.Response{}, errInner.Error
+		}
+		// Return response payload back to outer caller
+		return coreexecutor.Response{Payload: innerResp.Body}, nil
+	}
+
+	handler.SetModelRouterHost(mockHost)
+
+	body, _, errMsg := handler.ExecuteWithAuthManager(context.Background(), "openai", outerModel, []byte(fmt.Sprintf(`{"model":%q}`, outerModel)), "")
+	if errMsg != nil {
+		t.Fatalf("ExecuteWithAuthManager() error = %+v", errMsg)
+	}
+	if len(body) == 0 {
+		t.Fatal("empty response body")
+	}
+
+	// Since inner ExecuteModel was executed, the outer plugin executor must NOT publish a duplicate record for targetPluginID
+	plugin.assertNoRecord(t)
+}
+
+func TestHandlerPluginExecutorSkipsOuterFailureWhenPluginCallsHostModelExecute(t *testing.T) {
+	targetPluginID := "agent-wrapper-plugin-failure"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-nested-callback-failure", plugin)
+
+	outerModel := "agent-wrapper-model-fail"
+	innerModel := "inner-model-fail"
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	innerExecutor := &modelExecutionCaptureExecutor{
+		provider: "openai",
+		execute: func(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
+			return coreexecutor.Response{}, errors.New("inner failure")
+		},
+	}
+	manager.RegisterExecutor(innerExecutor)
+	auth := &coreauth.Auth{
+		ID:       "auth-" + innerModel,
+		Provider: innerExecutor.Identifier(),
+		Status:   coreauth.StatusActive,
+	}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("manager.Register(): %v", errRegister)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: innerModel}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+
+	mockHost := &mockPluginUsageHost{}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		if req.RequestedModel == outerModel {
+			return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+		}
+		return pluginapi.ModelRouteResponse{}, false
+	}
+	mockHost.execFunc = func(ctx context.Context, pluginID string, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
+		_, errInner := handler.ExecuteModel(ctx, ModelExecutionRequest{
+			EntryProtocol: "openai",
+			ExitProtocol:  "openai",
+			Model:         innerModel,
+			Body:          []byte(fmt.Sprintf(`{"model":%q}`, innerModel)),
+		})
+		if errInner != nil {
+			return coreexecutor.Response{}, errInner.Error
+		}
+		return coreexecutor.Response{Payload: []byte("ok")}, nil
+	}
+
+	handler.SetModelRouterHost(mockHost)
+
+	_, _, errMsg := handler.ExecuteWithAuthManager(context.Background(), "openai", outerModel, []byte(fmt.Sprintf(`{"model":%q}`, outerModel)), "")
+	if errMsg == nil {
+		t.Fatal("expected failure")
+	}
+
+	// Since inner ExecuteModel was executed, the outer plugin executor must NOT publish a duplicate failure record
+	plugin.assertNoRecord(t)
+}
+
+type mockPluginUsageHost struct {
+	handlerDirectExecutorRouteHost
+	execResp     coreexecutor.Response
+	execErr      error
+	execFunc     func(context.Context, string, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error)
+	streamResult *coreexecutor.StreamResult
+}
+
+func (h *mockPluginUsageHost) ExecutePluginExecutor(ctx context.Context, pluginID string, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
+	h.lastPluginID = pluginID
+	h.lastRequest = req
+	h.lastOptions = opts
+	if h.execFunc != nil {
+		return h.execFunc(ctx, pluginID, req, opts)
+	}
+	if h.execErr != nil {
+		return coreexecutor.Response{}, h.execErr
+	}
+	return h.execResp, nil
+}
+
+func (h *mockPluginUsageHost) ExecutePluginExecutorStream(ctx context.Context, pluginID string, req coreexecutor.Request, opts coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	h.lastPluginID = pluginID
+	h.lastRequest = req
+	h.lastOptions = opts
+	return h.streamResult, nil
+}

--- a/sdk/api/handlers/handlers_plugin_executor_usage_test.go
+++ b/sdk/api/handlers/handlers_plugin_executor_usage_test.go
@@ -1,0 +1,718 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+type noopUsagePlugin struct{}
+
+func (noopUsagePlugin) HandleUsage(context.Context, usage.Record) {}
+
+type capturePluginExecutorUsagePlugin struct {
+	targetProvider string
+	records        chan usage.Record
+}
+
+func newCapturePluginExecutorUsagePlugin(targetProvider string) *capturePluginExecutorUsagePlugin {
+	return &capturePluginExecutorUsagePlugin{
+		targetProvider: targetProvider,
+		records:        make(chan usage.Record, 50),
+	}
+}
+
+func (p *capturePluginExecutorUsagePlugin) HandleUsage(_ context.Context, record usage.Record) {
+	if p.targetProvider != "" && record.Provider != p.targetProvider {
+		return
+	}
+	select {
+	case p.records <- record:
+	default:
+	}
+}
+
+func (p *capturePluginExecutorUsagePlugin) waitRecord(t *testing.T) usage.Record {
+	t.Helper()
+	select {
+	case rec := <-p.records:
+		return rec
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for usage record")
+		return usage.Record{}
+	}
+}
+
+func (p *capturePluginExecutorUsagePlugin) assertNoRecord(t *testing.T) {
+	t.Helper()
+	select {
+	case rec := <-p.records:
+		t.Fatalf("expected no usage record for %q, got %+v", p.targetProvider, rec)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func registerUsagePluginForTest(t *testing.T, name string, plugin usage.Plugin) {
+	t.Helper()
+	usage.RegisterNamedPlugin(name, plugin)
+	t.Cleanup(func() {
+		usage.RegisterNamedPlugin(name, noopUsagePlugin{})
+	})
+}
+
+func TestHandlerPluginExecutorPublishesUsageNonStreamOpenAI(t *testing.T) {
+	targetPluginID := "custom-openai-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-nonstream-openai", plugin)
+
+	originalModel := "gpt-4o"
+
+	openAIResponseBody := []byte(`{"id":"chatcmpl-1","choices":[{"message":{"role":"assistant","content":"hello"}}],"usage":{"prompt_tokens":12,"completion_tokens":34,"total_tokens":46}}`)
+
+	mockHost := &mockPluginUsageHost{
+		execResp: coreexecutor.Response{
+			Payload: openAIResponseBody,
+		},
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	body, _, errMsg := handler.ExecuteWithAuthManager(context.Background(), "openai", originalModel, []byte(fmt.Sprintf(`{"model":%q}`, originalModel)), "")
+	if errMsg != nil {
+		t.Fatalf("ExecuteWithAuthManager() error = %+v", errMsg)
+	}
+	if len(body) == 0 {
+		t.Fatal("empty response body")
+	}
+
+	record := plugin.waitRecord(t)
+	if record.Provider != targetPluginID {
+		t.Errorf("record.Provider = %q, want %q", record.Provider, targetPluginID)
+	}
+	if record.Detail.InputTokens != 12 || record.Detail.OutputTokens != 34 || record.Detail.TotalTokens != 46 {
+		t.Errorf("record.Detail = %+v, want prompt=12 completion=34 total=46", record.Detail)
+	}
+}
+
+func TestHandlerPluginExecutorPublishesUsageStreamOpenAI(t *testing.T) {
+	targetPluginID := "custom-stream-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-stream-openai", plugin)
+
+	originalModel := "gpt-4o"
+
+	chunks := make(chan coreexecutor.StreamChunk, 3)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n")}
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: {\"choices\":[],\"usage\":{\"prompt_tokens\":15,\"completion_tokens\":25,\"total_tokens\":40}}\n\n")}
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: [DONE]\n\n")}
+	close(chunks)
+
+	mockHost := &mockPluginUsageHost{
+		streamResult: &coreexecutor.StreamResult{Chunks: chunks},
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", originalModel, []byte(fmt.Sprintf(`{"model":%q,"stream":true}`, originalModel)), "")
+	for range dataChan {
+	}
+	for err := range errChan {
+		if err != nil {
+			t.Fatalf("stream error = %+v", err)
+		}
+	}
+
+	record := plugin.waitRecord(t)
+	if record.Provider != targetPluginID {
+		t.Errorf("record.Provider = %q, want %q", record.Provider, targetPluginID)
+	}
+	if record.Detail.InputTokens != 15 || record.Detail.OutputTokens != 25 || record.Detail.TotalTokens != 40 {
+		t.Errorf("record.Detail = %+v, want prompt=15 completion=25 total=40", record.Detail)
+	}
+}
+
+func TestHandlerPluginExecutorPublishesUsageStreamCodex(t *testing.T) {
+	targetPluginID := "custom-codex-stream-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-stream-codex", plugin)
+
+	originalModel := "codex-5.2"
+
+	chunks := make(chan coreexecutor.StreamChunk, 2)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":18,\"output_tokens\":22,\"total_tokens\":40}}}\n\n")}
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: [DONE]\n\n")}
+	close(chunks)
+
+	mockHost := &mockPluginUsageHost{
+		streamResult: &coreexecutor.StreamResult{Chunks: chunks},
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai-response", originalModel, []byte(fmt.Sprintf(`{"model":%q,"stream":true}`, originalModel)), "")
+	for range dataChan {
+	}
+	for err := range errChan {
+		if err != nil {
+			t.Fatalf("stream error = %+v", err)
+		}
+	}
+
+	record := plugin.waitRecord(t)
+	if record.Provider != targetPluginID {
+		t.Errorf("record.Provider = %q, want %q", record.Provider, targetPluginID)
+	}
+	if record.Detail.InputTokens != 18 || record.Detail.OutputTokens != 22 || record.Detail.TotalTokens != 40 {
+		t.Errorf("record.Detail = %+v, want input=18 output=22 total=40", record.Detail)
+	}
+}
+
+func TestHandlerPluginExecutorPublishesUsageNonStreamClaude(t *testing.T) {
+	targetPluginID := "custom-claude-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-nonstream-claude", plugin)
+
+	originalModel := "claude-3-5-sonnet"
+
+	claudeResponseBody := []byte(`{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"hello"}],"usage":{"input_tokens":50,"output_tokens":30,"output_tokens_details":{"thinking_tokens":10}}}`)
+
+	mockHost := &mockPluginUsageHost{
+		execResp: coreexecutor.Response{
+			Payload: claudeResponseBody,
+		},
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	body, _, errMsg := handler.ExecuteWithAuthManager(context.Background(), "claude", originalModel, []byte(fmt.Sprintf(`{"model":%q,"messages":[{"role":"user","content":"hi"}]}`, originalModel)), "")
+	if errMsg != nil {
+		t.Fatalf("ExecuteWithAuthManager() error = %+v", errMsg)
+	}
+	if len(body) == 0 {
+		t.Fatal("empty response body")
+	}
+
+	record := plugin.waitRecord(t)
+	if record.Provider != targetPluginID {
+		t.Errorf("record.Provider = %q, want %q", record.Provider, targetPluginID)
+	}
+	if record.Detail.InputTokens != 50 || record.Detail.OutputTokens != 30 || record.Detail.ReasoningTokens != 10 || record.Detail.TotalTokens != 80 {
+		t.Errorf("record.Detail = %+v, want input=50 output=30 reasoning=10 total=80", record.Detail)
+	}
+}
+
+func TestHandlerPluginExecutorPublishesUsageStreamClaude(t *testing.T) {
+	targetPluginID := "custom-claude-stream-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-stream-claude", plugin)
+
+	originalModel := "claude-3-5-sonnet"
+
+	// Claude streams split usage between message_start (input, cache) and message_delta (output, thinking)
+	chunks := make(chan coreexecutor.StreamChunk, 4)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"usage\":{\"input_tokens\":100,\"cache_read_input_tokens\":50,\"cache_creation_input_tokens\":20,\"output_tokens\":1}}}\n\n")}
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\n")}
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("event: message_delta\ndata: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":25,\"output_tokens_details\":{\"thinking_tokens\":5}}}\n\n")}
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n")}
+	close(chunks)
+
+	mockHost := &mockPluginUsageHost{
+		streamResult: &coreexecutor.StreamResult{Chunks: chunks},
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "claude", originalModel, []byte(fmt.Sprintf(`{"model":%q,"stream":true}`, originalModel)), "")
+	for range dataChan {
+	}
+	for err := range errChan {
+		if err != nil {
+			t.Fatalf("stream error = %+v", err)
+		}
+	}
+
+	record := plugin.waitRecord(t)
+	if record.Provider != targetPluginID {
+		t.Errorf("record.Provider = %q, want %q", record.Provider, targetPluginID)
+	}
+	if record.Detail.InputTokens != 170 || record.Detail.CacheReadTokens != 50 || record.Detail.CacheCreationTokens != 20 || record.Detail.OutputTokens != 25 || record.Detail.ReasoningTokens != 5 || record.Detail.TotalTokens != 195 {
+		t.Errorf("record.Detail = %+v, want canonical input=170 cache_read=50 cache_creation=20 output=25 reasoning=5 total=195", record.Detail)
+	}
+	tb := record.Detail.TokenBreakdown
+	if !tb.Valid() || tb.TotalTokens != 195 || tb.Input.TotalTokens != 170 || tb.Input.UncachedTokens != 100 || tb.Input.CacheReadTokens != 50 || tb.Input.CacheWriteTokens != 20 || tb.Output.TotalTokens != 25 || tb.Output.NonReasoningTokens != 20 || tb.Output.ReasoningTokens != 5 {
+		t.Errorf("record.Detail.TokenBreakdown = %+v, want valid independent breakdown with total=195 input=170 output=25", tb)
+	}
+}
+
+func TestHandlerPluginExecutorPublishesUsageGemini(t *testing.T) {
+	targetPluginID := "custom-gemini-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-gemini", plugin)
+
+	originalModel := "gemini-2.5-flash"
+
+	geminiResponseBody := []byte(`{"candidates":[{"content":{"parts":[{"text":"hello"}]}}],"usageMetadata":{"promptTokenCount":40,"candidatesTokenCount":60,"totalTokenCount":100}}`)
+
+	mockHost := &mockPluginUsageHost{
+		execResp: coreexecutor.Response{
+			Payload: geminiResponseBody,
+		},
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	body, _, errMsg := handler.ExecuteWithAuthManager(context.Background(), "gemini", originalModel, []byte(fmt.Sprintf(`{"contents":[{"parts":[{"text":"hi"}]}]}`)), "")
+	if errMsg != nil {
+		t.Fatalf("ExecuteWithAuthManager() error = %+v", errMsg)
+	}
+	if len(body) == 0 {
+		t.Fatal("empty response body")
+	}
+
+	record := plugin.waitRecord(t)
+	if record.Provider != targetPluginID {
+		t.Errorf("record.Provider = %q, want %q", record.Provider, targetPluginID)
+	}
+	if record.Detail.InputTokens != 40 || record.Detail.OutputTokens != 60 || record.Detail.TotalTokens != 100 {
+		t.Errorf("record.Detail = %+v, want prompt=40 candidates=60 total=100", record.Detail)
+	}
+}
+
+func TestHandlerPluginExecutorPublishesUsageStreamInteractions(t *testing.T) {
+	targetPluginID := "custom-interactions-stream-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-stream-interactions", plugin)
+
+	originalModel := "gemini-2.5-flash"
+
+	chunks := make(chan coreexecutor.StreamChunk, 2)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: {\"event_type\":\"finish\",\"metadata\":{\"total_usage\":{\"total_input_tokens\":30,\"total_output_tokens\":70,\"total_tokens\":100}}}\n\n")}
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: [DONE]\n\n")}
+	close(chunks)
+
+	mockHost := &mockPluginUsageHost{
+		streamResult: &coreexecutor.StreamResult{Chunks: chunks},
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "interactions", originalModel, []byte(fmt.Sprintf(`{"model":%q,"stream":true}`, originalModel)), "")
+	for range dataChan {
+	}
+	for err := range errChan {
+		if err != nil {
+			t.Fatalf("stream error = %+v", err)
+		}
+	}
+
+	record := plugin.waitRecord(t)
+	if record.Provider != targetPluginID {
+		t.Errorf("record.Provider = %q, want %q", record.Provider, targetPluginID)
+	}
+	if record.Detail.InputTokens != 30 || record.Detail.OutputTokens != 70 || record.Detail.TotalTokens != 100 {
+		t.Errorf("record.Detail = %+v, want input=30 output=70 total=100", record.Detail)
+	}
+}
+
+func TestHandlerPluginExecutorPublishesUsageStreamAntigravity(t *testing.T) {
+	targetPluginID := "custom-antigravity-stream-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-stream-antigravity", plugin)
+
+	originalModel := "claude-3-5-sonnet"
+
+	chunks := make(chan coreexecutor.StreamChunk, 2)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: {\"response\":{\"usageMetadata\":{\"promptTokenCount\":33,\"candidatesTokenCount\":67,\"totalTokenCount\":100}}}\n\n")}
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: [DONE]\n\n")}
+	close(chunks)
+
+	mockHost := &mockPluginUsageHost{
+		streamResult: &coreexecutor.StreamResult{Chunks: chunks},
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "antigravity", originalModel, []byte(fmt.Sprintf(`{"model":%q,"stream":true}`, originalModel)), "")
+	for range dataChan {
+	}
+	for err := range errChan {
+		if err != nil {
+			t.Fatalf("stream error = %+v", err)
+		}
+	}
+
+	record := plugin.waitRecord(t)
+	if record.Provider != targetPluginID {
+		t.Errorf("record.Provider = %q, want %q", record.Provider, targetPluginID)
+	}
+	if record.Detail.InputTokens != 33 || record.Detail.OutputTokens != 67 || record.Detail.TotalTokens != 100 {
+		t.Errorf("record.Detail = %+v, want prompt=33 candidates=67 total=100", record.Detail)
+	}
+}
+
+func TestHandlerPluginExecutorPublishesFailure(t *testing.T) {
+	targetPluginID := "failing-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-failure", plugin)
+
+	originalModel := "gpt-4o"
+
+	mockHost := &mockPluginUsageHost{
+		execErr: errors.New("upstream plugin failure"),
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	_, _, errMsg := handler.ExecuteWithAuthManager(context.Background(), "openai", originalModel, []byte(fmt.Sprintf(`{"model":%q}`, originalModel)), "")
+	if errMsg == nil {
+		t.Fatal("expected ExecuteWithAuthManager() to fail")
+	}
+
+	record := plugin.waitRecord(t)
+	if record.Provider != targetPluginID {
+		t.Errorf("record.Provider = %q, want %q", record.Provider, targetPluginID)
+	}
+	if !record.Failed {
+		t.Error("record.Failed = false, want true")
+	}
+	if record.Fail.Body != "upstream plugin failure" {
+		t.Errorf("record.Fail.Body = %q, want %q", record.Fail.Body, "upstream plugin failure")
+	}
+}
+
+func TestHandlerPluginExecutorPublishesStreamFailure(t *testing.T) {
+	targetPluginID := "failing-stream-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-stream-failure", plugin)
+
+	originalModel := "gpt-4o"
+
+	chunks := make(chan coreexecutor.StreamChunk, 2)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n")}
+	chunks <- coreexecutor.StreamChunk{Err: errors.New("upstream stream broke")}
+	close(chunks)
+
+	mockHost := &mockPluginUsageHost{
+		streamResult: &coreexecutor.StreamResult{Chunks: chunks},
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	dataChan, _, errChan := handler.ExecuteStreamWithAuthManager(context.Background(), "openai", originalModel, []byte(fmt.Sprintf(`{"model":%q,"stream":true}`, originalModel)), "")
+	for range dataChan {
+	}
+	seenErr := false
+	for err := range errChan {
+		if err != nil {
+			seenErr = true
+		}
+	}
+	if !seenErr {
+		t.Fatal("expected stream error")
+	}
+
+	record := plugin.waitRecord(t)
+	if record.Provider != targetPluginID {
+		t.Errorf("record.Provider = %q, want %q", record.Provider, targetPluginID)
+	}
+	if !record.Failed {
+		t.Error("record.Failed = false, want true")
+	}
+}
+
+func TestHandlerPluginExecutorPublishesStreamCancellation(t *testing.T) {
+	targetPluginID := "canceling-stream-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-stream-cancel", plugin)
+
+	originalModel := "gpt-4o"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	chunks := make(chan coreexecutor.StreamChunk, 5)
+	chunks <- coreexecutor.StreamChunk{Payload: []byte("data: {\"choices\":[{\"delta\":{\"content\":\"Hi\"}}]}\n\n")}
+
+	mockHost := &mockPluginUsageHost{
+		streamResult: &coreexecutor.StreamResult{Chunks: chunks},
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	dataChan, _, _ := handler.ExecuteStreamWithAuthManager(ctx, "openai", originalModel, []byte(fmt.Sprintf(`{"model":%q,"stream":true}`, originalModel)), "")
+	// Receive first chunk then cancel context
+	<-dataChan
+	cancel()
+	close(chunks)
+
+	record := plugin.waitRecord(t)
+	if record.Provider != targetPluginID {
+		t.Errorf("record.Provider = %q, want %q", record.Provider, targetPluginID)
+	}
+	if !record.Failed {
+		t.Error("record.Failed = false, want true for canceled stream")
+	}
+}
+
+func TestHandlerPluginExecutorSkipsUsageForNestedExecution(t *testing.T) {
+	targetPluginID := "nested-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-usage-nested", plugin)
+
+	originalModel := "gpt-4o"
+
+	openAIResponseBody := []byte(`{"id":"chatcmpl-1","choices":[{"message":{"role":"assistant","content":"hello"}}],"usage":{"prompt_tokens":12,"completion_tokens":34,"total_tokens":46}}`)
+
+	mockHost := &mockPluginUsageHost{
+		execResp: coreexecutor.Response{
+			Payload: openAIResponseBody,
+		},
+	}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+	}
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil)
+	handler.SetModelRouterHost(mockHost)
+
+	// ExecuteModel triggers execution with InternalSource = true (host.model.execute callback)
+	resp, errMsg := handler.ExecuteModel(context.Background(), ModelExecutionRequest{
+		EntryProtocol: "openai",
+		ExitProtocol:  "openai",
+		Model:         originalModel,
+		Body:          []byte(fmt.Sprintf(`{"model":%q}`, originalModel)),
+	})
+	if errMsg != nil {
+		t.Fatalf("ExecuteModel() error = %+v", errMsg)
+	}
+	if len(resp.Body) == 0 {
+		t.Fatal("empty response body")
+	}
+
+	plugin.assertNoRecord(t)
+}
+
+func TestHandlerPluginExecutorSkipsOuterUsageWhenPluginCallsHostModelExecute(t *testing.T) {
+	targetPluginID := "agent-wrapper-plugin"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-nested-callback", plugin)
+
+	outerModel := "agent-wrapper-model"
+	innerModel := "inner-model"
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	innerExecutor := &modelExecutionCaptureExecutor{
+		provider: "openai",
+		execute: func(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
+			return coreexecutor.Response{
+				Payload: []byte(`{"id":"chatcmpl-inner","choices":[{"message":{"role":"assistant","content":"inner"}}],"usage":{"prompt_tokens":5,"completion_tokens":5,"total_tokens":10}}`),
+			}, nil
+		},
+	}
+	manager.RegisterExecutor(innerExecutor)
+	auth := &coreauth.Auth{
+		ID:       "auth-" + innerModel,
+		Provider: innerExecutor.Identifier(),
+		Status:   coreauth.StatusActive,
+	}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("manager.Register(): %v", errRegister)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: innerModel}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+
+	mockHost := &mockPluginUsageHost{}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		if req.RequestedModel == outerModel {
+			return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+		}
+		return pluginapi.ModelRouteResponse{}, false
+	}
+	// When the plugin executor executes, it simulates calling back into the host via ExecuteModel
+	mockHost.execFunc = func(ctx context.Context, pluginID string, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
+		// Plugin calls back into host.model.execute using the provided ctx
+		innerResp, errInner := handler.ExecuteModel(ctx, ModelExecutionRequest{
+			EntryProtocol: "openai",
+			ExitProtocol:  "openai",
+			Model:         innerModel,
+			Body:          []byte(fmt.Sprintf(`{"model":%q}`, innerModel)),
+		})
+		if errInner != nil {
+			return coreexecutor.Response{}, errInner.Error
+		}
+		// Return response payload back to outer caller
+		return coreexecutor.Response{Payload: innerResp.Body}, nil
+	}
+
+	handler.SetModelRouterHost(mockHost)
+
+	body, _, errMsg := handler.ExecuteWithAuthManager(context.Background(), "openai", outerModel, []byte(fmt.Sprintf(`{"model":%q}`, outerModel)), "")
+	if errMsg != nil {
+		t.Fatalf("ExecuteWithAuthManager() error = %+v", errMsg)
+	}
+	if len(body) == 0 {
+		t.Fatal("empty response body")
+	}
+
+	// Since inner ExecuteModel was executed, the outer plugin executor must NOT publish a duplicate record for targetPluginID
+	plugin.assertNoRecord(t)
+}
+
+func TestHandlerPluginExecutorSkipsOuterFailureWhenPluginCallsHostModelExecute(t *testing.T) {
+	targetPluginID := "agent-wrapper-plugin-failure"
+	plugin := newCapturePluginExecutorUsagePlugin(targetPluginID)
+	registerUsagePluginForTest(t, "test-plugin-executor-nested-callback-failure", plugin)
+
+	outerModel := "agent-wrapper-model-fail"
+	innerModel := "inner-model-fail"
+
+	manager := coreauth.NewManager(nil, nil, nil)
+	innerExecutor := &modelExecutionCaptureExecutor{
+		provider: "openai",
+		execute: func(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
+			return coreexecutor.Response{}, errors.New("inner failure")
+		},
+	}
+	manager.RegisterExecutor(innerExecutor)
+	auth := &coreauth.Auth{
+		ID:       "auth-" + innerModel,
+		Provider: innerExecutor.Identifier(),
+		Status:   coreauth.StatusActive,
+	}
+	if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("manager.Register(): %v", errRegister)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: innerModel}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+
+	mockHost := &mockPluginUsageHost{}
+	mockHost.hasRouters = true
+	mockHost.route = func(ctx context.Context, req pluginapi.ModelRouteRequest) (pluginapi.ModelRouteResponse, bool) {
+		if req.RequestedModel == outerModel {
+			return pluginapi.ModelRouteResponse{Handled: true, TargetKind: pluginapi.ModelRouteTargetExecutor, Target: targetPluginID}, true
+		}
+		return pluginapi.ModelRouteResponse{}, false
+	}
+	mockHost.execFunc = func(ctx context.Context, pluginID string, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
+		_, errInner := handler.ExecuteModel(ctx, ModelExecutionRequest{
+			EntryProtocol: "openai",
+			ExitProtocol:  "openai",
+			Model:         innerModel,
+			Body:          []byte(fmt.Sprintf(`{"model":%q}`, innerModel)),
+		})
+		if errInner != nil {
+			return coreexecutor.Response{}, errInner.Error
+		}
+		return coreexecutor.Response{Payload: []byte("ok")}, nil
+	}
+
+	handler.SetModelRouterHost(mockHost)
+
+	_, _, errMsg := handler.ExecuteWithAuthManager(context.Background(), "openai", outerModel, []byte(fmt.Sprintf(`{"model":%q}`, outerModel)), "")
+	if errMsg == nil {
+		t.Fatal("expected failure")
+	}
+
+	// Since inner ExecuteModel was executed, the outer plugin executor must NOT publish a duplicate failure record
+	plugin.assertNoRecord(t)
+}
+
+type mockPluginUsageHost struct {
+	handlerDirectExecutorRouteHost
+	execResp     coreexecutor.Response
+	execErr      error
+	execFunc     func(context.Context, string, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error)
+	streamResult *coreexecutor.StreamResult
+}
+
+func (h *mockPluginUsageHost) ExecutePluginExecutor(ctx context.Context, pluginID string, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
+	h.lastPluginID = pluginID
+	h.lastRequest = req
+	h.lastOptions = opts
+	if h.execFunc != nil {
+		return h.execFunc(ctx, pluginID, req, opts)
+	}
+	if h.execErr != nil {
+		return coreexecutor.Response{}, h.execErr
+	}
+	return h.execResp, nil
+}
+
+func (h *mockPluginUsageHost) ExecutePluginExecutorStream(ctx context.Context, pluginID string, req coreexecutor.Request, opts coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	h.lastPluginID = pluginID
+	h.lastRequest = req
+	h.lastOptions = opts
+	return h.streamResult, nil
+}

--- a/sdk/api/handlers/handlers_stream.go
+++ b/sdk/api/handlers/handlers_stream.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/interfaces"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/runtime/executor/helps"
 	coreexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
@@ -39,29 +40,38 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 		close(errChan)
 		return nil, nil, errChan
 	}
-	req, opts := h.pluginExecutorRequest(ctx, entryProtocol, responseProtocol, modelName, originalRequestedModel, rawJSON, alt, true, execOptions)
-	lifecycle := h.newRequestLifecycleTracker(ctx, entryProtocol, modelName, originalRequestedModel, true, opts.Metadata, execOptions.SkipInterceptorPluginID)
+	execCtx, nestedTracker := withNestedExecutionTracker(ctx)
+	req, opts := h.pluginExecutorRequest(execCtx, entryProtocol, responseProtocol, modelName, originalRequestedModel, rawJSON, alt, true, execOptions)
+	lifecycle := h.newRequestLifecycleTracker(execCtx, entryProtocol, modelName, originalRequestedModel, true, opts.Metadata, execOptions.SkipInterceptorPluginID)
 	var interceptErr *interfaces.ErrorMessage
-	req, opts, interceptErr = h.applyRequestInterceptorsBeforeAuth(ctx, entryProtocol, originalRequestedModel, lifecycle.requestID(), req, opts, execOptions.SkipInterceptorPluginID)
+	req, opts, interceptErr = h.applyRequestInterceptorsBeforeAuth(execCtx, entryProtocol, originalRequestedModel, lifecycle.requestID(), req, opts, execOptions.SkipInterceptorPluginID)
 	if interceptErr != nil {
-		lifecycle.completeError(ctx, interceptErr)
+		lifecycle.completeError(execCtx, interceptErr)
 		errChan := make(chan *interfaces.ErrorMessage, 1)
 		errChan <- interceptErr
 		close(errChan)
 		return nil, nil, errChan
 	}
-	req, opts, interceptErr = h.applyRequestInterceptorsAfterPluginExecutorRoute(ctx, host, executorPluginID, entryProtocol, originalRequestedModel, lifecycle.requestID(), req, opts, execOptions.SkipInterceptorPluginID)
+	req, opts, interceptErr = h.applyRequestInterceptorsAfterPluginExecutorRoute(execCtx, host, executorPluginID, entryProtocol, originalRequestedModel, lifecycle.requestID(), req, opts, execOptions.SkipInterceptorPluginID)
 	if interceptErr != nil {
-		lifecycle.completeError(ctx, interceptErr)
+		lifecycle.completeError(execCtx, interceptErr)
 		errChan := make(chan *interfaces.ErrorMessage, 1)
 		errChan <- interceptErr
 		close(errChan)
 		return nil, nil, errChan
 	}
-	streamResult, errStream := host.ExecutePluginExecutorStream(ctx, executorPluginID, req, opts)
+	var reporter *helps.UsageReporter
+	if !execOptions.InternalSource {
+		reporter = helps.NewUsageReporter(execCtx, executorPluginID, modelName, nil)
+		reporter.SetTranslatedReasoningEffort(req.Payload, entryProtocol)
+	}
+	streamResult, errStream := host.ExecutePluginExecutorStream(execCtx, executorPluginID, req, opts)
 	if errStream != nil {
+		if reporter != nil && !nestedTracker.hasNestedExecution() {
+			reporter.PublishFailure(execCtx, errStream)
+		}
 		errMsg := executionErrorMessage(errStream)
-		lifecycle.completeError(ctx, errMsg)
+		lifecycle.completeError(execCtx, errMsg)
 		errChan := make(chan *interfaces.ErrorMessage, 1)
 		errChan <- errMsg
 		close(errChan)
@@ -69,7 +79,10 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 	}
 	if streamResult == nil {
 		errMsg := &interfaces.ErrorMessage{StatusCode: http.StatusBadGateway, Error: fmt.Errorf("plugin executor returned nil stream")}
-		lifecycle.completeError(ctx, errMsg)
+		if reporter != nil && !nestedTracker.hasNestedExecution() {
+			reporter.PublishFailure(execCtx, errMsg.Error)
+		}
+		lifecycle.completeError(execCtx, errMsg)
 		errChan := make(chan *interfaces.ErrorMessage, 1)
 		errChan <- errMsg
 		close(errChan)
@@ -133,8 +146,19 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 		completionOutcome := pluginapi.RequestCompletionSucceeded
 		completionStatus := http.StatusOK
 		var completionErr error
+		var streamUsage helps.StreamUsageBuffer
 		defer func() {
 			lifecycle.complete(completionOutcome, completionStatus, completionErr)
+			if reporter != nil && !nestedTracker.hasNestedExecution() {
+				if completionOutcome != pluginapi.RequestCompletionSucceeded && completionErr != nil {
+					if !streamUsage.PublishFailure(execCtx, reporter, completionErr) {
+						reporter.PublishFailure(execCtx, completionErr)
+					}
+				} else {
+					streamUsage.Publish(execCtx, reporter)
+					reporter.EnsurePublished(execCtx)
+				}
+			}
 		}()
 		defer close(dataChan)
 		defer close(errChan)
@@ -188,6 +212,7 @@ func (h *BaseAPIHandler) streamWithPluginExecutor(ctx context.Context, entryProt
 			if len(chunk.Payload) == 0 {
 				continue
 			}
+			observePluginExecutorStreamUsage(responseProtocol, chunk.Payload, &streamUsage)
 			payload := cloneBytes(chunk.Payload)
 			if streamInterceptorsActive {
 				chunkReq := pluginapi.StreamChunkInterceptRequest{

--- a/sdk/api/handlers/model_execution.go
+++ b/sdk/api/handlers/model_execution.go
@@ -95,6 +95,7 @@ func (e *ModelExecutionStreamError) Error() string {
 // skip plugin IDs are set, that plugin's interceptors and router are skipped
 // for the nested model execution while other plugins may still run.
 func (h *BaseAPIHandler) ExecuteModel(ctx context.Context, req ModelExecutionRequest) (ModelExecutionResponse, *interfaces.ErrorMessage) {
+	markNestedExecution(ctx)
 	if req.Stream {
 		return ModelExecutionResponse{}, modelExecutionModeError("ExecuteModel requires Stream=false")
 	}
@@ -120,6 +121,7 @@ func (h *BaseAPIHandler) ExecuteModel(ctx context.Context, req ModelExecutionReq
 // skip plugin IDs are set, that plugin's interceptors and router are skipped
 // for the nested model execution while other plugins may still run.
 func (h *BaseAPIHandler) ExecuteModelStream(ctx context.Context, req ModelExecutionRequest) (ModelExecutionStream, *interfaces.ErrorMessage) {
+	markNestedExecution(ctx)
 	if !req.Stream {
 		return ModelExecutionStream{}, modelExecutionModeError("ExecuteModelStream requires Stream=true")
 	}

--- a/sdk/api/handlers/openai/openai_responses_compact_test.go
+++ b/sdk/api/handlers/openai/openai_responses_compact_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/klauspost/compress/zstd"
@@ -170,5 +171,205 @@ func TestOpenAIResponsesCompactDecodesZstdRequestBody(t *testing.T) {
 	}
 	if strings.TrimSpace(resp.Body.String()) != `{"ok":true}` {
 		t.Fatalf("body = %s", resp.Body.String())
+	}
+}
+
+type compactMockStatusError struct {
+	code int
+	msg  string
+}
+
+func (e compactMockStatusError) Error() string   { return e.msg }
+func (e compactMockStatusError) StatusCode() int { return e.code }
+
+type compactFailureMockExecutor struct {
+	compactErr error
+	normalResp []byte
+	calls      int
+	lastAlt    string
+	lastAuthID string
+}
+
+func (e *compactFailureMockExecutor) Identifier() string { return "test-compact-provider" }
+
+func (e *compactFailureMockExecutor) Execute(ctx context.Context, auth *coreauth.Auth, req coreexecutor.Request, opts coreexecutor.Options) (coreexecutor.Response, error) {
+	e.calls++
+	e.lastAlt = opts.Alt
+	if auth != nil {
+		e.lastAuthID = auth.ID
+	}
+	if opts.Alt == "responses/compact" {
+		if e.compactErr != nil {
+			return coreexecutor.Response{}, e.compactErr
+		}
+	}
+	respPayload := e.normalResp
+	if len(respPayload) == 0 {
+		respPayload = []byte(`{"id":"resp_123","object":"response","status":"completed"}`)
+	}
+	return coreexecutor.Response{Payload: respPayload}, nil
+}
+
+func (e *compactFailureMockExecutor) ExecuteStream(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (*coreexecutor.StreamResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (e *compactFailureMockExecutor) Refresh(ctx context.Context, auth *coreauth.Auth) (*coreauth.Auth, error) {
+	return auth, nil
+}
+
+func (e *compactFailureMockExecutor) CountTokens(context.Context, *coreauth.Auth, coreexecutor.Request, coreexecutor.Options) (coreexecutor.Response, error) {
+	return coreexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *compactFailureMockExecutor) HttpRequest(context.Context, *coreauth.Auth, *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestOpenAIResponsesCompactTransientFailureDoesNotCooldownAuthAndPreservesError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	executor := &compactFailureMockExecutor{
+		compactErr: compactMockStatusError{
+			code: http.StatusInternalServerError,
+			msg:  `{"error":{"message":"compact upstream temporary error","type":"api_error"}}`,
+		},
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	auth1 := &coreauth.Auth{ID: "auth1", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	auth2 := &coreauth.Auth{ID: "auth2", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth1); err != nil {
+		t.Fatalf("Register auth1: %v", err)
+	}
+	if _, err := manager.Register(context.Background(), auth2); err != nil {
+		t.Fatalf("Register auth2: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth1.ID, auth1.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	registry.GetGlobalRegistry().RegisterClient(auth2.ID, auth2.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth1.ID)
+		registry.GetGlobalRegistry().UnregisterClient(auth2.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses/compact", h.Compact)
+	router.POST("/v1/responses", h.Responses)
+
+	// Send compact request which fails upstream on all auths with 500
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", strings.NewReader(`{"model":"test-model","input":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	// 1. Should return upstream status 500 and upstream error message (not generic 503 Service temporarily unavailable)
+	if resp.Code != http.StatusInternalServerError {
+		t.Fatalf("compact status = %d, want %d; body = %s", resp.Code, http.StatusInternalServerError, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "compact upstream temporary error") {
+		t.Fatalf("compact body = %s, want containing 'compact upstream temporary error'", resp.Body.String())
+	}
+
+	// 2. Auth model states should NOT be marked unavailable for normal traffic
+	for _, authID := range []string{"auth1", "auth2"} {
+		a, ok := manager.GetByID(authID)
+		if !ok {
+			t.Fatalf("auth %s not found", authID)
+		}
+		if state, exists := a.ModelStates["test-model"]; exists && state != nil {
+			if state.Unavailable {
+				t.Fatalf("auth %s model state marked Unavailable after compact failure", authID)
+			}
+			if !state.NextRetryAfter.IsZero() && state.NextRetryAfter.After(time.Now()) {
+				t.Fatalf("auth %s model state has NextRetryAfter %v in future", authID, state.NextRetryAfter)
+			}
+		}
+	}
+
+	// 3. Normal /v1/responses request should succeed immediately without auth cooldown errors
+	reqNormal := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"test-model","input":"hello"}`))
+	reqNormal.Header.Set("Content-Type", "application/json")
+	respNormal := httptest.NewRecorder()
+	router.ServeHTTP(respNormal, reqNormal)
+
+	if respNormal.Code != http.StatusOK {
+		t.Fatalf("normal responses status = %d, want %d; body = %s", respNormal.Code, http.StatusOK, respNormal.Body.String())
+	}
+}
+
+func TestOpenAIResponsesCompactRequestFaultStopsFallbackAndPreservesError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	executor := &compactFailureMockExecutor{
+		compactErr: compactMockStatusError{
+			code: http.StatusNotFound,
+			msg:  `404 page not found`,
+		},
+	}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	auth1 := &coreauth.Auth{ID: "auth1", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	auth2 := &coreauth.Auth{ID: "auth2", Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth1); err != nil {
+		t.Fatalf("Register auth1: %v", err)
+	}
+	if _, err := manager.Register(context.Background(), auth2); err != nil {
+		t.Fatalf("Register auth2: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth1.ID, auth1.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	registry.GetGlobalRegistry().RegisterClient(auth2.ID, auth2.Provider, []*registry.ModelInfo{{ID: "test-model"}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth1.ID)
+		registry.GetGlobalRegistry().UnregisterClient(auth2.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses/compact", h.Compact)
+	router.POST("/v1/responses", h.Responses)
+
+	// Send compact request which fails upstream with 404 (endpoint not supported / invalid)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", strings.NewReader(`{"model":"test-model","input":"hello"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	// 1. Should return upstream status 404 and upstream error message
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("compact status = %d, want %d; body = %s", resp.Code, http.StatusNotFound, resp.Body.String())
+	}
+	if !strings.Contains(resp.Body.String(), "404 page not found") {
+		t.Fatalf("compact body = %s, want containing '404 page not found'", resp.Body.String())
+	}
+
+	// 2. Should stop fallback on request/capability fault (calls == 1)
+	if executor.calls != 1 {
+		t.Fatalf("executor calls = %d, want 1 (fallback should stop)", executor.calls)
+	}
+
+	// 3. Auth model states should NOT be marked unavailable for normal traffic
+	for _, authID := range []string{"auth1", "auth2"} {
+		a, ok := manager.GetByID(authID)
+		if !ok {
+			t.Fatalf("auth %s not found", authID)
+		}
+		if state, exists := a.ModelStates["test-model"]; exists && state != nil {
+			if state.Unavailable {
+				t.Fatalf("auth %s model state marked Unavailable after compact failure", authID)
+			}
+		}
+	}
+
+	// 4. Normal /v1/responses request should succeed immediately
+	reqNormal := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"test-model","input":"hello"}`))
+	reqNormal.Header.Set("Content-Type", "application/json")
+	respNormal := httptest.NewRecorder()
+	router.ServeHTTP(respNormal, reqNormal)
+
+	if respNormal.Code != http.StatusOK {
+		t.Fatalf("normal responses status = %d, want %d; body = %s", respNormal.Code, http.StatusOK, respNormal.Body.String())
 	}
 }

--- a/sdk/cliproxy/auth/conductor_compact_cooldown_test.go
+++ b/sdk/cliproxy/auth/conductor_compact_cooldown_test.go
@@ -1,0 +1,302 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type compactTestStatusError struct {
+	code int
+	msg  string
+}
+
+func (e compactTestStatusError) Error() string   { return e.msg }
+func (e compactTestStatusError) StatusCode() int { return e.code }
+
+type compactTestExecutor struct {
+	calls        int
+	compactErr   error
+	normalErr    error
+	responseBody []byte
+}
+
+func (e *compactTestExecutor) Identifier() string { return "compact-test-provider" }
+
+func (e *compactTestExecutor) Execute(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.calls++
+	if opts.Alt == "responses/compact" {
+		if e.compactErr != nil {
+			return cliproxyexecutor.Response{}, e.compactErr
+		}
+	} else {
+		if e.normalErr != nil {
+			return cliproxyexecutor.Response{}, e.normalErr
+		}
+	}
+	payload := e.responseBody
+	if len(payload) == 0 {
+		payload = []byte(`{"status":"ok"}`)
+	}
+	return cliproxyexecutor.Response{Payload: payload}, nil
+}
+
+func (e *compactTestExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, errors.New("stream not supported")
+}
+
+func (e *compactTestExecutor) Refresh(ctx context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (e *compactTestExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, errors.New("not supported")
+}
+
+func (e *compactTestExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, errors.New("not supported")
+}
+
+func TestManager_ResponsesCompact_TransientFailure_AvailabilityNeutral(t *testing.T) {
+	executor := &compactTestExecutor{
+		compactErr: compactTestStatusError{code: http.StatusInternalServerError, msg: "upstream compact 500"},
+	}
+	m := NewManager(nil, nil, nil)
+	m.RegisterExecutor(executor)
+
+	model := "gpt-5.6-sol"
+	auth1 := &Auth{ID: "auth1", Provider: executor.Identifier(), Status: StatusActive}
+	auth2 := &Auth{ID: "auth2", Provider: executor.Identifier(), Status: StatusActive}
+	if _, err := m.Register(context.Background(), auth1); err != nil {
+		t.Fatalf("Register auth1: %v", err)
+	}
+	if _, err := m.Register(context.Background(), auth2); err != nil {
+		t.Fatalf("Register auth2: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth1.ID, auth1.Provider, []*registry.ModelInfo{{ID: model}})
+	registry.GetGlobalRegistry().RegisterClient(auth2.ID, auth2.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth1.ID)
+		registry.GetGlobalRegistry().UnregisterClient(auth2.ID)
+	})
+
+	req := cliproxyexecutor.Request{Model: model, Payload: []byte(`{"input":"hello"}`)}
+	opts := cliproxyexecutor.Options{Alt: "responses/compact"}
+
+	start := time.Now()
+	_, errExec := m.Execute(context.Background(), []string{executor.Identifier()}, req, opts)
+	elapsed := time.Since(start)
+
+	if errExec == nil {
+		t.Fatal("Execute expected error, got nil")
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("Execute took %v, should not pause for cooldown wait", elapsed)
+	}
+	if executor.calls != 2 {
+		t.Fatalf("executor.calls = %d, want 2 (fallback across candidate auths)", executor.calls)
+	}
+
+	// Verify model states are not unavailable
+	for _, id := range []string{"auth1", "auth2"} {
+		a, ok := m.GetByID(id)
+		if !ok {
+			t.Fatalf("auth %s not found", id)
+		}
+		if state, exists := a.ModelStates[model]; exists && state != nil {
+			if state.Unavailable {
+				t.Fatalf("auth %s marked unavailable after compact failure", id)
+			}
+			if !state.NextRetryAfter.IsZero() && state.NextRetryAfter.After(time.Now()) {
+				t.Fatalf("auth %s has NextRetryAfter set in future: %v", id, state.NextRetryAfter)
+			}
+		}
+	}
+
+	// Normal request succeeds immediately
+	normalReq := cliproxyexecutor.Request{Model: model, Payload: []byte(`{"input":"hello"}`)}
+	normalOpts := cliproxyexecutor.Options{}
+	resp, errNormal := m.Execute(context.Background(), []string{executor.Identifier()}, normalReq, normalOpts)
+	if errNormal != nil {
+		t.Fatalf("normal Execute failed: %v", errNormal)
+	}
+	if string(resp.Payload) != `{"status":"ok"}` {
+		t.Fatalf("normal Execute payload = %s", string(resp.Payload))
+	}
+}
+
+func TestManager_ResponsesCompact_RequestFault_StopsFallback(t *testing.T) {
+	executor := &compactTestExecutor{
+		compactErr: compactTestStatusError{code: http.StatusNotFound, msg: "404 endpoint not found"},
+	}
+	m := NewManager(nil, nil, nil)
+	m.RegisterExecutor(executor)
+
+	model := "gpt-5.6-sol"
+	auth1 := &Auth{ID: "auth1", Provider: executor.Identifier(), Status: StatusActive}
+	auth2 := &Auth{ID: "auth2", Provider: executor.Identifier(), Status: StatusActive}
+	if _, err := m.Register(context.Background(), auth1); err != nil {
+		t.Fatalf("Register auth1: %v", err)
+	}
+	if _, err := m.Register(context.Background(), auth2); err != nil {
+		t.Fatalf("Register auth2: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth1.ID, auth1.Provider, []*registry.ModelInfo{{ID: model}})
+	registry.GetGlobalRegistry().RegisterClient(auth2.ID, auth2.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth1.ID)
+		registry.GetGlobalRegistry().UnregisterClient(auth2.ID)
+	})
+
+	req := cliproxyexecutor.Request{Model: model, Payload: []byte(`{"input":"hello"}`)}
+	opts := cliproxyexecutor.Options{Alt: "responses/compact"}
+
+	_, errExec := m.Execute(context.Background(), []string{executor.Identifier()}, req, opts)
+	if errExec == nil {
+		t.Fatal("Execute expected error, got nil")
+	}
+	if executor.calls != 1 {
+		t.Fatalf("executor.calls = %d, want 1 (fallback stopped on request fault)", executor.calls)
+	}
+
+	// Verify model states are not unavailable
+	for _, id := range []string{"auth1", "auth2"} {
+		a, ok := m.GetByID(id)
+		if !ok {
+			t.Fatalf("auth %s not found", id)
+		}
+		if state, exists := a.ModelStates[model]; exists && state != nil {
+			if state.Unavailable {
+				t.Fatalf("auth %s marked unavailable after compact 404 fault", id)
+			}
+		}
+	}
+}
+
+func TestManager_ResponsesCompact_Unauthorized_CoolsCredential(t *testing.T) {
+	executor := &compactTestExecutor{
+		compactErr: compactTestStatusError{code: http.StatusUnauthorized, msg: "401 unauthorized"},
+	}
+	m := NewManager(nil, nil, nil)
+	m.RegisterExecutor(executor)
+
+	model := "gpt-5.6-sol"
+	auth1 := &Auth{ID: "auth1", Provider: executor.Identifier(), Status: StatusActive}
+	if _, err := m.Register(context.Background(), auth1); err != nil {
+		t.Fatalf("Register auth1: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth1.ID, auth1.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth1.ID)
+	})
+
+	req := cliproxyexecutor.Request{Model: model, Payload: []byte(`{"input":"hello"}`)}
+	opts := cliproxyexecutor.Options{Alt: "responses/compact"}
+
+	_, errExec := m.Execute(context.Background(), []string{executor.Identifier()}, req, opts)
+	if errExec == nil {
+		t.Fatal("Execute expected error, got nil")
+	}
+
+	a, ok := m.GetByID("auth1")
+	if !ok {
+		t.Fatal("auth1 not found")
+	}
+	state, exists := a.ModelStates[model]
+	if !exists || state == nil {
+		t.Fatal("auth1 model state should be recorded for 401 unauthorized")
+	}
+	if !state.Unavailable {
+		t.Fatal("auth1 model state should be unavailable after 401 unauthorized")
+	}
+	if state.NextRetryAfter.IsZero() || !state.NextRetryAfter.After(time.Now()) {
+		t.Fatalf("auth1 NextRetryAfter not set in future for 401 unauthorized: %v", state.NextRetryAfter)
+	}
+}
+
+func TestManager_ResponsesCompact_Forbidden_CoolsCredential(t *testing.T) {
+	executor := &compactTestExecutor{
+		compactErr: compactTestStatusError{code: http.StatusForbidden, msg: "403 forbidden"},
+	}
+	m := NewManager(nil, nil, nil)
+	m.RegisterExecutor(executor)
+
+	model := "gpt-5.6-sol"
+	auth1 := &Auth{ID: "auth1", Provider: executor.Identifier(), Status: StatusActive}
+	if _, err := m.Register(context.Background(), auth1); err != nil {
+		t.Fatalf("Register auth1: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth1.ID, auth1.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth1.ID)
+	})
+
+	req := cliproxyexecutor.Request{Model: model, Payload: []byte(`{"input":"hello"}`)}
+	opts := cliproxyexecutor.Options{Alt: "responses/compact"}
+
+	_, errExec := m.Execute(context.Background(), []string{executor.Identifier()}, req, opts)
+	if errExec == nil {
+		t.Fatal("Execute expected error, got nil")
+	}
+
+	a, ok := m.GetByID("auth1")
+	if !ok {
+		t.Fatal("auth1 not found")
+	}
+	state, exists := a.ModelStates[model]
+	if !exists || state == nil {
+		t.Fatal("auth1 model state should be recorded for 403 forbidden")
+	}
+	if !state.Unavailable {
+		t.Fatal("auth1 model state should be unavailable after 403 forbidden")
+	}
+	if state.NextRetryAfter.IsZero() || !state.NextRetryAfter.After(time.Now()) {
+		t.Fatalf("auth1 NextRetryAfter not set in future for 403 forbidden: %v", state.NextRetryAfter)
+	}
+}
+
+func TestManager_ResponsesCompact_Quota429_CoolsCredential(t *testing.T) {
+	executor := &compactTestExecutor{
+		compactErr: compactTestStatusError{code: http.StatusTooManyRequests, msg: `{"error":{"type":"usage_limit_reached","message":"quota exceeded"}}`},
+	}
+	m := NewManager(nil, nil, nil)
+	m.RegisterExecutor(executor)
+
+	model := "gpt-5.6-sol"
+	auth1 := &Auth{ID: "auth1", Provider: executor.Identifier(), Status: StatusActive}
+	if _, err := m.Register(context.Background(), auth1); err != nil {
+		t.Fatalf("Register auth1: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth1.ID, auth1.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth1.ID)
+	})
+
+	req := cliproxyexecutor.Request{Model: model, Payload: []byte(`{"input":"hello"}`)}
+	opts := cliproxyexecutor.Options{Alt: "responses/compact"}
+
+	_, errExec := m.Execute(context.Background(), []string{executor.Identifier()}, req, opts)
+	if errExec == nil {
+		t.Fatal("Execute expected error, got nil")
+	}
+
+	a, ok := m.GetByID("auth1")
+	if !ok {
+		t.Fatal("auth1 not found")
+	}
+	state, exists := a.ModelStates[model]
+	if !exists || state == nil {
+		t.Fatal("auth1 model state should be recorded for 429 quota")
+	}
+	if !state.Quota.Exceeded {
+		t.Fatal("auth1 quota should be marked exceeded after 429 quota")
+	}
+	if state.NextRetryAfter.IsZero() || !state.NextRetryAfter.After(time.Now()) {
+		t.Fatalf("auth1 NextRetryAfter not set in future for 429 quota: %v", state.NextRetryAfter)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1597,6 +1597,58 @@ func isCountTokensEndpointNotFoundError(err error, requestedModel string) bool {
 	return !isExplicitModelNotFoundError(err, baseModel)
 }
 
+func isResponsesCompactRequest(opts cliproxyexecutor.Options) bool {
+	return opts.Alt == "responses/compact"
+}
+
+func isResponsesCompactRequestFaultError(opts cliproxyexecutor.Options, err error) bool {
+	if !isResponsesCompactRequest(opts) || err == nil {
+		return false
+	}
+	if isCredentialScopedError(err) || isCloudflareChallengeError(err) || isInvalidGrantError(err) {
+		return false
+	}
+	status := statusCodeFromError(err)
+	if clienterror.IsRequestFault(status, err) {
+		return true
+	}
+	switch status {
+	case http.StatusBadRequest,
+		http.StatusNotFound,
+		http.StatusMethodNotAllowed,
+		http.StatusConflict,
+		http.StatusRequestEntityTooLarge,
+		http.StatusUnprocessableEntity,
+		http.StatusNotImplemented:
+		return true
+	default:
+		return false
+	}
+}
+
+func isResponsesCompactAvailabilityNeutralError(opts cliproxyexecutor.Options, err error, resultErr *Error) bool {
+	if !isResponsesCompactRequest(opts) {
+		return false
+	}
+	if resultErr != nil && resultErr.Code == ErrorCodeForceCooldown {
+		return false
+	}
+	if isCredentialScopedError(err) || isCloudflareChallengeError(err) || isInvalidGrantError(err) {
+		return false
+	}
+	if resultErr != nil && (isCloudflareChallengeResultError(resultErr) || isInvalidGrantResultError(resultErr)) {
+		return false
+	}
+	status := statusCodeFromError(err)
+	if status == 0 && resultErr != nil {
+		status = statusCodeFromResult(resultErr)
+	}
+	if status == http.StatusUnauthorized || status == http.StatusPaymentRequired || status == http.StatusForbidden || status == http.StatusTooManyRequests {
+		return false
+	}
+	return true
+}
+
 func isExplicitModelNotFoundError(err error, requestedModel string) bool {
 	if err == nil {
 		return false

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -1742,6 +1742,58 @@ func isCountTokensEndpointNotFoundError(err error, requestedModel string) bool {
 	return !isExplicitModelNotFoundError(err, baseModel)
 }
 
+func isResponsesCompactRequest(opts cliproxyexecutor.Options) bool {
+	return opts.Alt == "responses/compact"
+}
+
+func isResponsesCompactRequestFaultError(opts cliproxyexecutor.Options, err error) bool {
+	if !isResponsesCompactRequest(opts) || err == nil {
+		return false
+	}
+	if isCredentialScopedError(err) || isCloudflareChallengeError(err) || isInvalidGrantError(err) {
+		return false
+	}
+	status := statusCodeFromError(err)
+	if clienterror.IsRequestFault(status, err) {
+		return true
+	}
+	switch status {
+	case http.StatusBadRequest,
+		http.StatusNotFound,
+		http.StatusMethodNotAllowed,
+		http.StatusConflict,
+		http.StatusRequestEntityTooLarge,
+		http.StatusUnprocessableEntity,
+		http.StatusNotImplemented:
+		return true
+	default:
+		return false
+	}
+}
+
+func isResponsesCompactAvailabilityNeutralError(opts cliproxyexecutor.Options, err error, resultErr *Error) bool {
+	if !isResponsesCompactRequest(opts) {
+		return false
+	}
+	if resultErr != nil && resultErr.Code == ErrorCodeForceCooldown {
+		return false
+	}
+	if isCredentialScopedError(err) || isCloudflareChallengeError(err) || isInvalidGrantError(err) {
+		return false
+	}
+	if resultErr != nil && (isCloudflareChallengeResultError(resultErr) || isInvalidGrantResultError(resultErr)) {
+		return false
+	}
+	status := statusCodeFromError(err)
+	if status == 0 && resultErr != nil {
+		status = statusCodeFromResult(resultErr)
+	}
+	if status == http.StatusUnauthorized || status == http.StatusPaymentRequired || status == http.StatusForbidden || status == http.StatusTooManyRequests {
+		return false
+	}
+	return true
+}
+
 func isExplicitModelNotFoundError(err error, requestedModel string) bool {
 	if err == nil {
 		return false

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
@@ -353,7 +355,9 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			if !restoreExecutionModel {
 				execReq = attachResolvedAPIKeyModelInfo(routing, execReq, auth, routeModel, upstreamModel)
 			}
+			startExec := time.Now()
 			resp, errExec := executor.Execute(execCtx, auth, execReq, execOpts)
+			durationExec := time.Since(startExec)
 			if errExec != nil {
 				if errCtx := execCtx.Err(); errCtx != nil {
 					return cliproxyexecutor.Response{}, errCtx
@@ -361,12 +365,17 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				if refreshed, okRefresh := m.tryRefreshAfterUnauthorized(execCtx, auth, errExec, didRefreshOnUnauthorized); okRefresh {
 					auth = refreshed
 					didRefreshOnUnauthorized = true
+					startRetry := time.Now()
 					resp, errExec = executor.Execute(execCtx, auth, execReq, execOpts)
+					durationRetry := time.Since(startRetry)
 					if errExec != nil {
+						warnLogUpstreamFailure(execCtx, entry, provider, upstreamModel, auth, durationRetry, errExec)
 						if errCtx := execCtx.Err(); errCtx != nil {
 							return cliproxyexecutor.Response{}, errCtx
 						}
 					}
+				} else {
+					warnLogUpstreamFailure(execCtx, entry, provider, upstreamModel, auth, durationExec, errExec)
 				}
 			}
 			if errCancel := claudeOAuthRequestCancellation(execCtx, auth, errExec); errCancel != nil {
@@ -513,7 +522,9 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			if !restoreExecutionModel {
 				execReq = attachResolvedAPIKeyModelInfo(routing, execReq, auth, routeModel, upstreamModel)
 			}
+			startExec := time.Now()
 			resp, errExec := executor.CountTokens(execCtx, auth, execReq, execOpts)
+			durationExec := time.Since(startExec)
 			if errExec != nil {
 				if errCtx := execCtx.Err(); errCtx != nil {
 					return cliproxyexecutor.Response{}, errCtx
@@ -521,12 +532,17 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 				if refreshed, okRefresh := m.tryRefreshAfterUnauthorized(execCtx, auth, errExec, didRefreshOnUnauthorized); okRefresh {
 					auth = refreshed
 					didRefreshOnUnauthorized = true
+					startRetry := time.Now()
 					resp, errExec = executor.CountTokens(execCtx, auth, execReq, execOpts)
+					durationRetry := time.Since(startRetry)
 					if errExec != nil {
+						warnLogUpstreamFailure(execCtx, entry, provider, upstreamModel, auth, durationRetry, errExec)
 						if errCtx := execCtx.Err(); errCtx != nil {
 							return cliproxyexecutor.Response{}, errCtx
 						}
 					}
+				} else {
+					warnLogUpstreamFailure(execCtx, entry, provider, upstreamModel, auth, durationExec, errExec)
 				}
 			}
 			if errCancel := claudeOAuthRequestCancellation(execCtx, auth, errExec); errCancel != nil {
@@ -1280,6 +1296,68 @@ func formatOauthIdentity(auth *Auth, provider string, accountInfo string) string
 		return accountInfo
 	}
 	return strings.Join(parts, " ")
+}
+
+func formatAuthIdentity(auth *Auth, provider string) string {
+	if auth == nil {
+		return "auth=nil"
+	}
+	accountType, accountInfo := auth.AccountInfo()
+	switch accountType {
+	case "api_key":
+		return fmt.Sprintf("api_key=%s", util.HideAPIKey(accountInfo))
+	case "oauth":
+		return formatOauthIdentity(auth, provider, accountInfo)
+	default:
+		if auth.FileName != "" {
+			return fmt.Sprintf("auth_file=%s", filepath.Base(auth.FileName))
+		}
+		if auth.ID != "" {
+			return fmt.Sprintf("auth_id=%s", auth.ID)
+		}
+		if accountInfo != "" {
+			return accountInfo
+		}
+		return "unknown"
+	}
+}
+
+func summarizeErrorForLog(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := strings.TrimSpace(err.Error())
+	const maxRunes = 300
+	runes := []rune(msg)
+	if len(runes) > maxRunes {
+		return string(runes[:maxRunes]) + "..."
+	}
+	return msg
+}
+
+func warnLogUpstreamFailure(ctx context.Context, entry *log.Entry, provider, model string, auth *Auth, duration time.Duration, err error) {
+	if err == nil {
+		return
+	}
+	if ctx != nil && errors.Is(ctx.Err(), context.Canceled) {
+		return
+	}
+	if errors.Is(err, context.Canceled) {
+		return
+	}
+	if isRequestInvalidError(err) {
+		return
+	}
+	if entry == nil {
+		if ctx != nil {
+			entry = logEntryWithRequestID(ctx)
+		} else {
+			entry = log.NewEntry(log.StandardLogger())
+		}
+	}
+	authIdent := formatAuthIdentity(auth, provider)
+	errSummary := summarizeErrorForLog(err)
+	entry.Warnf("upstream execution failed: provider=%s model=%s auth=%s duration=%s err=%s", provider, model, authIdent, duration.Round(time.Millisecond), errSummary)
 }
 
 // InjectCredentials delegates per-provider HTTP request preparation when supported.

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -49,12 +49,12 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 		return resp, unwrapRequestStopError(errHome)
 	}
 
-	_, maxRetryCredentials, maxWait := m.retrySettings()
+	defaultRequestRetry, maxRetryCredentials, maxWait := m.retrySettings()
 
 	var lastErr error
 	retryModel := authSelectionModelFromOptions(opts, req.Model)
 	for attempt := 0; ; attempt++ {
-		resp, errExec := m.executeMixedOnce(ctx, normalized, req, opts, maxRetryCredentials)
+		resp, errExec := m.executeMixedOnce(ctx, normalized, req, opts, maxRetryCredentials, attempt, defaultRequestRetry)
 		if errExec == nil {
 			return resp, nil
 		}
@@ -62,7 +62,7 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 			return cliproxyexecutor.Response{}, unwrapRequestStopError(errExec)
 		}
 		lastErr = errExec
-		wait, shouldRetry := m.shouldRetryAfterErrorWithHomeRetryLimit(ctx, opts, errExec, attempt, normalized, retryModel, maxWait, -1)
+		wait, shouldRetry := m.shouldRetryAfterErrorWithHomeRetryLimit(ctx, opts, errExec, attempt, normalized, retryModel, maxWait, -1, defaultRequestRetry)
 		if !shouldRetry {
 			break
 		}
@@ -96,12 +96,12 @@ func (m *Manager) ExecuteCount(ctx context.Context, providers []string, req clip
 		return resp, unwrapRequestStopError(errHome)
 	}
 
-	_, maxRetryCredentials, maxWait := m.retrySettings()
+	defaultRequestRetry, maxRetryCredentials, maxWait := m.retrySettings()
 
 	var lastErr error
 	retryModel := authSelectionModelFromOptions(opts, req.Model)
 	for attempt := 0; ; attempt++ {
-		resp, errExec := m.executeCountMixedOnce(ctx, normalized, req, opts, maxRetryCredentials)
+		resp, errExec := m.executeCountMixedOnce(ctx, normalized, req, opts, maxRetryCredentials, attempt, defaultRequestRetry)
 		if errExec == nil {
 			return resp, nil
 		}
@@ -109,7 +109,7 @@ func (m *Manager) ExecuteCount(ctx context.Context, providers []string, req clip
 			return cliproxyexecutor.Response{}, unwrapRequestStopError(errExec)
 		}
 		lastErr = errExec
-		wait, shouldRetry := m.shouldRetryAfterErrorWithHomeRetryLimit(ctx, opts, errExec, attempt, normalized, retryModel, maxWait, -1)
+		wait, shouldRetry := m.shouldRetryAfterErrorWithHomeRetryLimit(ctx, opts, errExec, attempt, normalized, retryModel, maxWait, -1, defaultRequestRetry)
 		if !shouldRetry {
 			break
 		}
@@ -137,7 +137,7 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 		return nil, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
 
-	_, maxRetryCredentials, maxWait := m.retrySettings()
+	defaultRequestRetry, maxRetryCredentials, maxWait := m.retrySettings()
 
 	var lastErr error
 	homeRetryLimit := -1
@@ -146,7 +146,7 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 	retryRoundPending := false
 	retryRoundWaited := false
 	for {
-		result, errStream := m.executeStreamMixedOnce(ctx, normalized, req, opts, maxRetryCredentials, &homeRetryLimit)
+		result, errStream := m.executeStreamMixedOnce(ctx, normalized, req, opts, maxRetryCredentials, &homeRetryLimit, attempt, defaultRequestRetry)
 		if errStream == nil {
 			return result, nil
 		}
@@ -168,7 +168,7 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 			return nil, unwrapRequestStopError(errStream)
 		}
 		lastErr = errStream
-		wait, shouldRetry := m.shouldRetryAfterErrorWithHomeRetryLimit(ctx, opts, errStream, attempt, normalized, retryModel, maxWait, homeRetryLimit)
+		wait, shouldRetry := m.shouldRetryAfterErrorWithHomeRetryLimit(ctx, opts, errStream, attempt, normalized, retryModel, maxWait, homeRetryLimit, defaultRequestRetry)
 		if !shouldRetry {
 			break
 		}
@@ -300,7 +300,7 @@ func mergeRequestHeaders(current, updates http.Header, clear []string) http.Head
 	return out
 }
 
-func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int) (cliproxyexecutor.Response, error) {
+func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int, retryRound int, defaultRequestRetry int) (cliproxyexecutor.Response, error) {
 	if len(providers) == 0 {
 		return cliproxyexecutor.Response{}, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
@@ -310,6 +310,11 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 	homeMode := m.HomeEnabled()
 	homeAuthCount := 1
 	tried := make(map[string]struct{})
+	if !homeMode {
+		for authID := range m.requestRetryRoundExclusions(retryRound, defaultRequestRetry) {
+			tried[authID] = struct{}{}
+		}
+	}
 	attempted := make(map[string]struct{})
 	var lastErr error
 	for {
@@ -321,7 +326,8 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 		}
 		pickOpts := opts
 		if homeMode {
-			pickOpts = withHomeAuthCount(opts, homeAuthCount)
+			pickOpts = withHomeRetryRound(pickOpts, retryRound)
+			pickOpts = withHomeAuthCount(pickOpts, homeAuthCount)
 			pickOpts = withHomeExcludedAuthIDs(pickOpts, tried)
 		}
 		auth, executor, provider, errPick := m.pickNextMixed(ctx, providers, routeModel, pickOpts, tried)
@@ -468,7 +474,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 	}
 }
 
-func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int) (cliproxyexecutor.Response, error) {
+func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int, retryRound int, defaultRequestRetry int) (cliproxyexecutor.Response, error) {
 	if len(providers) == 0 {
 		return cliproxyexecutor.Response{}, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
@@ -478,6 +484,11 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 	homeMode := m.HomeEnabled()
 	homeAuthCount := 1
 	tried := make(map[string]struct{})
+	if !homeMode {
+		for authID := range m.requestRetryRoundExclusions(retryRound, defaultRequestRetry) {
+			tried[authID] = struct{}{}
+		}
+	}
 	attempted := make(map[string]struct{})
 	var lastErr error
 	for {
@@ -489,7 +500,8 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 		}
 		pickOpts := opts
 		if homeMode {
-			pickOpts = withHomeAuthCount(opts, homeAuthCount)
+			pickOpts = withHomeRetryRound(pickOpts, retryRound)
+			pickOpts = withHomeAuthCount(pickOpts, homeAuthCount)
 			pickOpts = withHomeExcludedAuthIDs(pickOpts, tried)
 		}
 		auth, executor, provider, errPick := m.pickNextMixed(ctx, providers, routeModel, pickOpts, tried)
@@ -640,7 +652,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 	}
 }
 
-func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int, homeRetryLimit *int) (*cliproxyexecutor.StreamResult, error) {
+func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int, homeRetryLimit *int, retryRound int, defaultRequestRetry int) (*cliproxyexecutor.StreamResult, error) {
 	if len(providers) == 0 {
 		return nil, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
@@ -651,6 +663,11 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 	homeMode := m.HomeEnabled()
 	homeAuthCount := 1
 	tried := make(map[string]struct{})
+	if !homeMode {
+		for authID := range m.requestRetryRoundExclusions(retryRound, defaultRequestRetry) {
+			tried[authID] = struct{}{}
+		}
+	}
 	homeExcludedAuthIDs := make(map[string]struct{})
 	homeSameAuthRetries := make(map[string]int)
 	lastHomeAuthID := ""
@@ -672,7 +689,8 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 		}
 		pickOpts := opts
 		if homeMode {
-			pickOpts = withHomeAuthCount(opts, homeAuthCount)
+			pickOpts = withHomeRetryRound(pickOpts, retryRound)
+			pickOpts = withHomeAuthCount(pickOpts, homeAuthCount)
 			pickOpts = withHomeExcludedAuthIDs(pickOpts, homeExcludedAuthIDs)
 		}
 
@@ -1000,6 +1018,20 @@ func withHomeAuthCount(opts cliproxyexecutor.Options, count int) cliproxyexecuto
 		meta[k] = v
 	}
 	meta[homeAuthCountMetadataKey] = count
+	opts.Metadata = meta
+	return opts
+}
+
+func withHomeRetryRound(opts cliproxyexecutor.Options, retryRound int) cliproxyexecutor.Options {
+	meta := make(map[string]any, len(opts.Metadata)+1)
+	for key, value := range opts.Metadata {
+		meta[key] = value
+	}
+	if retryRound > 0 {
+		meta[homeRetryRoundMetadataKey] = retryRound
+	} else {
+		delete(meta, homeRetryRoundMetadataKey)
+	}
 	opts.Metadata = meta
 	return opts
 }

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -383,7 +383,11 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				}
 				action, okAction := matchRequestScopedErrorAction(auth, errExec, m.runtimeConfigSnapshot())
 				applyRequestScopedActionToResult(action, okAction, &result)
-				m.MarkResult(execCtx, result)
+				if isResponsesCompactAvailabilityNeutralError(execOpts, errExec, result.Error) {
+					m.recordAvailabilityNeutralResult(execCtx, result)
+				} else {
+					m.MarkResult(execCtx, result)
+				}
 				if okAction {
 					if isRequestScopedStop(action, okAction) {
 						return cliproxyexecutor.Response{}, wrapRequestStopError(errExec)
@@ -394,7 +398,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 					}
 					continue
 				}
-				if isRequestInvalidError(errExec) {
+				if isResponsesCompactRequestFaultError(execOpts, errExec) || isRequestInvalidError(errExec) {
 					return cliproxyexecutor.Response{}, errExec
 				}
 				authErr = errExec
@@ -420,7 +424,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				}
 				continue
 			}
-			if isRequestInvalidError(authErr) {
+			if isResponsesCompactRequestFaultError(opts, authErr) || isRequestInvalidError(authErr) {
 				return cliproxyexecutor.Response{}, authErr
 			}
 			lastErr = authErr

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -61,7 +62,7 @@ func (m *Manager) Execute(ctx context.Context, providers []string, req cliproxye
 			return cliproxyexecutor.Response{}, unwrapRequestStopError(errExec)
 		}
 		lastErr = errExec
-		wait, shouldRetry := m.shouldRetryAfterError(errExec, attempt, normalized, retryModel, maxWait)
+		wait, shouldRetry := m.shouldRetryAfterErrorWithHomeRetryLimit(ctx, opts, errExec, attempt, normalized, retryModel, maxWait, -1)
 		if !shouldRetry {
 			break
 		}
@@ -108,7 +109,7 @@ func (m *Manager) ExecuteCount(ctx context.Context, providers []string, req clip
 			return cliproxyexecutor.Response{}, unwrapRequestStopError(errExec)
 		}
 		lastErr = errExec
-		wait, shouldRetry := m.shouldRetryAfterError(errExec, attempt, normalized, retryModel, maxWait)
+		wait, shouldRetry := m.shouldRetryAfterErrorWithHomeRetryLimit(ctx, opts, errExec, attempt, normalized, retryModel, maxWait, -1)
 		if !shouldRetry {
 			break
 		}
@@ -139,23 +140,44 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 	_, maxRetryCredentials, maxWait := m.retrySettings()
 
 	var lastErr error
+	homeRetryLimit := -1
 	retryModel := authSelectionModelFromOptions(opts, req.Model)
-	for attempt := 0; ; attempt++ {
-		result, errStream := m.executeStreamMixedOnce(ctx, normalized, req, opts, maxRetryCredentials)
+	attempt := 0
+	retryRoundPending := false
+	retryRoundWaited := false
+	for {
+		result, errStream := m.executeStreamMixedOnce(ctx, normalized, req, opts, maxRetryCredentials, &homeRetryLimit)
 		if errStream == nil {
 			return result, nil
 		}
+		if m.HomeEnabled() && retryRoundPending {
+			if wait, okWait := pendingHomeRetryRoundDelay(errStream, maxWait, &homeRetryLimit, pinnedAuthIDFromMetadata(opts.Metadata) == ""); okWait && m.homeRetryAllowed(attempt-1, homeRetryLimit) {
+				if retryRoundWaited {
+					return nil, errStream
+				}
+				if errWait := waitForCooldown(ctx, wait, maxWait); errWait != nil {
+					return nil, errWait
+				}
+				retryRoundWaited = true
+				continue
+			}
+		}
+		retryRoundPending = false
+		retryRoundWaited = false
 		if isRequestTerminatedError(errStream) || isRequestStopError(errStream) {
 			return nil, unwrapRequestStopError(errStream)
 		}
 		lastErr = errStream
-		wait, shouldRetry := m.shouldRetryAfterError(errStream, attempt, normalized, retryModel, maxWait)
+		wait, shouldRetry := m.shouldRetryAfterErrorWithHomeRetryLimit(ctx, opts, errStream, attempt, normalized, retryModel, maxWait, homeRetryLimit)
 		if !shouldRetry {
 			break
 		}
 		if errWait := waitForCooldown(ctx, wait, maxWait); errWait != nil {
 			return nil, errWait
 		}
+		attempt++
+		retryRoundPending = m.HomeEnabled()
+		retryRoundWaited = false
 	}
 	if lastErr != nil {
 		lastErr = unwrapRequestStopError(lastErr)
@@ -168,7 +190,7 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 		}
 		var bootstrapErr *streamBootstrapError
 		if errors.As(lastErr, &bootstrapErr) && bootstrapErr != nil {
-			return streamErrorResult(bootstrapErr.Headers(), bootstrapErr.cause), nil
+			return streamErrorResult(bootstrapErr.Headers(), lastErr), nil
 		}
 		return nil, lastErr
 	}
@@ -291,7 +313,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 	attempted := make(map[string]struct{})
 	var lastErr error
 	for {
-		if !homeMode && maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials {
+		if maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials {
 			if lastErr != nil {
 				return cliproxyexecutor.Response{}, lastErr
 			}
@@ -300,6 +322,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 		pickOpts := opts
 		if homeMode {
 			pickOpts = withHomeAuthCount(opts, homeAuthCount)
+			pickOpts = withHomeExcludedAuthIDs(pickOpts, tried)
 		}
 		auth, executor, provider, errPick := m.pickNextMixed(ctx, providers, routeModel, pickOpts, tried)
 		if errPick != nil {
@@ -458,7 +481,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 	attempted := make(map[string]struct{})
 	var lastErr error
 	for {
-		if !homeMode && maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials {
+		if maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials {
 			if lastErr != nil {
 				return cliproxyexecutor.Response{}, lastErr
 			}
@@ -467,6 +490,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 		pickOpts := opts
 		if homeMode {
 			pickOpts = withHomeAuthCount(opts, homeAuthCount)
+			pickOpts = withHomeExcludedAuthIDs(pickOpts, tried)
 		}
 		auth, executor, provider, errPick := m.pickNextMixed(ctx, providers, routeModel, pickOpts, tried)
 		if errPick != nil {
@@ -616,7 +640,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 	}
 }
 
-func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int) (*cliproxyexecutor.StreamResult, error) {
+func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int, homeRetryLimit *int) (*cliproxyexecutor.StreamResult, error) {
 	if len(providers) == 0 {
 		return nil, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
@@ -627,12 +651,21 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 	homeMode := m.HomeEnabled()
 	homeAuthCount := 1
 	tried := make(map[string]struct{})
+	homeExcludedAuthIDs := make(map[string]struct{})
+	homeSameAuthRetries := make(map[string]int)
+	lastHomeAuthID := ""
+	homeSameAuthRetryPending := false
 	attempted := make(map[string]struct{})
 	unauthorizedRefreshTried := make(map[string]struct{})
 	var lastErr error
+	var roundTiming homeRetryRoundTiming
 	for {
-		if !homeMode && maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials {
+		allowSameAuthRetry := homeMode && homeSameAuthRetryPending && lastHomeAuthID != "" && homeSameAuthRetries[lastHomeAuthID] == 0
+		if maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials && !allowSameAuthRetry {
 			if lastErr != nil {
+				if homeMode {
+					return nil, markHomeRetryRoundExhausted(lastErr, roundTiming.RetryAfter(), true)
+				}
 				return nil, lastErr
 			}
 			return nil, &Error{Code: "auth_not_found", Message: "no auth available"}
@@ -640,6 +673,7 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 		pickOpts := opts
 		if homeMode {
 			pickOpts = withHomeAuthCount(opts, homeAuthCount)
+			pickOpts = withHomeExcludedAuthIDs(pickOpts, homeExcludedAuthIDs)
 		}
 
 		var selection *HomeDispatchSelection
@@ -658,7 +692,15 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			auth, executor, provider, errPick = m.pickNextMixed(ctx, providers, routeModel, pickOpts, tried)
 		}
 		if errPick != nil {
+			var homeCooldown *homeDispatchRetryAfterError
+			if homeMode && lastErr != nil && errors.As(errPick, &homeCooldown) && homeCooldown != nil {
+				observeHomeCooldownRetryLimit(homeCooldown, homeRetryLimit, pinnedAuthIDFromMetadata(opts.Metadata) == "")
+				return nil, markHomeRetryRoundExhausted(lastErr, homeCooldown.RetryAfter(), false)
+			}
 			if shouldReturnLastErrorOnPickFailure(homeMode, lastErr, errPick) {
+				if homeMode {
+					return nil, markHomeRetryRoundExhausted(lastErr, roundTiming.RetryAfter(), isHomeNextRoundImmediatelyAvailable(errPick))
+				}
 				return nil, lastErr
 			}
 			return nil, errPick
@@ -669,13 +711,56 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			}
 			return nil, &Error{Code: "executor_not_found", Message: "executor not registered"}
 		}
+		if homeMode {
+			m.observeHomeRetryLimit(auth, selection, homeRetryLimit)
+		}
+		if selection != nil && allowSameAuthRetry && maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials && auth.ID != lastHomeAuthID {
+			if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "max_retry_credentials"); errEnd != nil {
+				return nil, errEnd
+			}
+			if lastErr != nil {
+				return nil, markHomeRetryRoundExhausted(lastErr, roundTiming.RetryAfter(), true)
+			}
+			return nil, &Error{Code: "auth_not_found", Message: "no auth available"}
+		}
+		if homeMode && lastHomeAuthID != "" && auth.ID != lastHomeAuthID {
+			homeSameAuthRetryPending = false
+		}
 		if selection != nil {
-			if _, refreshedAlready := unauthorizedRefreshTried[auth.ID]; refreshedAlready {
-				selection.End("repeated_refresh_auth")
-				if lastErr != nil {
-					return nil, lastErr
+			// A legacy Home may ignore excluded_auth_ids and return the same
+			// credential again. Reject credentials explicitly excluded from this
+			// round while retaining the explicit same-auth retry path, which
+			// intentionally leaves the credential out of homeExcludedAuthIDs.
+			if _, alreadyTried := tried[auth.ID]; alreadyTried {
+				if _, excluded := homeExcludedAuthIDs[auth.ID]; excluded {
+					if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "repeated_excluded_auth"); errEnd != nil {
+						return nil, errEnd
+					}
+					if lastErr != nil {
+						return nil, markHomeRetryRoundExhausted(lastErr, roundTiming.RetryAfter(), false)
+					}
+					return nil, repeatedHomeAuthError()
+				} else {
+					homeSameAuthRetries[auth.ID]++
+					if homeSameAuthRetries[auth.ID] > 1 {
+						// A fresh Home selection may retry the same auth once for
+						// connection lifecycle or authorization recovery. Repeated
+						// failures must still rotate away from this credential.
+						homeExcludedAuthIDs[auth.ID] = struct{}{}
+						if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "repeated_same_auth"); errEnd != nil {
+							return nil, errEnd
+						}
+						continue
+					}
 				}
-				return nil, repeatedHomeAuthError()
+			}
+			if _, refreshedAlready := unauthorizedRefreshTried[auth.ID]; refreshedAlready {
+				homeExcludedAuthIDs[auth.ID] = struct{}{}
+				homeSameAuthRetryPending = false
+				if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "repeated_refresh_auth"); errEnd != nil {
+					return nil, errEnd
+				}
+				continue
 			}
 		}
 
@@ -712,6 +797,9 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 		}
 		if len(models) == 0 {
 			if selection != nil {
+				homeExcludedAuthIDs[auth.ID] = struct{}{}
+				lastHomeAuthID = auth.ID
+				homeSameAuthRetryPending = false
 				releaseAttempt()
 				if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "no_execution_models"); errEnd != nil {
 					return nil, errEnd
@@ -727,6 +815,17 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			auth, errPrepare = m.prepareRequestAuth(execCtx, executor, auth)
 		}
 		if errPrepare != nil {
+			if selection != nil {
+				excludeAuth := shouldExcludeHomeAuthAfterStreamError(execCtx, auth, errPrepare)
+				if _, refreshedAlready := unauthorizedRefreshTried[auth.ID]; refreshedAlready || homeSameAuthRetries[auth.ID] > 0 {
+					excludeAuth = true
+				}
+				if excludeAuth {
+					homeExcludedAuthIDs[auth.ID] = struct{}{}
+				}
+				lastHomeAuthID = auth.ID
+				homeSameAuthRetryPending = !excludeAuth
+			}
 			if selection == nil {
 				if errCancel := claudeOAuthRequestCancellation(execCtx, auth, errPrepare); errCancel != nil {
 					return nil, errCancel
@@ -740,6 +839,9 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 				m.MarkResult(execCtx, result)
 			}
 			lastErr = errPrepare
+			if homeMode {
+				roundTiming.Observe(lastErr)
+			}
 			if selection != nil {
 				if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "prepare_failed"); errEnd != nil {
 					return nil, errEnd
@@ -763,6 +865,17 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 		streamResult, errStream := m.executeStreamWithModelPool(execCtx, executor, auth, provider, execReq, execOpts, routeModel, streamExecutionModel, models, pooled, aliasResult, routing, !homeMode || selection != nil, selection != nil, unauthorizedRefreshTried)
 		if errStream != nil {
 			if selection != nil {
+				excludeAuth := shouldExcludeHomeAuthAfterStreamError(execCtx, auth, errStream)
+				if _, refreshedAlready := unauthorizedRefreshTried[auth.ID]; refreshedAlready || homeSameAuthRetries[auth.ID] > 0 {
+					excludeAuth = true
+				}
+				if excludeAuth {
+					homeExcludedAuthIDs[auth.ID] = struct{}{}
+				}
+				lastHomeAuthID = auth.ID
+				homeSameAuthRetryPending = !excludeAuth
+			}
+			if selection != nil {
 				releaseAttempt()
 				if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "stream_start_failed"); errEnd != nil {
 					return nil, errEnd
@@ -778,6 +891,9 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 				}
 				lastErr = errStream
 				if homeMode {
+					roundTiming.Observe(lastErr)
+				}
+				if homeMode {
 					homeAuthCount++
 				}
 				continue
@@ -786,6 +902,9 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 				return nil, errStream
 			}
 			lastErr = errStream
+			if homeMode {
+				roundTiming.Observe(lastErr)
+			}
 			if homeMode {
 				homeAuthCount++
 			}
@@ -799,6 +918,19 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 		}
 		return streamResult, nil
 	}
+}
+
+func shouldExcludeHomeAuthAfterStreamError(ctx context.Context, auth *Auth, err error) bool {
+	if err == nil || isConnectionLifecycleError(err) {
+		return false
+	}
+	// A 426 during a downstream websocket attempt is a transport fallback
+	// signal. OAuth authorization failures may also recover after a refresh.
+	// Both paths may retry the same credential once.
+	if cliproxyexecutor.DownstreamWebsocket(ctx) && statusCodeFromError(err) == http.StatusUpgradeRequired {
+		return false
+	}
+	return !isUnauthorizedError(err) || auth == nil || auth.AuthKind() != AuthKindOAuth
 }
 
 func cloneRequestMetadata(src map[string]any) map[string]any {
@@ -872,6 +1004,34 @@ func withHomeAuthCount(opts cliproxyexecutor.Options, count int) cliproxyexecuto
 	return opts
 }
 
+func withHomeExcludedAuthIDs(opts cliproxyexecutor.Options, tried map[string]struct{}) cliproxyexecutor.Options {
+	meta := make(map[string]any, len(opts.Metadata)+1)
+	for key, value := range opts.Metadata {
+		meta[key] = value
+	}
+	excluded := make(map[string]struct{})
+	for _, authID := range homeExcludedAuthIDsFromMetadata(meta) {
+		excluded[authID] = struct{}{}
+	}
+	for authID := range tried {
+		if authID = strings.TrimSpace(authID); authID != "" {
+			excluded[authID] = struct{}{}
+		}
+	}
+	if len(excluded) == 0 {
+		delete(meta, ExcludedAuthIDsMetadataKey)
+	} else {
+		ids := make([]string, 0, len(excluded))
+		for authID := range excluded {
+			ids = append(ids, authID)
+		}
+		sort.Strings(ids)
+		meta[ExcludedAuthIDsMetadataKey] = ids
+	}
+	opts.Metadata = meta
+	return opts
+}
+
 func homeAuthCountFromMetadata(meta map[string]any) int {
 	if len(meta) == 0 {
 		return 1
@@ -891,6 +1051,56 @@ func homeAuthCountFromMetadata(meta map[string]any) int {
 		}
 	}
 	return 1
+}
+
+func homeExcludedAuthIDsFromMetadata(meta map[string]any) []string {
+	if len(meta) == 0 {
+		return nil
+	}
+	raw, ok := meta[ExcludedAuthIDsMetadataKey]
+	if !ok {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	ids := make([]string, 0)
+	appendID := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		if _, exists := seen[value]; exists {
+			return
+		}
+		seen[value] = struct{}{}
+		ids = append(ids, value)
+	}
+	switch values := raw.(type) {
+	case []string:
+		for _, value := range values {
+			appendID(value)
+		}
+	case []any:
+		for _, value := range values {
+			if text, okText := value.(string); okText {
+				appendID(text)
+			}
+		}
+	case map[string]struct{}:
+		for value := range values {
+			appendID(value)
+		}
+	case map[string]bool:
+		for value, enabled := range values {
+			if enabled {
+				appendID(value)
+			}
+		}
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	sort.Strings(ids)
+	return ids
 }
 
 func hasRequestedModelMetadata(meta map[string]any) bool {

--- a/sdk/cliproxy/auth/conductor_execution.go
+++ b/sdk/cliproxy/auth/conductor_execution.go
@@ -4,12 +4,15 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
@@ -74,15 +77,16 @@ func (m *Manager) ExecuteCount(ctx context.Context, providers []string, req clip
 		return resp, unwrapRequestStopError(errHome)
 	}
 
-	_, maxRetryCredentials, maxWait := m.retrySettings()
+	defaultRequestRetry, maxRetryCredentials, maxWait := m.retrySettings()
 
 	var lastErr error
 	retryModel := authSelectionModelFromOptions(opts, req.Model)
 	retryWithoutPenaltyCounts := make(map[string]int)
 	retryWithoutPenaltyUsage := cliproxyexecutor.NewUsageAccumulator(coreusage.Detail{})
+	retryRound := 0
 	for attempt := 0; ; attempt++ {
 		attemptOpts := withRetryWithoutPenaltyUsageMetadata(opts, retryWithoutPenaltyUsage)
-		resp, errExec := m.executeCountMixedOnce(ctx, normalized, req, attemptOpts, maxRetryCredentials)
+		resp, errExec := m.executeCountMixedOnce(ctx, normalized, req, attemptOpts, maxRetryCredentials, retryRound, defaultRequestRetry)
 		if errExec == nil {
 			return resp, nil
 		}
@@ -93,7 +97,11 @@ func (m *Manager) ExecuteCount(ctx context.Context, providers []string, req clip
 		if detail, ok := retryWithoutPenaltyUsageDetail(errExec); ok {
 			retryWithoutPenaltyUsage.Add(detail)
 		}
-		wait, shouldRetry, terminalErr := m.shouldRetryAfterError(errExec, attempt, normalized, retryModel, maxWait, retryWithoutPenaltyCounts)
+		policyRound := retryRound
+		if !isRetryWithoutPenaltyError(errExec) {
+			policyRound = attempt
+		}
+		wait, shouldRetry, terminalErr := m.shouldRetryAfterErrorWithRetryPolicy(ctx, opts, errExec, policyRound, normalized, retryModel, maxWait, -1, defaultRequestRetry, retryWithoutPenaltyCounts)
 		if terminalErr != nil {
 			if resp, ok := retryWithoutPenaltyFallbackResponse(errExec); ok {
 				return resp, nil
@@ -105,6 +113,9 @@ func (m *Manager) ExecuteCount(ctx context.Context, providers []string, req clip
 		}
 		if errWait := waitForCooldown(ctx, wait, maxWait); errWait != nil {
 			return cliproxyexecutor.Response{}, errWait
+		}
+		if !isRetryWithoutPenaltyError(errExec) {
+			retryRound = policyRound + 1
 		}
 	}
 	if lastErr != nil {
@@ -142,6 +153,13 @@ func (m *Manager) ExecuteStream(ctx context.Context, providers []string, req cli
 	result, err = m.executeStreamCodexModelFallback(ctx, providers, req, opts, err)
 	if err == nil {
 		return result, nil
+	}
+	if isHomeRetryRoundExhausted(err) {
+		var homeBootstrapErr *streamBootstrapError
+		if errors.As(err, &homeBootstrapErr) && homeBootstrapErr != nil {
+			return streamErrorResult(SafeResponseHeaders(err), err), nil
+		}
+		return nil, err
 	}
 	var bootstrapErr *streamBootstrapError
 	if errors.As(err, &bootstrapErr) && bootstrapErr != nil {
@@ -253,7 +271,7 @@ func mergeRequestHeaders(current, updates http.Header, clear []string) http.Head
 	}
 	return out
 }
-func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int) (cliproxyexecutor.Response, error) {
+func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int, retryRound int, defaultRequestRetry int) (cliproxyexecutor.Response, error) {
 	if len(providers) == 0 {
 		return cliproxyexecutor.Response{}, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
@@ -263,10 +281,15 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 	homeMode := m.HomeEnabled()
 	homeAuthCount := 1
 	tried := excludedAuthIDsFromMetadata(opts.Metadata)
+	if !homeMode {
+		for authID := range m.requestRetryRoundExclusions(retryRound, defaultRequestRetry) {
+			tried[authID] = struct{}{}
+		}
+	}
 	attempted := make(map[string]struct{})
 	var lastErr error
 	for {
-		if !homeMode && maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials {
+		if maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials {
 			if lastErr != nil {
 				return cliproxyexecutor.Response{}, lastErr
 			}
@@ -274,7 +297,8 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 		}
 		pickOpts := opts
 		if homeMode {
-			pickOpts = withHomeAuthCount(opts, homeAuthCount)
+			pickOpts = withHomeAuthCount(pickOpts, homeAuthCount)
+			pickOpts = withHomeExcludedAuthIDs(pickOpts, tried)
 		}
 		var auth *Auth
 		var executor ProviderExecutor
@@ -372,7 +396,9 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 			if !restoreExecutionModel {
 				execReq = attachResolvedAPIKeyModelInfo(routing, execReq, auth, routeModel, upstreamModel)
 			}
+			startExec := time.Now()
 			resp, errExec := executor.Execute(execCtx, auth, execReq, execOpts)
+			durationExec := time.Since(startExec)
 			if errExec != nil {
 				if errCtx := execCtx.Err(); errCtx != nil {
 					return cliproxyexecutor.Response{}, errCtx
@@ -388,8 +414,11 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 					execCtx = contextWithAuthGeneration(execCtx, auth)
 					didRefreshOnUnauthorized = true
 					markCodexModelFallbackDispatch(execOpts, auth.ID)
+					startRetry := time.Now()
 					resp, errExec = executor.Execute(execCtx, auth, execReq, execOpts)
+					durationRetry := time.Since(startRetry)
 					if errExec != nil {
+						warnLogUpstreamFailure(execCtx, entry, provider, upstreamModel, auth, durationRetry, errExec)
 						if errCtx := execCtx.Err(); errCtx != nil {
 							return cliproxyexecutor.Response{}, errCtx
 						}
@@ -400,6 +429,8 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 							return cliproxyexecutor.Response{}, errExec
 						}
 					}
+				} else {
+					warnLogUpstreamFailure(execCtx, entry, provider, upstreamModel, auth, durationExec, errExec)
 				}
 			}
 			if errCancel := claudeOAuthRequestCancellation(execCtx, auth, errExec); errCancel != nil {
@@ -417,7 +448,11 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				}
 				action, okAction := matchRequestScopedErrorAction(auth, errExec, m.runtimeConfigSnapshot())
 				applyRequestScopedActionToResult(action, okAction, &result)
-				m.MarkResult(execCtx, result)
+				if isResponsesCompactAvailabilityNeutralError(execOpts, errExec, result.Error) {
+					m.recordAvailabilityNeutralResult(execCtx, result)
+				} else {
+					m.MarkResult(execCtx, result)
+				}
 				if okAction {
 					if isRequestScopedStop(action, okAction) {
 						return cliproxyexecutor.Response{}, wrapRequestStopError(errExec)
@@ -428,7 +463,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 					}
 					continue
 				}
-				if isRequestInvalidError(errExec) {
+				if isResponsesCompactRequestFaultError(execOpts, errExec) || isRequestInvalidError(errExec) {
 					return cliproxyexecutor.Response{}, errExec
 				}
 				authErr = errExec
@@ -454,7 +489,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 				}
 				continue
 			}
-			if isRequestInvalidError(authErr) {
+			if isResponsesCompactRequestFaultError(opts, authErr) || isRequestInvalidError(authErr) {
 				return cliproxyexecutor.Response{}, authErr
 			}
 			lastErr = authErr
@@ -465,7 +500,7 @@ func (m *Manager) executeMixedOnce(ctx context.Context, providers []string, req 
 		}
 	}
 }
-func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int) (cliproxyexecutor.Response, error) {
+func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int, retryRound int, defaultRequestRetry int) (cliproxyexecutor.Response, error) {
 	if len(providers) == 0 {
 		return cliproxyexecutor.Response{}, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
@@ -475,10 +510,15 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 	homeMode := m.HomeEnabled()
 	homeAuthCount := 1
 	tried := excludedAuthIDsFromMetadata(opts.Metadata)
+	if !homeMode {
+		for authID := range m.requestRetryRoundExclusions(retryRound, defaultRequestRetry) {
+			tried[authID] = struct{}{}
+		}
+	}
 	attempted := make(map[string]struct{})
 	var lastErr error
 	for {
-		if !homeMode && maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials {
+		if maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials {
 			if lastErr != nil {
 				return cliproxyexecutor.Response{}, lastErr
 			}
@@ -486,7 +526,8 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 		}
 		pickOpts := opts
 		if homeMode {
-			pickOpts = withHomeAuthCount(opts, homeAuthCount)
+			pickOpts = withHomeAuthCount(pickOpts, homeAuthCount)
+			pickOpts = withHomeExcludedAuthIDs(pickOpts, tried)
 		}
 		auth, executor, provider, errPick := m.pickNextMixed(ctx, providers, routeModel, pickOpts, tried)
 		if errPick != nil {
@@ -553,7 +594,9 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 			if !restoreExecutionModel {
 				execReq = attachResolvedAPIKeyModelInfo(routing, execReq, auth, routeModel, upstreamModel)
 			}
+			startExec := time.Now()
 			resp, errExec := executor.CountTokens(execCtx, auth, execReq, execOpts)
+			durationExec := time.Since(startExec)
 			if errExec != nil {
 				if errCtx := execCtx.Err(); errCtx != nil {
 					return cliproxyexecutor.Response{}, errCtx
@@ -565,8 +608,11 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 					auth = refreshed
 					execCtx = contextWithAuthGeneration(execCtx, auth)
 					didRefreshOnUnauthorized = true
+					startRetry := time.Now()
 					resp, errExec = executor.CountTokens(execCtx, auth, execReq, execOpts)
+					durationRetry := time.Since(startRetry)
 					if errExec != nil {
+						warnLogUpstreamFailure(execCtx, entry, provider, upstreamModel, auth, durationRetry, errExec)
 						if errCtx := execCtx.Err(); errCtx != nil {
 							return cliproxyexecutor.Response{}, errCtx
 						}
@@ -574,6 +620,8 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 							return cliproxyexecutor.Response{}, errExec
 						}
 					}
+				} else {
+					warnLogUpstreamFailure(execCtx, entry, provider, upstreamModel, auth, durationExec, errExec)
 				}
 			}
 			if errCancel := claudeOAuthRequestCancellation(execCtx, auth, errExec); errCancel != nil {
@@ -646,7 +694,7 @@ func (m *Manager) executeCountMixedOnce(ctx context.Context, providers []string,
 		}
 	}
 }
-func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int) (*cliproxyexecutor.StreamResult, error) {
+func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, maxRetryCredentials int, homeRetryLimit *int, retryRound int, defaultRequestRetry int) (*cliproxyexecutor.StreamResult, error) {
 	if len(providers) == 0 {
 		return nil, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
@@ -657,19 +705,35 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 	homeMode := m.HomeEnabled()
 	homeAuthCount := 1
 	tried := excludedAuthIDsFromMetadata(opts.Metadata)
+	if !homeMode {
+		for authID := range m.requestRetryRoundExclusions(retryRound, defaultRequestRetry) {
+			tried[authID] = struct{}{}
+		}
+	}
+	homeExcludedAuthIDs := make(map[string]struct{})
+	homeSameAuthRetries := make(map[string]int)
+	lastHomeAuthID := ""
+	homeSameAuthRetryPending := false
 	attempted := make(map[string]struct{})
 	unauthorizedRefreshTried := make(map[string]struct{})
 	var lastErr error
+	var roundTiming homeRetryRoundTiming
 	for {
-		if !homeMode && maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials {
+		allowSameAuthRetry := homeMode && homeSameAuthRetryPending && lastHomeAuthID != "" && homeSameAuthRetries[lastHomeAuthID] == 0
+		if maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials && !allowSameAuthRetry {
 			if lastErr != nil {
+				if homeMode {
+					return nil, markHomeRetryRoundExhausted(lastErr, roundTiming.RetryAfter(), true)
+				}
 				return nil, lastErr
 			}
 			return nil, &Error{Code: "auth_not_found", Message: "no auth available"}
 		}
 		pickOpts := opts
 		if homeMode {
-			pickOpts = withHomeAuthCount(opts, homeAuthCount)
+			pickOpts = withHomeRetryRound(pickOpts, retryRound)
+			pickOpts = withHomeAuthCount(pickOpts, homeAuthCount)
+			pickOpts = withHomeExcludedAuthIDs(pickOpts, homeExcludedAuthIDs)
 		}
 
 		var selection *HomeDispatchSelection
@@ -688,7 +752,15 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			auth, executor, provider, errPick = m.pickNextMixed(ctx, providers, routeModel, pickOpts, tried)
 		}
 		if errPick != nil {
+			var homeCooldown *homeDispatchRetryAfterError
+			if homeMode && lastErr != nil && errors.As(errPick, &homeCooldown) && homeCooldown != nil {
+				observeHomeCooldownRetryLimit(homeCooldown, homeRetryLimit, pinnedAuthIDFromMetadata(opts.Metadata) == "")
+				return nil, markHomeRetryRoundExhausted(lastErr, homeCooldown.RetryAfter(), false)
+			}
 			if shouldReturnLastErrorOnPickFailure(homeMode, lastErr, errPick) {
+				if homeMode {
+					return nil, markHomeRetryRoundExhausted(lastErr, roundTiming.RetryAfter(), isHomeNextRoundImmediatelyAvailable(errPick))
+				}
 				return nil, lastErr
 			}
 			return nil, errPick
@@ -699,13 +771,56 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			}
 			return nil, &Error{Code: "executor_not_found", Message: "executor not registered"}
 		}
+		if homeMode {
+			m.observeHomeRetryLimit(auth, selection, homeRetryLimit)
+		}
+		if selection != nil && allowSameAuthRetry && maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials && auth.ID != lastHomeAuthID {
+			if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "max_retry_credentials"); errEnd != nil {
+				return nil, errEnd
+			}
+			if lastErr != nil {
+				return nil, markHomeRetryRoundExhausted(lastErr, roundTiming.RetryAfter(), true)
+			}
+			return nil, &Error{Code: "auth_not_found", Message: "no auth available"}
+		}
+		if homeMode && lastHomeAuthID != "" && auth.ID != lastHomeAuthID {
+			homeSameAuthRetryPending = false
+		}
 		if selection != nil {
-			if _, refreshedAlready := unauthorizedRefreshTried[auth.ID]; refreshedAlready {
-				selection.End("repeated_refresh_auth")
-				if lastErr != nil {
-					return nil, lastErr
+			// A legacy Home may ignore excluded_auth_ids and return the same
+			// credential again. Reject credentials explicitly excluded from this
+			// round while retaining the explicit same-auth retry path, which
+			// intentionally leaves the credential out of homeExcludedAuthIDs.
+			if _, alreadyTried := tried[auth.ID]; alreadyTried {
+				if _, excluded := homeExcludedAuthIDs[auth.ID]; excluded {
+					if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "repeated_excluded_auth"); errEnd != nil {
+						return nil, errEnd
+					}
+					if lastErr != nil {
+						return nil, markHomeRetryRoundExhausted(lastErr, roundTiming.RetryAfter(), false)
+					}
+					return nil, repeatedHomeAuthError()
+				} else {
+					homeSameAuthRetries[auth.ID]++
+					if homeSameAuthRetries[auth.ID] > 1 {
+						// A fresh Home selection may retry the same auth once for
+						// connection lifecycle or authorization recovery. Repeated
+						// failures must still rotate away from this credential.
+						homeExcludedAuthIDs[auth.ID] = struct{}{}
+						if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "repeated_same_auth"); errEnd != nil {
+							return nil, errEnd
+						}
+						continue
+					}
 				}
-				return nil, repeatedHomeAuthError()
+			}
+			if _, refreshedAlready := unauthorizedRefreshTried[auth.ID]; refreshedAlready {
+				homeExcludedAuthIDs[auth.ID] = struct{}{}
+				homeSameAuthRetryPending = false
+				if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "repeated_refresh_auth"); errEnd != nil {
+					return nil, errEnd
+				}
+				continue
 			}
 		}
 
@@ -770,6 +885,9 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 		}
 		if len(models) == 0 {
 			if selection != nil {
+				homeExcludedAuthIDs[auth.ID] = struct{}{}
+				lastHomeAuthID = auth.ID
+				homeSameAuthRetryPending = false
 				releaseAttempt()
 				if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "no_execution_models"); errEnd != nil {
 					return nil, errEnd
@@ -785,6 +903,17 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 			auth, errPrepare = m.prepareRequestAuth(execCtx, executor, auth)
 		}
 		if errPrepare != nil {
+			if selection != nil {
+				excludeAuth := shouldExcludeHomeAuthAfterStreamError(execCtx, auth, errPrepare)
+				if _, refreshedAlready := unauthorizedRefreshTried[auth.ID]; refreshedAlready || homeSameAuthRetries[auth.ID] > 0 {
+					excludeAuth = true
+				}
+				if excludeAuth {
+					homeExcludedAuthIDs[auth.ID] = struct{}{}
+				}
+				lastHomeAuthID = auth.ID
+				homeSameAuthRetryPending = !excludeAuth
+			}
 			if selection == nil {
 				if errCancel := claudeOAuthRequestCancellation(execCtx, auth, errPrepare); errCancel != nil {
 					return nil, errCancel
@@ -798,6 +927,9 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 				m.MarkResult(execCtx, result)
 			}
 			lastErr = errPrepare
+			if homeMode {
+				roundTiming.Observe(lastErr)
+			}
 			if selection != nil {
 				if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "prepare_failed"); errEnd != nil {
 					return nil, errEnd
@@ -822,6 +954,17 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 		streamResult, errStream := m.executeStreamWithModelPool(execCtx, executor, auth, provider, execReq, execOpts, routeModel, streamExecutionModel, models, pooled, aliasResult, routing, !homeMode || selection != nil, selection != nil, unauthorizedRefreshTried)
 		if errStream != nil {
 			if selection != nil {
+				excludeAuth := shouldExcludeHomeAuthAfterStreamError(execCtx, auth, errStream)
+				if _, refreshedAlready := unauthorizedRefreshTried[auth.ID]; refreshedAlready || homeSameAuthRetries[auth.ID] > 0 {
+					excludeAuth = true
+				}
+				if excludeAuth {
+					homeExcludedAuthIDs[auth.ID] = struct{}{}
+				}
+				lastHomeAuthID = auth.ID
+				homeSameAuthRetryPending = !excludeAuth
+			}
+			if selection != nil {
 				releaseAttempt()
 				if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "stream_start_failed"); errEnd != nil {
 					return nil, errEnd
@@ -840,6 +983,9 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 				}
 				lastErr = errStream
 				if homeMode {
+					roundTiming.Observe(lastErr)
+				}
+				if homeMode {
 					homeAuthCount++
 				}
 				continue
@@ -848,6 +994,9 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 				return nil, errStream
 			}
 			lastErr = errStream
+			if homeMode {
+				roundTiming.Observe(lastErr)
+			}
 			if homeMode {
 				homeAuthCount++
 			}
@@ -863,6 +1012,19 @@ func (m *Manager) executeStreamMixedOnce(ctx context.Context, providers []string
 		streamHandedOff = true
 		return streamResult, nil
 	}
+}
+
+func shouldExcludeHomeAuthAfterStreamError(ctx context.Context, auth *Auth, err error) bool {
+	if err == nil || isConnectionLifecycleError(err) {
+		return false
+	}
+	// A 426 during a downstream websocket attempt is a transport fallback
+	// signal. OAuth authorization failures may also recover after a refresh.
+	// Both paths may retry the same credential once.
+	if cliproxyexecutor.DownstreamWebsocket(ctx) && statusCodeFromError(err) == http.StatusUpgradeRequired {
+		return false
+	}
+	return !isUnauthorizedError(err) || auth == nil || auth.AuthKind() != AuthKindOAuth
 }
 
 func cloneRequestMetadata(src map[string]any) map[string]any {
@@ -936,6 +1098,48 @@ func withHomeAuthCount(opts cliproxyexecutor.Options, count int) cliproxyexecuto
 	return opts
 }
 
+func withHomeRetryRound(opts cliproxyexecutor.Options, retryRound int) cliproxyexecutor.Options {
+	meta := make(map[string]any, len(opts.Metadata)+1)
+	for key, value := range opts.Metadata {
+		meta[key] = value
+	}
+	if retryRound > 0 {
+		meta[homeRetryRoundMetadataKey] = retryRound
+	} else {
+		delete(meta, homeRetryRoundMetadataKey)
+	}
+	opts.Metadata = meta
+	return opts
+}
+
+func withHomeExcludedAuthIDs(opts cliproxyexecutor.Options, tried map[string]struct{}) cliproxyexecutor.Options {
+	meta := make(map[string]any, len(opts.Metadata)+1)
+	for key, value := range opts.Metadata {
+		meta[key] = value
+	}
+	excluded := make(map[string]struct{})
+	for _, authID := range homeExcludedAuthIDsFromMetadata(meta) {
+		excluded[authID] = struct{}{}
+	}
+	for authID := range tried {
+		if authID = strings.TrimSpace(authID); authID != "" {
+			excluded[authID] = struct{}{}
+		}
+	}
+	if len(excluded) == 0 {
+		delete(meta, ExcludedAuthIDsMetadataKey)
+	} else {
+		ids := make([]string, 0, len(excluded))
+		for authID := range excluded {
+			ids = append(ids, authID)
+		}
+		sort.Strings(ids)
+		meta[ExcludedAuthIDsMetadataKey] = ids
+	}
+	opts.Metadata = meta
+	return opts
+}
+
 func homeAuthCountFromMetadata(meta map[string]any) int {
 	if len(meta) == 0 {
 		return 1
@@ -955,6 +1159,56 @@ func homeAuthCountFromMetadata(meta map[string]any) int {
 		}
 	}
 	return 1
+}
+
+func homeExcludedAuthIDsFromMetadata(meta map[string]any) []string {
+	if len(meta) == 0 {
+		return nil
+	}
+	raw, ok := meta[ExcludedAuthIDsMetadataKey]
+	if !ok {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	ids := make([]string, 0)
+	appendID := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		if _, exists := seen[value]; exists {
+			return
+		}
+		seen[value] = struct{}{}
+		ids = append(ids, value)
+	}
+	switch values := raw.(type) {
+	case []string:
+		for _, value := range values {
+			appendID(value)
+		}
+	case []any:
+		for _, value := range values {
+			if text, okText := value.(string); okText {
+				appendID(text)
+			}
+		}
+	case map[string]struct{}:
+		for value := range values {
+			appendID(value)
+		}
+	case map[string]bool:
+		for value, enabled := range values {
+			if enabled {
+				appendID(value)
+			}
+		}
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	sort.Strings(ids)
+	return ids
 }
 
 func hasRequestedModelMetadata(meta map[string]any) bool {
@@ -1372,6 +1626,68 @@ func formatOauthIdentity(auth *Auth, provider string, accountInfo string) string
 		return accountInfo
 	}
 	return strings.Join(parts, " ")
+}
+
+func formatAuthIdentity(auth *Auth, provider string) string {
+	if auth == nil {
+		return "auth=nil"
+	}
+	accountType, accountInfo := auth.AccountInfo()
+	switch accountType {
+	case "api_key":
+		return fmt.Sprintf("api_key=%s", util.HideAPIKey(accountInfo))
+	case "oauth":
+		return formatOauthIdentity(auth, provider, accountInfo)
+	default:
+		if auth.FileName != "" {
+			return fmt.Sprintf("auth_file=%s", filepath.Base(auth.FileName))
+		}
+		if auth.ID != "" {
+			return fmt.Sprintf("auth_id=%s", auth.ID)
+		}
+		if accountInfo != "" {
+			return accountInfo
+		}
+		return "unknown"
+	}
+}
+
+func summarizeErrorForLog(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := strings.TrimSpace(err.Error())
+	const maxRunes = 300
+	runes := []rune(msg)
+	if len(runes) > maxRunes {
+		return string(runes[:maxRunes]) + "..."
+	}
+	return msg
+}
+
+func warnLogUpstreamFailure(ctx context.Context, entry *log.Entry, provider, model string, auth *Auth, duration time.Duration, err error) {
+	if err == nil {
+		return
+	}
+	if ctx != nil && errors.Is(ctx.Err(), context.Canceled) {
+		return
+	}
+	if errors.Is(err, context.Canceled) {
+		return
+	}
+	if isRequestInvalidError(err) {
+		return
+	}
+	if entry == nil {
+		if ctx != nil {
+			entry = logEntryWithRequestID(ctx)
+		} else {
+			entry = log.NewEntry(log.StandardLogger())
+		}
+	}
+	authIdent := formatAuthIdentity(auth, provider)
+	errSummary := summarizeErrorForLog(err)
+	entry.Warnf("upstream execution failed: provider=%s model=%s auth=%s duration=%s err=%s", provider, model, authIdent, duration.Round(time.Millisecond), errSummary)
 }
 
 // InjectCredentials delegates per-provider HTTP request preparation when supported.

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -19,7 +19,11 @@ import (
 )
 
 const (
-	homeAuthCountMetadataKey = "__cliproxy_home_auth_count"
+	homeAuthCountMetadataKey  = "__cliproxy_home_auth_count"
+	homeRetryRoundMetadataKey = "request_retry_round"
+	// ExcludedAuthIDsMetadataKey stores credential IDs already attempted in the
+	// current request retry round.
+	ExcludedAuthIDsMetadataKey = "excluded_auth_ids"
 	// CloseAllExecutionSessionsID asks an executor to release all active execution sessions.
 	// Executors that do not support this marker may ignore it.
 	CloseAllExecutionSessionsID = "__all_execution_sessions__"
@@ -120,6 +124,139 @@ type homeErrorDetail struct {
 	Code         string `json:"code,omitempty"`
 	Retryable    bool   `json:"retryable,omitempty"`
 	RetryAfterMS int64  `json:"retry_after_ms,omitempty"`
+	RequestRetry *int   `json:"request_retry,omitempty"`
+}
+
+type homeDispatchRetryAfterError struct {
+	cause           *Error
+	retryAfter      time.Duration
+	requestRetry    int
+	hasRequestRetry bool
+}
+
+// homeRetryRoundExhaustedError marks a terminal error produced after the
+// current Home credential round has been exhausted. The wrapped error retains
+// its status and retry-after metadata for the outer request retry policy.
+type homeRetryRoundExhaustedError struct {
+	cause         error
+	retryAfter    time.Duration
+	hasRetryAfter bool
+	retryNow      bool
+}
+
+func (e *homeRetryRoundExhaustedError) Error() string {
+	if e == nil || e.cause == nil {
+		return ""
+	}
+	return e.cause.Error()
+}
+
+func (e *homeRetryRoundExhaustedError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+func (e *homeRetryRoundExhaustedError) RetryAfter() *time.Duration {
+	if e == nil || !e.hasRetryAfter {
+		return nil
+	}
+	value := e.retryAfter
+	return &value
+}
+
+func markHomeRetryRoundExhausted(err error, retryAfter *time.Duration, retryNow bool) error {
+	if err == nil {
+		return nil
+	}
+	marked := &homeRetryRoundExhaustedError{cause: err, retryNow: retryNow}
+	if retryAfter != nil {
+		marked.retryAfter = *retryAfter
+		marked.hasRetryAfter = true
+	}
+	return marked
+}
+
+func isHomeRetryRoundExhausted(err error) bool {
+	if err == nil {
+		return false
+	}
+	var marker *homeRetryRoundExhaustedError
+	return errors.As(err, &marker) && marker != nil
+}
+
+type homeRetryRoundTiming struct {
+	retryAfter time.Duration
+	immediate  bool
+	invalid    bool
+}
+
+func (t *homeRetryRoundTiming) Observe(err error) {
+	if t == nil || err == nil || t.immediate || t.invalid {
+		return
+	}
+	retryAfter := retryAfterFromError(err)
+	if retryAfter == nil {
+		return
+	}
+	if *retryAfter == 0 {
+		t.retryAfter = 0
+		t.immediate = true
+		return
+	}
+	if *retryAfter < 0 {
+		t.retryAfter = *retryAfter
+		t.invalid = true
+		return
+	}
+	if t.retryAfter <= 0 || *retryAfter < t.retryAfter {
+		t.retryAfter = *retryAfter
+	}
+}
+
+func (t *homeRetryRoundTiming) RetryAfter() *time.Duration {
+	if t == nil || t.immediate || (!t.invalid && t.retryAfter <= 0) {
+		return nil
+	}
+	value := t.retryAfter
+	return &value
+}
+
+func (e *homeDispatchRetryAfterError) Error() string {
+	if e == nil || e.cause == nil {
+		return ""
+	}
+	return e.cause.Error()
+}
+
+func (e *homeDispatchRetryAfterError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+func (e *homeDispatchRetryAfterError) StatusCode() int {
+	if e == nil || e.cause == nil {
+		return 0
+	}
+	return e.cause.HTTPStatus
+}
+
+func (e *homeDispatchRetryAfterError) RetryAfter() *time.Duration {
+	if e == nil || e.retryAfter <= 0 {
+		return nil
+	}
+	value := e.retryAfter
+	return &value
+}
+
+func (e *homeDispatchRetryAfterError) RequestRetryLimit() (int, bool) {
+	if e == nil || !e.hasRequestRetry {
+		return 0, false
+	}
+	return e.requestRetry, true
 }
 
 const (
@@ -159,6 +296,30 @@ func shouldReturnLastErrorOnPickFailure(homeMode bool, lastErr error, errPick er
 	}
 }
 
+func isHomeNextRoundImmediatelyAvailable(err error) bool {
+	var authErr *Error
+	if !errors.As(err, &authErr) || authErr == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(authErr.Code), "auth_unavailable")
+}
+
+func pendingHomeRetryRoundDelay(err error, maxWait time.Duration, retryLimit *int, acceptRemoteRetryLimit bool) (time.Duration, bool) {
+	if err == nil || isHomeRetryRoundExhausted(err) {
+		return 0, false
+	}
+	var homeCooldown *homeDispatchRetryAfterError
+	if !errors.As(err, &homeCooldown) || homeCooldown == nil {
+		return 0, false
+	}
+	observeHomeCooldownRetryLimit(homeCooldown, retryLimit, acceptRemoteRetryLimit)
+	retryAfter := homeCooldown.RetryAfter()
+	if retryAfter == nil || *retryAfter <= 0 || maxWait <= 0 || *retryAfter > maxWait {
+		return 0, false
+	}
+	return *retryAfter, true
+}
+
 func homeAuthAlreadyTried(tried map[string]struct{}, authID string) bool {
 	authID = strings.TrimSpace(authID)
 	if authID == "" || len(tried) == 0 {
@@ -181,6 +342,7 @@ type homeAuthDispatchResponse struct {
 	Provider      string `json:"provider"`
 	AuthIndex     string `json:"auth_index"`
 	UserAPIKey    string `json:"user_api_key"`
+	RequestRetry  *int   `json:"request_retry,omitempty"`
 	ForceMapping  bool   `json:"force_mapping"`
 	OriginalAlias string `json:"original_alias"`
 	Auth          Auth   `json:"auth"`
@@ -192,8 +354,24 @@ type homeAuthDispatcher interface {
 	AbortAmbiguousDispatch()
 }
 
+type homeDispatchConstraintsDispatcher interface {
+	RPopAuthWithConstraints(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, excludedAuthIDs []string, pinnedAuthID string) ([]byte, error)
+}
+
+type homeDispatchRetryRoundConstraintsDispatcher interface {
+	RPopAuthWithRetryRoundConstraints(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, retryRound int, excludedAuthIDs []string, pinnedAuthID string) ([]byte, error)
+}
+
 type homeCredentialPolicyDispatcher interface {
 	RPopAuthWithPolicy(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string) ([]byte, error)
+}
+
+type homeCredentialPolicyConstraintsDispatcher interface {
+	RPopAuthWithPolicyAndConstraints(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string, excludedAuthIDs []string, pinnedAuthID string) ([]byte, error)
+}
+
+type homeCredentialPolicyRetryRoundConstraintsDispatcher interface {
+	RPopAuthWithPolicyAndRetryRoundConstraints(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string, retryRound int, excludedAuthIDs []string, pinnedAuthID string) ([]byte, error)
 }
 
 var currentHomeDispatcher = func() homeAuthDispatcher {
@@ -325,7 +503,7 @@ func (m *Manager) lockHomeWebsocketSession(ctx context.Context, opts cliproxyexe
 	return mutex.Unlock
 }
 
-func (m *Manager) retainedHomeSessionSelection(ctx context.Context, opts cliproxyexecutor.Options, model string) (*HomeDispatchSelection, bool, error) {
+func (m *Manager) retainedHomeSessionSelection(ctx context.Context, opts cliproxyexecutor.Options, model string, excludedAuthIDs map[string]struct{}) (*HomeDispatchSelection, bool, error) {
 	if m == nil || !cliproxyexecutor.DownstreamWebsocket(ctx) {
 		return nil, false, nil
 	}
@@ -338,7 +516,7 @@ func (m *Manager) retainedHomeSessionSelection(ctx context.Context, opts cliprox
 	routeModel, validRouteModel := validCanonicalHomeConcurrencyModelKey(model)
 	var retained *HomeDispatchSelection
 	var ended []*HomeDispatchSelection
-	fallbackAttempt := homeAuthCountFromMetadata(opts.Metadata) > 1
+	fallbackAttempt := homeAuthCountFromMetadata(opts.Metadata) > 1 || homeRetryRoundFromMetadata(opts.Metadata) > 0
 	m.mu.Lock()
 	selections := m.homeSessionSelections[sessionID]
 	for key, selection := range selections {
@@ -348,7 +526,8 @@ func (m *Manager) retainedHomeSessionSelection(ctx context.Context, opts cliprox
 		}
 		matchesCredential := credentialID == "" || key.credentialID == credentialID
 		matchesRoute := validRouteModel && key.routeModel == routeModel
-		if !fallbackAttempt && matchesCredential && selection.Active() && matchesRoute && retained == nil {
+		_, excluded := excludedAuthIDs[strings.TrimSpace(key.credentialID)]
+		if !fallbackAttempt && !excluded && matchesCredential && selection.Active() && matchesRoute && retained == nil {
 			retained = selection
 			continue
 		}
@@ -711,7 +890,7 @@ func (m *Manager) pickNextViaHome(ctx context.Context, model string, opts clipro
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	selection, errSelection := m.pickHomeDispatchSelection(ctx, model, opts)
+	selection, errSelection := m.pickHomeDispatchSelection(ctx, model, withHomeExcludedAuthIDs(opts, tried))
 	if errSelection != nil {
 		return nil, nil, "", errSelection
 	}
@@ -739,7 +918,14 @@ func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, o
 	if requestedModel == "" {
 		requestedModel = requestedModelFromMetadata(opts.Metadata, model)
 	}
-	retained, retainedOK, errRetained := m.retainedHomeSessionSelection(ctx, opts, requestedModel)
+	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
+	retryRound := homeRetryRoundFromMetadata(opts.Metadata)
+	excludedAuthIDList := homeExcludedAuthIDsFromMetadata(opts.Metadata)
+	excludedAuthIDs := make(map[string]struct{}, len(excludedAuthIDList))
+	for _, authID := range excludedAuthIDList {
+		excludedAuthIDs[authID] = struct{}{}
+	}
+	retained, retainedOK, errRetained := m.retainedHomeSessionSelection(ctx, opts, requestedModel, excludedAuthIDs)
 	if errRetained != nil {
 		return nil, errRetained
 	}
@@ -747,8 +933,8 @@ func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, o
 		return retained, nil
 	}
 	if sessionID := homeExecutionSessionIDFromMetadata(opts.Metadata); sessionID != "" {
-		if credentialID := pinnedAuthIDFromMetadata(opts.Metadata); credentialID != "" {
-			if errEnd := m.endMismatchedHomeSessionSelections(ctx, sessionID, credentialID, requestedModel, true); errEnd != nil {
+		if pinnedAuthID != "" {
+			if errEnd := m.endMismatchedHomeSessionSelections(ctx, sessionID, pinnedAuthID, requestedModel, true); errEnd != nil {
 				return nil, errEnd
 			}
 		}
@@ -763,6 +949,11 @@ func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, o
 	if !client.HeartbeatOK() {
 		return nil, &Error{Code: "home_unavailable", Message: "home control center unavailable", HTTPStatus: http.StatusServiceUnavailable}
 	}
+	if pinnedAuthID != "" {
+		if _, excluded := excludedAuthIDs[pinnedAuthID]; excluded {
+			return nil, &Error{Code: "auth_not_found", Message: "pinned auth is unavailable in the current retry round", HTTPStatus: http.StatusServiceUnavailable}
+		}
+	}
 	pending, errBegin := registry.BeginDispatch()
 	if errBegin != nil {
 		return nil, &Error{Code: "home_unavailable", Message: "home execution registry unavailable", Retryable: true, HTTPStatus: http.StatusServiceUnavailable}
@@ -774,9 +965,21 @@ func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, o
 	var raw []byte
 	var errRPop error
 	if credentialPolicy == "" {
-		raw, errRPop = client.RPopAuth(ctx, requestedModel, sessionID, dispatchHeaders, homeAuthCountFromMetadata(opts.Metadata))
+		if retryRoundClient, okRetryRound := client.(homeDispatchRetryRoundConstraintsDispatcher); okRetryRound {
+			raw, errRPop = retryRoundClient.RPopAuthWithRetryRoundConstraints(ctx, requestedModel, sessionID, dispatchHeaders, homeAuthCountFromMetadata(opts.Metadata), retryRound, excludedAuthIDList, pinnedAuthID)
+		} else if constrainedClient, okConstraints := client.(homeDispatchConstraintsDispatcher); okConstraints {
+			raw, errRPop = constrainedClient.RPopAuthWithConstraints(ctx, requestedModel, sessionID, dispatchHeaders, homeAuthCountFromMetadata(opts.Metadata), excludedAuthIDList, pinnedAuthID)
+		} else {
+			raw, errRPop = client.RPopAuth(ctx, requestedModel, sessionID, dispatchHeaders, homeAuthCountFromMetadata(opts.Metadata))
+		}
+	} else if retryRoundPolicyClient, okRetryRound := client.(homeCredentialPolicyRetryRoundConstraintsDispatcher); okRetryRound {
+		raw, errRPop = retryRoundPolicyClient.RPopAuthWithPolicyAndRetryRoundConstraints(ctx, requestedModel, sessionID, dispatchHeaders, homeAuthCountFromMetadata(opts.Metadata), credentialPolicy, retryRound, excludedAuthIDList, pinnedAuthID)
 	} else if policyClient, okPolicy := client.(homeCredentialPolicyDispatcher); okPolicy {
-		raw, errRPop = policyClient.RPopAuthWithPolicy(ctx, requestedModel, sessionID, dispatchHeaders, homeAuthCountFromMetadata(opts.Metadata), credentialPolicy)
+		if constrainedClient, okConstraints := client.(homeCredentialPolicyConstraintsDispatcher); okConstraints {
+			raw, errRPop = constrainedClient.RPopAuthWithPolicyAndConstraints(ctx, requestedModel, sessionID, dispatchHeaders, homeAuthCountFromMetadata(opts.Metadata), credentialPolicy, excludedAuthIDList, pinnedAuthID)
+		} else {
+			raw, errRPop = policyClient.RPopAuthWithPolicy(ctx, requestedModel, sessionID, dispatchHeaders, homeAuthCountFromMetadata(opts.Metadata), credentialPolicy)
+		}
 	} else {
 		pending.End()
 		return nil, &Error{Code: "home_unavailable", Message: "home dispatcher does not support credential policies", HTTPStatus: http.StatusServiceUnavailable}
@@ -887,6 +1090,10 @@ func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, o
 		endScope()
 		return nil, &Error{Code: "invalid_auth", Message: "home returned auth without id", HTTPStatus: http.StatusBadGateway}
 	}
+	if pinnedAuthID != "" && strings.TrimSpace(auth.ID) != pinnedAuthID {
+		endScope()
+		return nil, &Error{Code: "auth_not_found", Message: "home returned an auth that does not match the pinned credential", HTTPStatus: http.StatusServiceUnavailable}
+	}
 	if errIdentity := verifyAccountedHomeConcurrencyIdentity(envelope.Tuple, &auth, dispatch.AuthIndex); errIdentity != nil {
 		endScope()
 		return nil, errIdentity
@@ -935,6 +1142,10 @@ func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, o
 		endScope()
 		return nil, &Error{Code: "home_unavailable", Message: "home execution registry unavailable", Retryable: true, HTTPStatus: http.StatusServiceUnavailable}
 	}
+	if pinnedAuthID == "" && dispatch.RequestRetry != nil && *dispatch.RequestRetry >= 0 {
+		selection.requestRetry = *dispatch.RequestRetry
+		selection.hasRequestRetry = true
+	}
 	if envelope.Present {
 		selection.accountedModel = envelope.Tuple.Model
 	}
@@ -945,6 +1156,27 @@ func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, o
 		}
 	}
 	return selection, nil
+}
+
+func homeRetryRoundFromMetadata(metadata map[string]any) int {
+	if metadata == nil {
+		return 0
+	}
+	switch value := metadata[homeRetryRoundMetadataKey].(type) {
+	case int:
+		if value > 0 {
+			return value
+		}
+	case int64:
+		if value > 0 {
+			return int(value)
+		}
+	case float64:
+		if value > 0 && value == float64(int(value)) {
+			return int(value)
+		}
+	}
+	return 0
 }
 
 func requestedModelFromMetadata(metadata map[string]any, fallback string) string {

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -19,7 +19,8 @@ import (
 )
 
 const (
-	homeAuthCountMetadataKey = "__cliproxy_home_auth_count"
+	homeAuthCountMetadataKey  = "__cliproxy_home_auth_count"
+	homeRetryRoundMetadataKey = "request_retry_round"
 	// ExcludedAuthIDsMetadataKey stores credential IDs already attempted in the
 	// current request retry round.
 	ExcludedAuthIDsMetadataKey = "excluded_auth_ids"
@@ -357,12 +358,20 @@ type homeDispatchConstraintsDispatcher interface {
 	RPopAuthWithConstraints(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, excludedAuthIDs []string, pinnedAuthID string) ([]byte, error)
 }
 
+type homeDispatchRetryRoundConstraintsDispatcher interface {
+	RPopAuthWithRetryRoundConstraints(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, retryRound int, excludedAuthIDs []string, pinnedAuthID string) ([]byte, error)
+}
+
 type homeCredentialPolicyDispatcher interface {
 	RPopAuthWithPolicy(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string) ([]byte, error)
 }
 
 type homeCredentialPolicyConstraintsDispatcher interface {
 	RPopAuthWithPolicyAndConstraints(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string, excludedAuthIDs []string, pinnedAuthID string) ([]byte, error)
+}
+
+type homeCredentialPolicyRetryRoundConstraintsDispatcher interface {
+	RPopAuthWithPolicyAndRetryRoundConstraints(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string, retryRound int, excludedAuthIDs []string, pinnedAuthID string) ([]byte, error)
 }
 
 var currentHomeDispatcher = func() homeAuthDispatcher {
@@ -507,7 +516,7 @@ func (m *Manager) retainedHomeSessionSelection(ctx context.Context, opts cliprox
 	routeModel, validRouteModel := validCanonicalHomeConcurrencyModelKey(model)
 	var retained *HomeDispatchSelection
 	var ended []*HomeDispatchSelection
-	fallbackAttempt := homeAuthCountFromMetadata(opts.Metadata) > 1
+	fallbackAttempt := homeAuthCountFromMetadata(opts.Metadata) > 1 || homeRetryRoundFromMetadata(opts.Metadata) > 0
 	m.mu.Lock()
 	selections := m.homeSessionSelections[sessionID]
 	for key, selection := range selections {
@@ -910,6 +919,7 @@ func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, o
 		requestedModel = requestedModelFromMetadata(opts.Metadata, model)
 	}
 	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
+	retryRound := homeRetryRoundFromMetadata(opts.Metadata)
 	excludedAuthIDList := homeExcludedAuthIDsFromMetadata(opts.Metadata)
 	excludedAuthIDs := make(map[string]struct{}, len(excludedAuthIDList))
 	for _, authID := range excludedAuthIDList {
@@ -955,11 +965,15 @@ func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, o
 	var raw []byte
 	var errRPop error
 	if credentialPolicy == "" {
-		if constrainedClient, okConstraints := client.(homeDispatchConstraintsDispatcher); okConstraints {
+		if retryRoundClient, okRetryRound := client.(homeDispatchRetryRoundConstraintsDispatcher); okRetryRound {
+			raw, errRPop = retryRoundClient.RPopAuthWithRetryRoundConstraints(ctx, requestedModel, sessionID, dispatchHeaders, homeAuthCountFromMetadata(opts.Metadata), retryRound, excludedAuthIDList, pinnedAuthID)
+		} else if constrainedClient, okConstraints := client.(homeDispatchConstraintsDispatcher); okConstraints {
 			raw, errRPop = constrainedClient.RPopAuthWithConstraints(ctx, requestedModel, sessionID, dispatchHeaders, homeAuthCountFromMetadata(opts.Metadata), excludedAuthIDList, pinnedAuthID)
 		} else {
 			raw, errRPop = client.RPopAuth(ctx, requestedModel, sessionID, dispatchHeaders, homeAuthCountFromMetadata(opts.Metadata))
 		}
+	} else if retryRoundPolicyClient, okRetryRound := client.(homeCredentialPolicyRetryRoundConstraintsDispatcher); okRetryRound {
+		raw, errRPop = retryRoundPolicyClient.RPopAuthWithPolicyAndRetryRoundConstraints(ctx, requestedModel, sessionID, dispatchHeaders, homeAuthCountFromMetadata(opts.Metadata), credentialPolicy, retryRound, excludedAuthIDList, pinnedAuthID)
 	} else if policyClient, okPolicy := client.(homeCredentialPolicyDispatcher); okPolicy {
 		if constrainedClient, okConstraints := client.(homeCredentialPolicyConstraintsDispatcher); okConstraints {
 			raw, errRPop = constrainedClient.RPopAuthWithPolicyAndConstraints(ctx, requestedModel, sessionID, dispatchHeaders, homeAuthCountFromMetadata(opts.Metadata), credentialPolicy, excludedAuthIDList, pinnedAuthID)
@@ -1142,6 +1156,27 @@ func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, o
 		}
 	}
 	return selection, nil
+}
+
+func homeRetryRoundFromMetadata(metadata map[string]any) int {
+	if metadata == nil {
+		return 0
+	}
+	switch value := metadata[homeRetryRoundMetadataKey].(type) {
+	case int:
+		if value > 0 {
+			return value
+		}
+	case int64:
+		if value > 0 {
+			return int(value)
+		}
+	case float64:
+		if value > 0 && value == float64(int(value)) {
+			return int(value)
+		}
+	}
+	return 0
 }
 
 func requestedModelFromMetadata(metadata map[string]any, fallback string) string {

--- a/sdk/cliproxy/auth/conductor_home.go
+++ b/sdk/cliproxy/auth/conductor_home.go
@@ -20,6 +20,9 @@ import (
 
 const (
 	homeAuthCountMetadataKey = "__cliproxy_home_auth_count"
+	// ExcludedAuthIDsMetadataKey stores credential IDs already attempted in the
+	// current request retry round.
+	ExcludedAuthIDsMetadataKey = "excluded_auth_ids"
 	// CloseAllExecutionSessionsID asks an executor to release all active execution sessions.
 	// Executors that do not support this marker may ignore it.
 	CloseAllExecutionSessionsID = "__all_execution_sessions__"
@@ -120,6 +123,139 @@ type homeErrorDetail struct {
 	Code         string `json:"code,omitempty"`
 	Retryable    bool   `json:"retryable,omitempty"`
 	RetryAfterMS int64  `json:"retry_after_ms,omitempty"`
+	RequestRetry *int   `json:"request_retry,omitempty"`
+}
+
+type homeDispatchRetryAfterError struct {
+	cause           *Error
+	retryAfter      time.Duration
+	requestRetry    int
+	hasRequestRetry bool
+}
+
+// homeRetryRoundExhaustedError marks a terminal error produced after the
+// current Home credential round has been exhausted. The wrapped error retains
+// its status and retry-after metadata for the outer request retry policy.
+type homeRetryRoundExhaustedError struct {
+	cause         error
+	retryAfter    time.Duration
+	hasRetryAfter bool
+	retryNow      bool
+}
+
+func (e *homeRetryRoundExhaustedError) Error() string {
+	if e == nil || e.cause == nil {
+		return ""
+	}
+	return e.cause.Error()
+}
+
+func (e *homeRetryRoundExhaustedError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+func (e *homeRetryRoundExhaustedError) RetryAfter() *time.Duration {
+	if e == nil || !e.hasRetryAfter {
+		return nil
+	}
+	value := e.retryAfter
+	return &value
+}
+
+func markHomeRetryRoundExhausted(err error, retryAfter *time.Duration, retryNow bool) error {
+	if err == nil {
+		return nil
+	}
+	marked := &homeRetryRoundExhaustedError{cause: err, retryNow: retryNow}
+	if retryAfter != nil {
+		marked.retryAfter = *retryAfter
+		marked.hasRetryAfter = true
+	}
+	return marked
+}
+
+func isHomeRetryRoundExhausted(err error) bool {
+	if err == nil {
+		return false
+	}
+	var marker *homeRetryRoundExhaustedError
+	return errors.As(err, &marker) && marker != nil
+}
+
+type homeRetryRoundTiming struct {
+	retryAfter time.Duration
+	immediate  bool
+	invalid    bool
+}
+
+func (t *homeRetryRoundTiming) Observe(err error) {
+	if t == nil || err == nil || t.immediate || t.invalid {
+		return
+	}
+	retryAfter := retryAfterFromError(err)
+	if retryAfter == nil {
+		return
+	}
+	if *retryAfter == 0 {
+		t.retryAfter = 0
+		t.immediate = true
+		return
+	}
+	if *retryAfter < 0 {
+		t.retryAfter = *retryAfter
+		t.invalid = true
+		return
+	}
+	if t.retryAfter <= 0 || *retryAfter < t.retryAfter {
+		t.retryAfter = *retryAfter
+	}
+}
+
+func (t *homeRetryRoundTiming) RetryAfter() *time.Duration {
+	if t == nil || t.immediate || (!t.invalid && t.retryAfter <= 0) {
+		return nil
+	}
+	value := t.retryAfter
+	return &value
+}
+
+func (e *homeDispatchRetryAfterError) Error() string {
+	if e == nil || e.cause == nil {
+		return ""
+	}
+	return e.cause.Error()
+}
+
+func (e *homeDispatchRetryAfterError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+func (e *homeDispatchRetryAfterError) StatusCode() int {
+	if e == nil || e.cause == nil {
+		return 0
+	}
+	return e.cause.HTTPStatus
+}
+
+func (e *homeDispatchRetryAfterError) RetryAfter() *time.Duration {
+	if e == nil || e.retryAfter <= 0 {
+		return nil
+	}
+	value := e.retryAfter
+	return &value
+}
+
+func (e *homeDispatchRetryAfterError) RequestRetryLimit() (int, bool) {
+	if e == nil || !e.hasRequestRetry {
+		return 0, false
+	}
+	return e.requestRetry, true
 }
 
 const (
@@ -159,6 +295,30 @@ func shouldReturnLastErrorOnPickFailure(homeMode bool, lastErr error, errPick er
 	}
 }
 
+func isHomeNextRoundImmediatelyAvailable(err error) bool {
+	var authErr *Error
+	if !errors.As(err, &authErr) || authErr == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(authErr.Code), "auth_unavailable")
+}
+
+func pendingHomeRetryRoundDelay(err error, maxWait time.Duration, retryLimit *int, acceptRemoteRetryLimit bool) (time.Duration, bool) {
+	if err == nil || isHomeRetryRoundExhausted(err) {
+		return 0, false
+	}
+	var homeCooldown *homeDispatchRetryAfterError
+	if !errors.As(err, &homeCooldown) || homeCooldown == nil {
+		return 0, false
+	}
+	observeHomeCooldownRetryLimit(homeCooldown, retryLimit, acceptRemoteRetryLimit)
+	retryAfter := homeCooldown.RetryAfter()
+	if retryAfter == nil || *retryAfter <= 0 || maxWait <= 0 || *retryAfter > maxWait {
+		return 0, false
+	}
+	return *retryAfter, true
+}
+
 func homeAuthAlreadyTried(tried map[string]struct{}, authID string) bool {
 	authID = strings.TrimSpace(authID)
 	if authID == "" || len(tried) == 0 {
@@ -181,6 +341,7 @@ type homeAuthDispatchResponse struct {
 	Provider      string `json:"provider"`
 	AuthIndex     string `json:"auth_index"`
 	UserAPIKey    string `json:"user_api_key"`
+	RequestRetry  *int   `json:"request_retry,omitempty"`
 	ForceMapping  bool   `json:"force_mapping"`
 	OriginalAlias string `json:"original_alias"`
 	Auth          Auth   `json:"auth"`
@@ -192,8 +353,16 @@ type homeAuthDispatcher interface {
 	AbortAmbiguousDispatch()
 }
 
+type homeDispatchConstraintsDispatcher interface {
+	RPopAuthWithConstraints(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, excludedAuthIDs []string, pinnedAuthID string) ([]byte, error)
+}
+
 type homeCredentialPolicyDispatcher interface {
 	RPopAuthWithPolicy(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string) ([]byte, error)
+}
+
+type homeCredentialPolicyConstraintsDispatcher interface {
+	RPopAuthWithPolicyAndConstraints(ctx context.Context, requestedModel string, sessionID string, headers http.Header, count int, credentialPolicy string, excludedAuthIDs []string, pinnedAuthID string) ([]byte, error)
 }
 
 var currentHomeDispatcher = func() homeAuthDispatcher {
@@ -325,7 +494,7 @@ func (m *Manager) lockHomeWebsocketSession(ctx context.Context, opts cliproxyexe
 	return mutex.Unlock
 }
 
-func (m *Manager) retainedHomeSessionSelection(ctx context.Context, opts cliproxyexecutor.Options, model string) (*HomeDispatchSelection, bool, error) {
+func (m *Manager) retainedHomeSessionSelection(ctx context.Context, opts cliproxyexecutor.Options, model string, excludedAuthIDs map[string]struct{}) (*HomeDispatchSelection, bool, error) {
 	if m == nil || !cliproxyexecutor.DownstreamWebsocket(ctx) {
 		return nil, false, nil
 	}
@@ -348,7 +517,8 @@ func (m *Manager) retainedHomeSessionSelection(ctx context.Context, opts cliprox
 		}
 		matchesCredential := credentialID == "" || key.credentialID == credentialID
 		matchesRoute := validRouteModel && key.routeModel == routeModel
-		if !fallbackAttempt && matchesCredential && selection.Active() && matchesRoute && retained == nil {
+		_, excluded := excludedAuthIDs[strings.TrimSpace(key.credentialID)]
+		if !fallbackAttempt && !excluded && matchesCredential && selection.Active() && matchesRoute && retained == nil {
 			retained = selection
 			continue
 		}
@@ -711,7 +881,7 @@ func (m *Manager) pickNextViaHome(ctx context.Context, model string, opts clipro
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	selection, errSelection := m.pickHomeDispatchSelection(ctx, model, opts)
+	selection, errSelection := m.pickHomeDispatchSelection(ctx, model, withHomeExcludedAuthIDs(opts, tried))
 	if errSelection != nil {
 		return nil, nil, "", errSelection
 	}
@@ -739,7 +909,13 @@ func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, o
 	if requestedModel == "" {
 		requestedModel = requestedModelFromMetadata(opts.Metadata, model)
 	}
-	retained, retainedOK, errRetained := m.retainedHomeSessionSelection(ctx, opts, requestedModel)
+	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
+	excludedAuthIDList := homeExcludedAuthIDsFromMetadata(opts.Metadata)
+	excludedAuthIDs := make(map[string]struct{}, len(excludedAuthIDList))
+	for _, authID := range excludedAuthIDList {
+		excludedAuthIDs[authID] = struct{}{}
+	}
+	retained, retainedOK, errRetained := m.retainedHomeSessionSelection(ctx, opts, requestedModel, excludedAuthIDs)
 	if errRetained != nil {
 		return nil, errRetained
 	}
@@ -747,8 +923,8 @@ func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, o
 		return retained, nil
 	}
 	if sessionID := homeExecutionSessionIDFromMetadata(opts.Metadata); sessionID != "" {
-		if credentialID := pinnedAuthIDFromMetadata(opts.Metadata); credentialID != "" {
-			if errEnd := m.endMismatchedHomeSessionSelections(ctx, sessionID, credentialID, requestedModel, true); errEnd != nil {
+		if pinnedAuthID != "" {
+			if errEnd := m.endMismatchedHomeSessionSelections(ctx, sessionID, pinnedAuthID, requestedModel, true); errEnd != nil {
 				return nil, errEnd
 			}
 		}
@@ -763,6 +939,11 @@ func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, o
 	if !client.HeartbeatOK() {
 		return nil, &Error{Code: "home_unavailable", Message: "home control center unavailable", HTTPStatus: http.StatusServiceUnavailable}
 	}
+	if pinnedAuthID != "" {
+		if _, excluded := excludedAuthIDs[pinnedAuthID]; excluded {
+			return nil, &Error{Code: "auth_not_found", Message: "pinned auth is unavailable in the current retry round", HTTPStatus: http.StatusServiceUnavailable}
+		}
+	}
 	pending, errBegin := registry.BeginDispatch()
 	if errBegin != nil {
 		return nil, &Error{Code: "home_unavailable", Message: "home execution registry unavailable", Retryable: true, HTTPStatus: http.StatusServiceUnavailable}
@@ -774,9 +955,17 @@ func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, o
 	var raw []byte
 	var errRPop error
 	if credentialPolicy == "" {
-		raw, errRPop = client.RPopAuth(ctx, requestedModel, sessionID, dispatchHeaders, homeAuthCountFromMetadata(opts.Metadata))
+		if constrainedClient, okConstraints := client.(homeDispatchConstraintsDispatcher); okConstraints {
+			raw, errRPop = constrainedClient.RPopAuthWithConstraints(ctx, requestedModel, sessionID, dispatchHeaders, homeAuthCountFromMetadata(opts.Metadata), excludedAuthIDList, pinnedAuthID)
+		} else {
+			raw, errRPop = client.RPopAuth(ctx, requestedModel, sessionID, dispatchHeaders, homeAuthCountFromMetadata(opts.Metadata))
+		}
 	} else if policyClient, okPolicy := client.(homeCredentialPolicyDispatcher); okPolicy {
-		raw, errRPop = policyClient.RPopAuthWithPolicy(ctx, requestedModel, sessionID, dispatchHeaders, homeAuthCountFromMetadata(opts.Metadata), credentialPolicy)
+		if constrainedClient, okConstraints := client.(homeCredentialPolicyConstraintsDispatcher); okConstraints {
+			raw, errRPop = constrainedClient.RPopAuthWithPolicyAndConstraints(ctx, requestedModel, sessionID, dispatchHeaders, homeAuthCountFromMetadata(opts.Metadata), credentialPolicy, excludedAuthIDList, pinnedAuthID)
+		} else {
+			raw, errRPop = policyClient.RPopAuthWithPolicy(ctx, requestedModel, sessionID, dispatchHeaders, homeAuthCountFromMetadata(opts.Metadata), credentialPolicy)
+		}
 	} else {
 		pending.End()
 		return nil, &Error{Code: "home_unavailable", Message: "home dispatcher does not support credential policies", HTTPStatus: http.StatusServiceUnavailable}
@@ -887,6 +1076,10 @@ func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, o
 		endScope()
 		return nil, &Error{Code: "invalid_auth", Message: "home returned auth without id", HTTPStatus: http.StatusBadGateway}
 	}
+	if pinnedAuthID != "" && strings.TrimSpace(auth.ID) != pinnedAuthID {
+		endScope()
+		return nil, &Error{Code: "auth_not_found", Message: "home returned an auth that does not match the pinned credential", HTTPStatus: http.StatusServiceUnavailable}
+	}
 	if errIdentity := verifyAccountedHomeConcurrencyIdentity(envelope.Tuple, &auth, dispatch.AuthIndex); errIdentity != nil {
 		endScope()
 		return nil, errIdentity
@@ -934,6 +1127,10 @@ func (m *Manager) pickHomeDispatchSelection(ctx context.Context, model string, o
 	if errSelection != nil {
 		endScope()
 		return nil, &Error{Code: "home_unavailable", Message: "home execution registry unavailable", Retryable: true, HTTPStatus: http.StatusServiceUnavailable}
+	}
+	if pinnedAuthID == "" && dispatch.RequestRetry != nil && *dispatch.RequestRetry >= 0 {
+		selection.requestRetry = *dispatch.RequestRetry
+		selection.hasRequestRetry = true
 	}
 	if envelope.Present {
 		selection.accountedModel = envelope.Tuple.Model

--- a/sdk/cliproxy/auth/conductor_home_execution.go
+++ b/sdk/cliproxy/auth/conductor_home_execution.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/tidwall/sjson"
@@ -139,7 +140,9 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 				}
 				return selection.Executor.Execute(execCtx, preparedAuth, execReq, execOpts)
 			}
+			startHomeExec := time.Now()
 			response, errExecute = execute()
+			durationHomeExec := time.Since(startHomeExec)
 			refreshAuth := preparedAuth
 			if countTokens {
 				if observedAuth, fingerprint := getEffectiveAuth(); isUnauthorizedError(errExecute) {
@@ -152,17 +155,25 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 			if errExecute != nil {
 				if refreshed, okRefresh, errRefresh := m.tryRefreshExecutionAuthAfterUnauthorized(execCtx, selection.Executor, refreshAuth, errExecute, didRefreshOnUnauthorized, true); errRefresh != nil {
 					errExecute = errRefresh
+					warnLogUpstreamFailure(execCtx, entry, selection.Provider, upstreamModel, preparedAuth, durationHomeExec, errExecute)
 				} else if okRefresh {
 					preparedAuth = refreshed
 					m.replaceHomeSelectionAuth(selection, preparedAuth)
 					didRefreshOnUnauthorized = true
 					publishSelectedAuthMetadata(opts.Metadata, preparedAuth)
 					setEffectiveAuth(preparedAuth)
+					startHomeRetry := time.Now()
 					response, errExecute = execute()
-					if countTokens && isUnauthorizedError(errExecute) {
-						_, fingerprint := getEffectiveAuth()
-						m.reportHomeUnauthorized(execCtx, preparedAuth, selection.Provider, resultModel, fingerprint)
+					durationHomeRetry := time.Since(startHomeRetry)
+					if errExecute != nil {
+						warnLogUpstreamFailure(execCtx, entry, selection.Provider, upstreamModel, preparedAuth, durationHomeRetry, errExecute)
+						if countTokens && isUnauthorizedError(errExecute) {
+							_, fingerprint := getEffectiveAuth()
+							m.reportHomeUnauthorized(execCtx, preparedAuth, selection.Provider, resultModel, fingerprint)
+						}
 					}
+				} else {
+					warnLogUpstreamFailure(execCtx, entry, selection.Provider, upstreamModel, preparedAuth, durationHomeExec, errExecute)
 				}
 			}
 			result := Result{AuthID: preparedAuth.ID, Provider: selection.Provider, Model: resultModel, Success: errExecute == nil, Options: execOpts}

--- a/sdk/cliproxy/auth/conductor_home_execution.go
+++ b/sdk/cliproxy/auth/conductor_home_execution.go
@@ -15,14 +15,14 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 	if unlockSession := m.lockHomeWebsocketSession(ctx, opts); unlockSession != nil {
 		defer unlockSession()
 	}
-	_, maxRetryCredentials, maxWait := m.retrySettings()
+	defaultRequestRetry, maxRetryCredentials, maxWait := m.retrySettings()
 	retryModel := authSelectionModelFromOptions(opts, req.Model)
 	homeRetryLimit := -1
 	attempt := 0
 	retryRoundPending := false
 	retryRoundWaited := false
 	for {
-		response, errExecute := m.executeHomeOnce(ctx, providers, req, opts, countTokens, maxRetryCredentials, &homeRetryLimit)
+		response, errExecute := m.executeHomeOnce(ctx, providers, req, opts, countTokens, maxRetryCredentials, &homeRetryLimit, attempt)
 		if errExecute == nil {
 			return response, nil
 		}
@@ -43,7 +43,7 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 		if isRequestTerminatedError(errExecute) || isRequestStopError(errExecute) {
 			return cliproxyexecutor.Response{}, unwrapRequestStopError(errExecute)
 		}
-		wait, shouldRetry := m.shouldRetryAfterErrorWithHomeRetryLimit(ctx, opts, errExecute, attempt, providers, retryModel, maxWait, homeRetryLimit)
+		wait, shouldRetry := m.shouldRetryAfterErrorWithHomeRetryLimit(ctx, opts, errExecute, attempt, providers, retryModel, maxWait, homeRetryLimit, defaultRequestRetry)
 		if !shouldRetry {
 			return cliproxyexecutor.Response{}, unwrapRequestStopError(errExecute)
 		}
@@ -56,7 +56,11 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 	}
 }
 
-func (m *Manager) executeHomeOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, countTokens bool, maxRetryCredentials int, homeRetryLimit *int) (cliproxyexecutor.Response, error) {
+func (m *Manager) executeHomeOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, countTokens bool, maxRetryCredentials int, homeRetryLimit *int, retryRounds ...int) (cliproxyexecutor.Response, error) {
+	retryRound := 0
+	if len(retryRounds) > 0 {
+		retryRound = retryRounds[0]
+	}
 	routeModel := authSelectionModelFromOptions(opts, req.Model)
 	responseAlias := requestedModelAliasFromOptions(opts, routeModel)
 	executionModel, restoreExecutionModel := executionModelForAuthSelection(opts, req.Model)
@@ -72,7 +76,8 @@ func (m *Manager) executeHomeOnce(ctx context.Context, providers []string, req c
 			}
 			return cliproxyexecutor.Response{}, &Error{Code: "auth_not_found", Message: "no auth available"}
 		}
-		pickOpts := withHomeAuthCount(opts, homeAuthCount)
+		pickOpts := withHomeRetryRound(opts, retryRound)
+		pickOpts = withHomeAuthCount(pickOpts, homeAuthCount)
 		pickOpts = withHomeExcludedAuthIDs(pickOpts, tried)
 		selection, errSelection := m.pickHomeDispatchSelection(ctx, routeModel, pickOpts)
 		if errSelection != nil {

--- a/sdk/cliproxy/auth/conductor_home_execution.go
+++ b/sdk/cliproxy/auth/conductor_home_execution.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -14,17 +15,74 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 	if unlockSession := m.lockHomeWebsocketSession(ctx, opts); unlockSession != nil {
 		defer unlockSession()
 	}
+	_, maxRetryCredentials, maxWait := m.retrySettings()
+	retryModel := authSelectionModelFromOptions(opts, req.Model)
+	homeRetryLimit := -1
+	attempt := 0
+	retryRoundPending := false
+	retryRoundWaited := false
+	for {
+		response, errExecute := m.executeHomeOnce(ctx, providers, req, opts, countTokens, maxRetryCredentials, &homeRetryLimit)
+		if errExecute == nil {
+			return response, nil
+		}
+		if retryRoundPending {
+			if wait, okWait := pendingHomeRetryRoundDelay(errExecute, maxWait, &homeRetryLimit, pinnedAuthIDFromMetadata(opts.Metadata) == ""); okWait && m.homeRetryAllowed(attempt-1, homeRetryLimit) {
+				if retryRoundWaited {
+					return cliproxyexecutor.Response{}, errExecute
+				}
+				if errWait := waitForCooldown(ctx, wait, maxWait); errWait != nil {
+					return cliproxyexecutor.Response{}, errWait
+				}
+				retryRoundWaited = true
+				continue
+			}
+		}
+		retryRoundPending = false
+		retryRoundWaited = false
+		if isRequestTerminatedError(errExecute) || isRequestStopError(errExecute) {
+			return cliproxyexecutor.Response{}, unwrapRequestStopError(errExecute)
+		}
+		wait, shouldRetry := m.shouldRetryAfterErrorWithHomeRetryLimit(ctx, opts, errExecute, attempt, providers, retryModel, maxWait, homeRetryLimit)
+		if !shouldRetry {
+			return cliproxyexecutor.Response{}, unwrapRequestStopError(errExecute)
+		}
+		if errWait := waitForCooldown(ctx, wait, maxWait); errWait != nil {
+			return cliproxyexecutor.Response{}, errWait
+		}
+		attempt++
+		retryRoundPending = true
+		retryRoundWaited = false
+	}
+}
+
+func (m *Manager) executeHomeOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, countTokens bool, maxRetryCredentials int, homeRetryLimit *int) (cliproxyexecutor.Response, error) {
 	routeModel := authSelectionModelFromOptions(opts, req.Model)
 	responseAlias := requestedModelAliasFromOptions(opts, routeModel)
 	executionModel, restoreExecutionModel := executionModelForAuthSelection(opts, req.Model)
 	opts = ensureRequestedModelMetadata(opts, routeModel)
 	tried := make(map[string]struct{})
+	attempted := make(map[string]struct{})
 	var lastErr error
+	var roundTiming homeRetryRoundTiming
 	for homeAuthCount := 1; ; homeAuthCount++ {
-		selection, errSelection := m.pickHomeDispatchSelection(ctx, routeModel, withHomeAuthCount(opts, homeAuthCount))
+		if maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials {
+			if lastErr != nil {
+				return cliproxyexecutor.Response{}, markHomeRetryRoundExhausted(lastErr, roundTiming.RetryAfter(), true)
+			}
+			return cliproxyexecutor.Response{}, &Error{Code: "auth_not_found", Message: "no auth available"}
+		}
+		pickOpts := withHomeAuthCount(opts, homeAuthCount)
+		pickOpts = withHomeExcludedAuthIDs(pickOpts, tried)
+		selection, errSelection := m.pickHomeDispatchSelection(ctx, routeModel, pickOpts)
 		if errSelection != nil {
+			var homeCooldown *homeDispatchRetryAfterError
+			if lastErr != nil && errors.As(errSelection, &homeCooldown) && homeCooldown != nil {
+				observeHomeCooldownRetryLimit(homeCooldown, homeRetryLimit, pinnedAuthIDFromMetadata(opts.Metadata) == "")
+				return cliproxyexecutor.Response{}, markHomeRetryRoundExhausted(lastErr, homeCooldown.RetryAfter(), false)
+			}
 			if shouldReturnLastErrorOnPickFailure(true, lastErr, errSelection) {
-				return cliproxyexecutor.Response{}, lastErr
+				return cliproxyexecutor.Response{}, markHomeRetryRoundExhausted(lastErr, roundTiming.RetryAfter(), isHomeNextRoundImmediatelyAvailable(errSelection))
 			}
 			return cliproxyexecutor.Response{}, errSelection
 		}
@@ -33,13 +91,18 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 			selection.End("missing_execution_target")
 			return cliproxyexecutor.Response{}, &Error{Code: "executor_not_found", Message: "executor not registered"}
 		}
+		m.observeHomeRetryLimit(auth, selection, homeRetryLimit)
 		if _, seen := tried[auth.ID]; seen {
-			selection.End("repeated_auth")
+			if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "repeated_auth"); errEnd != nil {
+				return cliproxyexecutor.Response{}, errEnd
+			}
 			if lastErr != nil {
-				return cliproxyexecutor.Response{}, lastErr
+				return cliproxyexecutor.Response{}, markHomeRetryRoundExhausted(lastErr, roundTiming.RetryAfter(), false)
 			}
 			return cliproxyexecutor.Response{}, repeatedHomeAuthError()
 		}
+		tried[auth.ID] = struct{}{}
+		attempted[auth.ID] = struct{}{}
 		entry := logEntryWithRequestID(ctx)
 		debugLogAuthSelection(entry, auth, selection.Provider, routeModel)
 		if errRuntimeAuth := m.bindHomeSelectionRuntimeAuth(ctx, opts, selection); errRuntimeAuth != nil {
@@ -47,7 +110,6 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 			return cliproxyexecutor.Response{}, errRuntimeAuth
 		}
 		publishSelectedAuthMetadata(opts.Metadata, auth)
-		tried[auth.ID] = struct{}{}
 		execCtx, releaseAttempt, errBind := homeExecutionAttemptContext(ctx, selection)
 		if errBind != nil {
 			selection.End("attempt_bind_failed")
@@ -73,6 +135,7 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 				return cliproxyexecutor.Response{}, errEnd
 			}
 			lastErr = &Error{Code: "auth_not_found", Message: "no execution models available"}
+			roundTiming.Observe(lastErr)
 			continue
 		}
 		preparedAuth, errPrepare := m.prepareHomeRequestAuth(execCtx, selection.Executor, selection)
@@ -83,6 +146,7 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 				return cliproxyexecutor.Response{}, errEnd
 			}
 			lastErr = errPrepare
+			roundTiming.Observe(lastErr)
 			continue
 		}
 		didRefreshOnUnauthorized := false
@@ -216,6 +280,7 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 				break
 			}
 		}
+		roundTiming.Observe(lastErr)
 		releaseAttempt()
 		if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "execution_failed"); errEnd != nil {
 			return cliproxyexecutor.Response{}, errEnd

--- a/sdk/cliproxy/auth/conductor_home_execution.go
+++ b/sdk/cliproxy/auth/conductor_home_execution.go
@@ -2,8 +2,10 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/tidwall/sjson"
@@ -13,17 +15,79 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 	if unlockSession := m.lockHomeWebsocketSession(ctx, opts); unlockSession != nil {
 		defer unlockSession()
 	}
+	defaultRequestRetry, maxRetryCredentials, maxWait := m.retrySettings()
+	retryModel := authSelectionModelFromOptions(opts, req.Model)
+	homeRetryLimit := -1
+	attempt := 0
+	retryRoundPending := false
+	retryRoundWaited := false
+	for {
+		response, errExecute := m.executeHomeOnce(ctx, providers, req, opts, countTokens, maxRetryCredentials, &homeRetryLimit, attempt)
+		if errExecute == nil {
+			return response, nil
+		}
+		if retryRoundPending {
+			if wait, okWait := pendingHomeRetryRoundDelay(errExecute, maxWait, &homeRetryLimit, pinnedAuthIDFromMetadata(opts.Metadata) == ""); okWait && m.homeRetryAllowed(attempt-1, homeRetryLimit) {
+				if retryRoundWaited {
+					return cliproxyexecutor.Response{}, errExecute
+				}
+				if errWait := waitForCooldown(ctx, wait, maxWait); errWait != nil {
+					return cliproxyexecutor.Response{}, errWait
+				}
+				retryRoundWaited = true
+				continue
+			}
+		}
+		retryRoundPending = false
+		retryRoundWaited = false
+		if isRequestTerminatedError(errExecute) || isRequestStopError(errExecute) {
+			return cliproxyexecutor.Response{}, unwrapRequestStopError(errExecute)
+		}
+		wait, shouldRetry := m.shouldRetryAfterErrorWithHomeRetryLimit(ctx, opts, errExecute, attempt, providers, retryModel, maxWait, homeRetryLimit, defaultRequestRetry)
+		if !shouldRetry {
+			return cliproxyexecutor.Response{}, unwrapRequestStopError(errExecute)
+		}
+		if errWait := waitForCooldown(ctx, wait, maxWait); errWait != nil {
+			return cliproxyexecutor.Response{}, errWait
+		}
+		attempt++
+		retryRoundPending = true
+		retryRoundWaited = false
+	}
+}
+
+func (m *Manager) executeHomeOnce(ctx context.Context, providers []string, req cliproxyexecutor.Request, opts cliproxyexecutor.Options, countTokens bool, maxRetryCredentials int, homeRetryLimit *int, retryRounds ...int) (cliproxyexecutor.Response, error) {
+	retryRound := 0
+	if len(retryRounds) > 0 {
+		retryRound = retryRounds[0]
+	}
 	routeModel := authSelectionModelFromOptions(opts, req.Model)
 	responseAlias := requestedModelAliasFromOptions(opts, routeModel)
 	executionModel, restoreExecutionModel := executionModelForAuthSelection(opts, req.Model)
 	opts = ensureRequestedModelMetadata(opts, routeModel)
 	tried := make(map[string]struct{})
+	attempted := make(map[string]struct{})
 	var lastErr error
+	var roundTiming homeRetryRoundTiming
 	for homeAuthCount := 1; ; homeAuthCount++ {
-		selection, errSelection := m.pickHomeDispatchSelection(ctx, routeModel, withHomeAuthCount(opts, homeAuthCount))
+		if maxRetryCredentials > 0 && len(attempted) >= maxRetryCredentials {
+			if lastErr != nil {
+				return cliproxyexecutor.Response{}, markHomeRetryRoundExhausted(lastErr, roundTiming.RetryAfter(), true)
+			}
+			return cliproxyexecutor.Response{}, &Error{Code: "auth_not_found", Message: "no auth available"}
+		}
+		pickOpts := withHomeRetryRound(opts, retryRound)
+		pickOpts = withHomeAuthCount(pickOpts, homeAuthCount)
+		pickOpts = withHomeExcludedAuthIDs(pickOpts, tried)
+		selection, errSelection := m.pickHomeDispatchSelection(ctx, routeModel, pickOpts)
 		if errSelection != nil {
+			var homeCooldown *homeDispatchRetryAfterError
+			if lastErr != nil && errors.As(errSelection, &homeCooldown) && homeCooldown != nil {
+				observeHomeCooldownRetryLimit(homeCooldown, homeRetryLimit, pinnedAuthIDFromMetadata(opts.Metadata) == "")
+				return cliproxyexecutor.Response{}, markHomeRetryRoundExhausted(lastErr, homeCooldown.RetryAfter(), false)
+			}
 			if shouldReturnLastErrorOnPickFailure(true, lastErr, errSelection) {
-				return cliproxyexecutor.Response{}, lastErr
+				return cliproxyexecutor.Response{}, markHomeRetryRoundExhausted(lastErr, roundTiming.RetryAfter(), isHomeNextRoundImmediatelyAvailable(errSelection))
 			}
 			return cliproxyexecutor.Response{}, errSelection
 		}
@@ -32,13 +96,18 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 			selection.End("missing_execution_target")
 			return cliproxyexecutor.Response{}, &Error{Code: "executor_not_found", Message: "executor not registered"}
 		}
+		m.observeHomeRetryLimit(auth, selection, homeRetryLimit)
 		if _, seen := tried[auth.ID]; seen {
-			selection.End("repeated_auth")
+			if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "repeated_auth"); errEnd != nil {
+				return cliproxyexecutor.Response{}, errEnd
+			}
 			if lastErr != nil {
-				return cliproxyexecutor.Response{}, lastErr
+				return cliproxyexecutor.Response{}, markHomeRetryRoundExhausted(lastErr, roundTiming.RetryAfter(), false)
 			}
 			return cliproxyexecutor.Response{}, repeatedHomeAuthError()
 		}
+		tried[auth.ID] = struct{}{}
+		attempted[auth.ID] = struct{}{}
 		entry := logEntryWithRequestID(ctx)
 		debugLogAuthSelection(entry, auth, selection.Provider, routeModel)
 		if errRuntimeAuth := m.bindHomeSelectionRuntimeAuth(ctx, opts, selection); errRuntimeAuth != nil {
@@ -46,7 +115,6 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 			return cliproxyexecutor.Response{}, errRuntimeAuth
 		}
 		publishSelectedAuthMetadata(opts.Metadata, auth)
-		tried[auth.ID] = struct{}{}
 		execCtx, releaseAttempt, errBind := homeExecutionAttemptContext(ctx, selection)
 		if errBind != nil {
 			selection.End("attempt_bind_failed")
@@ -72,6 +140,7 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 				return cliproxyexecutor.Response{}, errEnd
 			}
 			lastErr = &Error{Code: "auth_not_found", Message: "no execution models available"}
+			roundTiming.Observe(lastErr)
 			continue
 		}
 		preparedAuth, errPrepare := m.prepareHomeRequestAuth(execCtx, selection.Executor, selection)
@@ -82,6 +151,7 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 				return cliproxyexecutor.Response{}, errEnd
 			}
 			lastErr = errPrepare
+			roundTiming.Observe(lastErr)
 			continue
 		}
 		didRefreshOnUnauthorized := false
@@ -139,7 +209,9 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 				}
 				return selection.Executor.Execute(execCtx, preparedAuth, execReq, execOpts)
 			}
+			startHomeExec := time.Now()
 			response, errExecute = execute()
+			durationHomeExec := time.Since(startHomeExec)
 			refreshAuth := preparedAuth
 			if countTokens {
 				if observedAuth, fingerprint := getEffectiveAuth(); isUnauthorizedError(errExecute) {
@@ -152,17 +224,25 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 			if errExecute != nil {
 				if refreshed, okRefresh, errRefresh := m.tryRefreshExecutionAuthAfterUnauthorized(execCtx, selection.Executor, refreshAuth, errExecute, didRefreshOnUnauthorized, true); errRefresh != nil {
 					errExecute = errRefresh
+					warnLogUpstreamFailure(execCtx, entry, selection.Provider, upstreamModel, preparedAuth, durationHomeExec, errExecute)
 				} else if okRefresh {
 					preparedAuth = refreshed
 					m.replaceHomeSelectionAuth(selection, preparedAuth)
 					didRefreshOnUnauthorized = true
 					publishSelectedAuthMetadata(opts.Metadata, preparedAuth)
 					setEffectiveAuth(preparedAuth)
+					startHomeRetry := time.Now()
 					response, errExecute = execute()
-					if countTokens && isUnauthorizedError(errExecute) {
-						_, fingerprint := getEffectiveAuth()
-						m.reportHomeUnauthorized(execCtx, preparedAuth, selection.Provider, resultModel, fingerprint)
+					durationHomeRetry := time.Since(startHomeRetry)
+					if errExecute != nil {
+						warnLogUpstreamFailure(execCtx, entry, selection.Provider, upstreamModel, preparedAuth, durationHomeRetry, errExecute)
+						if countTokens && isUnauthorizedError(errExecute) {
+							_, fingerprint := getEffectiveAuth()
+							m.reportHomeUnauthorized(execCtx, preparedAuth, selection.Provider, resultModel, fingerprint)
+						}
 					}
+				} else {
+					warnLogUpstreamFailure(execCtx, entry, selection.Provider, upstreamModel, preparedAuth, durationHomeExec, errExecute)
 				}
 			}
 			result := resultForAuthWithOptions(preparedAuth, selection.Provider, resultModel, errExecute == nil, nil, execOpts)
@@ -205,6 +285,7 @@ func (m *Manager) executeHome(ctx context.Context, providers []string, req clipr
 				break
 			}
 		}
+		roundTiming.Observe(lastErr)
 		releaseAttempt()
 		if errEnd := m.endHomeSelectionBeforeRedispatch(ctx, selection, "execution_failed"); errEnd != nil {
 			return cliproxyexecutor.Response{}, errEnd

--- a/sdk/cliproxy/auth/conductor_lifecycle.go
+++ b/sdk/cliproxy/auth/conductor_lifecycle.go
@@ -10,7 +10,7 @@ import (
 	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 )
 
-// SetRetryConfig updates retry attempts, credential retry limit and cooldown wait interval.
+// SetRetryConfig updates additional credential retry rounds, the per-round credential limit, and the cooldown wait interval.
 func (m *Manager) SetRetryConfig(retry int, maxRetryInterval time.Duration, maxRetryCredentials int) {
 	if m == nil {
 		return

--- a/sdk/cliproxy/auth/conductor_lts.go
+++ b/sdk/cliproxy/auth/conductor_lts.go
@@ -293,7 +293,7 @@ func (m *Manager) executeWithoutModelFallback(ctx context.Context, providers []s
 		return m.executeHome(ctx, normalized, req, opts, false)
 	}
 
-	_, maxRetryCredentials, maxWait := m.retrySettings()
+	defaultRequestRetry, maxRetryCredentials, maxWait := m.retrySettings()
 
 	var lastErr error
 	retryModel := authSelectionModelFromOptions(opts, req.Model)
@@ -302,9 +302,10 @@ func (m *Manager) executeWithoutModelFallback(ctx context.Context, providers []s
 	retryWithoutPenaltyUsage := budget.usage
 	retryWithoutPenaltyHedgeState := budget.hedge
 	retryWithoutPenaltyFallback := newRetryWithoutPenaltyFallbackCandidate(false)
+	retryRound := 0
 	for attempt := 0; ; {
 		attemptOpts := withRetryWithoutPenaltyUsageMetadata(opts, retryWithoutPenaltyUsage)
-		resp, errExec := m.executeMixedOnce(ctx, normalized, req, attemptOpts, maxRetryCredentials)
+		resp, errExec := m.executeMixedOnce(ctx, normalized, req, attemptOpts, maxRetryCredentials, retryRound, defaultRequestRetry)
 		if errExec == nil {
 			if fallbackResp, ok := retryWithoutPenaltyMaybeSelectFallbackResponse(resp, retryWithoutPenaltyFallback, retryWithoutPenaltyUsage); ok {
 				return fallbackResp, nil
@@ -352,7 +353,11 @@ func (m *Manager) executeWithoutModelFallback(ctx context.Context, providers []s
 				if codexModelFallbackTargetWave(opts) && !isRetryWithoutPenaltyError(outcome.err) {
 					break
 				}
-				wait, shouldRetry, terminalErr := m.shouldRetryAfterError(outcome.err, attempt, normalized, retryModel, maxWait, retryWithoutPenaltyCounts)
+				policyRound := retryRound
+				if !isRetryWithoutPenaltyError(outcome.err) {
+					policyRound = attempt
+				}
+				wait, shouldRetry, terminalErr := m.shouldRetryAfterErrorWithRetryPolicy(ctx, opts, outcome.err, policyRound, normalized, retryModel, maxWait, -1, defaultRequestRetry, retryWithoutPenaltyCounts)
 				if terminalErr != nil {
 					if resp, ok := retryWithoutPenaltyCandidateFallbackResponse(retryWithoutPenaltyFallback.Err(outcome.err), retryWithoutPenaltyFallback, retryWithoutPenaltyUsage); ok {
 						return resp, nil
@@ -365,6 +370,9 @@ func (m *Manager) executeWithoutModelFallback(ctx context.Context, providers []s
 				if errWait := waitForCooldown(ctx, wait, maxWait); errWait != nil {
 					return cliproxyexecutor.Response{}, errWait
 				}
+				if !isRetryWithoutPenaltyError(outcome.err) {
+					retryRound = policyRound + 1
+				}
 				attempt++
 				continue
 			}
@@ -372,7 +380,11 @@ func (m *Manager) executeWithoutModelFallback(ctx context.Context, providers []s
 		if codexModelFallbackTargetWave(opts) && !isRetryWithoutPenaltyError(errExec) {
 			break
 		}
-		wait, shouldRetry, terminalErr := m.shouldRetryAfterError(errExec, attempt, normalized, retryModel, maxWait, retryWithoutPenaltyCounts)
+		policyRound := retryRound
+		if !isRetryWithoutPenaltyError(errExec) {
+			policyRound = attempt
+		}
+		wait, shouldRetry, terminalErr := m.shouldRetryAfterErrorWithRetryPolicy(ctx, opts, errExec, policyRound, normalized, retryModel, maxWait, -1, defaultRequestRetry, retryWithoutPenaltyCounts)
 		if terminalErr != nil {
 			if resp, ok := retryWithoutPenaltyCandidateFallbackResponse(retryWithoutPenaltyFallback.Err(errExec), retryWithoutPenaltyFallback, retryWithoutPenaltyUsage); ok {
 				return resp, nil
@@ -384,6 +396,9 @@ func (m *Manager) executeWithoutModelFallback(ctx context.Context, providers []s
 		}
 		if errWait := waitForCooldown(ctx, wait, maxWait); errWait != nil {
 			return cliproxyexecutor.Response{}, errWait
+		}
+		if !isRetryWithoutPenaltyError(errExec) {
+			retryRound = policyRound + 1
 		}
 		attempt++
 	}
@@ -406,7 +421,7 @@ func (m *Manager) executeStreamWithoutModelFallback(ctx context.Context, provide
 		return nil, &Error{Code: "provider_not_found", Message: "no provider supplied"}
 	}
 
-	_, maxRetryCredentials, maxWait := m.retrySettings()
+	defaultRequestRetry, maxRetryCredentials, maxWait := m.retrySettings()
 
 	var lastErr error
 	retryModel := authSelectionModelFromOptions(opts, req.Model)
@@ -415,15 +430,33 @@ func (m *Manager) executeStreamWithoutModelFallback(ctx context.Context, provide
 	retryWithoutPenaltyUsage := budget.usage
 	retryWithoutPenaltyHedgeState := budget.hedge
 	retryWithoutPenaltyFallback := newRetryWithoutPenaltyFallbackCandidate(true)
+	retryRound := 0
+	homeRetryLimit := -1
+	retryRoundPending := false
+	retryRoundWaited := false
 	for attempt := 0; ; {
 		attemptOpts := withRetryWithoutPenaltyUsageMetadata(opts, retryWithoutPenaltyUsage)
-		result, errStream := m.executeStreamMixedOnce(ctx, normalized, req, attemptOpts, maxRetryCredentials)
+		result, errStream := m.executeStreamMixedOnce(ctx, normalized, req, attemptOpts, maxRetryCredentials, &homeRetryLimit, retryRound, defaultRequestRetry)
 		if errStream == nil {
 			if fallbackResult, ok := retryWithoutPenaltyMaybeSelectFallbackStreamResult(result, retryWithoutPenaltyFallback, retryWithoutPenaltyUsage); ok {
 				return fallbackResult, nil
 			}
 			return result, nil
 		}
+		if m.HomeEnabled() && retryRoundPending {
+			if wait, okWait := pendingHomeRetryRoundDelay(errStream, maxWait, &homeRetryLimit, pinnedAuthIDFromMetadata(opts.Metadata) == ""); okWait && m.homeRetryAllowed(retryRound-1, homeRetryLimit) {
+				if retryRoundWaited {
+					return nil, errStream
+				}
+				if errWait := waitForCooldown(ctx, wait, maxWait); errWait != nil {
+					return nil, errWait
+				}
+				retryRoundWaited = true
+				continue
+			}
+		}
+		retryRoundPending = false
+		retryRoundWaited = false
 		if isRequestTerminatedError(errStream) || isRequestStopError(errStream) {
 			return nil, errStream
 		}
@@ -465,7 +498,11 @@ func (m *Manager) executeStreamWithoutModelFallback(ctx context.Context, provide
 				if codexModelFallbackTargetWave(opts) && !isRetryWithoutPenaltyError(outcome.err) {
 					break
 				}
-				wait, shouldRetry, terminalErr := m.shouldRetryAfterError(outcome.err, attempt, normalized, retryModel, maxWait, retryWithoutPenaltyCounts)
+				policyRound := retryRound
+				if !isRetryWithoutPenaltyError(outcome.err) && !m.HomeEnabled() {
+					policyRound = attempt
+				}
+				wait, shouldRetry, terminalErr := m.shouldRetryAfterErrorWithRetryPolicy(ctx, opts, outcome.err, policyRound, normalized, retryModel, maxWait, -1, defaultRequestRetry, retryWithoutPenaltyCounts)
 				if terminalErr != nil {
 					if result, ok := retryWithoutPenaltyCandidateFallbackStreamResult(retryWithoutPenaltyFallback.Err(outcome.err), retryWithoutPenaltyFallback, retryWithoutPenaltyUsage); ok {
 						return result, nil
@@ -478,6 +515,9 @@ func (m *Manager) executeStreamWithoutModelFallback(ctx context.Context, provide
 				if errWait := waitForCooldown(ctx, wait, maxWait); errWait != nil {
 					return nil, errWait
 				}
+				if !isRetryWithoutPenaltyError(outcome.err) {
+					retryRound = policyRound + 1
+				}
 				attempt++
 				continue
 			}
@@ -485,7 +525,11 @@ func (m *Manager) executeStreamWithoutModelFallback(ctx context.Context, provide
 		if codexModelFallbackTargetWave(opts) && !isRetryWithoutPenaltyError(errStream) {
 			break
 		}
-		wait, shouldRetry, terminalErr := m.shouldRetryAfterError(errStream, attempt, normalized, retryModel, maxWait, retryWithoutPenaltyCounts)
+		policyRound := retryRound
+		if !isRetryWithoutPenaltyError(errStream) && !m.HomeEnabled() {
+			policyRound = attempt
+		}
+		wait, shouldRetry, terminalErr := m.shouldRetryAfterErrorWithRetryPolicy(ctx, opts, errStream, policyRound, normalized, retryModel, maxWait, homeRetryLimit, defaultRequestRetry, retryWithoutPenaltyCounts)
 		if terminalErr != nil {
 			if result, ok := retryWithoutPenaltyCandidateFallbackStreamResult(retryWithoutPenaltyFallback.Err(errStream), retryWithoutPenaltyFallback, retryWithoutPenaltyUsage); ok {
 				return result, nil
@@ -497,6 +541,11 @@ func (m *Manager) executeStreamWithoutModelFallback(ctx context.Context, provide
 		}
 		if errWait := waitForCooldown(ctx, wait, maxWait); errWait != nil {
 			return nil, errWait
+		}
+		if !isRetryWithoutPenaltyError(errStream) {
+			retryRound = policyRound + 1
+			retryRoundPending = m.HomeEnabled()
+			retryRoundWaited = false
 		}
 		attempt++
 	}

--- a/sdk/cliproxy/auth/conductor_oauth_request_scoped_errors_test.go
+++ b/sdk/cliproxy/auth/conductor_oauth_request_scoped_errors_test.go
@@ -1,0 +1,181 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestOAuthRequestScopedErrors_AppliesToOAuthAuth(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	cfg := &internalconfig.Config{
+		OAuthRequestScopedErrors: map[string][]internalconfig.RequestScopedErrorRule{
+			"vertex": {
+				{
+					Status: 400,
+					Match: []string{
+						"maximum_context_length",
+						"context_length_exceeded",
+					},
+					MatchRegexr: []string{
+						"maximum_context_length$",
+						"^context_length_exceeded",
+					},
+					Action: "stop",
+				},
+			},
+		},
+	}
+
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(cfg)
+
+	auth1 := &Auth{
+		ID:         "auth-vertex-oauth",
+		Provider:   "vertex",
+		Status:     StatusActive,
+		Attributes: map[string]string{"auth_kind": "oauth", "priority": "10"},
+	}
+	auth2 := &Auth{
+		ID:         "auth-vertex-oauth-2",
+		Provider:   "vertex",
+		Status:     StatusActive,
+		Attributes: map[string]string{"auth_kind": "oauth", "priority": "5"},
+	}
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth1.ID, "vertex", []*registry.ModelInfo{{ID: "claude-3-5-sonnet"}})
+	reg.RegisterClient(auth2.ID, "vertex", []*registry.ModelInfo{{ID: "claude-3-5-sonnet"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(auth1.ID)
+		reg.UnregisterClient(auth2.ID)
+	})
+
+	if _, err := m.Register(context.Background(), auth1); err != nil {
+		t.Fatalf("register auth1: %v", err)
+	}
+	if _, err := m.Register(context.Background(), auth2); err != nil {
+		t.Fatalf("register auth2: %v", err)
+	}
+
+	execCount := 0
+	exec := &mockCustomErrorExecutor{
+		identifier: "vertex",
+		executeFn: func(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+			execCount++
+			return cliproxyexecutor.Response{}, customStatusError{
+				code: http.StatusBadRequest,
+				msg:  `{"error": "maximum_context_length"}`,
+			}
+		},
+	}
+	m.RegisterExecutor(exec)
+
+	req := cliproxyexecutor.Request{Model: "claude-3-5-sonnet"}
+	opts := cliproxyexecutor.Options{}
+
+	_, errExec := m.Execute(context.Background(), []string{"vertex"}, req, opts)
+	if errExec == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	// Action: stop should terminate immediately and not try auth2
+	if execCount != 1 {
+		t.Fatalf("expected execCount = 1 (stopped), got %d", execCount)
+	}
+
+	// Action: stop without cooldown should leave auth1 active
+	auth1State, ok := m.GetByID("auth-vertex-oauth")
+	if !ok || auth1State.Status != StatusActive || auth1State.Unavailable {
+		t.Fatalf("expected auth1 to remain active, got status=%v unavailable=%v", auth1State.Status, auth1State.Unavailable)
+	}
+}
+
+func TestOAuthRequestScopedErrors_DoesNotApplyToAPIKey(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	cfg := &internalconfig.Config{
+		OAuthRequestScopedErrors: map[string][]internalconfig.RequestScopedErrorRule{
+			"vertex": {
+				{
+					Status: 500,
+					Match:  []string{"internal_server_error"},
+					Action: "stop",
+				},
+			},
+		},
+	}
+
+	m := NewManager(nil, nil, nil)
+	m.SetConfig(cfg)
+
+	// API key auth must not use oauth-request-scoped-errors
+	auth1 := &Auth{
+		ID:         "auth-vertex-apikey",
+		Provider:   "vertex",
+		Status:     StatusActive,
+		Attributes: map[string]string{"auth_kind": "apikey", "api_key": "test-key", "priority": "10"},
+	}
+	auth2 := &Auth{
+		ID:         "auth-vertex-apikey-2",
+		Provider:   "vertex",
+		Status:     StatusActive,
+		Attributes: map[string]string{"auth_kind": "apikey", "api_key": "test-key-2", "priority": "5"},
+	}
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth1.ID, "vertex", []*registry.ModelInfo{{ID: "claude-3-5-sonnet"}})
+	reg.RegisterClient(auth2.ID, "vertex", []*registry.ModelInfo{{ID: "claude-3-5-sonnet"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(auth1.ID)
+		reg.UnregisterClient(auth2.ID)
+	})
+
+	if _, err := m.Register(context.Background(), auth1); err != nil {
+		t.Fatalf("register auth1: %v", err)
+	}
+	if _, err := m.Register(context.Background(), auth2); err != nil {
+		t.Fatalf("register auth2: %v", err)
+	}
+
+	execCount := 0
+	exec := &mockCustomErrorExecutor{
+		identifier: "vertex",
+		executeFn: func(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+			execCount++
+			if execCount == 1 {
+				return cliproxyexecutor.Response{}, customStatusError{
+					code: http.StatusInternalServerError,
+					msg:  `{"error": "internal_server_error"}`,
+				}
+			}
+			return cliproxyexecutor.Response{Payload: []byte(`{"success": true}`)}, nil
+		},
+	}
+	m.RegisterExecutor(exec)
+
+	req := cliproxyexecutor.Request{Model: "claude-3-5-sonnet"}
+	opts := cliproxyexecutor.Options{}
+
+	resp, errExec := m.Execute(context.Background(), []string{"vertex"}, req, opts)
+	if errExec != nil {
+		t.Fatalf("unexpected Execute error: %v", errExec)
+	}
+	if string(resp.Payload) != `{"success": true}` {
+		t.Fatalf("unexpected payload: %s", string(resp.Payload))
+	}
+
+	// Should not have stopped at auth1; fell back to auth2 because OAuth rule was skipped for API key
+	if execCount != 2 {
+		t.Fatalf("expected execCount = 2 (rotated because OAuth rule skipped for API key), got %d", execCount)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -36,9 +36,12 @@ func TestManager_ShouldRetryAfterError_RespectsAuthRequestRetryOverride(t *testi
 				Unavailable:    true,
 				Status:         StatusError,
 				NextRetryAfter: next,
+				LastError:      &Error{HTTPStatus: http.StatusInternalServerError, Message: "upstream unavailable"},
 			},
 		},
 	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
 	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
 		t.Fatalf("register auth: %v", errRegister)
 	}
@@ -83,6 +86,255 @@ func TestManager_ShouldRetryAfterError_SkipsWrappedHomeConcurrencyBusy(t *testin
 	}
 }
 
+func TestManager_ShouldRetryAfterError_RetriesLocalRoundWithoutCooldown(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(1, 0, 0)
+	model := "gpt-retry-without-cooldown-" + uuid.NewString()
+	registry.GetGlobalRegistry().RegisterClient("retry-auth", "codex", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient("retry-auth") })
+	if _, errRegister := m.Register(context.Background(), &Auth{ID: "retry-auth", Provider: "codex"}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	for _, status := range []int{http.StatusTooManyRequests, http.StatusBadGateway} {
+		wait, shouldRetry := m.shouldRetryAfterError(&Error{HTTPStatus: status, Message: "retryable failure"}, 0, []string{"codex"}, model, 0)
+		if !shouldRetry || wait != 0 {
+			t.Fatalf("status %d retry = (%v, %t), want (0, true)", status, wait, shouldRetry)
+		}
+		if _, shouldRetry = m.shouldRetryAfterError(&Error{HTTPStatus: status, Message: "retryable failure"}, 1, []string{"codex"}, model, 0); shouldRetry {
+			t.Fatalf("status %d retried after the configured additional round", status)
+		}
+	}
+}
+
+func TestManager_ShouldRetryAfterError_DoesNotWaitWhenAnotherCredentialIsAvailable(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(1, time.Minute, 1)
+	model := "retry-available-credential-" + uuid.NewString()
+	next := time.Now().Add(30 * time.Second)
+	auths := []*Auth{
+		{
+			ID:       "cooling-" + uuid.NewString(),
+			Provider: "codex",
+			ModelStates: map[string]*ModelState{
+				model: {Unavailable: true, Status: StatusError, NextRetryAfter: next},
+			},
+		},
+		{ID: "available-" + uuid.NewString(), Provider: "codex"},
+	}
+	for _, auth := range auths {
+		registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+		t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+		if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+			t.Fatalf("register auth %s: %v", auth.ID, errRegister)
+		}
+	}
+
+	wait, shouldRetry := m.shouldRetryAfterError(&Error{HTTPStatus: http.StatusTooManyRequests, Message: "rate limited"}, 0, []string{"codex"}, model, time.Minute)
+	if !shouldRetry || wait != 0 {
+		t.Fatalf("retry with available credential = (%v, %t), want immediate retry", wait, shouldRetry)
+	}
+}
+
+func TestManager_ShouldRetryAfterError_IgnoresUnrelatedModelOverride(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(0, 0, 0)
+	targetModel := "retry-target-" + uuid.NewString()
+	unrelatedModel := "retry-unrelated-" + uuid.NewString()
+	registryRef := registry.GetGlobalRegistry()
+	registryRef.RegisterClient("target-auth", "codex", []*registry.ModelInfo{{ID: targetModel}})
+	registryRef.RegisterClient("unrelated-auth", "codex", []*registry.ModelInfo{{ID: unrelatedModel}})
+	t.Cleanup(func() {
+		registryRef.UnregisterClient("target-auth")
+		registryRef.UnregisterClient("unrelated-auth")
+	})
+	if _, errRegister := m.Register(context.Background(), &Auth{ID: "target-auth", Provider: "codex", Metadata: map[string]any{"request_retry": 0}}); errRegister != nil {
+		t.Fatalf("register target auth: %v", errRegister)
+	}
+	if _, errRegister := m.Register(context.Background(), &Auth{ID: "unrelated-auth", Provider: "codex", Metadata: map[string]any{"request_retry": 2}}); errRegister != nil {
+		t.Fatalf("register unrelated auth: %v", errRegister)
+	}
+
+	if wait, shouldRetry := m.shouldRetryAfterError(&Error{HTTPStatus: http.StatusBadGateway, Message: "retryable failure"}, 0, []string{"codex"}, targetModel, 0); shouldRetry || wait != 0 {
+		t.Fatalf("unrelated model override retry = (%v, %t), want (0, false)", wait, shouldRetry)
+	}
+}
+
+func TestManager_ShouldRetryAfterError_IgnoresDisabledRetryOverride(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(0, 0, 0)
+	if _, errRegister := m.Register(context.Background(), &Auth{ID: "active-auth", Provider: "codex", Metadata: map[string]any{"request_retry": 0}}); errRegister != nil {
+		t.Fatalf("register active auth: %v", errRegister)
+	}
+	if _, errRegister := m.Register(context.Background(), &Auth{ID: "disabled-auth", Provider: "codex", Disabled: true, Metadata: map[string]any{"request_retry": 2}}); errRegister != nil {
+		t.Fatalf("register disabled auth: %v", errRegister)
+	}
+
+	if wait, shouldRetry := m.shouldRetryAfterError(&Error{HTTPStatus: http.StatusBadGateway, Message: "retryable failure"}, 0, []string{"codex"}, "", 0); shouldRetry || wait != 0 {
+		t.Fatalf("disabled override retry = (%v, %t), want (0, false)", wait, shouldRetry)
+	}
+}
+
+func TestManager_ShouldRetryAfterError_IgnoresNonRoundCooldownOverrides(t *testing.T) {
+	tests := []struct {
+		name  string
+		state *ModelState
+	}{
+		{name: "model disabled", state: &ModelState{Status: StatusDisabled}},
+		{name: "unauthorized", state: &ModelState{Status: StatusError, Unavailable: true, LastError: &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"}}},
+		{name: "payment required", state: &ModelState{Status: StatusError, Unavailable: true, LastError: &Error{HTTPStatus: http.StatusPaymentRequired, Message: "payment required"}}},
+		{name: "not found", state: &ModelState{Status: StatusError, Unavailable: true, LastError: &Error{HTTPStatus: http.StatusNotFound, Message: "not found"}}},
+		{name: "model unsupported", state: &ModelState{Status: StatusError, Unavailable: true, LastError: &Error{HTTPStatus: http.StatusBadRequest, Message: "model not supported"}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manager := NewManager(nil, nil, nil)
+			manager.SetRetryConfig(0, time.Minute, 0)
+			model := "retry-non-round-" + uuid.NewString()
+			if test.state.Status != StatusDisabled {
+				test.state.NextRetryAfter = time.Now().Add(time.Minute)
+			}
+			auths := []*Auth{
+				{ID: "retry-round-eligible-" + uuid.NewString(), Provider: "codex", Metadata: map[string]any{"request_retry": 0}},
+				{
+					ID:          "retry-round-ineligible-" + uuid.NewString(),
+					Provider:    "codex",
+					Metadata:    map[string]any{"request_retry": 2},
+					ModelStates: map[string]*ModelState{model: test.state},
+				},
+			}
+			for _, auth := range auths {
+				registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+				t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+				if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+					t.Fatalf("register %s: %v", auth.ID, errRegister)
+				}
+			}
+
+			if wait, shouldRetry := manager.shouldRetryAfterError(&Error{HTTPStatus: http.StatusBadGateway, Message: "upstream unavailable"}, 0, []string{"codex"}, model, time.Minute); shouldRetry || wait != 0 {
+				t.Fatalf("non-round cooldown override retry = (%v, %t), want (0, false)", wait, shouldRetry)
+			}
+		})
+	}
+}
+
+func TestManager_ShouldRetryAfterError_IgnoresRequestIneligibleOverrides(t *testing.T) {
+	tests := []struct {
+		name       string
+		ctx        context.Context
+		opts       cliproxyexecutor.Options
+		eligible   *Auth
+		ineligible *Auth
+	}{
+		{
+			name: "credential policy",
+			ctx:  withCredentialPolicy(context.Background(), CredentialPolicyCodexAlphaSearchV1),
+			eligible: &Auth{
+				ID:         "retry-policy-eligible",
+				Provider:   "codex",
+				Attributes: map[string]string{"auth_kind": "oauth"},
+				Metadata:   map[string]any{"request_retry": 0},
+			},
+			ineligible: &Auth{
+				ID:         "retry-policy-ineligible",
+				Provider:   "codex",
+				Attributes: map[string]string{"api_key": "ordinary"},
+				Metadata:   map[string]any{"request_retry": 2},
+			},
+		},
+		{
+			name: "pinned credential",
+			ctx:  context.Background(),
+			opts: cliproxyexecutor.Options{Metadata: map[string]any{cliproxyexecutor.PinnedAuthMetadataKey: "retry-pinned-eligible"}},
+			eligible: &Auth{
+				ID:       "retry-pinned-eligible",
+				Provider: "codex",
+				Metadata: map[string]any{"request_retry": 0},
+			},
+			ineligible: &Auth{
+				ID:       "retry-pinned-ineligible",
+				Provider: "codex",
+				Metadata: map[string]any{"request_retry": 2},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manager := NewManager(nil, nil, nil)
+			manager.SetRetryConfig(0, 0, 0)
+			model := "retry-eligibility-" + uuid.NewString()
+			for _, auth := range []*Auth{test.eligible, test.ineligible} {
+				registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+				t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+				if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+					t.Fatalf("register %s: %v", auth.ID, errRegister)
+				}
+			}
+
+			wait, shouldRetry := manager.shouldRetryAfterErrorWithHomeRetryLimit(test.ctx, test.opts, &Error{HTTPStatus: http.StatusBadGateway, Message: "retryable failure"}, 0, []string{"codex"}, model, 0, -1)
+			if shouldRetry || wait != 0 {
+				t.Fatalf("request-ineligible override retry = (%v, %t), want (0, false)", wait, shouldRetry)
+			}
+		})
+	}
+}
+
+func TestManager_RequestRetryRunsAdditionalLocalRoundWithoutCooldown(t *testing.T) {
+	previousDisableCooling := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisableCooling) })
+
+	tests := []struct {
+		name    string
+		execute func(*Manager, cliproxyexecutor.Request) error
+	}{
+		{
+			name: "nonstream",
+			execute: func(m *Manager, req cliproxyexecutor.Request) error {
+				_, errExecute := m.Execute(context.Background(), []string{"claude"}, req, cliproxyexecutor.Options{})
+				return errExecute
+			},
+		},
+		{
+			name: "count tokens",
+			execute: func(m *Manager, req cliproxyexecutor.Request) error {
+				_, errExecute := m.ExecuteCount(context.Background(), []string{"claude"}, req, cliproxyexecutor.Options{})
+				return errExecute
+			},
+		},
+		{
+			name: "stream",
+			execute: func(m *Manager, req cliproxyexecutor.Request) error {
+				_, errExecute := m.ExecuteStream(context.Background(), []string{"claude"}, req, cliproxyexecutor.Options{Stream: true})
+				return errExecute
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewManager(nil, nil, nil)
+			m.SetRetryConfig(1, 0, 0)
+			executor := &credentialRetryLimitExecutor{id: "claude"}
+			m.RegisterExecutor(executor)
+			authID := uuid.NewString()
+			model := "retry-model-" + authID
+			auth := &Auth{ID: authID, Provider: "claude", Metadata: map[string]any{"disable_cooling": true}}
+			registry.GetGlobalRegistry().RegisterClient(authID, "claude", []*registry.ModelInfo{{ID: model}})
+			t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(authID) })
+			if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+				t.Fatalf("register auth: %v", errRegister)
+			}
+
+			if errExecute := tc.execute(m, cliproxyexecutor.Request{Model: model}); errExecute == nil || statusCodeFromError(errExecute) != http.StatusInternalServerError {
+				t.Fatalf("execute error = %v, want status 500", errExecute)
+			}
+			if got := executor.Calls(); got != 2 {
+				t.Fatalf("executor calls = %d, want initial round plus one additional round", got)
+			}
+		})
+	}
+}
+
 func TestManager_ShouldRetryAfterError_UsesOAuthModelAliasForCooldown(t *testing.T) {
 	m := NewManager(nil, nil, nil)
 	m.SetRetryConfig(3, 30*time.Second, 0)
@@ -112,6 +364,8 @@ func TestManager_ShouldRetryAfterError_UsesOAuthModelAliasForCooldown(t *testing
 			},
 		},
 	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: upstreamModel}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
 	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
 		t.Fatalf("register auth: %v", errRegister)
 	}

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -271,7 +271,7 @@ func TestManager_ShouldRetryAfterError_IgnoresRequestIneligibleOverrides(t *test
 				}
 			}
 
-			wait, shouldRetry := manager.shouldRetryAfterErrorWithHomeRetryLimit(test.ctx, test.opts, &Error{HTTPStatus: http.StatusBadGateway, Message: "retryable failure"}, 0, []string{"codex"}, model, 0, -1)
+			wait, shouldRetry := manager.shouldRetryAfterErrorWithHomeRetryLimit(test.ctx, test.opts, &Error{HTTPStatus: http.StatusBadGateway, Message: "retryable failure"}, 0, []string{"codex"}, model, 0, -1, 0)
 			if shouldRetry || wait != 0 {
 				t.Fatalf("request-ineligible override retry = (%v, %t), want (0, false)", wait, shouldRetry)
 			}

--- a/sdk/cliproxy/auth/conductor_overrides_test.go
+++ b/sdk/cliproxy/auth/conductor_overrides_test.go
@@ -62,9 +62,12 @@ func TestManager_ShouldRetryAfterError_RespectsAuthRequestRetryOverride(t *testi
 				Unavailable:    true,
 				Status:         StatusError,
 				NextRetryAfter: next,
+				LastError:      &Error{HTTPStatus: http.StatusInternalServerError, Message: "upstream unavailable"},
 			},
 		},
 	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
 	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
 		t.Fatalf("register auth: %v", errRegister)
 	}
@@ -121,6 +124,255 @@ func TestManager_ShouldRetryAfterError_SkipsWrappedHomeConcurrencyBusy(t *testin
 	}
 }
 
+func TestManager_ShouldRetryAfterError_RetriesLocalRoundWithoutCooldown(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(1, 0, 0)
+	model := "gpt-retry-without-cooldown-" + uuid.NewString()
+	registry.GetGlobalRegistry().RegisterClient("retry-auth", "codex", []*registry.ModelInfo{{ID: model}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient("retry-auth") })
+	if _, errRegister := m.Register(context.Background(), &Auth{ID: "retry-auth", Provider: "codex"}); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	for _, status := range []int{http.StatusTooManyRequests, http.StatusBadGateway} {
+		wait, shouldRetry, _ := m.shouldRetryAfterError(&Error{HTTPStatus: status, Message: "retryable failure"}, 0, []string{"codex"}, model, 0, nil)
+		if !shouldRetry || wait != 0 {
+			t.Fatalf("status %d retry = (%v, %t), want (0, true)", status, wait, shouldRetry)
+		}
+		if _, shouldRetry, _ = m.shouldRetryAfterError(&Error{HTTPStatus: status, Message: "retryable failure"}, 1, []string{"codex"}, model, 0, nil); shouldRetry {
+			t.Fatalf("status %d retried after the configured additional round", status)
+		}
+	}
+}
+
+func TestManager_ShouldRetryAfterError_DoesNotWaitWhenAnotherCredentialIsAvailable(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(1, time.Minute, 1)
+	model := "retry-available-credential-" + uuid.NewString()
+	next := time.Now().Add(30 * time.Second)
+	auths := []*Auth{
+		{
+			ID:       "cooling-" + uuid.NewString(),
+			Provider: "codex",
+			ModelStates: map[string]*ModelState{
+				model: {Unavailable: true, Status: StatusError, NextRetryAfter: next},
+			},
+		},
+		{ID: "available-" + uuid.NewString(), Provider: "codex"},
+	}
+	for _, auth := range auths {
+		registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+		t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+		if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+			t.Fatalf("register auth %s: %v", auth.ID, errRegister)
+		}
+	}
+
+	wait, shouldRetry, _ := m.shouldRetryAfterError(&Error{HTTPStatus: http.StatusTooManyRequests, Message: "rate limited"}, 0, []string{"codex"}, model, time.Minute, nil)
+	if !shouldRetry || wait != 0 {
+		t.Fatalf("retry with available credential = (%v, %t), want immediate retry", wait, shouldRetry)
+	}
+}
+
+func TestManager_ShouldRetryAfterError_IgnoresUnrelatedModelOverride(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(0, 0, 0)
+	targetModel := "retry-target-" + uuid.NewString()
+	unrelatedModel := "retry-unrelated-" + uuid.NewString()
+	registryRef := registry.GetGlobalRegistry()
+	registryRef.RegisterClient("target-auth", "codex", []*registry.ModelInfo{{ID: targetModel}})
+	registryRef.RegisterClient("unrelated-auth", "codex", []*registry.ModelInfo{{ID: unrelatedModel}})
+	t.Cleanup(func() {
+		registryRef.UnregisterClient("target-auth")
+		registryRef.UnregisterClient("unrelated-auth")
+	})
+	if _, errRegister := m.Register(context.Background(), &Auth{ID: "target-auth", Provider: "codex", Metadata: map[string]any{"request_retry": 0}}); errRegister != nil {
+		t.Fatalf("register target auth: %v", errRegister)
+	}
+	if _, errRegister := m.Register(context.Background(), &Auth{ID: "unrelated-auth", Provider: "codex", Metadata: map[string]any{"request_retry": 2}}); errRegister != nil {
+		t.Fatalf("register unrelated auth: %v", errRegister)
+	}
+
+	if wait, shouldRetry, _ := m.shouldRetryAfterError(&Error{HTTPStatus: http.StatusBadGateway, Message: "retryable failure"}, 0, []string{"codex"}, targetModel, 0, nil); shouldRetry || wait != 0 {
+		t.Fatalf("unrelated model override retry = (%v, %t), want (0, false)", wait, shouldRetry)
+	}
+}
+
+func TestManager_ShouldRetryAfterError_IgnoresDisabledRetryOverride(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(0, 0, 0)
+	if _, errRegister := m.Register(context.Background(), &Auth{ID: "active-auth", Provider: "codex", Metadata: map[string]any{"request_retry": 0}}); errRegister != nil {
+		t.Fatalf("register active auth: %v", errRegister)
+	}
+	if _, errRegister := m.Register(context.Background(), &Auth{ID: "disabled-auth", Provider: "codex", Disabled: true, Metadata: map[string]any{"request_retry": 2}}); errRegister != nil {
+		t.Fatalf("register disabled auth: %v", errRegister)
+	}
+
+	if wait, shouldRetry, _ := m.shouldRetryAfterError(&Error{HTTPStatus: http.StatusBadGateway, Message: "retryable failure"}, 0, []string{"codex"}, "", 0, nil); shouldRetry || wait != 0 {
+		t.Fatalf("disabled override retry = (%v, %t), want (0, false)", wait, shouldRetry)
+	}
+}
+
+func TestManager_ShouldRetryAfterError_IgnoresNonRoundCooldownOverrides(t *testing.T) {
+	tests := []struct {
+		name  string
+		state *ModelState
+	}{
+		{name: "model disabled", state: &ModelState{Status: StatusDisabled}},
+		{name: "unauthorized", state: &ModelState{Status: StatusError, Unavailable: true, LastError: &Error{HTTPStatus: http.StatusUnauthorized, Message: "unauthorized"}}},
+		{name: "payment required", state: &ModelState{Status: StatusError, Unavailable: true, LastError: &Error{HTTPStatus: http.StatusPaymentRequired, Message: "payment required"}}},
+		{name: "not found", state: &ModelState{Status: StatusError, Unavailable: true, LastError: &Error{HTTPStatus: http.StatusNotFound, Message: "not found"}}},
+		{name: "model unsupported", state: &ModelState{Status: StatusError, Unavailable: true, LastError: &Error{HTTPStatus: http.StatusBadRequest, Message: "model not supported"}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manager := NewManager(nil, nil, nil)
+			manager.SetRetryConfig(0, time.Minute, 0)
+			model := "retry-non-round-" + uuid.NewString()
+			if test.state.Status != StatusDisabled {
+				test.state.NextRetryAfter = time.Now().Add(time.Minute)
+			}
+			auths := []*Auth{
+				{ID: "retry-round-eligible-" + uuid.NewString(), Provider: "codex", Metadata: map[string]any{"request_retry": 0}},
+				{
+					ID:          "retry-round-ineligible-" + uuid.NewString(),
+					Provider:    "codex",
+					Metadata:    map[string]any{"request_retry": 2},
+					ModelStates: map[string]*ModelState{model: test.state},
+				},
+			}
+			for _, auth := range auths {
+				registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+				t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+				if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+					t.Fatalf("register %s: %v", auth.ID, errRegister)
+				}
+			}
+
+			if wait, shouldRetry, _ := manager.shouldRetryAfterError(&Error{HTTPStatus: http.StatusBadGateway, Message: "upstream unavailable"}, 0, []string{"codex"}, model, time.Minute, nil); shouldRetry || wait != 0 {
+				t.Fatalf("non-round cooldown override retry = (%v, %t), want (0, false)", wait, shouldRetry)
+			}
+		})
+	}
+}
+
+func TestManager_ShouldRetryAfterError_IgnoresRequestIneligibleOverrides(t *testing.T) {
+	tests := []struct {
+		name       string
+		ctx        context.Context
+		opts       cliproxyexecutor.Options
+		eligible   *Auth
+		ineligible *Auth
+	}{
+		{
+			name: "credential policy",
+			ctx:  withCredentialPolicy(context.Background(), CredentialPolicyCodexAlphaSearchV1),
+			eligible: &Auth{
+				ID:         "retry-policy-eligible",
+				Provider:   "codex",
+				Attributes: map[string]string{"auth_kind": "oauth"},
+				Metadata:   map[string]any{"request_retry": 0},
+			},
+			ineligible: &Auth{
+				ID:         "retry-policy-ineligible",
+				Provider:   "codex",
+				Attributes: map[string]string{"api_key": "ordinary"},
+				Metadata:   map[string]any{"request_retry": 2},
+			},
+		},
+		{
+			name: "pinned credential",
+			ctx:  context.Background(),
+			opts: cliproxyexecutor.Options{Metadata: map[string]any{cliproxyexecutor.PinnedAuthMetadataKey: "retry-pinned-eligible"}},
+			eligible: &Auth{
+				ID:       "retry-pinned-eligible",
+				Provider: "codex",
+				Metadata: map[string]any{"request_retry": 0},
+			},
+			ineligible: &Auth{
+				ID:       "retry-pinned-ineligible",
+				Provider: "codex",
+				Metadata: map[string]any{"request_retry": 2},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manager := NewManager(nil, nil, nil)
+			manager.SetRetryConfig(0, 0, 0)
+			model := "retry-eligibility-" + uuid.NewString()
+			for _, auth := range []*Auth{test.eligible, test.ineligible} {
+				registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+				t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
+				if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+					t.Fatalf("register %s: %v", auth.ID, errRegister)
+				}
+			}
+
+			wait, shouldRetry := manager.shouldRetryAfterErrorWithHomeRetryLimit(test.ctx, test.opts, &Error{HTTPStatus: http.StatusBadGateway, Message: "retryable failure"}, 0, []string{"codex"}, model, 0, -1, 0)
+			if shouldRetry || wait != 0 {
+				t.Fatalf("request-ineligible override retry = (%v, %t), want (0, false)", wait, shouldRetry)
+			}
+		})
+	}
+}
+
+func TestManager_RequestRetryRunsAdditionalLocalRoundWithoutCooldown(t *testing.T) {
+	previousDisableCooling := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousDisableCooling) })
+
+	tests := []struct {
+		name    string
+		execute func(*Manager, cliproxyexecutor.Request) error
+	}{
+		{
+			name: "nonstream",
+			execute: func(m *Manager, req cliproxyexecutor.Request) error {
+				_, errExecute := m.Execute(context.Background(), []string{"claude"}, req, cliproxyexecutor.Options{})
+				return errExecute
+			},
+		},
+		{
+			name: "count tokens",
+			execute: func(m *Manager, req cliproxyexecutor.Request) error {
+				_, errExecute := m.ExecuteCount(context.Background(), []string{"claude"}, req, cliproxyexecutor.Options{})
+				return errExecute
+			},
+		},
+		{
+			name: "stream",
+			execute: func(m *Manager, req cliproxyexecutor.Request) error {
+				_, errExecute := m.ExecuteStream(context.Background(), []string{"claude"}, req, cliproxyexecutor.Options{Stream: true})
+				return errExecute
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewManager(nil, nil, nil)
+			m.SetRetryConfig(1, 0, 0)
+			executor := &credentialRetryLimitExecutor{id: "claude"}
+			m.RegisterExecutor(executor)
+			authID := uuid.NewString()
+			model := "retry-model-" + authID
+			auth := &Auth{ID: authID, Provider: "claude", Metadata: map[string]any{"disable_cooling": true}}
+			registry.GetGlobalRegistry().RegisterClient(authID, "claude", []*registry.ModelInfo{{ID: model}})
+			t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(authID) })
+			if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
+				t.Fatalf("register auth: %v", errRegister)
+			}
+
+			if errExecute := tc.execute(m, cliproxyexecutor.Request{Model: model}); errExecute == nil || statusCodeFromError(errExecute) != http.StatusInternalServerError {
+				t.Fatalf("execute error = %v, want status 500", errExecute)
+			}
+			if got := executor.Calls(); got != 2 {
+				t.Fatalf("executor calls = %d, want initial round plus one additional round", got)
+			}
+		})
+	}
+}
+
 func TestManager_ShouldRetryAfterError_UsesOAuthModelAliasForCooldown(t *testing.T) {
 	m := NewManager(nil, nil, nil)
 	m.SetRetryConfig(3, 30*time.Second, 0)
@@ -150,6 +402,8 @@ func TestManager_ShouldRetryAfterError_UsesOAuthModelAliasForCooldown(t *testing
 			},
 		},
 	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: upstreamModel}})
+	t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(auth.ID) })
 	if _, errRegister := m.Register(context.Background(), auth); errRegister != nil {
 		t.Fatalf("register auth: %v", errRegister)
 	}

--- a/sdk/cliproxy/auth/conductor_request_scoped_errors.go
+++ b/sdk/cliproxy/auth/conductor_request_scoped_errors.go
@@ -87,6 +87,16 @@ func extractRequestScopedErrorRules(auth *Auth, cfg *internalconfig.Config) []in
 		return nil
 	}
 
+	if auth.AuthKind() == AuthKindOAuth {
+		if len(cfg.OAuthRequestScopedErrors) > 0 {
+			provider := strings.ToLower(strings.TrimSpace(auth.Provider))
+			if rules, ok := cfg.OAuthRequestScopedErrors[provider]; ok && len(rules) > 0 {
+				return rules
+			}
+		}
+		return nil
+	}
+
 	provider := strings.ToLower(strings.TrimSpace(auth.Provider))
 	index := -1
 	if auth.Attributes != nil {

--- a/sdk/cliproxy/auth/conductor_retry_round_test.go
+++ b/sdk/cliproxy/auth/conductor_retry_round_test.go
@@ -1,0 +1,455 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sort"
+	"sync"
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/home"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executionregistry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type retryRoundCallExecutor struct {
+	identifier string
+	mu         sync.Mutex
+	executeIDs []string
+	streamIDs  []string
+	countIDs   []string
+}
+
+func (e *retryRoundCallExecutor) Identifier() string { return e.identifier }
+
+func (e *retryRoundCallExecutor) Execute(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.mu.Lock()
+	e.executeIDs = append(e.executeIDs, auth.ID)
+	e.mu.Unlock()
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusInternalServerError, Message: "retry-round test failure"}
+}
+
+func (e *retryRoundCallExecutor) ExecuteStream(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	e.mu.Lock()
+	e.streamIDs = append(e.streamIDs, auth.ID)
+	e.mu.Unlock()
+	return nil, &Error{HTTPStatus: http.StatusInternalServerError, Message: "retry-round test failure"}
+}
+
+func (*retryRoundCallExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (e *retryRoundCallExecutor) CountTokens(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.mu.Lock()
+	e.countIDs = append(e.countIDs, auth.ID)
+	e.mu.Unlock()
+	return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusInternalServerError, Message: "retry-round test failure"}
+}
+
+func (*retryRoundCallExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func (e *retryRoundCallExecutor) ids(kind string) []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	var source []string
+	switch kind {
+	case "execute":
+		source = e.executeIDs
+	case "stream":
+		source = e.streamIDs
+	case "count":
+		source = e.countIDs
+	}
+	return append([]string(nil), source...)
+}
+
+func registerRetryRoundLocalAuths(t *testing.T, manager *Manager, provider, model string, limits map[string]int) []string {
+	t.Helper()
+	ids := make([]string, 0, len(limits))
+	for id := range limits {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	reg := registry.GetGlobalRegistry()
+	for _, id := range ids {
+		reg.RegisterClient(id, provider, []*registry.ModelInfo{{ID: model}})
+		t.Cleanup(func() { reg.UnregisterClient(id) })
+		if _, errRegister := manager.Register(context.Background(), &Auth{
+			ID:       id,
+			Provider: provider,
+			Metadata: map[string]any{"request_retry": limits[id], "disable_cooling": true},
+		}); errRegister != nil {
+			t.Fatalf("register %s: %v", id, errRegister)
+		}
+	}
+	return ids
+}
+
+func countRetryRoundIDs(ids []string) map[string]int {
+	counts := make(map[string]int, len(ids))
+	for _, id := range ids {
+		counts[id]++
+	}
+	return counts
+}
+
+func TestExecuteRetryRoundCredentialWindows(t *testing.T) {
+	tests := []struct {
+		name   string
+		invoke func(*Manager, cliproxyexecutor.Request) error
+		kind   string
+	}{
+		{
+			name: "non-stream",
+			invoke: func(manager *Manager, req cliproxyexecutor.Request) error {
+				_, errExecute := manager.Execute(context.Background(), []string{"retry-round-test"}, req, cliproxyexecutor.Options{})
+				return errExecute
+			},
+			kind: "execute",
+		},
+		{
+			name: "count-tokens",
+			invoke: func(manager *Manager, req cliproxyexecutor.Request) error {
+				_, errExecute := manager.ExecuteCount(context.Background(), []string{"retry-round-test"}, req, cliproxyexecutor.Options{})
+				return errExecute
+			},
+			kind: "count",
+		},
+		{
+			name: "stream",
+			invoke: func(manager *Manager, req cliproxyexecutor.Request) error {
+				_, errExecute := manager.ExecuteStream(context.Background(), []string{"retry-round-test"}, req, cliproxyexecutor.Options{Stream: true})
+				return errExecute
+			},
+			kind: "stream",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manager := NewManager(nil, nil, nil)
+			manager.SetRetryConfig(3, 0, 0)
+			executor := &retryRoundCallExecutor{identifier: "retry-round-test"}
+			manager.RegisterExecutor(executor)
+			registerRetryRoundLocalAuths(t, manager, "retry-round-test", "retry-round-model", map[string]int{
+				"retry-round-a": 3,
+				"retry-round-b": 2,
+				"retry-round-c": 2,
+			})
+
+			if errExecute := test.invoke(manager, cliproxyexecutor.Request{Model: "retry-round-model"}); errExecute == nil {
+				t.Fatal("execution error = nil, want terminal retry error")
+			}
+			counts := countRetryRoundIDs(executor.ids(test.kind))
+			if counts["retry-round-a"] != 4 || counts["retry-round-b"] != 3 || counts["retry-round-c"] != 3 {
+				t.Fatalf("credential call counts = %#v, want A=4 B=3 C=3; calls=%v", counts, executor.ids(test.kind))
+			}
+		})
+	}
+}
+
+func TestExecuteRetryRoundMaxCredentialsAgesSkippedAuths(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	manager.SetRetryConfig(2, 0, 3)
+	executor := &retryRoundCallExecutor{identifier: "retry-round-test"}
+	manager.RegisterExecutor(executor)
+	registerRetryRoundLocalAuths(t, manager, "retry-round-test", "retry-round-model-cap", map[string]int{
+		"retry-cap-a": 1,
+		"retry-cap-b": 1,
+		"retry-cap-c": 1,
+		"retry-cap-d": 2,
+	})
+
+	if _, errExecute := manager.Execute(context.Background(), []string{"retry-round-test"}, cliproxyexecutor.Request{Model: "retry-round-model-cap"}, cliproxyexecutor.Options{}); errExecute == nil {
+		t.Fatal("execution error = nil, want terminal retry error")
+	}
+	calls := executor.ids("execute")
+	if len(calls) != 7 {
+		t.Fatalf("credential calls = %v, want three initial, three round-1, and one round-2 call", calls)
+	}
+	counts := countRetryRoundIDs(calls)
+	if counts["retry-cap-a"] > 2 || counts["retry-cap-b"] > 2 || counts["retry-cap-c"] > 2 || counts["retry-cap-d"] > 3 {
+		t.Fatalf("credential call counts exceed their round windows: %#v", counts)
+	}
+	if calls[len(calls)-1] != "retry-cap-d" {
+		t.Fatalf("last retry call = %q, want retry-cap-d; calls=%v", calls[len(calls)-1], calls)
+	}
+}
+
+type retryConfigMutationExecutor struct {
+	identifier  string
+	manager     *Manager
+	nextDefault int
+
+	mu    sync.Mutex
+	calls int
+}
+
+func (e *retryConfigMutationExecutor) Identifier() string { return e.identifier }
+
+func (e *retryConfigMutationExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	if e.recordCall() == 1 {
+		return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusInternalServerError, Message: "retry config changed"}
+	}
+	return cliproxyexecutor.Response{Payload: []byte("ok")}, nil
+}
+
+func (e *retryConfigMutationExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	if e.recordCall() == 1 {
+		return nil, &Error{HTTPStatus: http.StatusInternalServerError, Message: "retry config changed"}
+	}
+	chunks := make(chan cliproxyexecutor.StreamChunk)
+	close(chunks)
+	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (*retryConfigMutationExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (e *retryConfigMutationExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	if e.recordCall() == 1 {
+		return cliproxyexecutor.Response{}, &Error{HTTPStatus: http.StatusInternalServerError, Message: "retry config changed"}
+	}
+	return cliproxyexecutor.Response{Payload: []byte("ok")}, nil
+}
+
+func (*retryConfigMutationExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func (e *retryConfigMutationExecutor) recordCall() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.calls++
+	if e.calls == 1 {
+		e.manager.SetRetryConfig(e.nextDefault, 0, 0)
+	}
+	return e.calls
+}
+
+func (e *retryConfigMutationExecutor) callCount() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.calls
+}
+
+func TestExecuteSnapshotsDefaultRequestRetry(t *testing.T) {
+	paths := []struct {
+		name   string
+		invoke func(*Manager) error
+	}{
+		{
+			name: "non-stream",
+			invoke: func(manager *Manager) error {
+				_, errExecute := manager.Execute(context.Background(), []string{"retry-config-snapshot"}, cliproxyexecutor.Request{Model: "retry-config-snapshot-model"}, cliproxyexecutor.Options{})
+				return errExecute
+			},
+		},
+		{
+			name: "count-tokens",
+			invoke: func(manager *Manager) error {
+				_, errExecute := manager.ExecuteCount(context.Background(), []string{"retry-config-snapshot"}, cliproxyexecutor.Request{Model: "retry-config-snapshot-model"}, cliproxyexecutor.Options{})
+				return errExecute
+			},
+		},
+		{
+			name: "stream",
+			invoke: func(manager *Manager) error {
+				_, errExecute := manager.ExecuteStream(context.Background(), []string{"retry-config-snapshot"}, cliproxyexecutor.Request{Model: "retry-config-snapshot-model"}, cliproxyexecutor.Options{Stream: true})
+				return errExecute
+			},
+		},
+	}
+	scenarios := []struct {
+		name        string
+		initial     int
+		next        int
+		wantCalls   int
+		wantSuccess bool
+	}{
+		{name: "decrease after request starts", initial: 1, next: 0, wantCalls: 2, wantSuccess: true},
+		{name: "increase after request starts", initial: 0, next: 1, wantCalls: 1, wantSuccess: false},
+	}
+
+	for _, path := range paths {
+		for _, scenario := range scenarios {
+			t.Run(path.name+"/"+scenario.name, func(t *testing.T) {
+				manager := NewManager(nil, nil, nil)
+				manager.SetRetryConfig(scenario.initial, 0, 0)
+				executor := &retryConfigMutationExecutor{
+					identifier:  "retry-config-snapshot",
+					manager:     manager,
+					nextDefault: scenario.next,
+				}
+				manager.RegisterExecutor(executor)
+
+				const authID = "retry-config-snapshot-auth"
+				reg := registry.GetGlobalRegistry()
+				reg.RegisterClient(authID, "retry-config-snapshot", []*registry.ModelInfo{{ID: "retry-config-snapshot-model"}})
+				t.Cleanup(func() { reg.UnregisterClient(authID) })
+				if _, errRegister := manager.Register(context.Background(), &Auth{
+					ID:       authID,
+					Provider: "retry-config-snapshot",
+					Metadata: map[string]any{"disable_cooling": true},
+				}); errRegister != nil {
+					t.Fatalf("register auth: %v", errRegister)
+				}
+
+				errExecute := path.invoke(manager)
+				if scenario.wantSuccess && errExecute != nil {
+					t.Fatalf("execution error = %v, want success", errExecute)
+				}
+				if !scenario.wantSuccess && statusCodeFromError(errExecute) != http.StatusInternalServerError {
+					t.Fatalf("execution error = %v, want HTTP 500", errExecute)
+				}
+				if calls := executor.callCount(); calls != scenario.wantCalls {
+					t.Fatalf("executor calls = %d, want %d", calls, scenario.wantCalls)
+				}
+			})
+		}
+	}
+}
+
+type retryRoundHomeDispatcher struct {
+	mu       sync.Mutex
+	limits   map[string]int
+	rounds   []int
+	newCalls int
+	oldCalls int
+}
+
+func (*retryRoundHomeDispatcher) HeartbeatOK() bool { return true }
+
+func (d *retryRoundHomeDispatcher) RPopAuth(ctx context.Context, model, sessionID string, headers http.Header, count int) ([]byte, error) {
+	return d.RPopAuthWithRetryRoundConstraints(ctx, model, sessionID, headers, count, 0, nil, "")
+}
+
+func (d *retryRoundHomeDispatcher) RPopAuthWithConstraints(ctx context.Context, model, sessionID string, headers http.Header, count int, excluded []string, pinned string) ([]byte, error) {
+	d.mu.Lock()
+	d.oldCalls++
+	d.mu.Unlock()
+	return d.RPopAuthWithRetryRoundConstraints(ctx, model, sessionID, headers, count, 0, excluded, pinned)
+}
+
+func (d *retryRoundHomeDispatcher) RPopAuthWithRetryRoundConstraints(_ context.Context, _ string, _ string, _ http.Header, _ int, retryRound int, excluded []string, pinned string) ([]byte, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.newCalls++
+	d.rounds = append(d.rounds, retryRound)
+	excludedSet := make(map[string]struct{}, len(excluded))
+	for _, id := range excluded {
+		excludedSet[id] = struct{}{}
+	}
+	ids := make([]string, 0, len(d.limits))
+	maxRetry := 0
+	for id, limit := range d.limits {
+		if limit >= retryRound {
+			ids = append(ids, id)
+			if limit > maxRetry {
+				maxRetry = limit
+			}
+		}
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		if _, okExcluded := excludedSet[id]; okExcluded || (pinned != "" && pinned != id) {
+			continue
+		}
+		return json.Marshal(homeAuthDispatchResponse{
+			RequestRetry: func() *int { value := maxRetry; return &value }(),
+			Auth:         Auth{ID: id, Provider: "retry-round-home", Status: StatusActive, Metadata: map[string]any{"request_retry": d.limits[id]}},
+		})
+	}
+	return nil, home.ErrAuthNotFound
+}
+
+func (*retryRoundHomeDispatcher) AbortAmbiguousDispatch() {}
+
+func (d *retryRoundHomeDispatcher) roundsSeen() []int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]int(nil), d.rounds...)
+}
+
+func (d *retryRoundHomeDispatcher) dispatchMethodCalls() (int, int) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.newCalls, d.oldCalls
+}
+
+func TestExecuteHomeRetryRoundCredentialWindows(t *testing.T) {
+	tests := []struct {
+		name   string
+		invoke func(*Manager, cliproxyexecutor.Request) error
+	}{
+		{
+			name: "non-stream",
+			invoke: func(manager *Manager, req cliproxyexecutor.Request) error {
+				_, errExecute := manager.Execute(context.Background(), []string{"retry-round-home"}, req, cliproxyexecutor.Options{})
+				return errExecute
+			},
+		},
+		{
+			name: "count-tokens",
+			invoke: func(manager *Manager, req cliproxyexecutor.Request) error {
+				_, errExecute := manager.ExecuteCount(context.Background(), []string{"retry-round-home"}, req, cliproxyexecutor.Options{})
+				return errExecute
+			},
+		},
+		{
+			name: "stream",
+			invoke: func(manager *Manager, req cliproxyexecutor.Request) error {
+				_, errExecute := manager.ExecuteStream(context.Background(), []string{"retry-round-home"}, req, cliproxyexecutor.Options{Stream: true})
+				return errExecute
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(3, 0, 3)
+			dispatcher := &retryRoundHomeDispatcher{limits: map[string]int{
+				"retry-round-a": 3,
+				"retry-round-b": 2,
+				"retry-round-c": 2,
+			}}
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			executor := &retryRoundCallExecutor{identifier: "retry-round-home"}
+			manager.RegisterExecutor(executor)
+
+			if errExecute := test.invoke(manager, cliproxyexecutor.Request{Model: "retry-round-model"}); errExecute == nil {
+				t.Fatal("execution error = nil, want terminal retry error")
+			}
+			counts := countRetryRoundIDs(executor.ids(map[string]string{"non-stream": "execute", "count-tokens": "count", "stream": "stream"}[test.name]))
+			if counts["retry-round-a"] != 4 || counts["retry-round-b"] != 3 || counts["retry-round-c"] != 3 {
+				t.Fatalf("credential call counts = %#v, want A=4 B=3 C=3", counts)
+			}
+			rounds := dispatcher.roundsSeen()
+			if len(rounds) == 0 || rounds[0] != 0 {
+				t.Fatalf("Home retry rounds = %v, want initial round 0", rounds)
+			}
+			foundRoundOne := false
+			foundRoundTwo := false
+			foundRoundThree := false
+			for _, round := range rounds {
+				foundRoundOne = foundRoundOne || round == 1
+				foundRoundTwo = foundRoundTwo || round == 2
+				foundRoundThree = foundRoundThree || round == 3
+			}
+			if !foundRoundOne || !foundRoundTwo || !foundRoundThree {
+				t.Fatalf("Home retry rounds = %v, want rounds 0,1,2,3", rounds)
+			}
+			newCalls, oldCalls := dispatcher.dispatchMethodCalls()
+			if newCalls == 0 || oldCalls != 0 {
+				t.Fatalf("Home dispatcher method calls = new %d, old %d; want new interface only", newCalls, oldCalls)
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/rand/v2"
 	"net/http"
 	"reflect"
@@ -1078,12 +1079,14 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 	available, selectorAuths, errAvailable := m.availableAuthsForSelector(selector, candidates, provider, model, time.Now())
 	if errAvailable != nil {
 		m.mu.RUnlock()
+		m.warnLogAuthUnavailable(ctx, []string{provider}, model, opts, tried, errAvailable)
 		return nil, nil, errAvailable
 	}
 	m.mu.RUnlock()
 
 	selected, handled, errPick := m.pickViaPluginScheduler(ctx, pluginScheduler, provider, []string{provider}, model, opts, tried, available)
 	if errPick != nil {
+		m.warnLogAuthUnavailable(ctx, []string{provider}, model, opts, tried, errPick)
 		return nil, nil, errPick
 	}
 	if !handled {
@@ -1093,6 +1096,7 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 			if isBuiltInSelector(selector) {
 				errPick = restoreModelCooldownErrorModel(errPick, model)
 			}
+			m.warnLogAuthUnavailable(ctx, []string{provider}, model, opts, tried, errPick)
 			return nil, nil, errPick
 		}
 	}
@@ -1316,6 +1320,7 @@ func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cli
 		selected, errPick = m.scheduler.pickSingle(ctx, provider, model, opts, tried)
 	}
 	if errPick != nil {
+		m.warnLogAuthUnavailable(ctx, []string{provider}, model, opts, tried, errPick)
 		return nil, nil, errPick
 	}
 	if selected == nil {
@@ -1405,12 +1410,14 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 	available, selectorAuths, errAvailable := m.availableAuthsForSelector(selector, candidates, "mixed", model, time.Now())
 	if errAvailable != nil {
 		m.mu.RUnlock()
+		m.warnLogAuthUnavailable(ctx, providers, model, opts, tried, errAvailable)
 		return nil, nil, "", errAvailable
 	}
 	m.mu.RUnlock()
 
 	selected, handled, errPick := m.pickViaPluginScheduler(ctx, pluginScheduler, "mixed", providers, model, opts, tried, available)
 	if errPick != nil {
+		m.warnLogAuthUnavailable(ctx, providers, model, opts, tried, errPick)
 		return nil, nil, "", errPick
 	}
 	if !handled {
@@ -1420,6 +1427,7 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 			if isBuiltInSelector(selector) {
 				errPick = restoreModelCooldownErrorModel(errPick, model)
 			}
+			m.warnLogAuthUnavailable(ctx, providers, model, opts, tried, errPick)
 			return nil, nil, "", errPick
 		}
 	}
@@ -1508,6 +1516,7 @@ func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model s
 		selected, providerKey, errPick = m.scheduler.pickMixed(ctx, eligibleProviders, model, opts, tried)
 	}
 	if errPick != nil {
+		m.warnLogAuthUnavailable(ctx, eligibleProviders, model, opts, tried, errPick)
 		return nil, nil, "", errPick
 	}
 	if selected == nil {
@@ -1527,4 +1536,108 @@ func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model s
 		m.mu.Unlock()
 	}
 	return authCopy, executor, providerKey, nil
+}
+
+func isAuthUnavailableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var authErr *Error
+	if errors.As(err, &authErr) && authErr != nil {
+		return authErr.Code == "auth_unavailable" || authErr.Code == "model_cooldown"
+	}
+	var cooldownErr *modelCooldownError
+	return errors.As(err, &cooldownErr) && cooldownErr != nil
+}
+
+func authCoolingSummary(auth *Auth, model string, next time.Time, now time.Time) string {
+	if auth == nil {
+		return ""
+	}
+	ident := formatAuthIdentity(auth, auth.Provider)
+	reason := ""
+	if model != "" && len(auth.ModelStates) > 0 {
+		if state, ok := auth.ModelStates[model]; ok && state != nil {
+			reason = cooldownReason(state.StatusMessage, state.Quota, state.LastError)
+		} else if state, ok := auth.ModelStates[canonicalModelKey(model)]; ok && state != nil {
+			reason = cooldownReason(state.StatusMessage, state.Quota, state.LastError)
+		}
+	}
+	if reason == "" {
+		reason = cooldownReason(auth.StatusMessage, auth.Quota, auth.LastError)
+	}
+	if reason == "" {
+		reason = "cooldown"
+	}
+	remaining := "0s"
+	if !next.IsZero() && next.After(now) {
+		remaining = next.Sub(now).Round(time.Second).String()
+	}
+	return fmt.Sprintf("[%s, reason=%s, remaining=%s]", ident, reason, remaining)
+}
+
+func (m *Manager) warnLogAuthUnavailable(ctx context.Context, providers []string, model string, opts cliproxyexecutor.Options, tried map[string]struct{}, err error) {
+	if m == nil || err == nil || !isAuthUnavailableError(err) {
+		return
+	}
+	now := time.Now()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	eligibility := authSelectionEligibilityForRequest(ctx, opts)
+	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
+	providerSet := make(map[string]struct{}, len(providers))
+	for _, p := range providers {
+		if norm := strings.TrimSpace(strings.ToLower(p)); norm != "" && norm != "mixed" {
+			providerSet[norm] = struct{}{}
+		}
+	}
+	registryRef := registry.GetGlobalRegistry()
+
+	coolingSummaries := make([]string, 0)
+	totalCandidates := 0
+	for _, candidate := range m.auths {
+		if candidate == nil || candidate.Disabled {
+			continue
+		}
+		providerKey := executorKeyFromAuth(candidate)
+		if len(providerSet) > 0 {
+			if _, ok := providerSet[providerKey]; !ok {
+				continue
+			}
+		}
+		if _, ok := m.executors[providerKey]; !ok {
+			continue
+		}
+		if pinnedAuthID != "" && candidate.ID != pinnedAuthID {
+			continue
+		}
+		if !eligibility.allows(candidate) {
+			continue
+		}
+		if tried != nil {
+			if _, used := tried[candidate.ID]; used {
+				continue
+			}
+		}
+		if model != "" && !m.authSupportsRouteModel(registryRef, candidate, model) {
+			continue
+		}
+		totalCandidates++
+		checkModel := m.selectionModelForAuth(candidate, model)
+		blocked, reason, next := isAuthBlockedForModel(candidate, checkModel, now)
+		if blocked && reason == blockReasonCooldown {
+			coolingSummaries = append(coolingSummaries, authCoolingSummary(candidate, checkModel, next, now))
+		}
+	}
+
+	if len(coolingSummaries) > 0 {
+		sort.Strings(coolingSummaries)
+		entry := logEntryWithRequestID(ctx)
+		providerText := strings.Join(providers, ",")
+		if len(providers) == 1 {
+			entry.Warnf("auth unavailable: %d of %d candidate(s) for model %q (provider=%s) are in cooldown: %s", len(coolingSummaries), totalCandidates, model, providerText, strings.Join(coolingSummaries, ", "))
+		} else {
+			entry.Warnf("auth unavailable: %d of %d candidate(s) for model %q (providers=%s) are in cooldown: %s", len(coolingSummaries), totalCandidates, model, providerText, strings.Join(coolingSummaries, ", "))
+		}
+	}
 }

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -709,6 +709,37 @@ func (m *Manager) retrySettings() (int, int, time.Duration) {
 	return int(m.requestRetry.Load()), int(m.maxRetryCredentials.Load()), time.Duration(m.maxRetryInterval.Load())
 }
 
+func effectiveRequestRetryLimit(auth *Auth, defaultRetry int) int {
+	if defaultRetry < 0 {
+		defaultRetry = 0
+	}
+	if override, ok := auth.RequestRetryOverride(); ok {
+		return override
+	}
+	return defaultRetry
+}
+
+func (m *Manager) requestRetryRoundExclusions(retryRound int, defaultRequestRetry int) map[string]struct{} {
+	excluded := make(map[string]struct{})
+	if m == nil || retryRound <= 0 {
+		return excluded
+	}
+	if defaultRequestRetry < 0 {
+		defaultRequestRetry = 0
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, auth := range m.auths {
+		if auth == nil || strings.TrimSpace(auth.ID) == "" {
+			continue
+		}
+		if effectiveRequestRetryLimit(auth, defaultRequestRetry) < retryRound {
+			excluded[auth.ID] = struct{}{}
+		}
+	}
+	return excluded
+}
+
 func retryRoundAvailabilityForAuth(auth *Auth, model string, now time.Time) (bool, time.Time) {
 	blocked, reason, next := isAuthBlockedForModel(auth, model, now)
 	if !blocked {
@@ -757,14 +788,13 @@ func credentialRetryRoundStateEligible(lastErr *Error, quotaExceeded bool) bool 
 	return isCredentialRetryRoundStatus(statusCodeFromResult(lastErr))
 }
 
-func (m *Manager) closestCooldownWait(providers []string, model string, attempt int, eligibility authSelectionEligibility, pinnedAuthID string) (time.Duration, bool) {
+func (m *Manager) closestCooldownWait(providers []string, model string, attempt int, eligibility authSelectionEligibility, pinnedAuthID string, defaultRequestRetry int) (time.Duration, bool) {
 	if m == nil || len(providers) == 0 {
 		return 0, false
 	}
 	now := time.Now()
-	defaultRetry := int(m.requestRetry.Load())
-	if defaultRetry < 0 {
-		defaultRetry = 0
+	if defaultRequestRetry < 0 {
+		defaultRequestRetry = 0
 	}
 	providerSet := make(map[string]struct{}, len(providers))
 	for i := range providers {
@@ -798,13 +828,7 @@ func (m *Manager) closestCooldownWait(providers []string, model string, attempt 
 		if model != "" && !m.authSupportsRouteModel(registryRef, auth, model) {
 			continue
 		}
-		effectiveRetry := defaultRetry
-		if override, ok := auth.RequestRetryOverride(); ok {
-			effectiveRetry = override
-		}
-		if effectiveRetry < 0 {
-			effectiveRetry = 0
-		}
+		effectiveRetry := effectiveRequestRetryLimit(auth, defaultRequestRetry)
 		if attempt >= effectiveRetry {
 			continue
 		}
@@ -831,14 +855,13 @@ func (m *Manager) closestCooldownWait(providers []string, model string, attempt 
 	return minWait, found
 }
 
-func (m *Manager) retryAllowed(attempt int, providers []string, model string, eligibility authSelectionEligibility, pinnedAuthID string) bool {
+func (m *Manager) retryAllowed(attempt int, providers []string, model string, eligibility authSelectionEligibility, pinnedAuthID string, defaultRequestRetry int) bool {
 	if m == nil || attempt < 0 || len(providers) == 0 {
 		return false
 	}
 	now := time.Now()
-	defaultRetry := int(m.requestRetry.Load())
-	if defaultRetry < 0 {
-		defaultRetry = 0
+	if defaultRequestRetry < 0 {
+		defaultRequestRetry = 0
 	}
 	providerSet := make(map[string]struct{}, len(providers))
 	for i := range providers {
@@ -872,13 +895,7 @@ func (m *Manager) retryAllowed(attempt int, providers []string, model string, el
 		if model != "" && !m.authSupportsRouteModel(registryRef, auth, model) {
 			continue
 		}
-		effectiveRetry := defaultRetry
-		if override, ok := auth.RequestRetryOverride(); ok {
-			effectiveRetry = override
-		}
-		if effectiveRetry < 0 {
-			effectiveRetry = 0
-		}
+		effectiveRetry := effectiveRequestRetryLimit(auth, defaultRequestRetry)
 		if attempt >= effectiveRetry {
 			continue
 		}
@@ -894,7 +911,8 @@ func (m *Manager) retryAllowed(attempt int, providers []string, model string, el
 }
 
 func (m *Manager) shouldRetryAfterError(err error, attempt int, providers []string, model string, maxWait time.Duration) (time.Duration, bool) {
-	return m.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), cliproxyexecutor.Options{}, err, attempt, providers, model, maxWait, -1)
+	defaultRequestRetry, _, _ := m.retrySettings()
+	return m.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), cliproxyexecutor.Options{}, err, attempt, providers, model, maxWait, -1, defaultRequestRetry)
 }
 
 // maxWait limits only positive cooldown waits between credential retry rounds.
@@ -902,7 +920,7 @@ func (m *Manager) shouldRetryAfterError(err error, attempt int, providers []stri
 // credential failover or an additional round that request-retry permits to start
 // immediately. If every eligible credential still needs a positive cooldown,
 // retry stops without waiting.
-func (m *Manager) shouldRetryAfterErrorWithHomeRetryLimit(ctx context.Context, opts cliproxyexecutor.Options, err error, attempt int, providers []string, model string, maxWait time.Duration, homeRetryLimit int) (time.Duration, bool) {
+func (m *Manager) shouldRetryAfterErrorWithHomeRetryLimit(ctx context.Context, opts cliproxyexecutor.Options, err error, attempt int, providers []string, model string, maxWait time.Duration, homeRetryLimit int, defaultRequestRetry int) (time.Duration, bool) {
 	if err == nil {
 		return 0, false
 	}
@@ -953,10 +971,10 @@ func (m *Manager) shouldRetryAfterErrorWithHomeRetryLimit(ctx context.Context, o
 	}
 	eligibility := authSelectionEligibilityForRequest(ctx, opts)
 	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
-	if !isCredentialRetryRoundStatus(status) || !m.retryAllowed(attempt, providers, model, eligibility, pinnedAuthID) {
+	if !isCredentialRetryRoundStatus(status) || !m.retryAllowed(attempt, providers, model, eligibility, pinnedAuthID, defaultRequestRetry) {
 		return 0, false
 	}
-	wait, found := m.closestCooldownWait(providers, model, attempt, eligibility, pinnedAuthID)
+	wait, found := m.closestCooldownWait(providers, model, attempt, eligibility, pinnedAuthID, defaultRequestRetry)
 	if found {
 		if wait > 0 && (maxWait <= 0 || wait > maxWait) {
 			return 0, false

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -709,7 +709,55 @@ func (m *Manager) retrySettings() (int, int, time.Duration) {
 	return int(m.requestRetry.Load()), int(m.maxRetryCredentials.Load()), time.Duration(m.maxRetryInterval.Load())
 }
 
-func (m *Manager) closestCooldownWait(providers []string, model string, attempt int) (time.Duration, bool) {
+func retryRoundAvailabilityForAuth(auth *Auth, model string, now time.Time) (bool, time.Time) {
+	blocked, reason, next := isAuthBlockedForModel(auth, model, now)
+	if !blocked {
+		return true, time.Time{}
+	}
+	if auth == nil || next.IsZero() || reason == blockReasonDisabled {
+		return false, time.Time{}
+	}
+	if auth.Quota.Exceeded && auth.Quota.Reason == "credential_quota" && auth.Quota.NextRecoverAt.After(now) {
+		return credentialRetryRoundStateEligible(auth.LastError, true), next
+	}
+
+	modelKey := canonicalModelKey(model)
+	if modelKey != "" && len(auth.ModelStates) > 0 {
+		matchedBlocked := false
+		for stateModel, state := range auth.ModelStates {
+			if state == nil || canonicalModelKey(stateModel) != modelKey {
+				continue
+			}
+			if state.Status == StatusDisabled {
+				return false, time.Time{}
+			}
+			stateBlocked, _, stateNext := availabilityBlock(state.Unavailable, state.Quota.Exceeded, state.NextRetryAfter, state.Quota.NextRecoverAt, now)
+			if !stateBlocked {
+				continue
+			}
+			matchedBlocked = true
+			if stateNext.IsZero() || !credentialRetryRoundStateEligible(state.LastError, state.Quota.Exceeded) {
+				return false, time.Time{}
+			}
+		}
+		if matchedBlocked {
+			return true, next
+		}
+	}
+	if !credentialRetryRoundStateEligible(auth.LastError, auth.Quota.Exceeded) {
+		return false, time.Time{}
+	}
+	return true, next
+}
+
+func credentialRetryRoundStateEligible(lastErr *Error, quotaExceeded bool) bool {
+	if lastErr == nil {
+		return quotaExceeded
+	}
+	return isCredentialRetryRoundStatus(statusCodeFromResult(lastErr))
+}
+
+func (m *Manager) closestCooldownWait(providers []string, model string, attempt int, eligibility authSelectionEligibility, pinnedAuthID string) (time.Duration, bool) {
 	if m == nil || len(providers) == 0 {
 		return 0, false
 	}
@@ -726,6 +774,7 @@ func (m *Manager) closestCooldownWait(providers []string, model string, attempt 
 		}
 		providerSet[key] = struct{}{}
 	}
+	registryRef := registry.GetGlobalRegistry()
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	var (
@@ -733,11 +782,20 @@ func (m *Manager) closestCooldownWait(providers []string, model string, attempt 
 		minWait time.Duration
 	)
 	for _, auth := range m.auths {
-		if auth == nil {
+		if auth == nil || auth.Disabled || auth.Status == StatusDisabled {
+			continue
+		}
+		if pinnedAuthID != "" && auth.ID != pinnedAuthID {
+			continue
+		}
+		if !eligibility.allows(auth) {
 			continue
 		}
 		providerKey := executorKeyFromAuth(auth)
 		if _, ok := providerSet[providerKey]; !ok {
+			continue
+		}
+		if model != "" && !m.authSupportsRouteModel(registryRef, auth, model) {
 			continue
 		}
 		effectiveRetry := defaultRetry
@@ -754,9 +812,12 @@ func (m *Manager) closestCooldownWait(providers []string, model string, attempt 
 		if strings.TrimSpace(model) != "" {
 			checkModel = m.selectionModelForAuth(auth, model)
 		}
-		blocked, reason, next := isAuthBlockedForModel(auth, checkModel, now)
-		if !blocked || next.IsZero() || reason == blockReasonDisabled {
+		retryEligible, next := retryRoundAvailabilityForAuth(auth, checkModel, now)
+		if !retryEligible {
 			continue
+		}
+		if next.IsZero() {
+			return 0, true
 		}
 		wait := next.Sub(now)
 		if wait < 0 {
@@ -770,10 +831,11 @@ func (m *Manager) closestCooldownWait(providers []string, model string, attempt 
 	return minWait, found
 }
 
-func (m *Manager) retryAllowed(attempt int, providers []string) bool {
+func (m *Manager) retryAllowed(attempt int, providers []string, model string, eligibility authSelectionEligibility, pinnedAuthID string) bool {
 	if m == nil || attempt < 0 || len(providers) == 0 {
 		return false
 	}
+	now := time.Now()
 	defaultRetry := int(m.requestRetry.Load())
 	if defaultRetry < 0 {
 		defaultRetry = 0
@@ -790,14 +852,24 @@ func (m *Manager) retryAllowed(attempt int, providers []string) bool {
 		return false
 	}
 
+	registryRef := registry.GetGlobalRegistry()
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	for _, auth := range m.auths {
-		if auth == nil {
+		if auth == nil || auth.Disabled || auth.Status == StatusDisabled {
+			continue
+		}
+		if pinnedAuthID != "" && auth.ID != pinnedAuthID {
+			continue
+		}
+		if !eligibility.allows(auth) {
 			continue
 		}
 		providerKey := executorKeyFromAuth(auth)
 		if _, ok := providerSet[providerKey]; !ok {
+			continue
+		}
+		if model != "" && !m.authSupportsRouteModel(registryRef, auth, model) {
 			continue
 		}
 		effectiveRetry := defaultRetry
@@ -807,7 +879,14 @@ func (m *Manager) retryAllowed(attempt int, providers []string) bool {
 		if effectiveRetry < 0 {
 			effectiveRetry = 0
 		}
-		if attempt < effectiveRetry {
+		if attempt >= effectiveRetry {
+			continue
+		}
+		checkModel := model
+		if strings.TrimSpace(model) != "" {
+			checkModel = m.selectionModelForAuth(auth, model)
+		}
+		if retryEligible, _ := retryRoundAvailabilityForAuth(auth, checkModel, now); retryEligible {
 			return true
 		}
 	}
@@ -815,14 +894,20 @@ func (m *Manager) retryAllowed(attempt int, providers []string) bool {
 }
 
 func (m *Manager) shouldRetryAfterError(err error, attempt int, providers []string, model string, maxWait time.Duration) (time.Duration, bool) {
+	return m.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), cliproxyexecutor.Options{}, err, attempt, providers, model, maxWait, -1)
+}
+
+// maxWait limits only positive cooldown waits between credential retry rounds.
+// A non-positive value means no waiting: it does not disable same-round
+// credential failover or an additional round that request-retry permits to start
+// immediately. If every eligible credential still needs a positive cooldown,
+// retry stops without waiting.
+func (m *Manager) shouldRetryAfterErrorWithHomeRetryLimit(ctx context.Context, opts cliproxyexecutor.Options, err error, attempt int, providers []string, model string, maxWait time.Duration, homeRetryLimit int) (time.Duration, bool) {
 	if err == nil {
 		return 0, false
 	}
 	var homeBusy *HomeConcurrencyBusyError
 	if errors.As(err, &homeBusy) && homeBusy != nil {
-		return 0, false
-	}
-	if maxWait <= 0 {
 		return 0, false
 	}
 	status := statusCodeFromError(err)
@@ -832,24 +917,119 @@ func (m *Manager) shouldRetryAfterError(err error, attempt int, providers []stri
 	if isRequestInvalidError(err) || isRequestStopError(err) {
 		return 0, false
 	}
-	wait, found := m.closestCooldownWait(providers, model, attempt)
+	if m.HomeEnabled() {
+		var cooldownErr *homeDispatchRetryAfterError
+		if errors.As(err, &cooldownErr) && cooldownErr != nil {
+			observeHomeCooldownRetryLimit(cooldownErr, &homeRetryLimit, pinnedAuthIDFromMetadata(opts.Metadata) == "")
+		}
+	}
+	var exhausted *homeRetryRoundExhaustedError
+	if m.HomeEnabled() && errors.As(err, &exhausted) && exhausted != nil {
+		if !isCredentialRetryRoundStatus(status) || !m.homeRetryAllowed(attempt, homeRetryLimit) {
+			return 0, false
+		}
+		if exhausted.retryNow {
+			return 0, true
+		}
+		if retryAfter := retryAfterFromError(err); retryAfter != nil {
+			if *retryAfter < 0 || (*retryAfter > 0 && (maxWait <= 0 || *retryAfter > maxWait)) {
+				return 0, false
+			}
+			return *retryAfter, true
+		}
+		// Home will provide a cooldown error on the next round if all
+		// credentials are still cooling down; otherwise retry immediately.
+		return 0, true
+	}
+	if m.HomeEnabled() {
+		if status != http.StatusTooManyRequests || !m.homeRetryAllowed(attempt, homeRetryLimit) {
+			return 0, false
+		}
+		retryAfter := retryAfterFromError(err)
+		if retryAfter == nil || *retryAfter <= 0 || (maxWait <= 0 || *retryAfter > maxWait) {
+			return 0, false
+		}
+		return *retryAfter, true
+	}
+	eligibility := authSelectionEligibilityForRequest(ctx, opts)
+	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
+	if !isCredentialRetryRoundStatus(status) || !m.retryAllowed(attempt, providers, model, eligibility, pinnedAuthID) {
+		return 0, false
+	}
+	wait, found := m.closestCooldownWait(providers, model, attempt, eligibility, pinnedAuthID)
 	if found {
-		if wait > maxWait {
+		if wait > 0 && (maxWait <= 0 || wait > maxWait) {
 			return 0, false
 		}
 		return wait, true
 	}
-	if status != http.StatusTooManyRequests {
-		return 0, false
+	if retryAfter := retryAfterFromError(err); retryAfter != nil {
+		if *retryAfter < 0 || (*retryAfter > 0 && (maxWait <= 0 || *retryAfter > maxWait)) {
+			return 0, false
+		}
+		return *retryAfter, true
 	}
-	if !m.retryAllowed(attempt, providers) {
-		return 0, false
+	return 0, true
+}
+
+func (m *Manager) homeRetryAllowed(attempt int, retryLimit int) bool {
+	if m == nil || !m.HomeEnabled() || attempt < 0 {
+		return false
 	}
-	retryAfter := retryAfterFromError(err)
-	if retryAfter == nil || *retryAfter <= 0 || *retryAfter > maxWait {
-		return 0, false
+	if retryLimit < 0 {
+		retryLimit = int(m.requestRetry.Load())
+		if retryLimit < 0 {
+			retryLimit = 0
+		}
 	}
-	return *retryAfter, true
+	return attempt < retryLimit
+}
+
+func (m *Manager) observeHomeRetryLimit(auth *Auth, selection *HomeDispatchSelection, retryLimit *int) {
+	if m == nil || retryLimit == nil {
+		return
+	}
+	if selection != nil && selection.hasRequestRetry {
+		*retryLimit = selection.requestRetry
+		return
+	}
+	if auth == nil {
+		return
+	}
+	limit := int(m.requestRetry.Load())
+	if override, ok := auth.RequestRetryOverride(); ok {
+		limit = override
+	}
+	if limit < 0 {
+		limit = 0
+	}
+	if *retryLimit < 0 || limit > *retryLimit {
+		*retryLimit = limit
+	}
+}
+
+func observeHomeCooldownRetryLimit(cooldown *homeDispatchRetryAfterError, retryLimit *int, acceptRemoteRetryLimit bool) {
+	if cooldown == nil || retryLimit == nil || !acceptRemoteRetryLimit {
+		return
+	}
+	if remoteLimit, ok := cooldown.RequestRetryLimit(); ok {
+		*retryLimit = remoteLimit
+	}
+}
+
+func isCredentialRetryRoundStatus(status int) bool {
+	switch status {
+	case http.StatusForbidden,
+		http.StatusRequestTimeout,
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
 }
 
 // cooldownWaitJitterCap bounds the random jitter added to cooldown waits so a
@@ -860,7 +1040,7 @@ const cooldownWaitJitterCap = 2 * time.Second
 // concurrent requests waiting on the same recovery deadline do not wake in
 // lockstep and stampede the first credential that recovers. The jitter never
 // pushes the total wait past maxWait, which callers have already enforced as
-// the retry ceiling; maxWait <= 0 means no ceiling.
+// the retry ceiling; maxWait <= 0 is reserved for immediate retries.
 func jitteredCooldownWait(wait, maxWait time.Duration) time.Duration {
 	if wait <= 0 {
 		return wait
@@ -1199,6 +1379,7 @@ func (m *Manager) SelectHomeAuthWithCredentialPolicy(ctx context.Context, provid
 	tried := make(map[string]struct{})
 	for {
 		selectionOpts := withHomeAuthCount(opts, homeAuthCount)
+		selectionOpts = withHomeExcludedAuthIDs(selectionOpts, tried)
 		selection, errSelection := m.pickHomeDispatchSelection(selectionCtx, model, selectionOpts)
 		if errSelection != nil {
 			return nil, errSelection
@@ -1245,6 +1426,7 @@ func (m *Manager) SelectHomeAuthByKind(ctx context.Context, provider string, mod
 	tried := make(map[string]struct{})
 	for {
 		selectionOpts := withHomeAuthCount(opts, homeAuthCount)
+		selectionOpts = withHomeExcludedAuthIDs(selectionOpts, tried)
 		selection, errSelection := m.pickHomeDispatchSelection(ctx, model, selectionOpts)
 		if errSelection != nil {
 			return nil, errSelection

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/rand/v2"
 	"net/http"
 	"reflect"
@@ -864,14 +865,117 @@ func (m *Manager) retrySettings() (int, int, time.Duration) {
 	return int(m.requestRetry.Load()), int(m.maxRetryCredentials.Load()), time.Duration(m.maxRetryInterval.Load())
 }
 
-func (m *Manager) closestCooldownWait(providers []string, model string, attempt int) (time.Duration, bool) {
+func effectiveRequestRetryLimit(auth *Auth, defaultRetry int) int {
+	if defaultRetry < 0 {
+		defaultRetry = 0
+	}
+	if override, ok := auth.RequestRetryOverride(); ok {
+		return override
+	}
+	return defaultRetry
+}
+
+func (m *Manager) requestRetryRoundExclusions(retryRound int, defaultRequestRetry int) map[string]struct{} {
+	excluded := make(map[string]struct{})
+	if m == nil || retryRound <= 0 {
+		return excluded
+	}
+	if defaultRequestRetry < 0 {
+		defaultRequestRetry = 0
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, auth := range m.auths {
+		if auth == nil || strings.TrimSpace(auth.ID) == "" {
+			continue
+		}
+		if effectiveRequestRetryLimit(auth, defaultRequestRetry) < retryRound {
+			excluded[auth.ID] = struct{}{}
+		}
+	}
+	return excluded
+}
+
+func retryRoundAvailabilityForAuth(auth *Auth, model string, now time.Time) (bool, time.Time) {
+	blocked, reason, next := isAuthBlockedForModel(auth, model, now)
+	if !blocked {
+		return true, time.Time{}
+	}
+	if auth == nil || next.IsZero() || reason == blockReasonDisabled {
+		return false, time.Time{}
+	}
+	if auth.Quota.Exceeded && auth.Quota.Reason == "credential_quota" && auth.Quota.NextRecoverAt.After(now) {
+		return credentialRetryRoundStateEligible(auth.LastError, true), next
+	}
+
+	modelKey := canonicalModelKey(model)
+	if modelKey != "" && len(auth.ModelStates) > 0 {
+		matchedBlocked := false
+		for stateModel, state := range auth.ModelStates {
+			if state == nil || canonicalModelKey(stateModel) != modelKey {
+				continue
+			}
+			if state.Status == StatusDisabled {
+				return false, time.Time{}
+			}
+			stateBlocked, _, stateNext := availabilityBlock(state.Unavailable, state.Quota.Exceeded, state.NextRetryAfter, state.Quota.NextRecoverAt, now)
+			if !stateBlocked {
+				continue
+			}
+			matchedBlocked = true
+			if stateNext.IsZero() || !credentialRetryRoundStateEligible(state.LastError, state.Quota.Exceeded) {
+				return false, time.Time{}
+			}
+		}
+		if matchedBlocked {
+			return true, next
+		}
+	}
+	if !credentialRetryRoundStateEligible(auth.LastError, auth.Quota.Exceeded) {
+		return false, time.Time{}
+	}
+	return true, next
+}
+
+// shouldRetryAfterErrorWithHomeRetryLimit applies request-scoped retry policy while
+// preserving the upstream Home retry-limit contract.
+func (m *Manager) shouldRetryAfterErrorWithHomeRetryLimit(ctx context.Context, opts cliproxyexecutor.Options, err error, attempt int, providers []string, model string, maxWait time.Duration, homeRetryLimit int, defaultRequestRetry int) (time.Duration, bool) {
+	wait, ok, terminalErr := m.shouldRetryAfterErrorWithRetryPolicy(ctx, opts, err, attempt, providers, model, maxWait, homeRetryLimit, defaultRequestRetry, nil)
+	if terminalErr != nil {
+		return 0, false
+	}
+	return wait, ok
+}
+
+func credentialRetryRoundStateEligible(lastErr *Error, quotaExceeded bool) bool {
+	if lastErr == nil {
+		return quotaExceeded
+	}
+	return isCredentialRetryRoundStatus(statusCodeFromResult(lastErr))
+}
+
+func isCredentialRetryRoundStatus(status int) bool {
+	switch status {
+	case http.StatusForbidden,
+		http.StatusRequestTimeout,
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m *Manager) closestCooldownWait(providers []string, model string, attempt int, eligibility authSelectionEligibility, pinnedAuthID string, defaultRequestRetry int) (time.Duration, bool) {
 	if m == nil || len(providers) == 0 {
 		return 0, false
 	}
 	now := time.Now()
-	defaultRetry := int(m.requestRetry.Load())
-	if defaultRetry < 0 {
-		defaultRetry = 0
+	if defaultRequestRetry < 0 {
+		defaultRequestRetry = 0
 	}
 	providerSet := make(map[string]struct{}, len(providers))
 	for i := range providers {
@@ -881,6 +985,7 @@ func (m *Manager) closestCooldownWait(providers []string, model string, attempt 
 		}
 		providerSet[key] = struct{}{}
 	}
+	registryRef := registry.GetGlobalRegistry()
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	var (
@@ -888,20 +993,23 @@ func (m *Manager) closestCooldownWait(providers []string, model string, attempt 
 		minWait time.Duration
 	)
 	for _, auth := range m.auths {
-		if auth == nil {
+		if auth == nil || auth.Disabled || auth.Status == StatusDisabled {
+			continue
+		}
+		if pinnedAuthID != "" && auth.ID != pinnedAuthID {
+			continue
+		}
+		if !eligibility.allows(auth) {
 			continue
 		}
 		providerKey := executorKeyFromAuth(auth)
 		if _, ok := providerSet[providerKey]; !ok {
 			continue
 		}
-		effectiveRetry := defaultRetry
-		if override, ok := auth.RequestRetryOverride(); ok {
-			effectiveRetry = override
+		if model != "" && !m.authSupportsRouteModel(registryRef, auth, model) {
+			continue
 		}
-		if effectiveRetry < 0 {
-			effectiveRetry = 0
-		}
+		effectiveRetry := effectiveRequestRetryLimit(auth, defaultRequestRetry)
 		if attempt >= effectiveRetry {
 			continue
 		}
@@ -909,9 +1017,12 @@ func (m *Manager) closestCooldownWait(providers []string, model string, attempt 
 		if strings.TrimSpace(model) != "" {
 			checkModel = m.selectionModelForAuth(auth, model)
 		}
-		blocked, reason, next := isAuthBlockedForModel(auth, checkModel, now)
-		if !blocked || next.IsZero() || reason == blockReasonDisabled {
+		retryEligible, next := retryRoundAvailabilityForAuth(auth, checkModel, now)
+		if !retryEligible {
 			continue
+		}
+		if next.IsZero() {
+			return 0, true
 		}
 		wait := next.Sub(now)
 		if wait < 0 {
@@ -925,13 +1036,13 @@ func (m *Manager) closestCooldownWait(providers []string, model string, attempt 
 	return minWait, found
 }
 
-func (m *Manager) retryAllowed(attempt int, providers []string) bool {
+func (m *Manager) retryAllowed(attempt int, providers []string, model string, eligibility authSelectionEligibility, pinnedAuthID string, defaultRequestRetry int) bool {
 	if m == nil || attempt < 0 || len(providers) == 0 {
 		return false
 	}
-	defaultRetry := int(m.requestRetry.Load())
-	if defaultRetry < 0 {
-		defaultRetry = 0
+	now := time.Now()
+	if defaultRequestRetry < 0 {
+		defaultRequestRetry = 0
 	}
 	providerSet := make(map[string]struct{}, len(providers))
 	for i := range providers {
@@ -945,24 +1056,35 @@ func (m *Manager) retryAllowed(attempt int, providers []string) bool {
 		return false
 	}
 
+	registryRef := registry.GetGlobalRegistry()
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	for _, auth := range m.auths {
-		if auth == nil {
+		if auth == nil || auth.Disabled || auth.Status == StatusDisabled {
+			continue
+		}
+		if pinnedAuthID != "" && auth.ID != pinnedAuthID {
+			continue
+		}
+		if !eligibility.allows(auth) {
 			continue
 		}
 		providerKey := executorKeyFromAuth(auth)
 		if _, ok := providerSet[providerKey]; !ok {
 			continue
 		}
-		effectiveRetry := defaultRetry
-		if override, ok := auth.RequestRetryOverride(); ok {
-			effectiveRetry = override
+		if model != "" && !m.authSupportsRouteModel(registryRef, auth, model) {
+			continue
 		}
-		if effectiveRetry < 0 {
-			effectiveRetry = 0
+		effectiveRetry := effectiveRequestRetryLimit(auth, defaultRequestRetry)
+		if attempt >= effectiveRetry {
+			continue
 		}
-		if attempt < effectiveRetry {
+		checkModel := model
+		if strings.TrimSpace(model) != "" {
+			checkModel = m.selectionModelForAuth(auth, model)
+		}
+		if retryEligible, _ := retryRoundAvailabilityForAuth(auth, checkModel, now); retryEligible {
 			return true
 		}
 	}
@@ -970,6 +1092,16 @@ func (m *Manager) retryAllowed(attempt int, providers []string) bool {
 }
 
 func (m *Manager) shouldRetryAfterError(err error, attempt int, providers []string, model string, maxWait time.Duration, retryWithoutPenaltyCounts map[string]int) (time.Duration, bool, error) {
+	defaultRequestRetry, _, _ := m.retrySettings()
+	return m.shouldRetryAfterErrorWithRetryPolicy(context.Background(), cliproxyexecutor.Options{}, err, attempt, providers, model, maxWait, -1, defaultRequestRetry, retryWithoutPenaltyCounts)
+}
+
+// maxWait limits only positive cooldown waits between credential retry rounds.
+// A non-positive value means no waiting: it does not disable same-round
+// credential failover or an additional round that request-retry permits to start
+// immediately. If every eligible credential still needs a positive cooldown,
+// retry stops without waiting.
+func (m *Manager) shouldRetryAfterErrorWithRetryPolicy(ctx context.Context, opts cliproxyexecutor.Options, err error, attempt int, providers []string, model string, maxWait time.Duration, homeRetryLimit int, defaultRequestRetry int, retryWithoutPenaltyCounts map[string]int) (time.Duration, bool, error) {
 	if err == nil {
 		return 0, false, nil
 	}
@@ -987,16 +1119,21 @@ func (m *Manager) shouldRetryAfterError(err error, attempt int, providers []stri
 			retryWithoutPenaltyCounts[class]++
 			return 0, true, nil
 		}
-		if !m.retryAllowed(attempt, providers) {
+		if m.HomeEnabled() {
+			if !m.homeRetryAllowed(attempt, homeRetryLimit) {
+				return 0, false, nil
+			}
+			return 0, true, nil
+		}
+		eligibility := authSelectionEligibilityForRequest(ctx, opts)
+		pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
+		if !m.retryAllowed(attempt, providers, model, eligibility, pinnedAuthID, defaultRequestRetry) {
 			return 0, false, nil
 		}
 		return 0, true, nil
 	}
 	var homeBusy *HomeConcurrencyBusyError
 	if errors.As(err, &homeBusy) && homeBusy != nil {
-		return 0, false, nil
-	}
-	if maxWait <= 0 {
 		return 0, false, nil
 	}
 	status := statusCodeFromError(err)
@@ -1006,24 +1143,102 @@ func (m *Manager) shouldRetryAfterError(err error, attempt int, providers []stri
 	if isRequestInvalidError(err) || isRequestStopError(err) {
 		return 0, false, nil
 	}
-	wait, found := m.closestCooldownWait(providers, model, attempt)
+	if m.HomeEnabled() {
+		var cooldownErr *homeDispatchRetryAfterError
+		if errors.As(err, &cooldownErr) && cooldownErr != nil {
+			observeHomeCooldownRetryLimit(cooldownErr, &homeRetryLimit, pinnedAuthIDFromMetadata(opts.Metadata) == "")
+		}
+	}
+	var exhausted *homeRetryRoundExhaustedError
+	if m.HomeEnabled() && errors.As(err, &exhausted) && exhausted != nil {
+		if !isCredentialRetryRoundStatus(status) || !m.homeRetryAllowed(attempt, homeRetryLimit) {
+			return 0, false, nil
+		}
+		if exhausted.retryNow {
+			return 0, true, nil
+		}
+		if retryAfter := retryAfterFromError(err); retryAfter != nil {
+			if *retryAfter < 0 || (*retryAfter > 0 && (maxWait <= 0 || *retryAfter > maxWait)) {
+				return 0, false, nil
+			}
+			return *retryAfter, true, nil
+		}
+		return 0, true, nil
+	}
+	if m.HomeEnabled() {
+		if status != http.StatusTooManyRequests || !m.homeRetryAllowed(attempt, homeRetryLimit) {
+			return 0, false, nil
+		}
+		retryAfter := retryAfterFromError(err)
+		if retryAfter == nil || *retryAfter <= 0 || maxWait <= 0 || *retryAfter > maxWait {
+			return 0, false, nil
+		}
+		return *retryAfter, true, nil
+	}
+	eligibility := authSelectionEligibilityForRequest(ctx, opts)
+	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
+	if !isCredentialRetryRoundStatus(status) || !m.retryAllowed(attempt, providers, model, eligibility, pinnedAuthID, defaultRequestRetry) {
+		return 0, false, nil
+	}
+	wait, found := m.closestCooldownWait(providers, model, attempt, eligibility, pinnedAuthID, defaultRequestRetry)
 	if found {
-		if wait > maxWait {
+		if wait > 0 && (maxWait <= 0 || wait > maxWait) {
 			return 0, false, nil
 		}
 		return wait, true, nil
 	}
-	if status != http.StatusTooManyRequests {
-		return 0, false, nil
+	if retryAfter := retryAfterFromError(err); retryAfter != nil {
+		if *retryAfter < 0 || (*retryAfter > 0 && (maxWait <= 0 || *retryAfter > maxWait)) {
+			return 0, false, nil
+		}
+		return *retryAfter, true, nil
 	}
-	if !m.retryAllowed(attempt, providers) {
-		return 0, false, nil
+	return 0, true, nil
+}
+
+func (m *Manager) homeRetryAllowed(attempt int, retryLimit int) bool {
+	if m == nil || !m.HomeEnabled() || attempt < 0 {
+		return false
 	}
-	retryAfter := retryAfterFromError(err)
-	if retryAfter == nil || *retryAfter <= 0 || *retryAfter > maxWait {
-		return 0, false, nil
+	if retryLimit < 0 {
+		retryLimit = int(m.requestRetry.Load())
+		if retryLimit < 0 {
+			retryLimit = 0
+		}
 	}
-	return *retryAfter, true, nil
+	return attempt < retryLimit
+}
+
+func (m *Manager) observeHomeRetryLimit(auth *Auth, selection *HomeDispatchSelection, retryLimit *int) {
+	if m == nil || retryLimit == nil {
+		return
+	}
+	if selection != nil && selection.hasRequestRetry {
+		*retryLimit = selection.requestRetry
+		return
+	}
+	if auth == nil {
+		return
+	}
+	limit := int(m.requestRetry.Load())
+	if override, ok := auth.RequestRetryOverride(); ok {
+		limit = override
+	}
+	if limit < 0 {
+		limit = 0
+	}
+	if *retryLimit < 0 || limit > *retryLimit {
+		*retryLimit = limit
+	}
+}
+
+func observeHomeCooldownRetryLimit(cooldown *homeDispatchRetryAfterError, retryLimit *int, acceptRemoteRetryLimit bool) {
+	if cooldown == nil || retryLimit == nil || !acceptRemoteRetryLimit {
+		return
+	}
+	if remoteLimit, ok := cooldown.RequestRetryLimit(); ok {
+		*retryLimit = remoteLimit
+	}
 }
 
 const cooldownWaitJitterCap = 2 * time.Second
@@ -1212,12 +1427,14 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 	available, selectorAuths, errAvailable := m.availableAuthsForSelector(selector, candidates, provider, model, time.Now())
 	if errAvailable != nil {
 		m.mu.RUnlock()
+		m.warnLogAuthUnavailable(ctx, []string{provider}, model, opts, tried, errAvailable)
 		return nil, nil, errAvailable
 	}
 	m.mu.RUnlock()
 
 	selected, handled, errPick := m.pickViaPluginScheduler(ctx, pluginScheduler, provider, []string{provider}, model, opts, tried, available)
 	if errPick != nil {
+		m.warnLogAuthUnavailable(ctx, []string{provider}, model, opts, tried, errPick)
 		return nil, nil, errPick
 	}
 	if !handled {
@@ -1227,6 +1444,7 @@ func (m *Manager) pickNextLegacy(ctx context.Context, provider, model string, op
 			if isBuiltInSelector(selector) {
 				errPick = restoreModelCooldownErrorModel(errPick, model)
 			}
+			m.warnLogAuthUnavailable(ctx, []string{provider}, model, opts, tried, errPick)
 			return nil, nil, errPick
 		}
 	}
@@ -1329,6 +1547,7 @@ func (m *Manager) SelectHomeAuthWithCredentialPolicy(ctx context.Context, provid
 	tried := make(map[string]struct{})
 	for {
 		selectionOpts := withHomeAuthCount(opts, homeAuthCount)
+		selectionOpts = withHomeExcludedAuthIDs(selectionOpts, tried)
 		selection, errSelection := m.pickHomeDispatchSelection(selectionCtx, model, selectionOpts)
 		if errSelection != nil {
 			return nil, errSelection
@@ -1375,6 +1594,7 @@ func (m *Manager) SelectHomeAuthByKind(ctx context.Context, provider string, mod
 	tried := make(map[string]struct{})
 	for {
 		selectionOpts := withHomeAuthCount(opts, homeAuthCount)
+		selectionOpts = withHomeExcludedAuthIDs(selectionOpts, tried)
 		selection, errSelection := m.pickHomeDispatchSelection(ctx, model, selectionOpts)
 		if errSelection != nil {
 			return nil, errSelection
@@ -1453,6 +1673,7 @@ func (m *Manager) pickNext(ctx context.Context, provider, model string, opts cli
 		selected, errPick = m.scheduler.pickSingle(ctx, provider, model, opts, tried)
 	}
 	if errPick != nil {
+		m.warnLogAuthUnavailable(ctx, []string{provider}, model, opts, tried, errPick)
 		return nil, nil, errPick
 	}
 	if selected == nil {
@@ -1542,15 +1763,18 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 	m.mu.RUnlock()
 	candidates, errAvailable := m.filterCodexRateLimitContinuityCandidates(candidates, model, opts)
 	if errAvailable != nil {
+		m.warnLogAuthUnavailable(ctx, providers, model, opts, tried, errAvailable)
 		return nil, nil, "", errAvailable
 	}
 	available, selectorAuths, errAvailable := m.availableAuthsForSelector(selector, candidates, "mixed", model, time.Now())
 	if errAvailable != nil {
+		m.warnLogAuthUnavailable(ctx, providers, model, opts, tried, errAvailable)
 		return nil, nil, "", errAvailable
 	}
 
 	selected, handled, errPick := m.pickViaPluginScheduler(ctx, pluginScheduler, "mixed", providers, model, opts, tried, available)
 	if errPick != nil {
+		m.warnLogAuthUnavailable(ctx, providers, model, opts, tried, errPick)
 		return nil, nil, "", errPick
 	}
 	if !handled {
@@ -1560,6 +1784,7 @@ func (m *Manager) pickNextMixedLegacy(ctx context.Context, providers []string, m
 			if isBuiltInSelector(selector) {
 				errPick = restoreModelCooldownErrorModel(errPick, model)
 			}
+			m.warnLogAuthUnavailable(ctx, providers, model, opts, tried, errPick)
 			return nil, nil, "", errPick
 		}
 	}
@@ -1650,6 +1875,7 @@ func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model s
 		selected, providerKey, errPick = m.scheduler.pickMixed(ctx, eligibleProviders, model, opts, tried)
 	}
 	if errPick != nil {
+		m.warnLogAuthUnavailable(ctx, eligibleProviders, model, opts, tried, errPick)
 		return nil, nil, "", errPick
 	}
 	if selected == nil {
@@ -1669,4 +1895,108 @@ func (m *Manager) pickNextMixed(ctx context.Context, providers []string, model s
 		m.mu.Unlock()
 	}
 	return authCopy, executor, providerKey, nil
+}
+
+func isAuthUnavailableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var authErr *Error
+	if errors.As(err, &authErr) && authErr != nil {
+		return authErr.Code == "auth_unavailable" || authErr.Code == "model_cooldown"
+	}
+	var cooldownErr *modelCooldownError
+	return errors.As(err, &cooldownErr) && cooldownErr != nil
+}
+
+func authCoolingSummary(auth *Auth, model string, next time.Time, now time.Time) string {
+	if auth == nil {
+		return ""
+	}
+	ident := formatAuthIdentity(auth, auth.Provider)
+	reason := ""
+	if model != "" && len(auth.ModelStates) > 0 {
+		if state, ok := auth.ModelStates[model]; ok && state != nil {
+			reason = cooldownReason(state.StatusMessage, state.Quota, state.LastError)
+		} else if state, ok := auth.ModelStates[canonicalModelKey(model)]; ok && state != nil {
+			reason = cooldownReason(state.StatusMessage, state.Quota, state.LastError)
+		}
+	}
+	if reason == "" {
+		reason = cooldownReason(auth.StatusMessage, auth.Quota, auth.LastError)
+	}
+	if reason == "" {
+		reason = "cooldown"
+	}
+	remaining := "0s"
+	if !next.IsZero() && next.After(now) {
+		remaining = next.Sub(now).Round(time.Second).String()
+	}
+	return fmt.Sprintf("[%s, reason=%s, remaining=%s]", ident, reason, remaining)
+}
+
+func (m *Manager) warnLogAuthUnavailable(ctx context.Context, providers []string, model string, opts cliproxyexecutor.Options, tried map[string]struct{}, err error) {
+	if m == nil || err == nil || !isAuthUnavailableError(err) {
+		return
+	}
+	now := time.Now()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	eligibility := authSelectionEligibilityForRequest(ctx, opts)
+	pinnedAuthID := pinnedAuthIDFromMetadata(opts.Metadata)
+	providerSet := make(map[string]struct{}, len(providers))
+	for _, p := range providers {
+		if norm := strings.TrimSpace(strings.ToLower(p)); norm != "" && norm != "mixed" {
+			providerSet[norm] = struct{}{}
+		}
+	}
+	registryRef := registry.GetGlobalRegistry()
+
+	coolingSummaries := make([]string, 0)
+	totalCandidates := 0
+	for _, candidate := range m.auths {
+		if candidate == nil || candidate.Disabled {
+			continue
+		}
+		providerKey := executorKeyFromAuth(candidate)
+		if len(providerSet) > 0 {
+			if _, ok := providerSet[providerKey]; !ok {
+				continue
+			}
+		}
+		if _, ok := m.executors[providerKey]; !ok {
+			continue
+		}
+		if pinnedAuthID != "" && candidate.ID != pinnedAuthID {
+			continue
+		}
+		if !eligibility.allows(candidate) {
+			continue
+		}
+		if tried != nil {
+			if _, used := tried[candidate.ID]; used {
+				continue
+			}
+		}
+		if model != "" && !m.authSupportsRouteModel(registryRef, candidate, model) {
+			continue
+		}
+		totalCandidates++
+		checkModel := m.selectionModelForAuth(candidate, model)
+		blocked, reason, next := isAuthBlockedForModel(candidate, checkModel, now)
+		if blocked && reason == blockReasonCooldown {
+			coolingSummaries = append(coolingSummaries, authCoolingSummary(candidate, checkModel, next, now))
+		}
+	}
+
+	if len(coolingSummaries) > 0 {
+		sort.Strings(coolingSummaries)
+		entry := logEntryWithRequestID(ctx)
+		providerText := strings.Join(providers, ",")
+		if len(providers) == 1 {
+			entry.Warnf("auth unavailable: %d of %d candidate(s) for model %q (provider=%s) are in cooldown: %s", len(coolingSummaries), totalCandidates, model, providerText, strings.Join(coolingSummaries, ", "))
+		} else {
+			entry.Warnf("auth unavailable: %d of %d candidate(s) for model %q (providers=%s) are in cooldown: %s", len(coolingSummaries), totalCandidates, model, providerText, strings.Join(coolingSummaries, ", "))
+		}
+	}
 }

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"time"
 
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
@@ -115,6 +116,7 @@ func readStreamBootstrap(ctx context.Context, ch <-chan cliproxyexecutor.StreamC
 
 func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, resultModel string, headers http.Header, buffered []cliproxyexecutor.StreamChunk, remaining <-chan cliproxyexecutor.StreamChunk, aliasResult OAuthModelAliasResult, ephemeralResult bool, opts cliproxyexecutor.Options) *cliproxyexecutor.StreamResult {
 	out := make(chan cliproxyexecutor.StreamChunk)
+	streamStart := time.Now()
 	go func() {
 		defer close(out)
 		var failed bool
@@ -126,6 +128,8 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 		emit := func(chunk cliproxyexecutor.StreamChunk) bool {
 			if chunk.Err != nil && !failed {
 				failed = true
+				entry := logEntryWithRequestID(ctx)
+				warnLogUpstreamFailure(ctx, entry, provider, resultModel, auth, time.Since(streamStart), chunk.Err)
 				rerr := resultErrorFromError(chunk.Err)
 				action, okAction := matchRequestScopedErrorAction(auth, chunk.Err, m.runtimeConfigSnapshot())
 				result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: rerr, Options: opts}
@@ -230,7 +234,10 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		if errCtx := ctx.Err(); errCtx != nil {
 			return nil, errCtx
 		}
+		entry := logEntryWithRequestID(ctx)
+		startStream := time.Now()
 		streamResult, errStream := executor.ExecuteStream(ctx, auth, execReq, execOpts)
+		durationStream := time.Since(startStream)
 		if errStream != nil {
 			if errCtx := ctx.Err(); errCtx != nil {
 				return nil, errCtx
@@ -247,18 +254,26 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				}
 				if errRefresh != nil {
 					errStream = errRefresh
+					warnLogUpstreamFailure(ctx, entry, provider, execModel, auth, durationStream, errStream)
 				} else if okRefresh {
 					auth = refreshed
 					m.replaceHomeExecutionLifecycleAuth(execOpts.ExecutionLifecycle, auth)
 					publishSelectedAuthMetadata(execOpts.Metadata, auth)
 					didRefreshOnUnauthorized = true
+					startRetry := time.Now()
 					streamResult, errStream = executor.ExecuteStream(ctx, auth, execReq, execOpts)
+					durationRetry := time.Since(startRetry)
 					if errStream != nil {
+						warnLogUpstreamFailure(ctx, entry, provider, execModel, auth, durationRetry, errStream)
 						if errCtx := ctx.Err(); errCtx != nil {
 							return nil, errCtx
 						}
 					}
+				} else {
+					warnLogUpstreamFailure(ctx, entry, provider, execModel, auth, durationStream, errStream)
 				}
+			} else {
+				warnLogUpstreamFailure(ctx, entry, provider, execModel, auth, durationStream, errStream)
 			}
 		}
 		if !ephemeralResult {
@@ -316,6 +331,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				if errRefresh != nil {
 					discardStreamChunks(streamResult.Chunks)
 					bootstrapErr = errRefresh
+					warnLogUpstreamFailure(ctx, entry, provider, execModel, auth, time.Since(startStream), bootstrapErr)
 					streamResult = &cliproxyexecutor.StreamResult{}
 				} else if okRefresh {
 					discardStreamChunks(streamResult.Chunks)
@@ -323,6 +339,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 					m.replaceHomeExecutionLifecycleAuth(execOpts.ExecutionLifecycle, auth)
 					publishSelectedAuthMetadata(execOpts.Metadata, auth)
 					didRefreshOnUnauthorized = true
+					startRetry := time.Now()
 					retryStream, retryErr := executor.ExecuteStream(ctx, auth, execReq, execOpts)
 					retryStream, retryErr = validateStreamResult(retryStream, retryErr)
 					if retryErr != nil {
@@ -330,12 +347,20 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 							return nil, errCtx
 						}
 						bootstrapErr = retryErr
+						warnLogUpstreamFailure(ctx, entry, provider, execModel, auth, time.Since(startRetry), bootstrapErr)
 						streamResult = &cliproxyexecutor.StreamResult{}
 					} else {
 						streamResult = retryStream
 						buffered, closed, bootstrapErr = readStreamBootstrap(ctx, streamResult.Chunks)
+						if bootstrapErr != nil {
+							warnLogUpstreamFailure(ctx, entry, provider, execModel, auth, time.Since(startRetry), bootstrapErr)
+						}
 					}
+				} else {
+					warnLogUpstreamFailure(ctx, entry, provider, execModel, auth, time.Since(startStream), bootstrapErr)
 				}
+			} else {
+				warnLogUpstreamFailure(ctx, entry, provider, execModel, auth, time.Since(startStream), bootstrapErr)
 			}
 		}
 		if !ephemeralResult {
@@ -404,6 +429,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 
 		if closed && len(buffered) == 0 {
 			emptyErr := &Error{Code: "empty_stream", Message: "upstream stream closed before first payload", Retryable: true}
+			warnLogUpstreamFailure(ctx, entry, provider, execModel, auth, time.Since(startStream), emptyErr)
 			result := Result{AuthID: auth.ID, Provider: provider, Model: resultModel, Success: false, Error: emptyErr, Options: execOpts}
 			m.recordExecutionResult(ctx, result, auth, ephemeralResult)
 			if idx < len(execModels)-1 {

--- a/sdk/cliproxy/auth/conductor_stream.go
+++ b/sdk/cliproxy/auth/conductor_stream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"time"
 
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
@@ -114,6 +115,7 @@ func readStreamBootstrap(ctx context.Context, ch <-chan cliproxyexecutor.StreamC
 }
 func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, resultModel string, headers http.Header, metadata map[string]any, buffered []cliproxyexecutor.StreamChunk, remaining <-chan cliproxyexecutor.StreamChunk, aliasResult OAuthModelAliasResult, ephemeralResult bool, opts cliproxyexecutor.Options) *cliproxyexecutor.StreamResult {
 	out := make(chan cliproxyexecutor.StreamChunk)
+	streamStart := time.Now()
 	go func() {
 		defer close(out)
 		defer m.abandonCodexRateLimitContinuityAttempt(ctx)
@@ -127,6 +129,7 @@ func (m *Manager) wrapStreamResult(ctx context.Context, auth *Auth, provider, re
 			if chunk.Err != nil && !failed {
 				failed = true
 				if !isRetryWithoutPenaltyError(chunk.Err) {
+					warnLogUpstreamFailure(ctx, logEntryWithRequestID(ctx), provider, resultModel, auth, time.Since(streamStart), chunk.Err)
 					rerr := resultErrorFromError(chunk.Err)
 					result := resultForAuthWithOptions(auth, provider, resultModel, false, rerr, opts)
 					result.RetryAfter = retryAfterFromError(chunk.Err)
@@ -243,12 +246,15 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 		if errCtx := ctx.Err(); errCtx != nil {
 			return nil, errCtx
 		}
+		entry := logEntryWithRequestID(ctx)
+		startStream := time.Now()
 		if !selectedPublished {
 			publishSelectedAuthMetadata(execOpts.Metadata, auth)
 			selectedPublished = true
 		}
 		markCodexModelFallbackDispatch(execOpts, auth.ID)
 		streamResult, errStream := executor.ExecuteStream(ctx, auth, execReq, execOpts)
+		durationStream := time.Since(startStream)
 		if errStream != nil {
 			if errCtx := ctx.Err(); errCtx != nil {
 				return nil, errCtx
@@ -271,15 +277,19 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				}
 				if errRefresh != nil {
 					errStream = errRefresh
+					warnLogUpstreamFailure(ctx, entry, provider, execModel, auth, durationStream, errStream)
 				} else if okRefresh {
 					auth = refreshed
 					ctx = contextWithAuthGeneration(ctx, auth)
 					m.replaceHomeExecutionLifecycleAuth(execOpts.ExecutionLifecycle, auth)
 					publishSelectedAuthMetadata(execOpts.Metadata, auth)
 					didRefreshOnUnauthorized = true
+					startRetry := time.Now()
 					markCodexModelFallbackDispatch(execOpts, auth.ID)
 					streamResult, errStream = executor.ExecuteStream(ctx, auth, execReq, execOpts)
+					durationRetry := time.Since(startRetry)
 					if errStream != nil {
+						warnLogUpstreamFailure(ctx, entry, provider, execModel, auth, durationRetry, errStream)
 						if errCtx := ctx.Err(); errCtx != nil {
 							return nil, errCtx
 						}
@@ -290,7 +300,11 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 					if isRetryWithoutPenaltyError(errStream) {
 						return nil, errStream
 					}
+				} else {
+					warnLogUpstreamFailure(ctx, entry, provider, execModel, auth, durationStream, errStream)
 				}
+			} else {
+				warnLogUpstreamFailure(ctx, entry, provider, execModel, auth, durationStream, errStream)
 			}
 		}
 		if !ephemeralResult {
@@ -353,6 +367,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 				if errRefresh != nil {
 					discardStreamChunks(streamResult.Chunks)
 					bootstrapErr = errRefresh
+					warnLogUpstreamFailure(ctx, entry, provider, execModel, auth, time.Since(startStream), bootstrapErr)
 					streamResult = &cliproxyexecutor.StreamResult{}
 				} else if okRefresh {
 					discardStreamChunks(streamResult.Chunks)
@@ -361,6 +376,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 					m.replaceHomeExecutionLifecycleAuth(execOpts.ExecutionLifecycle, auth)
 					publishSelectedAuthMetadata(execOpts.Metadata, auth)
 					didRefreshOnUnauthorized = true
+					startRetry := time.Now()
 					markCodexModelFallbackDispatch(execOpts, auth.ID)
 					retryStream, retryErr := executor.ExecuteStream(ctx, auth, execReq, execOpts)
 					retryStream, retryErr = validateStreamResult(retryStream, retryErr)
@@ -369,12 +385,20 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 							return nil, errCtx
 						}
 						bootstrapErr = retryErr
+						warnLogUpstreamFailure(ctx, entry, provider, execModel, auth, time.Since(startRetry), bootstrapErr)
 						streamResult = &cliproxyexecutor.StreamResult{}
 					} else {
 						streamResult = retryStream
 						buffered, closed, bootstrapErr = readStreamBootstrap(ctx, streamResult.Chunks)
+						if bootstrapErr != nil {
+							warnLogUpstreamFailure(ctx, entry, provider, execModel, auth, time.Since(startRetry), bootstrapErr)
+						}
 					}
+				} else {
+					warnLogUpstreamFailure(ctx, entry, provider, execModel, auth, time.Since(startStream), bootstrapErr)
 				}
+			} else {
+				warnLogUpstreamFailure(ctx, entry, provider, execModel, auth, time.Since(startStream), bootstrapErr)
 			}
 		}
 		if !ephemeralResult {
@@ -451,6 +475,7 @@ func (m *Manager) executeStreamWithModelPool(ctx context.Context, executor Provi
 
 		if closed && len(buffered) == 0 {
 			emptyErr := &Error{Code: "empty_stream", Message: "upstream stream closed before first payload", Retryable: true}
+			warnLogUpstreamFailure(ctx, entry, provider, execModel, auth, time.Since(startStream), emptyErr)
 			result := resultForAuthWithOptions(auth, provider, resultModel, false, emptyErr, execOpts)
 			m.recordExecutionResult(ctx, result, auth, ephemeralResult)
 			if idx < len(execModels)-1 {

--- a/sdk/cliproxy/auth/conductor_stream_overload_failover_test.go
+++ b/sdk/cliproxy/auth/conductor_stream_overload_failover_test.go
@@ -1,0 +1,168 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// registerOverloadAuths registers n active codex credentials with descending priority so the
+// selection order is deterministic, and returns their IDs in expected pick order.
+func registerOverloadAuths(t *testing.T, m *Manager, n int) []string {
+	t.Helper()
+	reg := registry.GetGlobalRegistry()
+	ids := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("auth-overload-%d", i+1)
+		auth := &Auth{
+			ID:       id,
+			Provider: "codex",
+			Status:   StatusActive,
+			// Higher priority is picked first, so descending values keep the order stable.
+			Attributes: map[string]string{"priority": fmt.Sprintf("%d", 100-i)},
+		}
+		reg.RegisterClient(id, "codex", []*registry.ModelInfo{{ID: "gpt-5.6-terra"}})
+		if _, err := m.Register(context.Background(), auth); err != nil {
+			t.Fatalf("register %s: %v", id, err)
+		}
+		ids = append(ids, id)
+	}
+	t.Cleanup(func() {
+		for _, id := range ids {
+			reg.UnregisterClient(id)
+		}
+	})
+	return ids
+}
+
+func overloadStatusError() customStatusError {
+	return customStatusError{
+		code: http.StatusServiceUnavailable,
+		msg:  `{"error":{"type":"service_unavailable_error","code":"server_is_overloaded","message":"Our servers are currently overloaded. Please try again later.","param":null}}`,
+	}
+}
+
+func successStreamResult() *cliproxyexecutor.StreamResult {
+	ch := make(chan cliproxyexecutor.StreamChunk, 2)
+	ch <- cliproxyexecutor.StreamChunk{Payload: []byte(`data: {"type":"response.output_item.added"}`)}
+	ch <- cliproxyexecutor.StreamChunk{Payload: []byte(`data: {"type":"response.completed"}`)}
+	close(ch)
+	return &cliproxyexecutor.StreamResult{
+		Headers: http.Header{"Content-Type": []string{"text/event-stream"}},
+		Chunks:  ch,
+	}
+}
+
+// With stream-bootstrap-buffering enabled the codex executor returns the overload rejection
+// synchronously instead of relaying it in-stream. This test pins the operational question: with
+// request-retry=5 and max-retry-credentials=6, do three consecutive overloaded accounts get
+// skipped so the fourth credential serves the request?
+func TestExecuteStream_BootstrapOverload_SkipsConsecutiveOverloadedCredentials(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(5, 0, 6)
+	ids := registerOverloadAuths(t, m, 6)
+
+	var mu sync.Mutex
+	var order []string
+	overloaded := map[string]bool{ids[0]: true, ids[1]: true, ids[2]: true}
+
+	m.RegisterExecutor(&customStreamMockExecutor{
+		identifier: "codex",
+		streamFn: func(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+			mu.Lock()
+			order = append(order, auth.ID)
+			mu.Unlock()
+			if overloaded[auth.ID] {
+				return nil, overloadStatusError()
+			}
+			return successStreamResult(), nil
+		},
+	})
+
+	result, err := m.ExecuteStream(context.Background(), []string{"codex"},
+		cliproxyexecutor.Request{Model: "gpt-5.6-terra"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("expected the request to survive three overloaded credentials: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a stream result from the fourth credential")
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected chunk error: %v", chunk.Err)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(order) != 4 {
+		t.Fatalf("attempted %d credentials (%v), want exactly 4", len(order), order)
+	}
+	for i := 0; i < 3; i++ {
+		if overloaded[order[i]] != true {
+			t.Fatalf("attempt %d used %s, expected one of the overloaded credentials", i+1, order[i])
+		}
+	}
+	if overloaded[order[3]] {
+		t.Fatalf("final attempt used overloaded credential %s", order[3])
+	}
+}
+
+// The credential budget must be honoured: when every credential is overloaded the request fails
+// after max-retry-credentials attempts rather than looping forever.
+func TestExecuteStream_BootstrapOverload_StopsAtCredentialBudget(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	m := NewManager(nil, nil, nil)
+	// Six credentials exist and only four may be attempted in one round.
+	m.SetRetryConfig(5, 0, 4)
+	registerOverloadAuths(t, m, 6)
+
+	var mu sync.Mutex
+	attempts := 0
+	m.RegisterExecutor(&customStreamMockExecutor{
+		identifier: "codex",
+		streamFn: func(_ context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+			mu.Lock()
+			attempts++
+			mu.Unlock()
+			return nil, overloadStatusError()
+		},
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = m.ExecuteStream(context.Background(), []string{"codex"},
+			cliproxyexecutor.Request{Model: "gpt-5.6-terra"}, cliproxyexecutor.Options{})
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("ExecuteStream did not terminate within the credential budget")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if attempts == 0 {
+		t.Fatal("expected at least one attempt")
+	}
+	// A no-wait retry round may consume the remaining two credentials after the
+	// first four-credential sweep, but it must not exceed the available set.
+	if attempts < 4 || attempts > 6 {
+		t.Fatalf("attempts = %d, want between 4 and 6", attempts)
+	}
+	t.Logf("total upstream attempts across retry sweeps: %d", attempts)
+}

--- a/sdk/cliproxy/auth/conductor_stream_overload_failover_test.go
+++ b/sdk/cliproxy/auth/conductor_stream_overload_failover_test.go
@@ -126,7 +126,7 @@ func TestExecuteStream_BootstrapOverload_StopsAtCredentialBudget(t *testing.T) {
 	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
 
 	m := NewManager(nil, nil, nil)
-	// Six credentials exist but only four may be attempted.
+	// Six credentials exist and only four may be attempted in one round.
 	m.SetRetryConfig(5, 0, 4)
 	registerOverloadAuths(t, m, 6)
 
@@ -159,10 +159,10 @@ func TestExecuteStream_BootstrapOverload_StopsAtCredentialBudget(t *testing.T) {
 	if attempts == 0 {
 		t.Fatal("expected at least one attempt")
 	}
-	// The outer request-retry loop may restart the credential sweep, so assert the per-sweep
-	// budget is respected rather than a single exact total.
-	if attempts%4 != 0 {
-		t.Fatalf("attempts = %d, expected a multiple of the 4-credential budget", attempts)
+	// A no-wait retry round may consume the remaining two credentials after the
+	// first four-credential sweep, but it must not exceed the available set.
+	if attempts < 4 || attempts > 6 {
+		t.Fatalf("attempts = %d, want between 4 and 6", attempts)
 	}
 	t.Logf("total upstream attempts across retry sweeps: %d", attempts)
 }

--- a/sdk/cliproxy/auth/conductor_stream_overload_failover_test.go
+++ b/sdk/cliproxy/auth/conductor_stream_overload_failover_test.go
@@ -1,0 +1,168 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// registerOverloadAuths registers n active codex credentials with descending priority so the
+// selection order is deterministic, and returns their IDs in expected pick order.
+func registerOverloadAuths(t *testing.T, m *Manager, n int) []string {
+	t.Helper()
+	reg := registry.GetGlobalRegistry()
+	ids := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("auth-overload-%d", i+1)
+		auth := &Auth{
+			ID:       id,
+			Provider: "codex",
+			Status:   StatusActive,
+			// Higher priority is picked first, so descending values keep the order stable.
+			Attributes: map[string]string{"priority": fmt.Sprintf("%d", 100-i)},
+		}
+		reg.RegisterClient(id, "codex", []*registry.ModelInfo{{ID: "gpt-5.6-terra"}})
+		if _, err := m.Register(context.Background(), auth); err != nil {
+			t.Fatalf("register %s: %v", id, err)
+		}
+		ids = append(ids, id)
+	}
+	t.Cleanup(func() {
+		for _, id := range ids {
+			reg.UnregisterClient(id)
+		}
+	})
+	return ids
+}
+
+func overloadStatusError() customStatusError {
+	return customStatusError{
+		code: http.StatusServiceUnavailable,
+		msg:  `{"error":{"type":"service_unavailable_error","code":"server_is_overloaded","message":"Our servers are currently overloaded. Please try again later.","param":null}}`,
+	}
+}
+
+func successStreamResult() *cliproxyexecutor.StreamResult {
+	ch := make(chan cliproxyexecutor.StreamChunk, 2)
+	ch <- cliproxyexecutor.StreamChunk{Payload: []byte(`data: {"type":"response.output_item.added"}`)}
+	ch <- cliproxyexecutor.StreamChunk{Payload: []byte(`data: {"type":"response.completed"}`)}
+	close(ch)
+	return &cliproxyexecutor.StreamResult{
+		Headers: http.Header{"Content-Type": []string{"text/event-stream"}},
+		Chunks:  ch,
+	}
+}
+
+// With stream-bootstrap-buffering enabled the codex executor returns the overload rejection
+// synchronously instead of relaying it in-stream. This test pins the operational question: with
+// request-retry=5 and max-retry-credentials=6, do three consecutive overloaded accounts get
+// skipped so the fourth credential serves the request?
+func TestExecuteStream_BootstrapOverload_SkipsConsecutiveOverloadedCredentials(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(5, 0, 6)
+	ids := registerOverloadAuths(t, m, 6)
+
+	var mu sync.Mutex
+	var order []string
+	overloaded := map[string]bool{ids[0]: true, ids[1]: true, ids[2]: true}
+
+	m.RegisterExecutor(&customStreamMockExecutor{
+		identifier: "codex",
+		streamFn: func(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+			mu.Lock()
+			order = append(order, auth.ID)
+			mu.Unlock()
+			if overloaded[auth.ID] {
+				return nil, overloadStatusError()
+			}
+			return successStreamResult(), nil
+		},
+	})
+
+	result, err := m.ExecuteStream(context.Background(), []string{"codex"},
+		cliproxyexecutor.Request{Model: "gpt-5.6-terra"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("expected the request to survive three overloaded credentials: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a stream result from the fourth credential")
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected chunk error: %v", chunk.Err)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(order) != 4 {
+		t.Fatalf("attempted %d credentials (%v), want exactly 4", len(order), order)
+	}
+	for i := 0; i < 3; i++ {
+		if overloaded[order[i]] != true {
+			t.Fatalf("attempt %d used %s, expected one of the overloaded credentials", i+1, order[i])
+		}
+	}
+	if overloaded[order[3]] {
+		t.Fatalf("final attempt used overloaded credential %s", order[3])
+	}
+}
+
+// The credential budget must be honoured: when every credential is overloaded the request fails
+// after max-retry-credentials attempts rather than looping forever.
+func TestExecuteStream_BootstrapOverload_StopsAtCredentialBudget(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	m := NewManager(nil, nil, nil)
+	// Six credentials exist but only four may be attempted.
+	m.SetRetryConfig(5, 0, 4)
+	registerOverloadAuths(t, m, 6)
+
+	var mu sync.Mutex
+	attempts := 0
+	m.RegisterExecutor(&customStreamMockExecutor{
+		identifier: "codex",
+		streamFn: func(_ context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+			mu.Lock()
+			attempts++
+			mu.Unlock()
+			return nil, overloadStatusError()
+		},
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = m.ExecuteStream(context.Background(), []string{"codex"},
+			cliproxyexecutor.Request{Model: "gpt-5.6-terra"}, cliproxyexecutor.Options{})
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("ExecuteStream did not terminate within the credential budget")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if attempts == 0 {
+		t.Fatal("expected at least one attempt")
+	}
+	// The outer request-retry loop may restart the credential sweep, so assert the per-sweep
+	// budget is respected rather than a single exact total.
+	if attempts%4 != 0 {
+		t.Fatalf("attempts = %d, expected a multiple of the 4-credential budget", attempts)
+	}
+	t.Logf("total upstream attempts across retry sweeps: %d", attempts)
+}

--- a/sdk/cliproxy/auth/conductor_stream_overload_status_test.go
+++ b/sdk/cliproxy/auth/conductor_stream_overload_status_test.go
@@ -1,0 +1,138 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+// When every credential is exhausted by overload rejections the caller must receive a real
+// error carrying 503, not a committed 200 stream. This is what lets the downstream client and
+// any upstream proxy see the true capacity signal.
+func TestExecuteStream_AllCredentialsOverloaded_ReturnsStatusError(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(5, 0, 3)
+	registerOverloadAuths(t, m, 3)
+
+	m.RegisterExecutor(&customStreamMockExecutor{
+		identifier: "codex",
+		streamFn: func(_ context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+			// Mirrors the buffering-enabled codex executor: the rejection is returned
+			// synchronously, before any downstream chunk is committed.
+			return nil, overloadStatusError()
+		},
+	})
+
+	result, err := m.ExecuteStream(context.Background(), []string{"codex"},
+		cliproxyexecutor.Request{Model: "gpt-5.6-terra"}, cliproxyexecutor.Options{})
+
+	if err == nil {
+		t.Fatalf("expected a hard error once every credential is overloaded, got result=%v", result)
+	}
+	statusErr, ok := err.(interface{ StatusCode() int })
+	if !ok {
+		t.Fatalf("error %T does not expose StatusCode(): %v", err, err)
+	}
+	if got := statusErr.StatusCode(); got != http.StatusServiceUnavailable {
+		t.Fatalf("status code = %d, want %d", got, http.StatusServiceUnavailable)
+	}
+}
+
+// Contrast: the unbuffered path commits response.created first, so the rejection can only be
+// relayed inside an already-successful stream. The caller gets no error at all.
+func TestExecuteStream_UnbufferedOverload_StaysCommittedStream(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(5, 0, 3)
+	registerOverloadAuths(t, m, 3)
+
+	m.RegisterExecutor(&customStreamMockExecutor{
+		identifier: "codex",
+		streamFn: func(_ context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+			ch := make(chan cliproxyexecutor.StreamChunk, 2)
+			ch <- cliproxyexecutor.StreamChunk{Payload: []byte(`data: {"type":"response.created"}`)}
+			ch <- cliproxyexecutor.StreamChunk{Err: overloadStatusError()}
+			close(ch)
+			return &cliproxyexecutor.StreamResult{
+				Headers: http.Header{"Content-Type": []string{"text/event-stream"}},
+				Chunks:  ch,
+			}, nil
+		},
+	})
+
+	result, err := m.ExecuteStream(context.Background(), []string{"codex"},
+		cliproxyexecutor.Request{Model: "gpt-5.6-terra"}, cliproxyexecutor.Options{})
+	if err != nil {
+		t.Fatalf("unbuffered path should hand back a committed stream, got error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a committed stream result")
+	}
+	var sawErr bool
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			sawErr = true
+		}
+	}
+	if !sawErr {
+		t.Fatal("expected the overload rejection to arrive in-stream")
+	}
+}
+
+// Critical distinction: if an executor surfaces the rejection as the *first* stream chunk instead
+// of returning it synchronously, the conductor downgrades it to a committed stream carrying the
+// error (streamErrorResult), and the caller again observes no error. Returning synchronously is
+// therefore required to preserve the 503 status semantics.
+func TestExecuteStream_ErrorAsFirstChunk_IsDowngradedToCommittedStream(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	m := NewManager(nil, nil, nil)
+	m.SetRetryConfig(5, 0, 3)
+	registerOverloadAuths(t, m, 3)
+
+	m.RegisterExecutor(&customStreamMockExecutor{
+		identifier: "codex",
+		streamFn: func(_ context.Context, _ *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+			ch := make(chan cliproxyexecutor.StreamChunk, 1)
+			ch <- cliproxyexecutor.StreamChunk{Err: overloadStatusError()}
+			close(ch)
+			return &cliproxyexecutor.StreamResult{
+				Headers: http.Header{"Content-Type": []string{"text/event-stream"}},
+				Chunks:  ch,
+			}, nil
+		},
+	})
+
+	result, err := m.ExecuteStream(context.Background(), []string{"codex"},
+		cliproxyexecutor.Request{Model: "gpt-5.6-terra"}, cliproxyexecutor.Options{})
+
+	if err != nil {
+		t.Logf("first-chunk error surfaced as a hard error: %v", err)
+		t.Log("NOTE: this contradicts the streamErrorResult downgrade path; review if it changes")
+		return
+	}
+	if result == nil {
+		t.Fatal("expected either an error or a committed stream")
+	}
+	var sawErr bool
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			sawErr = true
+		}
+	}
+	if !sawErr {
+		t.Fatal("expected the rejection to be delivered in-stream after the downgrade")
+	}
+	t.Log("confirmed: an error delivered as the first chunk is downgraded to a committed stream")
+}

--- a/sdk/cliproxy/auth/conductor_warn_logging_test.go
+++ b/sdk/cliproxy/auth/conductor_warn_logging_test.go
@@ -1,0 +1,609 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+)
+
+func setupTestLoggerHook(t *testing.T) *logtest.Hook {
+	_, hook := logtest.NewNullLogger()
+	oldLevel := log.GetLevel()
+	log.SetLevel(log.WarnLevel)
+
+	// Deep-clone existing hooks
+	savedHooks := make(log.LevelHooks)
+	for lvl, hs := range log.StandardLogger().Hooks {
+		savedHooks[lvl] = append([]log.Hook(nil), hs...)
+	}
+
+	log.AddHook(hook)
+	t.Cleanup(func() {
+		log.SetLevel(oldLevel)
+		log.StandardLogger().ReplaceHooks(savedHooks)
+	})
+	return hook
+}
+
+func TestWarnLogOnAuthUnavailable_SingleProvider(t *testing.T) {
+	previousCooldown := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousCooldown) })
+
+	hook := setupTestLoggerHook(t)
+	m := NewManager(nil, nil, nil)
+
+	now := time.Now()
+	auth1 := &Auth{
+		ID:            "auth-cooling-1",
+		Provider:      "claude",
+		Status:        StatusActive,
+		FileName:      "claude-key-1.json",
+		StatusMessage: "rate_limit_exceeded",
+		Quota: QuotaState{
+			Exceeded:      true,
+			Reason:        "rate_limit_exceeded",
+			NextRecoverAt: now.Add(45 * time.Second),
+		},
+		NextRetryAfter: now.Add(45 * time.Second),
+	}
+	auth2 := &Auth{
+		ID:            "auth-cooling-2",
+		Provider:      "claude",
+		Status:        StatusActive,
+		FileName:      "claude-key-2.json",
+		StatusMessage: "quota_exceeded",
+		Quota: QuotaState{
+			Exceeded:      true,
+			Reason:        "quota_exceeded",
+			NextRecoverAt: now.Add(90 * time.Second),
+		},
+		NextRetryAfter: now.Add(90 * time.Second),
+	}
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth1.ID, "claude", []*registry.ModelInfo{{ID: "claude-3-5-sonnet"}})
+	reg.RegisterClient(auth2.ID, "claude", []*registry.ModelInfo{{ID: "claude-3-5-sonnet"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(auth1.ID)
+		reg.UnregisterClient(auth2.ID)
+	})
+
+	if _, err := m.Register(context.Background(), auth1); err != nil {
+		t.Fatalf("register auth1: %v", err)
+	}
+	if _, err := m.Register(context.Background(), auth2); err != nil {
+		t.Fatalf("register auth2: %v", err)
+	}
+
+	exec := &mockCustomErrorExecutor{
+		identifier: "claude",
+	}
+	m.RegisterExecutor(exec)
+
+	hook.Reset()
+
+	req := cliproxyexecutor.Request{Model: "claude-3-5-sonnet"}
+	opts := cliproxyexecutor.Options{}
+
+	_, errExec := m.Execute(context.Background(), []string{"claude"}, req, opts)
+	if errExec == nil {
+		t.Fatal("expected error from Execute, got nil")
+	}
+
+	// Verify exactly one Warn line was emitted explaining the cooling auths
+	warnCount := 0
+	for _, entry := range hook.AllEntries() {
+		if entry.Level == log.WarnLevel && strings.Contains(entry.Message, "auth unavailable") {
+			warnCount++
+			if !strings.Contains(entry.Message, "claude-key-1.json") ||
+				!strings.Contains(entry.Message, "rate_limit_exceeded") ||
+				!strings.Contains(entry.Message, "claude-key-2.json") ||
+				!strings.Contains(entry.Message, "quota_exceeded") ||
+				!strings.Contains(entry.Message, "remaining=") {
+				t.Fatalf("unexpected Warn log content: %s", entry.Message)
+			}
+		}
+	}
+	if warnCount != 1 {
+		t.Fatalf("expected exactly 1 Warn log, got %d. Logs: %#v", warnCount, hook.AllEntries())
+	}
+}
+
+func TestWarnLogOnAuthUnavailable_SessionAffinityLegacyPath(t *testing.T) {
+	previousCooldown := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousCooldown) })
+
+	hook := setupTestLoggerHook(t)
+	m := NewManager(nil, nil, nil)
+	affinity := NewSessionAffinitySelector(&RoundRobinSelector{})
+	defer affinity.Stop()
+	m.SetSelector(affinity)
+
+	now := time.Now()
+	auth1 := &Auth{
+		ID:            "auth-legacy-cooling-1",
+		Provider:      "claude",
+		Status:        StatusActive,
+		FileName:      "claude-legacy.json",
+		StatusMessage: "rate_limit_exceeded",
+		Quota: QuotaState{
+			Exceeded:      true,
+			Reason:        "rate_limit_exceeded",
+			NextRecoverAt: now.Add(45 * time.Second),
+		},
+		NextRetryAfter: now.Add(45 * time.Second),
+	}
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth1.ID, "claude", []*registry.ModelInfo{{ID: "claude-3-5-sonnet"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(auth1.ID)
+	})
+
+	if _, err := m.Register(context.Background(), auth1); err != nil {
+		t.Fatalf("register auth1: %v", err)
+	}
+
+	exec := &mockCustomErrorExecutor{
+		identifier: "claude",
+	}
+	m.RegisterExecutor(exec)
+
+	hook.Reset()
+
+	req := cliproxyexecutor.Request{Model: "claude-3-5-sonnet"}
+	opts := cliproxyexecutor.Options{}
+
+	_, errExec := m.Execute(context.Background(), []string{"claude"}, req, opts)
+	if errExec == nil {
+		t.Fatal("expected error from Execute, got nil")
+	}
+
+	warnCount := 0
+	for _, entry := range hook.AllEntries() {
+		if entry.Level == log.WarnLevel && strings.Contains(entry.Message, "auth unavailable") {
+			warnCount++
+			if !strings.Contains(entry.Message, "claude-legacy.json") ||
+				!strings.Contains(entry.Message, "rate_limit_exceeded") {
+				t.Fatalf("unexpected Warn log content: %s", entry.Message)
+			}
+		}
+	}
+	if warnCount != 1 {
+		t.Fatalf("expected exactly 1 Warn log from legacy path, got %d. Logs: %#v", warnCount, hook.AllEntries())
+	}
+}
+
+func TestWarnLogOnAuthUnavailable_MixedProviders(t *testing.T) {
+	previousCooldown := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousCooldown) })
+
+	hook := setupTestLoggerHook(t)
+	m := NewManager(nil, nil, nil)
+
+	now := time.Now()
+	auth1 := &Auth{
+		ID:            "auth-claude-cooling",
+		Provider:      "claude",
+		Status:        StatusActive,
+		FileName:      "claude.json",
+		StatusMessage: "rate_limit",
+		Quota: QuotaState{
+			Exceeded:      true,
+			Reason:        "rate_limit",
+			NextRecoverAt: now.Add(30 * time.Second),
+		},
+		NextRetryAfter: now.Add(30 * time.Second),
+	}
+	auth2 := &Auth{
+		ID:            "auth-codex-cooling",
+		Provider:      "codex",
+		Status:        StatusActive,
+		FileName:      "codex.json",
+		StatusMessage: "quota_exceeded",
+		Quota: QuotaState{
+			Exceeded:      true,
+			Reason:        "quota_exceeded",
+			NextRecoverAt: now.Add(60 * time.Second),
+		},
+		NextRetryAfter: now.Add(60 * time.Second),
+	}
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth1.ID, "claude", []*registry.ModelInfo{{ID: "gpt-5"}})
+	reg.RegisterClient(auth2.ID, "codex", []*registry.ModelInfo{{ID: "gpt-5"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(auth1.ID)
+		reg.UnregisterClient(auth2.ID)
+	})
+
+	if _, err := m.Register(context.Background(), auth1); err != nil {
+		t.Fatalf("register auth1: %v", err)
+	}
+	if _, err := m.Register(context.Background(), auth2); err != nil {
+		t.Fatalf("register auth2: %v", err)
+	}
+
+	m.RegisterExecutor(&mockCustomErrorExecutor{identifier: "claude"})
+	m.RegisterExecutor(&mockCustomErrorExecutor{identifier: "codex"})
+
+	hook.Reset()
+
+	req := cliproxyexecutor.Request{Model: "gpt-5"}
+	opts := cliproxyexecutor.Options{}
+
+	_, errExec := m.Execute(context.Background(), []string{"claude", "codex"}, req, opts)
+	if errExec == nil {
+		t.Fatal("expected error from Execute, got nil")
+	}
+
+	warnCount := 0
+	for _, entry := range hook.AllEntries() {
+		if entry.Level == log.WarnLevel && strings.Contains(entry.Message, "auth unavailable") {
+			warnCount++
+			if !strings.Contains(entry.Message, "claude.json") ||
+				!strings.Contains(entry.Message, "codex.json") ||
+				!strings.Contains(entry.Message, "providers=claude,codex") {
+				t.Fatalf("unexpected mixed Warn log: %s", entry.Message)
+			}
+		}
+	}
+	if warnCount != 1 {
+		t.Fatalf("expected exactly 1 mixed Warn log, got %d. Logs: %#v", warnCount, hook.AllEntries())
+	}
+}
+
+func TestWarnLogOnUpstreamFailure_NonStream(t *testing.T) {
+	previousCooldown := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousCooldown) })
+
+	hook := setupTestLoggerHook(t)
+	m := NewManager(nil, nil, nil)
+
+	auth := &Auth{
+		ID:         "auth-test-upstream",
+		Provider:   "codex",
+		FileName:   "codex-prod.json",
+		Status:     StatusActive,
+		Attributes: map[string]string{"priority": "10"},
+	}
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, "codex", []*registry.ModelInfo{{ID: "gpt-4o"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(auth.ID)
+	})
+
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	exec := &mockCustomErrorExecutor{
+		identifier: "codex",
+		executeFn: func(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+			time.Sleep(5 * time.Millisecond)
+			return cliproxyexecutor.Response{}, errors.New("500 Internal Server Error: upstream timeout")
+		},
+	}
+	m.RegisterExecutor(exec)
+
+	hook.Reset()
+
+	req := cliproxyexecutor.Request{Model: "gpt-4o"}
+	opts := cliproxyexecutor.Options{}
+
+	_, errExec := m.Execute(context.Background(), []string{"codex"}, req, opts)
+	if errExec == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	foundWarn := false
+	for _, entry := range hook.AllEntries() {
+		if entry.Level == log.WarnLevel && strings.Contains(entry.Message, "upstream execution failed") {
+			if strings.Contains(entry.Message, "provider=codex") &&
+				strings.Contains(entry.Message, "model=gpt-4o") &&
+				strings.Contains(entry.Message, "codex-prod.json") &&
+				strings.Contains(entry.Message, "duration=") &&
+				strings.Contains(entry.Message, "upstream timeout") {
+				foundWarn = true
+				break
+			}
+		}
+	}
+	if !foundWarn {
+		t.Fatalf("expected Warn log detailing upstream failure, got logs: %#v", hook.AllEntries())
+	}
+}
+
+func TestWarnLogOnUpstreamFailure_401RefreshSuccess_DoesNotLogWarn(t *testing.T) {
+	previousCooldown := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousCooldown) })
+
+	hook := setupTestLoggerHook(t)
+	m := NewManager(nil, nil, nil)
+
+	auth := &Auth{
+		ID:         "auth-test-401-refresh",
+		Provider:   "codex",
+		FileName:   "codex-oauth.json",
+		Status:     StatusActive,
+		Attributes: map[string]string{"auth_kind": "oauth", "priority": "10"},
+		Metadata:   map[string]any{"access_token": "old-token", "refresh_token": "valid-refresh-token"},
+	}
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, "codex", []*registry.ModelInfo{{ID: "gpt-4o"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(auth.ID)
+	})
+
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	callCount := 0
+	exec := &mockCustomErrorExecutor{
+		identifier: "codex",
+		executeFn: func(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+			callCount++
+			if callCount == 1 {
+				return cliproxyexecutor.Response{}, customStatusError{code: http.StatusUnauthorized, msg: "401 unauthorized"}
+			}
+			return cliproxyexecutor.Response{Payload: []byte(`{"ok":true}`)}, nil
+		},
+	}
+	m.RegisterExecutor(exec)
+
+	hook.Reset()
+
+	req := cliproxyexecutor.Request{Model: "gpt-4o"}
+	opts := cliproxyexecutor.Options{}
+
+	resp, errExec := m.Execute(context.Background(), []string{"codex"}, req, opts)
+	if errExec != nil {
+		t.Fatalf("unexpected error from Execute: %v", errExec)
+	}
+	if string(resp.Payload) != `{"ok":true}` {
+		t.Fatalf("unexpected response payload: %s", string(resp.Payload))
+	}
+
+	// 401 refresh was successful, so no upstream failure warning should be logged
+	for _, entry := range hook.AllEntries() {
+		if entry.Level == log.WarnLevel && strings.Contains(entry.Message, "upstream execution failed") {
+			t.Fatalf("did not expect upstream failure warning when 401 refresh succeeded, got: %s", entry.Message)
+		}
+	}
+}
+
+func TestWarnLogOnUpstreamFailure_ClientCanceled_DoesNotLogWarn(t *testing.T) {
+	previousCooldown := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousCooldown) })
+
+	hook := setupTestLoggerHook(t)
+	m := NewManager(nil, nil, nil)
+
+	auth := &Auth{
+		ID:         "auth-test-canceled",
+		Provider:   "codex",
+		FileName:   "codex-prod.json",
+		Status:     StatusActive,
+		Attributes: map[string]string{"priority": "10"},
+	}
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, "codex", []*registry.ModelInfo{{ID: "gpt-4o"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(auth.ID)
+	})
+
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	exec := &mockCustomErrorExecutor{
+		identifier: "codex",
+		executeFn: func(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+			return cliproxyexecutor.Response{}, ctx.Err()
+		},
+	}
+	m.RegisterExecutor(exec)
+
+	hook.Reset()
+
+	req := cliproxyexecutor.Request{Model: "gpt-4o"}
+	opts := cliproxyexecutor.Options{}
+
+	_, _ = m.Execute(ctx, []string{"codex"}, req, opts)
+
+	for _, entry := range hook.AllEntries() {
+		if entry.Level == log.WarnLevel && strings.Contains(entry.Message, "upstream execution failed") {
+			t.Fatalf("did not expect upstream failure warning on client cancellation, got: %s", entry.Message)
+		}
+	}
+}
+
+func TestWarnLogOnStreamUpstreamFailure(t *testing.T) {
+	previousCooldown := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousCooldown) })
+
+	hook := setupTestLoggerHook(t)
+	m := NewManager(nil, nil, nil)
+
+	auth := &Auth{
+		ID:         "auth-test-stream-upstream",
+		Provider:   "claude",
+		FileName:   "claude-stream.json",
+		Status:     StatusActive,
+		Attributes: map[string]string{"priority": "10"},
+	}
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, "claude", []*registry.ModelInfo{{ID: "claude-sonnet-4"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(auth.ID)
+	})
+
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	exec := &mockStreamErrorExecutor{
+		identifier: "claude",
+		executeStreamFn: func(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+			time.Sleep(5 * time.Millisecond)
+			return nil, errors.New("502 Bad Gateway: connection dropped")
+		},
+	}
+	m.RegisterExecutor(exec)
+
+	hook.Reset()
+
+	req := cliproxyexecutor.Request{Model: "claude-sonnet-4"}
+	opts := cliproxyexecutor.Options{}
+
+	_, errStream := m.ExecuteStream(context.Background(), []string{"claude"}, req, opts)
+	if errStream == nil {
+		t.Fatal("expected error from ExecuteStream, got nil")
+	}
+
+	foundWarn := false
+	for _, entry := range hook.AllEntries() {
+		if entry.Level == log.WarnLevel && strings.Contains(entry.Message, "upstream execution failed") {
+			if strings.Contains(entry.Message, "provider=claude") &&
+				strings.Contains(entry.Message, "model=claude-sonnet-4") &&
+				strings.Contains(entry.Message, "claude-stream.json") &&
+				strings.Contains(entry.Message, "duration=") &&
+				strings.Contains(entry.Message, "connection dropped") {
+				foundWarn = true
+				break
+			}
+		}
+	}
+	if !foundWarn {
+		t.Fatalf("expected Warn log detailing stream upstream failure, got logs: %#v", hook.AllEntries())
+	}
+}
+
+func TestWarnLogOnStreamBootstrapFailure(t *testing.T) {
+	previousCooldown := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previousCooldown) })
+
+	hook := setupTestLoggerHook(t)
+	m := NewManager(nil, nil, nil)
+
+	auth := &Auth{
+		ID:         "auth-test-bootstrap-upstream",
+		Provider:   "claude",
+		FileName:   "claude-bootstrap.json",
+		Status:     StatusActive,
+		Attributes: map[string]string{"priority": "10"},
+	}
+
+	reg := registry.GetGlobalRegistry()
+	reg.RegisterClient(auth.ID, "claude", []*registry.ModelInfo{{ID: "claude-sonnet-4"}})
+	t.Cleanup(func() {
+		reg.UnregisterClient(auth.ID)
+	})
+
+	if _, err := m.Register(context.Background(), auth); err != nil {
+		t.Fatalf("register auth: %v", err)
+	}
+
+	exec := &mockStreamErrorExecutor{
+		identifier: "claude",
+		executeStreamFn: func(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+			ch := make(chan cliproxyexecutor.StreamChunk, 1)
+			ch <- cliproxyexecutor.StreamChunk{Err: errors.New("504 Gateway Timeout: ttfb timeout")}
+			close(ch)
+			return &cliproxyexecutor.StreamResult{Chunks: ch}, nil
+		},
+	}
+	m.RegisterExecutor(exec)
+
+	hook.Reset()
+
+	req := cliproxyexecutor.Request{Model: "claude-sonnet-4"}
+	opts := cliproxyexecutor.Options{}
+
+	res, errStream := m.ExecuteStream(context.Background(), []string{"claude"}, req, opts)
+	if errStream != nil {
+		t.Fatalf("unexpected ExecuteStream bootstrap error: %v", errStream)
+	}
+	if res == nil || res.Chunks == nil {
+		t.Fatal("expected non-nil StreamResult")
+	}
+	firstChunk := <-res.Chunks
+	if firstChunk.Err == nil {
+		t.Fatal("expected bootstrap chunk error, got nil")
+	}
+
+	foundWarn := false
+	for _, entry := range hook.AllEntries() {
+		if entry.Level == log.WarnLevel && strings.Contains(entry.Message, "upstream execution failed") {
+			if strings.Contains(entry.Message, "provider=claude") &&
+				strings.Contains(entry.Message, "model=claude-sonnet-4") &&
+				strings.Contains(entry.Message, "claude-bootstrap.json") &&
+				strings.Contains(entry.Message, "ttfb timeout") {
+				foundWarn = true
+				break
+			}
+		}
+	}
+	if !foundWarn {
+		t.Fatalf("expected Warn log detailing stream bootstrap failure, got logs: %#v", hook.AllEntries())
+	}
+}
+
+type mockStreamErrorExecutor struct {
+	identifier      string
+	executeStreamFn func(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error)
+}
+
+func (e *mockStreamErrorExecutor) Identifier() string {
+	if e.identifier != "" {
+		return e.identifier
+	}
+	return "mock-stream"
+}
+
+func (e *mockStreamErrorExecutor) Execute(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *mockStreamErrorExecutor) ExecuteStream(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	if e.executeStreamFn != nil {
+		return e.executeStreamFn(ctx, auth, req, opts)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (e *mockStreamErrorExecutor) Refresh(ctx context.Context, auth *Auth) (*Auth, error) {
+	return auth, nil
+}
+
+func (e *mockStreamErrorExecutor) CountTokens(ctx context.Context, auth *Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, errors.New("not implemented")
+}
+
+func (e *mockStreamErrorExecutor) HttpRequest(ctx context.Context, auth *Auth, req *http.Request) (*http.Response, error) {
+	return nil, errors.New("not implemented")
+}

--- a/sdk/cliproxy/auth/config_apikey.go
+++ b/sdk/cliproxy/auth/config_apikey.go
@@ -8,8 +8,5 @@ func IsConfigAPIKeyAuth(auth *Auth) bool {
 	if auth.AuthKind() != AuthKindAPIKey {
 		return false
 	}
-	if auth.AuthSourceKind() != AuthSourceConfig {
-		return false
-	}
-	return authAttribute(auth, AttributeAPIKey) != ""
+	return auth.AuthSourceKind() == AuthSourceConfig
 }

--- a/sdk/cliproxy/auth/config_apikey_test.go
+++ b/sdk/cliproxy/auth/config_apikey_test.go
@@ -7,7 +7,7 @@ func TestIsConfigAPIKeyAuth(t *testing.T) {
 		t.Fatal("expected nil auth to be false")
 	}
 	if IsConfigAPIKeyAuth(&Auth{Attributes: map[string]string{"source": "config:codex[x]"}}) {
-		t.Fatal("expected missing api_key to be false")
+		t.Fatal("expected missing auth_kind and api_key to be false")
 	}
 	if IsConfigAPIKeyAuth(&Auth{
 		ID:       "codex:oauth:abc",
@@ -19,6 +19,16 @@ func TestIsConfigAPIKeyAuth(t *testing.T) {
 		},
 	}) {
 		t.Fatal("expected explicit oauth auth to be false")
+	}
+	if !IsConfigAPIKeyAuth(&Auth{
+		ID:       "codex:apikey:abc",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"auth_kind": "apikey",
+			"source":    "config:codex[abc]",
+		},
+	}) {
+		t.Fatal("expected empty api_key with auth_kind=apikey and config source to be true")
 	}
 	if !IsConfigAPIKeyAuth(&Auth{
 		ID:       "codex:apikey:abc",

--- a/sdk/cliproxy/auth/hedged_retry_without_penalty.go
+++ b/sdk/cliproxy/auth/hedged_retry_without_penalty.go
@@ -221,7 +221,7 @@ func (m *Manager) executeRetryWithoutPenaltyHedged(ctx context.Context, provider
 		reservedAttempts++
 		go func() {
 			defer coordinator.release(name)
-			resp, err := m.executeMixedOnce(laneCtx, providers, laneReq, laneOpts, maxRetryCredentials)
+			resp, err := m.executeMixedOnce(laneCtx, providers, laneReq, laneOpts, maxRetryCredentials, 0, 0)
 			dispatched := tracker.dispatched()
 			accounted := false
 			if err != nil && accumulator != nil {
@@ -385,7 +385,7 @@ func (m *Manager) executeStreamRetryWithoutPenaltyHedged(ctx context.Context, pr
 		reservedAttempts++
 		go func() {
 			defer coordinator.release(name)
-			stream, err := m.executeStreamMixedOnce(laneCtx, providers, laneReq, laneOpts, maxRetryCredentials)
+			stream, err := m.executeStreamMixedOnce(laneCtx, providers, laneReq, laneOpts, maxRetryCredentials, nil, 0, 0)
 			dispatched := tracker.dispatched()
 			accounted := false
 			if err != nil && accumulator != nil {
@@ -543,7 +543,7 @@ func (m *Manager) executeRetryWithoutPenaltyHedgedQuality(ctx context.Context, p
 		reservedAttempts++
 		go func() {
 			defer coordinator.release(name)
-			resp, err := m.executeMixedOnce(laneCtx, providers, laneReq, laneOpts, maxRetryCredentials)
+			resp, err := m.executeMixedOnce(laneCtx, providers, laneReq, laneOpts, maxRetryCredentials, 0, 0)
 			dispatched := tracker.dispatched()
 			accounted := false
 			if err != nil && accumulator != nil {
@@ -715,7 +715,7 @@ func (m *Manager) executeStreamRetryWithoutPenaltyHedgedQuality(ctx context.Cont
 		reservedAttempts++
 		go func() {
 			defer coordinator.release(name)
-			stream, err := m.executeStreamMixedOnce(laneCtx, providers, laneReq, laneOpts, maxRetryCredentials)
+			stream, err := m.executeStreamMixedOnce(laneCtx, providers, laneReq, laneOpts, maxRetryCredentials, nil, 0, 0)
 			var headers http.Header
 			var chunks []cliproxyexecutor.StreamChunk
 			var metadata map[string]any

--- a/sdk/cliproxy/auth/home_concurrency.go
+++ b/sdk/cliproxy/auth/home_concurrency.go
@@ -237,6 +237,17 @@ func decodeHomeDispatchError(raw []byte) error {
 	switch strings.ToLower(code) {
 	case "model_not_found":
 		result.HTTPStatus = http.StatusNotFound
+	case "model_cooldown":
+		result.HTTPStatus = http.StatusTooManyRequests
+		cooldownErr := &homeDispatchRetryAfterError{cause: result}
+		if detail.RetryAfterMS > 0 {
+			cooldownErr.retryAfter = time.Duration(detail.RetryAfterMS) * time.Millisecond
+		}
+		if detail.RequestRetry != nil && *detail.RequestRetry >= 0 {
+			cooldownErr.requestRetry = *detail.RequestRetry
+			cooldownErr.hasRequestRetry = true
+		}
+		return cooldownErr
 	case "authentication_error", "unauthorized", "no_credentials", "invalid_credential":
 		result.HTTPStatus = http.StatusUnauthorized
 	case "credential_concurrency_exceeded", "credential_model_concurrency_exceeded":
@@ -263,13 +274,30 @@ func verifyAccountedHomeConcurrencyIdentity(tuple homeConcurrencyTuple, auth *Au
 	return nil
 }
 
-// SafeResponseHeaders returns trusted response headers only for CPA's concrete Home busy error.
+// SafeResponseHeaders returns trusted response headers only for concrete
+// Home-generated retry errors.
 func SafeResponseHeaders(err error) http.Header {
 	var busy *HomeConcurrencyBusyError
-	if !errors.As(err, &busy) || busy == nil {
+	if errors.As(err, &busy) && busy != nil {
+		return busy.SafeResponseHeaders()
+	}
+	var exhausted *homeRetryRoundExhaustedError
+	if errors.As(err, &exhausted) && exhausted != nil {
+		retryAfter := exhausted.RetryAfter()
+		if retryAfter == nil {
+			return nil
+		}
+		return safeRetryAfterHeader(*retryAfter)
+	}
+	var cooldown *homeDispatchRetryAfterError
+	if !errors.As(err, &cooldown) || cooldown == nil {
 		return nil
 	}
-	return busy.SafeResponseHeaders()
+	retryAfter := cooldown.RetryAfter()
+	if retryAfter == nil {
+		return nil
+	}
+	return safeRetryAfterHeader(*retryAfter)
 }
 
 func safeRetryAfterHeader(retryAfter time.Duration) http.Header {

--- a/sdk/cliproxy/auth/home_execution_paths_test.go
+++ b/sdk/cliproxy/auth/home_execution_paths_test.go
@@ -492,7 +492,15 @@ type lifecycleRetryDispatcher struct {
 }
 
 func (d *lifecycleRetryDispatcher) HeartbeatOK() bool { return true }
-func (d *lifecycleRetryDispatcher) RPopAuth(_ context.Context, _ string, _ string, _ http.Header, _ int) ([]byte, error) {
+func (d *lifecycleRetryDispatcher) RPopAuth(ctx context.Context, model string, sessionID string, headers http.Header, count int) ([]byte, error) {
+	return d.RPopAuthWithConstraints(ctx, model, sessionID, headers, count, nil, "")
+}
+func (d *lifecycleRetryDispatcher) RPopAuthWithConstraints(_ context.Context, _ string, _ string, _ http.Header, _ int, excludedAuthIDs []string, _ string) ([]byte, error) {
+	for _, authID := range excludedAuthIDs {
+		if authID == "home-auth" {
+			return nil, home.ErrAuthNotFound
+		}
+	}
 	if d.calls.Add(1) == 2 && d.executor.first != nil {
 		d.firstEndedBeforeRedispatch.Store(!d.executor.first.Active() && d.executor.firstCtx.Err() != nil)
 	}
@@ -535,6 +543,7 @@ func TestHomeStreamLifecycleFailureEndsBeforeFreshDispatch(t *testing.T) {
 	registry := executionregistry.New()
 	manager := NewManager(nil, nil, nil)
 	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(0, time.Second, 1)
 	manager.PublishHomeDispatch(dispatcher, registry, 1)
 	manager.RegisterExecutor(executor)
 	ctx := cliproxyexecutor.WithDownstreamWebsocket(context.Background())
@@ -580,15 +589,54 @@ func TestHomeSelectionCancellationPreventsExecute(t *testing.T) {
 	}
 }
 
-type retryingHomeStreamExecutor struct {
+type freshHomeStreamSelectionDispatcher struct {
 	calls atomic.Int32
+}
+
+func (*freshHomeStreamSelectionDispatcher) HeartbeatOK() bool { return true }
+
+func (d *freshHomeStreamSelectionDispatcher) RPopAuth(ctx context.Context, model string, sessionID string, headers http.Header, count int) ([]byte, error) {
+	return d.RPopAuthWithConstraints(ctx, model, sessionID, headers, count, nil, "")
+}
+
+func (d *freshHomeStreamSelectionDispatcher) RPopAuthWithConstraints(_ context.Context, _ string, _ string, _ http.Header, _ int, excludedAuthIDs []string, _ string) ([]byte, error) {
+	d.calls.Add(1)
+	excluded := make(map[string]struct{}, len(excludedAuthIDs))
+	for _, authID := range excludedAuthIDs {
+		excluded[authID] = struct{}{}
+	}
+	for _, authID := range []string{"home-auth-a", "home-auth-b"} {
+		if _, okExcluded := excluded[authID]; okExcluded {
+			continue
+		}
+		return json.Marshal(homeAuthDispatchResponse{Auth: Auth{
+			ID:       authID,
+			Provider: "home-execution",
+			Status:   StatusActive,
+			Attributes: map[string]string{
+				AttributeAuthKind: AuthKindAPIKey,
+			},
+		}})
+	}
+	return nil, home.ErrAuthNotFound
+}
+
+func (*freshHomeStreamSelectionDispatcher) AbortAmbiguousDispatch() {}
+
+type retryingHomeStreamExecutor struct {
+	mu      sync.Mutex
+	calls   atomic.Int32
+	authIDs []string
 }
 
 func (*retryingHomeStreamExecutor) Identifier() string { return "home-execution" }
 func (*retryingHomeStreamExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
 	return cliproxyexecutor.Response{}, nil
 }
-func (e *retryingHomeStreamExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+func (e *retryingHomeStreamExecutor) ExecuteStream(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	e.mu.Lock()
+	e.authIDs = append(e.authIDs, auth.ID)
+	e.mu.Unlock()
 	if e.calls.Add(1) == 1 {
 		return nil, &Error{HTTPStatus: http.StatusUnauthorized, Message: "expired"}
 	}
@@ -607,10 +655,17 @@ func (*retryingHomeStreamExecutor) HttpRequest(context.Context, *Auth, *http.Req
 	return nil, nil
 }
 
+func (e *retryingHomeStreamExecutor) AuthIDs() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]string(nil), e.authIDs...)
+}
+
 func TestHomeStreamRetryUsesFreshSelection(t *testing.T) {
-	dispatcher := &retainingHomeExecutionDispatcher{}
+	dispatcher := &freshHomeStreamSelectionDispatcher{}
 	manager := NewManager(nil, nil, nil)
 	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(0, time.Second, 2)
 	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
 	executor := &retryingHomeStreamExecutor{}
 	manager.RegisterExecutor(executor)
@@ -623,6 +678,9 @@ func TestHomeStreamRetryUsesFreshSelection(t *testing.T) {
 	}
 	if got := dispatcher.calls.Load(); got != 2 {
 		t.Fatalf("Home RPOP calls = %d, want 2 for retrying stream invocations", got)
+	}
+	if got := executor.AuthIDs(); len(got) != 2 || got[0] != "home-auth-a" || got[1] != "home-auth-b" {
+		t.Fatalf("executor auth IDs = %v, want [home-auth-a home-auth-b]", got)
 	}
 }
 

--- a/sdk/cliproxy/auth/home_retry_contract_test.go
+++ b/sdk/cliproxy/auth/home_retry_contract_test.go
@@ -563,23 +563,23 @@ func TestHomeRetryPolicyUsesRemoteCredentialOverrideBeforeSelection(t *testing.T
 		hasRequestRetry: true,
 	}
 
-	wait, shouldRetry := manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), cliproxyexecutor.Options{}, errRemoteCooldown, 0, []string{"home-retry-contract"}, "gpt", time.Second, -1)
+	wait, shouldRetry := manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), cliproxyexecutor.Options{}, errRemoteCooldown, 0, []string{"home-retry-contract"}, "gpt", time.Second, -1, 0)
 	if !shouldRetry || wait != 10*time.Millisecond {
 		t.Fatalf("remote credential override retry = (%v, %t), want (10ms, true)", wait, shouldRetry)
 	}
-	if _, shouldRetry = manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), cliproxyexecutor.Options{}, errRemoteCooldown, 1, []string{"home-retry-contract"}, "gpt", time.Second, -1); shouldRetry {
+	if _, shouldRetry = manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), cliproxyexecutor.Options{}, errRemoteCooldown, 1, []string{"home-retry-contract"}, "gpt", time.Second, -1, 0); shouldRetry {
 		t.Fatal("remote credential override allowed more than one additional round")
 	}
 	pinnedOpts := cliproxyexecutor.Options{Metadata: map[string]any{
 		cliproxyexecutor.PinnedAuthMetadataKey: "home-retry-a",
 	}}
-	if _, shouldRetry = manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), pinnedOpts, errRemoteCooldown, 0, []string{"home-retry-contract"}, "gpt", time.Second, -1); shouldRetry {
+	if _, shouldRetry = manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), pinnedOpts, errRemoteCooldown, 0, []string{"home-retry-contract"}, "gpt", time.Second, -1, 0); shouldRetry {
 		t.Fatal("aggregate retry limit from unpinned Home credentials affected a pinned request")
 	}
 
 	errRemoteCooldown.requestRetry = 0
 	manager.SetRetryConfig(3, time.Second, 0)
-	if _, shouldRetry = manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), cliproxyexecutor.Options{}, errRemoteCooldown, 0, []string{"home-retry-contract"}, "gpt", time.Second, -1); shouldRetry {
+	if _, shouldRetry = manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), cliproxyexecutor.Options{}, errRemoteCooldown, 0, []string{"home-retry-contract"}, "gpt", time.Second, -1, 0); shouldRetry {
 		t.Fatal("explicit remote credential override 0 did not suppress the global retry setting")
 	}
 	retryLimit := 3
@@ -779,7 +779,7 @@ func TestHomeRetryRoundUsesAuthoritativeRemoteCooldown(t *testing.T) {
 		{
 			name: "stream",
 			execute: func(manager *Manager, retryLimit *int) error {
-				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, 2, retryLimit)
+				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, 2, retryLimit, 0, 0)
 				return errExecute
 			},
 		},
@@ -831,7 +831,7 @@ func TestHomeCooldownClassificationPreservesNonRetryableRoundStatus(t *testing.T
 		{
 			name: "stream",
 			execute: func(manager *Manager, retryLimit *int) error {
-				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, 2, retryLimit)
+				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, 2, retryLimit, 0, 0)
 				return errExecute
 			},
 		},
@@ -860,7 +860,7 @@ func TestHomeCooldownClassificationPreservesNonRetryableRoundStatus(t *testing.T
 			if retryLimit != 2 {
 				t.Fatalf("observed retry limit = %d, want authoritative Home limit 2", retryLimit)
 			}
-			if wait, shouldRetry := manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), cliproxyexecutor.Options{}, errExecute, 0, []string{"home-retry-contract"}, "gpt", time.Second, retryLimit); shouldRetry || wait != 0 {
+			if wait, shouldRetry := manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), cliproxyexecutor.Options{}, errExecute, 0, []string{"home-retry-contract"}, "gpt", time.Second, retryLimit, 0); shouldRetry || wait != 0 {
 				t.Fatalf("401 round retry = (%v, %t), want (0, false)", wait, shouldRetry)
 			}
 		})
@@ -882,7 +882,7 @@ func TestHomeRetryRoundStartsImmediatelyWhenHomeReportsAvailableNextRound(t *tes
 		{
 			name: "stream",
 			execute: func(manager *Manager, retryLimit *int) error {
-				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, 0, retryLimit)
+				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, 0, retryLimit, 0, 0)
 				return errExecute
 			},
 		},
@@ -911,7 +911,7 @@ func TestHomeRetryRoundStartsImmediatelyWhenHomeReportsAvailableNextRound(t *tes
 			if !isHomeRetryRoundExhausted(errExecute) {
 				t.Fatalf("execution error = %v, want exhausted retry round", errExecute)
 			}
-			wait, shouldRetry := manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), cliproxyexecutor.Options{}, errExecute, 0, []string{"home-retry-contract"}, "gpt", 10*time.Second, retryLimit)
+			wait, shouldRetry := manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), cliproxyexecutor.Options{}, errExecute, 0, []string{"home-retry-contract"}, "gpt", 10*time.Second, retryLimit, 0)
 			if !shouldRetry || wait != 0 {
 				t.Fatalf("next-round retry = (%v, %t), want immediate", wait, shouldRetry)
 			}
@@ -934,7 +934,7 @@ func TestHomeRetryRoundUsesRemoteCooldownWhenAttemptedErrorHasNoTiming(t *testin
 		{
 			name: "stream",
 			execute: func(manager *Manager, retryLimit *int) error {
-				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, 2, retryLimit)
+				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, 2, retryLimit, 0, 0)
 				return errExecute
 			},
 		},
@@ -1274,7 +1274,7 @@ func TestHomeLocalSelectionRejectionWaitsForReleaseAcknowledgement(t *testing.T)
 			blockedGroup:        executionregistry.ReleaseGroup{CredentialID: "home-retry-a", Model: "gpt"},
 			blockedSequence:     2,
 			execute: func(manager *Manager, maxRetryCredentials int, retryLimit *int) error {
-				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, maxRetryCredentials, retryLimit)
+				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, maxRetryCredentials, retryLimit, 0, 0)
 				return errExecute
 			},
 		},
@@ -1289,7 +1289,7 @@ func TestHomeLocalSelectionRejectionWaitsForReleaseAcknowledgement(t *testing.T)
 			blockedGroup:        executionregistry.ReleaseGroup{CredentialID: "home-retry-b", Model: "gpt"},
 			blockedSequence:     1,
 			execute: func(manager *Manager, maxRetryCredentials int, retryLimit *int) error {
-				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, maxRetryCredentials, retryLimit)
+				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, maxRetryCredentials, retryLimit, 0, 0)
 				return errExecute
 			},
 		},

--- a/sdk/cliproxy/auth/home_retry_contract_test.go
+++ b/sdk/cliproxy/auth/home_retry_contract_test.go
@@ -1,0 +1,1477 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/home"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executionregistry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type retryContractHomeDispatcher struct {
+	mu               sync.Mutex
+	authIDs          []string
+	excluded         [][]string
+	metadata         map[string]any
+	requestRetry     *int
+	websocket        bool
+	exhaustedPayload []byte
+}
+
+type legacyRepeatedStreamDispatcher struct {
+	calls atomic.Int32
+}
+
+type retryRoundStartCooldownDispatcher struct {
+	calls atomic.Int32
+}
+
+type retryRoundRepeatedCooldownDispatcher struct {
+	calls atomic.Int32
+}
+
+type retryRoundLimitDownshiftDispatcher struct {
+	calls atomic.Int32
+}
+
+type aggregateRetryHomeDispatcher struct {
+	calls atomic.Int32
+}
+
+func (*legacyRepeatedStreamDispatcher) HeartbeatOK() bool { return true }
+
+func (d *legacyRepeatedStreamDispatcher) RPopAuth(context.Context, string, string, http.Header, int) ([]byte, error) {
+	d.calls.Add(1)
+	return json.Marshal(homeAuthDispatchResponse{Auth: Auth{
+		ID:       "home-retry-a",
+		Provider: "home-retry-contract",
+		Status:   StatusActive,
+	}})
+}
+
+func (*legacyRepeatedStreamDispatcher) AbortAmbiguousDispatch() {}
+
+func (*retryRoundStartCooldownDispatcher) HeartbeatOK() bool { return true }
+
+func (d *retryRoundStartCooldownDispatcher) RPopAuth(ctx context.Context, model string, sessionID string, headers http.Header, count int) ([]byte, error) {
+	return d.RPopAuthWithConstraints(ctx, model, sessionID, headers, count, nil, "")
+}
+
+func (d *retryRoundStartCooldownDispatcher) RPopAuthWithConstraints(_ context.Context, _ string, _ string, _ http.Header, _ int, _ []string, _ string) ([]byte, error) {
+	if d.calls.Add(1) == 2 {
+		return []byte(`{"error":{"type":"model_cooldown","message":"credential is cooling down","retryable":true,"retry_after_ms":1,"request_retry":1}}`), nil
+	}
+	return json.Marshal(homeAuthDispatchResponse{Auth: Auth{
+		ID:       "home-retry-a",
+		Provider: "home-retry-contract",
+		Status:   StatusActive,
+	}})
+}
+
+func (*retryRoundStartCooldownDispatcher) AbortAmbiguousDispatch() {}
+
+func (*retryRoundRepeatedCooldownDispatcher) HeartbeatOK() bool { return true }
+
+func (d *retryRoundRepeatedCooldownDispatcher) RPopAuth(ctx context.Context, model string, sessionID string, headers http.Header, count int) ([]byte, error) {
+	return d.RPopAuthWithConstraints(ctx, model, sessionID, headers, count, nil, "")
+}
+
+func (d *retryRoundRepeatedCooldownDispatcher) RPopAuthWithConstraints(_ context.Context, _ string, _ string, _ http.Header, _ int, _ []string, _ string) ([]byte, error) {
+	if d.calls.Add(1) > 1 {
+		return []byte(`{"error":{"type":"model_cooldown","message":"credential is cooling down","retryable":true,"retry_after_ms":1,"request_retry":1}}`), nil
+	}
+	return json.Marshal(homeAuthDispatchResponse{Auth: Auth{
+		ID:       "home-retry-a",
+		Provider: "home-retry-contract",
+		Status:   StatusActive,
+	}})
+}
+
+func (*retryRoundRepeatedCooldownDispatcher) AbortAmbiguousDispatch() {}
+
+func (*retryRoundLimitDownshiftDispatcher) HeartbeatOK() bool { return true }
+
+func (d *retryRoundLimitDownshiftDispatcher) RPopAuth(ctx context.Context, model string, sessionID string, headers http.Header, count int) ([]byte, error) {
+	return d.RPopAuthWithConstraints(ctx, model, sessionID, headers, count, nil, "")
+}
+
+func (d *retryRoundLimitDownshiftDispatcher) RPopAuthWithConstraints(_ context.Context, _ string, _ string, _ http.Header, _ int, _ []string, _ string) ([]byte, error) {
+	switch d.calls.Add(1) {
+	case 1:
+		retryLimit := 1
+		return json.Marshal(homeAuthDispatchResponse{RequestRetry: &retryLimit, Auth: Auth{
+			ID:       "home-retry-a",
+			Provider: "home-retry-contract",
+			Status:   StatusActive,
+		}})
+	case 2:
+		return []byte(`{"error":{"type":"model_cooldown","message":"remaining credentials are cooling down","retryable":true,"retry_after_ms":1,"request_retry":0}}`), nil
+	default:
+		return json.Marshal(homeAuthDispatchResponse{Auth: Auth{
+			ID:       "home-retry-b",
+			Provider: "home-retry-contract",
+			Status:   StatusActive,
+		}})
+	}
+}
+
+func (*retryRoundLimitDownshiftDispatcher) AbortAmbiguousDispatch() {}
+
+func (*aggregateRetryHomeDispatcher) HeartbeatOK() bool { return true }
+
+func (d *aggregateRetryHomeDispatcher) RPopAuth(ctx context.Context, model string, sessionID string, headers http.Header, count int) ([]byte, error) {
+	return d.RPopAuthWithConstraints(ctx, model, sessionID, headers, count, nil, "")
+}
+
+func (d *aggregateRetryHomeDispatcher) RPopAuthWithConstraints(_ context.Context, _ string, _ string, _ http.Header, _ int, _ []string, _ string) ([]byte, error) {
+	authID := "home-retry-a"
+	override := 0
+	if d.calls.Add(1) > 1 {
+		authID = "home-retry-b"
+		override = 2
+	}
+	requestRetry := 2
+	return json.Marshal(homeAuthDispatchResponse{
+		RequestRetry: &requestRetry,
+		Auth: Auth{
+			ID:       authID,
+			Provider: "home-retry-contract",
+			Status:   StatusActive,
+			Metadata: map[string]any{"request_retry": override},
+		},
+	})
+}
+
+func (*aggregateRetryHomeDispatcher) AbortAmbiguousDispatch() {}
+
+func (*retryContractHomeDispatcher) HeartbeatOK() bool { return true }
+
+func (d *retryContractHomeDispatcher) RPopAuth(ctx context.Context, model string, sessionID string, headers http.Header, count int) ([]byte, error) {
+	return d.RPopAuthWithConstraints(ctx, model, sessionID, headers, count, nil, "")
+}
+
+func (d *retryContractHomeDispatcher) RPopAuthWithConstraints(_ context.Context, _ string, _ string, _ http.Header, _ int, excludedAuthIDs []string, pinnedAuthID string) ([]byte, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.excluded = append(d.excluded, append([]string(nil), excludedAuthIDs...))
+	excluded := make(map[string]struct{}, len(excludedAuthIDs))
+	for _, authID := range excludedAuthIDs {
+		excluded[authID] = struct{}{}
+	}
+	for _, authID := range d.authIDs {
+		if pinnedAuthID != "" && authID != pinnedAuthID {
+			continue
+		}
+		if _, okExcluded := excluded[authID]; okExcluded {
+			continue
+		}
+		attributes := map[string]string{}
+		if d.websocket {
+			attributes["websockets"] = "true"
+		}
+		return json.Marshal(homeAuthDispatchResponse{
+			RequestRetry: d.requestRetry,
+			Auth: Auth{
+				ID:         authID,
+				Provider:   "home-retry-contract",
+				Status:     StatusActive,
+				Metadata:   d.metadata,
+				Attributes: attributes,
+			},
+		})
+	}
+	if len(d.exhaustedPayload) > 0 {
+		return append([]byte(nil), d.exhaustedPayload...), nil
+	}
+	return nil, home.ErrAuthNotFound
+}
+
+func (*retryContractHomeDispatcher) AbortAmbiguousDispatch() {}
+
+func (d *retryContractHomeDispatcher) Excluded() [][]string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	result := make([][]string, len(d.excluded))
+	for index := range d.excluded {
+		result[index] = append([]string(nil), d.excluded[index]...)
+	}
+	return result
+}
+
+type retryContractHomeExecutor struct {
+	mu              sync.Mutex
+	calls           []string
+	failAll         bool
+	failure         error
+	failures        map[string]error
+	streamBootstrap bool
+	streamHeaders   http.Header
+}
+
+func (*retryContractHomeExecutor) Identifier() string { return "home-retry-contract" }
+
+func (e *retryContractHomeExecutor) Execute(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.mu.Lock()
+	e.calls = append(e.calls, auth.ID)
+	e.mu.Unlock()
+	if auth.ID == "home-retry-a" || e.failAll {
+		return cliproxyexecutor.Response{}, e.failureError(auth.ID)
+	}
+	return cliproxyexecutor.Response{Payload: []byte(auth.ID)}, nil
+}
+
+func (e *retryContractHomeExecutor) ExecuteStream(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	e.mu.Lock()
+	e.calls = append(e.calls, auth.ID)
+	e.mu.Unlock()
+	if auth.ID == "home-retry-a" || e.failAll {
+		errFailure := e.failureError(auth.ID)
+		if e.streamBootstrap {
+			chunks := make(chan cliproxyexecutor.StreamChunk, 1)
+			chunks <- cliproxyexecutor.StreamChunk{Err: errFailure}
+			close(chunks)
+			return &cliproxyexecutor.StreamResult{Headers: e.streamHeaders.Clone(), Chunks: chunks}, nil
+		}
+		return nil, errFailure
+	}
+	chunks := make(chan cliproxyexecutor.StreamChunk, 1)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte(auth.ID)}
+	close(chunks)
+	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (e *retryContractHomeExecutor) failureError(authID string) error {
+	if failure := e.failures[authID]; failure != nil {
+		return failure
+	}
+	if e.failure != nil {
+		return e.failure
+	}
+	return retryContractRateLimitError{}
+}
+
+func (*retryContractHomeExecutor) Refresh(context.Context, *Auth) (*Auth, error) { return nil, nil }
+
+func (e *retryContractHomeExecutor) CountTokens(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.mu.Lock()
+	e.calls = append(e.calls, auth.ID)
+	e.mu.Unlock()
+	if auth.ID == "home-retry-a" || e.failAll {
+		return cliproxyexecutor.Response{}, e.failureError(auth.ID)
+	}
+	return cliproxyexecutor.Response{Payload: []byte(auth.ID)}, nil
+}
+
+func (*retryContractHomeExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func (e *retryContractHomeExecutor) Calls() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]string(nil), e.calls...)
+}
+
+type retryContractRateLimitError struct {
+	retryAfter time.Duration
+}
+
+func (retryContractRateLimitError) Error() string { return "credential rate limited" }
+
+func (retryContractRateLimitError) StatusCode() int { return http.StatusTooManyRequests }
+
+func (e retryContractRateLimitError) RetryAfter() *time.Duration {
+	value := e.retryAfter
+	if value == 0 {
+		value = time.Millisecond
+	}
+	return &value
+}
+
+type retainingRetryContractHomeExecutor struct {
+	*retryContractHomeExecutor
+}
+
+func (e *retainingRetryContractHomeExecutor) Execute(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	if lifecycle, ok := opts.ExecutionLifecycle.(interface{ Retain() }); ok {
+		lifecycle.Retain()
+	}
+	return cliproxyexecutor.Response{Payload: []byte(auth.ID)}, nil
+}
+
+func TestHomePinnedAuthRejectsMismatchedDispatch(t *testing.T) {
+	dispatcher := &retryContractHomeDispatcher{authIDs: []string{"home-retry-b"}}
+	executor := &retryContractHomeExecutor{}
+	registry := executionregistry.New()
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.PublishHomeDispatch(dispatcher, registry, 1)
+	manager.RegisterExecutor(executor)
+
+	_, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.PinnedAuthMetadataKey: "home-retry-a",
+	}})
+	var authErr *Error
+	if !errors.As(errExecute, &authErr) || authErr == nil || authErr.Code != "auth_not_found" {
+		t.Fatalf("Execute() error = %T %v, want pinned auth_not_found", errExecute, errExecute)
+	}
+	if got := executor.Calls(); len(got) != 0 {
+		t.Fatalf("executor calls = %v, want no mismatched credential execution", got)
+	}
+	if errDrain := registry.Drain(context.Background()); errDrain != nil {
+		t.Fatalf("Drain() error = %v", errDrain)
+	}
+}
+
+func TestHomePinnedAuthRetriesOnlyPinnedCredential(t *testing.T) {
+	aggregateRetry := 3
+	dispatcher := &retryContractHomeDispatcher{
+		authIDs:      []string{"home-retry-b", "home-retry-a"},
+		metadata:     map[string]any{"request_retry": 1},
+		requestRetry: &aggregateRetry,
+	}
+	executor := &retryContractHomeExecutor{
+		failAll: true,
+		failure: &Error{HTTPStatus: http.StatusBadGateway, Message: "upstream unavailable"},
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(0, time.Second, 0)
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+	manager.RegisterExecutor(executor)
+
+	_, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.PinnedAuthMetadataKey: "home-retry-a",
+	}})
+	if errExecute == nil {
+		t.Fatal("Execute() error = nil, want terminal upstream error")
+	}
+	if got := executor.Calls(); len(got) != 2 || got[0] != "home-retry-a" || got[1] != "home-retry-a" {
+		t.Fatalf("executor calls = %v, want pinned auth once in each of two rounds", got)
+	}
+	excluded := dispatcher.Excluded()
+	if len(excluded) != 2 || len(excluded[0]) != 0 || len(excluded[1]) != 0 {
+		t.Fatalf("Home excluded auth IDs = %v, want a fresh pinned selection in each round", excluded)
+	}
+}
+
+func TestHomeExcludedCredentialEndsRetainedWebsocketSelection(t *testing.T) {
+	dispatcher := &retryContractHomeDispatcher{
+		authIDs:   []string{"home-retry-a", "home-retry-b"},
+		websocket: true,
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(0, time.Second, 2)
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+	manager.RegisterExecutor(&retainingRetryContractHomeExecutor{retryContractHomeExecutor: &retryContractHomeExecutor{}})
+
+	ctx := cliproxyexecutor.WithDownstreamWebsocket(context.Background())
+	opts := cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.ExecutionSessionMetadataKey: "home-retry-session",
+	}}
+	if _, errExecute := manager.Execute(ctx, []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, opts); errExecute != nil {
+		t.Fatalf("first Execute() error = %v", errExecute)
+	}
+
+	pickOpts := withHomeExcludedAuthIDs(opts, map[string]struct{}{"home-retry-a": {}})
+	selection, errPick := manager.pickHomeDispatchSelection(ctx, "gpt", pickOpts)
+	if errPick != nil {
+		t.Fatalf("pickHomeDispatchSelection() error = %v", errPick)
+	}
+	defer selection.End("test_complete")
+	if auth := selection.CloneAuth(); auth == nil || auth.ID != "home-retry-b" {
+		t.Fatalf("selected auth = %#v, want home-retry-b", auth)
+	}
+
+	excluded := dispatcher.Excluded()
+	if len(excluded) != 2 || len(excluded[0]) != 0 || len(excluded[1]) != 1 || excluded[1][0] != "home-retry-a" {
+		t.Fatalf("Home excluded auth IDs = %v, want [[], [home-retry-a]]", excluded)
+	}
+}
+
+func TestHomeRetryRoundTriesFreshCredentialWhenRequestRetryIsZero(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(map[bool]string{false: "nonstream", true: "stream"}[stream], func(t *testing.T) {
+			dispatcher := &retryContractHomeDispatcher{authIDs: []string{"home-retry-a", "home-retry-b"}}
+			executor := &retryContractHomeExecutor{}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(0, time.Second, 2)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			if stream {
+				result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+				if errExecute != nil {
+					t.Fatalf("ExecuteStream() error = %v", errExecute)
+				}
+				for range result.Chunks {
+				}
+			} else {
+				response, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{})
+				if errExecute != nil {
+					t.Fatalf("Execute() error = %v", errExecute)
+				}
+				if string(response.Payload) != "home-retry-b" {
+					t.Fatalf("response payload = %q, want home-retry-b", string(response.Payload))
+				}
+			}
+
+			if got := executor.Calls(); len(got) != 2 || got[0] != "home-retry-a" || got[1] != "home-retry-b" {
+				t.Fatalf("executor calls = %v, want [home-retry-a home-retry-b]", got)
+			}
+			excluded := dispatcher.Excluded()
+			if len(excluded) != 2 || len(excluded[0]) != 0 || len(excluded[1]) != 1 || excluded[1][0] != "home-retry-a" {
+				t.Fatalf("Home excluded auth IDs = %v, want [[], [home-retry-a]]", excluded)
+			}
+		})
+	}
+}
+
+func TestHomeCountTokensTriesFreshCredentialWhenRequestRetryIsZero(t *testing.T) {
+	dispatcher := &retryContractHomeDispatcher{authIDs: []string{"home-retry-a", "home-retry-b"}}
+	executor := &retryContractHomeExecutor{}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(0, time.Second, 2)
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+	manager.RegisterExecutor(executor)
+
+	response, errExecute := manager.ExecuteCount(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{})
+	if errExecute != nil {
+		t.Fatalf("ExecuteCount() error = %v", errExecute)
+	}
+	if string(response.Payload) != "home-retry-b" {
+		t.Fatalf("response payload = %q, want home-retry-b", string(response.Payload))
+	}
+	if got := executor.Calls(); len(got) != 2 || got[0] != "home-retry-a" || got[1] != "home-retry-b" {
+		t.Fatalf("executor calls = %v, want [home-retry-a home-retry-b]", got)
+	}
+	excluded := dispatcher.Excluded()
+	if len(excluded) != 2 || len(excluded[0]) != 0 || len(excluded[1]) != 1 || excluded[1][0] != "home-retry-a" {
+		t.Fatalf("Home excluded auth IDs = %v, want [[], [home-retry-a]]", excluded)
+	}
+}
+
+func TestHomeRetryPolicyAllowsRemoteCooldownWithoutLocalCredentials(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(1, time.Second, 0)
+	errRemoteCooldown := &homeDispatchRetryAfterError{
+		cause:      &Error{HTTPStatus: http.StatusTooManyRequests, Message: "all Home credentials are cooling down"},
+		retryAfter: 10 * time.Millisecond,
+	}
+
+	wait, shouldRetry := manager.shouldRetryAfterError(errRemoteCooldown, 0, []string{"home-retry-contract"}, "gpt", time.Second)
+	if !shouldRetry || wait != 10*time.Millisecond {
+		t.Fatalf("shouldRetryAfterError() = (%v, %t), want (10ms, true)", wait, shouldRetry)
+	}
+	if _, shouldRetry = manager.shouldRetryAfterError(errRemoteCooldown, 1, []string{"home-retry-contract"}, "gpt", time.Second); shouldRetry {
+		t.Fatal("shouldRetryAfterError() retried after the configured Home retry round")
+	}
+	wait, shouldRetry = manager.shouldRetryAfterError(errRemoteCooldown, 0, []string{"home-retry-contract"}, "gpt", 0)
+	if shouldRetry || wait != 0 {
+		t.Fatalf("shouldRetryAfterError() with zero wait interval = (%v, %t), want (0, false)", wait, shouldRetry)
+	}
+	errRoundExhausted := markHomeRetryRoundExhausted(&Error{HTTPStatus: http.StatusBadGateway, Message: "upstream unavailable"}, nil, false)
+	wait, shouldRetry = manager.shouldRetryAfterError(errRoundExhausted, 0, []string{"home-retry-contract"}, "gpt", 0)
+	if !shouldRetry || wait != 0 {
+		t.Fatalf("shouldRetryAfterError() immediate round = (%v, %t), want (0, true)", wait, shouldRetry)
+	}
+	var invalidTiming homeRetryRoundTiming
+	invalidTiming.Observe(retryContractRateLimitError{retryAfter: -time.Millisecond})
+	errInvalidWait := markHomeRetryRoundExhausted(retryContractRateLimitError{retryAfter: -time.Millisecond}, invalidTiming.RetryAfter(), false)
+	if wait, shouldRetry = manager.shouldRetryAfterError(errInvalidWait, 0, []string{"home-retry-contract"}, "gpt", 0); shouldRetry || wait != 0 {
+		t.Fatalf("shouldRetryAfterError() negative wait = (%v, %t), want (0, false)", wait, shouldRetry)
+	}
+}
+
+func TestRetryIntervalFiltersCooldownCredentials(t *testing.T) {
+	tests := []struct {
+		name        string
+		cooldowns   []time.Duration
+		wantRetry   bool
+		maxWantWait time.Duration
+	}{
+		{name: "short and long cooldowns", cooldowns: []time.Duration{10 * time.Second, time.Minute}, wantRetry: true, maxWantWait: 10 * time.Second},
+		{name: "only long cooldown", cooldowns: []time.Duration{time.Minute}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			const (
+				provider = "retry-interval-contract"
+				model    = "gpt"
+			)
+			manager := NewManager(nil, nil, nil)
+			manager.SetRetryConfig(1, 30*time.Second, 0)
+			now := time.Now()
+			for index, cooldown := range test.cooldowns {
+				authID := fmt.Sprintf("retry-interval-%s-%d", strings.ReplaceAll(test.name, " ", "-"), index)
+				deadline := now.Add(cooldown)
+				auth := &Auth{
+					ID:       authID,
+					Provider: provider,
+					Status:   StatusActive,
+					ModelStates: map[string]*ModelState{
+						model: {
+							Status:         StatusError,
+							Unavailable:    true,
+							NextRetryAfter: deadline,
+							LastError:      &Error{HTTPStatus: http.StatusTooManyRequests},
+							Quota:          QuotaState{Exceeded: true, NextRecoverAt: deadline},
+						},
+					},
+				}
+				registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+				t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(authID) })
+				if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+					t.Fatalf("Register() error = %v", errRegister)
+				}
+			}
+
+			wait, shouldRetry := manager.shouldRetryAfterError(&Error{HTTPStatus: http.StatusTooManyRequests}, 0, []string{provider}, model, 30*time.Second)
+			if shouldRetry != test.wantRetry {
+				t.Fatalf("shouldRetryAfterError() = (%v, %t), want retry %t", wait, shouldRetry, test.wantRetry)
+			}
+			if test.wantRetry && (wait <= 0 || wait > test.maxWantWait) {
+				t.Fatalf("shouldRetryAfterError() wait = %v, want the earliest cooldown within %v", wait, test.maxWantWait)
+			}
+		})
+	}
+}
+
+func TestHomeRetryPolicyUsesRemoteCredentialOverrideBeforeSelection(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(0, time.Second, 0)
+	errRemoteCooldown := &homeDispatchRetryAfterError{
+		cause:           &Error{HTTPStatus: http.StatusTooManyRequests, Message: "all Home credentials are cooling down"},
+		retryAfter:      10 * time.Millisecond,
+		requestRetry:    1,
+		hasRequestRetry: true,
+	}
+
+	wait, shouldRetry := manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), cliproxyexecutor.Options{}, errRemoteCooldown, 0, []string{"home-retry-contract"}, "gpt", time.Second, -1)
+	if !shouldRetry || wait != 10*time.Millisecond {
+		t.Fatalf("remote credential override retry = (%v, %t), want (10ms, true)", wait, shouldRetry)
+	}
+	if _, shouldRetry = manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), cliproxyexecutor.Options{}, errRemoteCooldown, 1, []string{"home-retry-contract"}, "gpt", time.Second, -1); shouldRetry {
+		t.Fatal("remote credential override allowed more than one additional round")
+	}
+	pinnedOpts := cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.PinnedAuthMetadataKey: "home-retry-a",
+	}}
+	if _, shouldRetry = manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), pinnedOpts, errRemoteCooldown, 0, []string{"home-retry-contract"}, "gpt", time.Second, -1); shouldRetry {
+		t.Fatal("aggregate retry limit from unpinned Home credentials affected a pinned request")
+	}
+
+	errRemoteCooldown.requestRetry = 0
+	manager.SetRetryConfig(3, time.Second, 0)
+	if _, shouldRetry = manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), cliproxyexecutor.Options{}, errRemoteCooldown, 0, []string{"home-retry-contract"}, "gpt", time.Second, -1); shouldRetry {
+		t.Fatal("explicit remote credential override 0 did not suppress the global retry setting")
+	}
+	retryLimit := 3
+	observeHomeCooldownRetryLimit(errRemoteCooldown, &retryLimit, true)
+	if retryLimit != 0 {
+		t.Fatalf("observed remote cooldown retry limit = %d, want authoritative 0", retryLimit)
+	}
+}
+
+func TestHomeRetryRoundCredentialLimitStartsNextRoundImmediately(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(1, time.Second, 1)
+	retryAfter := 5 * time.Second
+	errRoundExhausted := markHomeRetryRoundExhausted(
+		retryContractRateLimitError{retryAfter: retryAfter},
+		&retryAfter,
+		true,
+	)
+
+	wait, shouldRetry := manager.shouldRetryAfterError(errRoundExhausted, 0, []string{"home-retry-contract"}, "gpt", time.Second)
+	if !shouldRetry || wait != 0 {
+		t.Fatalf("credential-limit retry = (%v, %t), want immediate next round", wait, shouldRetry)
+	}
+	if got := SafeResponseHeaders(errRoundExhausted).Get("Retry-After"); got != "5" {
+		t.Fatalf("safe Retry-After header = %q, want 5", got)
+	}
+}
+
+func TestHomeCredentialLimitWaitsBeforeConsumingAdditionalRound(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(map[bool]string{false: "nonstream", true: "stream"}[stream], func(t *testing.T) {
+			dispatcher := &retryRoundStartCooldownDispatcher{}
+			executor := &retryContractHomeExecutor{failAll: true}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(1, time.Second, 1)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			if stream {
+				result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+				if errExecute == nil || result != nil {
+					t.Fatalf("ExecuteStream() = result %#v, error %v; want terminal retry error", result, errExecute)
+				}
+			} else {
+				if _, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{}); errExecute == nil {
+					t.Fatal("Execute() error = nil, want terminal retry error")
+				}
+			}
+			if got := executor.Calls(); len(got) != 2 {
+				t.Fatalf("executor calls = %v, want one execution in each of two rounds", got)
+			}
+			if got := dispatcher.calls.Load(); got != 3 {
+				t.Fatalf("Home dispatch calls = %d, want selection, cooldown wait, selection", got)
+			}
+		})
+	}
+}
+
+func TestHomePendingRetryRoundStopsWhenRemoteLimitDrops(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(map[bool]string{false: "nonstream", true: "stream"}[stream], func(t *testing.T) {
+			dispatcher := &retryRoundLimitDownshiftDispatcher{}
+			executor := &retryContractHomeExecutor{}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(1, time.Second, 1)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			if stream {
+				result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+				if errExecute == nil || result != nil {
+					t.Fatalf("ExecuteStream() = result %#v, error %v; want terminal cooldown error", result, errExecute)
+				}
+			} else {
+				if _, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{}); errExecute == nil {
+					t.Fatal("Execute() error = nil, want terminal cooldown error")
+				}
+			}
+			if got := executor.Calls(); len(got) != 1 || got[0] != "home-retry-a" {
+				t.Fatalf("executor calls = %v, want only the initial credential", got)
+			}
+			if got := dispatcher.calls.Load(); got != 2 {
+				t.Fatalf("Home dispatch calls = %d, want initial selection and one cooldown response", got)
+			}
+		})
+	}
+}
+
+func TestHomePendingRetryRoundStopsAfterRepeatedCooldown(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(map[bool]string{false: "nonstream", true: "stream"}[stream], func(t *testing.T) {
+			dispatcher := &retryRoundRepeatedCooldownDispatcher{}
+			executor := &retryContractHomeExecutor{failAll: true}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(1, time.Second, 1)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			if stream {
+				result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+				if errExecute == nil || result != nil {
+					t.Fatalf("ExecuteStream() = result %#v, error %v; want terminal cooldown error", result, errExecute)
+				}
+			} else {
+				if _, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{}); errExecute == nil {
+					t.Fatal("Execute() error = nil, want terminal cooldown error")
+				}
+			}
+			if got := executor.Calls(); len(got) != 1 {
+				t.Fatalf("executor calls = %v, want only the initial round execution", got)
+			}
+			if got := dispatcher.calls.Load(); got != 3 {
+				t.Fatalf("Home dispatch calls = %d, want selection and two cooldown responses", got)
+			}
+		})
+	}
+}
+
+func TestHomeRetryRoundUsesEarliestCredentialRetryAfter(t *testing.T) {
+	dispatcher := &retryContractHomeDispatcher{authIDs: []string{"home-retry-a", "home-retry-b"}}
+	executor := &retryContractHomeExecutor{
+		failAll: true,
+		failures: map[string]error{
+			"home-retry-a": retryContractRateLimitError{retryAfter: 5 * time.Millisecond},
+			"home-retry-b": retryContractRateLimitError{retryAfter: 50 * time.Millisecond},
+		},
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(1, time.Second, 2)
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+	manager.RegisterExecutor(executor)
+
+	retryLimit := -1
+	_, errExecute := manager.executeHomeOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{}, false, 2, &retryLimit)
+	if !isHomeRetryRoundExhausted(errExecute) {
+		t.Fatalf("executeHomeOnce() error = %v, want exhausted retry round", errExecute)
+	}
+	retryAfter := retryAfterFromError(errExecute)
+	if retryAfter == nil || *retryAfter != 5*time.Millisecond {
+		t.Fatalf("retry after = %v, want earliest credential delay 5ms", retryAfter)
+	}
+}
+
+func TestHomeStreamBootstrapErrorPreservesAggregatedRetryAfter(t *testing.T) {
+	dispatcher := &retryContractHomeDispatcher{authIDs: []string{"home-retry-a", "home-retry-b"}}
+	executor := &retryContractHomeExecutor{
+		failAll:         true,
+		streamBootstrap: true,
+		streamHeaders:   http.Header{"Retry-After": {"30"}},
+		failures: map[string]error{
+			"home-retry-a": retryContractRateLimitError{retryAfter: 1500 * time.Millisecond},
+			"home-retry-b": retryContractRateLimitError{retryAfter: 5 * time.Second},
+		},
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(0, time.Second, 2)
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+	manager.RegisterExecutor(executor)
+
+	result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+	if errExecute != nil {
+		t.Fatalf("ExecuteStream() error = %v", errExecute)
+	}
+	if result == nil {
+		t.Fatal("ExecuteStream() result = nil")
+	}
+	chunk, ok := <-result.Chunks
+	if !ok || chunk.Err == nil {
+		t.Fatalf("stream bootstrap chunk = %#v, %t; want terminal error", chunk, ok)
+	}
+	if !isHomeRetryRoundExhausted(chunk.Err) {
+		t.Fatalf("stream bootstrap error = %v, want exhausted retry round", chunk.Err)
+	}
+	if got := SafeResponseHeaders(chunk.Err).Get("Retry-After"); got != "2" {
+		t.Fatalf("safe Retry-After header = %q, want aggregated delay rounded to 2 seconds", got)
+	}
+}
+
+func TestHomeRetryRoundUsesAuthoritativeRemoteCooldown(t *testing.T) {
+	tests := []struct {
+		name    string
+		execute func(*Manager, *int) error
+	}{
+		{
+			name: "nonstream",
+			execute: func(manager *Manager, retryLimit *int) error {
+				_, errExecute := manager.executeHomeOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{}, false, 2, retryLimit)
+				return errExecute
+			},
+		},
+		{
+			name: "stream",
+			execute: func(manager *Manager, retryLimit *int) error {
+				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, 2, retryLimit)
+				return errExecute
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dispatcher := &retryContractHomeDispatcher{
+				authIDs:          []string{"home-retry-a"},
+				exhaustedPayload: []byte(`{"error":{"type":"model_cooldown","message":"remaining Home credentials are cooling down","retryable":true,"retry_after_ms":5000}}`),
+			}
+			executor := &retryContractHomeExecutor{
+				failAll: true,
+				failure: retryContractRateLimitError{retryAfter: 1500 * time.Millisecond},
+			}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(1, time.Second, 2)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			retryLimit := -1
+			errExecute := tc.execute(manager, &retryLimit)
+			if !isHomeRetryRoundExhausted(errExecute) {
+				t.Fatalf("execution error = %v, want exhausted retry round", errExecute)
+			}
+			retryAfter := retryAfterFromError(errExecute)
+			if retryAfter == nil || *retryAfter != 5*time.Second {
+				t.Fatalf("retry after = %v, want Home next-round cooldown 5s", retryAfter)
+			}
+			if got := SafeResponseHeaders(errExecute).Get("Retry-After"); got != "5" {
+				t.Fatalf("safe Retry-After header = %q, want Home next-round delay 5 seconds", got)
+			}
+		})
+	}
+}
+
+func TestHomeCooldownClassificationPreservesNonRetryableRoundStatus(t *testing.T) {
+	tests := []struct {
+		name    string
+		execute func(*Manager, *int) error
+	}{
+		{
+			name: "nonstream",
+			execute: func(manager *Manager, retryLimit *int) error {
+				_, errExecute := manager.executeHomeOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{}, false, 2, retryLimit)
+				return errExecute
+			},
+		},
+		{
+			name: "stream",
+			execute: func(manager *Manager, retryLimit *int) error {
+				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, 2, retryLimit)
+				return errExecute
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dispatcher := &retryContractHomeDispatcher{
+				authIDs:          []string{"home-retry-a"},
+				exhaustedPayload: []byte(`{"error":{"type":"model_cooldown","message":"another credential is cooling down","retryable":true,"retry_after_ms":5,"request_retry":2}}`),
+			}
+			executor := &retryContractHomeExecutor{
+				failAll: true,
+				failure: &Error{HTTPStatus: http.StatusUnauthorized, Message: "invalid credential"},
+			}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(3, time.Second, 2)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			retryLimit := -1
+			errExecute := test.execute(manager, &retryLimit)
+			if !isHomeRetryRoundExhausted(errExecute) || statusCodeFromError(errExecute) != http.StatusUnauthorized {
+				t.Fatalf("execution error = %T %v, want exhausted 401 round", errExecute, errExecute)
+			}
+			if retryLimit != 2 {
+				t.Fatalf("observed retry limit = %d, want authoritative Home limit 2", retryLimit)
+			}
+			if wait, shouldRetry := manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), cliproxyexecutor.Options{}, errExecute, 0, []string{"home-retry-contract"}, "gpt", time.Second, retryLimit); shouldRetry || wait != 0 {
+				t.Fatalf("401 round retry = (%v, %t), want (0, false)", wait, shouldRetry)
+			}
+		})
+	}
+}
+
+func TestHomeRetryRoundStartsImmediatelyWhenHomeReportsAvailableNextRound(t *testing.T) {
+	tests := []struct {
+		name    string
+		execute func(*Manager, *int) error
+	}{
+		{
+			name: "nonstream",
+			execute: func(manager *Manager, retryLimit *int) error {
+				_, errExecute := manager.executeHomeOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{}, false, 0, retryLimit)
+				return errExecute
+			},
+		},
+		{
+			name: "stream",
+			execute: func(manager *Manager, retryLimit *int) error {
+				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, 0, retryLimit)
+				return errExecute
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dispatcher := &retryContractHomeDispatcher{
+				authIDs:          []string{"home-retry-a", "home-retry-b"},
+				exhaustedPayload: []byte(`{"error":{"type":"auth_unavailable","message":"a credential is immediately available next round"}}`),
+			}
+			executor := &retryContractHomeExecutor{
+				failAll: true,
+				failures: map[string]error{
+					"home-retry-a": retryContractRateLimitError{retryAfter: 5 * time.Second},
+					"home-retry-b": &Error{HTTPStatus: http.StatusBadGateway, Message: "upstream unavailable"},
+				},
+			}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(1, 10*time.Second, 0)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			retryLimit := -1
+			errExecute := test.execute(manager, &retryLimit)
+			if !isHomeRetryRoundExhausted(errExecute) {
+				t.Fatalf("execution error = %v, want exhausted retry round", errExecute)
+			}
+			wait, shouldRetry := manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), cliproxyexecutor.Options{}, errExecute, 0, []string{"home-retry-contract"}, "gpt", 10*time.Second, retryLimit)
+			if !shouldRetry || wait != 0 {
+				t.Fatalf("next-round retry = (%v, %t), want immediate", wait, shouldRetry)
+			}
+		})
+	}
+}
+
+func TestHomeRetryRoundUsesRemoteCooldownWhenAttemptedErrorHasNoTiming(t *testing.T) {
+	tests := []struct {
+		name    string
+		execute func(*Manager, *int) error
+	}{
+		{
+			name: "nonstream",
+			execute: func(manager *Manager, retryLimit *int) error {
+				_, errExecute := manager.executeHomeOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{}, false, 2, retryLimit)
+				return errExecute
+			},
+		},
+		{
+			name: "stream",
+			execute: func(manager *Manager, retryLimit *int) error {
+				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, 2, retryLimit)
+				return errExecute
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dispatcher := &retryContractHomeDispatcher{
+				authIDs:          []string{"home-retry-a"},
+				exhaustedPayload: []byte(`{"error":{"type":"model_cooldown","message":"remaining Home credentials are cooling down","retryable":true,"retry_after_ms":1500}}`),
+			}
+			executor := &retryContractHomeExecutor{
+				failAll: true,
+				failure: &Error{HTTPStatus: http.StatusBadGateway, Message: "upstream unavailable"},
+			}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(1, 2*time.Second, 2)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			retryLimit := -1
+			errExecute := tc.execute(manager, &retryLimit)
+			if !isHomeRetryRoundExhausted(errExecute) {
+				t.Fatalf("execution error = %v, want exhausted retry round", errExecute)
+			}
+			retryAfter := retryAfterFromError(errExecute)
+			if retryAfter == nil || *retryAfter != 1500*time.Millisecond {
+				t.Fatalf("retry after = %v, want remote cooldown delay 1500ms", retryAfter)
+			}
+			if got := SafeResponseHeaders(errExecute).Get("Retry-After"); got != "2" {
+				t.Fatalf("safe Retry-After header = %q, want 2", got)
+			}
+		})
+	}
+}
+
+func TestHomeStreamOAuthUnauthorizedRotatesAfterRefreshRetry(t *testing.T) {
+	dispatcher := &retryContractHomeDispatcher{
+		authIDs: []string{"home-retry-a", "home-retry-b"},
+		metadata: map[string]any{
+			"auth_kind": "oauth",
+		},
+	}
+	executor := &retryContractHomeExecutor{
+		failures: map[string]error{
+			"home-retry-a": &Error{HTTPStatus: http.StatusUnauthorized, Message: "expired"},
+		},
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(0, time.Second, 2)
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+	manager.RegisterExecutor(executor)
+
+	result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+	if errExecute != nil {
+		t.Fatalf("ExecuteStream() error = %v", errExecute)
+	}
+	for range result.Chunks {
+	}
+	if got := executor.Calls(); len(got) != 3 || got[0] != "home-retry-a" || got[1] != "home-retry-a" || got[2] != "home-retry-b" {
+		t.Fatalf("executor calls = %v, want [home-retry-a home-retry-a home-retry-b]", got)
+	}
+	excluded := dispatcher.Excluded()
+	if len(excluded) != 2 || len(excluded[0]) != 0 || len(excluded[1]) != 1 || excluded[1][0] != "home-retry-a" {
+		t.Fatalf("Home excluded auth IDs = %v, want [[], [home-retry-a]]", excluded)
+	}
+}
+
+func TestHomeStreamLifecycleRecoveryFailureRotatesWithoutExtraDispatch(t *testing.T) {
+	dispatcher := &retryContractHomeDispatcher{authIDs: []string{"home-retry-a", "home-retry-b"}}
+	executor := &retryContractHomeExecutor{
+		failures: map[string]error{
+			"home-retry-a": errors.New("unexpected EOF"),
+		},
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(0, time.Second, 2)
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+	manager.RegisterExecutor(executor)
+
+	result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+	if errExecute != nil {
+		t.Fatalf("ExecuteStream() error = %v", errExecute)
+	}
+	for range result.Chunks {
+	}
+	if got := executor.Calls(); len(got) != 3 || got[0] != "home-retry-a" || got[1] != "home-retry-a" || got[2] != "home-retry-b" {
+		t.Fatalf("executor calls = %v, want [home-retry-a home-retry-a home-retry-b]", got)
+	}
+	excluded := dispatcher.Excluded()
+	if len(excluded) != 3 || len(excluded[0]) != 0 || len(excluded[1]) != 0 || len(excluded[2]) != 1 || excluded[2][0] != "home-retry-a" {
+		t.Fatalf("Home excluded auth IDs = %v, want [[], [], [home-retry-a]]", excluded)
+	}
+}
+
+func TestRetryRoundAvailabilityRejectsStaleQuotaForNonRetryableStatus(t *testing.T) {
+	now := time.Now()
+	for _, test := range []struct {
+		name      string
+		lastError *Error
+		want      bool
+	}{
+		{name: "implicit quota", want: true},
+		{name: "rate limit", lastError: &Error{HTTPStatus: http.StatusTooManyRequests}, want: true},
+		{name: "payment required", lastError: &Error{HTTPStatus: http.StatusPaymentRequired}, want: false},
+		{name: "not found", lastError: &Error{HTTPStatus: http.StatusNotFound}, want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			nextRetry := now.Add(time.Minute)
+			auth := &Auth{
+				ID:       "retry-round-stale-quota",
+				Provider: "codex",
+				Status:   StatusActive,
+				ModelStates: map[string]*ModelState{
+					"gpt": {
+						Status:         StatusError,
+						Unavailable:    true,
+						NextRetryAfter: nextRetry,
+						LastError:      test.lastError,
+						Quota:          QuotaState{Exceeded: true, NextRecoverAt: nextRetry},
+					},
+				},
+			}
+			got, next := retryRoundAvailabilityForAuth(auth, "gpt", now)
+			if got != test.want {
+				t.Fatalf("retryRoundAvailabilityForAuth() eligible = %t, want %t", got, test.want)
+			}
+			if got && !next.Equal(nextRetry) {
+				t.Fatalf("retryRoundAvailabilityForAuth() next = %v, want %v", next, nextRetry)
+			}
+		})
+	}
+}
+
+func TestHomeStreamAPIKeyUnauthorizedRotatesImmediately(t *testing.T) {
+	dispatcher := &retryContractHomeDispatcher{
+		authIDs: []string{"home-retry-a", "home-retry-b"},
+		metadata: map[string]any{
+			"auth_kind": "apikey",
+		},
+	}
+	executor := &retryContractHomeExecutor{
+		failures: map[string]error{
+			"home-retry-a": &Error{HTTPStatus: http.StatusUnauthorized, Message: "invalid api key"},
+		},
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(0, time.Second, 2)
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+	manager.RegisterExecutor(executor)
+
+	result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+	if errExecute != nil {
+		t.Fatalf("ExecuteStream() error = %v", errExecute)
+	}
+	for range result.Chunks {
+	}
+	if got := executor.Calls(); len(got) != 2 || got[0] != "home-retry-a" || got[1] != "home-retry-b" {
+		t.Fatalf("executor calls = %v, want [home-retry-a home-retry-b]", got)
+	}
+	excluded := dispatcher.Excluded()
+	if len(excluded) != 2 || len(excluded[0]) != 0 || len(excluded[1]) != 1 || excluded[1][0] != "home-retry-a" {
+		t.Fatalf("Home excluded auth IDs = %v, want [[], [home-retry-a]]", excluded)
+	}
+}
+
+func TestHomeModelCooldownErrorPreservesRetryContract(t *testing.T) {
+	errDecoded := decodeHomeDispatchError([]byte(`{"error":{"type":"model_cooldown","message":"all credentials are cooling down","retryable":true,"retry_after_ms":1500,"request_retry":2}}`))
+	var retryErr *homeDispatchRetryAfterError
+	if !errors.As(errDecoded, &retryErr) || retryErr == nil {
+		t.Fatalf("decodeHomeDispatchError() = %#v, want retry-after error", errDecoded)
+	}
+	if retryErr.StatusCode() != http.StatusTooManyRequests || retryErr.RetryAfter() == nil || *retryErr.RetryAfter() != 1500*time.Millisecond {
+		t.Fatalf("decoded Home cooldown = status %d retry-after %v, want 429/1500ms", retryErr.StatusCode(), retryErr.RetryAfter())
+	}
+	if retryLimit, ok := retryErr.RequestRetryLimit(); !ok || retryLimit != 2 {
+		t.Fatalf("decoded Home request retry limit = (%d, %t), want (2, true)", retryLimit, ok)
+	}
+	var cause *Error
+	if !errors.As(errDecoded, &cause) || cause == nil || cause.Code != "model_cooldown" || !cause.Retryable {
+		t.Fatalf("decoded Home cooldown cause = %#v, want retryable model_cooldown", cause)
+	}
+	if got := SafeResponseHeaders(errDecoded).Get("Retry-After"); got != "2" {
+		t.Fatalf("safe Retry-After header = %q, want 2", got)
+	}
+}
+
+func TestHomeRequestRetryCountsAdditionalCredentialRounds(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(map[bool]string{false: "nonstream", true: "stream"}[stream], func(t *testing.T) {
+			dispatcher := &retryContractHomeDispatcher{authIDs: []string{"home-retry-a", "home-retry-b"}}
+			executor := &retryContractHomeExecutor{failAll: true}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(1, time.Second, 2)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			if stream {
+				result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+				if errExecute == nil || result != nil {
+					t.Fatalf("ExecuteStream() = result %#v, error %v; want terminal rate-limit error", result, errExecute)
+				}
+			} else {
+				_, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{})
+				if errExecute == nil {
+					t.Fatal("Execute() error = nil, want rate-limit error")
+				}
+			}
+			if got := executor.Calls(); len(got) != 4 {
+				t.Fatalf("executor calls = %v, want four calls across two rounds", got)
+			}
+			excluded := dispatcher.Excluded()
+			if len(excluded) != 4 || len(excluded[0]) != 0 || len(excluded[1]) != 1 || excluded[1][0] != "home-retry-a" || len(excluded[2]) != 0 || len(excluded[3]) != 1 || excluded[3][0] != "home-retry-a" {
+				t.Fatalf("Home excluded auth IDs = %v, want [[], [home-retry-a], [], [home-retry-a]]", excluded)
+			}
+		})
+	}
+}
+
+func TestHomeRequestRetryRoundDoesNotRequireRetryAfter(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(map[bool]string{false: "nonstream", true: "stream"}[stream], func(t *testing.T) {
+			dispatcher := &retryContractHomeDispatcher{authIDs: []string{"home-retry-a", "home-retry-b"}}
+			executor := &retryContractHomeExecutor{
+				failAll: true,
+				failure: &Error{HTTPStatus: http.StatusBadGateway, Message: "upstream unavailable"},
+			}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(1, time.Second, 2)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			if stream {
+				result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+				if errExecute == nil || result != nil {
+					t.Fatalf("ExecuteStream() = result %#v, error %v; want terminal upstream error", result, errExecute)
+				}
+			} else {
+				_, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{})
+				if errExecute == nil {
+					t.Fatal("Execute() error = nil, want upstream error")
+				}
+			}
+			if got := executor.Calls(); len(got) != 4 {
+				t.Fatalf("executor calls = %v, want four calls across two rounds", got)
+			}
+		})
+	}
+}
+
+func TestHomeStreamLegacyDispatcherDoesNotSpinOnIgnoredExclusions(t *testing.T) {
+	dispatcher := &legacyRepeatedStreamDispatcher{}
+	executor := &retryContractHomeExecutor{
+		failAll: true,
+		failure: &Error{HTTPStatus: http.StatusBadGateway, Message: "upstream unavailable"},
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(1, time.Second, 2)
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+	manager.RegisterExecutor(executor)
+
+	result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+	if result != nil || errExecute == nil {
+		t.Fatalf("ExecuteStream() = result %#v, error %v; want terminal upstream error", result, errExecute)
+	}
+	if got := len(executor.Calls()); got != 2 {
+		t.Fatalf("executor calls = %d, want one attempt in each of two rounds", got)
+	}
+	if got := dispatcher.calls.Load(); got != 4 {
+		t.Fatalf("legacy Home dispatch calls = %d, want two dispatches in each of two rounds", got)
+	}
+}
+
+func TestHomeNonStreamLegacyDispatcherCompletesAdditionalRetryRound(t *testing.T) {
+	dispatcher := &legacyRepeatedStreamDispatcher{}
+	executor := &retryContractHomeExecutor{
+		failAll: true,
+		failure: &Error{HTTPStatus: http.StatusBadGateway, Message: "upstream unavailable"},
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(1, time.Second, 0)
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+	manager.RegisterExecutor(executor)
+
+	_, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{})
+	if errExecute == nil {
+		t.Fatal("Execute() error = nil, want terminal upstream error")
+	}
+	if got := len(executor.Calls()); got != 2 {
+		t.Fatalf("executor calls = %d, want one attempt in each of two rounds", got)
+	}
+	if got := dispatcher.calls.Load(); got != 4 {
+		t.Fatalf("legacy Home dispatch calls = %d, want two dispatches in each of two rounds", got)
+	}
+}
+
+func TestHomeLocalSelectionRejectionWaitsForReleaseAcknowledgement(t *testing.T) {
+	tests := []struct {
+		name                string
+		dispatcher          homeAuthDispatcher
+		executor            *retryContractHomeExecutor
+		maxRetryCredentials int
+		blockedGroup        executionregistry.ReleaseGroup
+		blockedSequence     int64
+		execute             func(*Manager, int, *int) error
+	}{
+		{
+			name: "nonstream repeated auth",
+			dispatcher: &accountedHomeExecutionDispatcher{auths: []Auth{
+				{ID: "home-retry-a", Provider: "home-retry-contract", Status: StatusActive},
+				{ID: "home-retry-a", Provider: "home-retry-contract", Status: StatusActive},
+			}},
+			executor:            &retryContractHomeExecutor{failure: &Error{HTTPStatus: http.StatusBadGateway, Message: "upstream unavailable"}},
+			maxRetryCredentials: 0,
+			blockedGroup:        executionregistry.ReleaseGroup{CredentialID: "home-retry-a", Model: "gpt"},
+			blockedSequence:     2,
+			execute: func(manager *Manager, maxRetryCredentials int, retryLimit *int) error {
+				_, errExecute := manager.executeHomeOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{}, false, maxRetryCredentials, retryLimit)
+				return errExecute
+			},
+		},
+		{
+			name: "stream repeated excluded auth",
+			dispatcher: &accountedHomeExecutionDispatcher{auths: []Auth{
+				{ID: "home-retry-a", Provider: "home-retry-contract", Status: StatusActive},
+				{ID: "home-retry-a", Provider: "home-retry-contract", Status: StatusActive},
+			}},
+			executor:            &retryContractHomeExecutor{failure: &Error{HTTPStatus: http.StatusBadGateway, Message: "upstream unavailable"}},
+			maxRetryCredentials: 0,
+			blockedGroup:        executionregistry.ReleaseGroup{CredentialID: "home-retry-a", Model: "gpt"},
+			blockedSequence:     2,
+			execute: func(manager *Manager, maxRetryCredentials int, retryLimit *int) error {
+				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, maxRetryCredentials, retryLimit)
+				return errExecute
+			},
+		},
+		{
+			name: "stream max retry credentials",
+			dispatcher: &accountedHomeExecutionDispatcher{auths: []Auth{
+				{ID: "home-retry-a", Provider: "home-retry-contract", Status: StatusActive},
+				{ID: "home-retry-b", Provider: "home-retry-contract", Status: StatusActive},
+			}},
+			executor:            &retryContractHomeExecutor{failure: errors.New("unexpected EOF")},
+			maxRetryCredentials: 1,
+			blockedGroup:        executionregistry.ReleaseGroup{CredentialID: "home-retry-b", Model: "gpt"},
+			blockedSequence:     1,
+			execute: func(manager *Manager, maxRetryCredentials int, retryLimit *int) error {
+				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, maxRetryCredentials, retryLimit)
+				return errExecute
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			registry := executionregistry.New()
+			acknowledged := make(chan struct{})
+			close(acknowledged)
+			unacknowledged := make(chan struct{})
+			var blockedReleaseSeen atomic.Bool
+			registry.SetReleaseSink(func(group executionregistry.ReleaseGroup, sequence int64) *executionregistry.ReleaseTicket {
+				done := (<-chan struct{})(acknowledged)
+				if group == test.blockedGroup && sequence == test.blockedSequence {
+					blockedReleaseSeen.Store(true)
+					done = unacknowledged
+				}
+				return executionregistry.NewReleaseTicket(group, sequence, done)
+			})
+
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{
+				Home:                  internalconfig.HomeConfig{Enabled: true},
+				CredentialConcurrency: internalconfig.CredentialConcurrencyConfig{CPACancelBound: 10 * time.Millisecond},
+			})
+			manager.PublishHomeDispatch(test.dispatcher, registry, 1)
+			manager.RegisterExecutor(test.executor)
+
+			retryLimit := -1
+			errExecute := test.execute(manager, test.maxRetryCredentials, &retryLimit)
+			if !blockedReleaseSeen.Load() {
+				t.Fatal("target release was not attempted")
+			}
+			var homeErr *Error
+			if !errors.As(errExecute, &homeErr) || homeErr == nil || homeErr.Code != "home_unavailable" {
+				t.Fatalf("execution error = %T %v, want Home release acknowledgement timeout", errExecute, errExecute)
+			}
+		})
+	}
+}
+
+func TestHomeRetryRoundHonorsCredentialRequestRetryOverride(t *testing.T) {
+	tests := []struct {
+		name          string
+		globalRetry   int
+		override      int
+		wantCallCount int
+	}{
+		{name: "override disables global rounds", globalRetry: 3, override: 0, wantCallCount: 2},
+		{name: "override enables rounds over global", globalRetry: 0, override: 1, wantCallCount: 4},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dispatcher := &retryContractHomeDispatcher{
+				authIDs:  []string{"home-retry-a", "home-retry-b"},
+				metadata: map[string]any{"request_retry": tc.override},
+			}
+			executor := &retryContractHomeExecutor{failAll: true}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(tc.globalRetry, time.Second, 2)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			_, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{})
+			if errExecute == nil {
+				t.Fatal("Execute() error = nil, want terminal rate-limit error")
+			}
+			if got := len(executor.Calls()); got != tc.wantCallCount {
+				t.Fatalf("executor call count = %d, want %d", got, tc.wantCallCount)
+			}
+		})
+	}
+}
+
+func TestHomeRetryRoundUsesSuccessfulDispatchAggregate(t *testing.T) {
+	tests := []struct {
+		name    string
+		execute func(*Manager) error
+	}{
+		{
+			name: "nonstream",
+			execute: func(manager *Manager) error {
+				_, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{})
+				return errExecute
+			},
+		},
+		{
+			name: "count tokens",
+			execute: func(manager *Manager) error {
+				_, errExecute := manager.ExecuteCount(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{})
+				return errExecute
+			},
+		},
+		{
+			name: "stream",
+			execute: func(manager *Manager) error {
+				result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+				if errExecute != nil {
+					return errExecute
+				}
+				for range result.Chunks {
+				}
+				return nil
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dispatcher := &aggregateRetryHomeDispatcher{}
+			executor := &retryContractHomeExecutor{}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(0, time.Second, 1)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			if errExecute := test.execute(manager); errExecute != nil {
+				t.Fatalf("execution error = %v", errExecute)
+			}
+			if got := executor.Calls(); len(got) != 2 || got[0] != "home-retry-a" || got[1] != "home-retry-b" {
+				t.Fatalf("executor calls = %v, want [home-retry-a home-retry-b]", got)
+			}
+			if got := dispatcher.calls.Load(); got != 2 {
+				t.Fatalf("Home dispatch calls = %d, want 2", got)
+			}
+		})
+	}
+}
+
+func TestHomeRetryRoundUsesAuthoritativeZeroAggregate(t *testing.T) {
+	tests := []struct {
+		name    string
+		execute func(*Manager) error
+	}{
+		{
+			name: "nonstream",
+			execute: func(manager *Manager) error {
+				_, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{})
+				return errExecute
+			},
+		},
+		{
+			name: "count tokens",
+			execute: func(manager *Manager) error {
+				_, errExecute := manager.ExecuteCount(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{})
+				return errExecute
+			},
+		},
+		{
+			name: "stream",
+			execute: func(manager *Manager) error {
+				_, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+				return errExecute
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			remoteRetry := 0
+			dispatcher := &retryContractHomeDispatcher{
+				authIDs:      []string{"home-retry-a", "home-retry-b"},
+				metadata:     map[string]any{"request_retry": 3},
+				requestRetry: &remoteRetry,
+			}
+			executor := &retryContractHomeExecutor{
+				failAll: true,
+				failure: &Error{HTTPStatus: http.StatusBadGateway, Message: "upstream unavailable"},
+			}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(3, time.Second, 2)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			if errExecute := test.execute(manager); errExecute == nil {
+				t.Fatal("execution error = nil, want terminal first-round error")
+			}
+			if got := executor.Calls(); len(got) != 2 {
+				t.Fatalf("executor calls = %v, want only the two first-round credentials", got)
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/auth/home_retry_contract_test.go
+++ b/sdk/cliproxy/auth/home_retry_contract_test.go
@@ -1,0 +1,1477 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/home"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executionregistry"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type retryContractHomeDispatcher struct {
+	mu               sync.Mutex
+	authIDs          []string
+	excluded         [][]string
+	metadata         map[string]any
+	requestRetry     *int
+	websocket        bool
+	exhaustedPayload []byte
+}
+
+type legacyRepeatedStreamDispatcher struct {
+	calls atomic.Int32
+}
+
+type retryRoundStartCooldownDispatcher struct {
+	calls atomic.Int32
+}
+
+type retryRoundRepeatedCooldownDispatcher struct {
+	calls atomic.Int32
+}
+
+type retryRoundLimitDownshiftDispatcher struct {
+	calls atomic.Int32
+}
+
+type aggregateRetryHomeDispatcher struct {
+	calls atomic.Int32
+}
+
+func (*legacyRepeatedStreamDispatcher) HeartbeatOK() bool { return true }
+
+func (d *legacyRepeatedStreamDispatcher) RPopAuth(context.Context, string, string, http.Header, int) ([]byte, error) {
+	d.calls.Add(1)
+	return json.Marshal(homeAuthDispatchResponse{Auth: Auth{
+		ID:       "home-retry-a",
+		Provider: "home-retry-contract",
+		Status:   StatusActive,
+	}})
+}
+
+func (*legacyRepeatedStreamDispatcher) AbortAmbiguousDispatch() {}
+
+func (*retryRoundStartCooldownDispatcher) HeartbeatOK() bool { return true }
+
+func (d *retryRoundStartCooldownDispatcher) RPopAuth(ctx context.Context, model string, sessionID string, headers http.Header, count int) ([]byte, error) {
+	return d.RPopAuthWithConstraints(ctx, model, sessionID, headers, count, nil, "")
+}
+
+func (d *retryRoundStartCooldownDispatcher) RPopAuthWithConstraints(_ context.Context, _ string, _ string, _ http.Header, _ int, _ []string, _ string) ([]byte, error) {
+	if d.calls.Add(1) == 2 {
+		return []byte(`{"error":{"type":"model_cooldown","message":"credential is cooling down","retryable":true,"retry_after_ms":1,"request_retry":1}}`), nil
+	}
+	return json.Marshal(homeAuthDispatchResponse{Auth: Auth{
+		ID:       "home-retry-a",
+		Provider: "home-retry-contract",
+		Status:   StatusActive,
+	}})
+}
+
+func (*retryRoundStartCooldownDispatcher) AbortAmbiguousDispatch() {}
+
+func (*retryRoundRepeatedCooldownDispatcher) HeartbeatOK() bool { return true }
+
+func (d *retryRoundRepeatedCooldownDispatcher) RPopAuth(ctx context.Context, model string, sessionID string, headers http.Header, count int) ([]byte, error) {
+	return d.RPopAuthWithConstraints(ctx, model, sessionID, headers, count, nil, "")
+}
+
+func (d *retryRoundRepeatedCooldownDispatcher) RPopAuthWithConstraints(_ context.Context, _ string, _ string, _ http.Header, _ int, _ []string, _ string) ([]byte, error) {
+	if d.calls.Add(1) > 1 {
+		return []byte(`{"error":{"type":"model_cooldown","message":"credential is cooling down","retryable":true,"retry_after_ms":1,"request_retry":1}}`), nil
+	}
+	return json.Marshal(homeAuthDispatchResponse{Auth: Auth{
+		ID:       "home-retry-a",
+		Provider: "home-retry-contract",
+		Status:   StatusActive,
+	}})
+}
+
+func (*retryRoundRepeatedCooldownDispatcher) AbortAmbiguousDispatch() {}
+
+func (*retryRoundLimitDownshiftDispatcher) HeartbeatOK() bool { return true }
+
+func (d *retryRoundLimitDownshiftDispatcher) RPopAuth(ctx context.Context, model string, sessionID string, headers http.Header, count int) ([]byte, error) {
+	return d.RPopAuthWithConstraints(ctx, model, sessionID, headers, count, nil, "")
+}
+
+func (d *retryRoundLimitDownshiftDispatcher) RPopAuthWithConstraints(_ context.Context, _ string, _ string, _ http.Header, _ int, _ []string, _ string) ([]byte, error) {
+	switch d.calls.Add(1) {
+	case 1:
+		retryLimit := 1
+		return json.Marshal(homeAuthDispatchResponse{RequestRetry: &retryLimit, Auth: Auth{
+			ID:       "home-retry-a",
+			Provider: "home-retry-contract",
+			Status:   StatusActive,
+		}})
+	case 2:
+		return []byte(`{"error":{"type":"model_cooldown","message":"remaining credentials are cooling down","retryable":true,"retry_after_ms":1,"request_retry":0}}`), nil
+	default:
+		return json.Marshal(homeAuthDispatchResponse{Auth: Auth{
+			ID:       "home-retry-b",
+			Provider: "home-retry-contract",
+			Status:   StatusActive,
+		}})
+	}
+}
+
+func (*retryRoundLimitDownshiftDispatcher) AbortAmbiguousDispatch() {}
+
+func (*aggregateRetryHomeDispatcher) HeartbeatOK() bool { return true }
+
+func (d *aggregateRetryHomeDispatcher) RPopAuth(ctx context.Context, model string, sessionID string, headers http.Header, count int) ([]byte, error) {
+	return d.RPopAuthWithConstraints(ctx, model, sessionID, headers, count, nil, "")
+}
+
+func (d *aggregateRetryHomeDispatcher) RPopAuthWithConstraints(_ context.Context, _ string, _ string, _ http.Header, _ int, _ []string, _ string) ([]byte, error) {
+	authID := "home-retry-a"
+	override := 0
+	if d.calls.Add(1) > 1 {
+		authID = "home-retry-b"
+		override = 2
+	}
+	requestRetry := 2
+	return json.Marshal(homeAuthDispatchResponse{
+		RequestRetry: &requestRetry,
+		Auth: Auth{
+			ID:       authID,
+			Provider: "home-retry-contract",
+			Status:   StatusActive,
+			Metadata: map[string]any{"request_retry": override},
+		},
+	})
+}
+
+func (*aggregateRetryHomeDispatcher) AbortAmbiguousDispatch() {}
+
+func (*retryContractHomeDispatcher) HeartbeatOK() bool { return true }
+
+func (d *retryContractHomeDispatcher) RPopAuth(ctx context.Context, model string, sessionID string, headers http.Header, count int) ([]byte, error) {
+	return d.RPopAuthWithConstraints(ctx, model, sessionID, headers, count, nil, "")
+}
+
+func (d *retryContractHomeDispatcher) RPopAuthWithConstraints(_ context.Context, _ string, _ string, _ http.Header, _ int, excludedAuthIDs []string, pinnedAuthID string) ([]byte, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.excluded = append(d.excluded, append([]string(nil), excludedAuthIDs...))
+	excluded := make(map[string]struct{}, len(excludedAuthIDs))
+	for _, authID := range excludedAuthIDs {
+		excluded[authID] = struct{}{}
+	}
+	for _, authID := range d.authIDs {
+		if pinnedAuthID != "" && authID != pinnedAuthID {
+			continue
+		}
+		if _, okExcluded := excluded[authID]; okExcluded {
+			continue
+		}
+		attributes := map[string]string{}
+		if d.websocket {
+			attributes["websockets"] = "true"
+		}
+		return json.Marshal(homeAuthDispatchResponse{
+			RequestRetry: d.requestRetry,
+			Auth: Auth{
+				ID:         authID,
+				Provider:   "home-retry-contract",
+				Status:     StatusActive,
+				Metadata:   d.metadata,
+				Attributes: attributes,
+			},
+		})
+	}
+	if len(d.exhaustedPayload) > 0 {
+		return append([]byte(nil), d.exhaustedPayload...), nil
+	}
+	return nil, home.ErrAuthNotFound
+}
+
+func (*retryContractHomeDispatcher) AbortAmbiguousDispatch() {}
+
+func (d *retryContractHomeDispatcher) Excluded() [][]string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	result := make([][]string, len(d.excluded))
+	for index := range d.excluded {
+		result[index] = append([]string(nil), d.excluded[index]...)
+	}
+	return result
+}
+
+type retryContractHomeExecutor struct {
+	mu              sync.Mutex
+	calls           []string
+	failAll         bool
+	failure         error
+	failures        map[string]error
+	streamBootstrap bool
+	streamHeaders   http.Header
+}
+
+func (*retryContractHomeExecutor) Identifier() string { return "home-retry-contract" }
+
+func (e *retryContractHomeExecutor) Execute(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.mu.Lock()
+	e.calls = append(e.calls, auth.ID)
+	e.mu.Unlock()
+	if auth.ID == "home-retry-a" || e.failAll {
+		return cliproxyexecutor.Response{}, e.failureError(auth.ID)
+	}
+	return cliproxyexecutor.Response{Payload: []byte(auth.ID)}, nil
+}
+
+func (e *retryContractHomeExecutor) ExecuteStream(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	e.mu.Lock()
+	e.calls = append(e.calls, auth.ID)
+	e.mu.Unlock()
+	if auth.ID == "home-retry-a" || e.failAll {
+		errFailure := e.failureError(auth.ID)
+		if e.streamBootstrap {
+			chunks := make(chan cliproxyexecutor.StreamChunk, 1)
+			chunks <- cliproxyexecutor.StreamChunk{Err: errFailure}
+			close(chunks)
+			return &cliproxyexecutor.StreamResult{Headers: e.streamHeaders.Clone(), Chunks: chunks}, nil
+		}
+		return nil, errFailure
+	}
+	chunks := make(chan cliproxyexecutor.StreamChunk, 1)
+	chunks <- cliproxyexecutor.StreamChunk{Payload: []byte(auth.ID)}
+	close(chunks)
+	return &cliproxyexecutor.StreamResult{Chunks: chunks}, nil
+}
+
+func (e *retryContractHomeExecutor) failureError(authID string) error {
+	if failure := e.failures[authID]; failure != nil {
+		return failure
+	}
+	if e.failure != nil {
+		return e.failure
+	}
+	return retryContractRateLimitError{}
+}
+
+func (*retryContractHomeExecutor) Refresh(context.Context, *Auth) (*Auth, error) { return nil, nil }
+
+func (e *retryContractHomeExecutor) CountTokens(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, _ cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	e.mu.Lock()
+	e.calls = append(e.calls, auth.ID)
+	e.mu.Unlock()
+	if auth.ID == "home-retry-a" || e.failAll {
+		return cliproxyexecutor.Response{}, e.failureError(auth.ID)
+	}
+	return cliproxyexecutor.Response{Payload: []byte(auth.ID)}, nil
+}
+
+func (*retryContractHomeExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func (e *retryContractHomeExecutor) Calls() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]string(nil), e.calls...)
+}
+
+type retryContractRateLimitError struct {
+	retryAfter time.Duration
+}
+
+func (retryContractRateLimitError) Error() string { return "credential rate limited" }
+
+func (retryContractRateLimitError) StatusCode() int { return http.StatusTooManyRequests }
+
+func (e retryContractRateLimitError) RetryAfter() *time.Duration {
+	value := e.retryAfter
+	if value == 0 {
+		value = time.Millisecond
+	}
+	return &value
+}
+
+type retainingRetryContractHomeExecutor struct {
+	*retryContractHomeExecutor
+}
+
+func (e *retainingRetryContractHomeExecutor) Execute(_ context.Context, auth *Auth, _ cliproxyexecutor.Request, opts cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	if lifecycle, ok := opts.ExecutionLifecycle.(interface{ Retain() }); ok {
+		lifecycle.Retain()
+	}
+	return cliproxyexecutor.Response{Payload: []byte(auth.ID)}, nil
+}
+
+func TestHomePinnedAuthRejectsMismatchedDispatch(t *testing.T) {
+	dispatcher := &retryContractHomeDispatcher{authIDs: []string{"home-retry-b"}}
+	executor := &retryContractHomeExecutor{}
+	registry := executionregistry.New()
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.PublishHomeDispatch(dispatcher, registry, 1)
+	manager.RegisterExecutor(executor)
+
+	_, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.PinnedAuthMetadataKey: "home-retry-a",
+	}})
+	var authErr *Error
+	if !errors.As(errExecute, &authErr) || authErr == nil || authErr.Code != "auth_not_found" {
+		t.Fatalf("Execute() error = %T %v, want pinned auth_not_found", errExecute, errExecute)
+	}
+	if got := executor.Calls(); len(got) != 0 {
+		t.Fatalf("executor calls = %v, want no mismatched credential execution", got)
+	}
+	if errDrain := registry.Drain(context.Background()); errDrain != nil {
+		t.Fatalf("Drain() error = %v", errDrain)
+	}
+}
+
+func TestHomePinnedAuthRetriesOnlyPinnedCredential(t *testing.T) {
+	aggregateRetry := 3
+	dispatcher := &retryContractHomeDispatcher{
+		authIDs:      []string{"home-retry-b", "home-retry-a"},
+		metadata:     map[string]any{"request_retry": 1},
+		requestRetry: &aggregateRetry,
+	}
+	executor := &retryContractHomeExecutor{
+		failAll: true,
+		failure: &Error{HTTPStatus: http.StatusBadGateway, Message: "upstream unavailable"},
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(0, time.Second, 0)
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+	manager.RegisterExecutor(executor)
+
+	_, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.PinnedAuthMetadataKey: "home-retry-a",
+	}})
+	if errExecute == nil {
+		t.Fatal("Execute() error = nil, want terminal upstream error")
+	}
+	if got := executor.Calls(); len(got) != 2 || got[0] != "home-retry-a" || got[1] != "home-retry-a" {
+		t.Fatalf("executor calls = %v, want pinned auth once in each of two rounds", got)
+	}
+	excluded := dispatcher.Excluded()
+	if len(excluded) != 2 || len(excluded[0]) != 0 || len(excluded[1]) != 0 {
+		t.Fatalf("Home excluded auth IDs = %v, want a fresh pinned selection in each round", excluded)
+	}
+}
+
+func TestHomeExcludedCredentialEndsRetainedWebsocketSelection(t *testing.T) {
+	dispatcher := &retryContractHomeDispatcher{
+		authIDs:   []string{"home-retry-a", "home-retry-b"},
+		websocket: true,
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(0, time.Second, 2)
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+	manager.RegisterExecutor(&retainingRetryContractHomeExecutor{retryContractHomeExecutor: &retryContractHomeExecutor{}})
+
+	ctx := cliproxyexecutor.WithDownstreamWebsocket(context.Background())
+	opts := cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.ExecutionSessionMetadataKey: "home-retry-session",
+	}}
+	if _, errExecute := manager.Execute(ctx, []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, opts); errExecute != nil {
+		t.Fatalf("first Execute() error = %v", errExecute)
+	}
+
+	pickOpts := withHomeExcludedAuthIDs(opts, map[string]struct{}{"home-retry-a": {}})
+	selection, errPick := manager.pickHomeDispatchSelection(ctx, "gpt", pickOpts)
+	if errPick != nil {
+		t.Fatalf("pickHomeDispatchSelection() error = %v", errPick)
+	}
+	defer selection.End("test_complete")
+	if auth := selection.CloneAuth(); auth == nil || auth.ID != "home-retry-b" {
+		t.Fatalf("selected auth = %#v, want home-retry-b", auth)
+	}
+
+	excluded := dispatcher.Excluded()
+	if len(excluded) != 2 || len(excluded[0]) != 0 || len(excluded[1]) != 1 || excluded[1][0] != "home-retry-a" {
+		t.Fatalf("Home excluded auth IDs = %v, want [[], [home-retry-a]]", excluded)
+	}
+}
+
+func TestHomeRetryRoundTriesFreshCredentialWhenRequestRetryIsZero(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(map[bool]string{false: "nonstream", true: "stream"}[stream], func(t *testing.T) {
+			dispatcher := &retryContractHomeDispatcher{authIDs: []string{"home-retry-a", "home-retry-b"}}
+			executor := &retryContractHomeExecutor{}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(0, time.Second, 2)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			if stream {
+				result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+				if errExecute != nil {
+					t.Fatalf("ExecuteStream() error = %v", errExecute)
+				}
+				for range result.Chunks {
+				}
+			} else {
+				response, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{})
+				if errExecute != nil {
+					t.Fatalf("Execute() error = %v", errExecute)
+				}
+				if string(response.Payload) != "home-retry-b" {
+					t.Fatalf("response payload = %q, want home-retry-b", string(response.Payload))
+				}
+			}
+
+			if got := executor.Calls(); len(got) != 2 || got[0] != "home-retry-a" || got[1] != "home-retry-b" {
+				t.Fatalf("executor calls = %v, want [home-retry-a home-retry-b]", got)
+			}
+			excluded := dispatcher.Excluded()
+			if len(excluded) != 2 || len(excluded[0]) != 0 || len(excluded[1]) != 1 || excluded[1][0] != "home-retry-a" {
+				t.Fatalf("Home excluded auth IDs = %v, want [[], [home-retry-a]]", excluded)
+			}
+		})
+	}
+}
+
+func TestHomeCountTokensTriesFreshCredentialWhenRequestRetryIsZero(t *testing.T) {
+	dispatcher := &retryContractHomeDispatcher{authIDs: []string{"home-retry-a", "home-retry-b"}}
+	executor := &retryContractHomeExecutor{}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(0, time.Second, 2)
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+	manager.RegisterExecutor(executor)
+
+	response, errExecute := manager.ExecuteCount(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{})
+	if errExecute != nil {
+		t.Fatalf("ExecuteCount() error = %v", errExecute)
+	}
+	if string(response.Payload) != "home-retry-b" {
+		t.Fatalf("response payload = %q, want home-retry-b", string(response.Payload))
+	}
+	if got := executor.Calls(); len(got) != 2 || got[0] != "home-retry-a" || got[1] != "home-retry-b" {
+		t.Fatalf("executor calls = %v, want [home-retry-a home-retry-b]", got)
+	}
+	excluded := dispatcher.Excluded()
+	if len(excluded) != 2 || len(excluded[0]) != 0 || len(excluded[1]) != 1 || excluded[1][0] != "home-retry-a" {
+		t.Fatalf("Home excluded auth IDs = %v, want [[], [home-retry-a]]", excluded)
+	}
+}
+
+func TestHomeRetryPolicyAllowsRemoteCooldownWithoutLocalCredentials(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(1, time.Second, 0)
+	errRemoteCooldown := &homeDispatchRetryAfterError{
+		cause:      &Error{HTTPStatus: http.StatusTooManyRequests, Message: "all Home credentials are cooling down"},
+		retryAfter: 10 * time.Millisecond,
+	}
+
+	wait, shouldRetry, _ := manager.shouldRetryAfterError(errRemoteCooldown, 0, []string{"home-retry-contract"}, "gpt", time.Second, nil)
+	if !shouldRetry || wait != 10*time.Millisecond {
+		t.Fatalf("shouldRetryAfterError() = (%v, %t), want (10ms, true)", wait, shouldRetry)
+	}
+	if _, shouldRetry, _ = manager.shouldRetryAfterError(errRemoteCooldown, 1, []string{"home-retry-contract"}, "gpt", time.Second, nil); shouldRetry {
+		t.Fatal("shouldRetryAfterError() retried after the configured Home retry round")
+	}
+	wait, shouldRetry, _ = manager.shouldRetryAfterError(errRemoteCooldown, 0, []string{"home-retry-contract"}, "gpt", 0, nil)
+	if shouldRetry || wait != 0 {
+		t.Fatalf("shouldRetryAfterError() with zero wait interval = (%v, %t), want (0, false)", wait, shouldRetry)
+	}
+	errRoundExhausted := markHomeRetryRoundExhausted(&Error{HTTPStatus: http.StatusBadGateway, Message: "upstream unavailable"}, nil, false)
+	wait, shouldRetry, _ = manager.shouldRetryAfterError(errRoundExhausted, 0, []string{"home-retry-contract"}, "gpt", 0, nil)
+	if !shouldRetry || wait != 0 {
+		t.Fatalf("shouldRetryAfterError() immediate round = (%v, %t), want (0, true)", wait, shouldRetry)
+	}
+	var invalidTiming homeRetryRoundTiming
+	invalidTiming.Observe(retryContractRateLimitError{retryAfter: -time.Millisecond})
+	errInvalidWait := markHomeRetryRoundExhausted(retryContractRateLimitError{retryAfter: -time.Millisecond}, invalidTiming.RetryAfter(), false)
+	if wait, shouldRetry, _ = manager.shouldRetryAfterError(errInvalidWait, 0, []string{"home-retry-contract"}, "gpt", 0, nil); shouldRetry || wait != 0 {
+		t.Fatalf("shouldRetryAfterError() negative wait = (%v, %t), want (0, false)", wait, shouldRetry)
+	}
+}
+
+func TestRetryIntervalFiltersCooldownCredentials(t *testing.T) {
+	tests := []struct {
+		name        string
+		cooldowns   []time.Duration
+		wantRetry   bool
+		maxWantWait time.Duration
+	}{
+		{name: "short and long cooldowns", cooldowns: []time.Duration{10 * time.Second, time.Minute}, wantRetry: true, maxWantWait: 10 * time.Second},
+		{name: "only long cooldown", cooldowns: []time.Duration{time.Minute}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			const (
+				provider = "retry-interval-contract"
+				model    = "gpt"
+			)
+			manager := NewManager(nil, nil, nil)
+			manager.SetRetryConfig(1, 30*time.Second, 0)
+			now := time.Now()
+			for index, cooldown := range test.cooldowns {
+				authID := fmt.Sprintf("retry-interval-%s-%d", strings.ReplaceAll(test.name, " ", "-"), index)
+				deadline := now.Add(cooldown)
+				auth := &Auth{
+					ID:       authID,
+					Provider: provider,
+					Status:   StatusActive,
+					ModelStates: map[string]*ModelState{
+						model: {
+							Status:         StatusError,
+							Unavailable:    true,
+							NextRetryAfter: deadline,
+							LastError:      &Error{HTTPStatus: http.StatusTooManyRequests},
+							Quota:          QuotaState{Exceeded: true, NextRecoverAt: deadline},
+						},
+					},
+				}
+				registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: model}})
+				t.Cleanup(func() { registry.GetGlobalRegistry().UnregisterClient(authID) })
+				if _, errRegister := manager.Register(context.Background(), auth); errRegister != nil {
+					t.Fatalf("Register() error = %v", errRegister)
+				}
+			}
+
+			wait, shouldRetry, _ := manager.shouldRetryAfterError(&Error{HTTPStatus: http.StatusTooManyRequests}, 0, []string{provider}, model, 30*time.Second, nil)
+			if shouldRetry != test.wantRetry {
+				t.Fatalf("shouldRetryAfterError() = (%v, %t), want retry %t", wait, shouldRetry, test.wantRetry)
+			}
+			if test.wantRetry && (wait <= 0 || wait > test.maxWantWait) {
+				t.Fatalf("shouldRetryAfterError() wait = %v, want the earliest cooldown within %v", wait, test.maxWantWait)
+			}
+		})
+	}
+}
+
+func TestHomeRetryPolicyUsesRemoteCredentialOverrideBeforeSelection(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(0, time.Second, 0)
+	errRemoteCooldown := &homeDispatchRetryAfterError{
+		cause:           &Error{HTTPStatus: http.StatusTooManyRequests, Message: "all Home credentials are cooling down"},
+		retryAfter:      10 * time.Millisecond,
+		requestRetry:    1,
+		hasRequestRetry: true,
+	}
+
+	wait, shouldRetry := manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), cliproxyexecutor.Options{}, errRemoteCooldown, 0, []string{"home-retry-contract"}, "gpt", time.Second, -1, 0)
+	if !shouldRetry || wait != 10*time.Millisecond {
+		t.Fatalf("remote credential override retry = (%v, %t), want (10ms, true)", wait, shouldRetry)
+	}
+	if _, shouldRetry = manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), cliproxyexecutor.Options{}, errRemoteCooldown, 1, []string{"home-retry-contract"}, "gpt", time.Second, -1, 0); shouldRetry {
+		t.Fatal("remote credential override allowed more than one additional round")
+	}
+	pinnedOpts := cliproxyexecutor.Options{Metadata: map[string]any{
+		cliproxyexecutor.PinnedAuthMetadataKey: "home-retry-a",
+	}}
+	if _, shouldRetry = manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), pinnedOpts, errRemoteCooldown, 0, []string{"home-retry-contract"}, "gpt", time.Second, -1, 0); shouldRetry {
+		t.Fatal("aggregate retry limit from unpinned Home credentials affected a pinned request")
+	}
+
+	errRemoteCooldown.requestRetry = 0
+	manager.SetRetryConfig(3, time.Second, 0)
+	if _, shouldRetry = manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), cliproxyexecutor.Options{}, errRemoteCooldown, 0, []string{"home-retry-contract"}, "gpt", time.Second, -1, 0); shouldRetry {
+		t.Fatal("explicit remote credential override 0 did not suppress the global retry setting")
+	}
+	retryLimit := 3
+	observeHomeCooldownRetryLimit(errRemoteCooldown, &retryLimit, true)
+	if retryLimit != 0 {
+		t.Fatalf("observed remote cooldown retry limit = %d, want authoritative 0", retryLimit)
+	}
+}
+
+func TestHomeRetryRoundCredentialLimitStartsNextRoundImmediately(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(1, time.Second, 1)
+	retryAfter := 5 * time.Second
+	errRoundExhausted := markHomeRetryRoundExhausted(
+		retryContractRateLimitError{retryAfter: retryAfter},
+		&retryAfter,
+		true,
+	)
+
+	wait, shouldRetry, _ := manager.shouldRetryAfterError(errRoundExhausted, 0, []string{"home-retry-contract"}, "gpt", time.Second, nil)
+	if !shouldRetry || wait != 0 {
+		t.Fatalf("credential-limit retry = (%v, %t), want immediate next round", wait, shouldRetry)
+	}
+	if got := SafeResponseHeaders(errRoundExhausted).Get("Retry-After"); got != "5" {
+		t.Fatalf("safe Retry-After header = %q, want 5", got)
+	}
+}
+
+func TestHomeCredentialLimitWaitsBeforeConsumingAdditionalRound(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(map[bool]string{false: "nonstream", true: "stream"}[stream], func(t *testing.T) {
+			dispatcher := &retryRoundStartCooldownDispatcher{}
+			executor := &retryContractHomeExecutor{failAll: true}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(1, time.Second, 1)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			if stream {
+				result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+				if errExecute == nil || result != nil {
+					t.Fatalf("ExecuteStream() = result %#v, error %v; want terminal retry error", result, errExecute)
+				}
+			} else {
+				if _, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{}); errExecute == nil {
+					t.Fatal("Execute() error = nil, want terminal retry error")
+				}
+			}
+			if got := executor.Calls(); len(got) != 2 {
+				t.Fatalf("executor calls = %v, want one execution in each of two rounds", got)
+			}
+			if got := dispatcher.calls.Load(); got != 3 {
+				t.Fatalf("Home dispatch calls = %d, want selection, cooldown wait, selection", got)
+			}
+		})
+	}
+}
+
+func TestHomePendingRetryRoundStopsWhenRemoteLimitDrops(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(map[bool]string{false: "nonstream", true: "stream"}[stream], func(t *testing.T) {
+			dispatcher := &retryRoundLimitDownshiftDispatcher{}
+			executor := &retryContractHomeExecutor{}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(1, time.Second, 1)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			if stream {
+				result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+				if errExecute == nil || result != nil {
+					t.Fatalf("ExecuteStream() = result %#v, error %v; want terminal cooldown error", result, errExecute)
+				}
+			} else {
+				if _, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{}); errExecute == nil {
+					t.Fatal("Execute() error = nil, want terminal cooldown error")
+				}
+			}
+			if got := executor.Calls(); len(got) != 1 || got[0] != "home-retry-a" {
+				t.Fatalf("executor calls = %v, want only the initial credential", got)
+			}
+			if got := dispatcher.calls.Load(); got != 2 {
+				t.Fatalf("Home dispatch calls = %d, want initial selection and one cooldown response", got)
+			}
+		})
+	}
+}
+
+func TestHomePendingRetryRoundStopsAfterRepeatedCooldown(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(map[bool]string{false: "nonstream", true: "stream"}[stream], func(t *testing.T) {
+			dispatcher := &retryRoundRepeatedCooldownDispatcher{}
+			executor := &retryContractHomeExecutor{failAll: true}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(1, time.Second, 1)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			if stream {
+				result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+				if errExecute == nil || result != nil {
+					t.Fatalf("ExecuteStream() = result %#v, error %v; want terminal cooldown error", result, errExecute)
+				}
+			} else {
+				if _, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{}); errExecute == nil {
+					t.Fatal("Execute() error = nil, want terminal cooldown error")
+				}
+			}
+			if got := executor.Calls(); len(got) != 1 {
+				t.Fatalf("executor calls = %v, want only the initial round execution", got)
+			}
+			if got := dispatcher.calls.Load(); got != 3 {
+				t.Fatalf("Home dispatch calls = %d, want selection and two cooldown responses", got)
+			}
+		})
+	}
+}
+
+func TestHomeRetryRoundUsesEarliestCredentialRetryAfter(t *testing.T) {
+	dispatcher := &retryContractHomeDispatcher{authIDs: []string{"home-retry-a", "home-retry-b"}}
+	executor := &retryContractHomeExecutor{
+		failAll: true,
+		failures: map[string]error{
+			"home-retry-a": retryContractRateLimitError{retryAfter: 5 * time.Millisecond},
+			"home-retry-b": retryContractRateLimitError{retryAfter: 50 * time.Millisecond},
+		},
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(1, time.Second, 2)
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+	manager.RegisterExecutor(executor)
+
+	retryLimit := -1
+	_, errExecute := manager.executeHomeOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{}, false, 2, &retryLimit)
+	if !isHomeRetryRoundExhausted(errExecute) {
+		t.Fatalf("executeHomeOnce() error = %v, want exhausted retry round", errExecute)
+	}
+	retryAfter := retryAfterFromError(errExecute)
+	if retryAfter == nil || *retryAfter != 5*time.Millisecond {
+		t.Fatalf("retry after = %v, want earliest credential delay 5ms", retryAfter)
+	}
+}
+
+func TestHomeStreamBootstrapErrorPreservesAggregatedRetryAfter(t *testing.T) {
+	dispatcher := &retryContractHomeDispatcher{authIDs: []string{"home-retry-a", "home-retry-b"}}
+	executor := &retryContractHomeExecutor{
+		failAll:         true,
+		streamBootstrap: true,
+		streamHeaders:   http.Header{"Retry-After": {"30"}},
+		failures: map[string]error{
+			"home-retry-a": retryContractRateLimitError{retryAfter: 1500 * time.Millisecond},
+			"home-retry-b": retryContractRateLimitError{retryAfter: 5 * time.Second},
+		},
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(0, time.Second, 2)
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+	manager.RegisterExecutor(executor)
+
+	result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+	if errExecute != nil {
+		t.Fatalf("ExecuteStream() error = %v", errExecute)
+	}
+	if result == nil {
+		t.Fatal("ExecuteStream() result = nil")
+	}
+	chunk, ok := <-result.Chunks
+	if !ok || chunk.Err == nil {
+		t.Fatalf("stream bootstrap chunk = %#v, %t; want terminal error", chunk, ok)
+	}
+	if !isHomeRetryRoundExhausted(chunk.Err) {
+		t.Fatalf("stream bootstrap error = %v, want exhausted retry round", chunk.Err)
+	}
+	if got := SafeResponseHeaders(chunk.Err).Get("Retry-After"); got != "2" {
+		t.Fatalf("safe Retry-After header = %q, want aggregated delay rounded to 2 seconds", got)
+	}
+}
+
+func TestHomeRetryRoundUsesAuthoritativeRemoteCooldown(t *testing.T) {
+	tests := []struct {
+		name    string
+		execute func(*Manager, *int) error
+	}{
+		{
+			name: "nonstream",
+			execute: func(manager *Manager, retryLimit *int) error {
+				_, errExecute := manager.executeHomeOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{}, false, 2, retryLimit)
+				return errExecute
+			},
+		},
+		{
+			name: "stream",
+			execute: func(manager *Manager, retryLimit *int) error {
+				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, 2, retryLimit, 0, 0)
+				return errExecute
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dispatcher := &retryContractHomeDispatcher{
+				authIDs:          []string{"home-retry-a"},
+				exhaustedPayload: []byte(`{"error":{"type":"model_cooldown","message":"remaining Home credentials are cooling down","retryable":true,"retry_after_ms":5000}}`),
+			}
+			executor := &retryContractHomeExecutor{
+				failAll: true,
+				failure: retryContractRateLimitError{retryAfter: 1500 * time.Millisecond},
+			}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(1, time.Second, 2)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			retryLimit := -1
+			errExecute := tc.execute(manager, &retryLimit)
+			if !isHomeRetryRoundExhausted(errExecute) {
+				t.Fatalf("execution error = %v, want exhausted retry round", errExecute)
+			}
+			retryAfter := retryAfterFromError(errExecute)
+			if retryAfter == nil || *retryAfter != 5*time.Second {
+				t.Fatalf("retry after = %v, want Home next-round cooldown 5s", retryAfter)
+			}
+			if got := SafeResponseHeaders(errExecute).Get("Retry-After"); got != "5" {
+				t.Fatalf("safe Retry-After header = %q, want Home next-round delay 5 seconds", got)
+			}
+		})
+	}
+}
+
+func TestHomeCooldownClassificationPreservesNonRetryableRoundStatus(t *testing.T) {
+	tests := []struct {
+		name    string
+		execute func(*Manager, *int) error
+	}{
+		{
+			name: "nonstream",
+			execute: func(manager *Manager, retryLimit *int) error {
+				_, errExecute := manager.executeHomeOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{}, false, 2, retryLimit)
+				return errExecute
+			},
+		},
+		{
+			name: "stream",
+			execute: func(manager *Manager, retryLimit *int) error {
+				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, 2, retryLimit, 0, 0)
+				return errExecute
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dispatcher := &retryContractHomeDispatcher{
+				authIDs:          []string{"home-retry-a"},
+				exhaustedPayload: []byte(`{"error":{"type":"model_cooldown","message":"another credential is cooling down","retryable":true,"retry_after_ms":5,"request_retry":2}}`),
+			}
+			executor := &retryContractHomeExecutor{
+				failAll: true,
+				failure: &Error{HTTPStatus: http.StatusUnauthorized, Message: "invalid credential"},
+			}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(3, time.Second, 2)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			retryLimit := -1
+			errExecute := test.execute(manager, &retryLimit)
+			if !isHomeRetryRoundExhausted(errExecute) || statusCodeFromError(errExecute) != http.StatusUnauthorized {
+				t.Fatalf("execution error = %T %v, want exhausted 401 round", errExecute, errExecute)
+			}
+			if retryLimit != 2 {
+				t.Fatalf("observed retry limit = %d, want authoritative Home limit 2", retryLimit)
+			}
+			if wait, shouldRetry := manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), cliproxyexecutor.Options{}, errExecute, 0, []string{"home-retry-contract"}, "gpt", time.Second, retryLimit, 0); shouldRetry || wait != 0 {
+				t.Fatalf("401 round retry = (%v, %t), want (0, false)", wait, shouldRetry)
+			}
+		})
+	}
+}
+
+func TestHomeRetryRoundStartsImmediatelyWhenHomeReportsAvailableNextRound(t *testing.T) {
+	tests := []struct {
+		name    string
+		execute func(*Manager, *int) error
+	}{
+		{
+			name: "nonstream",
+			execute: func(manager *Manager, retryLimit *int) error {
+				_, errExecute := manager.executeHomeOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{}, false, 0, retryLimit)
+				return errExecute
+			},
+		},
+		{
+			name: "stream",
+			execute: func(manager *Manager, retryLimit *int) error {
+				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, 0, retryLimit, 0, 0)
+				return errExecute
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dispatcher := &retryContractHomeDispatcher{
+				authIDs:          []string{"home-retry-a", "home-retry-b"},
+				exhaustedPayload: []byte(`{"error":{"type":"auth_unavailable","message":"a credential is immediately available next round"}}`),
+			}
+			executor := &retryContractHomeExecutor{
+				failAll: true,
+				failures: map[string]error{
+					"home-retry-a": retryContractRateLimitError{retryAfter: 5 * time.Second},
+					"home-retry-b": &Error{HTTPStatus: http.StatusBadGateway, Message: "upstream unavailable"},
+				},
+			}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(1, 10*time.Second, 0)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			retryLimit := -1
+			errExecute := test.execute(manager, &retryLimit)
+			if !isHomeRetryRoundExhausted(errExecute) {
+				t.Fatalf("execution error = %v, want exhausted retry round", errExecute)
+			}
+			wait, shouldRetry := manager.shouldRetryAfterErrorWithHomeRetryLimit(context.Background(), cliproxyexecutor.Options{}, errExecute, 0, []string{"home-retry-contract"}, "gpt", 10*time.Second, retryLimit, 0)
+			if !shouldRetry || wait != 0 {
+				t.Fatalf("next-round retry = (%v, %t), want immediate", wait, shouldRetry)
+			}
+		})
+	}
+}
+
+func TestHomeRetryRoundUsesRemoteCooldownWhenAttemptedErrorHasNoTiming(t *testing.T) {
+	tests := []struct {
+		name    string
+		execute func(*Manager, *int) error
+	}{
+		{
+			name: "nonstream",
+			execute: func(manager *Manager, retryLimit *int) error {
+				_, errExecute := manager.executeHomeOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{}, false, 2, retryLimit)
+				return errExecute
+			},
+		},
+		{
+			name: "stream",
+			execute: func(manager *Manager, retryLimit *int) error {
+				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, 2, retryLimit, 0, 0)
+				return errExecute
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dispatcher := &retryContractHomeDispatcher{
+				authIDs:          []string{"home-retry-a"},
+				exhaustedPayload: []byte(`{"error":{"type":"model_cooldown","message":"remaining Home credentials are cooling down","retryable":true,"retry_after_ms":1500}}`),
+			}
+			executor := &retryContractHomeExecutor{
+				failAll: true,
+				failure: &Error{HTTPStatus: http.StatusBadGateway, Message: "upstream unavailable"},
+			}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(1, 2*time.Second, 2)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			retryLimit := -1
+			errExecute := tc.execute(manager, &retryLimit)
+			if !isHomeRetryRoundExhausted(errExecute) {
+				t.Fatalf("execution error = %v, want exhausted retry round", errExecute)
+			}
+			retryAfter := retryAfterFromError(errExecute)
+			if retryAfter == nil || *retryAfter != 1500*time.Millisecond {
+				t.Fatalf("retry after = %v, want remote cooldown delay 1500ms", retryAfter)
+			}
+			if got := SafeResponseHeaders(errExecute).Get("Retry-After"); got != "2" {
+				t.Fatalf("safe Retry-After header = %q, want 2", got)
+			}
+		})
+	}
+}
+
+func TestHomeStreamOAuthUnauthorizedRotatesAfterRefreshRetry(t *testing.T) {
+	dispatcher := &retryContractHomeDispatcher{
+		authIDs: []string{"home-retry-a", "home-retry-b"},
+		metadata: map[string]any{
+			"auth_kind": "oauth",
+		},
+	}
+	executor := &retryContractHomeExecutor{
+		failures: map[string]error{
+			"home-retry-a": &Error{HTTPStatus: http.StatusUnauthorized, Message: "expired"},
+		},
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(0, time.Second, 2)
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+	manager.RegisterExecutor(executor)
+
+	result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+	if errExecute != nil {
+		t.Fatalf("ExecuteStream() error = %v", errExecute)
+	}
+	for range result.Chunks {
+	}
+	if got := executor.Calls(); len(got) != 3 || got[0] != "home-retry-a" || got[1] != "home-retry-a" || got[2] != "home-retry-b" {
+		t.Fatalf("executor calls = %v, want [home-retry-a home-retry-a home-retry-b]", got)
+	}
+	excluded := dispatcher.Excluded()
+	if len(excluded) != 2 || len(excluded[0]) != 0 || len(excluded[1]) != 1 || excluded[1][0] != "home-retry-a" {
+		t.Fatalf("Home excluded auth IDs = %v, want [[], [home-retry-a]]", excluded)
+	}
+}
+
+func TestHomeStreamLifecycleRecoveryFailureRotatesWithoutExtraDispatch(t *testing.T) {
+	dispatcher := &retryContractHomeDispatcher{authIDs: []string{"home-retry-a", "home-retry-b"}}
+	executor := &retryContractHomeExecutor{
+		failures: map[string]error{
+			"home-retry-a": errors.New("unexpected EOF"),
+		},
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(0, time.Second, 2)
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+	manager.RegisterExecutor(executor)
+
+	result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+	if errExecute != nil {
+		t.Fatalf("ExecuteStream() error = %v", errExecute)
+	}
+	for range result.Chunks {
+	}
+	if got := executor.Calls(); len(got) != 3 || got[0] != "home-retry-a" || got[1] != "home-retry-a" || got[2] != "home-retry-b" {
+		t.Fatalf("executor calls = %v, want [home-retry-a home-retry-a home-retry-b]", got)
+	}
+	excluded := dispatcher.Excluded()
+	if len(excluded) != 3 || len(excluded[0]) != 0 || len(excluded[1]) != 0 || len(excluded[2]) != 1 || excluded[2][0] != "home-retry-a" {
+		t.Fatalf("Home excluded auth IDs = %v, want [[], [], [home-retry-a]]", excluded)
+	}
+}
+
+func TestRetryRoundAvailabilityRejectsStaleQuotaForNonRetryableStatus(t *testing.T) {
+	now := time.Now()
+	for _, test := range []struct {
+		name      string
+		lastError *Error
+		want      bool
+	}{
+		{name: "implicit quota", want: true},
+		{name: "rate limit", lastError: &Error{HTTPStatus: http.StatusTooManyRequests}, want: true},
+		{name: "payment required", lastError: &Error{HTTPStatus: http.StatusPaymentRequired}, want: false},
+		{name: "not found", lastError: &Error{HTTPStatus: http.StatusNotFound}, want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			nextRetry := now.Add(time.Minute)
+			auth := &Auth{
+				ID:       "retry-round-stale-quota",
+				Provider: "codex",
+				Status:   StatusActive,
+				ModelStates: map[string]*ModelState{
+					"gpt": {
+						Status:         StatusError,
+						Unavailable:    true,
+						NextRetryAfter: nextRetry,
+						LastError:      test.lastError,
+						Quota:          QuotaState{Exceeded: true, NextRecoverAt: nextRetry},
+					},
+				},
+			}
+			got, next := retryRoundAvailabilityForAuth(auth, "gpt", now)
+			if got != test.want {
+				t.Fatalf("retryRoundAvailabilityForAuth() eligible = %t, want %t", got, test.want)
+			}
+			if got && !next.Equal(nextRetry) {
+				t.Fatalf("retryRoundAvailabilityForAuth() next = %v, want %v", next, nextRetry)
+			}
+		})
+	}
+}
+
+func TestHomeStreamAPIKeyUnauthorizedRotatesImmediately(t *testing.T) {
+	dispatcher := &retryContractHomeDispatcher{
+		authIDs: []string{"home-retry-a", "home-retry-b"},
+		metadata: map[string]any{
+			"auth_kind": "apikey",
+		},
+	}
+	executor := &retryContractHomeExecutor{
+		failures: map[string]error{
+			"home-retry-a": &Error{HTTPStatus: http.StatusUnauthorized, Message: "invalid api key"},
+		},
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(0, time.Second, 2)
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+	manager.RegisterExecutor(executor)
+
+	result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+	if errExecute != nil {
+		t.Fatalf("ExecuteStream() error = %v", errExecute)
+	}
+	for range result.Chunks {
+	}
+	if got := executor.Calls(); len(got) != 2 || got[0] != "home-retry-a" || got[1] != "home-retry-b" {
+		t.Fatalf("executor calls = %v, want [home-retry-a home-retry-b]", got)
+	}
+	excluded := dispatcher.Excluded()
+	if len(excluded) != 2 || len(excluded[0]) != 0 || len(excluded[1]) != 1 || excluded[1][0] != "home-retry-a" {
+		t.Fatalf("Home excluded auth IDs = %v, want [[], [home-retry-a]]", excluded)
+	}
+}
+
+func TestHomeModelCooldownErrorPreservesRetryContract(t *testing.T) {
+	errDecoded := decodeHomeDispatchError([]byte(`{"error":{"type":"model_cooldown","message":"all credentials are cooling down","retryable":true,"retry_after_ms":1500,"request_retry":2}}`))
+	var retryErr *homeDispatchRetryAfterError
+	if !errors.As(errDecoded, &retryErr) || retryErr == nil {
+		t.Fatalf("decodeHomeDispatchError() = %#v, want retry-after error", errDecoded)
+	}
+	if retryErr.StatusCode() != http.StatusTooManyRequests || retryErr.RetryAfter() == nil || *retryErr.RetryAfter() != 1500*time.Millisecond {
+		t.Fatalf("decoded Home cooldown = status %d retry-after %v, want 429/1500ms", retryErr.StatusCode(), retryErr.RetryAfter())
+	}
+	if retryLimit, ok := retryErr.RequestRetryLimit(); !ok || retryLimit != 2 {
+		t.Fatalf("decoded Home request retry limit = (%d, %t), want (2, true)", retryLimit, ok)
+	}
+	var cause *Error
+	if !errors.As(errDecoded, &cause) || cause == nil || cause.Code != "model_cooldown" || !cause.Retryable {
+		t.Fatalf("decoded Home cooldown cause = %#v, want retryable model_cooldown", cause)
+	}
+	if got := SafeResponseHeaders(errDecoded).Get("Retry-After"); got != "2" {
+		t.Fatalf("safe Retry-After header = %q, want 2", got)
+	}
+}
+
+func TestHomeRequestRetryCountsAdditionalCredentialRounds(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(map[bool]string{false: "nonstream", true: "stream"}[stream], func(t *testing.T) {
+			dispatcher := &retryContractHomeDispatcher{authIDs: []string{"home-retry-a", "home-retry-b"}}
+			executor := &retryContractHomeExecutor{failAll: true}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(1, time.Second, 2)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			if stream {
+				result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+				if errExecute == nil || result != nil {
+					t.Fatalf("ExecuteStream() = result %#v, error %v; want terminal rate-limit error", result, errExecute)
+				}
+			} else {
+				_, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{})
+				if errExecute == nil {
+					t.Fatal("Execute() error = nil, want rate-limit error")
+				}
+			}
+			if got := executor.Calls(); len(got) != 4 {
+				t.Fatalf("executor calls = %v, want four calls across two rounds", got)
+			}
+			excluded := dispatcher.Excluded()
+			if len(excluded) != 4 || len(excluded[0]) != 0 || len(excluded[1]) != 1 || excluded[1][0] != "home-retry-a" || len(excluded[2]) != 0 || len(excluded[3]) != 1 || excluded[3][0] != "home-retry-a" {
+				t.Fatalf("Home excluded auth IDs = %v, want [[], [home-retry-a], [], [home-retry-a]]", excluded)
+			}
+		})
+	}
+}
+
+func TestHomeRequestRetryRoundDoesNotRequireRetryAfter(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(map[bool]string{false: "nonstream", true: "stream"}[stream], func(t *testing.T) {
+			dispatcher := &retryContractHomeDispatcher{authIDs: []string{"home-retry-a", "home-retry-b"}}
+			executor := &retryContractHomeExecutor{
+				failAll: true,
+				failure: &Error{HTTPStatus: http.StatusBadGateway, Message: "upstream unavailable"},
+			}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(1, time.Second, 2)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			if stream {
+				result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+				if errExecute == nil || result != nil {
+					t.Fatalf("ExecuteStream() = result %#v, error %v; want terminal upstream error", result, errExecute)
+				}
+			} else {
+				_, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{})
+				if errExecute == nil {
+					t.Fatal("Execute() error = nil, want upstream error")
+				}
+			}
+			if got := executor.Calls(); len(got) != 4 {
+				t.Fatalf("executor calls = %v, want four calls across two rounds", got)
+			}
+		})
+	}
+}
+
+func TestHomeStreamLegacyDispatcherDoesNotSpinOnIgnoredExclusions(t *testing.T) {
+	dispatcher := &legacyRepeatedStreamDispatcher{}
+	executor := &retryContractHomeExecutor{
+		failAll: true,
+		failure: &Error{HTTPStatus: http.StatusBadGateway, Message: "upstream unavailable"},
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(1, time.Second, 2)
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+	manager.RegisterExecutor(executor)
+
+	result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+	if result != nil || errExecute == nil {
+		t.Fatalf("ExecuteStream() = result %#v, error %v; want terminal upstream error", result, errExecute)
+	}
+	if got := len(executor.Calls()); got != 2 {
+		t.Fatalf("executor calls = %d, want one attempt in each of two rounds", got)
+	}
+	if got := dispatcher.calls.Load(); got != 4 {
+		t.Fatalf("legacy Home dispatch calls = %d, want two dispatches in each of two rounds", got)
+	}
+}
+
+func TestHomeNonStreamLegacyDispatcherCompletesAdditionalRetryRound(t *testing.T) {
+	dispatcher := &legacyRepeatedStreamDispatcher{}
+	executor := &retryContractHomeExecutor{
+		failAll: true,
+		failure: &Error{HTTPStatus: http.StatusBadGateway, Message: "upstream unavailable"},
+	}
+	manager := NewManager(nil, nil, nil)
+	manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+	manager.SetRetryConfig(1, time.Second, 0)
+	manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+	manager.RegisterExecutor(executor)
+
+	_, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{})
+	if errExecute == nil {
+		t.Fatal("Execute() error = nil, want terminal upstream error")
+	}
+	if got := len(executor.Calls()); got != 2 {
+		t.Fatalf("executor calls = %d, want one attempt in each of two rounds", got)
+	}
+	if got := dispatcher.calls.Load(); got != 4 {
+		t.Fatalf("legacy Home dispatch calls = %d, want two dispatches in each of two rounds", got)
+	}
+}
+
+func TestHomeLocalSelectionRejectionWaitsForReleaseAcknowledgement(t *testing.T) {
+	tests := []struct {
+		name                string
+		dispatcher          homeAuthDispatcher
+		executor            *retryContractHomeExecutor
+		maxRetryCredentials int
+		blockedGroup        executionregistry.ReleaseGroup
+		blockedSequence     int64
+		execute             func(*Manager, int, *int) error
+	}{
+		{
+			name: "nonstream repeated auth",
+			dispatcher: &accountedHomeExecutionDispatcher{auths: []Auth{
+				{ID: "home-retry-a", Provider: "home-retry-contract", Status: StatusActive},
+				{ID: "home-retry-a", Provider: "home-retry-contract", Status: StatusActive},
+			}},
+			executor:            &retryContractHomeExecutor{failure: &Error{HTTPStatus: http.StatusBadGateway, Message: "upstream unavailable"}},
+			maxRetryCredentials: 0,
+			blockedGroup:        executionregistry.ReleaseGroup{CredentialID: "home-retry-a", Model: "gpt"},
+			blockedSequence:     2,
+			execute: func(manager *Manager, maxRetryCredentials int, retryLimit *int) error {
+				_, errExecute := manager.executeHomeOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{}, false, maxRetryCredentials, retryLimit)
+				return errExecute
+			},
+		},
+		{
+			name: "stream repeated excluded auth",
+			dispatcher: &accountedHomeExecutionDispatcher{auths: []Auth{
+				{ID: "home-retry-a", Provider: "home-retry-contract", Status: StatusActive},
+				{ID: "home-retry-a", Provider: "home-retry-contract", Status: StatusActive},
+			}},
+			executor:            &retryContractHomeExecutor{failure: &Error{HTTPStatus: http.StatusBadGateway, Message: "upstream unavailable"}},
+			maxRetryCredentials: 0,
+			blockedGroup:        executionregistry.ReleaseGroup{CredentialID: "home-retry-a", Model: "gpt"},
+			blockedSequence:     2,
+			execute: func(manager *Manager, maxRetryCredentials int, retryLimit *int) error {
+				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, maxRetryCredentials, retryLimit, 0, 0)
+				return errExecute
+			},
+		},
+		{
+			name: "stream max retry credentials",
+			dispatcher: &accountedHomeExecutionDispatcher{auths: []Auth{
+				{ID: "home-retry-a", Provider: "home-retry-contract", Status: StatusActive},
+				{ID: "home-retry-b", Provider: "home-retry-contract", Status: StatusActive},
+			}},
+			executor:            &retryContractHomeExecutor{failure: errors.New("unexpected EOF")},
+			maxRetryCredentials: 1,
+			blockedGroup:        executionregistry.ReleaseGroup{CredentialID: "home-retry-b", Model: "gpt"},
+			blockedSequence:     1,
+			execute: func(manager *Manager, maxRetryCredentials int, retryLimit *int) error {
+				_, errExecute := manager.executeStreamMixedOnce(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true}, maxRetryCredentials, retryLimit, 0, 0)
+				return errExecute
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			registry := executionregistry.New()
+			acknowledged := make(chan struct{})
+			close(acknowledged)
+			unacknowledged := make(chan struct{})
+			var blockedReleaseSeen atomic.Bool
+			registry.SetReleaseSink(func(group executionregistry.ReleaseGroup, sequence int64) *executionregistry.ReleaseTicket {
+				done := (<-chan struct{})(acknowledged)
+				if group == test.blockedGroup && sequence == test.blockedSequence {
+					blockedReleaseSeen.Store(true)
+					done = unacknowledged
+				}
+				return executionregistry.NewReleaseTicket(group, sequence, done)
+			})
+
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{
+				Home:                  internalconfig.HomeConfig{Enabled: true},
+				CredentialConcurrency: internalconfig.CredentialConcurrencyConfig{CPACancelBound: 10 * time.Millisecond},
+			})
+			manager.PublishHomeDispatch(test.dispatcher, registry, 1)
+			manager.RegisterExecutor(test.executor)
+
+			retryLimit := -1
+			errExecute := test.execute(manager, test.maxRetryCredentials, &retryLimit)
+			if !blockedReleaseSeen.Load() {
+				t.Fatal("target release was not attempted")
+			}
+			var homeErr *Error
+			if !errors.As(errExecute, &homeErr) || homeErr == nil || homeErr.Code != "home_unavailable" {
+				t.Fatalf("execution error = %T %v, want Home release acknowledgement timeout", errExecute, errExecute)
+			}
+		})
+	}
+}
+
+func TestHomeRetryRoundHonorsCredentialRequestRetryOverride(t *testing.T) {
+	tests := []struct {
+		name          string
+		globalRetry   int
+		override      int
+		wantCallCount int
+	}{
+		{name: "override disables global rounds", globalRetry: 3, override: 0, wantCallCount: 2},
+		{name: "override enables rounds over global", globalRetry: 0, override: 1, wantCallCount: 4},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dispatcher := &retryContractHomeDispatcher{
+				authIDs:  []string{"home-retry-a", "home-retry-b"},
+				metadata: map[string]any{"request_retry": tc.override},
+			}
+			executor := &retryContractHomeExecutor{failAll: true}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(tc.globalRetry, time.Second, 2)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			_, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{})
+			if errExecute == nil {
+				t.Fatal("Execute() error = nil, want terminal rate-limit error")
+			}
+			if got := len(executor.Calls()); got != tc.wantCallCount {
+				t.Fatalf("executor call count = %d, want %d", got, tc.wantCallCount)
+			}
+		})
+	}
+}
+
+func TestHomeRetryRoundUsesSuccessfulDispatchAggregate(t *testing.T) {
+	tests := []struct {
+		name    string
+		execute func(*Manager) error
+	}{
+		{
+			name: "nonstream",
+			execute: func(manager *Manager) error {
+				_, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{})
+				return errExecute
+			},
+		},
+		{
+			name: "count tokens",
+			execute: func(manager *Manager) error {
+				_, errExecute := manager.ExecuteCount(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{})
+				return errExecute
+			},
+		},
+		{
+			name: "stream",
+			execute: func(manager *Manager) error {
+				result, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+				if errExecute != nil {
+					return errExecute
+				}
+				for range result.Chunks {
+				}
+				return nil
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dispatcher := &aggregateRetryHomeDispatcher{}
+			executor := &retryContractHomeExecutor{}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(0, time.Second, 1)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			if errExecute := test.execute(manager); errExecute != nil {
+				t.Fatalf("execution error = %v", errExecute)
+			}
+			if got := executor.Calls(); len(got) != 2 || got[0] != "home-retry-a" || got[1] != "home-retry-b" {
+				t.Fatalf("executor calls = %v, want [home-retry-a home-retry-b]", got)
+			}
+			if got := dispatcher.calls.Load(); got != 2 {
+				t.Fatalf("Home dispatch calls = %d, want 2", got)
+			}
+		})
+	}
+}
+
+func TestHomeRetryRoundUsesAuthoritativeZeroAggregate(t *testing.T) {
+	tests := []struct {
+		name    string
+		execute func(*Manager) error
+	}{
+		{
+			name: "nonstream",
+			execute: func(manager *Manager) error {
+				_, errExecute := manager.Execute(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{})
+				return errExecute
+			},
+		},
+		{
+			name: "count tokens",
+			execute: func(manager *Manager) error {
+				_, errExecute := manager.ExecuteCount(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{})
+				return errExecute
+			},
+		},
+		{
+			name: "stream",
+			execute: func(manager *Manager) error {
+				_, errExecute := manager.ExecuteStream(context.Background(), []string{"home-retry-contract"}, cliproxyexecutor.Request{Model: "gpt"}, cliproxyexecutor.Options{Stream: true})
+				return errExecute
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			remoteRetry := 0
+			dispatcher := &retryContractHomeDispatcher{
+				authIDs:      []string{"home-retry-a", "home-retry-b"},
+				metadata:     map[string]any{"request_retry": 3},
+				requestRetry: &remoteRetry,
+			}
+			executor := &retryContractHomeExecutor{
+				failAll: true,
+				failure: &Error{HTTPStatus: http.StatusBadGateway, Message: "upstream unavailable"},
+			}
+			manager := NewManager(nil, nil, nil)
+			manager.SetConfig(&internalconfig.Config{Home: internalconfig.HomeConfig{Enabled: true}})
+			manager.SetRetryConfig(3, time.Second, 2)
+			manager.PublishHomeDispatch(dispatcher, executionregistry.New(), 1)
+			manager.RegisterExecutor(executor)
+
+			if errExecute := test.execute(manager); errExecute == nil {
+				t.Fatal("execution error = nil, want terminal first-round error")
+			}
+			if got := executor.Calls(); len(got) != 2 {
+				t.Fatalf("executor calls = %v, want only the two first-round credentials", got)
+			}
+		})
+	}
+}

--- a/sdk/cliproxy/auth/home_selection.go
+++ b/sdk/cliproxy/auth/home_selection.go
@@ -144,6 +144,8 @@ type HomeDispatchSelection struct {
 	authMu           sync.RWMutex
 	scope            *executionregistry.Scope
 	accountedModel   string
+	requestRetry     int
+	hasRequestRetry  bool
 	resources        *executionResources
 	attemptCancels   *attemptCancels
 	once             sync.Once


### PR DESCRIPTION
本 PR 是本轮 protected full-sync 的 Stage 1：以 merge commit 吸收 `router-for-me/CLIProxyAPI` 从 `55397bf68d01a99dc8fd523fe56719857afd579c` 到 `a834917e871d85d7fd9e49eaa590d1dfd4159f2a` 的 31 个 first-parent commits，并将 upstream 新的 credential retry rounds、Codex bootstrap buffering、plugin executor usage、OAuth/config/Home 行为适配到 CPA-Core-LTS 受保护契约。

**合并约束：必须使用 Create a merge commit，禁止 squash/rebase。** 本 PR 未发布、未部署；`a834917e..a7e3596b` 的剩余 upstream tail 将在 Stage 2 从合并后的新 `origin/main` 继续处理。

## Type

- [x] Protected upstream full-sync
- [x] Staged upstream full-sync
- [ ] LTS protected-delta patch
- [ ] LTS feature / downstream patch maintenance
- [ ] Maintenance docs / CI
- [ ] Emergency hotfix

## Upstream sync info

- Upstream repo: `router-for-me/CLIProxyAPI`
- Upstream branch: `main`
- Upstream from SHA: `55397bf68d01a99dc8fd523fe56719857afd579c`
- Upstream to SHA: `a834917e871d85d7fd9e49eaa590d1dfd4159f2a`
- Stage: 1，覆盖 post-`v7.2.136` 至 post-`v7.2.139`
- Sync branch: `codex/sync-upstream-stage-1-20260823`
- Merge commit: `109fcf68442ef1d91ff34a3c2443391e319962ae`

## Outcome and classification

- 普通吸收 18 commits：Gemini/Antigravity schema、signature、tool result、model catalog、Claude/OpenAI translator、xAI incomplete terminal 等修复。
- 适配后吸收 13 commits：logging cancellation、Claude dynamic headers/auth identity、compact request scope、OAuth request-scoped errors、base_URL-only credentials、Codex bootstrap buffering、plugin executor usage、credential retry rounds/Home filtering。
- 明确拒绝 0 commits：本段没有 sponsor、affiliate、返利文案或商业展示资产。
- 38 个 active downstream patches 均未获得完整 upstream equivalent；全部保持 `required`。`dynamic-custom-header-transport-coverage` 仅获得 Claude 半边等价实现，Codex direct image 两个调用点仍依赖 LTS。

关键适配：

- 将 upstream `request-retry` credential-round 语义与 LTS `retry-without-penalty`、hedged retry、model fallback、Home retry limit、pinned/excluded auth 和 generation fence 组合，special retry 不消耗普通 credential round。
- Codex HTTP/SSE bootstrap 只在 opt-in 时同步探测隐藏在 HTTP 200 stream 中的 overload；复用原有 abnormal-reasoning buffer、usage aggregation、fallback 和 replay 流水线，不覆盖 LTS 实现。
- plugin executor Claude stream usage 按 LTS canonical input contract 合并 cache buckets，避免 cache double count；nested execution 和 failure/cancellation attribution 保持 upstream 新行为。
- 保留完整 usage statistics、Management usage API/response shape、Panel asset source、Redis usage queue 和 commercial-neutral contract。

## Protected delta checklist

- [x] `usage-statistics-enabled` still exists
- [x] `internal/usage/` still exists
- [x] `/v0/management/usage` still exists
- [x] `/v0/management/usage/export` still exists
- [x] `/v0/management/usage/import` still exists
- [x] `docs/lts/core-feature-contracts.yaml` reviewed for touched protected or protected-adjacent features
- [x] `docs/lts/downstream-patches.yaml` reviewed for active patch retirement or reapplication
- [x] Usage record creation/schema reviewed and tested
- [x] Management usage response shape reviewed and tested
- [x] Export/import roundtrip reviewed and tested
- [x] CPA-Panel-LTS response shape reviewed; no shape change
- [x] Local auth/config/panel/release/source customizations reviewed

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| `full-usage-statistics-core` | retained capability | preserved | usage/management focused tests + full suite |
| `management-usage-api` | retained capability | preserved | routes/sentinels and response tests pass |
| `auth-identity-attribution` | retained capability | adapted | base_URL-only auth, warning metadata, retry-round tests |
| `config-compatibility-and-hot-reload` | retained capability | adapted | OAuth rules/config/watcher tests pass |
| `provider-runtime-usage-seams` | review seam | adapted | plugin executor protocol usage and cancellation tests pass |
| `codex-abnormal-reasoning-retry` | LTS feature | adapted | bootstrap probe composes with existing stream buffer/fallback tests |
| `panel-release-asset` | retained capability | preserved | source untouched; sentinel pass |
| `redis-compatible-usage-queue` | LTS feature | preserved | route/implementation untouched; full suite pass |
| `commercial-neutral-documentation` | retained capability | preserved | no commercial content absorbed |
| `codex-model-fallback` | downstream patch | patch-still-required | upstream retry rounds/bootstrap are same-model only; ledger regressions pass |
| `codex-rate-limit-continuity` | downstream patch | patch-still-required | no Healthy/FreshBlocked/ConfirmedCooldown equivalent; regressions pass |
| `codex-interactions-service-tier-response` | downstream patch | patch-still-required | no complete response-tier equivalent; regressions pass |
| `plugin-configured-enable-default` | downstream patch | patch-still-required | no equivalent in range; regressions pass |
| `home-plugin-sync-cancellation` | downstream patch | patch-still-required | no equivalent in range; regressions pass |
| `codex-gpt56-ultra-level` | downstream patch | patch-still-required | no server-side capability/wire equivalent; regressions pass |
| `codex-client-media-model-visibility` | downstream patch | patch-still-required | no complete SDK route equivalent; regressions pass |
| `codex-model-header-provider-snapshot` | downstream patch | patch-still-required | no immutable provider snapshot equivalent; regressions pass |
| `codex-oauth-client-identity-finalization` | downstream patch | patch-still-required | no final cross-transport identity pass; regressions pass |
| `codex-client-metadata-privacy` | downstream patch | patch-still-required | no workspace/privacy authority equivalent; regressions pass |
| `codex-model-not-found-request-scope` | downstream patch | patch-still-required | compact scope fix is not regular Codex model-404 scope; regressions pass |
| `codex-websocket-reader-generation` | downstream patch | patch-still-required | bootstrap buffering adds no generation ownership; regressions pass |
| `codex-spark-reasoning-summary-compat` | downstream patch | patch-still-required | no post-override transport sanitizer equivalent; regressions pass |
| `xai-explicit-tool-choice-none` | downstream patch | patch-still-required | incomplete-terminal fix does not replace authorization policy; regressions pass |
| `kimi-claude-delegated-auth-immutability` | downstream patch | patch-still-required | no request-local auth clone equivalent; regressions pass |
| `request-body-panic-tempfile-cleanup` | downstream patch | patch-still-required | no body ownership equivalent; regressions pass |
| `api-request-body-size-limit` | downstream patch | patch-still-required | no decoded-body limit equivalent; regressions pass |
| `object-store-auth-path-containment` | downstream patch | patch-still-required | no path-containment equivalent; regressions pass |
| `auth-token-private-file-permissions` | downstream patch | patch-still-required | no permission-hardening equivalent; regressions pass |
| `auth-store-list-error-propagation` | downstream patch | patch-still-required | no fail-closed list equivalent; regressions pass |
| `auth-store-metadata-hydration` | downstream patch | patch-still-required | base_URL/auth changes do not hydrate prefix/headers/disabled consistently; regressions pass |
| `panel-release-token-isolation` | downstream patch | patch-still-required | panel retrieval untouched; regressions pass |
| `gemini-unknown-method-not-found` | downstream patch | patch-still-required | route allowlist untouched; regressions pass |
| `count-tokens-not-found-no-cooldown` | downstream patch | patch-still-required | no complete count scope/attribution equivalent; regressions pass |
| `management-logs-bounded-response` | downstream patch | patch-still-required | log read bounds untouched; regressions pass |
| `transient-eof-cooldown` | downstream patch | patch-still-required | bootstrap delivery does not replace transport cooldown classification; regressions pass |
| `expired-availability-pruning` | downstream patch | patch-still-required | no pruning equivalent; regressions pass |
| `responses-chat-tool-call-turn-grouping` | downstream patch | patch-still-required | request grouping untouched; regressions pass |
| `codex-desktop-tool-overlay` | downstream patch | patch-still-required | tool overlay gates untouched; regressions pass |
| `codex-multi-agent-plaintext-contract` | downstream patch | patch-still-required | no plaintext provenance equivalent; regressions pass |
| `xai-multi-agent-plaintext-provenance` | downstream patch | patch-still-required | xAI provenance untouched; regressions pass |
| `provider-runtime-state-isolation` | downstream patch | patch-still-required | bootstrap is pre-delivery only; generation/non-buffering state still LTS; regressions pass |
| `auth-provider-generation-fence` | downstream patch | patch-still-required | retry-round paths still lack upstream lifecycle generation; adapted regressions pass |
| `codex-live-bootstrap-accounting-and-egress` | downstream patch | patch-still-required | Realtime live path untouched; regressions pass |
| `xai-implicit-responses-message-token-accounting` | downstream patch | patch-still-required | token estimator untouched; regressions pass |
| `xai-websocket-saturated-reader-invalidation` | downstream patch | patch-still-required | reader invalidation untouched; regressions pass |
| `xai-model-bad-credentials-auth-normalization` | downstream patch | patch-still-required | auth-level normalization still absent upstream; regressions pass |
| `dynamic-custom-header-transport-coverage` | downstream patch | patch-still-required | `5fef17e2` covers Claude only; Codex direct images still require LTS |

- [x] This upstream sync PR will use **Create a merge commit**; squash/rebase is forbidden.

## Conflict resolution notes

Resolved conflicts in:

- `config.example.yaml`
- `internal/api/handlers/management/config_lists.go`
- `internal/config/config_types.go`
- `internal/config/vertex_compat.go`
- `internal/runtime/executor/codex_executor_stream.go`
- `internal/runtime/executor/helps/claude_code_session.go`
- `sdk/cliproxy/auth/conductor_execution.go`
- `sdk/cliproxy/auth/conductor_selection.go`
- `sdk/cliproxy/auth/conductor_stream.go`

No file-level upstream overwrite was used. Resolution preserves LTS usage/Management/config/auth/retry/replay behavior while retaining upstream ancestry.

## Validation

- [x] `scripts/check-lts-contract.sh`
- [x] `go run ./scripts/ltsregistry --root . --base-ref origin/main`
- [x] `go test -count=1 ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'`
- [x] Server build: `go build -o /tmp/cpa-core-lts-server-build-20260823 ./cmd/server`
- [x] `go test -count=1 ./...`
- [x] `go list ./... | rg -v '/tmp$' | xargs go test -count=1`
- [x] `go test -count=1 ./internal/config ./internal/watcher/... ./internal/api/...`
- [x] `go test -count=1 ./internal/translator/...`
- [x] `go test -count=1 ./internal/runtime/executor`
- [x] `go test -count=1 ./sdk/api/...`
- [x] `go test -count=1 ./sdk/cliproxy/auth`
- [x] Focused race: `go test -race -count=1 ./internal/home ./sdk/cliproxy/auth -run 'Home|Concurrency|InFlight|Unauthorized|Dispatch|RetryWithoutPenalty|HedgedRetry'`
- [x] `git diff --check`

## Delivery boundary

- [x] Hugging Face/runtime smoke explicitly skipped: this PR does not publish a release or deploy a runtime.
- No release, tag, Docker publish, HF Space change, credential change, or production mutation is included.
- No active old fork PR/branch is being replaced by selective port; this is the canonical protected full-sync path.
