### PR TITLE
feat(qoder): support explicit SDK and direct OpenAI transports

### DIFF
--- a/examples/plugin/qoder/README.md
+++ b/examples/plugin/qoder/README.md
@@ -1,7 +1,16 @@
 # Qoder provider plugin
 
 This example implements the schema 5 `cpa-provider-qoder` dynamic plugin and
-connects it to the separately installed `cpa-qoder-runner`.
+connects it to the separately installed `cpa-qoder-runner`. The plugin supports
+two explicit Qoder transports in one provider:
+
+- `sdk_cli` (default): the verified Qoder Agent SDK/CLI path;
+- `direct_openai`: a configured OpenAI-compatible Qoder endpoint for raw
+  Chat/stream/tool requests.
+
+The transport can be the plugin default or an auth-file override. It is part of
+the execution-session identity, so one session never changes transport midway.
+There is no silent fallback between transports.
 
 The plugin implements `AuthProvider`, `ModelsForAuth`, `ProviderExecutor`,
 `ProviderReadiness`, `ExecutionCanceller`, and `ExecutionSessionCloser` through
@@ -19,6 +28,7 @@ working_directory: /private/tmp
 max_queue_frames: 128
 request_timeout: 30s
 model_cache_ttl: 1m
+transport: sdk_cli
 permission_default: deny
 permission_rules: []
 skills: []
@@ -26,6 +36,37 @@ setting_sources: []
 allowed_tools: []
 disallowed_tools: []
 mcp_servers: {}
