### PR TITLE
fix(codex): preserve queued websocket response on disconnect

### DIFF
--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -454,10 +454,11 @@ patches:
     retire_when: Upstream recognizes only the typed invalid_request_error model 404 as request-scoped, stops futile cross-auth retries without marking credentials or the model unavailable, preserves generic 404 cooldown behavior, and all listed regressions pass after removing the downstream implementation.
 
   - id: codex-websocket-reader-generation
-    reason: Reusable Codex WebSocket sessions need generation ownership so a stale reader or shutdown race cannot deliver to, clear, close, or deadlock a newer request.
+    reason: Reusable Codex WebSocket sessions need generation ownership so a stale reader or shutdown race cannot deliver to, clear, close, or deadlock a newer request, and a disconnect signal must not preempt a response already queued for the current request.
     introduced_in: 0877a26d333a3be918f5e48aadf0e4d71709ab2f
     affected_upstream_range: "through f0de1d008fe8881dcb7431cf97b147295874c2b2 (upstream main after v7.2.145, 2026-08-29); fcea738f improves typed WebSocket handshake failures but does not add generation-safe reader/request ownership. LTS composes the upstream handshake path with replacement, detach, invalidation, session-close, request-owned cancellation, retry-rebinding, and stale-reader guards, so the patch remains required. The f0de1d00 delta is README-only and does not affect this conclusion."
     files:
+      - internal/runtime/executor/codex_websockets_connection.go
       - internal/runtime/executor/codex_websockets_executor.go
       - internal/runtime/executor/codex_websockets_executor_test.go
       - internal/runtime/executor/codex_websockets_lts_test.go
@@ -466,6 +467,7 @@ patches:
       - internal/runtime/executor/xai_websockets_executor_test.go
     regression_tests:
       - TestCodexWebsocketHandshakeFailureReleasesExecutionSession
+      - TestCodexWebsocketReadPrefersQueuedMessageOverDisconnectSignal
       - TestCodexWebsocketStaleReaderCannotCloseNewActiveChannel
       - TestCodexWebsocketGenerationRetryRebindUsesCurrentConnection
       - TestCodexWebsocketGenerationRetryRebindRejectedAfterSessionClose
@@ -475,7 +477,7 @@ patches:
       - TestWebsocketExecutorsReconnectWhenSessionTargetChanges
     upstream_issue_or_pr: not-filed
     state: required
-    retire_when: Upstream assigns equivalent connection generations, validates reader/request ownership atomically, keeps channels request-owned, and passes every listed concurrency regression after the downstream implementation is removed.
+    retire_when: Upstream assigns equivalent connection generations, validates reader/request ownership atomically, keeps channels request-owned, preserves queued response ordering when a disconnect cancellation follows, and passes every listed concurrency regression after the downstream implementation is removed.
 
   - id: codex-spark-reasoning-summary-compat
     reason: GPT-5.3-Codex-Spark needs reasoning effort enabled but its upstream rejects reasoning.summary, so Core must remove only that unsupported field after final payload shaping across HTTP and WebSocket transports.

