### PR TITLE
fix(api): 支持配置 JSON 请求体上限

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -5,9 +5,9 @@ host: ""
 # Server port
 port: 8317
 
-# Maximum size in bytes for public API JSON request bodies and every decoded
-# Content-Encoding layer. The safe default is 16 MiB. Set a positive value to
-# allow larger bounded multimodal requests; 0 or negative values use the default.
+# Maximum size in bytes for standard protocol-handler JSON request bodies and
+# every decoded Content-Encoding layer. The safe default is 16 MiB. Set a positive
+# value to allow larger bounded multimodal requests; 0 or negative values use the default.
 api-request-body-max-bytes: 16777216
 
 # TLS settings for HTTPS. When enabled, the server listens with the provided certificate and key.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -5,6 +5,11 @@ host: ""
 # Server port
 port: 8317
 
+# Maximum size in bytes for public API JSON request bodies and every decoded
+# Content-Encoding layer. The safe default is 16 MiB. Set a positive value to
+# allow larger bounded multimodal requests; 0 or negative values use the default.
+api-request-body-max-bytes: 16777216
+
 # TLS settings for HTTPS. When enabled, the server listens with the provided certificate and key.
 tls:
   enable: false

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -564,10 +564,17 @@ patches:
     retire_when: Upstream removes unbounded or tempfile-backed request logging from the hot path, bounds request/response/deferred upstream previews, provides idempotent middleware-owned unwind cleanup for normal completion and all panic paths, and all listed regressions pass after removing the downstream implementation.
 
   - id: api-request-body-size-limit
-    reason: Public Claude, Gemini, OpenAI, Responses, image, and video JSON handlers previously used unbounded body reads and unbounded zstd expansion, so a small number of concurrent oversized requests could consume container memory before provider routing or normal validation ran.
+    reason: Public Claude, Gemini, OpenAI, Responses, image, and video JSON handlers previously used unbounded body reads and unbounded zstd expansion, so a small number of concurrent oversized requests could consume container memory before provider routing or normal validation ran. The bounded default remains 16 MiB, while api-request-body-max-bytes lets operators explicitly raise the same encoded and decoded limit for legitimate large multimodal requests.
     introduced_in: b2b593fad3f18bfe700fe5f11d4e88e10bbc7f16
     affected_upstream_range: through 17a65ee5470fbaf0e22fc219381e6a4ae9e07624 (upstream main, 2026-09-01); the new Gemini schema, translator, WebSocket, and proxy fixes do not add a decoded-body limit. Upstream handlers still use unbounded GetRawData/io.ReadAll behavior and do not enforce the same limit on every decoded Content-Encoding layer, so the patch remains required.
     files:
+      - config.example.yaml
+      - internal/config/api_request_body.go
+      - internal/config/api_request_body_test.go
+      - internal/config/sdk_config.go
+      - internal/watcher/diff/config_diff.go
+      - internal/watcher/diff/config_diff_test.go
+      - sdk/config/config.go
       - sdk/api/handlers/request_body.go
       - sdk/api/handlers/request_body_test.go
       - sdk/api/handlers/claude/code_handlers.go
@@ -581,9 +588,14 @@ patches:
       - TestReadRequestBodyRejectsIdentityBodyOverLimit
       - TestDecodeZstdRequestBodyRejectsDecodedBodyOverLimit
       - TestReadRequestBodyKeepsValidJSONFallbackForBadEncoding
-    upstream_issue_or_pr: not-filed
+      - TestBaseAPIHandlerReadRequestBodyAllowsConfiguredLargerBody
+      - TestBaseAPIHandlerReadRequestBodyUsesHotReloadedLimit
+      - TestBaseAPIHandlerReadRequestBodyAppliesConfiguredLimitAfterZstdDecode
+      - TestSDKConfigEffectiveAPIRequestBodyMaxBytes
+      - TestParseConfigBytesAPIRequestBodyMaxBytes
+    upstream_issue_or_pr: BlueSkyXN/CPA-Core-LTS#237
     state: required
-    retire_when: Upstream bounds encoded public API request bodies and every decoded Content-Encoding layer, returns 413 for limit violations without bypassing the limit through raw-JSON fallback, routes all affected handlers through the shared bounded reader, and all listed regressions pass after removing the downstream implementation.
+    retire_when: Upstream bounds encoded public API request bodies and every decoded Content-Encoding layer, provides an operator-controlled bounded override with a safe default, returns 413 for limit violations without bypassing the limit through raw-JSON fallback, routes all affected handlers through the shared bounded reader, and all listed regressions pass after removing the downstream implementation.
 
   - id: object-store-auth-path-containment
     reason: Object-store auth persistence must never create, overwrite, upload, delete, or render credential files outside its managed private roots, including traversal, sibling-prefix, absolute-path, pre-existing or dangling symlinks, junctions, initialized-root replacement, check/write path-swap races, and crash-persistent global-temp copies.