+```
+
+For `direct_openai`, configure the endpoint and exact model source. A PAT is
+exchanged for a short-lived Qoder job token when `direct_token_mode` is `auto`
+or `pat_exchange`; an existing `jt-`/`dt-` token is used directly:
+
+```yaml
+transport: direct_openai
+direct_endpoint: https://api2-v2.qoder.sh/model/v1/chat/completions
+direct_auth_endpoint: https://openapi.qoder.sh
+direct_token_mode: auto
+direct_models:
+  - id: qfmodel
+    display_name: Qwen3.8-Flash
+```
+
+`direct_models_endpoint` may be used instead of `direct_models` when the
+configured endpoint returns an OpenAI-compatible `{data:[...]}` catalog. CN and
+global endpoints must be selected explicitly; the plugin does not guess a
+region or convert a display name such as `Qwen3.8-Flash` into an executable ID.
+
+An individual auth file may opt into the second transport while the plugin
+default remains `sdk_cli`:
+
+```json
+{
+  "type": "qoder",
+  "auth_mode": "pat",
+  "transport": "direct_openai",
+  "access_token": "[REDACTED_SECRET]"
+}
 ```
 
 The optional capability settings are fixed administrator configuration, not
@@ -37,15 +78,17 @@ plain HTTP is accepted on loopback for controlled local testing. An execution
 session rejects changes to system, skill, tool, or MCP configuration instead
 of silently applying only part of a new configuration.
 
-The plugin does not run `npm install`, use the SDK-bundled `qodercli 1.0.30`,
-start an interactive login, or refresh a PAT. PATs enter the dedicated runner
-through an environment variable; JSONL frames identify that variable without
-carrying its value. Qoder SDK 1.0.10 then creates a short-lived mode-0600 auth
-payload for the CLI, so each runner receives a plugin-owned private `TMPDIR`
-and PAT `HOME`; the plugin terminates the Unix process group and removes that
-runtime directory after exit. Local CLI auth uses `qodercliAuth()` with
-`config_dir` selected through the isolated runner environment; `profile_id` is
-only a CPA label, and distinct accounts require distinct config directories.
+The `sdk_cli` path does not run `npm install`, use the SDK-bundled
+`qodercli 1.0.30`, start an interactive login, or refresh a PAT. PATs enter the
+dedicated runner through an environment variable; JSONL frames identify that
+variable without carrying its value. Qoder SDK 1.0.10 then creates a short-lived
+mode-0600 auth payload for the CLI, so each runner receives a plugin-owned
+private `TMPDIR` and PAT `HOME`; the plugin terminates the Unix process group
+and removes that runtime directory after exit. Local CLI auth uses
+`qodercliAuth()` with `config_dir` selected through the isolated runner
+environment; `profile_id` is only a CPA label, and distinct accounts require
+distinct config directories. The `direct_openai` path may exchange a PAT for a
+short-lived bearer token in runner memory and never persists the derived token.
 
 Known executable model IDs are recorded exactly as returned by the installed
 Qoder CLI. On the current CN catalog, `qfmodel` has the display name
@@ -58,6 +101,23 @@ account reports them. Chat system text, conversation history, text blocks, and
 base64 or HTTP(S) image blocks are converted to structured SDK input. Qoder
 executes its configured native tools and MCP tools inside the Agent session;
 those internal tool events are not exposed as client-owned OpenAI tool calls.
+
+## `direct_openai` behavior
+
+- Preserves the original Chat `messages`, images, `tools`, `tool_choice`, and
+  supported generation fields while forcing an upstream streaming request.
+- Provides both stream and non-stream projections through the shared AgentEvent
+  lifecycle; upstream usage is marked `provider_reported_unverified`.
+- Supports one bounded 401/403 refresh retry for PAT-exchanged credentials,
+  explicit cancel, close, downstream disconnect, and `[DONE]` validation.
+- Advertises `client_tools` but does not advertise native Qoder sessions,
+  skills, MCP, or Qoder CLI tools for this transport.
+- Requires an exact configured or live-discovered model ID. It never silently
+  falls back to `auto`.
+
+The direct adapter intentionally does not implement the reverse-engineered
+legacy COSY/QoderEncoding protocol. That protocol remains a separate
+characterization reference and is not part of the supported transport set.
 
 Build:
 

--- a/examples/plugin/qoder/go/auth.go
+++ b/examples/plugin/qoder/go/auth.go
@@ -13,6 +13,7 @@ import (
 type qoderAuth struct {
 	Type        string `json:"type"`
 	AuthMode    string `json:"auth_mode"`
+	Transport   string `json:"transport,omitempty"`
 	AccountID   string `json:"account_id,omitempty"`
 	AccessToken string `json:"access_token,omitempty"`
 	ProfileID   string `json:"profile_id,omitempty"`
@@ -30,9 +31,13 @@ func parseStoredAuth(raw []byte) (qoderAuth, error) {
 	}
 	auth.Type = pluginIdentifier
 	auth.AuthMode = strings.TrimSpace(auth.AuthMode)
+	auth.Transport = strings.ToLower(strings.TrimSpace(auth.Transport))
 	auth.AccountID = strings.TrimSpace(auth.AccountID)
 	auth.ProfileID = strings.TrimSpace(auth.ProfileID)
 	auth.ConfigDir = strings.TrimSpace(auth.ConfigDir)
+	if auth.Transport != "" && auth.Transport != "sdk_cli" && auth.Transport != "direct_openai" {
+		return qoderAuth{}, fmt.Errorf("Qoder transport must be sdk_cli or direct_openai")
+	}
 	switch auth.AuthMode {
 	case "pat":
 		if auth.AccessToken == "" || strings.TrimSpace(auth.AccessToken) != auth.AccessToken {
@@ -44,6 +49,9 @@ func parseStoredAuth(raw []byte) (qoderAuth, error) {
 		auth.ProfileID = ""
 		auth.ConfigDir = ""
 	case "local_cli":
+		if auth.Transport == "direct_openai" {
+			return qoderAuth{}, fmt.Errorf("Qoder local_cli auth cannot use direct_openai transport")
+		}
 		if auth.ProfileID == "" {
 			return qoderAuth{}, fmt.Errorf("Qoder local_cli profile_id is required")
 		}
@@ -75,6 +83,11 @@ func parseAuthRequest(raw []byte) (pluginapi.AuthParseResponse, error) {
 	}
 	label := "Qoder PAT"
 	attributes := map[string]string{"auth_mode": auth.AuthMode, "multi_account": "supported"}
+	metadata := map[string]any{"type": pluginIdentifier, "auth_mode": auth.AuthMode}
+	if auth.Transport != "" {
+		attributes["transport"] = auth.Transport
+		metadata["transport"] = auth.Transport
+	}
 	if auth.AuthMode == "local_cli" {
 		label = "Qoder Local CLI " + auth.ProfileID
 		attributes["profile_id"] = auth.ProfileID
@@ -85,7 +98,7 @@ func parseAuthRequest(raw []byte) (pluginapi.AuthParseResponse, error) {
 		FileName:    strings.TrimSpace(req.FileName),
 		Label:       label,
 		StorageJSON: bytes.Clone(req.RawJSON),
-		Metadata:    map[string]any{"type": pluginIdentifier, "auth_mode": auth.AuthMode},
+		Metadata:    metadata,
 		Attributes:  attributes,
 	}}, nil
 }

--- a/examples/plugin/qoder/go/config.go
+++ b/examples/plugin/qoder/go/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/url"
@@ -29,32 +30,55 @@ type mcpServerConfig struct {
 }
 
 type pluginConfig struct {
-	RunnerCommand     string                     `yaml:"runner_command"`
-	RunnerArgs        []string                   `yaml:"runner_args"`
-	QoderCLIPath      string                     `yaml:"qoder_cli_path"`
-	WorkingDirectory  string                     `yaml:"working_directory"`
-	MaxQueueFrames    int                        `yaml:"max_queue_frames"`
-	RequestTimeout    time.Duration              `yaml:"-"`
-	RequestTimeoutRaw string                     `yaml:"request_timeout"`
-	ModelCacheTTL     time.Duration              `yaml:"-"`
-	ModelCacheTTLRaw  string                     `yaml:"model_cache_ttl"`
-	PermissionDefault string                     `yaml:"permission_default"`
-	PermissionRules   []permissionRule           `yaml:"permission_rules"`
-	Skills            []string                   `yaml:"skills"`
-	SettingSources    []string                   `yaml:"setting_sources"`
-	AllowedTools      []string                   `yaml:"allowed_tools"`
-	DisallowedTools   []string                   `yaml:"disallowed_tools"`
-	MCPServers        map[string]mcpServerConfig `yaml:"mcp_servers"`
+	Transport            string                     `yaml:"transport"`
+	RunnerCommand        string                     `yaml:"runner_command"`
+	RunnerArgs           []string                   `yaml:"runner_args"`
+	QoderCLIPath         string                     `yaml:"qoder_cli_path"`
+	DirectEndpoint       string                     `yaml:"direct_endpoint"`
+	DirectModelsEndpoint string                     `yaml:"direct_models_endpoint"`
+	DirectAuthEndpoint   string                     `yaml:"direct_auth_endpoint"`
+	DirectTokenMode      string                     `yaml:"direct_token_mode"`
+	DirectModels         []directModelConfig        `yaml:"direct_models"`
+	WorkingDirectory     string                     `yaml:"working_directory"`
+	MaxQueueFrames       int                        `yaml:"max_queue_frames"`
+	RequestTimeout       time.Duration              `yaml:"-"`
+	RequestTimeoutRaw    string                     `yaml:"request_timeout"`
+	ModelCacheTTL        time.Duration              `yaml:"-"`
+	ModelCacheTTLRaw     string                     `yaml:"model_cache_ttl"`
+	PermissionDefault    string                     `yaml:"permission_default"`
+	PermissionRules      []permissionRule           `yaml:"permission_rules"`
+	Skills               []string                   `yaml:"skills"`
+	SettingSources       []string                   `yaml:"setting_sources"`
+	AllowedTools         []string                   `yaml:"allowed_tools"`
+	DisallowedTools      []string                   `yaml:"disallowed_tools"`
+	MCPServers           map[string]mcpServerConfig `yaml:"mcp_servers"`
+}
+
+type directModelConfig struct {
+	ID                      string   `yaml:"id" json:"id"`
+	DisplayName             string   `yaml:"display_name,omitempty" json:"display_name,omitempty"`
+	Description             string   `yaml:"description,omitempty" json:"description,omitempty"`
+	IsReasoning             bool     `yaml:"is_reasoning,omitempty" json:"is_reasoning,omitempty"`
+	IsVL                    bool     `yaml:"is_vl,omitempty" json:"is_vl,omitempty"`
+	MaxInputTokens          int64    `yaml:"max_input_tokens,omitempty" json:"max_input_tokens,omitempty"`
+	MaxOutputTokens         int64    `yaml:"max_output_tokens,omitempty" json:"max_output_tokens,omitempty"`
+	ReasoningEfforts        []string `yaml:"reasoning_efforts,omitempty" json:"reasoning_efforts,omitempty"`
+	DefaultReasoningEffort  string   `yaml:"default_reasoning_effort,omitempty" json:"default_reasoning_effort,omitempty"`
+	SupportsDisabled        bool     `yaml:"supports_disabled,omitempty" json:"supports_disabled,omitempty"`
+	AvailableContextWindows []int64  `yaml:"available_context_windows,omitempty" json:"available_context_windows,omitempty"`
+	DefaultContextWindow    int64    `yaml:"default_context_window,omitempty" json:"default_context_window,omitempty"`
 }
 
 func defaultPluginConfig() pluginConfig {
 	return pluginConfig{
+		Transport:         "sdk_cli",
 		RunnerCommand:     "cpa-qoder-runner",
 		WorkingDirectory:  os.TempDir(),
 		MaxQueueFrames:    128,
 		RequestTimeout:    30 * time.Second,
 		ModelCacheTTL:     time.Minute,
 		PermissionDefault: "deny",
+		DirectTokenMode:   "auto",
 	}
 }
 
@@ -66,7 +90,24 @@ func decodePluginConfig(raw []byte) (pluginConfig, error) {
 		}
 	}
 	cfg.RunnerCommand = strings.TrimSpace(cfg.RunnerCommand)
+	cfg.Transport = strings.ToLower(strings.TrimSpace(cfg.Transport))
 	cfg.QoderCLIPath = strings.TrimSpace(cfg.QoderCLIPath)
+	cfg.DirectEndpoint = strings.TrimSpace(cfg.DirectEndpoint)
+	cfg.DirectModelsEndpoint = strings.TrimSpace(cfg.DirectModelsEndpoint)
+	cfg.DirectAuthEndpoint = strings.TrimRight(strings.TrimSpace(cfg.DirectAuthEndpoint), "/")
+	cfg.DirectTokenMode = strings.ToLower(strings.TrimSpace(cfg.DirectTokenMode))
+	if cfg.Transport == "" {
+		cfg.Transport = "sdk_cli"
+	}
+	if cfg.DirectTokenMode == "" {
+		cfg.DirectTokenMode = "auto"
+	}
+	if cfg.Transport != "sdk_cli" && cfg.Transport != "direct_openai" {
+		return pluginConfig{}, fmt.Errorf("transport must be sdk_cli or direct_openai")
+	}
+	if cfg.DirectTokenMode != "auto" && cfg.DirectTokenMode != "bearer" && cfg.DirectTokenMode != "pat_exchange" {
+		return pluginConfig{}, fmt.Errorf("direct_token_mode must be auto, bearer, or pat_exchange")
+	}
 	cfg.WorkingDirectory = strings.TrimSpace(cfg.WorkingDirectory)
 	if cfg.RunnerCommand == "" || strings.ContainsRune(cfg.RunnerCommand, '\x00') {
 		return pluginConfig{}, fmt.Errorf("runner_command is required")
@@ -75,13 +116,73 @@ func decodePluginConfig(raw []byte) (pluginConfig, error) {
 		if strings.ContainsRune(arg, '\x00') {
 			return pluginConfig{}, fmt.Errorf("runner_args contains an invalid argument")
 		}
-		switch arg {
-		case "--stdio", "--cli-path", "--cwd", "--max-queue-frames", "--version":
-			return pluginConfig{}, fmt.Errorf("runner_args must not override plugin-owned runner arguments")
+		for _, owned := range []string{"--stdio", "--cli-path", "--cwd", "--max-queue-frames", "--version", "--transport", "--direct-endpoint", "--direct-models-endpoint", "--direct-auth-endpoint", "--direct-token-mode", "--direct-models-json"} {
+			if arg == owned || strings.HasPrefix(arg, owned+"=") {
+				return pluginConfig{}, fmt.Errorf("runner_args must not override plugin-owned runner arguments")
+			}
 		}
 	}
 	if cfg.QoderCLIPath != "" && (!filepath.IsAbs(cfg.QoderCLIPath) || strings.ContainsRune(cfg.QoderCLIPath, '\x00')) {
 		return pluginConfig{}, fmt.Errorf("qoder_cli_path must be an absolute path")
+	}
+	if cfg.Transport == "direct_openai" && cfg.DirectEndpoint == "" {
+		return pluginConfig{}, fmt.Errorf("direct_endpoint is required when transport is direct_openai")
+	}
+	if cfg.DirectEndpoint != "" {
+		if errEndpoint := validateDirectURL(cfg.DirectEndpoint, "direct_endpoint"); errEndpoint != nil {
+			return pluginConfig{}, errEndpoint
+		}
+	}
+	if cfg.DirectModelsEndpoint != "" {
+		if errEndpoint := validateDirectURL(cfg.DirectModelsEndpoint, "direct_models_endpoint"); errEndpoint != nil {
+			return pluginConfig{}, errEndpoint
+		}
+	}
+	if cfg.DirectAuthEndpoint != "" {
+		if errEndpoint := validateDirectURL(cfg.DirectAuthEndpoint, "direct_auth_endpoint"); errEndpoint != nil {
+			return pluginConfig{}, errEndpoint
+		}
+	}
+	if cfg.DirectTokenMode == "pat_exchange" && cfg.DirectAuthEndpoint == "" {
+		return pluginConfig{}, fmt.Errorf("direct_auth_endpoint is required when direct_token_mode is pat_exchange")
+	}
+	if cfg.DirectModels != nil && len(cfg.DirectModels) > 256 {
+		return pluginConfig{}, fmt.Errorf("direct_models supports at most 256 entries")
+	}
+	seenDirectModels := make(map[string]struct{}, len(cfg.DirectModels))
+	for index := range cfg.DirectModels {
+		model := &cfg.DirectModels[index]
+		model.ID = strings.TrimSpace(model.ID)
+		model.DisplayName = strings.TrimSpace(model.DisplayName)
+		model.Description = strings.TrimSpace(model.Description)
+		if model.ID == "" || len(model.ID) > 512 || strings.ContainsAny(model.ID, "\\x00\\r\\n") {
+			return pluginConfig{}, fmt.Errorf("direct_models contains an invalid id")
+		}
+		if _, exists := seenDirectModels[model.ID]; exists {
+			return pluginConfig{}, fmt.Errorf("direct_models contains duplicate id %q", model.ID)
+		}
+		seenDirectModels[model.ID] = struct{}{}
+		if model.DisplayName == "" {
+			model.DisplayName = model.ID
+		}
+		if len(model.DisplayName) > 512 || len(model.Description) > 4096 {
+			return pluginConfig{}, fmt.Errorf("direct_models contains an oversized display name or description")
+		}
+		if model.MaxInputTokens < 0 || model.MaxOutputTokens < 0 || model.DefaultContextWindow < 0 {
+			return pluginConfig{}, fmt.Errorf("direct_models contains a negative token limit")
+		}
+		if len(model.ReasoningEfforts) > 16 {
+			return pluginConfig{}, fmt.Errorf("direct_models reasoning_efforts supports at most 16 entries")
+		}
+		for effortIndex := range model.ReasoningEfforts {
+			model.ReasoningEfforts[effortIndex] = strings.TrimSpace(model.ReasoningEfforts[effortIndex])
+			if model.ReasoningEfforts[effortIndex] == "" || len(model.ReasoningEfforts[effortIndex]) > 64 {
+				return pluginConfig{}, fmt.Errorf("direct_models contains an invalid reasoning effort")
+			}
+		}
+	}
+	if cfg.DirectModelsEndpoint == "" && len(cfg.DirectModels) == 0 && cfg.Transport == "direct_openai" {
+		return pluginConfig{}, fmt.Errorf("direct_models or direct_models_endpoint is required for direct_openai transport")
 	}
 	if cfg.WorkingDirectory == "" || !filepath.IsAbs(cfg.WorkingDirectory) {
 		return pluginConfig{}, fmt.Errorf("working_directory must be an absolute path")
@@ -167,6 +268,34 @@ func decodePluginConfig(raw []byte) (pluginConfig, error) {
 		cfg.MCPServers[name] = server
 	}
 	return cfg, nil
+}
+
+func validateDirectURL(raw, name string) error {
+	parsed, errParse := url.Parse(strings.TrimSpace(raw))
+	if errParse != nil || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return fmt.Errorf("%s must be an absolute URL without credentials, query, or fragment", name)
+	}
+	if parsed.Scheme == "https" {
+		return nil
+	}
+	if parsed.Scheme != "http" || !isLoopbackHost(parsed.Hostname()) {
+		return fmt.Errorf("%s must use HTTPS; plain HTTP is allowed only on loopback", name)
+	}
+	return nil
+}
+
+func directModelsJSON(models []directModelConfig) (string, error) {
+	if len(models) == 0 {
+		return "", nil
+	}
+	raw, errMarshal := json.Marshal(models)
+	if errMarshal != nil {
+		return "", fmt.Errorf("encode direct_models: %w", errMarshal)
+	}
+	if len(raw) > 128*1024 {
+		return "", fmt.Errorf("direct_models JSON exceeds the bounded 128KiB runner argument limit")
+	}
+	return string(raw), nil
 }
 
 var (

--- a/examples/plugin/qoder/go/executor.go
+++ b/examples/plugin/qoder/go/executor.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"strings"
 	"time"
@@ -93,6 +94,15 @@ func (r *pluginRuntime) startTurn(req pluginapi.ExecutorRequest) (*runnerSession
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), r.loadedConfig().RequestTimeout)
 	defer cancel()
+	transport := r.transportForAuth(auth)
+	var chatRequest map[string]any
+	if transport == "direct_openai" {
+		var errChatRequest error
+		chatRequest, errChatRequest = decodeChatRequestForRunner(req.Payload)
+		if errChatRequest != nil {
+			return nil, errChatRequest
+		}
+	}
 	session, errSession := r.acquireSession(ctx, req, auth)
 	if errSession != nil {
 		return nil, errSession
@@ -113,7 +123,8 @@ func (r *pluginRuntime) startTurn(req pluginapi.ExecutorRequest) (*runnerSession
 		"system_prompt":        input.SystemPrompt,
 		"content":              input.Content,
 		"model":                req.Model,
-		"auth":                 auth.runnerAuth(),
+		"auth":                 auth.runnerAuth(transport),
+		"transport":            transport,
 		"skills":               cfg.Skills,
 		"setting_sources":      cfg.SettingSources,
 		"allowed_tools":        cfg.AllowedTools,
@@ -124,12 +135,29 @@ func (r *pluginRuntime) startTurn(req pluginapi.ExecutorRequest) (*runnerSession
 			"rules":   cfg.PermissionRules,
 		},
 	}
+	if transport == "direct_openai" {
+		params["chat_request"] = chatRequest
+	}
 	if errCall := session.client.call(ctx, "start", params, nil); errCall != nil {
 		r.completeTurn(session, req.RequestID)
 		r.dropSession(session)
 		return nil, errCall
 	}
 	return session, nil
+}
+
+func decodeChatRequestForRunner(raw []byte) (map[string]any, error) {
+	if len(raw) == 0 || len(raw) > maxExecutorBodyBytes {
+		return nil, newPluginCallError("invalid_request", "Qoder Chat request is empty or exceeds the bounded body limit", http.StatusBadRequest, false)
+	}
+	var request map[string]any
+	if errDecode := json.Unmarshal(raw, &request); errDecode != nil || request == nil {
+		return nil, newPluginCallError("invalid_request", "Qoder Chat request must be a JSON object", http.StatusBadRequest, false)
+	}
+	if _, ok := request["messages"]; !ok {
+		return nil, newPluginCallError("invalid_request", "Qoder Chat request must contain messages", http.StatusBadRequest, false)
+	}
+	return request, nil
 }
 
 func (r *pluginRuntime) forwardEvents(session *runnerSession, req rpcExecutorRequest) {

--- a/examples/plugin/qoder/go/lifecycle.go
+++ b/examples/plugin/qoder/go/lifecycle.go
@@ -78,27 +78,46 @@ func (r *pluginRuntime) loadedConfig() pluginConfig {
 	return r.config
 }
 
-func (r *pluginRuntime) startRunner(ctx context.Context, auth qoderAuth) (*runnerClient, error) {
+func (r *pluginRuntime) startRunner(ctx context.Context, auth qoderAuth, requestedTransport ...string) (*runnerClient, error) {
 	cfg := r.loadedConfig()
-	if cfg.QoderCLIPath == "" {
+	transport := r.transportForAuth(auth, requestedTransport...)
+	if transport == "sdk_cli" && cfg.QoderCLIPath == "" {
 		return nil, newPluginCallError("cli_path_required", "qoder_cli_path must explicitly select an external Qoder CLI", http.StatusServiceUnavailable, false)
+	}
+	if transport == "direct_openai" && cfg.DirectEndpoint == "" {
+		return nil, newPluginCallError("direct_endpoint_required", "direct_endpoint is required for direct_openai transport", http.StatusServiceUnavailable, false)
 	}
 	r.mu.Lock()
 	extra := cloneStringMap(r.runnerExtraEnv)
 	r.mu.Unlock()
-	client, errStart := newRunnerClient(cfg, auth, extra)
+	client, errStart := newRunnerClient(cfg, auth, extra, transport)
 	if errStart != nil {
 		return nil, errStart
 	}
-	if _, errHandshake := client.handshake(ctx); errHandshake != nil {
+	if _, errHandshake := client.handshake(ctx, transport); errHandshake != nil {
 		client.shutdown()
 		return nil, errHandshake
 	}
 	return client, nil
 }
 
+func (r *pluginRuntime) transportForAuth(auth qoderAuth, requestedTransport ...string) string {
+	if len(requestedTransport) > 0 && strings.TrimSpace(requestedTransport[0]) != "" {
+		return strings.ToLower(strings.TrimSpace(requestedTransport[0]))
+	}
+	if auth.Transport != "" {
+		return auth.Transport
+	}
+	cfg := r.loadedConfig()
+	if cfg.Transport == "" {
+		return "sdk_cli"
+	}
+	return cfg.Transport
+}
+
 func (r *pluginRuntime) acquireSession(ctx context.Context, req pluginapi.ExecutorRequest, auth qoderAuth) (*runnerSession, error) {
-	key := executionSessionKey(req, auth)
+	transport := r.transportForAuth(auth)
+	key := executionSessionKey(req, auth, transport)
 	r.mu.Lock()
 	if !r.accepting {
 		r.mu.Unlock()
@@ -123,7 +142,7 @@ func (r *pluginRuntime) acquireSession(ctx context.Context, req pluginapi.Execut
 	}
 	r.mu.Unlock()
 
-	client, errStart := r.startRunner(ctx, auth)
+	client, errStart := r.startRunner(ctx, auth, transport)
 	if errStart != nil {
 		return nil, errStart
 	}
@@ -253,7 +272,7 @@ func closeMatches(session *runnerSession, req pluginapi.CloseExecutionSessionReq
 func (r *pluginRuntime) readiness(req pluginapi.ReadinessRequest) pluginapi.ReadinessResponse {
 	cfg := r.loadedConfig()
 	checks := []pluginapi.ReadinessCheck{{Level: pluginapi.ReadinessLevelPluginInstalled, State: pluginapi.ReadinessStateReady, Version: pluginVersion}}
-	if cfg.QoderCLIPath == "" {
+	if cfg.QoderCLIPath == "" && readinessTransport(cfg, req) == "sdk_cli" {
 		checks = append(checks,
 			pluginapi.ReadinessCheck{Level: pluginapi.ReadinessLevelRunnerInstalled, State: pluginapi.ReadinessStateUnknown, Message: "runner command is configured but was not started"},
 			pluginapi.ReadinessCheck{Level: pluginapi.ReadinessLevelProtocolReady, State: pluginapi.ReadinessStateNotReady, Message: "qoder_cli_path is required"},
@@ -262,6 +281,20 @@ func (r *pluginRuntime) readiness(req pluginapi.ReadinessRequest) pluginapi.Read
 		return pluginapi.ReadinessResponse{Provider: pluginIdentifier, Ready: false, Generation: pluginVersion, Checks: checks}
 	}
 	if len(req.StorageJSON) == 0 {
+		if cfg.Transport == "direct_openai" {
+			protocolState := pluginapi.ReadinessStateReady
+			protocolMessage := "direct endpoint configuration is present; selected auth is required for remote checks"
+			if cfg.DirectEndpoint == "" {
+				protocolState = pluginapi.ReadinessStateNotReady
+				protocolMessage = "direct_endpoint is required for direct_openai"
+			}
+			checks = append(checks,
+				pluginapi.ReadinessCheck{Level: pluginapi.ReadinessLevelRunnerInstalled, State: pluginapi.ReadinessStateReady, Version: "direct-openai"},
+				pluginapi.ReadinessCheck{Level: pluginapi.ReadinessLevelProtocolReady, State: protocolState, Message: protocolMessage},
+				pluginapi.ReadinessCheck{Level: pluginapi.ReadinessLevelAuthReady, State: pluginapi.ReadinessStateUnknown, Message: "selected credential was not supplied"},
+			)
+			return pluginapi.ReadinessResponse{Provider: pluginIdentifier, Ready: req.Purpose != pluginapi.ReadinessPurposeAdmission && protocolState == pluginapi.ReadinessStateReady, Generation: pluginVersion, Capabilities: []string{"chat_completions", "stream", "direct_openai"}, Checks: checks}
+		}
 		checks = append(checks,
 			pluginapi.ReadinessCheck{Level: pluginapi.ReadinessLevelRunnerInstalled, State: pluginapi.ReadinessStateReady, Message: "runner command and explicit CLI path are configured"},
 			pluginapi.ReadinessCheck{Level: pluginapi.ReadinessLevelProtocolReady, State: pluginapi.ReadinessStateUnknown, Message: "runner handshake requires a selected auth-local process"},
@@ -280,7 +313,8 @@ func (r *pluginRuntime) readiness(req pluginapi.ReadinessRequest) pluginapi.Read
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.RequestTimeout)
 	defer cancel()
-	client, errStart := r.startRunner(ctx, auth)
+	transport := r.transportForAuth(auth)
+	client, errStart := r.startRunner(ctx, auth, transport)
 	if errStart != nil {
 		checks = append(checks,
 			pluginapi.ReadinessCheck{Level: pluginapi.ReadinessLevelRunnerInstalled, State: pluginapi.ReadinessStateNotReady, Message: "Qoder runner could not be started"},
@@ -291,7 +325,7 @@ func (r *pluginRuntime) readiness(req pluginapi.ReadinessRequest) pluginapi.Read
 	}
 	defer client.shutdown()
 	var state runnerReadiness
-	errProbe := client.call(ctx, "readiness", map[string]any{"auth": auth.runnerAuth()}, &state)
+	errProbe := client.call(ctx, "readiness", map[string]any{"auth": auth.runnerAuth(transport)}, &state)
 	if errProbe != nil {
 		checks = append(checks,
 			pluginapi.ReadinessCheck{Level: pluginapi.ReadinessLevelRunnerInstalled, State: pluginapi.ReadinessStateReady},
@@ -301,11 +335,29 @@ func (r *pluginRuntime) readiness(req pluginapi.ReadinessRequest) pluginapi.Read
 		return pluginapi.ReadinessResponse{Provider: pluginIdentifier, Ready: false, Generation: pluginVersion, Checks: checks}
 	}
 	checks = append(checks, state.Checks...)
-	checks = append(checks, pluginapi.ReadinessCheck{Level: pluginapi.ReadinessLevelSessionReady, State: pluginapi.ReadinessStateUnknown, Message: "session is created by executor start"})
+	capabilities := []string{"chat_completions", "stream", "sessions", "cancel", "close", "fixed_permissions"}
+	if transport == "direct_openai" {
+		capabilities = []string{"chat_completions", "stream", "cancel", "close", "direct_openai", "client_tools"}
+	} else {
+		checks = append(checks, pluginapi.ReadinessCheck{Level: pluginapi.ReadinessLevelSessionReady, State: pluginapi.ReadinessStateUnknown, Message: "session is created by executor start"})
+	}
 	return pluginapi.ReadinessResponse{
 		Provider: pluginIdentifier, Ready: state.Ready, Generation: pluginVersion,
-		Capabilities: []string{"chat_completions", "stream", "sessions", "cancel", "close", "fixed_permissions"}, Checks: checks,
+		Capabilities: capabilities, Checks: checks,
 	}
+}
+
+func readinessTransport(cfg pluginConfig, req pluginapi.ReadinessRequest) string {
+	if len(req.StorageJSON) > 0 {
+		var auth qoderAuth
+		if json.Unmarshal(req.StorageJSON, &auth) == nil && strings.EqualFold(strings.TrimSpace(auth.Transport), "direct_openai") {
+			return "direct_openai"
+		}
+	}
+	if cfg.Transport == "direct_openai" {
+		return "direct_openai"
+	}
+	return "sdk_cli"
 }
 
 func (r *pluginRuntime) quiesce() {
@@ -344,10 +396,17 @@ func effectiveExecutionSessionID(req pluginapi.ExecutorRequest) string {
 	return "request-" + strings.TrimSpace(req.RequestID)
 }
 
-func executionSessionKey(req pluginapi.ExecutorRequest, auth qoderAuth) string {
+func executionSessionKey(req pluginapi.ExecutorRequest, auth qoderAuth, requestedTransport ...string) string {
+	transport := auth.Transport
+	if len(requestedTransport) > 0 && strings.TrimSpace(requestedTransport[0]) != "" {
+		transport = strings.ToLower(strings.TrimSpace(requestedTransport[0]))
+	}
+	if transport == "" {
+		transport = "sdk_cli"
+	}
 	return sessionDigest([]string{
 		pluginIdentifier, strings.TrimSpace(req.AuthID), strings.TrimSpace(req.AuthIndex), effectiveExecutionSessionID(req),
-		strings.TrimSpace(req.CallerScope), strings.TrimSpace(req.WorkspaceIdentity), auth.AuthMode, auth.AccountID, auth.ProfileID, auth.ConfigDir,
+		strings.TrimSpace(req.CallerScope), strings.TrimSpace(req.WorkspaceIdentity), auth.AuthMode, transport, auth.AccountID, auth.ProfileID, auth.ConfigDir,
 	})
 }
 

--- a/examples/plugin/qoder/go/main.go
+++ b/examples/plugin/qoder/go/main.go
@@ -193,7 +193,12 @@ func (r *pluginRuntime) dispatch(method string, raw []byte) ([]byte, error) {
 		}
 		return okEnvelope(resp)
 	case pluginabi.MethodModelStatic:
-		return okEnvelope(pluginapi.ModelResponse{Provider: pluginIdentifier, Models: canonicalQoderModels()})
+		models := canonicalQoderModels()
+		cfg := r.loadedConfig()
+		if cfg.Transport == "direct_openai" && len(cfg.DirectModels) > 0 {
+			models = configuredDirectModels(cfg.DirectModels)
+		}
+		return okEnvelope(pluginapi.ModelResponse{Provider: pluginIdentifier, Models: models})
 	case pluginabi.MethodModelForAuth:
 		resp, errModels := r.modelsForAuth(raw)
 		if errModels != nil {
@@ -252,9 +257,15 @@ func pluginRegistration() registration {
 			Name: pluginName, Version: pluginVersion, Author: "BlueSkyXN",
 			GitHubRepository: "https://github.com/BlueSkyXN/CPA-Core-LTS",
 			ConfigFields: []pluginapi.ConfigField{
+				{Name: "transport", Type: pluginapi.ConfigFieldTypeEnum, EnumValues: []string{"sdk_cli", "direct_openai"}, Description: "Default Qoder transport; an auth file may explicitly select a transport. No request-side transport override is accepted."},
 				{Name: "runner_command", Type: pluginapi.ConfigFieldTypeString, Description: "Explicit cpa-qoder-runner executable or absolute path."},
 				{Name: "runner_args", Type: pluginapi.ConfigFieldTypeArray, Description: "Fixed runner arguments; model requests cannot override them."},
 				{Name: "qoder_cli_path", Type: pluginapi.ConfigFieldTypeString, Description: "Required external Qoder CLI absolute path. SDK bundled CLI fallback is disabled."},
+				{Name: "direct_endpoint", Type: pluginapi.ConfigFieldTypeString, Description: "Explicit HTTPS OpenAI-compatible Qoder endpoint for direct_openai; loopback HTTP is allowed only for local tests."},
+				{Name: "direct_models_endpoint", Type: pluginapi.ConfigFieldTypeString, Description: "Optional OpenAI-compatible model catalog endpoint for direct_openai; otherwise direct_models must be configured."},
+				{Name: "direct_auth_endpoint", Type: pluginapi.ConfigFieldTypeString, Description: "Optional Qoder OpenAPI base used for PAT-to-job-token exchange; never put a token in this URL."},
+				{Name: "direct_token_mode", Type: pluginapi.ConfigFieldTypeEnum, EnumValues: []string{"auto", "bearer", "pat_exchange"}, Description: "Direct credential interpretation: auto detects pt- PATs, bearer uses the supplied access token, pat_exchange exchanges a PAT before inference."},
+				{Name: "direct_models", Type: pluginapi.ConfigFieldTypeArray, Description: "Optional administrator-supplied exact direct model records; no guessed aliases or silent auto fallback."},
 				{Name: "working_directory", Type: pluginapi.ConfigFieldTypeString, Description: "Fixed runner workspace root."},
 				{Name: "max_queue_frames", Type: pluginapi.ConfigFieldTypeInteger, Description: "Bounded runner event queue capacity."},
 				{Name: "request_timeout", Type: pluginapi.ConfigFieldTypeString, Description: "Runner control request timeout."},

--- a/examples/plugin/qoder/go/models.go
+++ b/examples/plugin/qoder/go/models.go
@@ -84,6 +84,34 @@ func canonicalQoderModels() []pluginapi.ModelInfo {
 	return models
 }
 
+func configuredDirectModels(models []directModelConfig) []pluginapi.ModelInfo {
+	result := make([]pluginapi.ModelInfo, 0, len(models))
+	for _, model := range models {
+		inputModalities := []string{"text"}
+		if model.IsVL {
+			inputModalities = append(inputModalities, "image")
+		}
+		var thinking *pluginapi.ThinkingSupport
+		if model.IsReasoning || len(model.ReasoningEfforts) > 0 || model.SupportsDisabled {
+			thinking = &pluginapi.ThinkingSupport{Levels: append([]string(nil), model.ReasoningEfforts...), ZeroAllowed: model.SupportsDisabled}
+		}
+		contextLength := model.MaxInputTokens
+		for _, value := range model.AvailableContextWindows {
+			if value > contextLength {
+				contextLength = value
+			}
+		}
+		result = append(result, pluginapi.ModelInfo{
+			ID: model.ID, Name: model.ID, DisplayName: model.DisplayName, Description: model.Description,
+			Object: "model", OwnedBy: pluginIdentifier, Type: "agent", InputTokenLimit: model.MaxInputTokens,
+			OutputTokenLimit: model.MaxOutputTokens, ContextLength: contextLength, MaxCompletionTokens: model.MaxOutputTokens,
+			SupportedGenerationMethods: []string{"chat"}, SupportedInputModalities: inputModalities,
+			SupportedOutputModalities: []string{"text"}, Thinking: thinking, UserDefined: true,
+		})
+	}
+	return result
+}
+
 func (r *pluginRuntime) modelsForAuth(raw []byte) (pluginapi.ModelResponse, error) {
 	var req rpcAuthModelRequest
 	if errDecode := decodeRequest(raw, &req); errDecode != nil {
@@ -93,7 +121,8 @@ func (r *pluginRuntime) modelsForAuth(raw []byte) (pluginapi.ModelResponse, erro
 	if errAuth != nil {
 		return pluginapi.ModelResponse{}, newPluginCallError("invalid_auth", errAuth.Error(), http.StatusBadRequest, false)
 	}
-	cacheKey := authCacheKey(req.AuthID, req.AuthProvider, auth)
+	transport := r.transportForAuth(auth)
+	cacheKey := authCacheKey(req.AuthID, req.AuthProvider, auth, transport)
 	r.mu.Lock()
 	cached, ok := r.modelCache[cacheKey]
 	r.mu.Unlock()
@@ -104,14 +133,19 @@ func (r *pluginRuntime) modelsForAuth(raw []byte) (pluginapi.ModelResponse, erro
 	cfg := r.loadedConfig()
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.RequestTimeout)
 	defer cancel()
-	client, errStart := r.startRunner(ctx, auth)
+	client, errStart := r.startRunner(ctx, auth, transport)
 	if errStart != nil {
 		return pluginapi.ModelResponse{}, errStart
 	}
 	defer client.shutdown()
 	var result runnerModelsResponse
+	directModels, errDirectModels := directModelsJSON(cfg.DirectModels)
+	if errDirectModels != nil {
+		return pluginapi.ModelResponse{}, newPluginCallError("invalid_config", errDirectModels.Error(), http.StatusInternalServerError, false)
+	}
 	if errCall := client.call(ctx, "models", map[string]any{
-		"auth": auth.runnerAuth(), "cache_ttl_ms": cfg.ModelCacheTTL.Milliseconds(),
+		"auth": auth.runnerAuth(transport), "cache_ttl_ms": cfg.ModelCacheTTL.Milliseconds(),
+		"models_endpoint": cfg.DirectModelsEndpoint, "models_json": directModels,
 	}, &result); errCall != nil {
 		return pluginapi.ModelResponse{}, errCall
 	}
@@ -166,15 +200,26 @@ func qoderModelInfo(model runnerModel) pluginapi.ModelInfo {
 	}
 }
 
-func (auth qoderAuth) runnerAuth() map[string]any {
-	if auth.AuthMode == "pat" {
-		return map[string]any{"mode": "pat", "env_var": runnerPATEnv, "account_id": auth.AccountID}
+func (auth qoderAuth) runnerAuth(requestedTransport ...string) map[string]any {
+	transport := auth.Transport
+	if len(requestedTransport) > 0 && strings.TrimSpace(requestedTransport[0]) != "" {
+		transport = strings.ToLower(strings.TrimSpace(requestedTransport[0]))
 	}
-	return map[string]any{"mode": "local_cli", "profile_id": auth.ProfileID}
+	if auth.AuthMode == "pat" {
+		return map[string]any{"mode": "pat", "env_var": runnerPATEnv, "account_id": auth.AccountID, "transport": transport}
+	}
+	return map[string]any{"mode": "local_cli", "profile_id": auth.ProfileID, "transport": transport}
 }
 
-func authCacheKey(authID, provider string, auth qoderAuth) string {
-	return sessionDigest([]string{"qoder-models", strings.TrimSpace(provider), strings.TrimSpace(authID), auth.AuthMode, auth.AccountID, auth.ProfileID, auth.ConfigDir})
+func authCacheKey(authID, provider string, auth qoderAuth, requestedTransport ...string) string {
+	transport := auth.Transport
+	if len(requestedTransport) > 0 && strings.TrimSpace(requestedTransport[0]) != "" {
+		transport = strings.ToLower(strings.TrimSpace(requestedTransport[0]))
+	}
+	if transport == "" {
+		transport = "sdk_cli"
+	}
+	return sessionDigest([]string{"qoder-models", strings.TrimSpace(provider), strings.TrimSpace(authID), auth.AuthMode, transport, auth.AccountID, auth.ProfileID, auth.ConfigDir})
 }
 
 func cloneModels(input []pluginapi.ModelInfo) []pluginapi.ModelInfo {

--- a/examples/plugin/qoder/go/plugin_test.go
+++ b/examples/plugin/qoder/go/plugin_test.go
@@ -27,6 +27,13 @@ func TestAuthModesAndSecretSafeErrors(t *testing.T) {
 	if errLocal != nil || local.ProfileID != "cn-main" || local.ConfigDir != "/tmp/qoder-cn" {
 		t.Fatalf("parse local = %#v, %v", local, errLocal)
 	}
+	direct, errDirect := parseStoredAuth([]byte(`{"type":"qoder","auth_mode":"pat","transport":"direct_openai","access_token":"jt-fixture"}`))
+	if errDirect != nil || direct.Transport != "direct_openai" || direct.AuthMode != "pat" {
+		t.Fatalf("parse direct = %#v, %v", direct, errDirect)
+	}
+	if _, errLocalDirect := parseStoredAuth([]byte(`{"type":"qoder","auth_mode":"local_cli","transport":"direct_openai","profile_id":"cn-main","config_dir":"/tmp/qoder-cn"}`)); errLocalDirect == nil {
+		t.Fatal("local_cli direct transport was accepted")
+	}
 	if _, errWhitespace := parseStoredAuth([]byte(`{"type":"qoder","auth_mode":"pat","access_token":" bad "}`)); errWhitespace == nil {
 		t.Fatal("PAT with surrounding whitespace was accepted")
 	}
@@ -164,6 +171,35 @@ disallowed_tools: [Bash]
 	if errOverlap == nil {
 		t.Fatal("overlapping tool policy was accepted")
 	}
+	direct, errDirect := decodePluginConfig([]byte(`
+transport: direct_openai
+runner_command: /usr/local/bin/cpa-qoder-runner
+working_directory: /tmp
+direct_endpoint: https://api2-v2.example.test/model/v1/chat/completions
+direct_auth_endpoint: https://openapi.example.test
+direct_models:
+  - id: qfmodel
+    display_name: Qwen3.8-Flash
+`))
+	if errDirect != nil || direct.Transport != "direct_openai" || len(direct.DirectModels) != 1 {
+		t.Fatalf("direct config = %#v, %v", direct, errDirect)
+	}
+	if _, errNoModels := decodePluginConfig([]byte(`
+transport: direct_openai
+runner_command: /usr/local/bin/cpa-qoder-runner
+working_directory: /tmp
+direct_endpoint: https://api2-v2.example.test/model/v1/chat/completions
+`)); errNoModels == nil {
+		t.Fatal("direct config without model source was accepted")
+	}
+	if _, errOwnedArg := decodePluginConfig([]byte(`
+runner_command: /usr/local/bin/cpa-qoder-runner
+qoder_cli_path: /usr/local/bin/qoderclicn
+working_directory: /tmp
+runner_args: [--transport=direct_openai]
+`)); errOwnedArg == nil {
+		t.Fatal("runner_args overrode transport")
+	}
 }
 
 func TestRunnerCapabilityValidationErrorsRemainClientErrors(t *testing.T) {
@@ -215,6 +251,9 @@ func TestSessionKeyIncludesAllOwnershipDimensions(t *testing.T) {
 		if got := executionSessionKey(candidate, auth); got == want {
 			t.Fatalf("mutation %d did not change session key", index)
 		}
+	}
+	if executionSessionKey(base, auth, "direct_openai") == want {
+		t.Fatal("transport mutation did not change session key")
 	}
 }
 
@@ -368,6 +407,55 @@ func TestProjectionDoesNotExposeRunnerExecutedToolsAsClientToolCalls(t *testing.
 	}
 }
 
+func TestProjectionPreservesDirectClientToolCalls(t *testing.T) {
+	now := time.Now().UTC()
+	events := []pluginapi.AgentEventV1{
+		testAgentEvent(1, pluginapi.AgentEventToolStarted, map[string]any{"index": 0, "tool_call_id": "call-1", "name": "probe"}, now),
+		testAgentEvent(2, pluginapi.AgentEventToolUpdated, map[string]any{"index": 0, "partial_json": `{"x":`}, now),
+		testAgentEvent(3, pluginapi.AgentEventToolUpdated, map[string]any{"index": 0, "partial_json": `1}`}, now),
+		testAgentEvent(4, pluginapi.AgentEventTurnCompleted, pluginapi.AgentTerminalPayloadV1{State: pluginapi.AgentTerminalCompleted}, now),
+	}
+	projection := newEventProjection("request-1", "qfmodel")
+	var chunks [][]byte
+	for _, event := range events {
+		chunk, _, errChunk := projection.streamChunk(event)
+		if errChunk != nil {
+			t.Fatal(errChunk)
+		}
+		if len(chunk) > 0 {
+			chunks = append(chunks, chunk)
+		}
+	}
+	if len(chunks) != 4 {
+		t.Fatalf("direct tool chunks = %d, want 4", len(chunks))
+	}
+	if !bytes.Contains(bytes.Join(chunks, nil), []byte(`"tool_calls"`)) || !bytes.Contains(bytes.Join(chunks, nil), []byte(`"arguments":"1}"`)) {
+		t.Fatalf("direct tool call was not projected: %q", chunks)
+	}
+	response, errResponse := projection.nonStreamResponse()
+	if errResponse != nil {
+		t.Fatal(errResponse)
+	}
+	if !bytes.Contains(response.Payload, []byte(`"finish_reason":"tool_calls"`)) || !bytes.Contains(response.Payload, []byte(`"name":"probe"`)) {
+		t.Fatalf("non-stream direct tool call = %s", response.Payload)
+	}
+}
+
+func TestProjectionPreservesDirectTerminalErrorClassification(t *testing.T) {
+	now := time.Now().UTC()
+	projection := newEventProjection("request-1", "qfmodel")
+	_, _, errChunk := projection.streamChunk(testAgentEvent(1, pluginapi.AgentEventTurnFailed, pluginapi.AgentTerminalPayloadV1{
+		State: pluginapi.AgentTerminalFailed, Code: "quota_or_rate_limit", Message: "rate limited", Retryable: true,
+	}, now))
+	if errChunk == nil {
+		t.Fatal("direct terminal error was accepted as a successful stream")
+	}
+	callErr, ok := errChunk.(*pluginCallError)
+	if !ok || callErr.code != "quota_or_rate_limit" || callErr.statusCode != http.StatusTooManyRequests || !callErr.retryable {
+		t.Fatalf("terminal error = %#v, want typed 429 retryable error", errChunk)
+	}
+}
+
 func TestFakeRunnerProtocolModelsCancelCloseAndSecretIsolation(t *testing.T) {
 	cfg := fakeRunnerConfig(t)
 	auth := qoderAuth{Type: "qoder", AuthMode: "pat", AccountID: "acct", AccessToken: "pt-test-secret"}
@@ -441,6 +529,32 @@ func TestRunnerVersionMismatchAndBoundedEventQueue(t *testing.T) {
 		t.Fatal("runner queue overflow did not terminate client")
 	}
 	flood.shutdown()
+}
+
+func TestDirectTransportNegotiatesWithRunner(t *testing.T) {
+	cfg := fakeRunnerConfig(t)
+	cfg.DirectEndpoint = "https://api2-v2.example.test/model/v1/chat/completions"
+	cfg.DirectModels = []directModelConfig{{ID: "qfmodel", DisplayName: "Qwen3.8-Flash"}}
+	auth := qoderAuth{Type: "qoder", AuthMode: "pat", Transport: "direct_openai", AccessToken: "jt-fixture"}
+	client, errStart := newRunnerClient(cfg, auth, map[string]string{
+		"GO_WANT_QODER_FAKE_RUNNER": "1", "QODER_FAKE_MODE": "success", "QODER_FAKE_TRANSPORT": "direct_openai",
+	}, "direct_openai")
+	if errStart != nil {
+		t.Fatal(errStart)
+	}
+	defer client.shutdown()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, errHandshake := client.handshake(ctx, "direct_openai"); errHandshake != nil {
+		t.Fatal(errHandshake)
+	}
+	start := fakeStartParams()
+	start["auth"] = auth.runnerAuth("direct_openai")
+	start["transport"] = "direct_openai"
+	start["chat_request"] = map[string]any{"model": "qfmodel", "messages": []any{map[string]any{"role": "user", "content": "hello"}}}
+	if errCall := client.call(ctx, "start", start, nil); errCall != nil {
+		t.Fatal(errCall)
+	}
 }
 
 func TestRunnerExitTakesPriorityOverBufferedEvents(t *testing.T) {
@@ -658,7 +772,8 @@ func TestQoderFakeRunnerProcess(t *testing.T) {
 			if mode == "version-mismatch" {
 				version = 2
 			}
-			result = map[string]any{"runner": "cpa-qoder-runner", "runner_version": "0.1.0-test", "protocol_version": version, "sdk_version": "1.0.10"}
+			transport := os.Getenv("QODER_FAKE_TRANSPORT")
+			result = map[string]any{"runner": "cpa-qoder-runner", "runner_version": "0.1.0-test", "protocol_version": version, "sdk_version": "1.0.10", "transport": transport}
 		case "models":
 			result = map[string]any{"models": []any{map[string]any{"id": "qfmodel", "display_name": "Qwen3.8-Flash", "is_enabled": true}}}
 		case "readiness":

--- a/examples/plugin/qoder/go/projection.go
+++ b/examples/plugin/qoder/go/projection.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -18,10 +19,18 @@ type eventProjection struct {
 	text      strings.Builder
 	usage     pluginapi.AgentUsageV1
 	terminal  *pluginapi.AgentTerminalPayloadV1
+	toolCalls map[int]*projectedToolCall
+}
+
+type projectedToolCall struct {
+	Index     int
+	ID        string
+	Name      string
+	Arguments strings.Builder
 }
 
 func newEventProjection(requestID, model string) *eventProjection {
-	return &eventProjection{requestID: requestID, model: model, created: time.Now().Unix()}
+	return &eventProjection{requestID: requestID, model: model, created: time.Now().Unix(), toolCalls: make(map[int]*projectedToolCall)}
 }
 
 func (p *eventProjection) consume(event pluginapi.AgentEventV1) error {
@@ -43,6 +52,10 @@ func (p *eventProjection) consume(event pluginapi.AgentEventV1) error {
 		if errDecode := json.Unmarshal(event.Payload, &p.usage); errDecode != nil {
 			return fmt.Errorf("invalid Qoder usage event")
 		}
+	case pluginapi.AgentEventToolStarted:
+		p.consumeToolStarted(event.Payload)
+	case pluginapi.AgentEventToolUpdated:
+		p.consumeToolUpdated(event.Payload)
 	case pluginapi.AgentEventTurnCompleted, pluginapi.AgentEventTurnFailed, pluginapi.AgentEventTurnCancelled, pluginapi.AgentEventSessionClosed:
 		var terminal pluginapi.AgentTerminalPayloadV1
 		if errDecode := json.Unmarshal(event.Payload, &terminal); errDecode != nil {
@@ -58,17 +71,7 @@ func (p *eventProjection) nonStreamResponse() (pluginapi.ExecutorResponse, error
 		return pluginapi.ExecutorResponse{}, newPluginCallError("runner_lost", "Qoder runner ended without a terminal event", http.StatusBadGateway, true)
 	}
 	if p.terminal.State != pluginapi.AgentTerminalCompleted {
-		message := strings.TrimSpace(p.terminal.Message)
-		if message == "" {
-			message = "Qoder turn did not complete"
-		}
-		status := http.StatusBadGateway
-		if p.terminal.State == pluginapi.AgentTerminalCancelled {
-			status = 499
-		} else if p.terminal.State == pluginapi.AgentTerminalPermissionDenied || p.terminal.State == pluginapi.AgentTerminalPermissionUnsupported {
-			status = http.StatusForbidden
-		}
-		return pluginapi.ExecutorResponse{}, newPluginCallError(string(p.terminal.State), message, status, p.terminal.Retryable)
+		return pluginapi.ExecutorResponse{}, p.terminalError()
 	}
 	body := map[string]any{
 		"id":      "chatcmpl-" + p.requestID,
@@ -80,6 +83,11 @@ func (p *eventProjection) nonStreamResponse() (pluginapi.ExecutorResponse, error
 			"message":       map[string]any{"role": "assistant", "content": p.text.String()},
 			"finish_reason": "stop",
 		}},
+	}
+	if tools := p.toolCallPayload(); len(tools) > 0 {
+		choice := body["choices"].([]any)[0].(map[string]any)
+		choice["message"] = map[string]any{"role": "assistant", "content": nil, "tool_calls": tools}
+		choice["finish_reason"] = "tool_calls"
 	}
 	if usage := chatUsage(p.usage); usage != nil {
 		body["usage"] = usage
@@ -104,12 +112,131 @@ func (p *eventProjection) streamChunk(event pluginapi.AgentEventV1) ([]byte, boo
 		var payload pluginapi.AgentTextDeltaV1
 		_ = json.Unmarshal(event.Payload, &payload)
 		return chatChunk(p.requestID, p.model, p.created, map[string]any{"content": payload.Text}, nil, nil), false, nil
+	case pluginapi.AgentEventToolStarted:
+		if tool := p.latestTool(event.Payload); tool != nil {
+			return chatChunk(p.requestID, p.model, p.created, map[string]any{"tool_calls": []any{map[string]any{
+				"index": tool.Index, "id": tool.ID, "type": "function", "function": map[string]any{"name": tool.Name, "arguments": ""},
+			}}}, nil, nil), false, nil
+		}
+	case pluginapi.AgentEventToolUpdated:
+		var payload struct {
+			Index       int    `json:"index"`
+			PartialJSON string `json:"partial_json"`
+		}
+		if json.Unmarshal(event.Payload, &payload) == nil && p.toolCalls[payload.Index] != nil {
+			return chatChunk(p.requestID, p.model, p.created, map[string]any{"tool_calls": []any{map[string]any{
+				"index": payload.Index, "function": map[string]any{"arguments": payload.PartialJSON},
+			}}}, nil, nil), false, nil
+		}
 	case pluginapi.AgentEventTurnCompleted:
-		return chatChunk(p.requestID, p.model, p.created, map[string]any{}, "stop", chatUsage(p.usage)), true, nil
+		finishReason := any("stop")
+		if len(p.toolCalls) > 0 {
+			finishReason = "tool_calls"
+		}
+		return chatChunk(p.requestID, p.model, p.created, map[string]any{}, finishReason, chatUsage(p.usage)), true, nil
 	case pluginapi.AgentEventTurnFailed, pluginapi.AgentEventTurnCancelled, pluginapi.AgentEventSessionClosed:
-		return nil, true, newPluginCallError(string(p.terminal.State), "Qoder stream did not complete", http.StatusBadGateway, p.terminal.Retryable)
+		return nil, true, p.terminalError()
 	}
 	return nil, false, nil
+}
+
+func (p *eventProjection) terminalError() error {
+	if p.terminal == nil {
+		return newPluginCallError("runner_lost", "Qoder turn did not produce a terminal result", http.StatusBadGateway, true)
+	}
+	code := strings.TrimSpace(p.terminal.Code)
+	if code == "" {
+		code = string(p.terminal.State)
+	}
+	message := strings.TrimSpace(p.terminal.Message)
+	if message == "" {
+		message = "Qoder turn did not complete"
+	}
+	status := http.StatusBadGateway
+	switch code {
+	case "auth_expired", "direct_auth_failed", "direct_auth_invalid":
+		status = http.StatusUnauthorized
+	case "direct_invalid_request", "direct_request_missing", "direct_request_too_large", "unsupported_model":
+		status = http.StatusBadRequest
+	case "quota_or_rate_limit":
+		status = http.StatusTooManyRequests
+	case "direct_timeout":
+		status = http.StatusGatewayTimeout
+	case "request_cancelled":
+		status = 499
+	}
+	if p.terminal.State == pluginapi.AgentTerminalCancelled {
+		status = 499
+	} else if p.terminal.State == pluginapi.AgentTerminalPermissionDenied || p.terminal.State == pluginapi.AgentTerminalPermissionUnsupported {
+		status = http.StatusForbidden
+	}
+	return newPluginCallError(code, message, status, p.terminal.Retryable)
+}
+
+func (p *eventProjection) consumeToolStarted(raw []byte) {
+	var payload struct {
+		Index      *int   `json:"index"`
+		ToolCallID string `json:"tool_call_id"`
+		Name       string `json:"name"`
+	}
+	if json.Unmarshal(raw, &payload) != nil || payload.Index == nil {
+		// Native Qoder tools are intentionally not projected as client-owned
+		// calls. Direct transport tool events always carry an index.
+		return
+	}
+	index := *payload.Index
+	tool := p.toolCalls[index]
+	if tool == nil {
+		tool = &projectedToolCall{Index: index}
+		p.toolCalls[index] = tool
+	}
+	tool.ID = payload.ToolCallID
+	tool.Name = payload.Name
+}
+
+func (p *eventProjection) consumeToolUpdated(raw []byte) {
+	var payload struct {
+		Index       int    `json:"index"`
+		PartialJSON string `json:"partial_json"`
+	}
+	if json.Unmarshal(raw, &payload) != nil {
+		return
+	}
+	if tool := p.toolCalls[payload.Index]; tool != nil {
+		tool.Arguments.WriteString(payload.PartialJSON)
+	}
+}
+
+func (p *eventProjection) latestTool(raw []byte) *projectedToolCall {
+	var payload struct {
+		Index *int `json:"index"`
+	}
+	if json.Unmarshal(raw, &payload) != nil || payload.Index == nil {
+		return nil
+	}
+	return p.toolCalls[*payload.Index]
+}
+
+func (p *eventProjection) toolCallPayload() []any {
+	if len(p.toolCalls) == 0 {
+		return nil
+	}
+	indexes := make([]int, 0, len(p.toolCalls))
+	for index := range p.toolCalls {
+		indexes = append(indexes, index)
+	}
+	sort.Ints(indexes)
+	result := make([]any, 0, len(indexes))
+	for _, index := range indexes {
+		tool := p.toolCalls[index]
+		result = append(result, map[string]any{
+			"index":    tool.Index,
+			"id":       tool.ID,
+			"type":     "function",
+			"function": map[string]any{"name": tool.Name, "arguments": tool.Arguments.String()},
+		})
+	}
+	return result
 }
 
 func chatChunk(requestID, model string, created int64, delta map[string]any, finishReason any, usage map[string]any) []byte {

--- a/examples/plugin/qoder/go/runner_client.go
+++ b/examples/plugin/qoder/go/runner_client.go
@@ -59,6 +59,7 @@ type runnerHandshake struct {
 	RunnerVersion   string   `json:"runner_version"`
 	ProtocolVersion int      `json:"protocol_version"`
 	SDKVersion      string   `json:"sdk_version"`
+	Transport       string   `json:"transport"`
 	Capabilities    []string `json:"capabilities"`
 }
 
@@ -77,7 +78,20 @@ type runnerClient struct {
 	runtimeRoot string
 }
 
-func newRunnerClient(cfg pluginConfig, auth qoderAuth, extraEnv map[string]string) (*runnerClient, error) {
+func newRunnerClient(cfg pluginConfig, auth qoderAuth, extraEnv map[string]string, requestedTransport ...string) (*runnerClient, error) {
+	transport := auth.Transport
+	if len(requestedTransport) > 0 && strings.TrimSpace(requestedTransport[0]) != "" {
+		transport = strings.ToLower(strings.TrimSpace(requestedTransport[0]))
+	}
+	if transport == "" {
+		transport = cfg.Transport
+	}
+	if transport == "" {
+		transport = "sdk_cli"
+	}
+	if transport != "sdk_cli" && transport != "direct_openai" {
+		return nil, newPluginCallError("invalid_transport", "Qoder transport is unsupported", http.StatusBadRequest, false)
+	}
 	runtimeRoot, errRuntimeRoot := os.MkdirTemp(cfg.WorkingDirectory, ".cpa-qoder-runner-")
 	if errRuntimeRoot != nil {
 		return nil, newPluginCallError("runner_unavailable", "Qoder runner private runtime directory could not be created", http.StatusServiceUnavailable, true)
@@ -94,12 +108,26 @@ func newRunnerClient(cfg pluginConfig, auth qoderAuth, extraEnv map[string]strin
 		}
 	}
 	args := append([]string(nil), cfg.RunnerArgs...)
-	args = append(args,
-		"--stdio",
-		"--cli-path", cfg.QoderCLIPath,
-		"--cwd", cfg.WorkingDirectory,
-		"--max-queue-frames", strconv.Itoa(cfg.MaxQueueFrames),
-	)
+	args = append(args, "--stdio", "--transport", transport, "--cwd", cfg.WorkingDirectory, "--max-queue-frames", strconv.Itoa(cfg.MaxQueueFrames))
+	if transport == "sdk_cli" {
+		args = append(args, "--cli-path", cfg.QoderCLIPath)
+	} else {
+		if cfg.DirectEndpoint != "" {
+			args = append(args, "--direct-endpoint", cfg.DirectEndpoint)
+		}
+		if cfg.DirectModelsEndpoint != "" {
+			args = append(args, "--direct-models-endpoint", cfg.DirectModelsEndpoint)
+		}
+		if cfg.DirectAuthEndpoint != "" {
+			args = append(args, "--direct-auth-endpoint", cfg.DirectAuthEndpoint)
+		}
+		args = append(args, "--direct-token-mode", cfg.DirectTokenMode)
+		if modelsJSON, errModels := directModelsJSON(cfg.DirectModels); errModels != nil {
+			return nil, newPluginCallError("invalid_config", errModels.Error(), http.StatusInternalServerError, false)
+		} else if modelsJSON != "" {
+			args = append(args, "--direct-models-json", modelsJSON)
+		}
+	}
 	cmd := exec.Command(cfg.RunnerCommand, args...)
 	configureRunnerProcess(cmd)
 	cmd.Env = runnerEnvironment(auth, extraEnv, runtimeRoot)
@@ -129,13 +157,22 @@ func newRunnerClient(cfg pluginConfig, auth qoderAuth, extraEnv map[string]strin
 	return client, nil
 }
 
-func (c *runnerClient) handshake(ctx context.Context) (runnerHandshake, error) {
+func (c *runnerClient) handshake(ctx context.Context, requestedTransport ...string) (runnerHandshake, error) {
 	var result runnerHandshake
 	if errCall := c.call(ctx, "handshake", map[string]any{}, &result); errCall != nil {
 		return runnerHandshake{}, errCall
 	}
-	if result.Runner != "cpa-qoder-runner" || result.ProtocolVersion != runnerProtocol || result.RunnerVersion == "" {
+	if strings.TrimSpace(result.Transport) == "" {
+		// Runner protocol v1 predates explicit transport negotiation. Preserve
+		// compatibility for existing SDK/CLI runners while still rejecting an
+		// old runner when a direct transport was explicitly requested below.
+		result.Transport = "sdk_cli"
+	}
+	if result.Runner != "cpa-qoder-runner" || result.ProtocolVersion != runnerProtocol || result.RunnerVersion == "" || result.Transport != "sdk_cli" && result.Transport != "direct_openai" {
 		return runnerHandshake{}, newPluginCallError("runner_version_mismatch", "Qoder runner handshake is incompatible", http.StatusServiceUnavailable, false)
+	}
+	if len(requestedTransport) > 0 && strings.TrimSpace(requestedTransport[0]) != "" && result.Transport != strings.ToLower(strings.TrimSpace(requestedTransport[0])) {
+		return runnerHandshake{}, newPluginCallError("runner_version_mismatch", "Qoder runner transport does not match the selected auth transport", http.StatusServiceUnavailable, false)
 	}
 	return result, nil
 }
@@ -313,13 +350,17 @@ func runnerCallError(value *runnerError) error {
 	}
 	status := http.StatusBadGateway
 	switch value.Code {
-	case "auth_expired", "auth_not_configured":
+	case "auth_expired", "auth_not_configured", "direct_auth_failed", "direct_auth_invalid":
 		status = http.StatusUnauthorized
-	case "invalid_params", "invalid_content", "invalid_configuration", "prompt_required", "content_required", "model_required", "invalid_permission_policy":
+	case "quota_or_rate_limit":
+		status = http.StatusTooManyRequests
+	case "direct_timeout":
+		status = http.StatusGatewayTimeout
+	case "invalid_params", "invalid_content", "invalid_configuration", "prompt_required", "content_required", "model_required", "invalid_permission_policy", "unsupported_model", "direct_invalid_request", "direct_models_invalid", "direct_request_missing", "direct_request_too_large":
 		status = http.StatusBadRequest
 	case "turn_conflict", "session_configuration_changed":
 		status = http.StatusConflict
-	case "runner_quiescing", "cli_unavailable", "cli_path_required", "sdk_cli_version_mismatch":
+	case "runner_quiescing", "cli_unavailable", "cli_path_required", "sdk_cli_version_mismatch", "direct_endpoint_required", "direct_endpoint_invalid", "direct_auth_config", "models_unavailable", "models_schema_invalid":
 		status = http.StatusServiceUnavailable
 	}
 	message := strings.TrimSpace(value.Message)

--- a/examples/runner/qoder/README.md
+++ b/examples/runner/qoder/README.md
@@ -1,7 +1,17 @@
 # cpa-qoder-runner
 
 `cpa-qoder-runner` is the versioned Node.js boundary between the native
-`cpa-provider-qoder` plugin and `@qoder-ai/qoder-agent-sdk`.
+`cpa-provider-qoder` plugin and Qoder. It supports two explicit transports:
+
+- `sdk_cli` (default): Qoder Agent SDK + an administrator-selected external
+  `qoderclicn`/`qodercli`, with native sessions, workspace tools, skills, MCP,
+  permissions, image input, and agent events.
+- `direct_openai`: an OpenAI-compatible Qoder endpoint, with client-owned
+  messages/tools and standard SSE. It is a model/chat transport, not a native
+  Qoder Agent session; no skills, MCP, or native tool execution are advertised.
+
+The transport is selected by administrator configuration or an auth profile,
+never by a client request. A session keeps one transport for its lifetime.
 
 The runner deliberately requires an external Qoder CLI path:
 
@@ -10,6 +20,24 @@ npm ci --ignore-scripts
 npm run build
 node dist/index.js --stdio --cli-path /absolute/path/to/qodercli
 ```
