### PR TITLE
fix(release): 从精确 tag 构建 Release 与 GHCR 资产

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,6 +4,17 @@ on:
   push:
     tags:
       - 'v*-lts-*'
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Existing v*-lts-* tag to build and publish'
+        required: true
+        type: string
+      update_latest:
+        description: 'Move latest aliases to this tag after both architectures succeed'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -12,20 +23,96 @@ permissions:
 env:
   APP_NAME: CPA-Core-LTS
   IMAGE_NAME: ghcr.io/blueskyxn/cpa-core-lts
+  RELEASE_TAG: ${{ github.event.inputs.release_tag || github.ref_name }}
+  UPDATE_LATEST: ${{ github.event_name == 'push' || inputs.update_latest }}
 
 jobs:
+  validate-release-catalog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Checkout current release tooling
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          path: _release_tools
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Verify release source
+        run: |
+          set -euo pipefail
+          if [[ "${RELEASE_TAG}" != v*-lts-* ]]; then
+            echo "Only Core LTS image tags matching v*-lts-* are supported." >&2
+            exit 1
+          fi
+          tag_commit="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+          head_commit="$(git rev-parse HEAD)"
+          if [[ "$head_commit" != "$tag_commit" ]]; then
+            echo "Release source mismatch: HEAD=${head_commit}, ${RELEASE_TAG}=${tag_commit}." >&2
+            exit 1
+          fi
+          echo "Verified ${RELEASE_TAG} at ${tag_commit}."
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: _release_tools/go.mod
+          cache: true
+          cache-dependency-path: _release_tools/go.sum
+      - name: Refresh models catalog
+        run: |
+          (
+            cd _release_tools
+            MODEL_CATALOG_DIR="$GITHUB_WORKSPACE/internal/registry/models" \
+              bash .github/scripts/refresh-model-catalogs.sh
+          )
+      - name: Upload validated models catalog
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-models-catalog
+          path: |
+            internal/registry/models/models.json
+            internal/registry/models/codex_client_models.json
+          if-no-files-found: error
+          retention-days: 1
+
   docker_amd64:
