### PR TITLE
test(websocket): make retry fixture connection order deterministic

### DIFF
--- a/internal/runtime/executor/websocket_session_target_test.go
+++ b/internal/runtime/executor/websocket_session_target_test.go
@@ -244,12 +244,12 @@ func TestWebsocketRetryBindFailureClearsActiveSessionState(t *testing.T) {
 			defer close(serverRelease)
 			var connections atomic.Int32
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				connection := connections.Add(1)
 				conn, errUpgrade := upgrader.Upgrade(w, r, nil)
 				if errUpgrade != nil {
 					t.Errorf("upgrade websocket: %v", errUpgrade)
 					return
 				}
-				connection := connections.Add(1)
 				defer func() { _ = conn.Close() }()
 				if connection == 1 {
 					_, _, _ = conn.ReadMessage()


### PR DESCRIPTION
## Type

- [ ] Protected upstream full-sync
- [ ] Staged upstream full-sync
- [ ] LTS protected-delta patch
- [ ] LTS feature / downstream patch maintenance
- [x] Maintenance docs / CI
- [ ] Emergency hotfix

## Why

After PR #231 merged cleanly, the refreshed exact-head observation for PR #232 failed once in `TestWebsocketRetryBindFailureClearsActiveSessionState/xAI_stream` with an unexpected EOF.

This was not a media-visibility regression and not another production read-ordering defect. The shared retry fixture assigned its ordinal only after `websocket.Upgrader.Upgrade` had written the handshake. At that point the client dial can already return and initiate the next connection, so under GitHub runner load two server handlers can exchange ordinals. The final healthy connection can then be treated as fixture connection 2, which intentionally closes immediately.

## Change

- Move the existing atomic connection increment immediately before `Upgrade`.
- Keep the same three-connection scenario, lifecycle rejection, EOF behavior, assertions, and server-release synchronization.
- Do not change production code, add sleeps, add retries, weaken assertions, or expand the test matrix.

The counter now advances before the handshake becomes visible to the client, so each later dial cannot overtake the previous fixture ordinal.

## Scope review

- Files changed: one existing test file.
- Diff: one line moved (`+1/-1`).
- Runtime/API/config/usage/Panel behavior: untouched.
- Dependencies and abstractions: none added.
- LTS registry: untouched because no maintained product behavior changed.

## Validation

- [x] GitHub failure evidence: run `33256958809`, job `99112268884`
- [x] `go test ./internal/runtime/executor -run '^TestWebsocketRetryBindFailureClearsActiveSessionState$' -count=100`
- [x] `go test ./internal/runtime/executor`
- [x] `git diff --check`

No Release, deployment, or runtime UAT is included.
