### PR TITLE
chore(lts): retire redundant Codex media visibility patch

### DIFF
--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -288,7 +288,8 @@ patches:
       - TestModelsWithClientVersionReturnsCodexCatalog
       - TestPreserveLTSMediaModelVisibility
     upstream_issue_or_pr: router-for-me/CLIProxyAPI@1cc72b9d13c43b725727a6ba4a30906004310a35
-    state: removable
+    state: retired
+    retired_in: e0b9f08cfc8f9e24a4e38dc556361bb0e41af258
     retire_when: After this removable baseline is merged, remove the redundant SDK visibility overlay in a dedicated retirement PR, retain the canonical internal builder behavior, run the listed regressions, and record the implementation-removal commit in retired_in.
 
   - id: codex-model-header-provider-snapshot

--- a/sdk/api/handlers/openai/codex_client_models.go
+++ b/sdk/api/handlers/openai/codex_client_models.go
@@ -1,8 +1,6 @@
 package openai
 
 import (
-	"strings"
-
 	codexmodels "github.com/router-for-me/CLIProxyAPI/v7/internal/client/codex/models"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
 )
@@ -13,39 +11,22 @@ func (h *OpenAIAPIHandler) codexClientModelsResponse(clientVersion ...string) ma
 		version = clientVersion[0]
 	}
 	optimizeMultiAgentV2 := h != nil && h.Cfg != nil && h.Cfg.CodexOptimizeMultiAgentV2
-	return preserveLTSMediaModelVisibility(codexmodels.BuildResponseForClient(h.Models(), registry.GetGlobalRegistry().GetModelProviders, optimizeMultiAgentV2, version))
+	return codexmodels.BuildResponseForClient(h.Models(), registry.GetGlobalRegistry().GetModelProviders, optimizeMultiAgentV2, version)
 }
 
 // CodexClientModelsResponse builds a Codex client model response.
 func CodexClientModelsResponse(models []map[string]any) map[string]any {
-	return preserveLTSMediaModelVisibility(codexmodels.BuildResponse(models, nil, false))
+	return codexmodels.BuildResponse(models, nil, false)
 }
 
 // CodexClientModelsResponseWithMultiAgentV2 builds a Codex client model response
 // and advertises multi-agent v2 for synthesized models when enabled.
 func CodexClientModelsResponseWithMultiAgentV2(models []map[string]any, enabled bool) map[string]any {
-	return preserveLTSMediaModelVisibility(codexmodels.BuildResponse(models, nil, enabled))
+	return codexmodels.BuildResponse(models, nil, enabled)
 }
 
 // CodexClientModelsResponseForClient builds a Codex client model response
 // tailored for a specific client version.
 func CodexClientModelsResponseForClient(models []map[string]any, clientVersion string, enabled bool) map[string]any {
-	return preserveLTSMediaModelVisibility(codexmodels.BuildResponseForClient(models, nil, enabled, clientVersion))
-}
-
-// preserveLTSMediaModelVisibility keeps the removable downstream guard in place
-// until its dedicated retirement change lands on an already-merged baseline.
-func preserveLTSMediaModelVisibility(response map[string]any) map[string]any {
-	models, ok := response["models"].([]map[string]any)
-	if !ok {
-		return response
-	}
-	for _, model := range models {
-		slug, _ := model["slug"].(string)
-		switch strings.TrimSpace(slug) {
-		case "grok-imagine-image-quality", "gpt-image-1.5", "gpt-image-2", "grok-imagine-image", "grok-imagine-image-2.0", "grok-imagine-video", "grok-imagine-video-1.5", "grok-imagine-video-1.5-preview":
-			model["visibility"] = "hide"
-		}
-	}
-	return response
+	return codexmodels.BuildResponseForClient(models, nil, enabled, clientVersion)
 }

--- a/sdk/api/handlers/openai/codex_client_models_test.go
+++ b/sdk/api/handlers/openai/codex_client_models_test.go
@@ -58,24 +58,6 @@ func TestCodexClientModelsResponseMultiAgentV2FollowsConfig(t *testing.T) {
 	}
 }
 