+
+Direct OpenAI mode requires an explicit endpoint and either an exact model list
+or an OpenAI-compatible model catalog endpoint:
+
+```bash
+node dist/index.js --stdio \
+  --transport direct_openai \
+  --direct-endpoint https://api2-v2.qoder.sh/model/v1/chat/completions \
+  --direct-auth-endpoint https://openapi.qoder.sh \
+  --direct-models-json '[{"id":"qfmodel","display_name":"Qwen3.8-Flash"}]'
+```
+
+`--direct-token-mode auto` treats a `pt-` source as a PAT and exchanges it at
+`/api/v1/jobToken/exchange`; `jt-`/`dt-` sources are used as bearer tokens.
+The exchange and one subsequent 401/403 refresh retry stay inside the runner;
+tokens are never written to the JSONL protocol or logs. CN and global Qoder
+endpoints must be configured explicitly because their product families are not
+interchangeable.
 
 The checked-in `.npmrc` sets `ignore-scripts=true` because Qoder SDK
 postinstall may download runtime assets; `--ignore-scripts` is retained above
@@ -32,10 +60,12 @@ stdin and stdout carry one JSON object per line. Every request and response has
 - `shutdown`
 
 `start` carries structured text/image content plus the system prompt and the
-Plugin's fixed skill, setting-source, tool, and MCP policy. The runner passes
-those values to Qoder Agent SDK 1.0.10 only when it creates the native session;
-later turns must retain the same fixed configuration. Live model discovery
-preserves Qoder's vision, reasoning, token-limit, and context-window metadata.
+Plugin's fixed skill, setting-source, tool, and MCP policy. The original bounded
+Chat request is also carried for `direct_openai`, where messages and client
+tools are preserved. The runner passes fixed values to Qoder Agent SDK 1.0.10
+only when it creates the native session; later turns must retain the same fixed
+configuration. Live model discovery preserves Qoder's vision, reasoning,
+token-limit, and context-window metadata.
 
 PAT runners receive the PAT through a per-process environment variable and the
 request names only that variable. Qoder SDK 1.0.10 materializes a temporary

