### PR TITLE
fix(release): constrain known historical catalog failures

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,11 @@ on:
         required: false
         default: false
         type: boolean
+      allow_known_historical_catalog_failure:
+        description: 'Allow the known GPT-5.6 Ultra test failure in v1-lts-0.0.10 and v1-lts-0.0.11'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -24,6 +29,7 @@ env:
   GO_VERSION: '1.26.4'
   RELEASE_TAG: ${{ github.event.inputs.release_tag || github.ref_name }}
   REWRITE_RELEASE_NOTES: ${{ github.event_name == 'workflow_dispatch' && inputs.rewrite_release_notes || false }}
+  ALLOW_KNOWN_HISTORICAL_CATALOG_FAILURE: ${{ github.event_name == 'workflow_dispatch' && inputs.allow_known_historical_catalog_failure || false }}
 
 jobs:
   validate-release-catalog:
@@ -69,10 +75,53 @@ jobs:
               bash .github/scripts/refresh-model-catalogs.sh
           )
       - name: Validate GPT-5.6 Ultra compatibility
+        shell: bash
         run: |
-          go test ./internal/registry ./internal/thinking \
+          set -euo pipefail
+          validation_log="$RUNNER_TEMP/gpt56-catalog-validation.log"
+          if go test ./internal/registry ./internal/thinking \
             ./internal/runtime/executor ./sdk/api/handlers/openai \
-            -run 'GPT56|Ultra|CodexWire' -count=1
+            -run 'GPT56|Ultra|CodexWire' -count=1 2>&1 | tee "$validation_log"; then
+            exit 0
+          fi
+
+          if [[ "$ALLOW_KNOWN_HISTORICAL_CATALOG_FAILURE" != "true" ]]; then
+            exit 1
+          fi
+          case "$RELEASE_TAG" in
+            v1-lts-0.0.10|v1-lts-0.0.11) ;;
+            *)
+              echo "The catalog validation exception is restricted to v1-lts-0.0.10 and v1-lts-0.0.11." >&2
+              exit 1
+              ;;
+          esac
+
+          failed_packages="$(awk '$1 == "FAIL" && NF > 1 {print $2}' "$validation_log" | sort -u)"
+          expected_package="github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
+          if [[ "$failed_packages" != "$expected_package" ]]; then
+            printf 'Unexpected failing packages:\n%s\n' "$failed_packages" >&2
+            exit 1
+          fi
+
+          expected_failures=(
+            "--- FAIL: TestGPT56UltraCodexThinking"
+            "--- FAIL: TestGPT56UltraCodexThinking/sol_body"
+            "--- FAIL: TestGPT56UltraCodexThinking/sol_suffix_overrides_body"
+            "--- FAIL: TestGPT56UltraCodexThinking/terra_body"
+            "--- FAIL: TestGPT56UltraCodexThinking/terra_suffix_overrides_body"
+          )
+          failure_count="$(grep -Fc -- '--- FAIL:' "$validation_log")"
+          if [[ "$failure_count" -ne "${#expected_failures[@]}" ]]; then
+            echo "Unexpected number of historical catalog test failures: $failure_count." >&2
+            exit 1
+          fi
+          for marker in "${expected_failures[@]}"; do
+            if ! grep -Fq -- "$marker" "$validation_log"; then
+              echo "Missing expected historical catalog failure: $marker" >&2
+              exit 1
+            fi
+          done
+          echo "::warning::Accepted the known immutable-tag GPT-5.6 Ultra test failure for $RELEASE_TAG."
       - name: Upload validated models catalog
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## 结果与问题

历史 Release 重建在 `v1-lts-0.0.10` 和 `v1-lts-0.0.11` 被当前 GPT-5.6 Ultra catalog 门禁阻断。两个 immutable tag 都处在 Ultra 支持的历史中间状态：精确 tag 源码中的 `TestGPT56UltraCodexThinking` 已存在，但对应实现尚未完成；从 `v1-lts-0.0.12` 开始该测试才恢复通过。直接要求这两个旧 tag 通过后续门禁，会导致正确的 exact-tag rebuild 永远无法完成。

## 改动

- 为手工 `workflow_dispatch` 增加默认关闭的 `allow_known_historical_catalog_failure`。
- 仅允许 `v1-lts-0.0.10` 和 `v1-lts-0.0.11` 使用该例外。
- 即使显式启用，也仍实际运行测试，并要求唯一失败 package 是 `internal/thinking`，且失败集合精确等于已确认的 5 个 GPT-5.6 Ultra test/subtest；任何新增失败继续 fail closed。
- 普通 tag push、其他历史 tag 和未显式启用的 dispatch 行为不变；Docker workflow 不受影响。

## 验证

- `actionlint .github/workflows/release.yaml`
- `scripts/check-lts-contract.sh`
- `go build -o <temp>/cli-proxy-api ./cmd/server`
- `git diff --check`
- 从 `v1-lts-0.0.10` tag tree 刷新当前 catalog 后实跑目标 tests，确认只有预期的 1 个 package / 5 个 test markers 失败，并通过新增的 fail-closed 匹配逻辑
- 线上失败证据：run `33841736647`（`.10`）和 `33841742773`（`.11`）；`.12` run `33841747618` 已通过同一门禁和完整构建

合并后只会对 `.10`、`.11` 的历史重建显式启用该输入，并再次读回 15 个资产及二进制 provenance。