--- a/internal/runtime/executor/codex_websockets_connection.go
+++ b/internal/runtime/executor/codex_websockets_connection.go
@@ -138,27 +138,44 @@ func readCodexWebsocketMessage(ctx context.Context, sess *codexWebsocketSession,
 	if requestSignal == nil || requestSignal.ctx == nil {
 		return 0, nil, fmt.Errorf("codex websockets executor: session request signal is nil")
 	}
+	readEvent := func(ev codexWebsocketRead, ok bool) (int, []byte, error, bool) {
+		if !ok {
+			return 0, nil, fmt.Errorf("codex websockets executor: session read channel closed"), true
+		}
+		if ev.connection != connection {
+			return 0, nil, nil, false
+		}
+		if ev.err != nil {
+			return 0, nil, ev.err, true
+		}
+		return ev.msgType, ev.payload, nil, true
+	}
 	for {
 		select {
 		case <-ctx.Done():
 			return 0, nil, ctx.Err()
 		case <-requestSignal.ctx.Done():
-			cause := context.Cause(requestSignal.ctx)
-			if cause == nil {
-				cause = context.Canceled
+			// The reader loop can enqueue a final response and then immediately
+			// cancel the request after observing the peer close. Preserve channel
+			// order so the queued response wins over the later disconnect signal.
+			for {
+				select {
+				case ev, ok := <-readCh:
+					if msgType, payload, errRead, matched := readEvent(ev, ok); matched {
+						return msgType, payload, errRead
+					}
+				default:
+					cause := context.Cause(requestSignal.ctx)
+					if cause == nil {
+						cause = context.Canceled
+					}
+					return 0, nil, cause
+				}
 			}
-			return 0, nil, cause
 		case ev, ok := <-readCh:
-			if !ok {
-				return 0, nil, fmt.Errorf("codex websockets executor: session read channel closed")
+			if msgType, payload, errRead, matched := readEvent(ev, ok); matched {
+				return msgType, payload, errRead
 			}
-			if ev.connection != connection {
-				continue
-			}
-			if ev.err != nil {
-				return 0, nil, ev.err
-			}
-			return ev.msgType, ev.payload, nil
 		}
 	}
 }

--- a/internal/runtime/executor/codex_websockets_lts_test.go
+++ b/internal/runtime/executor/codex_websockets_lts_test.go
@@ -366,6 +366,31 @@ func TestCodexWebsocketGenerationRetryRebindUsesCurrentConnection(t *testing.T) 
 	sess.clearActiveConnection(newConnection, readCh)
 }
 
+func TestCodexWebsocketReadPrefersQueuedMessageOverDisconnectSignal(t *testing.T) {
+	connection := codexWebsocketConnectionRef{conn: &websocket.Conn{}, generation: 1}
+	wantPayload := []byte(`{"type":"response.completed"}`)
+	disconnectErr := errors.New("upstream disconnected after response")
+
+	for i := 0; i < 100; i++ {
+		readCh := make(chan codexWebsocketRead, 1)
+		requestSignal := newCodexWebsocketRequestSignal()
+		readCh <- codexWebsocketRead{
+			connection: connection,
+			msgType:    websocket.TextMessage,
+			payload:    wantPayload,
+		}
+		requestSignal.cancel(disconnectErr)
+
+		msgType, payload, errRead := readCodexWebsocketMessage(context.Background(), &codexWebsocketSession{}, connection, readCh, requestSignal)
+		if errRead != nil {
+			t.Fatalf("iteration %d read error = %v, want queued response", i, errRead)
+		}
+		if msgType != websocket.TextMessage || !bytes.Equal(payload, wantPayload) {
+			t.Fatalf("iteration %d response = type %d payload %s, want type %d payload %s", i, msgType, payload, websocket.TextMessage, wantPayload)
+		}
+	}
+}
+
 func TestCodexWebsocketGenerationRetryRebindRejectedAfterSessionClose(t *testing.T) {
 	sess := &codexWebsocketSession{sessionID: "retry-rebind-after-close"}
 	oldConnection := codexWebsocketConnectionRef{conn: &websocket.Conn{}, generation: 11}


### PR DESCRIPTION
## Type

- [ ] Protected upstream full-sync
- [ ] Staged upstream full-sync
- [ ] LTS protected-delta patch
- [x] LTS feature / downstream patch maintenance
- [ ] Maintenance docs / CI
- [ ] Emergency hotfix

## Why

After protected full-sync PR #230 merged, required `lts-contract` passed, but main run [33254266524](https://github.com/BlueSkyXN/CPA-Core-LTS/actions/runs/33254266524) exposed the same Codex non-stream WebSocket failure pattern twice:

- `TestCodexWebsocketNonstreamLifecycleBindFailureDetachesConnection`
- `TestWebsocketRetryBindFailureClearsActiveSessionState/Codex_nonstream`

The reader can enqueue `response.completed`, then immediately observe the peer close and cancel the request signal. When both the response channel and cancellation are ready, the old `select` could choose the later EOF first and discard the already queued response.

## Change

- When the request disconnect signal fires, consume any event already queued for the current connection before returning the cancellation cause.
- Preserve FIFO semantics: a queued response is delivered first; a queued error remains an error; cancellation is returned only when no current-connection event is queued.
- Add a regression that makes the response and disconnect signal ready before the read and verifies the response always wins.
- Update the existing `codex-websocket-reader-generation` patch ledger entry; this is an adaptation of that still-required downstream patch, not a new LTS feature.

## Protected delta review

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| `codex-websocket-reader-generation` | downstream patch | `adapted`, `patch-still-required` | Upstream baseline `f0de1d008fe8881dcb7431cf97b147295874c2b2` still lacks generation-safe request ownership and queued-response/disconnect ordering; ledger files, regression test, reason, and retirement gate updated |
| request lifecycle | review seam | `adapted` | Change is limited to current-connection read arbitration; auth, model resolution, token accounting, logging metadata, usage response shape, config hot reload, panel source, and plugin runtime are untouched |
| usage / Management / Panel contracts | retained capability | `preserved` | Contract guard, focused usage/Management tests, full repository tests, and server build pass |

No upstream merge conflict is involved. This corrects a downstream read-ordering race revealed by main-branch CI load.

## Validation

- [x] `scripts/check-lts-contract.sh`
- [x] `go run ./scripts/ltsregistry --root . --base-ref origin/main`
- [x] `go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'`
- [x] `go build -o /tmp/cpa-core-lts-server-ws-race ./cmd/server`
- [x] `go test ./...`
- [x] `git diff --check`
- [x] Failing regression was observed before the fix
- [x] New regression plus both CI-failing tests passed with `-count=1000`
- [x] The same three tests passed under `go test -race` with `-count=100`

## Delivery note

This PR does not create an `introduced_in` or `retired_in` ledger reference. Normal merge policy is sufficient after exact-head CI and review. No Release, deployment, or runtime UAT is included.