--- a/docs/lts/downstream-patches.yaml
+++ b/docs/lts/downstream-patches.yaml
@@ -583,6 +583,7 @@ patches:
       - sdk/api/handlers/openai/openai_handlers.go
       - sdk/api/handlers/openai/openai_images_handlers.go
       - sdk/api/handlers/openai/openai_responses_handlers.go
+      - sdk/api/handlers/openai/openai_responses_request_body_limit_test.go
       - sdk/api/handlers/openai/openai_videos_handlers.go
     regression_tests:
       - TestReadRequestBodyRejectsIdentityBodyOverLimit
@@ -593,9 +594,10 @@ patches:
       - TestBaseAPIHandlerReadRequestBodyAppliesConfiguredLimitAfterZstdDecode
       - TestSDKConfigEffectiveAPIRequestBodyMaxBytes
       - TestParseConfigBytesAPIRequestBodyMaxBytes
+      - TestOpenAIResponsesUsesHotReloadedRequestBodyLimit
     upstream_issue_or_pr: BlueSkyXN/CPA-Core-LTS#237
     state: required
-    retire_when: Upstream bounds encoded public API request bodies and every decoded Content-Encoding layer, provides an operator-controlled bounded override with a safe default, returns 413 for limit violations without bypassing the limit through raw-JSON fallback, routes all affected handlers through the shared bounded reader, and all listed regressions pass after removing the downstream implementation.
+    retire_when: Upstream bounds encoded standard protocol-handler JSON request bodies and every decoded Content-Encoding layer, provides an operator-controlled bounded override with a safe default, returns 413 for limit violations without bypassing the limit through raw-JSON fallback, routes all affected handlers through the shared bounded reader, and all listed regressions pass after removing the downstream implementation.
 
   - id: object-store-auth-path-containment
     reason: Object-store auth persistence must never create, overwrite, upload, delete, or render credential files outside its managed private roots, including traversal, sibling-prefix, absolute-path, pre-existing or dangling symlinks, junctions, initialized-root replacement, check/write path-swap races, and crash-persistent global-temp copies.

--- a/internal/config/api_request_body.go
+++ b/internal/config/api_request_body.go
@@ -2,8 +2,8 @@ package config
 
 const DefaultAPIRequestBodyMaxBytes int64 = 16 << 20
 