--- a/examples/runner/qoder/src/direct.ts
+++ b/examples/runner/qoder/src/direct.ts
@@ -316,6 +316,9 @@ export class DirectOpenAIAdapter implements QoderAdapter {
     } catch {
       throw new ProtocolError("invalid_upstream_response", "Qoder direct response was not valid JSON");
     }
+    if (isRecord(value) && isRecord(value.error)) {
+      throw new ProtocolError("direct_upstream_error", "Qoder direct response reported an upstream error", true);
+    }
     await this.consumeChunk(turn, isRecord(value) ? value : {});
     if (!turn.canceled && !turn.session.closed) {
       await this.emitTerminal(turn, "turn.completed", "completed");

--- a/examples/runner/qoder/src/direct.ts
+++ b/examples/runner/qoder/src/direct.ts
@@ -1,0 +1,750 @@
+import { ProtocolError } from "./protocol.js";
+import type {
+  ActiveTurn,
+  AgentEventType,
+  AgentEventV1,
+  AuthSpec,
+  ModelRecord,
+  ModelsParams,
+  QoderAdapter,
+  QoderTransport,
+  StartParams,
+} from "./types.js";
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 10 * 60 * 1000;
+const MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
+const MAX_ERROR_BYTES = 8 * 1024;
+
+type DirectTokenMode = "auto" | "bearer" | "pat_exchange";
+
+type DirectOptions = {
+  endpoint: string;
+  modelsEndpoint?: string;
+  authEndpoint?: string;
+  tokenMode: DirectTokenMode;
+  models: ModelRecord[];
+  requestTimeoutMs?: number;
+  fetchImpl?: typeof fetch;
+};
+
+type TokenState = {
+  source: string;
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt: number;
+  patExchange: boolean;
+};
+
+type DirectSession = {
+  executionSessionID: string;
+  nativeSessionID: string;
+  current?: DirectTurn;
+  closed: boolean;
+};
+
+type DirectTurn = {
+  session: DirectSession;
+  params: StartParams;
+  emit: (event: AgentEventV1) => Promise<void>;
+  controller: AbortController;
+  sequence: number;
+  canceled: boolean;
+  terminal: boolean;
+  sawData: boolean;
+  finishReason?: string;
+  toolCalls: Map<number, { id?: string; name?: string }>;
+};
+
+type DirectChunk = {
+  choices?: unknown;
+  usage?: unknown;
+};
+
+export class DirectOpenAIAdapter implements QoderAdapter {
+  readonly transport: QoderTransport = "direct_openai";
+  private readonly sessions = new Map<string, DirectSession>();
+  private readonly tokenManager: DirectTokenManager;
+  private readonly fetchImpl: typeof fetch;
+  private readonly requestTimeoutMs: number;
+  private readonly modelsConfig: ModelRecord[];
+  private discoveredModels?: ModelRecord[];
+  private readonly authEndpoint?: string;
+
+  constructor(private readonly options: DirectOptions) {
+    const authEndpoint = options.authEndpoint?.replace(/\/+$/, "");
+    this.authEndpoint = authEndpoint;
+    if (!isSupportedEndpoint(options.endpoint)) {
+      throw new ProtocolError("direct_endpoint_invalid", "direct endpoint must use HTTPS or loopback HTTP");
+    }
+    if (options.modelsEndpoint && !isSupportedEndpoint(options.modelsEndpoint)) {
+      throw new ProtocolError("direct_endpoint_invalid", "direct models endpoint must use HTTPS or loopback HTTP");
+    }
+    if (options.authEndpoint && !isSupportedEndpoint(options.authEndpoint)) {
+      throw new ProtocolError("direct_endpoint_invalid", "direct auth endpoint must use HTTPS or loopback HTTP");
+    }
+    if (options.tokenMode === "pat_exchange" && !authEndpoint) {
+      throw new ProtocolError("direct_auth_config", "direct PAT exchange requires an auth endpoint");
+    }
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.requestTimeoutMs = Math.max(1000, options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS);
+    this.modelsConfig = validateModelRecords(options.models);
+    this.tokenManager = new DirectTokenManager(
+      authEndpoint,
+      options.tokenMode,
+      this.fetchImpl,
+      this.requestTimeoutMs,
+    );
+  }
+
+  async readiness(auth?: AuthSpec): Promise<{ auth_ready: boolean; message: string }> {
+    if (!isSupportedEndpoint(this.options.endpoint)) {
+      throw new ProtocolError("direct_endpoint_invalid", "direct endpoint is invalid");
+    }
+    if (!auth) return { auth_ready: false, message: "selected Qoder direct auth was not supplied" };
+    if (auth.mode !== "pat") {
+      return { auth_ready: false, message: "direct_openai requires a PAT or bearer access-token auth" };
+    }
+    const source = process.env[auth.env_var] ?? "";
+    if (!source) return { auth_ready: false, message: "configured Qoder direct token source is unavailable" };
+    if ((this.options.tokenMode === "pat_exchange" || this.options.tokenMode === "auto" && source.startsWith("pt-")) && !this.authEndpoint) {
+      return { auth_ready: false, message: "direct PAT exchange endpoint is not configured" };
+    }
+    return { auth_ready: true, message: "Qoder direct OpenAI transport is configured; remote acceptance is checked on execution" };
+  }
+
+  async models(params: ModelsParams): Promise<ModelRecord[]> {
+    const configured = parseModelJSON(params.models_json);
+    if (configured.length > 0) {
+      this.discoveredModels = cloneModels(configured);
+      return cloneModels(configured);
+    }
+    if (this.modelsConfig.length > 0) {
+      this.discoveredModels = cloneModels(this.modelsConfig);
+      return cloneModels(this.modelsConfig);
+    }
+    const endpoint = params.models_endpoint || this.options.modelsEndpoint;
+    if (!endpoint) {
+      throw new ProtocolError("models_unavailable", "direct_openai requires direct_models or direct_models_endpoint", true);
+    }
+    if (!isSupportedEndpoint(endpoint)) {
+      throw new ProtocolError("direct_endpoint_invalid", "direct models endpoint must use HTTPS or loopback HTTP");
+    }
+    const auth = params.auth;
+    const response = await this.tokenManager.fetchWithAuth(auth, async (token) => {
+      return this.fetchWithTimeout(endpoint, {
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      });
+    });
+    if (!response.ok) throw await directHTTPError(response, "direct model discovery");
+    const raw = await readResponseText(response, MAX_RESPONSE_BYTES);
+    const models = parseModelResponse(raw);
+    this.discoveredModels = cloneModels(models);
+    return models;
+  }
+
+  async start(params: StartParams, emit: (event: AgentEventV1) => Promise<void>): Promise<ActiveTurn> {
+    if (!params.chat_request || !isRecord(params.chat_request)) {
+      throw new ProtocolError("direct_request_missing", "direct_openai requires the original Chat request");
+    }
+    const session = this.sessions.get(params.execution_session_id) ?? {
+      executionSessionID: params.execution_session_id,
+      nativeSessionID: `direct-${params.execution_session_id}`,
+      closed: false,
+    };
+    if (session.closed) throw new ProtocolError("session_closed", "Qoder direct execution session is closed");
+    if (session.current) throw new ProtocolError("turn_conflict", "Qoder direct execution session already has an active turn", true);
+    this.sessions.set(params.execution_session_id, session);
+
+    const turn: DirectTurn = {
+      session,
+      params,
+      emit,
+      controller: new AbortController(),
+      sequence: 0,
+      canceled: false,
+      terminal: false,
+      sawData: false,
+      toolCalls: new Map(),
+    };
+    session.current = turn;
+    await this.emit(turn, "session.created", { native_session_id: session.nativeSessionID, transport: this.transport });
+    await this.emit(turn, "turn.started", { transport: this.transport });
+    void this.runTurn(turn);
+    return {
+      cancel: async () => {
+        if (session.current !== turn || turn.terminal) return;
+        turn.canceled = true;
+        turn.controller.abort();
+      },
+    };
+  }
+
+  async close(executionSessionID: string): Promise<void> {
+    const session = this.sessions.get(executionSessionID);
+    if (!session) return;
+    session.closed = true;
+    this.sessions.delete(executionSessionID);
+    const current = session.current;
+    if (!current) return;
+    current.canceled = true;
+    current.controller.abort();
+    session.current = undefined;
+    await this.emitTerminal(current, "session.closed", "session_closed", "session_closed", "Qoder direct execution session was closed");
+  }
+
+  async shutdown(): Promise<void> {
+    await Promise.all([...this.sessions.keys()].map((id) => this.close(id)));
+  }
+
+  private async runTurn(turn: DirectTurn): Promise<void> {
+    let timedOut = false;
+    const turnTimer = setTimeout(() => {
+      timedOut = true;
+      turn.controller.abort();
+    }, this.requestTimeoutMs);
+    try {
+      await this.ensureModel(turn.params);
+      if (turn.canceled || turn.session.closed || turn.controller.signal.aborted) {
+        await this.emitTerminal(turn, "turn.cancelled", "cancelled", "request_cancelled", "Qoder direct turn was cancelled");
+        return;
+      }
+      const request = buildDirectRequest(turn.params);
+      const rawBody = JSON.stringify(request);
+      if (Buffer.byteLength(rawBody) > MAX_RESPONSE_BYTES) {
+        throw new ProtocolError("direct_request_too_large", "Qoder direct request exceeds the bounded body limit");
+      }
+      const response = await this.tokenManager.fetchWithAuth(turn.params.auth, async (token) => {
+        return this.fetchWithTimeout(this.options.endpoint, {
+          method: "POST",
+          headers: {
+            Accept: "text/event-stream",
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+            "X-Request-ID": turn.params.request_id,
+            "X-Session-ID": turn.params.execution_session_id,
+          },
+          body: rawBody,
+          signal: turn.controller.signal,
+        });
+      }, turn.controller.signal);
+      if (!response.ok) throw await directHTTPError(response, "Qoder direct inference");
+      const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+      if (contentType.includes("application/json") && !contentType.includes("text/event-stream")) {
+        await this.consumeJSONResponse(turn, await readResponseText(response, MAX_RESPONSE_BYTES));
+      } else {
+        await this.consumeSSE(turn, response);
+      }
+      if (turn.terminal) return;
+      if (turn.canceled || turn.session.closed) {
+        await this.emitTerminal(turn, "turn.cancelled", "cancelled", "request_cancelled", "Qoder direct turn was cancelled");
+      } else if (timedOut) {
+        await this.emitTerminal(turn, "turn.failed", "failed", "direct_timeout", "Qoder direct turn exceeded the configured timeout", true);
+      } else {
+        throw new ProtocolError("stream_truncated", "Qoder direct stream ended before [DONE]", true);
+      }
+    } catch (error) {
+      if (turn.terminal) return;
+      if (turn.canceled || turn.session.closed) {
+        await this.emitTerminal(turn, "turn.cancelled", "cancelled", "request_cancelled", "Qoder direct turn was cancelled");
+      } else if (timedOut) {
+        await this.emitTerminal(turn, "turn.failed", "failed", "direct_timeout", "Qoder direct turn exceeded the configured timeout", true);
+      } else {
+        const safe = error instanceof ProtocolError
+          ? error
+          : new ProtocolError("connection_lifecycle", "Qoder direct connection failed", true);
+        await this.emitTerminal(turn, "turn.failed", "failed", safe.code, safe.message, safe.retryable);
+      }
+    } finally {
+      clearTimeout(turnTimer);
+      if (turn.session.current === turn) turn.session.current = undefined;
+    }
+  }
+
+  private async ensureModel(params: StartParams): Promise<void> {
+    const catalog = this.discoveredModels ?? (this.modelsConfig.length > 0 ? this.modelsConfig : await this.models({ auth: params.auth }));
+    if (!catalog.some((model) => model.id === params.model)) {
+      throw new ProtocolError("unsupported_model", "Qoder direct model must match an exact catalog ID");
+    }
+  }
+
+  private async consumeSSE(turn: DirectTurn, response: Response): Promise<void> {
+    if (!response.body) throw new ProtocolError("stream_truncated", "Qoder direct response has no body", true);
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let bytes = 0;
+    let doneReceived = false;
+    try {
+      while (!doneReceived) {
+        if (turn.canceled || turn.session.closed) {
+          await reader.cancel();
+          return;
+        }
+        const next = await reader.read();
+        if (next.done) break;
+        bytes += next.value.byteLength;
+        if (bytes > MAX_RESPONSE_BYTES) throw new ProtocolError("stream_too_large", "Qoder direct response exceeds the bounded limit");
+        buffer += decoder.decode(next.value, { stream: true });
+        const lines = buffer.split(/\r?\n/);
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          if (!line.startsWith("data:")) continue;
+          const result = await this.consumeDataLine(turn, line.slice(5).trim());
+          if (result) {
+            doneReceived = true;
+            break;
+          }
+        }
+      }
+      if (!doneReceived && buffer.trim().startsWith("data:")) {
+        doneReceived = await this.consumeDataLine(turn, buffer.trim().slice(5).trim());
+      }
+    } finally {
+      reader.releaseLock();
+    }
+    if (!doneReceived && !turn.canceled && !turn.session.closed) {
+      throw new ProtocolError("stream_truncated", "Qoder direct stream ended before [DONE]", true);
+    }
+  }
+
+  private async consumeJSONResponse(turn: DirectTurn, raw: string): Promise<void> {
+    let value: unknown;
+    try {
+      value = JSON.parse(raw);
+    } catch {
+      throw new ProtocolError("invalid_upstream_response", "Qoder direct response was not valid JSON");
+    }
+    await this.consumeChunk(turn, isRecord(value) ? value : {});
+    if (!turn.canceled && !turn.session.closed) turn.sawData = true;
+    if (!turn.canceled && !turn.session.closed) {
+      await this.emitTerminal(turn, "turn.completed", "completed");
+    }
+  }
+
+  private async consumeDataLine(turn: DirectTurn, data: string): Promise<boolean> {
+    if (!data) return false;
+    if (data === "[DONE]") {
+      if (!turn.canceled && !turn.session.closed) {
+        await this.emitTerminal(turn, "turn.completed", "completed");
+      }
+      return true;
+    }
+    let value: unknown;
+    try {
+      value = JSON.parse(data);
+    } catch {
+      throw new ProtocolError("invalid_upstream_response", "Qoder direct SSE data was not valid JSON");
+    }
+    if (!isRecord(value)) return false;
+    if (isRecord(value.error)) {
+      throw new ProtocolError("direct_upstream_error", "Qoder direct stream reported an upstream error", true);
+    }
+    let chunk: Record<string, unknown> = value;
+    if (typeof value.body === "string") {
+      try {
+        const nested = JSON.parse(value.body);
+        if (isRecord(nested)) chunk = nested;
+      } catch {
+        throw new ProtocolError("invalid_upstream_response", "Qoder direct nested SSE body was not valid JSON");
+      }
+    }
+    if (isRecord(chunk.error)) {
+      throw new ProtocolError("direct_upstream_error", "Qoder direct stream reported an upstream error", true);
+    }
+    await this.consumeChunk(turn, chunk);
+    return false;
+  }
+
+  private async consumeChunk(turn: DirectTurn, chunk: DirectChunk): Promise<void> {
+    const usage = isRecord(chunk.usage) ? chunk.usage : isRecord((chunk as Record<string, unknown>).raw_usage) ? (chunk as Record<string, any>).raw_usage : undefined;
+    if (usage) {
+      const input = numberOrUndefined(usage.input_tokens ?? usage.prompt_tokens);
+      const output = numberOrUndefined(usage.output_tokens ?? usage.completion_tokens);
+      const total = numberOrUndefined(usage.total_tokens) ?? (input !== undefined && output !== undefined ? input + output : undefined);
+      if (input !== undefined || output !== undefined || total !== undefined) {
+        await this.emit(turn, "usage.updated", {
+          input_tokens: input,
+          output_tokens: output,
+          total_tokens: total,
+          provenance: "provider_reported_unverified",
+        });
+      }
+    }
+    if (!Array.isArray(chunk.choices)) return;
+    for (const rawChoice of chunk.choices) {
+      if (!isRecord(rawChoice)) continue;
+      const delta = isRecord(rawChoice.delta) ? rawChoice.delta : isRecord(rawChoice.message) ? rawChoice.message : {};
+      const content = typeof delta.content === "string" ? delta.content : "";
+      const reasoning = typeof delta.reasoning_content === "string"
+        ? delta.reasoning_content
+        : typeof delta.reasoning === "string" ? delta.reasoning : "";
+      if (content) {
+        turn.sawData = true;
+        await this.emit(turn, "message.delta", { text: content });
+      }
+      if (reasoning) {
+        turn.sawData = true;
+        await this.emit(turn, "reasoning.delta", { text: reasoning });
+      }
+      if (Array.isArray(delta.tool_calls)) await this.consumeToolCalls(turn, delta.tool_calls);
+      if (typeof rawChoice.finish_reason === "string" && rawChoice.finish_reason.trim() !== "") {
+        turn.finishReason = rawChoice.finish_reason;
+      }
+    }
+  }
+
+  private async consumeToolCalls(turn: DirectTurn, calls: unknown[]): Promise<void> {
+    for (const rawCall of calls) {
+      if (!isRecord(rawCall)) continue;
+      const index = numberOrUndefined(rawCall.index) ?? turn.toolCalls.size;
+      const fn = isRecord(rawCall.function) ? rawCall.function : {};
+      const previous = turn.toolCalls.get(index);
+      if (!previous) {
+        const entry = { id: stringOrUndefined(rawCall.id), name: stringOrUndefined(fn.name) };
+        turn.toolCalls.set(index, entry);
+        await this.emit(turn, "tool.started", { index, tool_call_id: entry.id, name: entry.name });
+      } else {
+        if (!previous.id) previous.id = stringOrUndefined(rawCall.id);
+        if (!previous.name) previous.name = stringOrUndefined(fn.name);
+      }
+      const argumentsPart = stringOrUndefined(fn.arguments);
+      if (argumentsPart) await this.emit(turn, "tool.updated", { index, partial_json: argumentsPart });
+    }
+  }
+
+  private async emit(turn: DirectTurn, type: AgentEventType, payload?: unknown): Promise<void> {
+    if (turn.terminal && !isTerminal(type)) return;
+    turn.sequence += 1;
+    await turn.emit({
+      schema_version: 1,
+      type,
+      request_id: turn.params.request_id,
+      execution_session_id: turn.params.execution_session_id,
+      turn_id: turn.params.turn_id,
+      provider: "qoder",
+      auth_id: turn.params.auth_id,
+      auth_index: turn.params.auth_index,
+      sequence: turn.sequence,
+      timestamp: new Date().toISOString(),
+      payload,
+    });
+  }
+
+  private async emitTerminal(
+    turn: DirectTurn,
+    type: "turn.completed" | "turn.failed" | "turn.cancelled" | "session.closed",
+    state: string,
+    code?: string,
+    message?: string,
+    retryable = false,
+  ): Promise<void> {
+    if (turn.terminal) return;
+    if (type === "turn.completed") {
+      for (const [index] of turn.toolCalls) await this.emit(turn, "tool.completed", { index });
+      turn.terminal = true;
+      await this.emit(turn, type, { state: "completed" });
+      return;
+    }
+    turn.terminal = true;
+    await this.emit(turn, type, { state, code, message, retryable });
+  }
+
+  private fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.requestTimeoutMs);
+    const signal = init.signal;
+    const onAbort = () => controller.abort();
+    signal?.addEventListener("abort", onAbort, { once: true });
+    return this.fetchImpl(url, { ...init, signal: controller.signal }).finally(() => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    });
+  }
+}
+
+class DirectTokenManager {
+  private state?: TokenState;
+
+  constructor(
+    private readonly authEndpoint: string | undefined,
+    private readonly tokenMode: DirectTokenMode,
+    private readonly fetchImpl: typeof fetch,
+    private readonly requestTimeoutMs: number,
+  ) {}
+
+  async fetchWithAuth(
+    auth: AuthSpec,
+    request: (token: string) => Promise<Response>,
+    signal?: AbortSignal,
+  ): Promise<Response> {
+    if (signal?.aborted) throw new ProtocolError("request_cancelled", "Qoder direct request was cancelled");
+    const state = await this.ensure(auth, signal);
+    if (signal?.aborted) throw new ProtocolError("request_cancelled", "Qoder direct request was cancelled");
+    let response = await request(state.accessToken);
+    if ((response.status === 401 || response.status === 403) && state.patExchange) {
+      await response.body?.cancel().catch(() => undefined);
+      const refreshed = await this.refreshOrExchange(state, signal);
+      response = await request(refreshed.accessToken);
+    }
+    return response;
+  }
+
+  private async ensure(auth: AuthSpec, signal?: AbortSignal): Promise<TokenState> {
+    if (auth.mode !== "pat") throw new ProtocolError("direct_auth_invalid", "direct_openai requires PAT or bearer token auth");
+    const source = String(process.env[auth.env_var] ?? "");
+    if (!source) throw new ProtocolError("auth_not_configured", "Qoder direct token environment source is not configured");
+    const patExchange = this.tokenMode === "pat_exchange" || this.tokenMode === "auto" && source.startsWith("pt-");
+    if (!patExchange) {
+      this.state = { source, accessToken: source, expiresAt: Number.POSITIVE_INFINITY, patExchange: false };
+      return this.state;
+    }
+    if (!this.authEndpoint) throw new ProtocolError("direct_auth_config", "direct PAT exchange endpoint is not configured");
+    if (this.state?.source === source && this.state.expiresAt > Date.now() + 30_000) return this.state;
+    this.state = await this.exchange(source, signal);
+    return this.state;
+  }
+
+  private async refreshOrExchange(state: TokenState, signal?: AbortSignal): Promise<TokenState> {
+    if (state.refreshToken && this.authEndpoint) {
+      try {
+        this.state = await this.refresh(state.refreshToken, signal);
+        this.state.source = state.source;
+        this.state.patExchange = true;
+        return this.state;
+      } catch {
+        // A short-lived refresh token can expire before the long-lived PAT.
+      }
+    }
+    this.state = await this.exchange(state.source, signal);
+    return this.state;
+  }
+
+  private async exchange(pat: string, signal?: AbortSignal): Promise<TokenState> {
+    return this.tokenRequest("/api/v1/jobToken/exchange", { personal_token: pat }, pat, signal);
+  }
+
+  private async refresh(refreshToken: string, signal?: AbortSignal): Promise<TokenState> {
+    return this.tokenRequest("/api/v1/jobToken/refresh", { refresh_token: refreshToken }, "", signal);
+  }
+
+  private async tokenRequest(path: string, body: Record<string, string>, source: string, signal?: AbortSignal): Promise<TokenState> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.requestTimeoutMs);
+    const onAbort = () => controller.abort();
+    signal?.addEventListener("abort", onAbort, { once: true });
+    try {
+      const response = await this.fetchImpl(`${this.authEndpoint}${path}`, {
+        method: "POST",
+        headers: { Accept: "application/json", "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+      if (!response.ok) throw new ProtocolError("direct_auth_failed", `Qoder direct auth endpoint returned HTTP ${response.status}`, response.status >= 500);
+      const raw = await readResponseText(response, MAX_ERROR_BYTES);
+      let value: unknown;
+      try {
+        value = JSON.parse(raw);
+      } catch {
+        throw new ProtocolError("direct_auth_failed", "Qoder direct auth response was not valid JSON");
+      }
+      const record = isRecord(value) && isRecord(value.data) ? value.data : value;
+      const token = isRecord(record) ? stringOrUndefined(record.token ?? record.access_token) : undefined;
+      if (!isRecord(record) || !token) {
+        throw new ProtocolError("direct_auth_failed", "Qoder direct auth response did not contain an access token");
+      }
+      return {
+        source,
+        accessToken: token,
+        refreshToken: stringOrUndefined(record.refresh_token),
+        expiresAt: expiryFromTokenRecord(record),
+        patExchange: true,
+      };
+    } finally {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    }
+  }
+}
+
+function buildDirectRequest(params: StartParams): Record<string, unknown> {
+  const original = params.chat_request;
+  if (!original || !isRecord(original)) throw new ProtocolError("direct_request_missing", "direct_openai requires a JSON Chat request");
+  const messages = original.messages;
+  if (!Array.isArray(messages) || messages.length === 0) throw new ProtocolError("invalid_request", "direct_openai requires a non-empty messages array");
+  const request: Record<string, unknown> = { ...original, model: params.model, stream: true };
+  const existingOptions = isRecord(original.stream_options) ? { ...original.stream_options } : {};
+  request.stream_options = { ...existingOptions, include_usage: true };
+  const metadata = isRecord(original.metadata) ? { ...original.metadata } : {};
+  const context = isRecord(metadata.context) ? { ...metadata.context } : {};
+  metadata.context = {
+    ...context,
+    request_id: params.request_id,
+    request_set_id: params.request_id,
+    session_id: params.execution_session_id,
+    task_id: "common",
+    client_type: "cpa-qoder-direct",
+  };
+  request.metadata = metadata;
+  return request;
+}
+
+async function directHTTPError(response: Response, operation: string): Promise<ProtocolError> {
+  const status = response.status;
+  await readResponseText(response, MAX_ERROR_BYTES).catch(() => "");
+  const suffix = ` (HTTP ${status})`;
+  if (status === 401 || status === 403) return new ProtocolError("auth_expired", `${operation} authentication was rejected${suffix}`);
+  if (status === 429) return new ProtocolError("quota_or_rate_limit", `${operation} was rate limited${suffix}`, true);
+  if (status >= 500) return new ProtocolError("direct_upstream_error", `${operation} failed upstream${suffix}`, true);
+  return new ProtocolError("direct_invalid_request", `${operation} was rejected${suffix}`);
+}
+
+async function readResponseText(response: Response, maxBytes: number): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) return "";
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const next = await reader.read();
+      if (next.done) break;
+      total += next.value.byteLength;
+      if (total > maxBytes) throw new ProtocolError("response_too_large", "Qoder direct response exceeds the bounded limit");
+      chunks.push(next.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+}
+
+function parseModelJSON(raw: string | undefined): ModelRecord[] {
+  if (!raw) return [];
+  try {
+    const value = JSON.parse(raw);
+    if (Array.isArray(value)) return validateModelRecords(value);
+    if (isRecord(value) && Array.isArray(value.models)) return validateModelRecords(value.models);
+  } catch {
+    throw new ProtocolError("direct_models_invalid", "direct_models JSON is invalid");
+  }
+  throw new ProtocolError("direct_models_invalid", "direct_models JSON must be an array or an object with models");
+}
+
+function parseModelResponse(raw: string): ModelRecord[] {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    throw new ProtocolError("models_schema_invalid", "direct model response was not valid JSON", true);
+  }
+  const records = isRecord(value) && Array.isArray(value.data)
+    ? value.data
+    : isRecord(value) && Array.isArray(value.models) ? value.models : Array.isArray(value) ? value : undefined;
+  if (!records) throw new ProtocolError("models_schema_invalid", "direct model response has no model array", true);
+  const models = validateModelRecords(records);
+  if (models.length === 0) throw new ProtocolError("models_unavailable", "direct model response contained no enabled model IDs", true);
+  return models;
+}
+
+function validateModelRecords(values: unknown[]): ModelRecord[] {
+  const seen = new Set<string>();
+  const models: ModelRecord[] = [];
+  for (const value of values) {
+    if (typeof value === "string") {
+      const id = value.trim();
+      if (id && !seen.has(id)) {
+        seen.add(id);
+        models.push({ id, display_name: id });
+      }
+      continue;
+    }
+    if (!isRecord(value)) throw new ProtocolError("direct_models_invalid", "direct model record is invalid");
+    const id = String(value.id ?? value.model ?? value.value ?? "").trim();
+    if (!id || id.length > 512 || seen.has(id)) continue;
+    const display = String(value.display_name ?? value.displayName ?? value.name ?? id).trim() || id;
+    seen.add(id);
+    models.push({
+      id,
+      display_name: display,
+      description: stringOrUndefined(value.description),
+      source: stringOrUndefined(value.source),
+      is_default: booleanOrUndefined(value.is_default ?? value.isDefault),
+      is_enabled: value.is_enabled === false || value.isEnabled === false ? false : true,
+      is_reasoning: booleanOrUndefined(value.is_reasoning ?? value.isReasoning),
+      is_vl: booleanOrUndefined(value.is_vl ?? value.isVl),
+      max_input_tokens: numberOrUndefined(value.max_input_tokens ?? value.maxInputTokens),
+      max_output_tokens: numberOrUndefined(value.max_output_tokens ?? value.maxOutputTokens),
+      reasoning_efforts: stringArrayOrUndefined(value.reasoning_efforts ?? value.efforts),
+      default_reasoning_effort: stringOrUndefined(value.default_reasoning_effort ?? value.defaultEffort),
+      supports_disabled: booleanOrUndefined(value.supports_disabled ?? value.supportsDisabled),
+      available_context_windows: numberArrayOrUndefined(value.available_context_windows ?? value.availableContextWindows),
+      default_context_window: numberOrUndefined(value.default_context_window ?? value.defaultContextWindow),
+    });
+  }
+  return models.filter((model) => model.is_enabled !== false).map(({ is_enabled: _enabled, ...model }) => model);
+}
+
+function cloneModels(models: ModelRecord[]): ModelRecord[] {
+  return models.map((model) => ({ ...model, reasoning_efforts: model.reasoning_efforts ? [...model.reasoning_efforts] : undefined, available_context_windows: model.available_context_windows ? [...model.available_context_windows] : undefined }));
+}
+
+function expiryFromTokenRecord(record: Record<string, unknown>): number {
+  const expiresAt = typeof record.expires_at === "string" ? Date.parse(record.expires_at) : NaN;
+  if (Number.isFinite(expiresAt)) return expiresAt;
+  const expiresIn = numberOrUndefined(record.expires_in);
+  if (expiresIn !== undefined && expiresIn > 0 && expiresIn <= 7 * 24 * 60 * 60) {
+    return Date.now() + Math.max(60_000, expiresIn * 1000);
+  }
+  return Date.now() + Math.max(60_000, expiresIn ?? 86_400_000);
+}
+
+function isSupportedEndpoint(raw: string): boolean {
+  try {
+    const url = new URL(raw);
+    if (url.username || url.password || url.search || url.hash || !url.hostname) return false;
+    if (url.protocol === "https:") return true;
+    if (url.protocol !== "http:") return false;
+    return url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "::1";
+  } catch {
+    return false;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isTerminal(type: AgentEventType): boolean {
+  return type === "turn.completed" || type === "turn.failed" || type === "turn.cancelled" || type === "session.closed";
+}
+
+function numberOrUndefined(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function stringOrUndefined(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function booleanOrUndefined(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function stringArrayOrUndefined(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((item): item is string => typeof item === "string" && item.trim() !== "").map((item) => item.trim());
+}
+
+function numberArrayOrUndefined(value: unknown): number[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((item): item is number => typeof item === "number" && Number.isFinite(item));
+}

--- a/examples/runner/qoder/src/direct.ts
+++ b/examples/runner/qoder/src/direct.ts
@@ -150,7 +150,8 @@ export class DirectOpenAIAdapter implements QoderAdapter {
     if (!params.chat_request || !isRecord(params.chat_request)) {
       throw new ProtocolError("direct_request_missing", "direct_openai requires the original Chat request");
     }
-    const session = this.sessions.get(params.execution_session_id) ?? {
+    const existing = this.sessions.get(params.execution_session_id);
+    const session = existing ?? {
       executionSessionID: params.execution_session_id,
       nativeSessionID: `direct-${params.execution_session_id}`,
       closed: false,
@@ -171,7 +172,7 @@ export class DirectOpenAIAdapter implements QoderAdapter {
       toolCalls: new Map(),
     };
     session.current = turn;
-    await this.emit(turn, "session.created", { native_session_id: session.nativeSessionID, transport: this.transport });
+    if (!existing) await this.emit(turn, "session.created", { native_session_id: session.nativeSessionID, transport: this.transport });
     await this.emit(turn, "turn.started", { transport: this.transport });
     void this.runTurn(turn);
     return {
@@ -446,10 +447,12 @@ export class DirectOpenAIAdapter implements QoderAdapter {
     if (type === "turn.completed") {
       for (const [index] of turn.toolCalls) await this.emit(turn, "tool.completed", { index });
       turn.terminal = true;
+      if (turn.session.current === turn) turn.session.current = undefined;
       await this.emit(turn, type, { state: "completed" });
       return;
     }
     turn.terminal = true;
+    if (turn.session.current === turn) turn.session.current = undefined;
     await this.emit(turn, type, { state, code, message, retryable });
   }
 

--- a/examples/runner/qoder/src/direct.ts
+++ b/examples/runner/qoder/src/direct.ts
@@ -50,8 +50,6 @@ type DirectTurn = {
   sequence: number;
   canceled: boolean;
   terminal: boolean;
-  sawData: boolean;
-  finishReason?: string;
   toolCalls: Map<number, { id?: string; name?: string }>;
 };
 
@@ -168,7 +166,6 @@ export class DirectOpenAIAdapter implements QoderAdapter {
       sequence: 0,
       canceled: false,
       terminal: false,
-      sawData: false,
       toolCalls: new Map(),
     };
     session.current = turn;
@@ -320,7 +317,6 @@ export class DirectOpenAIAdapter implements QoderAdapter {
       throw new ProtocolError("invalid_upstream_response", "Qoder direct response was not valid JSON");
     }
     await this.consumeChunk(turn, isRecord(value) ? value : {});
-    if (!turn.canceled && !turn.session.closed) turn.sawData = true;
     if (!turn.canceled && !turn.session.closed) {
       await this.emitTerminal(turn, "turn.completed", "completed");
     }
@@ -384,17 +380,12 @@ export class DirectOpenAIAdapter implements QoderAdapter {
         ? delta.reasoning_content
         : typeof delta.reasoning === "string" ? delta.reasoning : "";
       if (content) {
-        turn.sawData = true;
         await this.emit(turn, "message.delta", { text: content });
       }
       if (reasoning) {
-        turn.sawData = true;
         await this.emit(turn, "reasoning.delta", { text: reasoning });
       }
       if (Array.isArray(delta.tool_calls)) await this.consumeToolCalls(turn, delta.tool_calls);
-      if (typeof rawChoice.finish_reason === "string" && rawChoice.finish_reason.trim() !== "") {
-        turn.finishReason = rawChoice.finish_reason;
-      }
     }
   }
 

--- a/examples/runner/qoder/src/index.ts
+++ b/examples/runner/qoder/src/index.ts
@@ -2,40 +2,84 @@
 import process from "node:process";
 
 import { ProtocolError } from "./protocol.js";
+import { DirectOpenAIAdapter } from "./direct.js";
 import { QoderSDKAdapter } from "./qoder.js";
 import { RunnerServer, runJSONLServer } from "./server.js";
+import type { ModelRecord, QoderTransport } from "./types.js";
 
 type CLIOptions = {
+  transport: QoderTransport;
   cliPath: string;
   cwd: string;
   maxQueueFrames: number;
+  directEndpoint: string;
+  directModelsEndpoint: string;
+  directAuthEndpoint: string;
+  directTokenMode: "auto" | "bearer" | "pat_exchange";
+  directModels: ModelRecord[];
 };
 
 function parseArgs(args: string[]): CLIOptions {
+  let transport: QoderTransport = "sdk_cli";
   let cliPath = "";
   let cwd = process.cwd();
   let maxQueueFrames = 128;
+  let directEndpoint = "";
+  let directModelsEndpoint = "";
+  let directAuthEndpoint = "";
+  let directTokenMode: CLIOptions["directTokenMode"] = "auto";
+  let directModels: ModelRecord[] = [];
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
     if (arg === "--stdio") continue;
-    if (arg === "--cli-path") cliPath = String(args[++index] ?? "");
+    if (arg === "--transport") {
+      const value = String(args[++index] ?? "");
+      if (value !== "sdk_cli" && value !== "direct_openai") throw new ProtocolError("invalid_argument", "--transport must be sdk_cli or direct_openai");
+      transport = value;
+    } else if (arg === "--cli-path") cliPath = String(args[++index] ?? "");
     else if (arg === "--cwd") cwd = String(args[++index] ?? "");
     else if (arg === "--max-queue-frames") maxQueueFrames = Number(args[++index]);
+    else if (arg === "--direct-endpoint") directEndpoint = String(args[++index] ?? "");
+    else if (arg === "--direct-models-endpoint") directModelsEndpoint = String(args[++index] ?? "");
+    else if (arg === "--direct-auth-endpoint") directAuthEndpoint = String(args[++index] ?? "");
+    else if (arg === "--direct-token-mode") {
+      const value = String(args[++index] ?? "");
+      if (value !== "auto" && value !== "bearer" && value !== "pat_exchange") throw new ProtocolError("invalid_argument", "--direct-token-mode must be auto, bearer, or pat_exchange");
+      directTokenMode = value;
+    } else if (arg === "--direct-models-json") {
+      const value = String(args[++index] ?? "");
+      try {
+        const parsed = JSON.parse(value);
+        if (!Array.isArray(parsed)) throw new Error("array required");
+        directModels = parsed as ModelRecord[];
+      } catch {
+        throw new ProtocolError("invalid_argument", "--direct-models-json must be a JSON array");
+      }
+    }
     else if (arg === "--version") {
       process.stdout.write("cpa-qoder-runner 0.1.0\n");
       process.exit(0);
     } else throw new ProtocolError("invalid_argument", `unsupported runner argument: ${arg}`);
   }
-  if (!cliPath) throw new ProtocolError("cli_path_required", "--cli-path is required; bundled Qoder CLI fallback is disabled");
+  if (transport === "sdk_cli" && !cliPath) throw new ProtocolError("cli_path_required", "--cli-path is required for sdk_cli; bundled Qoder CLI fallback is disabled");
+  if (transport === "direct_openai" && !directEndpoint) throw new ProtocolError("direct_endpoint_required", "--direct-endpoint is required for direct_openai");
   if (!Number.isInteger(maxQueueFrames) || maxQueueFrames < 1 || maxQueueFrames > 4096) {
     throw new ProtocolError("invalid_argument", "--max-queue-frames must be between 1 and 4096");
   }
-  return { cliPath, cwd, maxQueueFrames };
+  return { transport, cliPath, cwd, maxQueueFrames, directEndpoint, directModelsEndpoint, directAuthEndpoint, directTokenMode, directModels };
 }
 
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2));
-  const adapter = new QoderSDKAdapter(options.cliPath, options.cwd);
+  const adapter = options.transport === "direct_openai"
+    ? new DirectOpenAIAdapter({
+      endpoint: options.directEndpoint,
+      modelsEndpoint: options.directModelsEndpoint || undefined,
+      authEndpoint: options.directAuthEndpoint || undefined,
+      tokenMode: options.directTokenMode,
+      models: options.directModels,
+    })
+    : new QoderSDKAdapter(options.cliPath, options.cwd);
   const server = new RunnerServer(adapter, process.stdout, options.maxQueueFrames);
   await runJSONLServer(server, process.stdin);
 }

--- a/examples/runner/qoder/src/qoder.ts
+++ b/examples/runner/qoder/src/qoder.ts
@@ -23,6 +23,7 @@ import type {
   ModelRecord,
   ModelsParams,
   QoderAdapter,
+  QoderTransport,
   StartParams,
 } from "./types.js";
 
@@ -120,6 +121,7 @@ class SDKSession {
 }
 
 export class QoderSDKAdapter implements QoderAdapter {
+  readonly transport: QoderTransport = "sdk_cli";
   private readonly sessions = new Map<string, SDKSession>();
   private readonly modelCache = new Map<string, { expires: number; models: ModelRecord[] }>();
 

--- a/examples/runner/qoder/src/server.ts
+++ b/examples/runner/qoder/src/server.ts
@@ -17,6 +17,7 @@ import {
   type CloseParams,
   type ModelsParams,
   type QoderAdapter,
+  type QoderTransport,
   type ReadinessParams,
   type RunnerRequest,
   type RunnerResponse,
@@ -62,18 +63,22 @@ export class RunnerServer {
 
   private async dispatch(request: RunnerRequest): Promise<unknown> {
     switch (request.method) {
-      case "handshake":
+      case "handshake": {
+        const transport: QoderTransport = this.adapter.transport ?? "sdk_cli";
         return {
           runner: RUNNER_NAME,
           runner_version: RUNNER_VERSION,
           protocol_version: RUNNER_PROTOCOL_VERSION,
-          sdk_version: QODER_SDK_VERSION,
+          sdk_version: transport === "direct_openai" ? "not_applicable" : QODER_SDK_VERSION,
+          transport,
           node_version: process.version,
           capabilities: [
-            "readiness", "models", "sessions", "events", "cancel", "close", "structured_input",
-            "image_input", "fixed_permissions", "fixed_skills", "fixed_mcp",
+            ...(transport === "direct_openai"
+              ? ["readiness", "models", "events", "cancel", "close", "direct_openai", "client_tools", "structured_input", "image_input"]
+              : ["readiness", "models", "sessions", "events", "cancel", "close", "structured_input", "image_input", "fixed_permissions", "fixed_skills", "fixed_mcp"]),
           ],
         };
+      }
       case "readiness": {
         const params = asObject<ReadinessParams>(request.params);
         const state = await this.adapter.readiness(params.auth);

--- a/examples/runner/qoder/src/types.ts
+++ b/examples/runner/qoder/src/types.ts
@@ -3,8 +3,10 @@ export const RUNNER_NAME = "cpa-qoder-runner";
 export const RUNNER_VERSION = "0.1.0";
 export const QODER_SDK_VERSION = "1.0.10";
 
+export type QoderTransport = "sdk_cli" | "direct_openai";
+
 export type AuthSpec =
-  | { mode: "pat"; env_var: string; account_id?: string }
+  | { mode: "pat"; env_var: string; account_id?: string; transport?: QoderTransport }
   | { mode: "local_cli"; profile_id?: string };
 
 export type PermissionRule = {
@@ -52,11 +54,15 @@ export type StartParams = Correlation & {
   allowed_tools?: string[];
   disallowed_tools?: string[];
   mcp_servers?: Record<string, FixedMcpServerConfig>;
+  /** Original bounded Chat Completions object, preserved for direct transport. */
+  chat_request?: Record<string, unknown>;
 };
 
 export type ModelsParams = {
   auth: AuthSpec;
   cache_ttl_ms?: number;
+  models_endpoint?: string;
+  models_json?: string;
 };
 
 export type ReadinessParams = {
@@ -148,6 +154,7 @@ export interface ActiveTurn {
 }
 
 export interface QoderAdapter {
+  readonly transport?: QoderTransport;
   readiness(auth?: AuthSpec): Promise<{ auth_ready: boolean; message: string }>;
   models(params: ModelsParams): Promise<ModelRecord[]>;
   start(params: StartParams, emit: (event: AgentEventV1) => Promise<void>): Promise<ActiveTurn>;

--- a/examples/runner/qoder/test/runner.test.mjs
+++ b/examples/runner/qoder/test/runner.test.mjs
@@ -3,6 +3,7 @@ import { PassThrough, Writable } from "node:stream";
 import test from "node:test";
 
 import { BoundedFrameWriter, ProtocolError, redactStderr } from "../dist/protocol.js";
+import { DirectOpenAIAdapter } from "../dist/direct.js";
 import { toModelRecord, userMessage } from "../dist/qoder.js";
 import { RunnerServer } from "../dist/server.js";
 
@@ -270,4 +271,222 @@ test("stderr redaction removes direct and header secrets", () => {
   const safe = redactStderr(`token=${secret} Authorization: Bearer ${secret}`, [secret]);
   assert.equal(safe.includes(secret), false);
   assert.match(safe, /REDACTED_SECRET/);
+});
+
+test("direct OpenAI transport preserves exact model, tools, usage, and lifecycle events", async () => {
+  const envVar = "CPA_TEST_QODER_DIRECT_TOKEN";
+  process.env[envVar] = "jt-fixture";
+  const calls = [];
+  const adapter = new DirectOpenAIAdapter({
+    endpoint: "https://direct.example.test/model/v1/chat/completions",
+    modelsEndpoint: "https://direct.example.test/model/v1/models",
+    tokenMode: "bearer",
+    models: [],
+    fetchImpl: async (url, init = {}) => {
+      calls.push({ url: String(url), init });
+      if (String(url).endsWith("/models")) {
+        return new Response(JSON.stringify({ data: [{ id: "qfmodel", display_name: "Qwen3.8-Flash", is_enabled: true }] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response([
+        'data: {"choices":[{"delta":{"role":"assistant"}}]}',
+        'data: {"choices":[{"delta":{"content":"ok"}}]}',
+        'data: {"choices":[{"delta":{"reasoning_content":"trace"}}]}',
+        'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"raw_usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}',
+        "data: [DONE]",
+        "",
+      ].join("\n"), { status: 200, headers: { "content-type": "text/event-stream" } });
+    },
+  });
+  try {
+    const models = await adapter.models({ auth: { mode: "pat", env_var: envVar }, models_endpoint: "https://direct.example.test/model/v1/models" });
+    assert.deepEqual(models.map((model) => model.id), ["qfmodel"]);
+    const params = {
+      ...startParams(),
+      auth: { mode: "pat", env_var: envVar, transport: "direct_openai" },
+      chat_request: {
+        model: "client-alias",
+        messages: [{ role: "user", content: "hello" }],
+        stream: false,
+        tools: [{ type: "function", function: { name: "probe", parameters: { type: "object" } } }],
+      },
+    };
+    const events = [];
+    let terminal;
+    const completed = new Promise((resolve) => { terminal = resolve; });
+    await adapter.start(params, async (event) => {
+      events.push(event);
+      if (event.type === "turn.completed" || event.type === "turn.failed" || event.type === "turn.cancelled") terminal(event);
+    });
+    await completed;
+    assert.deepEqual(events.map((event) => event.type), [
+      "session.created", "turn.started", "message.delta", "reasoning.delta", "usage.updated", "turn.completed",
+    ]);
+    const inference = calls.find((call) => call.url.endsWith("/chat/completions"));
+    assert.ok(inference);
+    assert.equal(inference.init.headers.Authorization, "Bearer jt-fixture");
+    const body = JSON.parse(inference.init.body);
+    assert.equal(body.model, "qfmodel");
+    assert.equal(body.stream, true);
+    assert.equal(body.stream_options.include_usage, true);
+    assert.deepEqual(body.tools[0].function.parameters, { type: "object" });
+    assert.equal(body.metadata.context.request_id, params.request_id);
+    await adapter.close(params.execution_session_id);
+  } finally {
+    delete process.env[envVar];
+    await adapter.shutdown();
+  }
+});
+
+test("direct OpenAI transport exchanges PAT and retries one unauthorized response with refresh token", async () => {
+  const envVar = "CPA_TEST_QODER_DIRECT_PAT";
+  process.env[envVar] = "pt-fixture";
+  const calls = [];
+  let inferenceCalls = 0;
+  const adapter = new DirectOpenAIAdapter({
+    endpoint: "https://direct.example.test/model/v1/chat/completions",
+    authEndpoint: "https://openapi.example.test",
+    tokenMode: "auto",
+    models: [{ id: "qfmodel", display_name: "Qwen3.8-Flash" }],
+    fetchImpl: async (url, init = {}) => {
+      calls.push({ url: String(url), init });
+      if (String(url).endsWith("/jobToken/exchange")) {
+        return new Response(JSON.stringify({ token: "jt-one", refresh_token: "jrt-one", expires_in: 86400000 }), { status: 200 });
+      }
+      if (String(url).endsWith("/jobToken/refresh")) {
+        return new Response(JSON.stringify({ token: "jt-two", refresh_token: "jrt-two", expires_in: 86400000 }), { status: 200 });
+      }
+      inferenceCalls += 1;
+      if (inferenceCalls === 1) return new Response("unauthorized", { status: 401 });
+      return new Response('data: {"choices":[{"delta":{"content":"ok"}}]}\ndata: [DONE]\n', {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    },
+  });
+  try {
+    const params = {
+      ...startParams(),
+      auth: { mode: "pat", env_var: envVar, transport: "direct_openai" },
+      chat_request: { model: "qfmodel", messages: [{ role: "user", content: "hello" }] },
+    };
+    const events = [];
+    let terminal;
+    const completed = new Promise((resolve) => { terminal = resolve; });
+    await adapter.start(params, async (event) => {
+      events.push(event);
+      if (event.type === "turn.completed" || event.type === "turn.failed" || event.type === "turn.cancelled") terminal(event);
+    });
+    await completed;
+    assert.equal(events.at(-1).type, "turn.completed");
+    const inference = calls.filter((call) => call.url.endsWith("/chat/completions"));
+    assert.equal(inference.length, 2);
+    assert.equal(inference[0].init.headers.Authorization, "Bearer jt-one");
+    assert.equal(inference[1].init.headers.Authorization, "Bearer jt-two");
+  } finally {
+    delete process.env[envVar];
+    await adapter.shutdown();
+  }
+});
+
+test("direct OpenAI transport aborts the upstream request on cancel", async () => {
+  const envVar = "CPA_TEST_QODER_DIRECT_CANCEL_TOKEN";
+  process.env[envVar] = "jt-fixture";
+  const adapter = new DirectOpenAIAdapter({
+    endpoint: "https://direct.example.test/model/v1/chat/completions",
+    tokenMode: "bearer",
+    models: [{ id: "qfmodel" }],
+    fetchImpl: async (_url, init = {}) => await new Promise((_resolve, reject) => {
+      init.signal.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), { once: true });
+    }),
+  });
+  try {
+    const params = {
+      ...startParams(),
+      auth: { mode: "pat", env_var: envVar, transport: "direct_openai" },
+      chat_request: { model: "qfmodel", messages: [{ role: "user", content: "hello" }] },
+    };
+    const events = [];
+    let terminal;
+    const completed = new Promise((resolve) => { terminal = resolve; });
+    const turn = await adapter.start(params, async (event) => {
+      events.push(event);
+      if (event.type === "turn.completed" || event.type === "turn.failed" || event.type === "turn.cancelled") terminal(event);
+    });
+    await turn.cancel();
+    const finalEvent = await completed;
+    assert.equal(finalEvent.type, "turn.cancelled");
+    assert.equal(events.at(-1).payload.code, "request_cancelled");
+  } finally {
+    delete process.env[envVar];
+    await adapter.shutdown();
+  }
+});
+
+test("direct OpenAI transport projects client tool-call deltas into AgentEventV1", async () => {
+  const envVar = "CPA_TEST_QODER_DIRECT_TOOL_TOKEN";
+  process.env[envVar] = "jt-fixture";
+  const adapter = new DirectOpenAIAdapter({
+    endpoint: "https://direct.example.test/model/v1/chat/completions",
+    tokenMode: "bearer",
+    models: [{ id: "qfmodel" }],
+    fetchImpl: async () => new Response([
+      'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-1","type":"function","function":{"name":"probe","arguments":"{\\"x\\":1}"}}]}}]}',
+      "data: [DONE]",
+      "",
+    ].join("\n"), { status: 200, headers: { "content-type": "text/event-stream" } }),
+  });
+  try {
+    const params = {
+      ...startParams(),
+      auth: { mode: "pat", env_var: envVar, transport: "direct_openai" },
+      chat_request: { model: "qfmodel", messages: [{ role: "user", content: "call probe" }], tools: [{ type: "function", function: { name: "probe" } }] },
+    };
+    const events = [];
+    let terminal;
+    const completed = new Promise((resolve) => { terminal = resolve; });
+    await adapter.start(params, async (event) => {
+      events.push(event);
+      if (event.type === "turn.completed" || event.type === "turn.failed" || event.type === "turn.cancelled") terminal(event);
+    });
+    await completed;
+    assert.deepEqual(events.map((event) => event.type), [
+      "session.created", "turn.started", "tool.started", "tool.updated", "tool.completed", "turn.completed",
+    ]);
+    assert.equal(events.find((event) => event.type === "tool.updated").payload.partial_json, '{"x":1}');
+  } finally {
+    delete process.env[envVar];
+    await adapter.shutdown();
+  }
+});
+
+test("direct OpenAI transport rejects a display-name or guessed model alias", async () => {
+  const envVar = "CPA_TEST_QODER_DIRECT_MODEL_TOKEN";
+  process.env[envVar] = "jt-fixture";
+  const adapter = new DirectOpenAIAdapter({
+    endpoint: "https://direct.example.test/model/v1/chat/completions",
+    tokenMode: "bearer",
+    models: [{ id: "qfmodel", display_name: "Qwen3.8-Flash" }],
+    fetchImpl: async () => { throw new Error("network must not be called for an unknown model"); },
+  });
+  try {
+    const params = {
+      ...startParams(),
+      model: "Qwen3.8-Flash",
+      auth: { mode: "pat", env_var: envVar, transport: "direct_openai" },
+      chat_request: { model: "Qwen3.8-Flash", messages: [{ role: "user", content: "hello" }] },
+    };
+    let terminal;
+    const completed = new Promise((resolve) => { terminal = resolve; });
+    await adapter.start(params, async (event) => {
+      if (event.type === "turn.failed") terminal(event);
+    });
+    const result = await completed;
+    assert.equal(result.payload.code, "unsupported_model");
+  } finally {
+    delete process.env[envVar];
+    await adapter.shutdown();
+  }
 });

--- a/examples/runner/qoder/test/runner.test.mjs
+++ b/examples/runner/qoder/test/runner.test.mjs
@@ -333,6 +333,22 @@ test("direct OpenAI transport preserves exact model, tools, usage, and lifecycle
     assert.equal(body.stream_options.include_usage, true);
     assert.deepEqual(body.tools[0].function.parameters, { type: "object" });
     assert.equal(body.metadata.context.request_id, params.request_id);
+    const second = {
+      ...params,
+      request_id: "request-2",
+      turn_id: "turn-2",
+      chat_request: { ...params.chat_request, model: "qfmodel" },
+    };
+    const secondEvents = [];
+    let secondTerminal;
+    const secondCompleted = new Promise((resolve) => { secondTerminal = resolve; });
+    await adapter.start(second, async (event) => {
+      secondEvents.push(event);
+      if (event.type === "turn.completed" || event.type === "turn.failed" || event.type === "turn.cancelled") secondTerminal(event);
+    });
+    await secondCompleted;
+    assert.equal(secondEvents[0].type, "turn.started");
+    assert.equal(secondEvents.some((event) => event.type === "session.created"), false);
     await adapter.close(params.execution_session_id);
   } finally {
     delete process.env[envVar];


### PR DESCRIPTION
## Type

- [x] LTS feature / downstream patch maintenance

## Outcome

This PR adds a second explicit Qoder execution path without changing the existing verified SDK/CLI default. `cpa-provider-qoder` can now select `sdk_cli` or `direct_openai` globally or per auth profile, while both paths use the same versioned JSONL runner, correlation, lifecycle, readiness, cancellation, close, and usage projection.

## Changes

- Add `DirectOpenAIAdapter` with bounded standard/nested SSE parsing, JSON fallback, raw usage handling, client tool-call projection, exact model admission, PAT-to-job-token exchange, one 401/403 refresh retry, and abort-based cancellation.
- Add transport negotiation to runner handshake and include transport in auth/model/session cache identity.
- Preserve the original Chat request only for direct transport so messages, images, tools, tool choice, and supported generation fields are not flattened.
- Preserve direct client tool calls in Chat stream and non-stream projections while keeping SDK-native Qoder tools out of client-owned tool calls.
- Add explicit endpoint, auth endpoint, token mode, and exact model configuration validation; forbid runner argument overrides.
- Keep the existing SDK/CLI path as the default and preserve its native sessions, skills, MCP, permissions, and workspace behavior.
- Update provider and runner documentation and add fake protocol, auth, model, stream, tool, error, and cancellation regressions.

## Compatibility and boundaries

- Existing `sdk_cli` auth files and configurations remain valid; missing transport continues to mean `sdk_cli`.
- `direct_openai` is a raw Chat/model transport. It does not advertise native Qoder sessions, skills, MCP, or Qoder CLI tools.
- CN and global direct endpoints must be configured explicitly; the plugin does not guess a region or silently fall back to `auto`.
- The reverse-engineered COSY/QoderEncoding path is not introduced as a runtime dependency.
- No CPA Core public API, LTS usage schema, panel, release, deployment, or external gateway dependency is changed.

## Protected delta / LTS classification

No files under `internal/usage`, Management usage handlers, `docs/lts`, or the LTS registry were changed. Existing LTS contract sentinels and registry validation were rerun.

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| Qoder provider/runner | newly-added capability | preserved SDK default plus explicit direct adapter | nested Go/Node tests; full Go tests |
| LTS protected usage contract | retained capability | untouched | `scripts/check-lts-contract.sh`; usage-related packages in `go test ./...` |

## Validation

- `go test -count=1 ./...` (repository root): passed
- `cd examples/plugin/qoder/go && go test -race -count=1 ./...`: passed
- `cd examples/plugin/qoder/go && go vet ./...`: passed
- Qoder plugin c-shared build: passed
- `cd examples/runner/qoder && npm test`: 15 passed, 0 failed
- `scripts/check-lts-contract.sh`: passed
- `go run ./scripts/ltsregistry --root .`: passed
- `go build ./cmd/server`: passed
- `git diff --check`: passed

## Runtime boundary

The new direct transport was validated with deterministic fake upstreams and JSONL smoke. It was not deployed to the Hugging Face Space in this PR, so no direct-transport real-account or production-runtime acceptance is claimed. Existing SDK/CLI real-account evidence remains separate from this change.

## Review focus

Please review the transport selector/session identity, PAT exchange and refresh ownership, exact-model admission, direct SSE/tool projection, and the no-silent-fallback behavior.
