### PR TITLE
feat(usage): expose first-byte timing in Core statistics

### DIFF
--- a/docs/lts/core-feature-contracts.yaml
+++ b/docs/lts/core-feature-contracts.yaml
@@ -37,6 +37,7 @@ features:
       - RequestDetail
       - auth_index
       - latency_ms
+      - ttfb_ms
       - reasoning_effort
       - service_tier
       - request_service_tier

--- a/docs/lts/sync-runbook.md
+++ b/docs/lts/sync-runbook.md
@@ -183,7 +183,7 @@ Validator 会把当前 ledger 与 `--base-ref`（CI 使用 PR base branch）比�
 - `internal/usage/`：保留 LTS 完整统计，必要时适配 upstream 新结构。
 - `usage-statistics-enabled`：必须继续控制新 usage record 写入，不影响既有 snapshot/export/import 读取。
 - `/v0/management/usage`、`/export`、`/import`：必须保留。
-- usage record schema：保留 API key、auth file/source、model、token、latency、success/failure、auth index 等字段。
+- usage record schema：保留 API key、auth file/source、model、token、latency、首字节 `ttfb_ms`、success/failure、auth index 等字段。
 - Management usage response shape：保持 CPA-Panel-LTS 兼容。
 - config schema：接收 upstream 新项，同时保留旧配置兼容。
 - panel release source：保持 `BlueSkyXN/CPA-Panel-LTS`，除非用户明确改变策略。
@@ -212,7 +212,7 @@ git diff --check
 
 最小行为级 contract tests 必须覆盖：
 
-- usage record creation / schema：API key、auth source、model、token、latency、success/failure。
+- usage record creation / schema：API key、auth source、model、token、latency、首字节 `ttfb_ms`、success/failure。
 - Management usage response shape：`usage`、`failed_requests`、`apis`、`models`、`details`。
 - export/import roundtrip：导出后导入仍保留核心字段。
 