-// EffectiveAPIRequestBodyMaxBytes returns the configured public API request
-// body limit, preserving the bounded default for omitted or invalid values.
+// EffectiveAPIRequestBodyMaxBytes returns the configured standard protocol-handler
+// JSON request body limit, preserving the bounded default for omitted or invalid values.
 func (c *SDKConfig) EffectiveAPIRequestBodyMaxBytes() int64 {
 	if c == nil || c.APIRequestBodyMaxBytes <= 0 {
 		return DefaultAPIRequestBodyMaxBytes

--- a/internal/config/api_request_body.go
+++ b/internal/config/api_request_body.go
@@ -1,0 +1,12 @@
+package config
+
+const DefaultAPIRequestBodyMaxBytes int64 = 16 << 20
+
+// EffectiveAPIRequestBodyMaxBytes returns the configured public API request
+// body limit, preserving the bounded default for omitted or invalid values.
+func (c *SDKConfig) EffectiveAPIRequestBodyMaxBytes() int64 {
+	if c == nil || c.APIRequestBodyMaxBytes <= 0 {
+		return DefaultAPIRequestBodyMaxBytes
+	}
+	return c.APIRequestBodyMaxBytes
+}

--- a/internal/config/api_request_body_test.go
+++ b/internal/config/api_request_body_test.go
@@ -1,0 +1,34 @@
+package config
+
+import "testing"
+
+func TestSDKConfigEffectiveAPIRequestBodyMaxBytes(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *SDKConfig
+		want int64
+	}{
+		{name: "nil", cfg: nil, want: DefaultAPIRequestBodyMaxBytes},
+		{name: "omitted", cfg: &SDKConfig{}, want: DefaultAPIRequestBodyMaxBytes},
+		{name: "negative", cfg: &SDKConfig{APIRequestBodyMaxBytes: -1}, want: DefaultAPIRequestBodyMaxBytes},
+		{name: "configured", cfg: &SDKConfig{APIRequestBodyMaxBytes: 64 << 20}, want: 64 << 20},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.EffectiveAPIRequestBodyMaxBytes(); got != tt.want {
+				t.Fatalf("EffectiveAPIRequestBodyMaxBytes() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseConfigBytesAPIRequestBodyMaxBytes(t *testing.T) {
+	cfg, err := ParseConfigBytes([]byte("api-request-body-max-bytes: 67108864\n"))
+	if err != nil {
+		t.Fatalf("ParseConfigBytes: %v", err)
+	}
+	if cfg.APIRequestBodyMaxBytes != 64<<20 {
+		t.Fatalf("APIRequestBodyMaxBytes = %d, want %d", cfg.APIRequestBodyMaxBytes, 64<<20)
+	}
+}

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -42,6 +42,10 @@ type SDKConfig struct {
 	// RequestLog enables or disables detailed request logging functionality.
 	RequestLog bool `yaml:"request-log" json:"request-log"`
 
+	// APIRequestBodyMaxBytes limits encoded public API request bodies and each
+	// decoded Content-Encoding layer. Non-positive values use the safe default.
+	APIRequestBodyMaxBytes int64 `yaml:"api-request-body-max-bytes,omitempty" json:"api-request-body-max-bytes,omitempty"`
+
 	// CodexOptimizeMultiAgentV2 mirrors the provider-wide runtime setting for API handlers.
 	CodexOptimizeMultiAgentV2 bool `yaml:"-" json:"-"`
 

--- a/internal/config/sdk_config.go
+++ b/internal/config/sdk_config.go
@@ -42,8 +42,8 @@ type SDKConfig struct {
 	// RequestLog enables or disables detailed request logging functionality.
 	RequestLog bool `yaml:"request-log" json:"request-log"`
 
-	// APIRequestBodyMaxBytes limits encoded public API request bodies and each
-	// decoded Content-Encoding layer. Non-positive values use the safe default.
+	// APIRequestBodyMaxBytes limits encoded standard protocol-handler JSON request
+	// bodies and each decoded Content-Encoding layer. Non-positive values use the safe default.
 	APIRequestBodyMaxBytes int64 `yaml:"api-request-body-max-bytes,omitempty" json:"api-request-body-max-bytes,omitempty"`
 
 	// CodexOptimizeMultiAgentV2 mirrors the provider-wide runtime setting for API handlers.

--- a/internal/watcher/diff/config_diff.go
+++ b/internal/watcher/diff/config_diff.go
@@ -67,6 +67,9 @@ func BuildConfigChangeDetails(oldCfg, newCfg *config.Config) []string {
 	if oldCfg.RequestLog != newCfg.RequestLog {
 		changes = append(changes, fmt.Sprintf("request-log: %t -> %t", oldCfg.RequestLog, newCfg.RequestLog))
 	}
+	if oldCfg.EffectiveAPIRequestBodyMaxBytes() != newCfg.EffectiveAPIRequestBodyMaxBytes() {
+		changes = append(changes, fmt.Sprintf("api-request-body-max-bytes: %d -> %d", oldCfg.EffectiveAPIRequestBodyMaxBytes(), newCfg.EffectiveAPIRequestBodyMaxBytes()))
+	}
 	if oldCfg.LogsMaxTotalSizeMB != newCfg.LogsMaxTotalSizeMB {
 		changes = append(changes, fmt.Sprintf("logs-max-total-size-mb: %d -> %d", oldCfg.LogsMaxTotalSizeMB, newCfg.LogsMaxTotalSizeMB))
 	}

--- a/internal/watcher/diff/config_diff_test.go
+++ b/internal/watcher/diff/config_diff_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestBuildConfigChangeDetails(t *testing.T) {
 	oldCfg := &config.Config{
+		SDKConfig:                       config.SDKConfig{APIRequestBodyMaxBytes: 16 << 20},
 		Port:                            8080,
 		AuthDir:                         "/tmp/auth-old",
 		RedisUsageQueueRetentionSeconds: 60,
@@ -43,6 +44,7 @@ func TestBuildConfigChangeDetails(t *testing.T) {
 	}
 
 	newCfg := &config.Config{
+		SDKConfig:                       config.SDKConfig{APIRequestBodyMaxBytes: 64 << 20},
 		Port:                            9090,
 		AuthDir:                         "/tmp/auth-new",
 		RedisUsageQueueRetentionSeconds: 300,
@@ -90,6 +92,7 @@ func TestBuildConfigChangeDetails(t *testing.T) {
 
 	expectContains(t, details, "port: 8080 -> 9090")
 	expectContains(t, details, "auth-dir: /tmp/auth-old -> /tmp/auth-new")
+	expectContains(t, details, "api-request-body-max-bytes: 16777216 -> 67108864")
 	expectContains(t, details, "redis-usage-queue-retention-seconds: 60 -> 300")
 	expectContains(t, details, "gemini[0].excluded-models: updated (1 -> 2 entries)")
 	expectContains(t, details, "ampcode.upstream-url: http://old-upstream -> http://new-upstream")

--- a/sdk/api/handlers/claude/code_handlers.go
+++ b/sdk/api/handlers/claude/code_handlers.go
@@ -69,7 +69,7 @@ func (h *ClaudeCodeAPIHandler) Models() []map[string]any {
 //   - c: The Gin context for the request.
 func (h *ClaudeCodeAPIHandler) ClaudeMessages(c *gin.Context) {
 	// Extract raw JSON data from the incoming request
-	rawJSON, err := handlers.ReadRequestBody(c)
+	rawJSON, err := h.ReadRequestBody(c)
 	// If data retrieval fails, return a 400 Bad Request error.
 	if err != nil {
 		c.JSON(handlers.RequestBodyStatusCode(err), handlers.ErrorResponse{
@@ -101,7 +101,7 @@ func (h *ClaudeCodeAPIHandler) ClaudeMessages(c *gin.Context) {
 //   - c: The Gin context for the request.
 func (h *ClaudeCodeAPIHandler) ClaudeCountTokens(c *gin.Context) {
 	// Extract raw JSON data from the incoming request
-	rawJSON, err := handlers.ReadRequestBody(c)
+	rawJSON, err := h.ReadRequestBody(c)
 	// If data retrieval fails, return a 400 Bad Request error.
 	if err != nil {
 		c.JSON(handlers.RequestBodyStatusCode(err), handlers.ErrorResponse{

--- a/sdk/api/handlers/gemini/gemini_handlers.go
+++ b/sdk/api/handlers/gemini/gemini_handlers.go
@@ -162,7 +162,7 @@ func (h *GeminiAPIHandler) GeminiHandler(c *gin.Context) {
 		})
 		return
 	}
-	rawJSON, errRead := handlers.ReadRequestBody(c)
+	rawJSON, errRead := h.ReadRequestBody(c)
 	if errRead != nil {
 		c.JSON(handlers.RequestBodyStatusCode(errRead), handlers.ErrorResponse{
 			Error: handlers.ErrorDetail{

--- a/sdk/api/handlers/gemini/interactions_handlers.go
+++ b/sdk/api/handlers/gemini/interactions_handlers.go
@@ -91,7 +91,7 @@ func buildInteractionsExecutionRequest(target interactionsRequestTarget, modelNa
 
 // Interactions handles POST /v1beta/interactions.
 func (h *GeminiAPIHandler) Interactions(c *gin.Context) {
-	rawJSON, errRead := handlers.ReadRequestBody(c)
+	rawJSON, errRead := h.ReadRequestBody(c)
 	if errRead != nil {
 		c.JSON(handlers.RequestBodyStatusCode(errRead), handlers.ErrorResponse{Error: handlers.ErrorDetail{Message: errRead.Error(), Type: "invalid_request_error"}})
 		return

--- a/sdk/api/handlers/openai/openai_handlers.go
+++ b/sdk/api/handlers/openai/openai_handlers.go
@@ -102,7 +102,7 @@ func (h *OpenAIAPIHandler) OpenAIModels(c *gin.Context) {
 // Parameters:
 //   - c: The Gin context containing the HTTP request and response
 func (h *OpenAIAPIHandler) ChatCompletions(c *gin.Context) {
-	rawJSON, err := handlers.ReadRequestBody(c)
+	rawJSON, err := h.ReadRequestBody(c)
 	// If data retrieval fails, return a request-body error.
 	if err != nil {
 		c.JSON(handlers.RequestBodyStatusCode(err), handlers.ErrorResponse{
@@ -157,7 +157,7 @@ func shouldTreatAsResponsesFormat(rawJSON []byte) bool {
 // Parameters:
 //   - c: The Gin context containing the HTTP request and response
 func (h *OpenAIAPIHandler) Completions(c *gin.Context) {
-	rawJSON, err := handlers.ReadRequestBody(c)
+	rawJSON, err := h.ReadRequestBody(c)
 	// If data retrieval fails, return a request-body error.
 	if err != nil {
 		c.JSON(handlers.RequestBodyStatusCode(err), handlers.ErrorResponse{

--- a/sdk/api/handlers/openai/openai_images_handlers.go
+++ b/sdk/api/handlers/openai/openai_images_handlers.go
@@ -602,7 +602,7 @@ func (h *OpenAIAPIHandler) ImagesGenerations(c *gin.Context) {
 		return
 	}
 
-	rawJSON, err := handlers.ReadRequestBody(c)
+	rawJSON, err := h.ReadRequestBody(c)
 	if err != nil {
 		c.JSON(handlers.RequestBodyStatusCode(err), handlers.ErrorResponse{
 			Error: handlers.ErrorDetail{
@@ -889,7 +889,7 @@ func (h *OpenAIAPIHandler) imagesEditsFromMultipart(c *gin.Context) {
 }
 
 func (h *OpenAIAPIHandler) imagesEditsFromJSON(c *gin.Context) {
-	rawJSON, err := handlers.ReadRequestBody(c)
+	rawJSON, err := h.ReadRequestBody(c)
 	if err != nil {
 		c.JSON(handlers.RequestBodyStatusCode(err), handlers.ErrorResponse{
 			Error: handlers.ErrorDetail{

--- a/sdk/api/handlers/openai/openai_responses_handlers.go
+++ b/sdk/api/handlers/openai/openai_responses_handlers.go
@@ -518,7 +518,7 @@ func (h *OpenAIResponsesAPIHandler) prepareCodexMultiAgentV2Tools(c *gin.Context
 // Parameters:
 //   - c: The Gin context containing the HTTP request and response
 func (h *OpenAIResponsesAPIHandler) Responses(c *gin.Context) {
-	rawJSON, err := handlers.ReadRequestBody(c)
+	rawJSON, err := h.ReadRequestBody(c)
 	// If data retrieval fails, return a request-body error.
 	if err != nil {
 		c.JSON(handlers.RequestBodyStatusCode(err), handlers.ErrorResponse{
@@ -543,7 +543,7 @@ func (h *OpenAIResponsesAPIHandler) Responses(c *gin.Context) {
 }
 
 func (h *OpenAIResponsesAPIHandler) Compact(c *gin.Context) {
-	rawJSON, err := handlers.ReadRequestBody(c)
+	rawJSON, err := h.ReadRequestBody(c)
 	if err != nil {
 		c.JSON(handlers.RequestBodyStatusCode(err), handlers.ErrorResponse{
 			Error: handlers.ErrorDetail{

--- a/sdk/api/handlers/openai/openai_responses_request_body_limit_test.go
+++ b/sdk/api/handlers/openai/openai_responses_request_body_limit_test.go
@@ -1,0 +1,67 @@
+package openai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/registry"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/api/handlers"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
+)
+
+func TestOpenAIResponsesUsesHotReloadedRequestBodyLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	executor := &compactCaptureExecutor{}
+	manager := coreauth.NewManager(nil, nil, nil)
+	manager.RegisterExecutor(executor)
+
+	const (
+		authID  = "request-body-limit-auth"
+		modelID = "request-body-limit-model"
+	)
+	auth := &coreauth.Auth{ID: authID, Provider: executor.Identifier(), Status: coreauth.StatusActive}
+	if _, err := manager.Register(context.Background(), auth); err != nil {
+		t.Fatalf("Register auth: %v", err)
+	}
+	registry.GetGlobalRegistry().RegisterClient(auth.ID, auth.Provider, []*registry.ModelInfo{{ID: modelID}})
+	t.Cleanup(func() {
+		registry.GetGlobalRegistry().UnregisterClient(auth.ID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{APIRequestBodyMaxBytes: 64}, manager)
+	h := NewOpenAIResponsesAPIHandler(base)
+	router := gin.New()
+	router.POST("/v1/responses", h.Responses)
+	body := `{"model":"` + modelID + `","input":"` + strings.Repeat("x", 64) + `"}`
+	if len(body) <= 64 || len(body) > 128 {
+		t.Fatalf("test body length = %d, want 65..128", len(body))
+	}
+
+	request := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp := httptest.NewRecorder()
+		router.ServeHTTP(resp, req)
+		return resp
+	}
+
+	if resp := request(); resp.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status before reload = %d, want %d; body=%s", resp.Code, http.StatusRequestEntityTooLarge, resp.Body.String())
+	}
+	if executor.calls != 0 {
+		t.Fatalf("executor calls before reload = %d, want 0", executor.calls)
+	}
+
+	base.UpdateClients(&sdkconfig.SDKConfig{APIRequestBodyMaxBytes: 128})
+	if resp := request(); resp.Code != http.StatusOK {
+		t.Fatalf("status after reload = %d, want %d; body=%s", resp.Code, http.StatusOK, resp.Body.String())
+	}
+	if executor.calls != 1 {
+		t.Fatalf("executor calls after reload = %d, want 1", executor.calls)
+	}
+}

--- a/sdk/api/handlers/openai/openai_videos_handlers.go
+++ b/sdk/api/handlers/openai/openai_videos_handlers.go
@@ -234,13 +234,13 @@ func responseVideosModel(model string) string {
 	return canonicalXAIVideosModel(model)
 }
 
-func readVideosCreateRequest(c *gin.Context) ([]byte, error) {
+func (h *OpenAIAPIHandler) readVideosCreateRequest(c *gin.Context) ([]byte, error) {
 	contentType := strings.ToLower(strings.TrimSpace(c.ContentType()))
 	switch contentType {
 	case "multipart/form-data", "application/x-www-form-urlencoded":
 		return videosCreateRequestFromForm(c)
 	default:
-		rawJSON, err := handlers.ReadRequestBody(c)
+		rawJSON, err := h.ReadRequestBody(c)
 		if err != nil {
 			return nil, err
 		}
@@ -251,8 +251,8 @@ func readVideosCreateRequest(c *gin.Context) ([]byte, error) {
 	}
 }
 
-func readXAIVideosNativeRequest(c *gin.Context) ([]byte, error) {
-	rawJSON, err := handlers.ReadRequestBody(c)
+func (h *OpenAIAPIHandler) readXAIVideosNativeRequest(c *gin.Context) ([]byte, error) {
+	rawJSON, err := h.ReadRequestBody(c)
 	if err != nil {
 		return nil, err
 	}
@@ -270,8 +270,8 @@ func videosCreateCompatTargetForJSON(rawJSON []byte) videosCreateCompatTarget {
 	return videosCreateCompatOpenAI
 }
 
-func readVideosCreateCompatRequest(c *gin.Context) ([]byte, error) {
-	rawBody, err := handlers.ReadRequestBody(c)
+func (h *OpenAIAPIHandler) readVideosCreateCompatRequest(c *gin.Context) ([]byte, error) {
+	rawBody, err := h.ReadRequestBody(c)
 	if err != nil {
 		return nil, err
 	}
@@ -718,7 +718,7 @@ func openAIVideoStatus(status string) string {
 }
 
 func (h *OpenAIAPIHandler) VideosCreate(c *gin.Context) {
-	rawJSON, err := readVideosCreateRequest(c)
+	rawJSON, err := h.readVideosCreateRequest(c)
 	if err != nil {
 		writeVideosFailedError(c, handlers.RequestBodyStatusCode(err), defaultOpenAIVideosModel, "invalid_request_error", fmt.Sprintf("Invalid request: %v", err))
 		return
@@ -749,7 +749,7 @@ func (h *OpenAIAPIHandler) VideosCreateCompat(c *gin.Context) {
 		return
 	}
 
-	rawBody, err := readVideosCreateCompatRequest(c)
+	rawBody, err := h.readVideosCreateCompatRequest(c)
 	if err != nil {
 		writeVideosFailedError(c, handlers.RequestBodyStatusCode(err), defaultOpenAIVideosModel, "invalid_request_error", fmt.Sprintf("Invalid request: %v", err))
 		return
@@ -775,7 +775,7 @@ func (h *OpenAIAPIHandler) XAIVideosExtensions(c *gin.Context) {
 }
 
 func (h *OpenAIAPIHandler) handleXAIVideosNativePost(c *gin.Context) {
-	rawJSON, err := readXAIVideosNativeRequest(c)
+	rawJSON, err := h.readXAIVideosNativeRequest(c)
 	if err != nil {
 		c.JSON(handlers.RequestBodyStatusCode(err), handlers.ErrorResponse{
 			Error: handlers.ErrorDetail{

--- a/sdk/api/handlers/openai/openai_videos_handlers_test.go
+++ b/sdk/api/handlers/openai/openai_videos_handlers_test.go
@@ -269,8 +269,9 @@ func TestReadVideosCreateCompatRequestDecodesContentEncoding(t *testing.T) {
 
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
+	handler := NewOpenAIAPIHandler(apihandlers.NewBaseAPIHandlers(&sdkconfig.SDKConfig{}, nil))
 	router.POST(videosPath, func(c *gin.Context) {
-		got, errRead := readVideosCreateCompatRequest(c)
+		got, errRead := handler.readVideosCreateCompatRequest(c)
 		if errRead != nil {
 			t.Fatalf("readVideosCreateCompatRequest() error = %v", errRead)
 		}

--- a/sdk/api/handlers/request_body.go
+++ b/sdk/api/handlers/request_body.go
@@ -11,9 +11,10 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/klauspost/compress/zstd"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 )
 
-const defaultMaxRequestBodyBytes int64 = 16 << 20
+const defaultMaxRequestBodyBytes int64 = sdkconfig.DefaultAPIRequestBodyMaxBytes
 
 // ErrRequestBodyTooLarge reports that either the encoded request body or one
 // decoded Content-Encoding layer exceeded the API request body limit.
@@ -22,11 +23,29 @@ var ErrRequestBodyTooLarge = errors.New("request body too large")
 // ReadRequestBody reads the incoming request body and decodes supported
 // Content-Encoding values before handlers inspect JSON fields.
 func ReadRequestBody(c *gin.Context) ([]byte, error) {
+	return readRequestBodyWithLimit(c, defaultMaxRequestBodyBytes)
+}
+
+// ReadRequestBody reads an incoming request using this handler instance's
+// hot-reloadable request body limit.
+func (h *BaseAPIHandler) ReadRequestBody(c *gin.Context) ([]byte, error) {
+	limit := defaultMaxRequestBodyBytes
+	if h != nil {
+		limit = h.Cfg.EffectiveAPIRequestBodyMaxBytes()
+	}
+	return readRequestBodyWithLimit(c, limit)
+}
+
+func readRequestBodyWithLimit(c *gin.Context, limit int64) ([]byte, error) {
 	if c == nil || c.Request == nil || c.Request.Body == nil {
 		return nil, nil
 	}
 
-	raw, err := readAllRequestBodyWithLimit(c.Request.Body, defaultMaxRequestBodyBytes)
+	if limit <= 0 {
+		limit = defaultMaxRequestBodyBytes
+	}
+
+	raw, err := readAllRequestBodyWithLimit(c.Request.Body, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +58,7 @@ func ReadRequestBody(c *gin.Context) ([]byte, error) {
 		return raw, nil
 	}
 
-	decoded, err := decodeRequestBodyWithLimit(raw, encoding, defaultMaxRequestBodyBytes)
+	decoded, err := decodeRequestBodyWithLimit(raw, encoding, limit)
 	if err != nil {
 		if !errors.Is(err, ErrRequestBodyTooLarge) && json.Valid(raw) {
 			return raw, nil
@@ -112,7 +131,11 @@ func readAllRequestBodyWithLimit(reader io.Reader, limit int64) ([]byte, error) 
 		limit = 0
 	}
 
-	body, err := io.ReadAll(io.LimitReader(reader, limit+1))
+	readLimit := limit
+	if readLimit < 1<<63-1 {
+		readLimit++
+	}
+	body, err := io.ReadAll(io.LimitReader(reader, readLimit))
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/api/handlers/request_body_test.go
+++ b/sdk/api/handlers/request_body_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/klauspost/compress/zstd"
+	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 )
 
 func TestReadRequestBodyRejectsIdentityBodyOverLimit(t *testing.T) {
@@ -42,6 +43,59 @@ func TestDecodeZstdRequestBodyRejectsDecodedBodyOverLimit(t *testing.T) {
 	}
 }
 
+func TestBaseAPIHandlerReadRequestBodyAllowsConfiguredLargerBody(t *testing.T) {
+	body := bytes.Repeat([]byte("x"), int(defaultMaxRequestBodyBytes)+1)
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{APIRequestBodyMaxBytes: int64(len(body))}, nil)
+	c := newRequestBodyTestContext(body, "")
+
+	got, err := handler.ReadRequestBody(c)
+	if err != nil {
+		t.Fatalf("ReadRequestBody error = %v", err)
+	}
+	if len(got) != len(body) {
+		t.Fatalf("ReadRequestBody length = %d, want %d", len(got), len(body))
+	}
+}
+
+func TestBaseAPIHandlerReadRequestBodyUsesHotReloadedLimit(t *testing.T) {
+	body := bytes.Repeat([]byte("x"), 65)
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{APIRequestBodyMaxBytes: 64}, nil)
+
+	_, err := handler.ReadRequestBody(newRequestBodyTestContext(body, ""))
+	if !errors.Is(err, ErrRequestBodyTooLarge) {
+		t.Fatalf("ReadRequestBody error = %v, want ErrRequestBodyTooLarge", err)
+	}
+
+	handler.UpdateClients(&sdkconfig.SDKConfig{APIRequestBodyMaxBytes: 128})
+	got, err := handler.ReadRequestBody(newRequestBodyTestContext(body, ""))
+	if err != nil {
+		t.Fatalf("ReadRequestBody after UpdateClients error = %v", err)
+	}
+	if len(got) != len(body) {
+		t.Fatalf("ReadRequestBody length = %d, want %d", len(got), len(body))
+	}
+}
+
+func TestBaseAPIHandlerReadRequestBodyAppliesConfiguredLimitAfterZstdDecode(t *testing.T) {
+	payload := bytes.Repeat([]byte("x"), 65)
+	compressed := compressRequestBodyForTest(t, payload)
+	handler := NewBaseAPIHandlers(&sdkconfig.SDKConfig{APIRequestBodyMaxBytes: 64}, nil)
+
+	_, err := handler.ReadRequestBody(newRequestBodyTestContext(compressed, "zstd"))
+	if !errors.Is(err, ErrRequestBodyTooLarge) {
+		t.Fatalf("ReadRequestBody error = %v, want ErrRequestBodyTooLarge", err)
+	}
+
+	handler.UpdateClients(&sdkconfig.SDKConfig{APIRequestBodyMaxBytes: 128})
+	got, err := handler.ReadRequestBody(newRequestBodyTestContext(compressed, "zstd"))
+	if err != nil {
+		t.Fatalf("ReadRequestBody after UpdateClients error = %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("ReadRequestBody = %q, want %q", got, payload)
+	}
+}
+
 func TestReadRequestBodyKeepsValidJSONFallbackForBadEncoding(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
@@ -57,4 +111,30 @@ func TestReadRequestBodyKeepsValidJSONFallbackForBadEncoding(t *testing.T) {
 	if !bytes.Equal(got, body) {
 		t.Fatalf("ReadRequestBody = %q, want raw JSON fallback %q", got, body)
 	}
+}
+
+func newRequestBodyTestContext(body []byte, encoding string) *gin.Context {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest("POST", "/v1/responses", bytes.NewReader(body))
+	if encoding != "" {
+		c.Request.Header.Set("Content-Encoding", encoding)
+	}
+	return c
+}
+
+func compressRequestBodyForTest(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	var compressed bytes.Buffer
+	encoder, err := zstd.NewWriter(&compressed)
+	if err != nil {
+		t.Fatalf("zstd.NewWriter: %v", err)
+	}
+	if _, err = encoder.Write(payload); err != nil {
+		t.Fatalf("zstd write: %v", err)
+	}
+	if err = encoder.Close(); err != nil {
+		t.Fatalf("zstd close: %v", err)
+	}
+	return compressed.Bytes()
 }

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -35,7 +35,8 @@ type OpenAICompatibilityModel = internalconfig.OpenAICompatibilityModel
 type TLS = internalconfig.TLSConfig
 
 const (
-	DefaultPanelGitHubRepository = internalconfig.DefaultPanelGitHubRepository
+	DefaultPanelGitHubRepository  = internalconfig.DefaultPanelGitHubRepository
+	DefaultAPIRequestBodyMaxBytes = internalconfig.DefaultAPIRequestBodyMaxBytes
 )
 
 func LoadConfig(configFile string) (*Config, error) { return internalconfig.LoadConfig(configFile) }


### PR DESCRIPTION
## 结果

接续外部贡献者 PR #238（`hooxing`），保留原作者提交归属，并将其适配到当前 `main` 基线。

大型 multimodal `/v1/responses` 请求在图片转为 base64 JSON 后可能超过 LTS 现有的 16 MiB 请求体上限。本 PR 保留该内存安全默认值，同时增加 operator override：

```yaml
api-request-body-max-bytes: 67108864
```

- 未配置、`0` 或负数仍使用 16 MiB。
- 正数同时约束 encoded body 和每一层解码后的 `Content-Encoding` body，超限仍返回 HTTP 413。
- 内置 handler 从当前 `SDKConfig` 解析限制，普通 config hot reload 无需重启即可生效。
- package-level `handlers.ReadRequestBody` 继续固定使用 16 MiB，保持现有 SDK 行为兼容。

Fixes #237

## 范围边界

该配置仅覆盖现有 shared reader 管辖的 standard protocol-handler JSON request bodies，包括 Responses/Compact、Chat/Completions、Claude、Gemini/Interactions 及 JSON image/video paths。

本 PR 不修改 Amp fallback、`/v1/alpha/search`、Management API、multipart uploads、outbound compression、Panel、Release 或 deployment，也不扩展为全局 `BaseAPIHandler.Cfg` 并发模型重构。

## Type

- [ ] Protected upstream full-sync
- [ ] Staged upstream full-sync
- [ ] LTS protected-delta patch
- [x] LTS feature / downstream patch maintenance
- [ ] Maintenance docs / CI
- [ ] Emergency hotfix

## Upstream sync info

- Upstream repo: N/A; this is an LTS downstream compatibility patch
- Upstream branch: N/A
- Upstream from SHA: N/A
- Upstream to SHA: N/A
- Sync branch: N/A

## Protected delta checklist

- [x] `usage-statistics-enabled` still exists
- [x] `internal/usage/` still exists
- [x] `/v0/management/usage` still exists
- [x] `/v0/management/usage/export` still exists
- [x] `/v0/management/usage/import` still exists
- [x] `docs/lts/core-feature-contracts.yaml` reviewed for touched protected or protected-adjacent features
- [x] `docs/lts/downstream-patches.yaml` reviewed and updated for `api-request-body-size-limit`
- [x] Usage record creation/schema is unchanged and covered by the LTS contract suite
- [x] Management usage response shape is unchanged and covered by focused tests
- [x] Usage export/import behavior is unchanged and covered by focused tests
- [x] CPA-Panel-LTS response shape is unchanged
- [x] Local auth/config/panel/release/source customizations reviewed; only config schema/hot reload is affected

## LTS classification review

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| `api-request-body-size-limit` | downstream patch | adapted | 保留 16 MiB 默认与 413 行为；增加 bounded operator override；同一限制用于 encoded/decoded body；当前 upstream baseline `17a65ee5470fbaf0e22fc219381e6a4ae9e07624` 仍无等价限制；新增 config、identity、zstd、hot-reload 和真实 `/v1/responses` route 回归。 |

- [x] 本 PR 不创建或删除 `introduced_in` / `retired_in` 指向的实现提交；原 `introduced_in: b2b593f...` 继续可达。

## Conflict resolution notes

- 使用 `cherry-pick -x 09021a71` 保留 #238 的原作者归属。
- 保留当前 `v7.2.147 / 17a65ee5` downstream ledger 基线，没有退回原 PR 的旧 `f0de1d00` 记录。
- 将配置说明限定为 standard protocol-handler JSON request bodies，避免宣称覆盖所有 public routes。
- 新增真实 Gin `/v1/responses` route 测试，验证 64-byte limit 返回 413，hot reload 到 128 bytes 后同一请求进入 executor。

## Validation

以下本地验证均通过，head 为 `abdceef34ac1120b9e7ce1907dbc314d0d7d8c87`：

- [x] `scripts/check-lts-contract.sh`
- [x] `go run ./scripts/ltsregistry --root .`
- [x] `go test -count=1 ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'`
- [x] `go build -o /tmp/cpa-core-lts-pr238-server ./cmd/server`
- [x] `go test -count=1 ./...`
- [x] `go test -race -count=1 ./internal/api ./sdk/api/handlers ./sdk/api/handlers/openai`
- [x] `go test -count=1 ./internal/config ./internal/watcher/diff ./sdk/api/handlers ./sdk/api/handlers/claude ./sdk/api/handlers/gemini ./sdk/api/handlers/openai`
- [x] `git diff --check`

GitHub exact-head CI 在 PR 创建后执行；CI 结果不由上述本地验证替代。

## Optional real runtime smoke

- [x] Explicitly skipped: 此分支未部署到生产服务；Release、deployment、runtime readback 与业务 UAT 不属于本 PR 的合并前源码验证。
- Space: N/A
- Runtime SHA: N/A
- CPA-Core-LTS branch/SHA deployed: N/A
- `/healthz` status: N/A
- `/management.html` status: N/A
- `/v0/management/usage*` status: N/A
