### PR TITLE
docs(agents): 对齐源码核验与 Usage v3 协作指引

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,16 @@
 
 如果 upstream diff 触碰 request lifecycle、auth identity、model resolution、token accounting、logging metadata、Management usage response shape、config hot reload、panel release source、plugin runtime 或 usage queue，即使没有文本冲突，也必须写 `Protected delta review`。
 
+## Source lookup priority
+
+源码查找和 GitHub 远程状态核验是两类操作，不要混用：
+
+- **当前项目代码**：先读取当前 worktree 以及本地 `main` / `origin/main`；优先使用 `rg`、`git show`、`git diff`、`git log`。不要仅因任务出现“当前”“最新”或“原作者”就调用 `gh api`。
+- **原作者 upstream 代码**：先读取本地 `upstream/main` 及其他 remote-tracking refs。只有本地 ref 缺失或明显过旧，且确实需要最新 upstream 源码时，才说明原因并执行只读目的的 `git fetch upstream`（需要网络，会更新本地 remote-tracking refs），随后核对 fetch 前后的 SHA。
+- **GitHub 远程状态**：PR、CI、Release、Issue、远程分支状态等元数据才使用 `gh` / `gh api`；本地 refs 尚未包含的源码优先通过上面的 `git fetch upstream` 获取，不用 `gh api` 代替 Git 历史。调用 `gh` 时必须显式指定目标仓库（LTS 使用 `-R BlueSkyXN/CPA-Core-LTS`，upstream 使用 `-R router-for-me/CLIProxyAPI`）。
+- **部署和运行态**：部署版本、runtime、UAT 和外部服务状态必须单独核验，不能用本地源码、GitHub 源码或 PR 状态替代。
+- 如果确实需要远程查询，先写明本地检查过的 ref、远程查询要解决的问题及预期证据；不得用远程内容覆盖 dirty worktree 或替代本地未提交改动。
+
 ## Directory map
 
 | Path | Responsibility | Local AGENTS.md | Read when |

--- a/internal/api/handlers/management/AGENTS.md
+++ b/internal/api/handlers/management/AGENTS.md
@@ -11,7 +11,7 @@ Key files: `handler.go`, `config_*.go`, `auth_files*.go`, `oauth_sessions.go`, `
 - Management availability, route registration, remote-access policy, and credential validation are separate concerns. Home mode keeps the Management surface unavailable.
 - Config writes must preserve comments/order through existing config helpers and must trigger the established generation-ordered reload path.
 - Auth file upload/download/delete/patch must preserve safe filename/path handling, private-file permissions, registered-record synchronization, plugin-virtual-source rules, and the rollback behavior implemented by each flow.
-- Usage export/import follows the canonical v2 contract in `internal/usage/AGENTS.md`; malformed, unsupported, ambiguous, or overflowing imports fail atomically with stable error codes.
+- Usage export/import follows the canonical v3 contract in `internal/usage/AGENTS.md`; released v1/v2 payloads migrate only when their token and timing semantics are provable, while malformed, unsupported, ambiguous, or overflowing imports fail atomically with stable error codes.
 - Plugin routes must remain namespaced and must not collide with built-in method/path pairs.
 
 ## Do not

--- a/internal/usage/AGENTS.md
+++ b/internal/usage/AGENTS.md
@@ -9,9 +9,10 @@ Key files: `logger_plugin.go`, `internal/api/handlers/management/usage.go`, `sdk
 - `usage-statistics-enabled` 只控制是否继续记录新数据；不要破坏已有 snapshot/export/import 的读取能力。
 - Snapshot JSON 字段要继续兼容 Panel：`total_requests`、`success_count`、`failure_count`、`total_tokens`、`apis`、`models`、`details`、day/hour buckets。
 - Request detail 必须保留 timestamp、latency、source、auth_index、token breakdown、failed 状态。
-- Canonical v2 request detail 还包括 alias、`reasoning_effort`、request/outbound/response/effective service tier、`generate`、`failure_reason`、`failure_status`。
+- Canonical request detail 还包括 alias、`reasoning_effort`、request/outbound/response/effective service tier、`generate`、`failure_reason`、`failure_status`。
+- Canonical v3 timing 使用 `timing_version: 1`：`ttfb_ms` 是首个非空 upstream byte/payload，`ttft_ms` 是首个非空 reasoning content，`ttfa_ms` 是首个非空用户可见 assistant text；缺失事件保持 absent，不伪造零值。
 - Token 统计要兼容 input/output/reasoning/cached/cache-read/cache-creation/total，并保留现有 normalise 逻辑。
-- Export 使用 `CanonicalExportVersion = 2`。Import 只接受受支持的 canonical v2 或可证明语义的 released v1 migration，并返回稳定 error code / migration receipt。
+- Export 使用 `CanonicalExportVersion = 3`。Import 接受 canonical v3，并仅迁移 token/timing 语义可证明的 released v1/v2 payload；migration 必须返回稳定 error code / receipt。
 - Import 必须先完整校验 shape、token semantics 和 aggregate overflow，再原子 merge；不能部分写入。重复记录按现有 dedup identity 跳过。
 - 没有 API key 时统计 key 依次使用 request endpoint、provider、`unknown`；不要把所有非 API-key 请求折叠到同一 bucket。
 
@@ -33,6 +34,6 @@ Key files: `logger_plugin.go`, `internal/api/handlers/management/usage.go`, `sdk
 - `go test ./internal/usage`
 - `go test ./internal/api/handlers/management -run Usage`
 - `go test ./test -run Usage`
-- Canonical import/export changes: `go test ./internal/usage ./internal/api/handlers/management -run 'MigrateV1|CanonicalV2|UsageManagementImport'`
+- Canonical import/export changes: `go test ./internal/usage ./internal/api/handlers/management -run 'MigrateV1|CanonicalV3|TimingV3|UsageManagementImport'`
 - Contract guard: `scripts/check-lts-contract.sh`
 - 跨字段或 import/export 兼容性改动后，再运行 `go test ./...`。


### PR DESCRIPTION
## 结果

把已经存在但未提交的 source lookup 协作规则独立落盘，并将 Usage/Management navigation cards 从 canonical v2 更新到已合入主线的 canonical v3。该变更不与产品代码 PR 混合。

## 变更

- 根 `AGENTS.md` 明确区分当前源码、本地 `upstream/main`、GitHub PR/CI 元数据和部署运行态的核验来源。
- `internal/usage/AGENTS.md` 对齐 `CanonicalExportVersion = 3`、`timing_version: 1`、TTFB/TTFT/TTFA 语义和 v1/v2 migration。
- Management navigation card 同步 canonical v3 的 fail-closed import 边界。

## 边界

- 只修改 3 个 `AGENTS.md`。
- 不修改 Go 源码、API、schema、测试、workflow、Release 或部署。

## 验证

- 回读 `internal/usage/logger_plugin.go`：`CanonicalExportVersion = 3`。
- 回读 `sdk/cliproxy/usage/manager.go`：`TimingVersionV1` 及 TTFB/TTFT/TTFA 注释与本文一致。
- `git diff --check`：通过。