--- a/internal/api/handlers/management/usage.go
+++ b/internal/api/handlers/management/usage.go
@@ -220,6 +220,7 @@ func validateUsageImportRawShape(data []byte) error {
 					detailObject,
 					"timestamp",
 					"latency_ms",
+					"ttfb_ms",
 					"source",
 					"auth_index",
 					"alias",

--- a/internal/api/handlers/management/usage_contract_test.go
+++ b/internal/api/handlers/management/usage_contract_test.go
@@ -66,6 +66,9 @@ func TestUsageManagementResponseShapeAndImportExportRoundTrip(t *testing.T) {
 	if !bytes.Contains(exportedJSON, []byte(`"generate":false`)) {
 		t.Fatalf("exported usage missing explicit generate=false: %s", exportedJSON)
 	}
+	if !bytes.Contains(exportedJSON, []byte(`"ttfb_ms":500`)) {
+		t.Fatalf("exported usage missing ttfb_ms: %s", exportedJSON)
+	}
 	requireCanonicalReasoningEffortJSON(t, exportedJSON, "exported usage")
 	var legacyDecoded struct {
 		Version int `json:"version"`
@@ -1142,6 +1145,7 @@ func recordPanelContractUsage(stats *usage.RequestStatistics) {
 		Generate:             coreusage.GenerateFlag(false),
 		RequestedAt:          time.Date(2026, 6, 10, 11, 30, 0, 0, time.UTC),
 		Latency:              2 * time.Second,
+		TTFT:                 500 * time.Millisecond,
 		Detail: coreusage.Detail{
 			InputTokens:     5,
 			OutputTokens:    7,
@@ -1365,6 +1369,9 @@ func requirePanelUsageShape(t *testing.T, snapshot usage.StatisticsSnapshot) {
 	}
 	if detail.LatencyMs != 2000 {
 		t.Fatalf("detail.latency_ms = %d, want 2000", detail.LatencyMs)
+	}
+	if detail.TTFBMs != 500 {
+		t.Fatalf("detail.ttfb_ms = %d, want 500", detail.TTFBMs)
 	}
 	if detail.Failed {
 		t.Fatalf("detail.failed = true, want false")

--- a/internal/usage/logger_plugin.go
+++ b/internal/usage/logger_plugin.go
@@ -100,8 +100,11 @@ type modelStats struct {
 
 // RequestDetail stores request-level metadata and token usage for a single request.
 type RequestDetail struct {
-	Timestamp            time.Time  `json:"timestamp"`
-	LatencyMs            int64      `json:"latency_ms"`
+	Timestamp time.Time `json:"timestamp"`
+	LatencyMs int64     `json:"latency_ms"`
+	// TTFBMs records the first upstream response byte/payload latency. The
+	// runtime currently carries this value in the legacy Record.TTFT field.
+	TTFBMs               int64      `json:"ttfb_ms,omitempty"`
 	Source               string     `json:"source"`
 	UsageProvenance      string     `json:"usage_provenance,omitempty"`
 	AuthIndex            string     `json:"auth_index"`
@@ -470,6 +473,7 @@ func (s *RequestStatistics) Record(ctx context.Context, record coreusage.Record)
 	requestDetail := RequestDetail{
 		Timestamp:            timestamp,
 		LatencyMs:            normaliseLatency(record.Latency),
+		TTFBMs:               normaliseLatency(record.TTFT),
 		Source:               record.Source,
 		UsageProvenance:      coreusage.CanonicalUsageProvenance(record.UsageProvenance),
 		AuthIndex:            record.AuthIndex,
@@ -647,6 +651,9 @@ func (s *RequestStatistics) MergeSnapshot(snapshot StatisticsSnapshot) (MergeRes
 				detail.UsageProvenance = coreusage.CanonicalUsageProvenance(detail.UsageProvenance)
 				if detail.LatencyMs < 0 {
 					detail.LatencyMs = 0
+				}
+				if detail.TTFBMs < 0 {
+					detail.TTFBMs = 0
 				}
 				key := dedupKey(apiName, modelName, detail)
 				if _, exists := seen[key]; exists {

--- a/internal/usage/logger_plugin_test.go
+++ b/internal/usage/logger_plugin_test.go
@@ -19,6 +19,7 @@ func TestRequestStatisticsRecordIncludesLatency(t *testing.T) {
 		Model:       "gpt-5.4",
 		RequestedAt: time.Date(2026, 3, 20, 12, 0, 0, 0, time.UTC),
 		Latency:     1500 * time.Millisecond,
+		TTFT:        450 * time.Millisecond,
 		Detail: coreusage.Detail{
 			InputTokens:  10,
 			OutputTokens: 20,
@@ -33,6 +34,9 @@ func TestRequestStatisticsRecordIncludesLatency(t *testing.T) {
 	}
 	if details[0].LatencyMs != 1500 {
 		t.Fatalf("latency_ms = %d, want 1500", details[0].LatencyMs)
+	}
+	if details[0].TTFBMs != 450 {
+		t.Fatalf("ttfb_ms = %d, want 450", details[0].TTFBMs)
 	}
 }
 

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -166,6 +166,7 @@ require_grep "codex_client_models.json" .github/scripts/refresh-model-catalogs.s
 require_grep "responsesWebsocketCanAttestContextReset" sdk/api/handlers/openai/openai_responses_websocket.go sdk/api/handlers/openai/openai_responses_websocket_test.go
 require_grep "ModelFallbackZeroDispatch" sdk/cliproxy/auth/codex_model_fallback.go docs/lts/core-feature-contracts.yaml
 require_grep "auth_index" internal/usage internal/api/handlers/management internal/runtime/executor/helps internal/redisqueue
+require_grep "ttfb_ms" internal/usage internal/api/handlers/management
 require_grep "UserEndpoint" internal/auth/xai/types.go internal/auth/xai/xai.go docs/lts/core-feature-contracts.yaml
 require_grep "UserEndpointUserAgent" internal/auth/xai/types.go internal/auth/xai/xai.go docs/lts/core-feature-contracts.yaml
 require_grep 'case "amd64"' internal/auth/xai/types.go


### PR DESCRIPTION
## Outcome

Expose CPA Core existing first-upstream-response timing as an optional ttfb_ms field in request-level usage details so Management usage export/import and downstream Panel consumers can read it without changing the existing usage schema.

## Changes

- Map sdk/cliproxy/usage.Record.TTFT into internal/usage.RequestDetail.TTFBMs.
- Preserve the field through Management usage raw-shape validation and export/import round trips.
- Normalize negative imported values to zero.
- Update the protected Core feature registry, LTS runbook, contract sentinel, and focused regression tests.

## Compatibility and boundaries

- The new JSON field is optional; existing records and legacy imports remain valid.
- ttfb_ms means the first non-empty upstream response byte or payload observed by the existing runtime hook. It is not claimed to be semantic first-token latency.
- No public route is added or removed, and no existing usage field is replaced.
- The companion Panel display and derived TPS work is separate; this PR only exposes the Core-side field.

## Validation

- gofmt -d on all touched Go files: no output.
- go test ./internal/usage ./internal/api/handlers/management ./test -run Usage-or-usage: passed.
- go test ./...: passed.
- scripts/check-lts-contract.sh: passed.
- go build server smoke: passed.
- git diff --check: passed.

## Delivery boundary

This PR is opened against main; it is not merged until the remote checks and head are re-read. No release, deployment, or live runtime acceptance is claimed.