-func TestPreserveLTSMediaModelVisibility(t *testing.T) {
-	response := map[string]any{
-		"models": []map[string]any{
-			{"slug": "grok-imagine-video-1.5", "visibility": "list"},
-			{"slug": "gpt-5.6-sol", "visibility": "list"},
-		},
-	}
-
-	preserveLTSMediaModelVisibility(response)
-	models := response["models"].([]map[string]any)
-	if got := models[0]["visibility"]; got != "hide" {
-		t.Fatalf("media visibility = %#v, want hide", got)
-	}
-	if got := models[1]["visibility"]; got != "list" {
-		t.Fatalf("non-media visibility = %#v, want list", got)
-	}
-}
-
 func TestCodexClientModelsResponseClientVersionFiltering(t *testing.T) {
 	modelRegistry := registry.GetGlobalRegistry()
 	modelRegistry.RegisterClient("codex-version-filter-sdk-test", "openai-compatibility", []*registry.ModelInfo{


### PR DESCRIPTION
## Type

- [ ] Protected upstream full-sync
- [ ] Staged upstream full-sync
- [ ] LTS protected-delta patch
- [x] LTS feature / downstream patch maintenance
- [ ] Maintenance docs / CI
- [ ] Emergency hotfix

## Why

Protected full-sync PR #230 moved `codex-client-media-model-visibility` to `removable` only after upstream commit `1cc72b9d13c43b725727a6ba4a30906004310a35` entered the merged LTS baseline. That commit routes SDK/non-Home Codex catalog responses through `internal/client/codex/models`, whose canonical `applyCodexClientVisibilityOverride` already hides the same image/video endpoint models.

The SDK overlay therefore became duplicate behavior. This dedicated PR completes the mandatory second phase of the downstream patch lifecycle instead of deleting the overlay inside the upstream sync.

## Change

Commit `e0b9f08cfc8f9e24a4e38dc556361bb0e41af258`:

- removes `preserveLTSMediaModelVisibility` and its four wrapper calls;
- removes the now-unused `strings` import;
- removes the overlay-only `TestPreserveLTSMediaModelVisibility`;
- keeps all public SDK response helpers delegating to the canonical internal builder.

Commit `27ab8580`:

- advances `codex-client-media-model-visibility` from `removable` to `retired`;
- records the implementation-removal commit in `retired_in`;
- preserves the historical ledger entry, affected files, regression record, upstream evidence, and retirement condition.

## LTS classification review

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| `codex-client-media-model-visibility` | downstream patch | `upstream-equivalent`, `retired` | Upstream `1cc72b9d` is in baseline `f0de1d008fe8881dcb7431cf97b147295874c2b2`; canonical internal builder contains the complete visibility override; route regression passes after overlay deletion |
| Codex client catalog capabilities | LTS feature / review seam | `preserved` | Internal model builder, client-version filtering, Multi-Agent v2 shaping, registry provider lookup, and SDK public helpers remain intact |
| usage / Management / auth / runtime / Panel contracts | retained capability | `preserved` | Not touched; contract guard and full repository suite pass |

No protected conflict or behavior replacement is hidden here: only the now-redundant SDK post-processing layer is removed.

## Validation

- [x] `go run ./scripts/ltsregistry --root . --base-ref origin/main`
- [x] `scripts/check-lts-contract.sh`
- [x] `go test ./internal/client/codex/models ./sdk/api/handlers/openai`
- [x] `go test ./internal/api ./sdk/api/handlers/openai`
- [x] `go test ./internal/api -run '^TestModelsWithClientVersionReturnsCodexCatalog$' -count=20`
- [x] `go test ./...`
- [x] `go build -o /tmp/cpa-core-lts-server-media-retirement ./cmd/server`
- [x] `git diff --check origin/main...HEAD`

## Required merge method

This PR must use **Create a merge commit**. Do not squash or rebase: `retired_in` references `e0b9f08cfc8f9e24a4e38dc556361bb0e41af258`, which must remain reachable in product history.

No Release, deployment, or runtime UAT is included.
