### PR TITLE
fix(release): 恢复严格的 Release 元数据契约

### DIFF
--- a/scripts/generate-lts-release-notes.sh
+++ b/scripts/generate-lts-release-notes.sh
@@ -107,8 +107,8 @@ is_placeholder_summary() {
 }
 
 if is_placeholder_summary "$summary" "$tag"; then
-  echo "warning: tag ${tag} has a placeholder summary; using generic title." >&2
-  summary="CPA Core LTS ${tag}"
+  echo "Release tag ${tag} must contain a meaningful user-facing summary." >&2
+  exit 1
 fi
 
 companion_lines="$(
@@ -117,15 +117,14 @@ companion_lines="$(
     sed 's/[[:space:]]*$//'
 )"
 companion_count="$(printf '%s\n' "$companion_lines" | awk 'NF { count++ } END { print count + 0 }')"
-companion_tag=""
-if [[ "$companion_count" -eq 1 ]]; then
-  companion_tag="$(printf '%s\n' "$companion_lines" | sed -n '1p')"
-  if [[ "$companion_tag" != v*-lts-* ]]; then
-    echo "warning: ${COMPANION_TRAILER} value does not match v*-lts-*: ${companion_tag}; skipping companion." >&2
-    companion_tag=""
-  fi
-else
-  echo "warning: tag ${tag} has ${companion_count} ${COMPANION_TRAILER} trailers (expected 1); skipping companion." >&2
+if [[ "$companion_count" -ne 1 ]]; then
+  echo "Release tag ${tag} must contain exactly one ${COMPANION_TRAILER}: v*-lts-* trailer." >&2
+  exit 1
+fi
+companion_tag="$(printf '%s\n' "$companion_lines" | sed -n '1p')"
+if [[ "$companion_tag" != v*-lts-* ]]; then
+  echo "${COMPANION_TRAILER} value must match v*-lts-*: ${companion_tag}" >&2
+  exit 1
 fi
 
 previous_lts_tag() {
@@ -187,11 +186,9 @@ title="${tag} — ${short_summary}"
 
 {
   printf '## 摘要\n\n%s\n\n' "$summary"
-  if [[ -n "$companion_tag" ]]; then
-    printf '## 配套版本\n\n'
-    printf -- '- 配套 %s：[%s](https://github.com/%s/releases/tag/%s)\n\n' \
-      "$COMPANION_LABEL" "$companion_tag" "$companion_repo" "$companion_tag"
-  fi
+  printf '## 配套版本\n\n'
+  printf -- '- 配套 %s：[%s](https://github.com/%s/releases/tag/%s)\n\n' \
+    "$COMPANION_LABEL" "$companion_tag" "$companion_repo" "$companion_tag"
 
   cat <<'EOF'
 <!-- cliproxyapi-linux-release-assets:start -->

--- a/scripts/generate-lts-release-notes_test.sh
+++ b/scripts/generate-lts-release-notes_test.sh
@@ -121,55 +121,30 @@ git commit -qam lightweight
 git tag v1-lts-0.0.3
 expect_failure 'must be an annotated tag' v1-lts-0.0.3
 
-# --- Lenient fallback tests: script should succeed with degraded output ---
-
-expect_success() {
-  local tag="$1"
-  local out_file="$FIXTURE_DIR/lenient-${tag}.md"
-  local title_out="$FIXTURE_DIR/lenient-${tag}-title.txt"
-  local stderr_file="$FIXTURE_DIR/lenient-${tag}-stderr.txt"
-  if ! PATH="$MOCK_BIN:$PATH" GH_MOCK_LOG="$GH_MOCK_LOG" \
-    bash "$FIXTURE_DIR/repo/scripts/generate-lts-release-notes.sh" \
-      --tag "$tag" \
-      --notes-file "$out_file" \
-      --title-file "$title_out" \
-      >"$stderr_file" 2>&1; then
-    fail "$tag should succeed with lenient fallback"
-  fi
-}
-
 printf 'placeholder\n' >>fixture.txt
 git commit -qam placeholder
 git tag -a v1-lts-0.0.4 \
   -m 'CPA Core LTS v1-lts-0.0.4' \
   -m 'Companion-Panel: v1-lts-0.0.4'
-expect_success v1-lts-0.0.4
-assert_contains "$FIXTURE_DIR/lenient-v1-lts-0.0.4-title.txt" 'v1-lts-0.0.4'
-assert_contains "$FIXTURE_DIR/lenient-v1-lts-0.0.4.md" 'CPA-Panel-LTS'
+expect_failure 'meaningful user-facing summary' v1-lts-0.0.4
 
 printf 'missing companion\n' >>fixture.txt
 git commit -qam missing-companion
 git tag -a v1-lts-0.0.5 -m 'Core LTS: missing companion fixture'
-expect_success v1-lts-0.0.5
-assert_contains "$FIXTURE_DIR/lenient-v1-lts-0.0.5.md" 'Core LTS: missing companion fixture'
-assert_not_contains "$FIXTURE_DIR/lenient-v1-lts-0.0.5.md" '## 配套版本'
+expect_failure 'exactly one Companion-Panel' v1-lts-0.0.5
 
 printf 'invalid companion\n' >>fixture.txt
 git commit -qam invalid-companion
 git tag -a v1-lts-0.0.6 \
   -m 'Core LTS: invalid companion fixture' \
   -m 'Companion-Panel: panel-latest'
-expect_success v1-lts-0.0.6
-assert_contains "$FIXTURE_DIR/lenient-v1-lts-0.0.6.md" 'Core LTS: invalid companion fixture'
-assert_not_contains "$FIXTURE_DIR/lenient-v1-lts-0.0.6.md" '## 配套版本'
+expect_failure 'must match v*-lts-*' v1-lts-0.0.6
 
 printf 'duplicate companion\n' >>fixture.txt
 git commit -qam duplicate-companion
 git tag -a v1-lts-0.0.7 \
   -m 'Core LTS: duplicate companion fixture' \
   -m $'Companion-Panel: v1-lts-0.0.6\nCompanion-Panel: v1-lts-0.0.7'
-expect_success v1-lts-0.0.7
-assert_contains "$FIXTURE_DIR/lenient-v1-lts-0.0.7.md" 'Core LTS: duplicate companion fixture'
-assert_not_contains "$FIXTURE_DIR/lenient-v1-lts-0.0.7.md" '## 配套版本'
+expect_failure 'exactly one Companion-Panel' v1-lts-0.0.7
 
 printf 'release notes generator tests passed.\n'


### PR DESCRIPTION
## 结果与问题

恢复 Release-note generator 的严格校验，防止未来正式 Release 在 tag 摘要或配套 Panel 版本缺失、非法、重复时继续发布。

最近的历史迁移兼容改动曾把这些情况从失败降为 warning，但仓库 runbook 仍明确要求 annotated tag 具有有意义的 subject，并且 tag body 必须且只能包含一条合法的 `Companion-Panel: v*-lts-*`。本 PR 重新让实现与既有契约一致。

## 改动

- placeholder subject 恢复为错误并终止。
- 缺失或重复 `Companion-Panel` 恢复为错误并终止。
- companion tag 不匹配 `v*-lts-*` 时恢复为错误并终止。
- Release notes 始终包含经过校验的配套 Panel 版本。
- 回归测试覆盖 placeholder、缺失、非法、重复 companion 和 lightweight tag。

## 验证

- `scripts/generate-lts-release-notes_test.sh`
- `shellcheck scripts/generate-lts-release-notes.sh scripts/generate-lts-release-notes_test.sh`
- `bash -n scripts/generate-lts-release-notes.sh scripts/generate-lts-release-notes_test.sh`
- `scripts/check-lts-contract.sh`
- `git diff --check`

## 边界

本 PR 不修改 workflow trigger、产品代码、现有 tag、GitHub Release 或 GHCR 镜像，也不重写历史 Release 正文。