+    needs: validate-release-catalog
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
-          cache: true
-      - name: Refresh models catalog
-        run: bash .github/scripts/refresh-model-catalogs.sh
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Verify release source
+        run: |
+          set -euo pipefail
+          if [[ "${RELEASE_TAG}" != v*-lts-* ]]; then
+            echo "Only Core LTS image tags matching v*-lts-* are supported." >&2
+            exit 1
+          fi
+          tag_commit="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+          head_commit="$(git rev-parse HEAD)"
+          if [[ "$head_commit" != "$tag_commit" ]]; then
+            echo "Release source mismatch: HEAD=${head_commit}, ${RELEASE_TAG}=${tag_commit}." >&2
+            exit 1
+          fi
+          {
+            echo "VERSION=${RELEASE_TAG}"
+            echo "COMMIT=$(git rev-parse --short "$tag_commit")"
+            echo "BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          } >> "$GITHUB_ENV"
+      - name: Download validated models catalog
+        uses: actions/download-artifact@v4
+        with:
+          name: docker-models-catalog
+          path: internal/registry/models
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GHCR
@@ -34,13 +121,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Generate Build Metadata
-        run: |
-          {
-            echo "VERSION=${GITHUB_REF_NAME}"
-            echo "COMMIT=$(git rev-parse --short HEAD)"
-            echo "BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          } >> "$GITHUB_ENV"
       - name: Build and push (amd64)
         uses: docker/build-push-action@v6
         with:
@@ -51,22 +131,41 @@ jobs:
             VERSION=${{ env.VERSION }}
             COMMIT=${{ env.COMMIT }}
             BUILD_DATE=${{ env.BUILD_DATE }}
-          tags: |
-            ${{ env.IMAGE_NAME }}:latest-amd64
-            ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-amd64
+          tags: ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-amd64
 
   docker_arm64:
+    needs: validate-release-catalog
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
-          cache: true
-      - name: Refresh models catalog
-        run: bash .github/scripts/refresh-model-catalogs.sh
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Verify release source
+        run: |
+          set -euo pipefail
+          if [[ "${RELEASE_TAG}" != v*-lts-* ]]; then
+            echo "Only Core LTS image tags matching v*-lts-* are supported." >&2
+            exit 1
+          fi
+          tag_commit="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+          head_commit="$(git rev-parse HEAD)"
+          if [[ "$head_commit" != "$tag_commit" ]]; then
+            echo "Release source mismatch: HEAD=${head_commit}, ${RELEASE_TAG}=${tag_commit}." >&2
+            exit 1
+          fi
+          {
+            echo "VERSION=${RELEASE_TAG}"
+            echo "COMMIT=$(git rev-parse --short "$tag_commit")"
+            echo "BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          } >> "$GITHUB_ENV"
+      - name: Download validated models catalog
+        uses: actions/download-artifact@v4
+        with:
+          name: docker-models-catalog
+          path: internal/registry/models
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GHCR
@@ -75,13 +174,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Generate Build Metadata
-        run: |
-          {
-            echo "VERSION=${GITHUB_REF_NAME}"
-            echo "COMMIT=$(git rev-parse --short HEAD)"
-            echo "BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          } >> "$GITHUB_ENV"
       - name: Build and push (arm64)
         uses: docker/build-push-action@v6
         with:
@@ -92,9 +184,7 @@ jobs:
             VERSION=${{ env.VERSION }}
             COMMIT=${{ env.COMMIT }}
             BUILD_DATE=${{ env.BUILD_DATE }}
-          tags: |
-            ${{ env.IMAGE_NAME }}:latest-arm64
-            ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-arm64
+          tags: ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-arm64
 
   docker_manifest:
     runs-on: ubuntu-latest
@@ -102,8 +192,6 @@ jobs:
       - docker_amd64
       - docker_arm64
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GHCR
@@ -112,20 +200,28 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Generate Build Metadata
-        run: |
-          {
-            echo "VERSION=${GITHUB_REF_NAME}"
-            echo "COMMIT=$(git rev-parse --short HEAD)"
-            echo "BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          } >> "$GITHUB_ENV"
       - name: Create and push multi-arch manifests
         run: |
+          set -euo pipefail
+          version="${RELEASE_TAG}"
           docker buildx imagetools create \
-            --tag "${IMAGE_NAME}:latest" \
-            "${IMAGE_NAME}:latest-amd64" \
-            "${IMAGE_NAME}:latest-arm64"
-          docker buildx imagetools create \
-            --tag "${IMAGE_NAME}:${VERSION}" \
-            "${IMAGE_NAME}:${VERSION}-amd64" \
-            "${IMAGE_NAME}:${VERSION}-arm64"
+            --tag "${IMAGE_NAME}:${version}" \
+            "${IMAGE_NAME}:${version}-amd64" \
+            "${IMAGE_NAME}:${version}-arm64"
+          docker buildx imagetools inspect "${IMAGE_NAME}:${version}"
+
+          if [[ "${UPDATE_LATEST}" == "true" ]]; then
+            docker buildx imagetools create \
+              --tag "${IMAGE_NAME}:latest-amd64" \
+              "${IMAGE_NAME}:${version}-amd64"
+            docker buildx imagetools create \
+              --tag "${IMAGE_NAME}:latest-arm64" \
+              "${IMAGE_NAME}:${version}-arm64"
+            docker buildx imagetools create \
+              --tag "${IMAGE_NAME}:latest" \
+              "${IMAGE_NAME}:${version}-amd64" \
+              "${IMAGE_NAME}:${version}-arm64"
+            docker buildx imagetools inspect "${IMAGE_NAME}:latest"
+          else
+            echo "Preserving latest aliases for manual backfill of ${version}."
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,16 +29,45 @@ jobs:
   validate-release-catalog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout release source
+        uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
+          fetch-tags: true
+      - name: Checkout current release tooling
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          path: _release_tools
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Verify release source
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${RELEASE_TAG}" != v*-lts-* ]]; then
+            echo "Only Core LTS release tags matching v*-lts-* are supported." >&2
+            exit 1
+          fi
+          tag_commit="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+          head_commit="$(git rev-parse HEAD)"
+          if [[ "$head_commit" != "$tag_commit" ]]; then
+            echo "Release source mismatch: HEAD=${head_commit}, ${RELEASE_TAG}=${tag_commit}." >&2
+            exit 1
+          fi
+          echo "Verified ${RELEASE_TAG} at ${tag_commit}."
       - uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
       - name: Refresh models catalog
-        run: bash .github/scripts/refresh-model-catalogs.sh
+        run: |
+          (
+            cd _release_tools
+            MODEL_CATALOG_DIR="$GITHUB_WORKSPACE/internal/registry/models" \
+              bash .github/scripts/refresh-model-catalogs.sh
+          )
       - name: Validate GPT-5.6 Ultra compatibility
         run: |
           go test ./internal/registry ./internal/thinking \
@@ -58,9 +87,17 @@ jobs:
     needs: validate-release-catalog
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout release source
+        uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Checkout current release tooling
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          path: _release_tools
           fetch-depth: 0
           fetch-tags: true
       - name: Create release
@@ -90,7 +127,7 @@ jobs:
           notes_file="$(mktemp)"
           title_file="$(mktemp)"
           trap 'rm -f "$notes_file" "$title_file"' EXIT
-          bash scripts/generate-lts-release-notes.sh \
+          bash _release_tools/scripts/generate-lts-release-notes.sh \
             --tag "${RELEASE_TAG}" \
             --notes-file "$notes_file" \
             --title-file "$title_file"
@@ -134,10 +171,12 @@ jobs:
             asset_arch: aarch64
             archive_format: zip
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout release source
+        uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
+          fetch-tags: true
       - name: Download validated models catalog
         uses: actions/download-artifact@v4
         with:
@@ -163,9 +202,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          tag_commit="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+          head_commit="$(git rev-parse HEAD)"
+          if [[ "$head_commit" != "$tag_commit" ]]; then
+            echo "Release source mismatch: HEAD=${head_commit}, ${RELEASE_TAG}=${tag_commit}." >&2
+            exit 1
+          fi
           {
             echo "RELEASE_VERSION=${RELEASE_TAG#v}"
-            echo "COMMIT=$(git rev-parse --short HEAD)"
+            echo "COMMIT=$(git rev-parse --short "$tag_commit")"
             echo "BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           } >> "$GITHUB_ENV"
       - name: Build archive
@@ -203,50 +248,6 @@ jobs:
           name: ${{ matrix.target }}
           path: dist/CLIProxyAPI_*
           if-no-files-found: error
-      - name: Upload release assets
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          assets=(dist/CLIProxyAPI_*.tar.gz dist/CLIProxyAPI_*.zip)
-          if [[ ${#assets[@]} -eq 0 ]]; then
-            printf 'expected archive assets, found %s\n' "${#assets[@]}" >&2
-            printf '%s\n' "${assets[@]}" >&2
-            exit 1
-          fi
-          gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
-      - name: Refresh release checksums
-        continue-on-error: true
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          tmp_dir="$(mktemp -d)"
-          trap 'rm -rf "$tmp_dir"' EXIT
-          gh release download "$RELEASE_TAG" \
-            --pattern 'CLIProxyAPI_*.tar.gz' \
-            --pattern 'CLIProxyAPI_*.zip' \
-            --pattern 'sky-cpa-core-lts_*.tar.gz' \
-            --dir "$tmp_dir" \
-            --clobber
-          (
-            cd "$tmp_dir"
-            shopt -s nullglob
-            archives=(CLIProxyAPI_*.tar.gz CLIProxyAPI_*.zip sky-cpa-core-lts_*.tar.gz)
-            if [[ ${#archives[@]} -eq 0 ]]; then
-              echo "No release archives found"
-              exit 0
-            fi
-            if command -v sha256sum >/dev/null 2>&1; then
-              sha256sum "${archives[@]}" | sort -k2 > checksums.txt
-            else
-              shasum -a 256 "${archives[@]}" | sort -k2 > checksums.txt
-            fi
-          )
-          gh release upload "$RELEASE_TAG" "$tmp_dir/checksums.txt" --clobber
 
   build-linux-glibc:
     name: build linux-${{ matrix.goarch }} glibc
@@ -267,10 +268,12 @@ jobs:
             asset_arch: aarch64
             manylinux_image: quay.io/pypa/manylinux2014_aarch64
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout release source
+        uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
+          fetch-tags: true
       - name: Download validated models catalog
         uses: actions/download-artifact@v4
         with:
@@ -283,9 +286,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          tag_commit="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+          head_commit="$(git rev-parse HEAD)"
+          if [[ "$head_commit" != "$tag_commit" ]]; then
+            echo "Release source mismatch: HEAD=${head_commit}, ${RELEASE_TAG}=${tag_commit}." >&2
+            exit 1
+          fi
           {
             echo "RELEASE_VERSION=${RELEASE_TAG#v}"
-            echo "COMMIT=$(git rev-parse --short HEAD)"
+            echo "COMMIT=$(git rev-parse --short "$tag_commit")"
             echo "BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           } >> "$GITHUB_ENV"
       - name: Build archive
@@ -353,50 +362,6 @@ jobs:
             dist/CLIProxyAPI_*
             dist/sky-cpa-core-lts_*
           if-no-files-found: error
-      - name: Upload release assets
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          assets=(dist/CLIProxyAPI_*.tar.gz dist/sky-cpa-core-lts_*.tar.gz)
-          if [[ ${#assets[@]} -eq 0 ]]; then
-            printf 'expected archive assets, found %s\n' "${#assets[@]}" >&2
-            printf '%s\n' "${assets[@]}" >&2
-            exit 1
-          fi
-          gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
-      - name: Refresh release checksums
-        continue-on-error: true
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          tmp_dir="$(mktemp -d)"
-          trap 'rm -rf "$tmp_dir"' EXIT
-          gh release download "$RELEASE_TAG" \
-            --pattern 'CLIProxyAPI_*.tar.gz' \
-            --pattern 'CLIProxyAPI_*.zip' \
-            --pattern 'sky-cpa-core-lts_*.tar.gz' \
-            --dir "$tmp_dir" \
-            --clobber
-          (
-            cd "$tmp_dir"
-            shopt -s nullglob
-            archives=(CLIProxyAPI_*.tar.gz CLIProxyAPI_*.zip sky-cpa-core-lts_*.tar.gz)
-            if [[ ${#archives[@]} -eq 0 ]]; then
-              echo "No release archives found"
-              exit 0
-            fi
-            if command -v sha256sum >/dev/null 2>&1; then
-              sha256sum "${archives[@]}" | sort -k2 > checksums.txt
-            else
-              shasum -a 256 "${archives[@]}" | sort -k2 > checksums.txt
-            fi
-          )
-          gh release upload "$RELEASE_TAG" "$tmp_dir/checksums.txt" --clobber
 
   build-linux-no-plugin:
     name: build linux-${{ matrix.goarch }} no-plugin
@@ -413,10 +378,12 @@ jobs:
             goarch: arm64
             asset_arch: aarch64
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout release source
+        uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
+          fetch-tags: true
       - name: Download validated models catalog
         uses: actions/download-artifact@v4
         with:
@@ -442,9 +409,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          tag_commit="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+          head_commit="$(git rev-parse HEAD)"
+          if [[ "$head_commit" != "$tag_commit" ]]; then
+            echo "Release source mismatch: HEAD=${head_commit}, ${RELEASE_TAG}=${tag_commit}." >&2
+            exit 1
+          fi
           {
             echo "RELEASE_VERSION=${RELEASE_TAG#v}"
-            echo "COMMIT=$(git rev-parse --short HEAD)"
+            echo "COMMIT=$(git rev-parse --short "$tag_commit")"
             echo "BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           } >> "$GITHUB_ENV"
       - name: Build archive
@@ -490,50 +463,6 @@ jobs:
             dist/CLIProxyAPI_*
             dist/sky-cpa-core-lts_*
           if-no-files-found: error
-      - name: Upload release assets
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          assets=(dist/CLIProxyAPI_*.tar.gz dist/sky-cpa-core-lts_*.tar.gz)
-          if [[ ${#assets[@]} -eq 0 ]]; then
-            printf 'expected archive assets, found %s\n' "${#assets[@]}" >&2
-            printf '%s\n' "${assets[@]}" >&2
-            exit 1
-          fi
-          gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
-      - name: Refresh release checksums
-        continue-on-error: true
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          tmp_dir="$(mktemp -d)"
-          trap 'rm -rf "$tmp_dir"' EXIT
-          gh release download "$RELEASE_TAG" \
-            --pattern 'CLIProxyAPI_*.tar.gz' \
-            --pattern 'CLIProxyAPI_*.zip' \
-            --pattern 'sky-cpa-core-lts_*.tar.gz' \
-            --dir "$tmp_dir" \
-            --clobber
-          (
-            cd "$tmp_dir"
-            shopt -s nullglob
-            archives=(CLIProxyAPI_*.tar.gz CLIProxyAPI_*.zip sky-cpa-core-lts_*.tar.gz)
-            if [[ ${#archives[@]} -eq 0 ]]; then
-              echo "No release archives found"
-              exit 0
-            fi
-            if command -v sha256sum >/dev/null 2>&1; then
-              sha256sum "${archives[@]}" | sort -k2 > checksums.txt
-            else
-              shasum -a 256 "${archives[@]}" | sort -k2 > checksums.txt
-            fi
-          )
-          gh release upload "$RELEASE_TAG" "$tmp_dir/checksums.txt" --clobber
 
   build-freebsd:
     name: build ${{ matrix.target }}
@@ -559,10 +488,12 @@ jobs:
             asset_suffix: _no-plugin
             cgo_enabled: false
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout release source
+        uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
+          fetch-tags: true
       - name: Download validated models catalog
         uses: actions/download-artifact@v4
         with:
@@ -587,8 +518,14 @@ jobs:
         id: metadata
         run: |
           set -euo pipefail
+          tag_commit="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+          head_commit="$(git rev-parse HEAD)"
+          if [[ "$head_commit" != "$tag_commit" ]]; then
+            echo "Release source mismatch: HEAD=${head_commit}, ${RELEASE_TAG}=${tag_commit}." >&2
+            exit 1
+          fi
           release_version="${RELEASE_TAG#v}"
-          commit="$(git rev-parse --short HEAD)"
+          commit="$(git rev-parse --short "$tag_commit")"
           build_date="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           {
             echo "RELEASE_VERSION=$release_version"
@@ -653,75 +590,79 @@ jobs:
           name: ${{ matrix.target }}
           path: dist/CLIProxyAPI_*
           if-no-files-found: error
-      - name: Upload release assets
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          shopt -s nullglob
-          assets=(dist/CLIProxyAPI_*.tar.gz)
-          if [[ ${#assets[@]} -eq 0 ]]; then
-            printf 'expected archive assets, found %s\n' "${#assets[@]}" >&2
-            printf '%s\n' "${assets[@]}" >&2
-            exit 1
-          fi
-          gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
-      - name: Refresh release checksums
-        continue-on-error: true
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          tmp_dir="$(mktemp -d)"
-          trap 'rm -rf "$tmp_dir"' EXIT
-          gh release download "$RELEASE_TAG" \
-            --pattern 'CLIProxyAPI_*.tar.gz' \
-            --pattern 'CLIProxyAPI_*.zip' \
-            --pattern 'sky-cpa-core-lts_*.tar.gz' \
-            --dir "$tmp_dir" \
-            --clobber
-          (
-            cd "$tmp_dir"
-            shopt -s nullglob
-            archives=(CLIProxyAPI_*.tar.gz CLIProxyAPI_*.zip sky-cpa-core-lts_*.tar.gz)
-            if [[ ${#archives[@]} -eq 0 ]]; then
-              echo "No release archives found"
-              exit 0
-            fi
-            if command -v sha256sum >/dev/null 2>&1; then
-              sha256sum "${archives[@]}" | sort -k2 > checksums.txt
-            else
-              shasum -a 256 "${archives[@]}" | sort -k2 > checksums.txt
-            fi
-          )
-          gh release upload "$RELEASE_TAG" "$tmp_dir/checksums.txt" --clobber
 
-  publish-checksums:
+  publish-release-assets:
     runs-on: ubuntu-latest
-    if: always()
     needs:
       - build-hosted
       - build-linux-glibc
       - build-linux-no-plugin
       - build-freebsd
     steps:
+      - name: Checkout release source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+          fetch-tags: true
       - uses: actions/download-artifact@v4
         with:
           path: dist
           merge-multiple: true
-      - name: Publish final checksums
+      - name: Validate and publish release assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           cd dist
           shopt -s nullglob
+          release_version="${RELEASE_TAG#v}"
+          expected=(
+            "CLIProxyAPI_${release_version}_darwin_amd64.tar.gz"
+            "CLIProxyAPI_${release_version}_darwin_aarch64.tar.gz"
+            "CLIProxyAPI_${release_version}_windows_amd64.zip"
+            "CLIProxyAPI_${release_version}_windows_aarch64.zip"
+            "CLIProxyAPI_${release_version}_linux_amd64.tar.gz"
+            "CLIProxyAPI_${release_version}_linux_aarch64.tar.gz"
+            "CLIProxyAPI_${release_version}_linux_amd64_no-plugin.tar.gz"
+            "CLIProxyAPI_${release_version}_linux_aarch64_no-plugin.tar.gz"
+            "sky-cpa-core-lts_${release_version}_linux_amd64.tar.gz"
+            "sky-cpa-core-lts_${release_version}_linux_aarch64.tar.gz"
+            "sky-cpa-core-lts_${release_version}_linux_amd64_no-plugin.tar.gz"
+            "sky-cpa-core-lts_${release_version}_linux_aarch64_no-plugin.tar.gz"
+            "CLIProxyAPI_${release_version}_freebsd_amd64.tar.gz"
+            "CLIProxyAPI_${release_version}_freebsd_aarch64_no-plugin.tar.gz"
+          )
           archives=(CLIProxyAPI_*.tar.gz CLIProxyAPI_*.zip sky-cpa-core-lts_*.tar.gz)
-          if [[ ${#archives[@]} -eq 0 ]]; then
-            echo "No release archives found"
-            exit 0
+          if [[ ${#archives[@]} -ne ${#expected[@]} ]]; then
+            printf 'Expected %s release archives, found %s.\n' "${#expected[@]}" "${#archives[@]}" >&2
+            printf '  found: %s\n' "${archives[@]}" >&2
+            exit 1
           fi
+          for asset in "${expected[@]}"; do
+            if [[ ! -f "$asset" ]]; then
+              echo "Missing expected release asset: $asset" >&2
+              exit 1
+            fi
+          done
+
+          expected_commit="$(git rev-parse --short "${RELEASE_TAG}^{commit}")"
+          verify_dir="$(mktemp -d)"
+          trap 'rm -rf "$verify_dir"' EXIT
+          tar -C "$verify_dir" -xzf "CLIProxyAPI_${release_version}_linux_amd64.tar.gz" cli-proxy-api
+          version_output="$("$verify_dir/cli-proxy-api" --help 2>&1)"
+          version_line="$(printf '%s\n' "$version_output" | sed -n '1p')"
+          if [[ "$version_line" != *"Version: ${release_version}, Commit: ${expected_commit},"* ]]; then
+            echo "Release binary provenance mismatch: $version_line" >&2
+            exit 1
+          fi
+
           sha256sum "${archives[@]}" | sort -k2 > checksums.txt
-          gh release upload "$RELEASE_TAG" checksums.txt --clobber
+          gh release upload "$RELEASE_TAG" "${archives[@]}" checksums.txt --clobber
+
+          printf '%s\n' "${expected[@]}" checksums.txt | sort > expected-assets.txt
+          gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name' | sort > published-assets.txt
+          if ! diff -u expected-assets.txt published-assets.txt; then
+            echo "Published release asset set does not match the validated build output." >&2
+            exit 1
+          fi

--- a/docs/lts/core-feature-contracts.yaml
+++ b/docs/lts/core-feature-contracts.yaml
@@ -152,6 +152,27 @@ features:
       - go test ./internal/managementasset
       - go build -o test-output ./cmd/server && rm -f test-output
 
+  - id: release-artifact-provenance
+    kind: retained-capability
+    support: protected
+    owner: cpa-core-lts
+    upstream_relation: divergent
+    reason: Release archives and GHCR images must be built from the exact requested annotated tag, while current tooling may be checked out separately for historical repair.
+    core_files:
+      - .github/workflows/release.yaml
+      - .github/workflows/docker-image.yml
+      - scripts/migrate-tags-lts.sh
+      - scripts/cleanup-ghcr-tls-images.sh
+    required_markers:
+      - RELEASE_TAG
+      - Checkout current release tooling
+      - Release source mismatch
+      - publish-release-assets
+      - update_latest
+    validation:
+      - scripts/check-lts-contract.sh
+      - actionlint .github/workflows/release.yaml .github/workflows/docker-image.yml
+
   - id: auth-identity-attribution
     kind: retained-capability
     support: protected

--- a/docs/lts/protected-deltas.yaml
+++ b/docs/lts/protected-deltas.yaml
@@ -77,6 +77,20 @@ retained_capabilities:
       - go test ./internal/managementasset
     conflict_policy: preserve_panel_compatibility
 
+  - id: release-artifact-provenance
+    registry_feature: release-artifact-provenance
+    must_keep: true
+    markers:
+      - exact-tag release source checkout
+      - separate current release tooling checkout
+      - release source mismatch guard
+      - publish assets only after every platform build succeeds
+      - manual GHCR backfill preserves latest aliases by default
+    validation:
+      - scripts/check-lts-contract.sh
+      - actionlint release workflows
+    conflict_policy: preserve_exact_tag_artifact_provenance
+
   - id: auth-identity-attribution
     registry_feature: auth-identity-attribution
     must_keep: true

--- a/scripts/check-lts-contract.sh
+++ b/scripts/check-lts-contract.sh
@@ -163,6 +163,24 @@ require_grep "ResolveCodexReasoningReplaySessionKey" internal/cache/codex_reason
 require_grep "ValidateCodexClientModelsLTSCompatibility" internal/registry/codex_client_models.go internal/registry/codex_client_models_test.go cmd/validate_codex_models/main.go
 require_grep "refresh-model-catalogs.sh" .github/workflows/pr-test-build.yml .github/workflows/release.yaml .github/workflows/docker-image.yml
 require_grep "codex_client_models.json" .github/scripts/refresh-model-catalogs.sh
+require_grep "ref: \${{ env.RELEASE_TAG }}" .github/workflows/release.yaml .github/workflows/docker-image.yml
+require_grep "Checkout current release tooling" .github/workflows/release.yaml
+require_grep "Release source mismatch" .github/workflows/release.yaml .github/workflows/docker-image.yml
+require_grep "publish-release-assets" .github/workflows/release.yaml
+require_grep "workflow_dispatch:" .github/workflows/docker-image.yml
+require_grep "update_latest:" .github/workflows/docker-image.yml
+require_grep "release-artifact-provenance" docs/lts/core-feature-contracts.yaml docs/lts/protected-deltas.yaml
+require_grep "read:packages" scripts/cleanup-ghcr-tls-images.sh
+require_grep "delete:packages" scripts/cleanup-ghcr-tls-images.sh
+if grep -Fq "ref: \${{ github.ref }}" .github/workflows/release.yaml .github/workflows/docker-image.yml; then
+  echo "release workflows must not build github.ref when RELEASE_TAG can name another tag" >&2
+  exit 1
+fi
+release_upload_count="$(grep -Fc "gh release upload \"\$RELEASE_TAG\"" .github/workflows/release.yaml)"
+if [ "$release_upload_count" -ne 1 ]; then
+  echo "release assets and checksums must be uploaded together after all build jobs succeed" >&2
+  exit 1
+fi
 require_grep "responsesWebsocketCanAttestContextReset" sdk/api/handlers/openai/openai_responses_websocket.go sdk/api/handlers/openai/openai_responses_websocket_test.go
 require_grep "ModelFallbackZeroDispatch" sdk/cliproxy/auth/codex_model_fallback.go docs/lts/core-feature-contracts.yaml
 require_grep "auth_index" internal/usage internal/api/handlers/management internal/runtime/executor/helps internal/redisqueue

--- a/scripts/cleanup-ghcr-tls-images.sh
+++ b/scripts/cleanup-ghcr-tls-images.sh
@@ -1,70 +1,174 @@
 #!/usr/bin/env bash
-# cleanup-ghcr-tls-images.sh — Delete old v1-tls-* Docker images from GHCR
-#
-# Usage:
-#   bash scripts/cleanup-ghcr-tls-images.sh [--dry-run]
-#
-# Requirements: gh CLI (authenticated with packages:delete scope)
+# cleanup-ghcr-tls-images.sh — Delete superseded v*-tls-* Docker image versions.
 set -euo pipefail
 
-DRY_RUN=false
+APPLY=false
 PACKAGE_NAME="cpa-core-lts"
 OWNER="BlueSkyXN"
 
+usage() {
+  cat <<'EOF'
+Usage: scripts/cleanup-ghcr-tls-images.sh [--dry-run | --apply] [--owner OWNER]
+
+The default is a read-only dry run. Deletion requires --apply. Every v*-tls-*
+tag must have a matching v*-lts-* tag, and a version carrying latest or any
+other non-tls tag is refused.
+
+Requirements:
+  - gh CLI authenticated with read:packages for inspection
+  - delete:packages additionally required with --apply
+EOF
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --dry-run) DRY_RUN=true; shift ;;
+    --dry-run) APPLY=false; shift ;;
+    --apply)   APPLY=true; shift ;;
     --owner)   OWNER="${2:-}"; shift 2 ;;
     -h|--help)
-      echo "Usage: $0 [--dry-run] [--owner OWNER]"
+      usage
       exit 0
       ;;
-    *) echo "unknown: $1" >&2; exit 2 ;;
+    *) echo "unknown: $1" >&2; usage >&2; exit 2 ;;
   esac
 done
 
-echo "Package: ghcr.io/${OWNER}/${PACKAGE_NAME}"
-echo ""
+if [[ -z "$OWNER" ]]; then
+  echo "--owner must not be empty" >&2
+  exit 2
+fi
 
 if ! command -v gh >/dev/null 2>&1; then
   echo "gh CLI is required but not found" >&2
   exit 1
 fi
 
-# List all versions and filter for tls pattern
-echo "Fetching package versions..."
-versions_json="$(gh api \
-  "/orgs/${OWNER}/packages/container/${PACKAGE_NAME}/versions" \
-  --paginate --jq '.[] | select(.metadata.container.tags[]? | test("^v[0-9]+-tls-")) | .id' 2>/dev/null || \
-  gh api \
-  "/users/${OWNER}/packages/container/${PACKAGE_NAME}/versions" \
-  --paginate --jq '.[] | select(.metadata.container.tags[]? | test("^v[0-9]+-tls-")) | .id' 2>/dev/null || echo "")"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+versions_file="$tmp_dir/versions.tsv"
+user_errors_file="$tmp_dir/gh-user-errors.txt"
+org_errors_file="$tmp_dir/gh-org-errors.txt"
+targets_file="$tmp_dir/targets.tsv"
+lts_tags_file="$tmp_dir/lts-tags.txt"
 
-if [[ -z "$versions_json" ]]; then
-  echo "No v*-tls-* tagged images found on GHCR."
-  echo "(This may also mean the API call needs 'packages:delete' scope)"
+fetch_versions() {
+  local endpoint="$1"
+  local errors_file="$2"
+  gh api "$endpoint" --paginate \
+    --jq '.[] | [.id, ((.metadata.container.tags // []) | join(","))] | @tsv' \
+    >"$versions_file" 2>"$errors_file"
+}
+
+user_endpoint="/users/${OWNER}/packages/container/${PACKAGE_NAME}/versions"
+org_endpoint="/orgs/${OWNER}/packages/container/${PACKAGE_NAME}/versions"
+package_endpoint=""
+
+if fetch_versions "$user_endpoint" "$user_errors_file"; then
+  package_endpoint="$user_endpoint"
+elif fetch_versions "$org_endpoint" "$org_errors_file"; then
+  package_endpoint="$org_endpoint"
+else
+  echo "Unable to read GHCR package versions for ${OWNER}/${PACKAGE_NAME}." >&2
+  echo "Confirm the owner type and a token with read:packages; no deletion was attempted." >&2
+  echo "User endpoint:" >&2
+  sed -n '1,4p' "$user_errors_file" >&2
+  echo "Organization endpoint:" >&2
+  sed -n '1,4p' "$org_errors_file" >&2
+  exit 1
+fi
+
+echo "Package: ghcr.io/${OWNER}/${PACKAGE_NAME}"
+echo "Endpoint: ${package_endpoint}"
+
+: >"$lts_tags_file"
+while IFS=$'\t' read -r _ tags_csv; do
+  [[ -z "$tags_csv" ]] && continue
+  IFS=',' read -r -a tags <<<"$tags_csv"
+  for tag in "${tags[@]}"; do
+    if [[ "$tag" == v*-lts-* ]]; then
+      printf '%s\n' "$tag" >>"$lts_tags_file"
+    fi
+  done
+done <"$versions_file"
+sort -u -o "$lts_tags_file" "$lts_tags_file"
+
+: >"$targets_file"
+unsafe=false
+while IFS=$'\t' read -r version_id tags_csv; do
+  [[ -z "$version_id" || -z "$tags_csv" ]] && continue
+  IFS=',' read -r -a tags <<<"$tags_csv"
+  has_tls_tag=false
+  has_shared_tag=false
+
+  for tag in "${tags[@]}"; do
+    if [[ "$tag" == v*-tls-* ]]; then
+      has_tls_tag=true
+      replacement="${tag/-tls-/-lts-}"
+      if ! grep -Fqx -- "$replacement" "$lts_tags_file"; then
+        echo "BLOCKED version $version_id: $tag has no verified replacement tag $replacement" >&2
+        unsafe=true
+      fi
+    else
+      has_shared_tag=true
+    fi
+  done
+
+  if [[ "$has_tls_tag" == "true" ]]; then
+    if [[ "$has_shared_tag" == "true" ]]; then
+      echo "BLOCKED version $version_id: non-tls tags share this version ($tags_csv)" >&2
+      unsafe=true
+    fi
+    printf '%s\t%s\n' "$version_id" "$tags_csv" >>"$targets_file"
+  fi
+done <"$versions_file"
+
+if [[ "$unsafe" == "true" ]]; then
+  echo "Refusing cleanup until every replacement exists and latest/shared tags have moved." >&2
+  exit 1
+fi
+
+target_count="$(wc -l <"$targets_file" | tr -d '[:space:]')"
+if [[ "$target_count" -eq 0 ]]; then
+  echo "No removable v*-tls-* tagged image versions found."
   exit 0
 fi
 
-count="$(printf '%s\n' "$versions_json" | wc -l | tr -d ' ')"
-echo "Found $count GHCR image versions with v*-tls-* tags"
+echo "Found $target_count removable GHCR image versions:"
+while IFS=$'\t' read -r version_id tags_csv; do
+  printf '  %s  %s\n' "$version_id" "$tags_csv"
+done <"$targets_file"
 
-if [[ "$DRY_RUN" == "true" ]]; then
-  echo "DRY RUN — would delete the following version IDs:"
-  printf '  %s\n' $versions_json
+if [[ "$APPLY" != "true" ]]; then
+  echo "DRY RUN — no versions were deleted. Re-run with --apply after reviewing the list."
   exit 0
 fi
 
-echo "Deleting..."
-while IFS= read -r version_id; do
-  [[ -z "$version_id" ]] && continue
-  gh api --method DELETE \
-    "/orgs/${OWNER}/packages/container/${PACKAGE_NAME}/versions/${version_id}" 2>/dev/null || \
-  gh api --method DELETE \
-    "/users/${OWNER}/packages/container/${PACKAGE_NAME}/versions/${version_id}" 2>/dev/null || \
-  echo "  FAILED to delete version $version_id"
-  echo "  OK deleted version $version_id"
-done <<< "$versions_json"
+failures=0
+while IFS=$'\t' read -r version_id tags_csv; do
+  if gh api --method DELETE "${package_endpoint}/${version_id}" >/dev/null; then
+    echo "  OK deleted version $version_id ($tags_csv)"
+  else
+    echo "  FAILED to delete version $version_id ($tags_csv)" >&2
+    failures=$((failures + 1))
+  fi
+done <"$targets_file"
 
-echo ""
-echo "GHCR cleanup complete. New v*-lts-* images will be created by the docker-image workflow."
+if [[ "$failures" -ne 0 ]]; then
+  echo "GHCR cleanup failed for $failures version(s)." >&2
+  exit 1
+fi
+
+if ! fetch_versions "$package_endpoint" "$user_errors_file"; then
+  echo "Deleted versions, but failed to read back the package state." >&2
+  sed -n '1,8p' "$user_errors_file" >&2
+  exit 1
+fi
+
+while IFS=$'\t' read -r version_id _; do
+  if awk -F '\t' -v id="$version_id" '$1 == id { found = 1 } END { exit !found }' "$versions_file"; then
+    echo "GHCR cleanup readback failed: version $version_id still exists." >&2
+    exit 1
+  fi
+done <"$targets_file"
+
+echo "GHCR cleanup complete and deletion readback passed."

--- a/scripts/migrate-tags-lts.sh
+++ b/scripts/migrate-tags-lts.sh
@@ -3,16 +3,16 @@
 #
 # This script handles:
 #   1. Recreating annotated git tags with corrected names (tls → lts)
-#   2. Migrating GitHub Releases (with assets) to the new tag names
+#   2. Migrating GitHub Releases and preserving the old assets as transitional copies
 #   3. Cleaning up old tags locally and on the remote
 #
 # Usage:
-#   bash scripts/migrate-tags-lts.sh [--dry-run] [--repo OWNER/NAME] [--skip-releases]
+#   bash scripts/migrate-tags-lts.sh [--dry-run | --apply] [--repo OWNER/NAME] [--skip-releases]
 #
-# Requirements: git, gh CLI (authenticated), curl (for GHCR cleanup)
+# Requirements: git, gh CLI (authenticated)
 set -euo pipefail
 
-DRY_RUN=false
+DRY_RUN=true
 SKIP_RELEASES=false
 REPO="${REPO:-BlueSkyXN/CPA-Core-LTS}"
 TAG_PATTERN='v1-tls-*'
@@ -20,10 +20,11 @@ TAG_PATTERN='v1-tls-*'
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dry-run)   DRY_RUN=true; shift ;;
+    --apply)     DRY_RUN=false; shift ;;
     --skip-releases) SKIP_RELEASES=true; shift ;;
     --repo)      REPO="${2:-}"; shift 2 ;;
     -h|--help)
-      echo "Usage: $0 [--dry-run] [--repo OWNER/NAME] [--skip-releases]"
+      echo "Usage: $0 [--dry-run | --apply] [--repo OWNER/NAME] [--skip-releases]"
       exit 0
       ;;
     *) echo "unknown: $1" >&2; exit 2 ;;
@@ -31,15 +32,18 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ "$DRY_RUN" == "true" ]]; then
-  echo "=== DRY RUN MODE — no changes will be made ==="
+  echo "=== DRY RUN MODE — no changes will be made; use --apply to mutate tags or Releases ==="
 fi
 
 echo "Target repo: $REPO"
 echo "Tag pattern: $TAG_PATTERN"
 echo ""
 
-# Collect old tags (sorted by version)
-mapfile -t OLD_TAGS < <(git tag --list "$TAG_PATTERN" --sort=v:refname)
+# Collect old tags (sorted by version). Keep compatibility with macOS Bash 3.2.
+OLD_TAGS=()
+while IFS= read -r old_tag; do
+  [[ -n "$old_tag" ]] && OLD_TAGS+=("$old_tag")
+done < <(git tag --list "$TAG_PATTERN" --sort=v:refname)
 if [[ ${#OLD_TAGS[@]} -eq 0 ]]; then
   echo "No tags matching $TAG_PATTERN found."
   exit 0
@@ -52,14 +56,18 @@ echo ""
 # ─── Phase 1: Create new annotated tags locally ───
 echo "━━━ Phase 1: Create new v1-lts-* annotated tags ━━━"
 
-declare -A TAG_MAP  # old_tag -> new_tag
 for old_tag in "${OLD_TAGS[@]}"; do
   new_tag="${old_tag/tls/lts}"
-  TAG_MAP["$old_tag"]="$new_tag"
 
   # Check if new tag already exists
   if git rev-parse -q --verify "refs/tags/$new_tag" >/dev/null 2>&1; then
-    echo "  SKIP $new_tag (already exists)"
+    old_commit="$(git rev-parse "${old_tag}^{commit}")"
+    new_commit="$(git rev-parse "${new_tag}^{commit}")"
+    if [[ "$new_commit" != "$old_commit" ]]; then
+      echo "  ERROR $new_tag points to $new_commit, expected $old_commit" >&2
+      exit 1
+    fi
+    echo "  SKIP $new_tag (already exists at ${new_commit:0:8})"
     continue
   fi
 
@@ -96,16 +104,26 @@ echo ""
 echo "━━━ Phase 2: Push new tags to origin ━━━"
 
 if [[ "$DRY_RUN" == "true" ]]; then
-  echo "  DRY-RUN: git push origin ${#OLD_TAGS[@]} new tags"
-else
-  push_args=()
   for old_tag in "${OLD_TAGS[@]}"; do
-    new_tag="${TAG_MAP[$old_tag]}"
-    push_args+=("refs/tags/$new_tag")
+    new_tag="${old_tag/tls/lts}"
+    echo "  DRY-RUN: git push origin refs/tags/${new_tag}:refs/tags/${new_tag}"
   done
-  git push origin "${push_args[@]}"
-  echo "  OK pushed ${#push_args[@]} new tags"
+else
+  for old_tag in "${OLD_TAGS[@]}"; do
+    new_tag="${old_tag/tls/lts}"
+    git push origin "refs/tags/${new_tag}:refs/tags/${new_tag}"
+    expected_commit="$(git rev-parse "${new_tag}^{commit}")"
+    remote_commit="$(git ls-remote origin "refs/tags/${new_tag}^{}" | awk 'NR == 1 { print $1 }')"
+    if [[ "$remote_commit" != "$expected_commit" ]]; then
+      echo "  ERROR remote ${new_tag} resolves to ${remote_commit:-missing}, expected $expected_commit" >&2
+      exit 1
+    fi
+    echo "  OK pushed and verified $new_tag (${expected_commit:0:8})"
+  done
 fi
+
+echo "  NOTE: renamed historical tags may not contain a workflow that matches v*-lts-*."
+echo "        Rebuild them with the fixed workflow_dispatch path; do not rely on tag push events."
 
 echo ""
 
@@ -115,26 +133,24 @@ echo "━━━ Phase 3: Migrate GitHub Releases ━━━"
 if [[ "$SKIP_RELEASES" == "true" ]]; then
   echo "  SKIPPED (--skip-releases)"
 elif ! command -v gh >/dev/null 2>&1; then
-  echo "  SKIPPED (gh CLI not found)"
+  echo "  ERROR gh CLI is required unless --skip-releases is used" >&2
+  exit 1
 else
   for old_tag in "${OLD_TAGS[@]}"; do
-    new_tag="${TAG_MAP[$old_tag]}"
+    new_tag="${old_tag/tls/lts}"
     echo "  Processing $old_tag → $new_tag ..."
 
-    # Check if old release exists
-    if ! gh release view "$old_tag" -R "$REPO" >/dev/null 2>&1; then
-      echo "    No GitHub release for $old_tag, skipping"
+    if [[ "$DRY_RUN" == "true" ]]; then
+      echo "    DRY-RUN: copy and verify release $old_tag → $new_tag, then delete $old_tag"
       continue
     fi
 
-    if [[ "$DRY_RUN" == "true" ]]; then
-      echo "    DRY-RUN: migrate release $old_tag → $new_tag"
-      continue
-    fi
+    # Fail closed: an authentication/permission error must not look like a missing release.
+    gh release view "$old_tag" -R "$REPO" >/dev/null
 
     # Get old release title and notes
-    old_title="$(gh release view "$old_tag" -R "$REPO" --json name -q .name 2>/dev/null || echo "")"
-    old_notes="$(gh release view "$old_tag" -R "$REPO" --json body -q .body 2>/dev/null || echo "")"
+    old_title="$(gh release view "$old_tag" -R "$REPO" --json name -q .name)"
+    old_notes="$(gh release view "$old_tag" -R "$REPO" --json body -q .body)"
 
     # Fix title and notes: replace tls → lts
     new_title="$(printf '%s' "$old_title" | sed 's/tls/lts/g; s/TLS/LTS/g')"
@@ -142,28 +158,37 @@ else
 
     # Download assets to temp dir
     tmp_dir="$(mktemp -d)"
-    trap "rm -rf '$tmp_dir'" EXIT
-    gh release download "$old_tag" -R "$REPO" --dir "$tmp_dir" --clobber 2>/dev/null || true
-
-    # Delete old release
-    gh release delete "$old_tag" -R "$REPO" --yes 2>/dev/null || true
-    echo "    Deleted old release $old_tag"
-
-    # Create new release
     notes_file="$(mktemp)"
-    printf '%s' "$new_notes" > "$notes_file"
-    gh release create "$new_tag" -R "$REPO" --title "$new_title" --notes-file "$notes_file" 2>/dev/null || \
-      gh release create "$new_tag" -R "$REPO" --title "$new_title" --notes "$new_notes" 2>/dev/null || true
-    rm -f "$notes_file"
-
-    # Re-upload assets
+    trap 'rm -rf "$tmp_dir"; rm -f "$notes_file"' EXIT
+    gh release download "$old_tag" -R "$REPO" --dir "$tmp_dir" --clobber
     shopt -s nullglob
     assets=("$tmp_dir"/*)
-    if [[ ${#assets[@]} -gt 0 ]]; then
-      gh release upload "$new_tag" -R "$REPO" "${assets[@]}" --clobber
-      echo "    Re-uploaded ${#assets[@]} assets"
+    if [[ ${#assets[@]} -eq 0 ]]; then
+      echo "    ERROR old release $old_tag has no downloadable assets" >&2
+      exit 1
     fi
+
+    printf '%s' "$new_notes" > "$notes_file"
+    if gh release view "$new_tag" -R "$REPO" >/dev/null 2>&1; then
+      gh release edit "$new_tag" -R "$REPO" --title "$new_title" --notes-file "$notes_file"
+    else
+      gh release create "$new_tag" -R "$REPO" --title "$new_title" --notes-file "$notes_file"
+    fi
+
+    # Upload and read back before removing the old release.
+    gh release upload "$new_tag" -R "$REPO" "${assets[@]}" --clobber
+    uploaded_count="$(gh release view "$new_tag" -R "$REPO" --json assets --jq '.assets | length')"
+    if [[ "$uploaded_count" -ne ${#assets[@]} ]]; then
+      echo "    ERROR release $new_tag has $uploaded_count assets, expected ${#assets[@]}" >&2
+      exit 1
+    fi
+    echo "    Uploaded and verified ${#assets[@]} transitional assets"
+
+    gh release delete "$old_tag" -R "$REPO" --yes
+    echo "    Deleted old release $old_tag after new release verification"
+
     rm -rf "$tmp_dir"
+    rm -f "$notes_file"
     trap - EXIT
 
     echo "    OK release $new_tag created"
@@ -180,19 +205,32 @@ if [[ "$DRY_RUN" == "true" ]]; then
     echo "  DRY-RUN: git tag -d $old_tag && git push origin :refs/tags/$old_tag"
   done
 else
-  # Delete old tags locally
+  # Delete and read back old remote tags before removing the local recovery refs.
   for old_tag in "${OLD_TAGS[@]}"; do
-    git tag -d "$old_tag" 2>/dev/null || true
+    git push origin ":refs/tags/$old_tag"
+    set +e
+    git ls-remote --exit-code origin "refs/tags/$old_tag" >/dev/null
+    readback_status=$?
+    set -e
+    case "$readback_status" in
+      2)
+        echo "  OK deleted remote tag $old_tag"
+        ;;
+      0)
+        echo "  ERROR remote tag $old_tag still exists" >&2
+        exit 1
+        ;;
+      *)
+        echo "  ERROR could not read back remote tag $old_tag" >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  for old_tag in "${OLD_TAGS[@]}"; do
+    git tag -d "$old_tag"
   done
   echo "  OK deleted ${#OLD_TAGS[@]} local tags"
-
-  # Delete old tags from remote
-  delete_args=()
-  for old_tag in "${OLD_TAGS[@]}"; do
-    delete_args+=(":refs/tags/$old_tag")
-  done
-  git push origin "${delete_args[@]}" 2>/dev/null || true
-  echo "  OK deleted ${#OLD_TAGS[@]} remote tags"
 fi
 
 echo ""
@@ -203,5 +241,7 @@ echo "  1. Update workflow files: v*-tls-* → v*-lts-*"
 echo "  2. Update scripts/generate-lts-release-notes.sh"
 echo "  3. Update docs/lts/sync-runbook.md"
 echo "  4. Update test files"
-echo "  5. GHCR: old v1-tls-* Docker images remain; consider deleting via GitHub Packages UI"
-echo "  6. Repeat for CPA-Panel-LTS if needed"
+echo "  5. Rebuild every new Release from its exact tag with workflow_dispatch."
+echo "     Copied assets are transitional and do not prove corrected version/provenance."
+echo "  6. Build and verify v*-lts-* GHCR images before deleting any v*-tls-* images."
+echo "  7. Repeat for CPA-Panel-LTS if needed"


### PR DESCRIPTION
## 结论与问题

修复历史 `workflow_dispatch` 把 `release_tag` 只用于版本名、却从触发分支（通常是 `main`）构建产品源码的问题。此前因此可能出现“历史 Release 名称正确，但二进制/资产来自另一个 commit”的错误 provenance；GHCR 也缺少可控的历史 tag 补建入口。

本 PR 只修复发布链路和迁移/清理防护，不创建或覆盖 Release、不推 tag、不发布或删除 GHCR 镜像。

## Type

- [x] LTS protected-delta patch
- [x] Maintenance docs / CI

## 主要变更

- Release 与 Docker 产品源码始终 checkout 精确 `RELEASE_TAG`，并校验 `HEAD == <tag>^{commit}`。
- 当前 release/catalog 工具独立 checkout 到 `_release_tools`，可以修复旧 tag，又不会用当前 `main` 代替历史产品源码。
- Core 的 14 个平台归档先全部构建并上传为 Actions artifacts；全部成功后才统一校验版本/commit、生成 `checksums.txt` 并覆盖 Release，避免并行 job 部分发布。
- Docker workflow 新增 `workflow_dispatch.release_tag`；手工补建默认保留 `latest`，只有 tag push 或显式 `update_latest=true` 才移动 latest aliases。
- amd64/arm64 使用同一份验证后的 model catalog。
- tag migration 和 GHCR cleanup 改为默认 dry-run、显式 `--apply`、失败封闭及操作后回读；没有 replacement 或仍持有 `latest` 的旧镜像拒绝删除。
- 将 exact-tag artifact provenance 登记为 LTS protected contract，并加入 sentinel。

## 兼容性与边界

- 保留 `v*-lts-*` tag 格式、现有 14 个归档名称、`checksums.txt`、`management.html` 来源和 model catalog refresh。
- 手工历史 GHCR backfill 不会意外把 `latest` 指向旧版本。
- 本 PR 合并后仍需单独 dispatch 历史 Release/Docker workflow，并逐项回读；PR 绿灯本身不代表历史资产已修复。
- 旧 `v*-tls-*` GHCR 镜像暂不删除，避免仍使用旧 tag 的消费者中断。

## LTS classification review

| Item | Class | Conclusion | Evidence / validation |
|---|---|---|---|
| `release-artifact-provenance` | retained capability | newly-added | exact-tag checkout、source guard、统一发布 job、contract sentinel |
| `codex-gpt56-ultra-level` | downstream patch | preserved | model catalog refresh 保留，并由同一次验证结果供所有构建使用 |

## Validation

- [x] `actionlint .github/workflows/release.yaml .github/workflows/docker-image.yml`
- [x] `shellcheck scripts/check-lts-contract.sh scripts/migrate-tags-lts.sh scripts/cleanup-ghcr-tls-images.sh`
- [x] `bash -n`（上述 shell scripts）
- [x] `scripts/generate-lts-release-notes_test.sh`
- [x] `scripts/check-lts-contract.sh`
- [x] `go run ./scripts/ltsregistry --root .`（由 contract guard 执行）
- [x] `go build ./cmd/server`（输出到临时目录）
- [x] `git diff --check`
- [x] 从最老 `v1-lts-0.0.3` tag tree 演练 catalog refresh、目标 package tests、host/Linux build；二进制读回 `Version: 1-lts-0.0.3, Commit: d38cc057`，与 tag target 一致
- [x] GHCR cleanup 的 replacement、shared/latest 拒绝、DELETE failure、成功删除回读均以 mock `gh` 验证
- [ ] `go test ./...`：未运行；本 PR 不修改 Go 源码，使用 contract guard、server build 与最老 tag build 演练覆盖实际风险面
- [ ] Live Release/GHCR：PR 内不发布，合并后单独执行并回读

## Review focus

1. `_release_tools` 与精确 tag 产品 checkout 的边界是否清晰。
2. 14 个资产只在所有 build jobs 成功后统一发布的依赖关系。
3. Docker `update_latest` 默认值与历史 backfill 行为。
4. GHCR cleanup 对 replacement 和共享 tag 的 fail-closed 条件。
