### PR TITLE
sync(lts): 吸收协议、会话和插件修复并保留统计契约（1/2）

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -592,7 +592,8 @@ nonstream-keepalive-interval: 0
 # Anthropic-Beta is assembled per request rather than sent as a fixed list, matching
 # Claude Code: context-1m sits right after claude-code, mid-conversation-system
 # is added only for models that accept a role=system turn, advanced-tool-use only when
-# the request declares tools, and server-side-fallback / fallback-credit /
+# the request uses tool search (deferred tools) or another advanced tool-use feature,
+# afk-mode sits between fast-mode and extended-cache-ttl, and server-side-fallback / fallback-credit /
 # structured-outputs trail effort. On direct api.anthropic.com a caller may only ask for
 # betas real Claude Code also sends, and they are placed at their observed positions;
 # anything else is dropped so the outgoing set stays one a real client could produce.

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -58,8 +58,7 @@ type Handler struct {
 	configReloadHook        func(context.Context, *config.Config)
 	pluginStoreRegistryURL  string
 	pluginStoreHTTPClient   pluginstore.HTTPDoer
-	pluginReleaseCacheMu    sync.Mutex
-	pluginReleaseCache      map[string]pluginReleaseCacheEntry
+	pluginReleases          pluginReleaseCache
 }
 
 type configReloadSnapshot struct {

--- a/internal/api/handlers/management/handler.go
+++ b/internal/api/handlers/management/handler.go
@@ -58,6 +58,7 @@ type Handler struct {
 	configReloadHook        func(context.Context, *config.Config)
 	pluginStoreRegistryURL  string
 	pluginStoreHTTPClient   pluginstore.HTTPDoer
+	pluginStoreRateLimiter  *pluginstore.GitHubRateLimiter
 	pluginReleases          pluginReleaseCache
 }
 

--- a/internal/api/handlers/management/plugin_store.go
+++ b/internal/api/handlers/management/plugin_store.go
@@ -9,8 +9,6 @@ import (
 	"net/http"
 	"runtime"
 	"strings"
-	"sync"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -22,20 +20,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
-
-const (
-	// pluginReleaseCacheTTL bounds how long a resolved latest release version is
-	// reused before the GitHub API is queried again.
-	pluginReleaseCacheTTL = 10 * time.Minute
-	// pluginReleaseFailureCacheTTL throttles retries after a failed lookup so a
-	// rate-limited or unreachable API is not hammered on every listing.
-	pluginReleaseFailureCacheTTL = 30 * time.Second
-)
-
-type pluginReleaseCacheEntry struct {
-	version   string
-	expiresAt time.Time
-}
 
 type pluginStoreListResponse struct {
 	PluginsEnabled bool                   `json:"plugins_enabled"`
@@ -186,6 +170,8 @@ func (h *Handler) ListPluginStore(c *gin.Context) {
 		storeVersion := plugin.Version
 		if latestVersions[index] != "" {
 			storeVersion = latestVersions[index]
+		} else if cachedVersion := h.pluginReleases.cached(client, plugin); cachedVersion != "" {
+			storeVersion = cachedVersion
 		}
 		entries = append(entries, pluginStoreListEntry{
 			StoreID:             htmlsanitize.String(item.source.ID + "/" + plugin.ID),
@@ -542,13 +528,13 @@ func (h *Handler) newPluginStoreClient(proxyURL string, registryURL string, stor
 		registryURL = pluginstore.DefaultRegistryURL
 	}
 	if httpClient != nil {
-		return pluginstore.Client{HTTPClient: httpClient, RegistryURL: registryURL, Auth: storeAuth}
+		return pluginstore.Client{HTTPClient: httpClient, NetworkScope: strings.TrimSpace(proxyURL), RegistryURL: registryURL, Auth: storeAuth}
 	}
 	client := &http.Client{}
 	if strings.TrimSpace(proxyURL) != "" {
 		util.SetProxy(&sdkconfig.SDKConfig{ProxyURL: strings.TrimSpace(proxyURL)}, client)
 	}
-	return pluginstore.Client{HTTPClient: client, RegistryURL: registryURL, Auth: storeAuth}
+	return pluginstore.Client{HTTPClient: client, NetworkScope: strings.TrimSpace(proxyURL), RegistryURL: registryURL, Auth: storeAuth}
 }
 
 func (h *Handler) fetchSourcedPlugins(ctx context.Context, proxyURL string, storeAuth []pluginstore.AuthConfig, sources []pluginstore.Source) ([]sourcedPlugin, []pluginStoreSourceErr) {
@@ -676,64 +662,6 @@ func sanitizePluginStorePlatforms(platforms []pluginstore.Platform) []pluginStor
 
 func pluginAuthConfigured(source pluginstore.Source, plugin pluginstore.Plugin, storeAuth []pluginstore.AuthConfig) bool {
 	return pluginstore.PluginAuthConfigured(source, plugin, storeAuth)
-}
-
-// latestPluginVersions resolves the latest release version of each registry
-// plugin concurrently, returning results positionally aligned with plugins.
-// Unresolved entries are left empty so callers can fall back gracefully.
-func (h *Handler) latestPluginVersions(ctx context.Context, client pluginstore.Client, plugins []pluginstore.Plugin) []string {
-	versions := make([]string, len(plugins))
-	var wg sync.WaitGroup
-	for index := range plugins {
-		wg.Add(1)
-		go func(index int) {
-			defer wg.Done()
-			versions[index] = h.latestPluginVersion(ctx, client, plugins[index])
-		}(index)
-	}
-	wg.Wait()
-	return versions
-}
-
-// latestPluginVersion returns the plugin's latest release version, caching
-// lookups per repository so repeated listings do not exhaust the GitHub API
-// rate limit. Failed lookups are cached for a shorter interval and reported
-// as an empty version.
-func (h *Handler) latestPluginVersion(ctx context.Context, client pluginstore.Client, plugin pluginstore.Plugin) string {
-	if pluginstore.PluginInstallType(plugin) != pluginstore.InstallTypeGitHubRelease {
-		return ""
-	}
-	repository := strings.TrimSpace(plugin.Repository)
-	if repository == "" {
-		return ""
-	}
-	now := time.Now()
-	h.pluginReleaseCacheMu.Lock()
-	entry, found := h.pluginReleaseCache[repository]
-	h.pluginReleaseCacheMu.Unlock()
-	if found && now.Before(entry.expiresAt) {
-		return entry.version
-	}
-
-	version := ""
-	ttl := pluginReleaseFailureCacheTTL
-	release, errRelease := client.FetchLatestRelease(ctx, plugin)
-	if errRelease != nil {
-		log.WithError(errRelease).WithField("plugin_id", plugin.ID).Warn("pluginstore: failed to fetch latest release")
-	} else if latestVersion, errVersion := pluginstore.ReleaseVersion(release); errVersion != nil {
-		log.WithError(errVersion).WithField("plugin_id", plugin.ID).Warn("pluginstore: invalid latest release tag")
-	} else {
-		version = latestVersion
-		ttl = pluginReleaseCacheTTL
-	}
-
-	h.pluginReleaseCacheMu.Lock()
-	if h.pluginReleaseCache == nil {
-		h.pluginReleaseCache = make(map[string]pluginReleaseCacheEntry)
-	}
-	h.pluginReleaseCache[repository] = pluginReleaseCacheEntry{version: version, expiresAt: now.Add(ttl)}
-	h.pluginReleaseCacheMu.Unlock()
-	return version
 }
 
 func pluginLocalStatuses(pluginsEnabled bool, pluginsDir string, configs map[string]config.PluginInstanceConfig, host *pluginhost.Host) (map[string]pluginLocalStatus, error) {

--- a/internal/api/handlers/management/plugin_store.go
+++ b/internal/api/handlers/management/plugin_store.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"net/http"
 	"runtime"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -40,6 +42,7 @@ type pluginStoreSourceErr struct {
 	SourceName string `json:"source_name"`
 	SourceURL  string `json:"source_url"`
 	Message    string `json:"message"`
+	cause      error
 }
 
 type pluginStoreListEntry struct {
@@ -274,6 +277,9 @@ func (h *Handler) installPluginFromStore(c *gin.Context, goos, goarch string) {
 		return
 	}
 	if errInstall != nil {
+		if writePluginStoreRateLimit(c, errInstall) {
+			return
+		}
 		if errors.Is(errInstall, pluginstore.ErrLoadedPluginLocked) {
 			c.JSON(http.StatusConflict, gin.H{
 				"error":            "plugin_update_requires_restart",
@@ -390,9 +396,29 @@ func installPluginStoreGitHubRelease(ctx context.Context, client pluginstore.Cli
 		if errInstall == nil {
 			return result, nil
 		}
+		var rateLimit *pluginstore.RateLimitError
+		if errors.As(errInstall, &rateLimit) || ctx.Err() != nil {
+			return pluginstore.InstallResult{}, errInstall
+		}
 		errs = append(errs, fmt.Errorf("%s: %w", tag, errInstall))
 	}
 	return pluginstore.InstallResult{}, fmt.Errorf("install release by tag: %w", errors.Join(errs...))
+}
+
+func writePluginStoreRateLimit(c *gin.Context, err error) bool {
+	var rateLimit *pluginstore.RateLimitError
+	if !errors.As(err, &rateLimit) {
+		return false
+	}
+	retryAfter := rateLimit.RetryAfterSeconds(time.Now())
+	c.Header("Retry-After", strconv.FormatInt(retryAfter, 10))
+	c.JSON(http.StatusTooManyRequests, gin.H{
+		"error":       "plugin_store_rate_limited",
+		"message":     rateLimit.Error(),
+		"retry_after": retryAfter,
+		"retry_at":    rateLimit.RetryAt.UTC().Format(time.RFC3339),
+	})
+	return true
 }
 
 func pluginStoreManifestForInstall(source pluginstore.Source, plugin pluginstore.Plugin, result pluginstore.InstallResult) (pluginstore.Manifest, error) {
@@ -521,20 +547,22 @@ func (h *Handler) pluginStoreSources(sourceConfigs []string) ([]pluginstore.Sour
 func (h *Handler) newPluginStoreClient(proxyURL string, registryURL string, storeAuth []pluginstore.AuthConfig) pluginstore.Client {
 	registryURL = strings.TrimSpace(registryURL)
 	var httpClient pluginstore.HTTPDoer
+	var limiter *pluginstore.GitHubRateLimiter
 	if h != nil {
 		httpClient = h.pluginStoreHTTPClient
+		limiter = h.pluginStoreRateLimiter
 	}
 	if registryURL == "" {
 		registryURL = pluginstore.DefaultRegistryURL
 	}
 	if httpClient != nil {
-		return pluginstore.Client{HTTPClient: httpClient, NetworkScope: strings.TrimSpace(proxyURL), RegistryURL: registryURL, Auth: storeAuth}
+		return pluginstore.Client{HTTPClient: httpClient, NetworkScope: strings.TrimSpace(proxyURL), RateLimiter: limiter, RegistryURL: registryURL, Auth: storeAuth}
 	}
 	client := &http.Client{}
 	if strings.TrimSpace(proxyURL) != "" {
 		util.SetProxy(&sdkconfig.SDKConfig{ProxyURL: strings.TrimSpace(proxyURL)}, client)
 	}
-	return pluginstore.Client{HTTPClient: client, NetworkScope: strings.TrimSpace(proxyURL), RegistryURL: registryURL, Auth: storeAuth}
+	return pluginstore.Client{HTTPClient: client, NetworkScope: strings.TrimSpace(proxyURL), RateLimiter: limiter, RegistryURL: registryURL, Auth: storeAuth}
 }
 
 func (h *Handler) fetchSourcedPlugins(ctx context.Context, proxyURL string, storeAuth []pluginstore.AuthConfig, sources []pluginstore.Source) ([]sourcedPlugin, []pluginStoreSourceErr) {
@@ -549,6 +577,7 @@ func (h *Handler) fetchSourcedPlugins(ctx context.Context, proxyURL string, stor
 				SourceName: source.Name,
 				SourceURL:  source.URL,
 				Message:    errRegistry.Error(),
+				cause:      errRegistry,
 			})
 			continue
 		}
@@ -569,6 +598,9 @@ func (h *Handler) findPluginStoreInstallTarget(ctx context.Context, proxyURL str
 			client := h.newPluginStoreClient(proxyURL, source.URL, storeAuth)
 			registry, errRegistry := client.FetchRegistry(ctx)
 			if errRegistry != nil {
+				if writePluginStoreRateLimit(c, errRegistry) {
+					return pluginstore.Source{}, pluginstore.Plugin{}, pluginstore.Client{}, false
+				}
 				c.JSON(http.StatusBadGateway, gin.H{"error": "plugin_store_registry_failed", "message": errRegistry.Error()})
 				return pluginstore.Source{}, pluginstore.Plugin{}, pluginstore.Client{}, false
 			}
@@ -592,6 +624,9 @@ func (h *Handler) findPluginStoreInstallTarget(ctx context.Context, proxyURL str
 	}
 	if len(matches) == 0 {
 		if len(plugins) == 0 && len(sourceErrors) > 0 {
+			if writePluginStoreRateLimit(c, sourceErrors[0].cause) {
+				return pluginstore.Source{}, pluginstore.Plugin{}, pluginstore.Client{}, false
+			}
 			c.JSON(http.StatusBadGateway, gin.H{"error": "plugin_store_registry_failed", "message": sourceErrors[0].Message})
 			return pluginstore.Source{}, pluginstore.Plugin{}, pluginstore.Client{}, false
 		}

--- a/internal/api/handlers/management/plugin_store.go
+++ b/internal/api/handlers/management/plugin_store.go
@@ -153,16 +153,23 @@ func (h *Handler) ListPluginStore(c *gin.Context) {
 		return
 	}
 
-	latestInput := make([]pluginstore.Plugin, 0, len(plugins))
-	for _, item := range plugins {
-		latestInput = append(latestInput, item.plugin)
-	}
-	client := h.newPluginStoreClient(proxyURL, "", storeAuth)
-	latestVersions := h.latestPluginVersions(c.Request.Context(), client, latestInput)
 	pluginSourceCounts := make(map[string]int, len(plugins))
 	for _, item := range plugins {
 		pluginSourceCounts[item.plugin.ID]++
 	}
+	// Browsing the catalog must not spend API quota on uninstalled plugins or
+	// on sources that cannot update the installed plugin. Keep positional
+	// placeholders so release versions still align with the catalog entries.
+	latestInput := make([]pluginstore.Plugin, len(plugins))
+	for index, item := range plugins {
+		status := statuses[item.plugin.ID]
+		_, _, sourceAllowsUpdate := pluginStoreInstallSourceStatus(status, sources, item.source.ID, pluginSourceCounts[item.plugin.ID])
+		if status.Installed && sourceAllowsUpdate {
+			latestInput[index] = item.plugin
+		}
+	}
+	client := h.newPluginStoreClient(proxyURL, "", storeAuth)
+	latestVersions := h.latestPluginVersions(c.Request.Context(), client, latestInput)
 
 	entries := make([]pluginStoreListEntry, 0, len(plugins))
 	for index, item := range plugins {

--- a/internal/api/handlers/management/plugin_store_release.go
+++ b/internal/api/handlers/management/plugin_store_release.go
@@ -1,0 +1,162 @@
+package management
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginstore"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	pluginReleaseCacheTTL        = time.Hour
+	pluginReleaseFailureCacheTTL = 30 * time.Second
+	pluginReleaseConcurrency     = 2
+)
+
+type pluginReleaseCacheEntry struct {
+	version     string
+	nextCheckAt time.Time
+}
+
+type pluginReleaseLookup struct {
+	done     chan struct{}
+	version  string
+	canceled bool
+}
+
+// pluginReleaseCache shares both in-flight lookups and the concurrency budget
+// across all catalog requests handled by this management server.
+type pluginReleaseCache struct {
+	mu       sync.Mutex
+	entries  map[string]pluginReleaseCacheEntry
+	inflight map[string]*pluginReleaseLookup
+	slots    chan struct{}
+	nowFunc  func() time.Time
+}
+
+func (cache *pluginReleaseCache) now() time.Time {
+	if cache.nowFunc != nil {
+		return cache.nowFunc()
+	}
+	return time.Now()
+}
+
+func pluginReleaseKey(client pluginstore.Client, plugin pluginstore.Plugin) string {
+	if pluginstore.PluginInstallType(plugin) != pluginstore.InstallTypeGitHubRelease || plugin.Repository == "" {
+		return ""
+	}
+	key, errKey := client.LatestReleaseCacheKey(plugin)
+	if errKey != nil {
+		return ""
+	}
+	return key
+}
+
+// cached returns the last successful result without causing network activity.
+func (cache *pluginReleaseCache) cached(client pluginstore.Client, plugin pluginstore.Plugin) string {
+	key := pluginReleaseKey(client, plugin)
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	return cache.entries[key].version
+}
+
+// latestPluginVersions preserves catalog order, including skipped placeholders.
+func (h *Handler) latestPluginVersions(ctx context.Context, client pluginstore.Client, plugins []pluginstore.Plugin) []string {
+	versions := make([]string, len(plugins))
+	var wg sync.WaitGroup
+	for index, plugin := range plugins {
+		if pluginReleaseKey(client, plugin) == "" {
+			continue
+		}
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			versions[index] = h.latestPluginVersion(ctx, client, plugins[index])
+		}(index)
+	}
+	wg.Wait()
+	return versions
+}
+
+func (h *Handler) latestPluginVersion(ctx context.Context, client pluginstore.Client, plugin pluginstore.Plugin) string {
+	if pluginstore.PluginInstallType(plugin) != pluginstore.InstallTypeGitHubRelease {
+		return ""
+	}
+	client, key, errPrepare := client.PrepareLatestRelease(plugin)
+	if errPrepare != nil {
+		return ""
+	}
+	cache := &h.pluginReleases
+	var entry pluginReleaseCacheEntry
+	var lookup *pluginReleaseLookup
+	for {
+		cache.mu.Lock()
+		entry = cache.entries[key]
+		if cache.now().Before(entry.nextCheckAt) || ctx.Err() != nil {
+			cache.mu.Unlock()
+			return entry.version
+		}
+		if pending := cache.inflight[key]; pending != nil {
+			cache.mu.Unlock()
+			select {
+			case <-pending.done:
+				if pending.canceled && ctx.Err() == nil {
+					// A live waiter takes ownership after a canceled leader. All
+					// other waiters coalesce behind the replacement lookup.
+					continue
+				}
+				return pending.version
+			case <-ctx.Done():
+				return entry.version
+			}
+		}
+		if cache.entries == nil {
+			cache.entries = make(map[string]pluginReleaseCacheEntry)
+		}
+		if cache.inflight == nil {
+			cache.inflight = make(map[string]*pluginReleaseLookup)
+			cache.slots = make(chan struct{}, pluginReleaseConcurrency)
+		}
+		lookup = &pluginReleaseLookup{done: make(chan struct{})}
+		cache.inflight[key] = lookup
+		cache.mu.Unlock()
+		break
+	}
+
+	// Every listing uses the same slots. Canceled waiters do not consume a slot
+	// or install a negative cache entry.
+	select {
+	case cache.slots <- struct{}{}:
+		if ctx.Err() == nil {
+			release, errRelease := client.FetchLatestRelease(ctx, plugin)
+			version := ""
+			if errRelease == nil {
+				version, errRelease = pluginstore.ReleaseVersion(release)
+			}
+			if ctx.Err() == nil {
+				ttl := pluginReleaseFailureCacheTTL
+				if errRelease != nil {
+					log.WithError(errRelease).WithField("plugin_id", plugin.ID).Warn("pluginstore: failed to fetch latest release")
+				} else {
+					entry.version = version
+					ttl = pluginReleaseCacheTTL
+				}
+				// Start the TTL when the lookup finishes, not when it was queued.
+				entry.nextCheckAt = cache.now().Add(ttl)
+			}
+		}
+		<-cache.slots
+	case <-ctx.Done():
+	}
+
+	cache.mu.Lock()
+	cache.entries[key] = entry
+	lookup.version = entry.version
+	lookup.canceled = ctx.Err() != nil
+	delete(cache.inflight, key)
+	close(lookup.done)
+	cache.mu.Unlock()
+	return entry.version
+}

--- a/internal/api/handlers/management/plugin_store_release.go
+++ b/internal/api/handlers/management/plugin_store_release.go
@@ -2,6 +2,7 @@ package management
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -145,6 +146,10 @@ func (h *Handler) latestPluginVersion(ctx context.Context, client pluginstore.Cl
 				}
 				// Start the TTL when the lookup finishes, not when it was queued.
 				entry.nextCheckAt = cache.now().Add(ttl)
+				var rateLimit *pluginstore.RateLimitError
+				if errors.As(errRelease, &rateLimit) {
+					entry.nextCheckAt = rateLimit.RetryAt
+				}
 			}
 		}
 		<-cache.slots

--- a/internal/api/handlers/management/plugin_store_release_test.go
+++ b/internal/api/handlers/management/plugin_store_release_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -325,6 +326,128 @@ func TestPluginReleaseCacheSeparatesCredentialsAndEgress(t *testing.T) {
 		if strings.Contains(key, "token-") {
 			t.Fatalf("cache key contains credential: %q", key)
 		}
+	}
+}
+
+func TestPluginReleaseChecksStopQueuedRequestsDuringCooldown(t *testing.T) {
+	t.Parallel()
+	started, release := make(chan struct{}, 10), make(chan struct{})
+	var calls atomic.Int32
+	reset := time.Now().Add(time.Hour).Truncate(time.Second)
+	h := &Handler{pluginStoreRateLimiter: &pluginstore.GitHubRateLimiter{}}
+	h.pluginStoreHTTPClient = pluginReleaseDoerFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		started <- struct{}{}
+		<-release
+		headers := make(http.Header)
+		headers.Set("X-RateLimit-Remaining", "0")
+		headers.Set("X-RateLimit-Reset", strconv.FormatInt(reset.Unix(), 10))
+		return &http.Response{StatusCode: 403, Header: headers, Body: io.NopCloser(strings.NewReader("limited"))}, nil
+	})
+	client := h.newPluginStoreClient("", "", nil)
+	plugins := make([]pluginstore.Plugin, 10)
+	h.pluginReleases.entries = make(map[string]pluginReleaseCacheEntry)
+	for index := range plugins {
+		plugins[index] = pluginstore.Plugin{ID: fmt.Sprintf("plugin-%d", index), Repository: fmt.Sprintf("https://github.com/owner/plugin-%d", index)}
+		h.pluginReleases.entries[pluginReleaseKey(client, plugins[index])] = pluginReleaseCacheEntry{version: "1.0.0"}
+	}
+	result := make(chan []string, 1)
+	go func() { result <- h.latestPluginVersions(context.Background(), client, plugins) }()
+	for range pluginReleaseConcurrency {
+		<-started
+	}
+	close(release)
+	for _, version := range <-result {
+		if version != "1.0.0" {
+			t.Fatalf("cooldown discarded previous version: %q", version)
+		}
+	}
+	if calls.Load() != pluginReleaseConcurrency {
+		t.Fatalf("requests=%d, want only the %d already in flight", calls.Load(), pluginReleaseConcurrency)
+	}
+	for _, entry := range h.pluginReleases.entries {
+		if !entry.nextCheckAt.Equal(reset) {
+			t.Fatalf("next check=%s, want GitHub reset %s", entry.nextCheckAt, reset)
+		}
+	}
+}
+
+func TestPluginStoreListingCooldownAlsoBlocksInstallation(t *testing.T) {
+	t.Parallel()
+	var apiCalls atomic.Int32
+	h := &Handler{
+		cfg:                    &config.Config{Plugins: config.PluginsConfig{Dir: writeManagementPluginFile(t, "sample-provider")}},
+		pluginStoreRateLimiter: &pluginstore.GitHubRateLimiter{},
+		pluginStoreHTTPClient: pluginReleaseDoerFunc(func(req *http.Request) (*http.Response, error) {
+			if req.URL.Host != "api.github.com" {
+				return fakePluginStoreHTTPClient{pluginstore.DefaultRegistryURL: registryJSON(t)}.Do(req)
+			}
+			apiCalls.Add(1)
+			headers := make(http.Header)
+			headers.Set("Retry-After", "3600")
+			return &http.Response{StatusCode: 429, Header: headers, Body: io.NopCloser(strings.NewReader("limited"))}, nil
+		}),
+	}
+	body := listPluginStoreForTest(t, h)
+	if len(body.Plugins) != 1 || body.Plugins[0].Version != "0.1.0" {
+		t.Fatalf("listing failed to fall back during cooldown: %#v", body)
+	}
+	for _, query := range []string{"", "?version=0.2.0"} {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Params = gin.Params{{Key: "id", Value: "sample-provider"}}
+		c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/plugin-store/sample-provider/install"+query, nil)
+		h.InstallPluginFromStore(c)
+		if rec.Code != http.StatusTooManyRequests || !strings.Contains(rec.Body.String(), "plugin_store_rate_limited") || !strings.Contains(rec.Body.String(), "retry_at") {
+			t.Fatalf("install status=%d body=%s", rec.Code, rec.Body.String())
+		}
+		retryAfter, errRetry := strconv.Atoi(rec.Header().Get("Retry-After"))
+		if errRetry != nil || retryAfter <= 0 {
+			t.Fatalf("Retry-After=%q", rec.Header().Get("Retry-After"))
+		}
+	}
+	if apiCalls.Load() != 1 {
+		t.Fatalf("cooldown installation made more requests: %d", apiCalls.Load())
+	}
+}
+
+func TestPluginStoreInstallationPropagatesRegistryRateLimit(t *testing.T) {
+	t.Parallel()
+	h := &Handler{
+		cfg:                    &config.Config{Plugins: config.PluginsConfig{Dir: t.TempDir()}},
+		pluginStoreRegistryURL: "https://api.github.com/repos/owner/store/contents/registry.json",
+		pluginStoreRateLimiter: &pluginstore.GitHubRateLimiter{},
+		pluginStoreHTTPClient: pluginReleaseDoerFunc(func(*http.Request) (*http.Response, error) {
+			headers := make(http.Header)
+			headers.Set("Retry-After", "3600")
+			return &http.Response{StatusCode: 429, Header: headers, Body: io.NopCloser(strings.NewReader("limited"))}, nil
+		}),
+	}
+	for _, query := range []string{"", "?source=official"} {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Params = gin.Params{{Key: "id", Value: "sample-provider"}}
+		c.Request = httptest.NewRequest(http.MethodPost, "/v0/management/plugin-store/sample-provider/install"+query, nil)
+		h.InstallPluginFromStore(c)
+		if rec.Code != http.StatusTooManyRequests || rec.Header().Get("Retry-After") == "" {
+			t.Fatalf("install status=%d body=%s", rec.Code, rec.Body.String())
+		}
+	}
+}
+
+func TestPluginStoreTagInstallationStopsOnRateLimitError(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	client := pluginstore.Client{HTTPClient: pluginReleaseDoerFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return nil, &pluginstore.RateLimitError{StatusCode: 429, RetryAt: time.Now().Add(time.Hour)}
+	})}
+	_, errInstall := installPluginStoreGitHubRelease(context.Background(), client, pluginstore.Plugin{
+		ID: "sample-provider", Name: "Sample", Description: "Test plugin", Author: "owner", Repository: "https://github.com/owner/repo",
+	}, "1.0.0", pluginstore.InstallOptions{PluginsDir: t.TempDir(), GOOS: "linux", GOARCH: "amd64"})
+	var rateLimit *pluginstore.RateLimitError
+	if !errors.As(errInstall, &rateLimit) || calls != 1 {
+		t.Fatalf("error=%v calls=%d, want immediate rate-limit failure without alternate tag", errInstall, calls)
 	}
 }
 

--- a/internal/api/handlers/management/plugin_store_release_test.go
+++ b/internal/api/handlers/management/plugin_store_release_test.go
@@ -1,0 +1,97 @@
+package management
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginstore"
+)
+
+func listPluginStoreForTest(t *testing.T, h *Handler) pluginStoreListResponse {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v0/management/plugin-store", nil)
+	h.ListPluginStore(c)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", rec.Code, rec.Body.String())
+	}
+	var body pluginStoreListResponse
+	if errDecode := json.Unmarshal(rec.Body.Bytes(), &body); errDecode != nil {
+		t.Fatal(errDecode)
+	}
+	return body
+}
+
+func TestListPluginStoreSkipsUninstalledReleases(t *testing.T) {
+	t.Parallel()
+
+	registry := pluginstore.Registry{SchemaVersion: pluginstore.SchemaVersion}
+	for index := range 100 {
+		version := ""
+		if index%2 == 0 {
+			version = "1.0.0"
+		}
+		registry.Plugins = append(registry.Plugins, pluginstore.Plugin{
+			ID: fmt.Sprintf("plugin-%d", index), Name: "Plugin", Description: "Test plugin", Author: "test",
+			Version: version, Repository: fmt.Sprintf("https://github.com/test/plugin-%d", index),
+		})
+	}
+	data, errMarshal := json.Marshal(registry)
+	if errMarshal != nil {
+		t.Fatal(errMarshal)
+	}
+	httpClient := &countingPluginStoreHTTPClient{responses: fakePluginStoreHTTPClient{
+		pluginstore.DefaultRegistryURL: data,
+	}}
+	h := &Handler{
+		cfg: &config.Config{Plugins: config.PluginsConfig{
+			Dir: t.TempDir(),
+			// Configuration alone does not mean the plugin is installed.
+			Configs: map[string]config.PluginInstanceConfig{"plugin-0": pluginConfigFromYAML(t, "enabled: true\n")},
+		}},
+		pluginStoreHTTPClient: httpClient,
+	}
+	for range 2 {
+		body := listPluginStoreForTest(t, h)
+		if len(body.Plugins) != 100 {
+			t.Fatalf("plugins = %d, want 100", len(body.Plugins))
+		}
+		for index, entry := range body.Plugins {
+			if entry.Version != registry.Plugins[index].Version || entry.Installed || entry.UpdateAvailable {
+				t.Fatalf("unexpected catalog entry: %#v", entry)
+			}
+		}
+	}
+	httpClient.mu.Lock()
+	defer httpClient.mu.Unlock()
+	if len(httpClient.counts) != 1 || httpClient.counts[pluginstore.DefaultRegistryURL] != 2 {
+		t.Fatalf("requests = %v, want registry requests only", httpClient.counts)
+	}
+}
+
+func TestListPluginStoreSkipsInstalledDirectRelease(t *testing.T) {
+	t.Parallel()
+
+	httpClient := &countingPluginStoreHTTPClient{responses: fakePluginStoreHTTPClient{
+		pluginstore.DefaultRegistryURL: directRegistryJSON("https://downloads.example/plugin.zip", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+	}}
+	h := &Handler{
+		cfg:                   &config.Config{Plugins: config.PluginsConfig{Dir: writeManagementPluginFile(t, "sample-provider")}},
+		pluginStoreHTTPClient: httpClient,
+	}
+	body := listPluginStoreForTest(t, h)
+	if len(body.Plugins) != 1 || !body.Plugins[0].Installed || body.Plugins[0].Version != "0.4.0" {
+		t.Fatalf("unexpected direct catalog entry: %#v", body.Plugins)
+	}
+	httpClient.mu.Lock()
+	defer httpClient.mu.Unlock()
+	if len(httpClient.counts) != 1 {
+		t.Fatalf("requests = %v, want registry request only", httpClient.counts)
+	}
+}

--- a/internal/api/handlers/management/plugin_store_release_test.go
+++ b/internal/api/handlers/management/plugin_store_release_test.go
@@ -1,11 +1,18 @@
 package management
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
@@ -93,5 +100,243 @@ func TestListPluginStoreSkipsInstalledDirectRelease(t *testing.T) {
 	defer httpClient.mu.Unlock()
 	if len(httpClient.counts) != 1 {
 		t.Fatalf("requests = %v, want registry request only", httpClient.counts)
+	}
+}
+
+type pluginReleaseDoerFunc func(*http.Request) (*http.Response, error)
+
+func (f pluginReleaseDoerFunc) Do(req *http.Request) (*http.Response, error) { return f(req) }
+
+func pluginReleaseResponse(tag string) *http.Response {
+	return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"tag_name":"` + tag + `"}`))}
+}
+
+func TestPluginReleaseCacheRetainsSuccessAndUsesCompletionTime(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	h := &Handler{pluginReleases: pluginReleaseCache{nowFunc: func() time.Time { return now }}}
+	plugin := pluginstore.Plugin{Repository: "https://github.com/test/plugin"}
+	calls := 0
+	client := pluginstore.Client{HTTPClient: pluginReleaseDoerFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		now = now.Add(time.Minute)
+		switch calls {
+		case 1:
+			return pluginReleaseResponse("v1.0.0"), nil
+		case 2:
+			return nil, errors.New("offline")
+		case 3:
+			return pluginReleaseResponse("invalid-tag"), nil
+		default:
+			return pluginReleaseResponse("v2.0.0"), nil
+		}
+	})}
+	check := func(want string, wantCalls int) {
+		t.Helper()
+		if got := h.latestPluginVersion(context.Background(), client, plugin); got != want || calls != wantCalls {
+			t.Fatalf("version=%q calls=%d, want %q/%d", got, calls, want, wantCalls)
+		}
+	}
+	check("1.0.0", 1)
+	now = now.Add(pluginReleaseCacheTTL - time.Second)
+	check("1.0.0", 1)
+	now = now.Add(time.Second)
+	check("1.0.0", 2)
+	check("1.0.0", 2)
+	now = now.Add(pluginReleaseFailureCacheTTL)
+	check("1.0.0", 3)
+	now = now.Add(pluginReleaseFailureCacheTTL)
+	check("2.0.0", 4)
+}
+
+// Done reports that a caller reached a cancelable wait, without relying on sleeps.
+type pluginReleaseWaitContext struct {
+	context.Context
+	waiting chan struct{}
+	once    sync.Once
+}
+
+func (ctx *pluginReleaseWaitContext) Done() <-chan struct{} {
+	ctx.once.Do(func() { close(ctx.waiting) })
+	return ctx.Context.Done()
+}
+
+func TestPluginReleaseCacheCoalescesConcurrentLookups(t *testing.T) {
+	t.Parallel()
+	started, release := make(chan struct{}), make(chan struct{})
+	var calls atomic.Int32
+	client := pluginstore.Client{HTTPClient: pluginReleaseDoerFunc(func(*http.Request) (*http.Response, error) {
+		if calls.Add(1) == 1 {
+			close(started)
+		}
+		<-release
+		return pluginReleaseResponse("v1.0.0"), nil
+	})}
+	h := &Handler{}
+	plugin := pluginstore.Plugin{Repository: "https://github.com/test/plugin"}
+	results := make(chan string, 21)
+	go func() { results <- h.latestPluginVersion(context.Background(), client, plugin) }()
+	<-started
+	for range 20 {
+		ctx := &pluginReleaseWaitContext{Context: context.Background(), waiting: make(chan struct{})}
+		go func() { results <- h.latestPluginVersion(ctx, client, plugin) }()
+		<-ctx.waiting
+	}
+	close(release)
+	for range 21 {
+		if got := <-results; got != "1.0.0" {
+			t.Fatalf("version = %q", got)
+		}
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("calls = %d, want 1", calls.Load())
+	}
+}
+
+func TestPluginReleaseCacheCanceledLeaderHandsOffToFollower(t *testing.T) {
+	t.Parallel()
+	started := make(chan struct{})
+	var calls atomic.Int32
+	client := pluginstore.Client{HTTPClient: pluginReleaseDoerFunc(func(req *http.Request) (*http.Response, error) {
+		if calls.Add(1) == 1 {
+			close(started)
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		}
+		return pluginReleaseResponse("v1.0.0"), nil
+	})}
+	h := &Handler{}
+	plugin := pluginstore.Plugin{Repository: "https://github.com/test/plugin"}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	leaderResult := make(chan string, 1)
+	go func() { leaderResult <- h.latestPluginVersion(ctx, client, plugin) }()
+	<-started
+	waitCtx := &pluginReleaseWaitContext{Context: context.Background(), waiting: make(chan struct{})}
+	followerResult := make(chan string, 1)
+	go func() { followerResult <- h.latestPluginVersion(waitCtx, client, plugin) }()
+	<-waitCtx.waiting
+	cancel()
+	if got := <-leaderResult; got != "" {
+		t.Fatalf("canceled leader version = %q", got)
+	}
+	if got := <-followerResult; got != "1.0.0" || calls.Load() != 2 {
+		t.Fatalf("handoff version=%q calls=%d, want 1.0.0 and canceled + successful request", got, calls.Load())
+	}
+}
+
+func TestPluginReleaseCacheCanceledFollowerDoesNotCancelLeader(t *testing.T) {
+	t.Parallel()
+	started, release := make(chan struct{}), make(chan struct{})
+	client := pluginstore.Client{HTTPClient: pluginReleaseDoerFunc(func(*http.Request) (*http.Response, error) {
+		close(started)
+		<-release
+		return pluginReleaseResponse("v1.0.0"), nil
+	})}
+	h := &Handler{}
+	plugin := pluginstore.Plugin{Repository: "https://github.com/test/plugin"}
+	leaderResult := make(chan string, 1)
+	go func() { leaderResult <- h.latestPluginVersion(context.Background(), client, plugin) }()
+	<-started
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	waitCtx := &pluginReleaseWaitContext{Context: ctx, waiting: make(chan struct{})}
+	followerResult := make(chan string, 1)
+	go func() { followerResult <- h.latestPluginVersion(waitCtx, client, plugin) }()
+	<-waitCtx.waiting
+	cancel()
+	if got := <-followerResult; got != "" {
+		t.Fatalf("canceled follower version = %q", got)
+	}
+	close(release)
+	if got := <-leaderResult; got != "1.0.0" {
+		t.Fatalf("leader version = %q", got)
+	}
+}
+
+func TestPluginReleaseCacheSharesConcurrencyAndCancelsQueuedLookup(t *testing.T) {
+	t.Parallel()
+	started, release := make(chan struct{}, 10), make(chan struct{})
+	var calls atomic.Int32
+	client := pluginstore.Client{HTTPClient: pluginReleaseDoerFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		started <- struct{}{}
+		<-release
+		return pluginReleaseResponse("v1.0.0"), nil
+	})}
+	h := &Handler{}
+	results := make(chan string, pluginReleaseConcurrency)
+	for index := range pluginReleaseConcurrency {
+		go func() {
+			results <- h.latestPluginVersion(context.Background(), client, pluginstore.Plugin{Repository: fmt.Sprintf("https://github.com/test/plugin-%d", index)})
+		}()
+	}
+	for range pluginReleaseConcurrency {
+		<-started
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	waitCtx := &pluginReleaseWaitContext{Context: ctx, waiting: make(chan struct{})}
+	queuedResult := make(chan string, 1)
+	plugin := pluginstore.Plugin{Repository: "https://github.com/test/queued"}
+	go func() { queuedResult <- h.latestPluginVersion(waitCtx, client, plugin) }()
+	<-waitCtx.waiting
+	cancel()
+	if got := <-queuedResult; got != "" || calls.Load() != pluginReleaseConcurrency {
+		t.Fatalf("queued version=%q calls=%d", got, calls.Load())
+	}
+	close(release)
+	for range pluginReleaseConcurrency {
+		<-results
+	}
+	if got := h.latestPluginVersion(context.Background(), client, plugin); got != "1.0.0" || calls.Load() != pluginReleaseConcurrency+1 {
+		t.Fatalf("canceled lookup was negatively cached: version=%q calls=%d", got, calls.Load())
+	}
+}
+
+func TestPluginReleaseCacheSeparatesCredentialsAndEgress(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	client := pluginstore.Client{HTTPClient: pluginReleaseDoerFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return pluginReleaseResponse("v1.0.0"), nil
+	})}
+	h := &Handler{}
+	plugin := pluginstore.Plugin{Repository: "https://github.com/test/plugin"}
+	for _, token := range []string{"", "token-a", "token-b", "token-a"} {
+		client.ResolvedAuth = nil
+		if token != "" {
+			client.ResolvedAuth = []pluginstore.ResolvedAuthConfig{{Match: "https://api.github.com/", Type: pluginstore.AuthTypeGitHubToken, Token: pluginstore.Secret(token)}}
+			client.ResolvedAuthExpiresAt = time.Now().Add(time.Hour)
+		}
+		if got := h.latestPluginVersion(context.Background(), client, plugin); got != "1.0.0" {
+			t.Fatalf("version = %q", got)
+		}
+	}
+	if calls.Load() != 3 {
+		t.Fatalf("calls = %d, want 3", calls.Load())
+	}
+	client.NetworkScope = "other-proxy"
+	h.latestPluginVersion(context.Background(), client, plugin)
+	if calls.Load() != 4 {
+		t.Fatalf("calls after proxy change = %d, want 4", calls.Load())
+	}
+	for key := range h.pluginReleases.entries {
+		if strings.Contains(key, "token-") {
+			t.Fatalf("cache key contains credential: %q", key)
+		}
+	}
+}
+
+func TestListPluginStoreUsesCachedUninstalledVersionWithoutRefresh(t *testing.T) {
+	t.Parallel()
+	httpClient := &countingPluginStoreHTTPClient{responses: fakePluginStoreHTTPClient{pluginstore.DefaultRegistryURL: registryJSON(t)}}
+	h := &Handler{cfg: &config.Config{Plugins: config.PluginsConfig{Dir: t.TempDir()}}, pluginStoreHTTPClient: httpClient}
+	plugin := pluginstore.Plugin{Repository: "https://github.com/author-name/cliproxy-sample-provider-plugin"}
+	key := pluginReleaseKey(h.newPluginStoreClient("", "", nil), plugin)
+	h.pluginReleases.entries = map[string]pluginReleaseCacheEntry{key: {version: "2.0.0"}}
+	body := listPluginStoreForTest(t, h)
+	if body.Plugins[0].Version != "2.0.0" || len(httpClient.counts) != 1 {
+		t.Fatalf("plugins=%#v requests=%v", body.Plugins, httpClient.counts)
 	}
 }

--- a/internal/api/handlers/management/plugin_store_test.go
+++ b/internal/api/handlers/management/plugin_store_test.go
@@ -301,6 +301,7 @@ func TestListPluginStoreShowsLatestReleaseVersionAndCaches(t *testing.T) {
 		pluginStoreRegistryURL: "https://registry.example/registry.json",
 		pluginStoreHTTPClient:  httpClient,
 	}
+	h.cfg.Plugins.Dir = writeManagementPluginFile(t, "sample-provider")
 
 	listOnce := func() pluginStoreListResponse {
 		rec := httptest.NewRecorder()
@@ -457,10 +458,10 @@ func TestListPluginStoreMatchesInstalledStatusToManifestSource(t *testing.T) {
 			},
 		},
 		configFilePath: writeTestConfigFile(t),
-		pluginStoreHTTPClient: fakePluginStoreHTTPClient{
+		pluginStoreHTTPClient: &countingPluginStoreHTTPClient{responses: fakePluginStoreHTTPClient{
 			pluginstore.DefaultRegistryURL: registryJSON(t),
 			communityURL:                   thirdPartySampleRegistryJSON(t),
-		},
+		}},
 	}
 
 	rec := httptest.NewRecorder()
@@ -505,6 +506,13 @@ func TestListPluginStoreMatchesInstalledStatusToManifestSource(t *testing.T) {
 	community := entries[communitySourceID]
 	if community.InstalledSourceID != pluginstore.DefaultSourceID || community.InstallSourceStatus != "different" || community.UpdateAvailable {
 		t.Fatalf("community entry = %#v, want different source without update", community)
+	}
+	httpClient := h.pluginStoreHTTPClient.(*countingPluginStoreHTTPClient)
+	if calls := httpClient.count("https://api.github.com/repos/author-name/cliproxy-sample-provider-plugin/releases/latest"); calls != 1 {
+		t.Fatalf("installed source release calls = %d, want 1", calls)
+	}
+	if calls := httpClient.count("https://api.github.com/repos/community/cliproxy-sample-provider-plugin/releases/latest"); calls != 0 {
+		t.Fatalf("different source release calls = %d, want 0", calls)
 	}
 }
 

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -48,8 +48,8 @@ func (s *Server) setupRoutes() {
 
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
 	}
-	s.engine.GET("/healthz", healthzHandler)
-	s.engine.HEAD("/healthz", healthzHandler)
+	s.engine.GET("/healthz", logging.SkipGinRequestLogging, healthzHandler)
+	s.engine.HEAD("/healthz", logging.SkipGinRequestLogging, healthzHandler)
 
 	s.engine.GET("/management.html", s.serveManagementControlPanel)
 	openaiHandlers := openai.NewOpenAIAPIHandler(s.handlers)

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -48,8 +48,8 @@ func (s *Server) setupRoutes() {
 
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
 	}
-	s.engine.GET("/healthz", logging.SkipGinRequestLogging, healthzHandler)
-	s.engine.HEAD("/healthz", logging.SkipGinRequestLogging, healthzHandler)
+	s.engine.GET("/healthz", healthzHandler)
+	s.engine.HEAD("/healthz", healthzHandler)
 
 	s.engine.GET("/management.html", s.serveManagementControlPanel)
 	openaiHandlers := openai.NewOpenAIAPIHandler(s.handlers)

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -20,6 +20,7 @@ import (
 	managementHandlers "github.com/router-for-me/CLIProxyAPI/v7/internal/api/handlers/management"
 	claudemodels "github.com/router-for-me/CLIProxyAPI/v7/internal/client/claude/models"
 	proxyconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/home"
 	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/pluginhost"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/redisqueue"
@@ -668,44 +669,61 @@ func TestHealthz(t *testing.T) {
 	})
 }
 
-func TestHealthzSkipsAccessLogging(t *testing.T) {
+func TestHealthzAccessLogging(t *testing.T) {
 	server := newTestServer(t)
+	previousHome := home.Current()
+	home.ClearCurrent()
+	t.Cleanup(func() { home.SetCurrent(previousHome) })
 	logger := log.StandardLogger()
 	previousHooks := logger.ReplaceHooks(make(log.LevelHooks))
 	previousLevel := logger.GetLevel()
 	hook := logtest.NewLocal(logger)
 	logger.SetLevel(log.InfoLevel)
-	t.Cleanup(func() {
-		logger.ReplaceHooks(previousHooks)
-		logger.SetLevel(previousLevel)
-	})
-
-	for _, method := range []string{http.MethodGet, http.MethodHead} {
-		t.Run(method, func(t *testing.T) {
-			hook.Reset()
-			recorder := httptest.NewRecorder()
-			server.engine.ServeHTTP(recorder, httptest.NewRequest(method, "/healthz", nil))
-			if recorder.Code != http.StatusOK {
-				t.Fatalf("health probe status = %d, want 200", recorder.Code)
+	t.Cleanup(func() { logger.ReplaceHooks(previousHooks); logger.SetLevel(previousLevel) })
+	for _, tc := range []struct {
+		name        string
+		homeEnabled bool
+		status      int
+	}{
+		{"healthy", false, http.StatusOK},
+		{"home_unavailable", true, http.StatusServiceUnavailable},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server.cfg.Home.Enabled = tc.homeEnabled
+			for _, method := range []string{http.MethodGet, http.MethodHead} {
+				t.Run(method, func(t *testing.T) {
+					hook.Reset()
+					recorder := httptest.NewRecorder()
+					server.engine.ServeHTTP(recorder, httptest.NewRequest(method, "/healthz", nil))
+					if recorder.Code != tc.status {
+						t.Fatalf("status = %d, want %d", recorder.Code, tc.status)
+					}
+					count := 0
+					for _, entry := range hook.AllEntries() {
+						if _, ok := entry.Data["request_id"]; ok && strings.Contains(entry.Message, `"/healthz"`) {
+							count++
+							if tc.homeEnabled && entry.Level != log.ErrorLevel {
+								t.Errorf("failed probe log level = %v, want error", entry.Level)
+							}
+						}
+					}
+					wantCount := 0
+					if tc.homeEnabled {
+						wantCount = 1
+					}
+					if count != wantCount {
+						t.Errorf("probe access logs = %d, want %d", count, wantCount)
+					}
+					hook.Reset()
+					server.engine.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/healthz-access-log-control", nil))
+					for _, entry := range hook.AllEntries() {
+						if _, ok := entry.Data["request_id"]; ok && strings.Contains(entry.Message, `"/healthz-access-log-control"`) {
+							return
+						}
+					}
+					t.Error("ordinary request did not emit an access log after health probe")
+				})
 			}
-			for _, entry := range hook.AllEntries() {
-				if _, isAccessLog := entry.Data["request_id"]; isAccessLog && strings.Contains(entry.Message, `"/healthz"`) {
-					t.Errorf("health probe emitted an access log: %s", entry.Message)
-				}
-			}
-
-			hook.Reset()
-			ordinary := httptest.NewRecorder()
-			server.engine.ServeHTTP(ordinary, httptest.NewRequest(http.MethodGet, "/healthz-access-log-control", nil))
-			if ordinary.Code != http.StatusNotFound {
-				t.Fatalf("control status = %d, want 404", ordinary.Code)
-			}
-			for _, entry := range hook.AllEntries() {
-				if _, isAccessLog := entry.Data["request_id"]; isAccessLog && strings.Contains(entry.Message, `"/healthz-access-log-control"`) {
-					return
-				}
-			}
-			t.Error("ordinary request did not emit an access log after health probe")
 		})
 	}
 }

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -32,6 +32,8 @@ import (
 	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 	sdkconfig "github.com/router-for-me/CLIProxyAPI/v7/sdk/config"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
 	"gopkg.in/yaml.v3"
 )
 
@@ -664,6 +666,48 @@ func TestHealthz(t *testing.T) {
 			t.Fatalf("expected empty body for HEAD request, got %q", rr.Body.String())
 		}
 	})
+}
+
+func TestHealthzSkipsAccessLogging(t *testing.T) {
+	server := newTestServer(t)
+	logger := log.StandardLogger()
+	previousHooks := logger.ReplaceHooks(make(log.LevelHooks))
+	previousLevel := logger.GetLevel()
+	hook := logtest.NewLocal(logger)
+	logger.SetLevel(log.InfoLevel)
+	t.Cleanup(func() {
+		logger.ReplaceHooks(previousHooks)
+		logger.SetLevel(previousLevel)
+	})
+
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		t.Run(method, func(t *testing.T) {
+			hook.Reset()
+			recorder := httptest.NewRecorder()
+			server.engine.ServeHTTP(recorder, httptest.NewRequest(method, "/healthz", nil))
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("health probe status = %d, want 200", recorder.Code)
+			}
+			for _, entry := range hook.AllEntries() {
+				if _, isAccessLog := entry.Data["request_id"]; isAccessLog && strings.Contains(entry.Message, `"/healthz"`) {
+					t.Errorf("health probe emitted an access log: %s", entry.Message)
+				}
+			}
+
+			hook.Reset()
+			ordinary := httptest.NewRecorder()
+			server.engine.ServeHTTP(ordinary, httptest.NewRequest(http.MethodGet, "/healthz-access-log-control", nil))
+			if ordinary.Code != http.StatusNotFound {
+				t.Fatalf("control status = %d, want 404", ordinary.Code)
+			}
+			for _, entry := range hook.AllEntries() {
+				if _, isAccessLog := entry.Data["request_id"]; isAccessLog && strings.Contains(entry.Message, `"/healthz-access-log-control"`) {
+					return
+				}
+			}
+			t.Error("ordinary request did not emit an access log after health probe")
+		})
+	}
 }
 
 func TestCodexLiveRoutesRequireAuthAndAreRegistered(t *testing.T) {

--- a/internal/homeplugins/network_scope_test.go
+++ b/internal/homeplugins/network_scope_test.go
@@ -1,0 +1,69 @@
+package homeplugins
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	internalpluginstore "github.com/router-for-me/CLIProxyAPI/v7/internal/pluginstore"
+	sdkpluginstore "github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginstore"
+)
+
+type networkScopeDoer func(*http.Request) (*http.Response, error)
+
+func (f networkScopeDoer) Do(req *http.Request) (*http.Response, error) { return f(req) }
+
+func TestPluginStoreClientsShareProxyCooldown(t *testing.T) {
+	var proxyCalls atomic.Int32
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		proxyCalls.Add(1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer proxy.Close()
+
+	const tokenEnv = "HOME_PLUGIN_NETWORK_SCOPE_TEST_TOKEN"
+	t.Setenv(tokenEnv, t.Name())
+	auth := []sdkpluginstore.ResolvedAuthConfig{{
+		Match: "https://api.github.com/", Type: sdkpluginstore.AuthTypeGitHubToken,
+		Token: sdkpluginstore.Secret(t.Name()),
+	}}
+	expiresAt := time.Now().Add(time.Hour)
+	plugin := sdkpluginstore.Plugin{Repository: "https://github.com/test/home-network-scope"}
+	// Seed the same process-wide cooldown used by management and Home clients.
+	seed := sdkpluginstore.NewClientWithResolvedAuthExpiry(networkScopeDoer(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusTooManyRequests, Header: http.Header{"Retry-After": {"3600"}}, Body: io.NopCloser(strings.NewReader("limited"))}, nil
+	}), "", auth, expiresAt).WithNetworkScope(proxy.URL)
+	_, errRelease := seed.FetchLatestRelease(context.Background(), plugin)
+	var rateLimit *internalpluginstore.RateLimitError
+	if !errors.As(errRelease, &rateLimit) {
+		t.Fatalf("seed cooldown: %v", errRelease)
+	}
+
+	cfg := &config.Config{}
+	cfg.ProxyURL = " " + proxy.URL + " "
+	cfg.Plugins.StoreAuth = []sdkpluginstore.AuthConfig{{
+		Match: "https://api.github.com/", Type: sdkpluginstore.AuthTypeGitHubToken, TokenEnv: tokenEnv,
+	}}
+	for name, client := range map[string]sdkpluginstore.Client{
+		"configured auth": newPluginStoreClient(cfg),
+		"resolved auth":   newResolvedPluginStoreClient(cfg, auth, expiresAt),
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, errRelease := client.FetchLatestRelease(context.Background(), plugin)
+			var rateLimit *internalpluginstore.RateLimitError
+			if !errors.As(errRelease, &rateLimit) {
+				t.Fatalf("Home client did not inherit the proxy cooldown: %v", errRelease)
+			}
+		})
+	}
+	if proxyCalls.Load() != 0 {
+		t.Fatalf("cooldown made %d proxy requests, want 0", proxyCalls.Load())
+	}
+}

--- a/internal/homeplugins/sync.go
+++ b/internal/homeplugins/sync.go
@@ -803,21 +803,27 @@ func yamlMappingValue(node *yaml.Node, key string) *yaml.Node {
 var newPluginStoreClient = func(cfg *config.Config) sdkpluginstore.Client {
 	client := &http.Client{}
 	var storeAuth []sdkpluginstore.AuthConfig
-	if cfg != nil && strings.TrimSpace(cfg.ProxyURL) != "" {
-		util.SetProxy(&sdkconfig.SDKConfig{ProxyURL: strings.TrimSpace(cfg.ProxyURL)}, client)
-	}
+	var proxyURL string
 	if cfg != nil {
+		proxyURL = strings.TrimSpace(cfg.ProxyURL)
 		storeAuth = cfg.Plugins.StoreAuth
 	}
-	return sdkpluginstore.NewClientWithAuth(client, "", storeAuth)
+	if proxyURL != "" {
+		util.SetProxy(&sdkconfig.SDKConfig{ProxyURL: proxyURL}, client)
+	}
+	return sdkpluginstore.NewClientWithAuth(client, "", storeAuth).WithNetworkScope(proxyURL)
 }
 
 var newResolvedPluginStoreClient = func(cfg *config.Config, auth []sdkpluginstore.ResolvedAuthConfig, expiresAt time.Time) sdkpluginstore.Client {
 	client := &http.Client{}
-	if cfg != nil && strings.TrimSpace(cfg.ProxyURL) != "" {
-		util.SetProxy(&sdkconfig.SDKConfig{ProxyURL: strings.TrimSpace(cfg.ProxyURL)}, client)
+	var proxyURL string
+	if cfg != nil {
+		proxyURL = strings.TrimSpace(cfg.ProxyURL)
 	}
-	return sdkpluginstore.NewClientWithResolvedAuthExpiry(client, "", auth, expiresAt)
+	if proxyURL != "" {
+		util.SetProxy(&sdkconfig.SDKConfig{ProxyURL: proxyURL}, client)
+	}
+	return sdkpluginstore.NewClientWithResolvedAuthExpiry(client, "", auth, expiresAt).WithNetworkScope(proxyURL)
 }
 
 func pluginConfigEnabled(item config.PluginInstanceConfig) bool {

--- a/internal/logging/gin_logger.go
+++ b/internal/logging/gin_logger.go
@@ -55,6 +55,12 @@ func GinLogrusLogger() gin.HandlerFunc {
 
 		c.Next()
 
+		// Keep failed health probes visible, including responses from global middleware.
+		if path == "/healthz" && (c.Request.Method == http.MethodGet || c.Request.Method == http.MethodHead) &&
+			c.Writer.Status() >= http.StatusOK && c.Writer.Status() < http.StatusMultipleChoices {
+			return
+		}
+
 		if shouldSkipGinRequestLogging(c) {
 			return
 		}

--- a/internal/logging/gin_logger_test.go
+++ b/internal/logging/gin_logger_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
 )
 
 func TestGinLogrusRecoveryRepanicsErrAbortHandler(t *testing.T) {
@@ -146,5 +148,46 @@ func TestGinLogrusLoggerAddsRequestIDForCodexBackend(t *testing.T) {
 	}
 	if requestIDFromGin != requestIDFromContext {
 		t.Fatalf("expected Gin request ID %q to match context request ID %q", requestIDFromGin, requestIDFromContext)
+	}
+}
+
+func TestGinLogrusLoggerHealthProbeStatus(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := log.StandardLogger()
+	previousHooks := logger.ReplaceHooks(make(log.LevelHooks))
+	previousLevel := logger.GetLevel()
+	hook := logtest.NewLocal(logger)
+	logger.SetLevel(log.InfoLevel)
+	t.Cleanup(func() { logger.ReplaceHooks(previousHooks); logger.SetLevel(previousLevel) })
+	for _, tc := range []struct {
+		name, method, path string
+		status             int
+		wantLog            bool
+	}{
+		{"get_ok", "GET", "/healthz", 200, false},
+		{"head_ok", "HEAD", "/healthz", 200, false},
+		{"success_boundary", "GET", "/healthz", 299, false},
+		{"redirect", "GET", "/healthz", 300, true},
+		{"client_error", "GET", "/healthz", 400, true},
+		{"server_error", "HEAD", "/healthz", 503, true},
+		{"similar_path", "GET", "/healthz-extra", 200, true},
+		{"other_method", "POST", "/healthz", 200, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := gin.New()
+			engine.Use(GinLogrusLogger())
+			// Simulate an early global middleware response before route handlers run.
+			engine.Use(func(c *gin.Context) { c.AbortWithStatus(tc.status) })
+			engine.Handle(tc.method, tc.path, func(c *gin.Context) { t.Error("aborted request reached route handler") })
+			hook.Reset()
+			recorder := httptest.NewRecorder()
+			engine.ServeHTTP(recorder, httptest.NewRequest(tc.method, tc.path, nil))
+			if recorder.Code != tc.status {
+				t.Fatalf("status = %d, want %d", recorder.Code, tc.status)
+			}
+			if got := len(hook.AllEntries()) > 0; got != tc.wantLog {
+				t.Errorf("access log present = %v, want %v", got, tc.wantLog)
+			}
+		})
 	}
 }

--- a/internal/pluginhost/affinity_callbacks.go
+++ b/internal/pluginhost/affinity_callbacks.go
@@ -1,0 +1,61 @@
+package pluginhost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+func (h *Host) callHostAffinityLookup(ctx context.Context, request []byte) ([]byte, error) {
+	_ = ctx
+	var req pluginapi.HostAffinityLookupRequest
+	if errUnmarshal := json.Unmarshal(request, &req); errUnmarshal != nil {
+		return nil, fmt.Errorf("decode host affinity lookup request: %w", errUnmarshal)
+	}
+	req.Provider = strings.TrimSpace(req.Provider)
+	req.Model = strings.TrimSpace(req.Model)
+	req.SessionID = strings.TrimSpace(req.SessionID)
+	if req.Provider == "" {
+		return nil, fmt.Errorf("provider is required")
+	}
+	if req.Model == "" {
+		return nil, fmt.Errorf("model is required")
+	}
+	if req.SessionID == "" {
+		return nil, fmt.Errorf("session_id is required")
+	}
+
+	now := time.Now().UTC()
+	manager := h.currentAuthManager()
+	if manager == nil {
+		return marshalRPCResult(pluginapi.HostAffinityLookupResponse{
+			Status:     pluginapi.HostAffinityStatusUnsupported,
+			ObservedAt: now,
+		})
+	}
+
+	auth, status := manager.LookupSessionAffinity(req.Provider, req.Model, req.SessionID)
+	if status != pluginapi.HostAffinityStatusBound || auth == nil {
+		return marshalRPCResult(pluginapi.HostAffinityLookupResponse{
+			Status:     status,
+			ObservedAt: now,
+		})
+	}
+
+	auth.EnsureIndex()
+	disabled := auth.Disabled || auth.Status == coreauth.StatusDisabled
+	unavailable := auth.Unavailable || auth.Status == coreauth.StatusError
+
+	return marshalRPCResult(pluginapi.HostAffinityLookupResponse{
+		Status:      pluginapi.HostAffinityStatusBound,
+		AuthIndex:   auth.Index,
+		ObservedAt:  now,
+		Disabled:    disabled,
+		Unavailable: unavailable,
+	})
+}

--- a/internal/pluginhost/affinity_callbacks_test.go
+++ b/internal/pluginhost/affinity_callbacks_test.go
@@ -1,0 +1,532 @@
+package pluginhost
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginabi"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
+)
+
+type mockPluginScheduler struct{}
+
+func (m *mockPluginScheduler) PickAuth(ctx context.Context, req pluginapi.SchedulerPickRequest) (pluginapi.SchedulerPickResponse, bool, error) {
+	return pluginapi.SchedulerPickResponse{}, false, nil
+}
+
+func TestHostAffinityLookupCallback_Contract(t *testing.T) {
+	host := New()
+	manager := coreauth.NewManager(nil, nil, nil)
+	selector := coreauth.NewSessionAffinitySelector(nil)
+	manager.SetSelector(selector)
+	host.SetAuthManager(manager)
+
+	authA := &coreauth.Auth{
+		ID:       "claude-owner-a@example.com.json",
+		Provider: "anthropic",
+		FileName: "claude-owner-a@example.com.json",
+		Label:    "auth-a",
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{
+			"type":    "anthropic",
+			"api_key": "secret-api-key-a",
+			"email":   "owner-a@example.com",
+		},
+		Attributes: map[string]string{
+			"path": "/etc/secrets/claude-owner-a@example.com.json",
+		},
+	}
+	authA.EnsureIndex()
+
+	authB := &coreauth.Auth{
+		ID:       "claude-owner-b@example.com.json",
+		Provider: "anthropic",
+		FileName: "claude-owner-b@example.com.json",
+		Label:    "auth-b",
+		Status:   coreauth.StatusActive,
+		Metadata: map[string]any{
+			"type":    "anthropic",
+			"api_key": "secret-api-key-b",
+			"email":   "owner-b@example.com",
+		},
+		Attributes: map[string]string{
+			"path": "/etc/secrets/claude-owner-b@example.com.json",
+		},
+	}
+	authB.EnsureIndex()
+
+	if _, errReg := manager.Register(context.Background(), authA); errReg != nil {
+		t.Fatalf("register authA: %v", errReg)
+	}
+	if _, errReg := manager.Register(context.Background(), authB); errReg != nil {
+		t.Fatalf("register authB: %v", errReg)
+	}
+
+	t.Run("absent binding returns unbound", func(t *testing.T) {
+		reqPayload, _ := json.Marshal(pluginapi.HostAffinityLookupRequest{
+			Provider:  "anthropic",
+			Model:     "claude-3-7-sonnet",
+			SessionID: "non-existent-session",
+		})
+		rawResp, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAffinityLookup, reqPayload)
+		if errCall != nil {
+			t.Fatalf("callFromPlugin error = %v", errCall)
+		}
+		resp, errDecode := decodeRPCEnvelope[pluginapi.HostAffinityLookupResponse](rawResp)
+		if errDecode != nil {
+			t.Fatalf("decode response: %v", errDecode)
+		}
+		if resp.Status != pluginapi.HostAffinityStatusUnbound {
+			t.Fatalf("status = %q, want %q", resp.Status, pluginapi.HostAffinityStatusUnbound)
+		}
+		if resp.AuthIndex != "" {
+			t.Fatalf("unexpected auth in unbound response: %#v", resp)
+		}
+	})
+
+	t.Run("bound session lookup and payload hygiene without email leak", func(t *testing.T) {
+		opts := cliproxyexecutor.Options{
+			Headers:  map[string][]string{"X-Claude-Code-Session-Id": {"bound-session-1"}},
+			Metadata: make(map[string]any),
+		}
+		picked, errPick := selector.Pick(context.Background(), "anthropic", "claude-3-7-sonnet", opts, []*coreauth.Auth{authA})
+		if errPick != nil || picked.ID != authA.ID {
+			t.Fatalf("pick failed: auth=%v err=%v", picked, errPick)
+		}
+
+		reqPayload, _ := json.Marshal(pluginapi.HostAffinityLookupRequest{
+			Provider:  "anthropic",
+			Model:     "claude-3-7-sonnet",
+			SessionID: "bound-session-1",
+		})
+		rawResp, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAffinityLookup, reqPayload)
+		if errCall != nil {
+			t.Fatalf("callFromPlugin error = %v", errCall)
+		}
+
+		// Verify no secret, email, credential ID, or physical file path leaked in raw json
+		rawStr := string(rawResp)
+		for _, sensitive := range []string{"secret-api-key-a", "owner-a@example.com", "claude-owner-a@example.com.json", "/etc/secrets"} {
+			if strings.Contains(rawStr, sensitive) {
+				t.Fatalf("raw response leaked sensitive token %q: %s", sensitive, rawStr)
+			}
+		}
+
+		resp, errDecode := decodeRPCEnvelope[pluginapi.HostAffinityLookupResponse](rawResp)
+		if errDecode != nil {
+			t.Fatalf("decode response: %v", errDecode)
+		}
+		if resp.Status != pluginapi.HostAffinityStatusBound {
+			t.Fatalf("status = %q, want %q", resp.Status, pluginapi.HostAffinityStatusBound)
+		}
+		if resp.AuthIndex != authA.Index {
+			t.Fatalf("auth_index = %q, want %q", resp.AuthIndex, authA.Index)
+		}
+		if resp.Disabled || resp.Unavailable {
+			t.Fatalf("unexpected disabled/unavailable flags: disabled=%v unavailable=%v", resp.Disabled, resp.Unavailable)
+		}
+		if resp.ObservedAt.IsZero() {
+			t.Fatalf("observed_at is zero")
+		}
+	})
+
+	t.Run("thinking suffix normalization", func(t *testing.T) {
+		reqPayload, _ := json.Marshal(pluginapi.HostAffinityLookupRequest{
+			Provider:  "anthropic",
+			Model:     "claude-3-7-sonnet(high)",
+			SessionID: "bound-session-1",
+		})
+		rawResp, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAffinityLookup, reqPayload)
+		if errCall != nil {
+			t.Fatalf("callFromPlugin error = %v", errCall)
+		}
+		resp, errDecode := decodeRPCEnvelope[pluginapi.HostAffinityLookupResponse](rawResp)
+		if errDecode != nil {
+			t.Fatalf("decode response: %v", errDecode)
+		}
+		if resp.Status != pluginapi.HostAffinityStatusBound || resp.AuthIndex != authA.Index {
+			t.Fatalf("normalized thinking model lookup failed: %#v", resp)
+		}
+	})
+
+	t.Run("long session ID normalization (> 256 bytes)", func(t *testing.T) {
+		longSessionID := strings.Repeat("s", 252) // prefix "claude:" + 252 chars = 259 chars > 256
+		opts := cliproxyexecutor.Options{
+			Headers:  map[string][]string{"X-Claude-Code-Session-Id": {longSessionID}},
+			Metadata: make(map[string]any),
+		}
+		picked, errPick := selector.Pick(context.Background(), "anthropic", "claude-3-7-sonnet", opts, []*coreauth.Auth{authA})
+		if errPick != nil || picked.ID != authA.ID {
+			t.Fatalf("pick failed: auth=%v err=%v", picked, errPick)
+		}
+
+		reqPayload, _ := json.Marshal(pluginapi.HostAffinityLookupRequest{
+			Provider:  "anthropic",
+			Model:     "claude-3-7-sonnet",
+			SessionID: longSessionID,
+		})
+		rawResp, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAffinityLookup, reqPayload)
+		if errCall != nil {
+			t.Fatalf("callFromPlugin error = %v", errCall)
+		}
+		resp, errDecode := decodeRPCEnvelope[pluginapi.HostAffinityLookupResponse](rawResp)
+		if errDecode != nil {
+			t.Fatalf("decode response: %v", errDecode)
+		}
+		if resp.Status != pluginapi.HostAffinityStatusBound || resp.AuthIndex != authA.Index {
+			t.Fatalf("long session lookup failed: %#v", resp)
+		}
+	})
+
+	t.Run("rebinding A to B reflects updated binding", func(t *testing.T) {
+		sessionID := "rebind-session"
+		opts := cliproxyexecutor.Options{
+			Headers:  map[string][]string{"X-Claude-Code-Session-Id": {sessionID}},
+			Metadata: make(map[string]any),
+		}
+		picked, _ := selector.Pick(context.Background(), "anthropic", "claude-3-7-sonnet", opts, []*coreauth.Auth{authA})
+		if picked.ID != authA.ID {
+			t.Fatalf("initial pick = %s, want %s", picked.ID, authA.ID)
+		}
+
+		// Rebind to authB
+		picked2, _ := selector.Pick(context.Background(), "anthropic", "claude-3-7-sonnet", opts, []*coreauth.Auth{authB})
+		if picked2.ID != authB.ID {
+			t.Fatalf("second pick = %s, want %s", picked2.ID, authB.ID)
+		}
+
+		reqPayload, _ := json.Marshal(pluginapi.HostAffinityLookupRequest{
+			Provider:  "anthropic",
+			Model:     "claude-3-7-sonnet",
+			SessionID: sessionID,
+		})
+		rawResp, _ := host.callFromPlugin(context.Background(), pluginabi.MethodHostAffinityLookup, reqPayload)
+		resp, _ := decodeRPCEnvelope[pluginapi.HostAffinityLookupResponse](rawResp)
+		if resp.Status != pluginapi.HostAffinityStatusBound || resp.AuthIndex != authB.Index {
+			t.Fatalf("lookup after rebinding: got index=%q status=%q, want index=%q", resp.AuthIndex, resp.Status, authB.Index)
+		}
+	})
+
+	t.Run("unknown subagent does not guess parent binding", func(t *testing.T) {
+		// Parent is bound to authA
+		parentSession := "parent-main-thread-100"
+		opts := cliproxyexecutor.Options{
+			Headers:  map[string][]string{"Session-Id": {parentSession}},
+			Metadata: make(map[string]any),
+		}
+		selector.Pick(context.Background(), "anthropic", "claude-3-7-sonnet", opts, []*coreauth.Auth{authA})
+
+		// Query unknown child subagent
+		reqPayload, _ := json.Marshal(pluginapi.HostAffinityLookupRequest{
+			Provider:  "anthropic",
+			Model:     "claude-3-7-sonnet",
+			SessionID: "codex:" + parentSession + ":subagent-child-unknown",
+		})
+		rawResp, _ := host.callFromPlugin(context.Background(), pluginabi.MethodHostAffinityLookup, reqPayload)
+		resp, _ := decodeRPCEnvelope[pluginapi.HostAffinityLookupResponse](rawResp)
+		if resp.Status != pluginapi.HostAffinityStatusUnbound {
+			t.Fatalf("unknown subagent lookup status = %q, want %q", resp.Status, pluginapi.HostAffinityStatusUnbound)
+		}
+	})
+
+	t.Run("ambiguous unqualified session resolves to ambiguous across namespaces", func(t *testing.T) {
+		// Bind "ambig-sess" under claude to authA, and under codex to authB
+		optsClaude := cliproxyexecutor.Options{
+			Headers:  map[string][]string{"X-Claude-Code-Session-Id": {"ambig-sess"}},
+			Metadata: make(map[string]any),
+		}
+		selector.Pick(context.Background(), "anthropic", "claude-3-7-sonnet", optsClaude, []*coreauth.Auth{authA})
+
+		optsCodex := cliproxyexecutor.Options{
+			Headers:  map[string][]string{"Session-Id": {"ambig-sess"}},
+			Metadata: make(map[string]any),
+		}
+		selector.Pick(context.Background(), "anthropic", "claude-3-7-sonnet", optsCodex, []*coreauth.Auth{authB})
+
+		// Query bare "ambig-sess" without namespace
+		reqPayload, _ := json.Marshal(pluginapi.HostAffinityLookupRequest{
+			Provider:  "anthropic",
+			Model:     "claude-3-7-sonnet",
+			SessionID: "ambig-sess",
+		})
+		rawResp, _ := host.callFromPlugin(context.Background(), pluginabi.MethodHostAffinityLookup, reqPayload)
+		resp, _ := decodeRPCEnvelope[pluginapi.HostAffinityLookupResponse](rawResp)
+		if resp.Status != pluginapi.HostAffinityStatusAmbiguous {
+			t.Fatalf("ambiguous session status = %q, want %q", resp.Status, pluginapi.HostAffinityStatusAmbiguous)
+		}
+
+		// Qualified queries resolve unambiguously
+		reqClaude, _ := json.Marshal(pluginapi.HostAffinityLookupRequest{
+			Provider:  "anthropic",
+			Model:     "claude-3-7-sonnet",
+			SessionID: "claude:ambig-sess",
+		})
+		rawClaude, _ := host.callFromPlugin(context.Background(), pluginabi.MethodHostAffinityLookup, reqClaude)
+		respClaude, _ := decodeRPCEnvelope[pluginapi.HostAffinityLookupResponse](rawClaude)
+		if respClaude.Status != pluginapi.HostAffinityStatusBound || respClaude.AuthIndex != authA.Index {
+			t.Fatalf("qualified claude session status = %q index = %q, want bound %q", respClaude.Status, respClaude.AuthIndex, authA.Index)
+		}
+	})
+
+	t.Run("extended namespaces resolve bare ID (task, clientreq, geminicache, execution)", func(t *testing.T) {
+		testCases := []struct {
+			name   string
+			opts   cliproxyexecutor.Options
+			bareID string
+			qualID string
+			auth   *coreauth.Auth
+		}{
+			{
+				name: "task header",
+				opts: cliproxyexecutor.Options{
+					Headers:  map[string][]string{"X-Task-ID": {"task-xyz-1"}},
+					Metadata: make(map[string]any),
+				},
+				bareID: "task-xyz-1",
+				qualID: "task:task-xyz-1",
+				auth:   authA,
+			},
+			{
+				name: "client request id header",
+				opts: cliproxyexecutor.Options{
+					Headers:  map[string][]string{"X-Client-Request-Id": {"crid-abc-2"}},
+					Metadata: make(map[string]any),
+				},
+				bareID: "crid-abc-2",
+				qualID: "clientreq:crid-abc-2",
+				auth:   authB,
+			},
+			{
+				name: "gemini cache payload",
+				opts: cliproxyexecutor.Options{
+					OriginalRequest: []byte(`{"cachedContent":"cached-gemini-3"}`),
+					Metadata:        make(map[string]any),
+				},
+				bareID: "cached-gemini-3",
+				qualID: "geminicache:cached-gemini-3",
+				auth:   authA,
+			},
+			{
+				name: "execution session metadata",
+				opts: cliproxyexecutor.Options{
+					Metadata: map[string]any{
+						cliproxyexecutor.ExecutionSessionMetadataKey: "exec-run-4",
+					},
+				},
+				bareID: "exec-run-4",
+				qualID: "execution:exec-run-4",
+				auth:   authB,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				picked, errPick := selector.Pick(context.Background(), "anthropic", "claude-3-7-sonnet", tc.opts, []*coreauth.Auth{authA, authB})
+				if errPick != nil || picked.ID != tc.auth.ID {
+					t.Fatalf("pick failed: auth=%v err=%v", picked, errPick)
+				}
+
+				// Query via bare ID
+				reqBare, _ := json.Marshal(pluginapi.HostAffinityLookupRequest{
+					Provider:  "anthropic",
+					Model:     "claude-3-7-sonnet",
+					SessionID: tc.bareID,
+				})
+				rawBare, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAffinityLookup, reqBare)
+				if errCall != nil {
+					t.Fatalf("callFromPlugin error = %v", errCall)
+				}
+				respBare, _ := decodeRPCEnvelope[pluginapi.HostAffinityLookupResponse](rawBare)
+				if respBare.Status != pluginapi.HostAffinityStatusBound || respBare.AuthIndex != tc.auth.Index {
+					t.Fatalf("bare lookup %q: got status=%q index=%q, want bound index=%q", tc.bareID, respBare.Status, respBare.AuthIndex, tc.auth.Index)
+				}
+
+				// Query via qualified ID
+				reqQual, _ := json.Marshal(pluginapi.HostAffinityLookupRequest{
+					Provider:  "anthropic",
+					Model:     "claude-3-7-sonnet",
+					SessionID: tc.qualID,
+				})
+				rawQual, _ := host.callFromPlugin(context.Background(), pluginabi.MethodHostAffinityLookup, reqQual)
+				respQual, _ := decodeRPCEnvelope[pluginapi.HostAffinityLookupResponse](rawQual)
+				if respQual.Status != pluginapi.HostAffinityStatusBound || respQual.AuthIndex != tc.auth.Index {
+					t.Fatalf("qual lookup %q: got status=%q index=%q, want bound index=%q", tc.qualID, respQual.Status, respQual.AuthIndex, tc.auth.Index)
+				}
+			})
+		}
+
+		// Conflict test: bind task:shared-clash to authA and claude:shared-clash to authB
+		optsClash1 := cliproxyexecutor.Options{
+			Headers:  map[string][]string{"X-Task-ID": {"shared-clash"}},
+			Metadata: make(map[string]any),
+		}
+		selector.Pick(context.Background(), "anthropic", "claude-3-7-sonnet", optsClash1, []*coreauth.Auth{authA})
+		optsClash2 := cliproxyexecutor.Options{
+			Headers:  map[string][]string{"X-Claude-Code-Session-Id": {"shared-clash"}},
+			Metadata: make(map[string]any),
+		}
+		selector.Pick(context.Background(), "anthropic", "claude-3-7-sonnet", optsClash2, []*coreauth.Auth{authB})
+
+		reqClash, _ := json.Marshal(pluginapi.HostAffinityLookupRequest{
+			Provider:  "anthropic",
+			Model:     "claude-3-7-sonnet",
+			SessionID: "shared-clash",
+		})
+		rawClash, _ := host.callFromPlugin(context.Background(), pluginabi.MethodHostAffinityLookup, reqClash)
+		respClash, _ := decodeRPCEnvelope[pluginapi.HostAffinityLookupResponse](rawClash)
+		if respClash.Status != pluginapi.HostAffinityStatusAmbiguous {
+			t.Fatalf("clash lookup status = %q, want %q", respClash.Status, pluginapi.HostAffinityStatusAmbiguous)
+		}
+	})
+
+	t.Run("disabled credential returns bound with disabled flag", func(t *testing.T) {
+		sessionID := "disabled-cred-session"
+		opts := cliproxyexecutor.Options{
+			Headers:  map[string][]string{"X-Claude-Code-Session-Id": {sessionID}},
+			Metadata: make(map[string]any),
+		}
+		selector.Pick(context.Background(), "anthropic", "claude-3-7-sonnet", opts, []*coreauth.Auth{authA})
+
+		// Disable authA in manager
+		authA.Disabled = true
+		manager.Update(context.Background(), authA)
+		defer func() {
+			authA.Disabled = false
+			manager.Update(context.Background(), authA)
+		}()
+
+		reqPayload, _ := json.Marshal(pluginapi.HostAffinityLookupRequest{
+			Provider:  "anthropic",
+			Model:     "claude-3-7-sonnet",
+			SessionID: sessionID,
+		})
+		rawResp, _ := host.callFromPlugin(context.Background(), pluginabi.MethodHostAffinityLookup, reqPayload)
+		resp, _ := decodeRPCEnvelope[pluginapi.HostAffinityLookupResponse](rawResp)
+		if resp.Status != pluginapi.HostAffinityStatusBound {
+			t.Fatalf("status = %q, want bound", resp.Status)
+		}
+		if !resp.Disabled {
+			t.Fatalf("expected disabled = true, got %v", resp.Disabled)
+		}
+	})
+
+	t.Run("unsupported when plugin scheduler active", func(t *testing.T) {
+		managerWithPluginSched := coreauth.NewManager(nil, nil, nil)
+		managerWithPluginSched.SetSelector(selector)
+		managerWithPluginSched.SetPluginScheduler(&mockPluginScheduler{})
+		hostWithPluginSched := New()
+		hostWithPluginSched.SetAuthManager(managerWithPluginSched)
+
+		reqPayload, _ := json.Marshal(pluginapi.HostAffinityLookupRequest{
+			Provider:  "anthropic",
+			Model:     "claude-3-7-sonnet",
+			SessionID: "bound-session-1",
+		})
+		rawResp, _ := hostWithPluginSched.callFromPlugin(context.Background(), pluginabi.MethodHostAffinityLookup, reqPayload)
+		resp, _ := decodeRPCEnvelope[pluginapi.HostAffinityLookupResponse](rawResp)
+		if resp.Status != pluginapi.HostAffinityStatusUnsupported {
+			t.Fatalf("status with plugin scheduler = %q, want %q", resp.Status, pluginapi.HostAffinityStatusUnsupported)
+		}
+	})
+
+	t.Run("unsupported when selector is not session affinity", func(t *testing.T) {
+		managerNoAffinity := coreauth.NewManager(nil, nil, nil)
+		managerNoAffinity.SetSelector(&coreauth.RoundRobinSelector{})
+		hostNoAffinity := New()
+		hostNoAffinity.SetAuthManager(managerNoAffinity)
+
+		reqPayload, _ := json.Marshal(pluginapi.HostAffinityLookupRequest{
+			Provider:  "anthropic",
+			Model:     "claude-3-7-sonnet",
+			SessionID: "bound-session-1",
+		})
+		rawResp, _ := hostNoAffinity.callFromPlugin(context.Background(), pluginabi.MethodHostAffinityLookup, reqPayload)
+		resp, _ := decodeRPCEnvelope[pluginapi.HostAffinityLookupResponse](rawResp)
+		if resp.Status != pluginapi.HostAffinityStatusUnsupported {
+			t.Fatalf("status with round robin = %q, want %q", resp.Status, pluginapi.HostAffinityStatusUnsupported)
+		}
+	})
+
+	t.Run("invalid input validation", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			req  pluginapi.HostAffinityLookupRequest
+		}{
+			{"empty provider", pluginapi.HostAffinityLookupRequest{Provider: "", Model: "m", SessionID: "s"}},
+			{"empty model", pluginapi.HostAffinityLookupRequest{Provider: "p", Model: "", SessionID: "s"}},
+			{"empty session", pluginapi.HostAffinityLookupRequest{Provider: "p", Model: "m", SessionID: ""}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				reqPayload, _ := json.Marshal(tc.req)
+				_, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAffinityLookup, reqPayload)
+				if errCall == nil {
+					t.Fatalf("expected error for %s, got nil", tc.name)
+				}
+			})
+		}
+	})
+
+	t.Run("LCP session binding observation", func(t *testing.T) {
+		lcpOpts := cliproxyexecutor.Options{
+			OriginalRequest: []byte(`{"messages":[{"role":"system","content":"host-lcp-sys"},{"role":"user","content":"host-lcp-user"}]}`),
+			Metadata: map[string]any{
+				cliproxyexecutor.CallerScopeMetadataKey: "plugin-caller",
+			},
+		}
+		picked, errPick := selector.Pick(context.Background(), "anthropic", "claude-3-7-sonnet", lcpOpts, []*coreauth.Auth{authA})
+		if errPick != nil || picked.ID != authA.ID {
+			t.Fatalf("LCP Pick failed: %v", errPick)
+		}
+		lcpSessionID, _ := lcpOpts.Metadata[cliproxyexecutor.LCPAffinitySessionIDMetadataKey].(string)
+		if lcpSessionID == "" {
+			t.Fatalf("missing LCP session ID in metadata")
+		}
+
+		reqPayload, _ := json.Marshal(pluginapi.HostAffinityLookupRequest{
+			Provider:  "anthropic",
+			Model:     "claude-3-7-sonnet",
+			SessionID: lcpSessionID,
+		})
+		rawResp, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAffinityLookup, reqPayload)
+		if errCall != nil {
+			t.Fatalf("callFromPlugin error = %v", errCall)
+		}
+		resp, errDecode := decodeRPCEnvelope[pluginapi.HostAffinityLookupResponse](rawResp)
+		if errDecode != nil {
+			t.Fatalf("decode response: %v", errDecode)
+		}
+		if resp.Status != pluginapi.HostAffinityStatusBound || resp.AuthIndex != authA.Index {
+			t.Fatalf("LCP observation failed: got status=%q index=%q, want bound %q", resp.Status, resp.AuthIndex, authA.Index)
+		}
+	})
+
+	t.Run("concurrent reads", func(t *testing.T) {
+		reqPayload, _ := json.Marshal(pluginapi.HostAffinityLookupRequest{
+			Provider:  "anthropic",
+			Model:     "claude-3-7-sonnet",
+			SessionID: "bound-session-1",
+		})
+		var wg sync.WaitGroup
+		for i := 0; i < 20; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				rawResp, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAffinityLookup, reqPayload)
+				if errCall != nil {
+					t.Errorf("concurrent callFromPlugin error: %v", errCall)
+					return
+				}
+				resp, errDecode := decodeRPCEnvelope[pluginapi.HostAffinityLookupResponse](rawResp)
+				if errDecode != nil || resp.Status != pluginapi.HostAffinityStatusBound {
+					t.Errorf("concurrent response error: %#v %v", resp, errDecode)
+				}
+			}()
+		}
+		wg.Wait()
+	})
+}

--- a/internal/pluginhost/host_callbacks.go
+++ b/internal/pluginhost/host_callbacks.go
@@ -129,6 +129,8 @@ func (h *Host) callFromPlugin(ctx context.Context, method string, request []byte
 		return h.callHostAuthGetRuntime(ctx, request)
 	case pluginabi.MethodHostAuthSave:
 		return h.callHostAuthSave(ctx, request)
+	case pluginabi.MethodHostAffinityLookup:
+		return h.callHostAffinityLookup(ctx, request)
 	default:
 		return nil, fmt.Errorf("unsupported host callback %s", method)
 	}

--- a/internal/pluginhost/management.go
+++ b/internal/pluginhost/management.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/htmlsanitize"
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginabi"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 	log "github.com/sirupsen/logrus"
 )
@@ -20,10 +21,11 @@ const (
 )
 
 type managementRouteRecord struct {
-	pluginID string
-	path     string
-	version  string
-	route    pluginapi.ManagementRoute
+	pluginID      string
+	path          string
+	version       string
+	schemaVersion uint32
+	route         pluginapi.ManagementRoute
 }
 
 type resourceRouteRecord struct {
@@ -76,10 +78,11 @@ func (h *Host) RegisterManagementRoutes(ctx context.Context, reserved map[string
 			item.Method = method
 			item.Path = path
 			nextRoutes[key] = managementRouteRecord{
-				pluginID: record.id,
-				path:     record.path,
-				version:  record.version,
-				route:    item,
+				pluginID:      record.id,
+				path:          record.path,
+				version:       record.version,
+				schemaVersion: record.plugin.SchemaVersion,
+				route:         item,
 			}
 		}
 
@@ -264,7 +267,9 @@ func (h *Host) ServeManagementHTTP(w http.ResponseWriter, r *http.Request) bool 
 		http.Error(w, "plugin management handler failed", http.StatusBadGateway)
 		return true
 	}
-	resp.Body = escapeManagementResponseBody(resp)
+	if managementResponseEscapesHTML(record.schemaVersion) {
+		resp.Body = escapeManagementResponseBody(resp)
+	}
 
 	for keyHeader, values := range resp.Headers {
 		for _, value := range values {
@@ -346,6 +351,10 @@ func escapeManagementResponseBody(resp pluginapi.ManagementResponse) []byte {
 		return resp.Body
 	}
 	return body
+}
+
+func managementResponseEscapesHTML(schemaVersion uint32) bool {
+	return schemaVersion < pluginabi.SchemaVersionRawManagementResponse
 }
 
 func (h *Host) callResourceHandler(ctx context.Context, record resourceRouteRecord, req pluginapi.ManagementRequest) (resp pluginapi.ManagementResponse, err error) {

--- a/internal/pluginhost/management_test.go
+++ b/internal/pluginhost/management_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginabi"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/pluginapi"
 )
 
@@ -119,6 +120,144 @@ func TestServeManagementHTMLEscapesJSONResponseStrings(t *testing.T) {
 	}
 	if body["count"] != float64(1) {
 		t.Fatalf("count = %#v, want unchanged number", body["count"])
+	}
+}
+
+func TestServeManagementPreservesRawJSONOnSchemaVersion6(t *testing.T) {
+	rawJSON := `{"prompt":"You are a security auditor. Analyze <input> for vulnerabilities & \"threats\"."}`
+	host := newHostWithRecords(
+		capabilityRecord{
+			id: "raw-json",
+			plugin: pluginapi.Plugin{
+				SchemaVersion: pluginabi.SchemaVersionRawManagementResponse,
+				Capabilities: pluginapi.Capabilities{
+					ManagementAPI: &managementPluginDouble{routes: []pluginapi.ManagementRoute{{
+						Method: http.MethodGet,
+						Path:   "/plugins/raw-json/config",
+						Handler: managementHandlerFunc(func(context.Context, pluginapi.ManagementRequest) (pluginapi.ManagementResponse, error) {
+							return pluginapi.ManagementResponse{
+								Headers: http.Header{"Content-Type": []string{"application/json; charset=utf-8"}},
+								Body:    []byte(rawJSON),
+							}, nil
+						}),
+					}}},
+				},
+			},
+		},
+		capabilityRecord{
+			id: "legacy-json",
+			plugin: pluginapi.Plugin{
+				SchemaVersion: pluginabi.SchemaVersionStreamChunkOmitHistory, // schema_version 5 (legacy)
+				Capabilities: pluginapi.Capabilities{
+					ManagementAPI: &managementPluginDouble{routes: []pluginapi.ManagementRoute{{
+						Method: http.MethodGet,
+						Path:   "/plugins/legacy-json/config",
+						Handler: managementHandlerFunc(func(context.Context, pluginapi.ManagementRequest) (pluginapi.ManagementResponse, error) {
+							return pluginapi.ManagementResponse{
+								Headers: http.Header{"Content-Type": []string{"application/json; charset=utf-8"}},
+								Body:    []byte(rawJSON),
+							}, nil
+						}),
+					}}},
+				},
+			},
+		},
+	)
+	host.RegisterManagementRoutes(context.Background(), nil)
+
+	// Schema version 6: raw JSON is preserved
+	req := httptest.NewRequest(http.MethodGet, "/v0/management/plugins/raw-json/config", nil)
+	rec := httptest.NewRecorder()
+	if !host.ServeManagementHTTP(rec, req) {
+		t.Fatal("ServeManagementHTTP() = false, want true")
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if rec.Body.String() != rawJSON {
+		t.Fatalf("body = %q, want raw %q", rec.Body.String(), rawJSON)
+	}
+
+	// Schema version 5 (legacy): HTML escaping still applies for compatibility
+	req = httptest.NewRequest(http.MethodGet, "/v0/management/plugins/legacy-json/config", nil)
+	rec = httptest.NewRecorder()
+	if !host.ServeManagementHTTP(rec, req) {
+		t.Fatal("ServeManagementHTTP() legacy = false, want true")
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("legacy status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	wantLegacy := `{"prompt":"You are a security auditor. Analyze &lt;input&gt; for vulnerabilities &amp; &#34;threats&#34;."}`
+	if rec.Body.String() != wantLegacy {
+		t.Fatalf("legacy body = %q, want escaped %q", rec.Body.String(), wantLegacy)
+	}
+}
+
+func TestServeManagementGetPutRoundTripPreservesImmutableField(t *testing.T) {
+	const defaultPrompt = "Analyze <input> for vulnerabilities & \"threats\"."
+	var storedPrompt = defaultPrompt
+
+	host := newHostWithRecords(capabilityRecord{
+		id: "roundtrip-plugin",
+		plugin: pluginapi.Plugin{
+			SchemaVersion: pluginabi.SchemaVersionRawManagementResponse,
+			Capabilities: pluginapi.Capabilities{
+				ManagementAPI: &managementPluginDouble{routes: []pluginapi.ManagementRoute{
+					{
+						Method: http.MethodGet,
+						Path:   "/plugins/roundtrip-plugin/config",
+						Handler: managementHandlerFunc(func(context.Context, pluginapi.ManagementRequest) (pluginapi.ManagementResponse, error) {
+							payload, _ := json.Marshal(map[string]string{"system_prompt": storedPrompt})
+							return pluginapi.ManagementResponse{
+								Headers: http.Header{"Content-Type": []string{"application/json; charset=utf-8"}},
+								Body:    payload,
+							}, nil
+						}),
+					},
+					{
+						Method: http.MethodPut,
+						Path:   "/plugins/roundtrip-plugin/config",
+						Handler: managementHandlerFunc(func(_ context.Context, req pluginapi.ManagementRequest) (pluginapi.ManagementResponse, error) {
+							var body map[string]string
+							if errUnmarshal := json.Unmarshal(req.Body, &body); errUnmarshal != nil {
+								return pluginapi.ManagementResponse{StatusCode: http.StatusBadRequest, Body: []byte(`{"error":"invalid json"}`)}, nil
+							}
+							if body["system_prompt"] != defaultPrompt {
+								return pluginapi.ManagementResponse{StatusCode: http.StatusBadRequest, Body: []byte(`{"error":"system_prompts default prompt is immutable"}`)}, nil
+							}
+							storedPrompt = body["system_prompt"]
+							return pluginapi.ManagementResponse{
+								StatusCode: http.StatusOK,
+								Headers:    http.Header{"Content-Type": []string{"application/json"}},
+								Body:       []byte(`{"status":"ok"}`),
+							}, nil
+						}),
+					},
+				}},
+			},
+		},
+	})
+	host.RegisterManagementRoutes(context.Background(), nil)
+
+	// Step 1: GET the configuration
+	reqGet := httptest.NewRequest(http.MethodGet, "/v0/management/plugins/roundtrip-plugin/config", nil)
+	recGet := httptest.NewRecorder()
+	if !host.ServeManagementHTTP(recGet, reqGet) {
+		t.Fatal("ServeManagementHTTP() GET = false, want true")
+	}
+	if recGet.Code != http.StatusOK {
+		t.Fatalf("GET code = %d, want 200", recGet.Code)
+	}
+
+	// Step 2: PUT the unmodified configuration back
+	reqPut := httptest.NewRequest(http.MethodPut, "/v0/management/plugins/roundtrip-plugin/config", recGet.Body)
+	reqPut.Header.Set("Content-Type", "application/json")
+	recPut := httptest.NewRecorder()
+	if !host.ServeManagementHTTP(recPut, reqPut) {
+		t.Fatal("ServeManagementHTTP() PUT = false, want true")
+	}
+	if recPut.Code != http.StatusOK {
+		t.Fatalf("PUT code = %d, want 200; body=%s", recPut.Code, recPut.Body.String())
 	}
 }
 

--- a/internal/pluginstore/github.go
+++ b/internal/pluginstore/github.go
@@ -25,6 +25,7 @@ type Client struct {
 	HTTPClient HTTPDoer
 	// NetworkScope distinguishes request state for different proxy/egress configurations.
 	NetworkScope          string
+	RateLimiter           *GitHubRateLimiter
 	RegistryURL           string
 	UserAgent             string
 	Auth                  []AuthConfig
@@ -147,10 +148,18 @@ func (c Client) releaseAssetAPIAuthenticated(apiURL string) bool {
 
 func (c Client) get(ctx context.Context, requestURL string, accept string, kind string, maxSize int64) ([]byte, error) {
 	currentURL := strings.TrimSpace(requestURL)
+	limiter := c.githubRateLimiter()
 	for redirects := 0; ; redirects++ {
+		if errContext := ctx.Err(); errContext != nil {
+			return nil, errContext
+		}
 		headers, authenticated, errAuth := c.authHeaders(currentURL, kind)
 		if errAuth != nil {
 			return nil, errAuth
+		}
+		rateKey := githubRateLimitKey(currentURL, c.NetworkScope, headers, authenticated)
+		if errLimit := limiter.check(rateKey); errLimit != nil {
+			return nil, errLimit
 		}
 		if headers.Get("Accept") == "" {
 			headers.Set("Accept", accept)
@@ -171,6 +180,7 @@ func (c Client) get(ctx context.Context, requestURL string, accept string, kind 
 			return nil, errDo
 		}
 		if pluginStoreRedirectStatus(resp.StatusCode) {
+			_ = limiter.observe(rateKey, resp.StatusCode, resp.Header, nil)
 			nextURL, errRedirect := pluginStoreRedirectURL(resp, currentURL)
 			if errClose := resp.Body.Close(); errClose != nil {
 				log.WithError(errClose).Debug("failed to close plugin store redirect body")
@@ -184,7 +194,7 @@ func (c Client) get(ctx context.Context, requestURL string, accept string, kind 
 			currentURL = nextURL
 			continue
 		}
-		return readPluginStoreResponse(resp, maxSize, authenticated)
+		return readPluginStoreResponse(resp, maxSize, authenticated, limiter, rateKey)
 	}
 }
 
@@ -258,19 +268,30 @@ func pluginStoreRedirectURL(resp *http.Response, requestURL string) (string, err
 	return next.String(), nil
 }
 
-func readPluginStoreResponse(resp *http.Response, maxSize int64, authenticated bool) ([]byte, error) {
+func readPluginStoreResponse(resp *http.Response, maxSize int64, authenticated bool, limiter *GitHubRateLimiter, rateKey string) ([]byte, error) {
 	defer func() {
 		if errClose := resp.Body.Close(); errClose != nil {
 			log.WithError(errClose).Debug("failed to close plugin store response body")
 		}
 	}()
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		if authenticated {
+		// Apply header-based limits before reading a potentially slow body.
+		if errLimit := limiter.observe(rateKey, resp.StatusCode, resp.Header, nil); errLimit != nil {
+			return nil, errLimit
+		}
+		if authenticated && (rateKey == "" || resp.StatusCode != http.StatusForbidden) {
 			return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
 		}
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		if errLimit := limiter.observe(rateKey, resp.StatusCode, resp.Header, body); errLimit != nil {
+			return nil, errLimit
+		}
+		if authenticated {
+			return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+		}
 		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
+	_ = limiter.observe(rateKey, resp.StatusCode, resp.Header, nil)
 	reader := io.Reader(resp.Body)
 	if maxSize > 0 {
 		reader = io.LimitReader(resp.Body, maxSize+1)

--- a/internal/pluginstore/github.go
+++ b/internal/pluginstore/github.go
@@ -22,12 +22,15 @@ const maxPluginStoreRedirects = 10
 type HTTPDoer = httpfetch.Doer
 
 type Client struct {
-	HTTPClient            HTTPDoer
+	HTTPClient HTTPDoer
+	// NetworkScope distinguishes request state for different proxy/egress configurations.
+	NetworkScope          string
 	RegistryURL           string
 	UserAgent             string
 	Auth                  []AuthConfig
 	ResolvedAuth          []ResolvedAuthConfig
 	ResolvedAuthExpiresAt time.Time
+	preparedAuth          *preparedPluginStoreAuth
 }
 
 type Release struct {
@@ -145,19 +148,15 @@ func (c Client) releaseAssetAPIAuthenticated(apiURL string) bool {
 func (c Client) get(ctx context.Context, requestURL string, accept string, kind string, maxSize int64) ([]byte, error) {
 	currentURL := strings.TrimSpace(requestURL)
 	for redirects := 0; ; redirects++ {
-		if errURL := validatePluginStoreRequestURL(c.Auth, currentURL, kind); errURL != nil {
-			return nil, errURL
-		}
-		if errExpiry := validateResolvedAuthExpiry(c.ResolvedAuth, c.ResolvedAuthExpiresAt, time.Now().UTC(), currentURL, kind); errExpiry != nil {
-			return nil, errExpiry
-		}
-		headers := http.Header{
-			"Accept":     []string{accept},
-			"User-Agent": []string{c.userAgent()},
-		}
-		authenticated, errAuth := applyPluginStoreAuthForClient(headers, c.ResolvedAuth, c.Auth, currentURL, kind)
+		headers, authenticated, errAuth := c.authHeaders(currentURL, kind)
 		if errAuth != nil {
 			return nil, errAuth
+		}
+		if headers.Get("Accept") == "" {
+			headers.Set("Accept", accept)
+		}
+		if headers.Get("User-Agent") == "" {
+			headers.Set("User-Agent", c.userAgent())
 		}
 		resp, errDo := pluginStoreGetNoRedirect(ctx, c.httpClient(), currentURL, headers)
 		if authenticated {

--- a/internal/pluginstore/github_rate_limit.go
+++ b/internal/pluginstore/github_rate_limit.go
@@ -1,0 +1,190 @@
+package pluginstore
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RateLimitError reports a GitHub API cooldown without exposing response bodies
+// or credentials. RetryAt is also populated for requests blocked locally.
+type RateLimitError struct {
+	StatusCode int
+	RetryAt    time.Time
+}
+
+func (err *RateLimitError) Error() string {
+	return fmt.Sprintf("GitHub API rate limited; retry after %s", err.RetryAt.UTC().Format(time.RFC3339))
+}
+
+// RetryAfterSeconds rounds up so clients never retry before the reset time.
+func (err *RateLimitError) RetryAfterSeconds(now time.Time) int64 {
+	delay := err.RetryAt.Sub(now)
+	if delay <= 0 {
+		return 0
+	}
+	seconds := int64(delay / time.Second)
+	if delay%time.Second != 0 {
+		seconds++
+	}
+	return seconds
+}
+
+type githubCooldown struct {
+	retryAt  time.Time
+	status   int
+	failures uint8
+}
+
+// GitHubRateLimiter shares cooldowns across repositories, release metadata and
+// API asset downloads. Its zero value is ready for use. Clients without an
+// explicit limiter share the process-wide default.
+type GitHubRateLimiter struct {
+	mu          sync.Mutex
+	entries     map[string]githubCooldown
+	nextPruneAt time.Time
+	nowFunc     func() time.Time
+}
+
+var defaultGitHubRateLimiter GitHubRateLimiter
+
+func (c Client) githubRateLimiter() *GitHubRateLimiter {
+	if c.RateLimiter != nil {
+		return c.RateLimiter
+	}
+	return &defaultGitHubRateLimiter
+}
+
+func (limiter *GitHubRateLimiter) now() time.Time {
+	if limiter.nowFunc != nil {
+		return limiter.nowFunc()
+	}
+	return time.Now()
+}
+
+func githubRateLimitKey(requestURL, networkScope string, headers http.Header, authenticated bool) string {
+	parsed, errParse := url.Parse(requestURL)
+	if errParse != nil || !strings.EqualFold(parsed.Scheme, "https") || !strings.EqualFold(parsed.Hostname(), "api.github.com") || (parsed.Port() != "" && parsed.Port() != "443") {
+		return ""
+	}
+	return "api.github.com/" + requestIdentity(networkScope, headers, authenticated)
+}
+
+func (limiter *GitHubRateLimiter) check(key string) error {
+	if key == "" {
+		return nil
+	}
+	limiter.mu.Lock()
+	defer limiter.mu.Unlock()
+	now := limiter.now()
+	limiter.pruneLocked(now)
+	entry := limiter.entries[key]
+	if now.Before(entry.retryAt) {
+		return &RateLimitError{StatusCode: entry.status, RetryAt: entry.retryAt}
+	}
+	return nil
+}
+
+// pruneLocked drops inactive identities after a grace period so credential and
+// proxy rotation cannot leave cooldown state behind indefinitely. Retaining
+// recently expired entries preserves secondary-limit backoff across retries.
+func (limiter *GitHubRateLimiter) pruneLocked(now time.Time) {
+	if now.Before(limiter.nextPruneAt) {
+		return
+	}
+	for key, entry := range limiter.entries {
+		if !now.Before(entry.retryAt.Add(time.Hour)) {
+			delete(limiter.entries, key)
+		}
+	}
+	limiter.nextPruneAt = now.Add(time.Hour)
+}
+
+// observe records even successful responses that consume the final request.
+// A late success must not clear a cooldown established by another request.
+func (limiter *GitHubRateLimiter) observe(key string, status int, headers http.Header, body []byte) error {
+	if key == "" {
+		return nil
+	}
+	limiter.mu.Lock()
+	defer limiter.mu.Unlock()
+	now := limiter.now()
+	limiter.pruneLocked(now)
+	entry := limiter.entries[key]
+	remainingZero := strings.TrimSpace(headers.Get("X-RateLimit-Remaining")) == "0"
+	retryAt := githubRetryAfter(headers.Get("Retry-After"), now)
+	rateLimited := status == http.StatusTooManyRequests || (status == http.StatusForbidden &&
+		(remainingZero || !retryAt.IsZero() || githubRateLimitMessage(body)))
+	if !rateLimited && !remainingZero {
+		if status >= http.StatusOK && status < http.StatusMultipleChoices && !now.Before(entry.retryAt) {
+			delete(limiter.entries, key)
+		}
+		return nil
+	}
+	if remainingZero {
+		if reset, errReset := strconv.ParseInt(strings.TrimSpace(headers.Get("X-RateLimit-Reset")), 10, 64); errReset == nil && reset > 0 {
+			if resetAt := time.Unix(reset, 0); resetAt.After(retryAt) {
+				retryAt = resetAt
+			}
+		}
+	}
+	if !retryAt.After(now) {
+		if !rateLimited {
+			return nil
+		}
+		// Headerless secondary limits start at one minute and back off up to an
+		// hour. Only an actual upstream rejection increments this counter.
+		delay := time.Minute * time.Duration(1<<entry.failures)
+		if delay > time.Hour {
+			delay = time.Hour
+		}
+		retryAt = now.Add(delay)
+		if entry.failures < 6 {
+			entry.failures++
+		}
+	}
+	if retryAt.After(entry.retryAt) {
+		entry.retryAt = retryAt
+	}
+	entry.status = status
+	if !rateLimited {
+		entry.status = http.StatusTooManyRequests
+	}
+	if limiter.entries == nil {
+		limiter.entries = make(map[string]githubCooldown)
+	}
+	limiter.entries[key] = entry
+	if rateLimited {
+		return &RateLimitError{StatusCode: status, RetryAt: entry.retryAt}
+	}
+	return nil
+}
+
+func githubRetryAfter(value string, now time.Time) time.Time {
+	value = strings.TrimSpace(value)
+	if seconds, errSeconds := strconv.ParseInt(value, 10, 64); errSeconds == nil && seconds >= 0 && seconds <= int64((1<<63-1)/time.Second) {
+		return now.Add(time.Duration(seconds) * time.Second)
+	}
+	if retryAt, errDate := http.ParseTime(value); errDate == nil {
+		return retryAt
+	}
+	return time.Time{}
+}
+
+func githubRateLimitMessage(body []byte) bool {
+	var message struct {
+		Message string `json:"message"`
+	}
+	if errDecode := json.Unmarshal(body, &message); errDecode != nil {
+		return false
+	}
+	text := strings.ToLower(message.Message)
+	return strings.Contains(text, "secondary rate limit") ||
+		strings.Contains(text, "api rate limit exceeded") ||
+		strings.Contains(text, "abuse detection")
+}

--- a/internal/pluginstore/github_rate_limit_test.go
+++ b/internal/pluginstore/github_rate_limit_test.go
@@ -1,0 +1,341 @@
+package pluginstore
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func githubTestHeaders(values map[string]string) http.Header {
+	headers := make(http.Header)
+	for name, value := range values {
+		headers.Set(name, value)
+	}
+	return headers
+}
+
+func TestGitHubRateLimitHeaders(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	reset := strconv.FormatInt(now.Add(time.Hour).Unix(), 10)
+	tests := []struct {
+		name    string
+		status  int
+		headers map[string]string
+		body    string
+		wait    time.Duration
+	}{
+		{name: "primary forbidden", status: 403, headers: map[string]string{"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": reset}, wait: time.Hour},
+		{name: "retry seconds", status: 429, headers: map[string]string{"Retry-After": "120"}, wait: 2 * time.Minute},
+		{name: "retry date", status: 429, headers: map[string]string{"Retry-After": now.Add(3 * time.Minute).Format(http.TimeFormat)}, wait: 3 * time.Minute},
+		{name: "reset wins", status: 403, headers: map[string]string{"Retry-After": "120", "X-RateLimit-Remaining": "0", "X-RateLimit-Reset": reset}, wait: time.Hour},
+		{name: "retry wins", status: 429, headers: map[string]string{"Retry-After": "7200", "X-RateLimit-Remaining": "0", "X-RateLimit-Reset": reset}, wait: 2 * time.Hour},
+		{name: "secondary message", status: 403, body: `{"message":"You have exceeded a secondary rate limit."}`, wait: time.Minute},
+		{name: "abuse message", status: 403, body: `{"message":"You have triggered an abuse detection mechanism."}`, wait: time.Minute},
+		{name: "retry forbidden", status: 403, headers: map[string]string{"Retry-After": "60"}, wait: time.Minute},
+		{name: "headerless too many requests", status: 429, wait: time.Minute},
+		{name: "invalid retry", status: 429, headers: map[string]string{"Retry-After": "invalid"}, wait: time.Minute},
+		{name: "overflow retry", status: 429, headers: map[string]string{"Retry-After": "9223372036854775807"}, wait: time.Minute},
+		{name: "negative retry", status: 429, headers: map[string]string{"Retry-After": "-10"}, wait: time.Minute},
+		{name: "past reset", status: 403, headers: map[string]string{"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1"}, wait: time.Minute},
+		{name: "invalid reset", status: 403, headers: map[string]string{"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "invalid"}, wait: time.Minute},
+		{name: "permission denied", status: 403, body: `{"message":"Resource not accessible by integration"}`},
+		{name: "invalid body", status: 403, body: "forbidden"},
+		{name: "not found", status: 404},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			limiter := &GitHubRateLimiter{nowFunc: func() time.Time { return now }}
+			errLimit := limiter.observe("quota", tt.status, githubTestHeaders(tt.headers), []byte(tt.body))
+			if tt.wait == 0 {
+				if errLimit != nil || limiter.check("quota") != nil {
+					t.Fatalf("non-rate-limit response started cooldown: %v", errLimit)
+				}
+				return
+			}
+			var rateLimit *RateLimitError
+			if !errors.As(errLimit, &rateLimit) || rateLimit.StatusCode != tt.status || !rateLimit.RetryAt.Equal(now.Add(tt.wait)) {
+				t.Fatalf("error=%v, want status=%d retry=%s", errLimit, tt.status, now.Add(tt.wait))
+			}
+			if errCheck := limiter.check("quota"); !errors.As(errCheck, &rateLimit) {
+				t.Fatalf("check=%v, want cooldown", errCheck)
+			}
+		})
+	}
+}
+
+func TestGitHubRateLimitKeyCanonicalHost(t *testing.T) {
+	t.Parallel()
+	want := githubRateLimitKey("https://api.github.com/repos/owner/repo", "", nil, false)
+	for _, requestURL := range []string{"https://api.github.com:443/repos/other/repo", "https://API.GITHUB.COM/releases"} {
+		if got := githubRateLimitKey(requestURL, "", nil, false); got != want || got == "" {
+			t.Fatalf("key for %s = %q, want %q", requestURL, got, want)
+		}
+	}
+	for _, requestURL := range []string{"https://api.github.com:444/repos/owner/repo", "http://api.github.com/", "https://api.github.com.example/", "https://raw.githubusercontent.com/"} {
+		if got := githubRateLimitKey(requestURL, "", nil, false); got != "" {
+			t.Fatalf("unrelated URL %s has GitHub quota key %q", requestURL, got)
+		}
+	}
+}
+
+func TestGitHubRateLimitPrunesInactiveIdentities(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	limiter := &GitHubRateLimiter{nowFunc: func() time.Time { return now }}
+	_ = limiter.observe("old-token", 429, nil, nil)
+	_ = limiter.observe("active-token", 429, githubTestHeaders(map[string]string{"Retry-After": "7200"}), nil)
+	now = now.Add(time.Hour + time.Minute)
+	_ = limiter.check("new-token")
+	if _, exists := limiter.entries["old-token"]; exists {
+		t.Fatal("inactive credential cooldown was not pruned")
+	}
+	if errCheck := limiter.check("active-token"); errCheck == nil {
+		t.Fatal("active cooldown was pruned")
+	}
+}
+
+func TestGitHubRateLimitBackoffAndRecovery(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	limiter := &GitHubRateLimiter{nowFunc: func() time.Time { return now }}
+	for _, delay := range []time.Duration{time.Minute, 2 * time.Minute, 4 * time.Minute, 8 * time.Minute, 16 * time.Minute, 32 * time.Minute, time.Hour, time.Hour} {
+		errLimit := limiter.observe("quota", 429, nil, nil)
+		var rateLimit *RateLimitError
+		if !errors.As(errLimit, &rateLimit) || !rateLimit.RetryAt.Equal(now.Add(delay)) {
+			t.Fatalf("backoff=%v, want %s", errLimit, delay)
+		}
+		for range 5 {
+			if limiter.check("quota") == nil {
+				t.Fatal("local check lost cooldown")
+			}
+		}
+		now = now.Add(delay)
+		if errCheck := limiter.check("quota"); errCheck != nil {
+			t.Fatalf("expired cooldown: %v", errCheck)
+		}
+	}
+	_ = limiter.observe("quota", 200, nil, nil)
+	var rateLimit *RateLimitError
+	if errLimit := limiter.observe("quota", 429, nil, nil); !errors.As(errLimit, &rateLimit) || !rateLimit.RetryAt.Equal(now.Add(time.Minute)) {
+		t.Fatalf("success did not reset backoff: %v", errLimit)
+	}
+}
+
+func TestGitHubRateLimitSuccessfulExhaustionAndLateResponses(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	limiter := &GitHubRateLimiter{nowFunc: func() time.Time { return now }}
+	headers := githubTestHeaders(map[string]string{"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": strconv.FormatInt(now.Add(time.Hour).Unix(), 10)})
+	if errObserve := limiter.observe("quota", 200, headers, nil); errObserve != nil {
+		t.Fatalf("final successful request failed: %v", errObserve)
+	}
+	_ = limiter.observe("quota", 200, nil, nil)
+	_ = limiter.observe("quota", 429, githubTestHeaders(map[string]string{"Retry-After": "60"}), nil)
+	var rateLimit *RateLimitError
+	if errCheck := limiter.check("quota"); !errors.As(errCheck, &rateLimit) || !rateLimit.RetryAt.Equal(now.Add(time.Hour)) {
+		t.Fatalf("late response shortened cooldown: %v", errCheck)
+	}
+}
+
+func TestGitHubCooldownSharedAcrossClientsRepositoriesAndAssets(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	limiter := &GitHubRateLimiter{nowFunc: func() time.Time { return now }}
+	calls := 0
+	doer := pluginIdentityDoerFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return &http.Response{StatusCode: 429, Header: githubTestHeaders(map[string]string{"Retry-After": "60"}), Body: io.NopCloser(strings.NewReader("limited"))}, nil
+		}
+		return &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"tag_name":"v1.0.0"}`))}, nil
+	})
+	first := Client{HTTPClient: doer, RateLimiter: limiter}
+	second := Client{HTTPClient: doer, RateLimiter: limiter}
+	ctx := context.Background()
+	_, errFirst := first.FetchLatestRelease(ctx, Plugin{Repository: "https://github.com/owner/first"})
+	_, errSecond := second.FetchReleaseByTag(ctx, Plugin{Repository: "https://github.com/other/second"}, "v1.0.0")
+	_, errAsset := second.DownloadAsset(ctx, ReleaseAsset{APIURL: "https://api.github.com:443/repos/other/second/releases/assets/1"})
+	for _, errRequest := range []error{errFirst, errSecond, errAsset} {
+		var rateLimit *RateLimitError
+		if !errors.As(errRequest, &rateLimit) {
+			t.Fatalf("request error=%v, want rate limit", errRequest)
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("calls=%d, want 1", calls)
+	}
+	if _, errRaw := second.get(ctx, DefaultRegistryURL, "application/json", RequestKindRegistry, 0); errRaw != nil {
+		t.Fatalf("API cooldown blocked raw registry: %v", errRaw)
+	}
+	now = now.Add(time.Minute)
+	if _, errRecovered := second.FetchLatestRelease(ctx, Plugin{Repository: "https://github.com/other/second"}); errRecovered != nil || calls != 3 {
+		t.Fatalf("recovery error=%v calls=%d", errRecovered, calls)
+	}
+}
+
+func TestGitHubCooldownSeparatesCredentialsAndNetworkScope(t *testing.T) {
+	t.Parallel()
+	limiter := &GitHubRateLimiter{}
+	calls := 0
+	client := Client{RateLimiter: limiter, HTTPClient: pluginIdentityDoerFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return &http.Response{StatusCode: 429, Header: githubTestHeaders(map[string]string{"Retry-After": "3600"}), Body: io.NopCloser(strings.NewReader("limited"))}, nil
+	})}
+	plugin := Plugin{Repository: "https://github.com/owner/repo"}
+	for _, token := range []string{"", "token-a", "token-b", "token-a", ""} {
+		client.ResolvedAuth = nil
+		if token != "" {
+			client.ResolvedAuth = []ResolvedAuthConfig{{Match: "https://api.github.com/", Type: AuthTypeGitHubToken, Token: Secret(token)}}
+		}
+		_, _ = client.FetchLatestRelease(context.Background(), plugin)
+	}
+	if calls != 3 {
+		t.Fatalf("credential scopes made %d calls, want 3", calls)
+	}
+	client.NetworkScope = "other-egress"
+	_, _ = client.FetchLatestRelease(context.Background(), plugin)
+	if calls != 4 {
+		t.Fatalf("egress scopes made %d calls, want 4", calls)
+	}
+}
+
+func TestGitHubRateLimitAuthenticatedBodyIsNotExposed(t *testing.T) {
+	t.Parallel()
+	client := Client{
+		RateLimiter:  &GitHubRateLimiter{},
+		ResolvedAuth: []ResolvedAuthConfig{{Match: "https://api.github.com/", Type: AuthTypeGitHubToken, Token: Secret("secret-token")}},
+		HTTPClient: pluginIdentityDoerFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: 403, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"message":"secondary rate limit: secret-token"}`))}, nil
+		}),
+	}
+	_, errRelease := client.FetchLatestRelease(context.Background(), Plugin{Repository: "https://github.com/owner/repo"})
+	var rateLimit *RateLimitError
+	if !errors.As(errRelease, &rateLimit) || strings.Contains(errRelease.Error(), "secret-token") {
+		t.Fatalf("unsafe or unclassified error: %v", errRelease)
+	}
+}
+
+func TestGitHubDefaultCooldownBlocksConcurrentNewClients(t *testing.T) {
+	t.Parallel()
+	var calls atomic.Int32
+	client := Client{NetworkScope: t.Name(), HTTPClient: pluginIdentityDoerFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return &http.Response{StatusCode: 429, Header: githubTestHeaders(map[string]string{"Retry-After": "3600"}), Body: io.NopCloser(strings.NewReader("limited"))}, nil
+	})}
+	key := githubRateLimitKey("https://api.github.com/", client.NetworkScope, nil, false)
+	t.Cleanup(func() {
+		defaultGitHubRateLimiter.mu.Lock()
+		delete(defaultGitHubRateLimiter.entries, key)
+		defaultGitHubRateLimiter.mu.Unlock()
+	})
+	_, _ = client.FetchLatestRelease(context.Background(), Plugin{Repository: "https://github.com/owner/first"})
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Go(func() {
+			copyClient := Client{NetworkScope: client.NetworkScope, HTTPClient: client.HTTPClient}
+			_, errRelease := copyClient.FetchLatestRelease(context.Background(), Plugin{Repository: "https://github.com/other/second"})
+			var rateLimit *RateLimitError
+			if !errors.As(errRelease, &rateLimit) {
+				t.Errorf("request error = %v", errRelease)
+			}
+		})
+	}
+	wg.Wait()
+	if calls.Load() != 1 {
+		t.Fatalf("calls=%d, want 1", calls.Load())
+	}
+}
+
+type githubHeaderOnlyBody struct {
+	reads  int
+	closed bool
+}
+
+func (body *githubHeaderOnlyBody) Read([]byte) (int, error) {
+	body.reads++
+	return 0, errors.New("body must not be read")
+}
+
+func (body *githubHeaderOnlyBody) Close() error {
+	body.closed = true
+	return nil
+}
+
+func TestGitHubHeaderCooldownClosesBodyWithoutReading(t *testing.T) {
+	t.Parallel()
+	body := &githubHeaderOnlyBody{}
+	client := Client{RateLimiter: &GitHubRateLimiter{}, HTTPClient: pluginIdentityDoerFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 429, Header: githubTestHeaders(map[string]string{"Retry-After": "60"}), Body: body}, nil
+	})}
+	_, errRelease := client.FetchLatestRelease(context.Background(), Plugin{Repository: "https://github.com/owner/repo"})
+	var rateLimit *RateLimitError
+	if !errors.As(errRelease, &rateLimit) || body.reads != 0 || !body.closed {
+		t.Fatalf("error=%v reads=%d closed=%v", errRelease, body.reads, body.closed)
+	}
+}
+
+func TestGitHubSuccessfulFinalRequestReturnsRelease(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	client := Client{RateLimiter: &GitHubRateLimiter{}, HTTPClient: pluginIdentityDoerFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return &http.Response{
+			StatusCode: 200,
+			Header:     githubTestHeaders(map[string]string{"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": strconv.FormatInt(time.Now().Add(time.Hour).Unix(), 10)}),
+			Body:       io.NopCloser(strings.NewReader(`{"tag_name":"v1.0.0"}`)),
+		}, nil
+	})}
+	release, errRelease := client.FetchLatestRelease(context.Background(), Plugin{Repository: "https://github.com/owner/repo"})
+	if errRelease != nil || release.TagName != "v1.0.0" {
+		t.Fatalf("release=%#v error=%v", release, errRelease)
+	}
+	_, errNext := client.FetchLatestRelease(context.Background(), Plugin{Repository: "https://github.com/owner/other"})
+	var rateLimit *RateLimitError
+	if !errors.As(errNext, &rateLimit) || calls != 1 {
+		t.Fatalf("next error=%v calls=%d", errNext, calls)
+	}
+}
+
+func TestNonGitHubRateLimitDoesNotCoolGitHub(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	client := Client{RateLimiter: &GitHubRateLimiter{}, HTTPClient: pluginIdentityDoerFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		if req.URL.Host != "api.github.com" {
+			return &http.Response{StatusCode: 429, Header: githubTestHeaders(map[string]string{"Retry-After": "3600"}), Body: io.NopCloser(strings.NewReader("limited"))}, nil
+		}
+		return &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"tag_name":"v1.0.0"}`))}, nil
+	})}
+	_, errRegistry := client.FetchRegistry(context.Background())
+	var rateLimit *RateLimitError
+	if errRegistry == nil || errors.As(errRegistry, &rateLimit) {
+		t.Fatalf("non-API error=%v, want ordinary HTTP error", errRegistry)
+	}
+	_, errRelease := client.FetchLatestRelease(context.Background(), Plugin{Repository: "https://github.com/owner/repo"})
+	if errRelease != nil || calls != 2 {
+		t.Fatalf("release error=%v calls=%d", errRelease, calls)
+	}
+}
+
+func TestRateLimitRetryAfterRoundsUp(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(100, 0)
+	for _, tt := range []struct {
+		delay time.Duration
+		want  int64
+	}{{-time.Second, 0}, {0, 0}, {time.Nanosecond, 1}, {time.Second, 1}, {time.Second + time.Nanosecond, 2}} {
+		errLimit := &RateLimitError{RetryAt: now.Add(tt.delay)}
+		if got := errLimit.RetryAfterSeconds(now); got != tt.want {
+			t.Fatalf("RetryAfterSeconds(%s)=%d, want %d", tt.delay, got, tt.want)
+		}
+	}
+}

--- a/internal/pluginstore/request_identity.go
+++ b/internal/pluginstore/request_identity.go
@@ -1,0 +1,65 @@
+package pluginstore
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type preparedPluginStoreAuth struct {
+	requestURL    string
+	kind          string
+	headers       http.Header
+	authenticated bool
+}
+
+// LatestReleaseCacheKey identifies a repository under the effective credentials
+// and network scope, without retaining credential material in the key.
+func (c Client) LatestReleaseCacheKey(plugin Plugin) (string, error) {
+	_, key, errPrepare := c.PrepareLatestRelease(plugin)
+	return key, errPrepare
+}
+
+// PrepareLatestRelease binds the cache identity and initial release request to
+// the same credential snapshot, even when environment values change in a queue.
+func (c Client) PrepareLatestRelease(plugin Plugin) (Client, string, error) {
+	owner, repo, errRepository := GitHubRepositoryParts(plugin.Repository)
+	if errRepository != nil {
+		return Client{}, "", errRepository
+	}
+	requestURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/latest", url.PathEscape(owner), url.PathEscape(repo))
+	headers, authenticated, errHeaders := c.authHeaders(requestURL, RequestKindMetadata)
+	if errHeaders != nil {
+		return Client{}, "", errHeaders
+	}
+	c.preparedAuth = &preparedPluginStoreAuth{requestURL: requestURL, kind: RequestKindMetadata, headers: headers, authenticated: authenticated}
+	return c, strings.ToLower(requestURL) + "/" + requestIdentity(c.NetworkScope, headers, authenticated), nil
+}
+
+func (c Client) authHeaders(requestURL, kind string) (http.Header, bool, error) {
+	if errURL := validatePluginStoreRequestURL(c.Auth, requestURL, kind); errURL != nil {
+		return nil, false, errURL
+	}
+	if errExpiry := validateResolvedAuthExpiry(c.ResolvedAuth, c.ResolvedAuthExpiresAt, time.Now().UTC(), requestURL, kind); errExpiry != nil {
+		return nil, false, errExpiry
+	}
+	if prepared := c.preparedAuth; prepared != nil && prepared.requestURL == requestURL && prepared.kind == kind {
+		return prepared.headers.Clone(), prepared.authenticated, nil
+	}
+	headers := make(http.Header)
+	authenticated, errAuth := applyPluginStoreAuthForClient(headers, c.ResolvedAuth, c.Auth, requestURL, kind)
+	return headers, authenticated, errAuth
+}
+
+func requestIdentity(networkScope string, headers http.Header, authenticated bool) string {
+	hash := sha256.New()
+	_, _ = fmt.Fprintf(hash, "%s\x00%t\x00", networkScope, authenticated)
+	if authenticated {
+		// Header.Write sorts header names, making equivalent auth rules share a key.
+		_ = headers.Write(hash)
+	}
+	return fmt.Sprintf("%x", hash.Sum(nil))
+}

--- a/internal/pluginstore/request_identity_test.go
+++ b/internal/pluginstore/request_identity_test.go
@@ -1,0 +1,82 @@
+package pluginstore
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLatestReleaseCacheKeyNormalizesRepository(t *testing.T) {
+	t.Parallel()
+	client := Client{}
+	key, errKey := client.LatestReleaseCacheKey(Plugin{Repository: "https://github.com/Owner/Repo/"})
+	if errKey != nil {
+		t.Fatal(errKey)
+	}
+	other, errOther := client.LatestReleaseCacheKey(Plugin{Repository: "https://github.com/owner/repo"})
+	if errOther != nil || key != other {
+		t.Fatalf("equivalent repository keys differ: %q / %q (%v)", key, other, errOther)
+	}
+}
+
+func TestLatestReleaseCacheKeyTracksEnvironmentCredentials(t *testing.T) {
+	plugin := Plugin{Repository: "https://github.com/owner/repo"}
+	client := Client{Auth: []AuthConfig{{Match: "https://api.github.com/", Type: AuthTypeGitHubToken, TokenEnv: "PLUGIN_STORE_CACHE_TEST_TOKEN"}}}
+	t.Setenv("PLUGIN_STORE_CACHE_TEST_TOKEN", "secret-token-one")
+	first, errFirst := client.LatestReleaseCacheKey(plugin)
+	if errFirst != nil {
+		t.Fatal(errFirst)
+	}
+	t.Setenv("PLUGIN_STORE_CACHE_TEST_TOKEN", "secret-token-two")
+	second, errSecond := client.LatestReleaseCacheKey(plugin)
+	if errSecond != nil || first == second {
+		t.Fatalf("credential rotation did not change key: %v", errSecond)
+	}
+	if strings.Contains(first+second, "secret-token") {
+		t.Fatal("cache keys retain raw credentials")
+	}
+}
+
+type pluginIdentityDoerFunc func(*http.Request) (*http.Response, error)
+
+func (f pluginIdentityDoerFunc) Do(req *http.Request) (*http.Response, error) { return f(req) }
+
+func TestPrepareLatestReleaseSnapshotsEnvironmentCredentials(t *testing.T) {
+	plugin := Plugin{Repository: "https://github.com/owner/repo"}
+	client := Client{
+		Auth: []AuthConfig{{Match: "https://api.github.com/", Type: AuthTypeGitHubToken, TokenEnv: "PLUGIN_STORE_SNAPSHOT_TEST_TOKEN"}},
+		HTTPClient: pluginIdentityDoerFunc(func(req *http.Request) (*http.Response, error) {
+			if got := req.Header.Get("Authorization"); got != "Bearer original-token" {
+				t.Errorf("request did not use the credential snapshot")
+			}
+			return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"tag_name":"v1.0.0"}`))}, nil
+		}),
+	}
+	t.Setenv("PLUGIN_STORE_SNAPSHOT_TEST_TOKEN", "original-token")
+	prepared, originalKey, errPrepare := client.PrepareLatestRelease(plugin)
+	if errPrepare != nil {
+		t.Fatal(errPrepare)
+	}
+	t.Setenv("PLUGIN_STORE_SNAPSHOT_TEST_TOKEN", "rotated-token")
+	rotatedKey, errKey := client.LatestReleaseCacheKey(plugin)
+	if errKey != nil || originalKey == rotatedKey {
+		t.Fatalf("rotation did not change the unprepared identity: %v", errKey)
+	}
+	if _, errRelease := prepared.FetchLatestRelease(context.Background(), plugin); errRelease != nil {
+		t.Fatal(errRelease)
+	}
+}
+
+func TestLatestReleaseCacheKeyRejectsExpiredCredentials(t *testing.T) {
+	t.Parallel()
+	client := Client{
+		ResolvedAuth:          []ResolvedAuthConfig{{Match: "https://api.github.com/", Type: AuthTypeGitHubToken, Token: Secret("secret")}},
+		ResolvedAuthExpiresAt: time.Unix(1, 0),
+	}
+	if _, errKey := client.LatestReleaseCacheKey(Plugin{Repository: "https://github.com/owner/repo"}); errKey == nil {
+		t.Fatal("expired credentials must not access a cached private release")
+	}
+}

--- a/internal/redisqueue/plugin.go
+++ b/internal/redisqueue/plugin.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	coresession "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/session"
 	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 )
 
@@ -73,6 +74,8 @@ func (p *usageQueuePlugin) HandleUsage(ctx context.Context, record coreusage.Rec
 	} else if parentSessionID == "" && sessionID == strings.TrimSpace(clientRequestMetadata.SessionID) {
 		parentSessionID = strings.TrimSpace(clientRequestMetadata.ParentSessionID)
 	}
+	sessionID = coresession.NormalizeToCanonicalUUID(sessionID)
+	parentSessionID = coresession.NormalizeToCanonicalUUID(parentSessionID)
 	if sessionID == "" || sessionID == parentSessionID {
 		parentSessionID = ""
 	}

--- a/internal/redisqueue/plugin_test.go
+++ b/internal/redisqueue/plugin_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	internallogging "github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	coresession "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/session"
 	coreusage "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 )
 
@@ -610,8 +611,40 @@ func TestUsageQueuePluginPayloadIncludesExplicitSessionHierarchy(t *testing.T) {
 
 		payload := popSinglePayload(t)
 		requireStringField(t, payload, "request_id", "ctx-session-req-1")
-		requireStringField(t, payload, "session_id", "slot:pi-worker-1")
-		requireStringField(t, payload, "parent_session_id", "slot:pi-main-root")
+		wantSession := coresession.NormalizeToCanonicalUUID("slot:pi-worker-1")
+		wantParent := coresession.NormalizeToCanonicalUUID("slot:pi-main-root")
+		requireStringField(t, payload, "session_id", wantSession)
+		requireStringField(t, payload, "parent_session_id", wantParent)
+		if len(wantSession) != 36 || wantSession[14] != '8' {
+			t.Fatalf("expected 36-char UUIDv8 for session_id, got %q", wantSession)
+		}
+		if len(wantParent) != 36 || wantParent[14] != '8' {
+			t.Fatalf("expected 36-char UUIDv8 for parent_session_id, got %q", wantParent)
+		}
+	})
+}
+
+func TestUsageQueuePluginPayloadNormalizesPrefixedNativeUUID(t *testing.T) {
+	withEnabledQueue(t, func() {
+		ctx := internallogging.WithRequestID(context.Background(), "ctx-native-uuid-1")
+		ctx = internallogging.WithEndpoint(ctx, "POST /v1/chat/completions")
+		ctx = internallogging.WithResponseStatusHolder(ctx)
+		internallogging.SetResponseStatus(ctx, http.StatusOK)
+
+		plugin := &usageQueuePlugin{}
+		plugin.HandleUsage(ctx, coreusage.Record{
+			Provider:        "codex",
+			Model:           "gpt-5.6-sol",
+			APIKey:          "test-key",
+			SessionID:       "codex:01a07e72-c84d-7fd3-8207-d217b41cc649",
+			ParentSessionID: "codex:01a07e71-a1b2-7c3d-98e1-f23456789abc",
+			RequestedAt:     time.Date(2026, 8, 31, 0, 0, 0, 0, time.UTC),
+			Latency:         1000 * time.Millisecond,
+		})
+
+		payload := popSinglePayload(t)
+		requireStringField(t, payload, "session_id", "01a07e72-c84d-7fd3-8207-d217b41cc649")
+		requireStringField(t, payload, "parent_session_id", "01a07e71-a1b2-7c3d-98e1-f23456789abc")
 	})
 }
 
@@ -635,7 +668,8 @@ func TestUsageQueuePluginPayloadPreventsSelfReferentialLoop(t *testing.T) {
 
 		payload := popSinglePayload(t)
 		requireStringField(t, payload, "request_id", "ctx-loop-req-1")
-		requireStringField(t, payload, "session_id", "loop-sess-1")
+		wantSession := coresession.NormalizeToCanonicalUUID("loop-sess-1")
+		requireStringField(t, payload, "session_id", wantSession)
 		if _, exists := payload["parent_session_id"]; exists {
 			t.Fatalf("expected parent_session_id to be omitted on self-referential loop, got %s", payload["parent_session_id"])
 		}
@@ -667,7 +701,8 @@ func TestUsageQueuePluginPayloadSameOriginFallback(t *testing.T) {
 		})
 
 		payload := popSinglePayload(t)
-		requireStringField(t, payload, "session_id", "new-custom-root")
+		wantSession := coresession.NormalizeToCanonicalUUID("new-custom-root")
+		requireStringField(t, payload, "session_id", wantSession)
 		if _, exists := payload["parent_session_id"]; exists {
 			t.Fatalf("expected parent_session_id to be omitted when record is independent root, got %s", payload["parent_session_id"])
 		}

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -219,10 +219,15 @@ func closeAntigravityAuthIdleTransports(auth *cliproxyauth.Auth) {
 // antigravityTransportKey identifies one connection pool. At most one of proxy and
 // base is set: proxy for a credential-scoped proxy pool, base for a transport handed
 // in through the request context, and neither for a direct pool.
+// Resolved pool settings (shortMode, idleConnTimeout, maxIdleConnsPerHost) are included
+// in the key to prevent stale transport reuse across configuration hot-reloads under load.
 type antigravityTransportKey struct {
-	credential string
-	proxy      string
-	base       *http.Transport
+	credential          string
+	proxy               string
+	base                *http.Transport
+	shortMode           bool
+	idleConnTimeout     time.Duration
+	maxIdleConnsPerHost int
 }
 
 func defaultAntigravityBaseTransport() *http.Transport {
@@ -315,9 +320,17 @@ func antigravityHTTP11Transport(auth *cliproxyauth.Auth, base *http.Transport, c
 	if base == nil {
 		return nil
 	}
+	var cfg *config.Config
+	if len(cfgs) > 0 {
+		cfg = cfgs[0]
+	}
+	settings := resolveAntigravityPoolSettings(cfg)
 	key := antigravityTransportKey{
-		credential: antigravityTransportScope(auth),
-		base:       base,
+		credential:          antigravityTransportScope(auth),
+		base:                base,
+		shortMode:           settings.shortMode,
+		idleConnTimeout:     settings.idleConnTimeout,
+		maxIdleConnsPerHost: settings.maxIdleConnsPerHost,
 	}
 	transport, errGet := antigravityTransports.Get(key, func() (*http.Transport, error) {
 		return cloneTransportWithHTTP11(base, cfgs...), nil
@@ -341,9 +354,17 @@ func antigravityProxiedHTTP11Transport(auth *cliproxyauth.Auth, proxyURL string,
 	if proxyURL == "" {
 		return nil
 	}
+	var cfg *config.Config
+	if len(cfgs) > 0 {
+		cfg = cfgs[0]
+	}
+	settings := resolveAntigravityPoolSettings(cfg)
 	key := antigravityTransportKey{
-		credential: antigravityTransportScope(auth),
-		proxy:      proxyURL,
+		credential:          antigravityTransportScope(auth),
+		proxy:               proxyURL,
+		shortMode:           settings.shortMode,
+		idleConnTimeout:     settings.idleConnTimeout,
+		maxIdleConnsPerHost: settings.maxIdleConnsPerHost,
 	}
 	transport, errGet := antigravityTransports.Get(key, func() (*http.Transport, error) {
 		base, _, errBuild := proxyutil.BuildHTTPTransport(proxyURL)

--- a/internal/runtime/executor/antigravity_executor.go
+++ b/internal/runtime/executor/antigravity_executor.go
@@ -523,6 +523,7 @@ func ensureAntigravityGeminiBoundaryUserContent(modelName string, payload []byte
 
 type antigravityContentEdit struct {
 	index       int64
+	path        string
 	start       int
 	end         int
 	replacement []byte
@@ -651,6 +652,13 @@ func normalizeAntigravityGeminiFunctionResponseRoles(rawJSON []byte) []byte {
 		})
 		return true
 	})
+	return applyAntigravityIndexedEdits(rawJSON, edits, validOffsets)
+}
+
+// applyAntigravityIndexedEdits splices collected JSON fragments into the original
+// request with one body copy. Applying SJSON once per field made large histories
+// scale with history size multiplied by the number of edits.
+func applyAntigravityIndexedEdits(rawJSON []byte, edits []antigravityContentEdit, validOffsets bool) []byte {
 	if len(edits) == 0 {
 		return rawJSON
 	}
@@ -685,7 +693,10 @@ func normalizeAntigravityGeminiFunctionResponseRoles(rawJSON []byte) []byte {
 func applyAntigravityContentEditsWithSJSON(rawJSON []byte, edits []antigravityContentEdit) []byte {
 	out := rawJSON
 	for _, edit := range edits {
-		path := fmt.Sprintf("request.contents.%d", edit.index)
+		path := edit.path
+		if path == "" {
+			path = fmt.Sprintf("request.contents.%d", edit.index)
+		}
 		if updated, errSet := sjson.SetRawBytes(out, path, edit.replacement); errSet == nil {
 			out = updated
 		}
@@ -693,6 +704,9 @@ func applyAntigravityContentEditsWithSJSON(rawJSON []byte, edits []antigravityCo
 	return out
 }
 
+// repairAntigravityGeminiFunctionResponseNames copies missing or placeholder
+// functionResponse names from the matching functionCall. Edits are applied to
+// each part in isolation, then spliced into the request with one body copy.
 func repairAntigravityGeminiFunctionResponseNames(rawJSON []byte) []byte {
 	contents := util.GetGJSONBytesNoCopy(rawJSON, "request.contents")
 	if !contents.IsArray() {
@@ -721,7 +735,8 @@ func repairAntigravityGeminiFunctionResponseNames(rawJSON []byte) []byte {
 		return rawJSON
 	}
 
-	out := rawJSON
+	edits := make([]antigravityContentEdit, 0)
+	validOffsets := true
 	contents.ForEach(func(contentIdx, content gjson.Result) bool {
 		parts := content.Get("parts")
 		if !parts.IsArray() {
@@ -729,23 +744,39 @@ func repairAntigravityGeminiFunctionResponseNames(rawJSON []byte) []byte {
 		}
 		parts.ForEach(func(partIdx, part gjson.Result) bool {
 			fr := part.Get("functionResponse")
-			if fr.Exists() {
-				id := strings.TrimSpace(fr.Get("id").String())
-				name := strings.TrimSpace(fr.Get("name").String())
-				if id != "" && (name == "" || name == "unknown") {
-					if realName, ok := callIDToName[id]; ok {
-						path := fmt.Sprintf("request.contents.%d.parts.%d.functionResponse.name", contentIdx.Int(), partIdx.Int())
-						if updated, errSet := sjson.SetBytes(out, path, realName); errSet == nil {
-							out = updated
-						}
-					}
-				}
+			if !fr.Exists() {
+				return true
 			}
+			id := strings.TrimSpace(fr.Get("id").String())
+			name := strings.TrimSpace(fr.Get("name").String())
+			if id == "" || (name != "" && name != "unknown") {
+				return true
+			}
+			realName, ok := callIDToName[id]
+			if !ok {
+				return true
+			}
+			updatedPart, errSet := sjson.SetBytes([]byte(part.Raw), "functionResponse.name", realName)
+			if errSet != nil {
+				return true
+			}
+			start := part.Index
+			end := start + len(part.Raw)
+			if start < 0 || end < start || end > len(rawJSON) || !bytes.Equal(rawJSON[start:end], []byte(part.Raw)) {
+				validOffsets = false
+			}
+			edits = append(edits, antigravityContentEdit{
+				index:       contentIdx.Int(),
+				path:        fmt.Sprintf("request.contents.%d.parts.%d", contentIdx.Int(), partIdx.Int()),
+				start:       start,
+				end:         end,
+				replacement: updatedPart,
+			})
 			return true
 		})
 		return true
 	})
-	return out
+	return applyAntigravityIndexedEdits(rawJSON, edits, validOffsets)
 }
 
 func validateAntigravityRequestSignatures(ctx context.Context, modelName string, from sdktranslator.Format, rawJSON []byte) ([]byte, error) {

--- a/internal/runtime/executor/antigravity_executor_transport_test.go
+++ b/internal/runtime/executor/antigravity_executor_transport_test.go
@@ -915,7 +915,14 @@ func TestCloseAntigravityAuthIdleTransportsEvictsIdlePool(t *testing.T) {
 	}
 
 	scope := antigravityTransportScope(auth)
-	key := antigravityTransportKey{credential: scope, base: antigravityBaseTransport}
+	settings := resolveAntigravityPoolSettings(cfg)
+	key := antigravityTransportKey{
+		credential:          scope,
+		base:                antigravityBaseTransport,
+		shortMode:           settings.shortMode,
+		idleConnTimeout:     settings.idleConnTimeout,
+		maxIdleConnsPerHost: settings.maxIdleConnsPerHost,
+	}
 
 	// Verify it's cached
 	if !antigravityTransports.Contains(key) {
@@ -969,7 +976,14 @@ func TestAntigravityCountTokens429EvictsIdleTransports(t *testing.T) {
 	}
 
 	scope := antigravityTransportScope(auth)
-	key := antigravityTransportKey{credential: scope, base: antigravityBaseTransport}
+	settings := resolveAntigravityPoolSettings(cfg)
+	key := antigravityTransportKey{
+		credential:          scope,
+		base:                antigravityBaseTransport,
+		shortMode:           settings.shortMode,
+		idleConnTimeout:     settings.idleConnTimeout,
+		maxIdleConnsPerHost: settings.maxIdleConnsPerHost,
+	}
 	if !antigravityTransports.Contains(key) {
 		t.Fatal("expected transport to be in cache before count_tokens")
 	}
@@ -986,5 +1000,41 @@ func TestAntigravityCountTokens429EvictsIdleTransports(t *testing.T) {
 	// Verify transport is evicted
 	if antigravityTransports.Contains(key) {
 		t.Fatal("expected transport to be evicted after 429 in CountTokens")
+	}
+}
+
+// TestAntigravityTransportKeySeparatesPoolSettingsAcrossReload verifies that clients
+// with different connection-pool settings produce distinct cache keys and never share
+// stale transports during hot-reload under load.
+func TestAntigravityTransportKeySeparatesPoolSettingsAcrossReload(t *testing.T) {
+	auth := antigravityAuthWithIDAndProxy("auth-key-separation", "")
+
+	// 1. Client with short connection mode (default enabled: false)
+	cfgShort := &config.Config{}
+	clientShort := newAntigravityHTTPClient(context.Background(), cfgShort, auth, 0)
+
+	// 2. Client with pooled mode (enabled: true)
+	enabledPool := true
+	cfgPooled := &config.Config{
+		Antigravity: config.AntigravityConfig{
+			ConnectionPool: config.AntigravityConnectionPoolConfig{
+				Enabled: &enabledPool,
+			},
+		},
+	}
+	clientPooled := newAntigravityHTTPClient(context.Background(), cfgPooled, auth, 0)
+
+	// Transports must NOT be shared because their pool settings keys differ!
+	if clientShort.Transport == clientPooled.Transport {
+		t.Fatal("expected short mode and pooled mode to use distinct transports in cache")
+	}
+
+	trShort := clientShort.Transport.(*http.Transport)
+	trPooled := clientPooled.Transport.(*http.Transport)
+	if trShort.MaxIdleConnsPerHost != -1 {
+		t.Fatalf("short transport MaxIdleConnsPerHost = %d, want -1", trShort.MaxIdleConnsPerHost)
+	}
+	if trPooled.MaxIdleConnsPerHost != antigravityDefaultMaxIdleConnsPerHost {
+		t.Fatalf("pooled transport MaxIdleConnsPerHost = %d, want %d", trPooled.MaxIdleConnsPerHost, antigravityDefaultMaxIdleConnsPerHost)
 	}
 }

--- a/internal/runtime/executor/antigravity_preupstream_rewrite_differential_test.go
+++ b/internal/runtime/executor/antigravity_preupstream_rewrite_differential_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"strings"
 	"testing"
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
+	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
 
@@ -16,6 +18,8 @@ func TestNormalizeAntigravityGeminiFunctionResponseRolesMatchesLegacy(t *testing
 		[]byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"call-1","name":"read","args":{}}},{"functionCall":{"id":"call-2","name":"write","args":{}}}]},{"role":"user","parts":[{"functionResponse":{"id":"call-2","name":"write","response":{"ok":2}}},{"functionResponse":{"id":"call-1","name":"read","response":{"ok":1}}}]}]}}`),
 		[]byte("{\r\n  \"request\" : {\r\n    \"contents\" : [\r\n      {\"role\":\"model\",\"parts\":[{\"functionCall\":{\"id\":\"a\",\"name\":\"one\"}},{\"functionCall\":{\"id\":\"b\",\"name\":\"two\"}}]},\r\n      {\"role\" : \"user\", \"parts\" : [ { \"functionResponse\" : {\"id\":\"a\",\"name\":\"one\"} }, { \"functionResponse\" : {\"id\":\"b\",\"name\":\"two\"} } ]}\r\n    ]\r\n  }\r\n}"),
 		[]byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"a","name":"actual"}}]},{"parts":[{"functionResponse":{"id":"a","name":"unknown"}}]}]}}`),
+		[]byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"a","name":"actual"}}]},{"role":"user","parts":[{"functionResponse":{"id":"a","name":"","response":{"ok":true}}}]}]}}`),
+		[]byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"a","name":"actual"}}]},{"role":"user","parts":[{"functionResponse":{"id":"a","response":{"ok":true}}}]}]}}`),
 		[]byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"a","name":"one"}}]},{"role":"user","role":"model","parts":[{"functionResponse":{"id":"a","name":"one"}}]}]}}`),
 		[]byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"a","name":"one"}}]},{"role":"user","parts":[{"functionResponse":{"id":"a","name":"one"}}],"parts":[{"text":"duplicate"}]}]}}`),
 		[]byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"a","name":"one"}}]},{"role":"user","parts":[{"functionResponse":{"id":"a","name":"one"}}]}],"contents":[{"role":"user","parts":[]}]}}`),
@@ -71,8 +75,15 @@ func randomAntigravityFunctionHistory(randomSource *rand.Rand) []byte {
 				call["id"] = id
 				response["id"] = id
 			}
-			if id != "" && randomSource.Intn(8) == 0 {
-				response["name"] = "unknown"
+			if id != "" {
+				switch randomSource.Intn(10) {
+				case 0:
+					response["name"] = "unknown"
+				case 1:
+					response["name"] = ""
+				case 2:
+					delete(response, "name")
+				}
 			}
 			calls = append(calls, map[string]any{"functionCall": call})
 			responses = append(responses, map[string]any{"functionResponse": response})
@@ -102,6 +113,142 @@ func randomAntigravityFunctionHistory(randomSource *rand.Rand) []byte {
 		panic(errMarshal)
 	}
 	return payload
+}
+
+func TestRepairAntigravityGeminiFunctionResponseNamesMatchesLegacy(t *testing.T) {
+	fixtures := [][]byte{
+		[]byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"call-1","name":"read"}}]},{"role":"user","parts":[{"functionResponse":{"id":"call-1","name":"unknown","response":{"ok":true}}}]}]}}`),
+		[]byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"call-1","name":"read"}}]},{"role":"user","parts":[{"functionResponse":{"id":"call-1","name":"","response":{"ok":true}}}]}]}}`),
+		[]byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"call-1","name":"read"}}]},{"role":"user","parts":[{"functionResponse":{"id":"call-1","response":{"ok":true}}}]}]}}`),
+		[]byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"call-1","name":"read"}}]},{"role":"user","parts":[{"functionResponse":{"id":"call-1","name":"read","response":{"ok":true}}}]}]}}`),
+		[]byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"call-1","name":"read"}}]},{"role":"user","parts":[{"functionResponse":{"name":"unknown","response":{"ok":true}}}]}]}}`),
+		[]byte(`{"request":{"contents":[{"role":"user","parts":[{"functionResponse":{"id":"call-1","name":"unknown","response":{"ok":true}}}]}]}}`),
+		[]byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"call-1","name":"read"}},{"functionCall":{"id":"call-2","name":"write"}}]},{"role":"user","parts":[{"functionResponse":{"id":"call-1","name":"unknown"}},{"functionResponse":{"id":"call-2","name":""}}]}]}}`),
+		[]byte("{\r\n  \"request\" : {\r\n    \"contents\" : [\r\n      {\"role\":\"model\",\"parts\":[{\"functionCall\":{\"id\":\"a\",\"name\":\"one\"}}]},\r\n      {\"role\" : \"user\", \"parts\" : [ { \"functionResponse\" : {\"id\":\"a\",\"name\":\"unknown\"} } ]}\r\n    ]\r\n  }\r\n}"),
+		[]byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"a","name":"unknown"}}]},{"role":"user","parts":[{"functionResponse":{"id":"a","name":"unknown"}}]}]}}`),
+		[]byte(`{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"a","name":"one"}}]},{"role":"user","parts":[{"functionResponse":{"id":"a","name":"one"}}]}]`),
+	}
+
+	randomSource := rand.New(rand.NewSource(0xA617A5))
+	for range 1_000 {
+		fixtures = append(fixtures, randomAntigravityFunctionHistory(randomSource))
+	}
+
+	changed := 0
+	unchanged := 0
+	for index, fixture := range fixtures {
+		want := legacyRepairAntigravityGeminiFunctionResponseNames(fixture)
+		got := repairAntigravityGeminiFunctionResponseNames(fixture)
+		if !bytes.Equal(got, want) {
+			t.Fatalf("case %d differs: input_bytes=%d got_bytes=%d want_bytes=%d got=%s want=%s", index, len(fixture), len(got), len(want), got, want)
+		}
+		if bytes.Equal(fixture, want) {
+			unchanged++
+		} else {
+			changed++
+		}
+		if again := repairAntigravityGeminiFunctionResponseNames(got); !bytes.Equal(again, got) {
+			t.Fatalf("case %d is not idempotent", index)
+		}
+	}
+	if changed == 0 || unchanged == 0 {
+		t.Fatalf("degenerate fixtures: changed=%d unchanged=%d", changed, unchanged)
+	}
+}
+
+func TestRepairAntigravityGeminiFunctionResponseNames(t *testing.T) {
+	tests := []struct {
+		name          string
+		payload       string
+		wantName      map[string]string
+		wantUnchanged bool
+	}{
+		{
+			name:     "empty name repaired",
+			payload:  `{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"call-1","name":"read"}}]},{"role":"user","parts":[{"functionResponse":{"id":"call-1","name":"","response":{"ok":true}}}]}]}}`,
+			wantName: map[string]string{"request.contents.1.parts.0.functionResponse.name": "read"},
+		},
+		{
+			name:     "unknown name repaired",
+			payload:  `{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"call-1","name":"read"}}]},{"role":"user","parts":[{"functionResponse":{"id":"call-1","name":"unknown","response":{"ok":true}}}]}]}}`,
+			wantName: map[string]string{"request.contents.1.parts.0.functionResponse.name": "read"},
+		},
+		{
+			name:     "missing name field repaired",
+			payload:  `{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"call-1","name":"read"}}]},{"role":"user","parts":[{"functionResponse":{"id":"call-1","response":{"ok":true}}}]}]}}`,
+			wantName: map[string]string{"request.contents.1.parts.0.functionResponse.name": "read"},
+		},
+		{
+			name:          "good name left alone",
+			payload:       `{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"call-1","name":"read"}}]},{"role":"user","parts":[{"functionResponse":{"id":"call-1","name":"already_good","response":{"ok":true}}}]}]}}`,
+			wantName:      map[string]string{"request.contents.1.parts.0.functionResponse.name": "already_good"},
+			wantUnchanged: true,
+		},
+		{
+			name:          "missing id skipped",
+			payload:       `{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"call-1","name":"read"}}]},{"role":"user","parts":[{"functionResponse":{"name":"unknown","response":{"ok":true}}}]}]}}`,
+			wantName:      map[string]string{"request.contents.1.parts.0.functionResponse.name": "unknown"},
+			wantUnchanged: true,
+		},
+		{
+			name:    "multiple repairs in one request",
+			payload: `{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"call-1","name":"read"}},{"functionCall":{"id":"call-2","name":"write"}}]},{"role":"user","parts":[{"functionResponse":{"id":"call-2","name":"unknown"}},{"functionResponse":{"id":"call-1","name":""}}]}]}}`,
+			wantName: map[string]string{
+				"request.contents.1.parts.0.functionResponse.name": "write",
+				"request.contents.1.parts.1.functionResponse.name": "read",
+			},
+		},
+		{
+			name:          "no-op when map empty",
+			payload:       `{"request":{"contents":[{"role":"user","parts":[{"functionResponse":{"id":"call-1","name":"unknown","response":{"ok":true}}}]}]}}`,
+			wantName:      map[string]string{"request.contents.0.parts.0.functionResponse.name": "unknown"},
+			wantUnchanged: true,
+		},
+		{
+			name:          "functionCall name unknown is not mapped",
+			payload:       `{"request":{"contents":[{"role":"model","parts":[{"functionCall":{"id":"call-1","name":"unknown"}}]},{"role":"user","parts":[{"functionResponse":{"id":"call-1","name":"unknown"}}]}]}}`,
+			wantName:      map[string]string{"request.contents.1.parts.0.functionResponse.name": "unknown"},
+			wantUnchanged: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			payload := []byte(test.payload)
+			got := repairAntigravityGeminiFunctionResponseNames(payload)
+			wantLegacy := legacyRepairAntigravityGeminiFunctionResponseNames(payload)
+			if !bytes.Equal(got, wantLegacy) {
+				t.Fatalf("differs from legacy oracle: got=%s want=%s", got, wantLegacy)
+			}
+			if test.wantUnchanged && !bytes.Equal(got, payload) {
+				t.Fatalf("payload changed: got=%s", got)
+			}
+			for path, wantName := range test.wantName {
+				if gotName := gjson.GetBytes(got, path).String(); gotName != wantName {
+					t.Fatalf("%s = %q, want %q; output=%s", path, gotName, wantName, got)
+				}
+			}
+		})
+	}
+}
+
+func TestApplyAntigravityIndexedEditsFallsBackWhenOffsetsInvalid(t *testing.T) {
+	payload := []byte(`{"request":{"contents":[{"role":"user","parts":[{"functionResponse":{"id":"call-1","name":"unknown"}}]}]}}`)
+	replacement := []byte(`{"functionResponse":{"id":"call-1","name":"read"}}`)
+	edits := []antigravityContentEdit{{
+		path:        "request.contents.0.parts.0",
+		start:       -1,
+		end:         -1,
+		replacement: replacement,
+	}}
+	want, errSet := sjson.SetRawBytes(payload, "request.contents.0.parts.0", replacement)
+	if errSet != nil {
+		t.Fatal(errSet)
+	}
+	got := applyAntigravityIndexedEdits(payload, edits, false)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("fallback differs: got=%s want=%s", got, want)
+	}
 }
 
 func TestApplyAntigravityContentEditsWithSJSONFallback(t *testing.T) {
@@ -239,4 +386,47 @@ func randomAntigravitySchemaRequest(randomSource *rand.Rand) string {
 		panic(errMarshal)
 	}
 	return string(payload)
+}
+
+var antigravityNameRepairBenchmarkOutput []byte
+
+func BenchmarkRepairAntigravityGeminiFunctionResponseNames(b *testing.B) {
+	payload := syntheticAntigravityNameRepairBenchmarkPayload(1<<20, 32)
+	b.Run("legacy", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(payload)))
+		for b.Loop() {
+			antigravityNameRepairBenchmarkOutput = legacyRepairAntigravityGeminiFunctionResponseNames(payload)
+		}
+	})
+	b.Run("batched", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(payload)))
+		for b.Loop() {
+			antigravityNameRepairBenchmarkOutput = repairAntigravityGeminiFunctionResponseNames(payload)
+		}
+	})
+}
+
+func syntheticAntigravityNameRepairBenchmarkPayload(inlineBytes, turns int) []byte {
+	var payload strings.Builder
+	payload.Grow(inlineBytes + turns*320)
+	payload.WriteString(`{"request":{"contents":[{"role":"user","parts":[{"inlineData":{"mimeType":"application/octet-stream","data":"`)
+	payload.WriteString(strings.Repeat("a", inlineBytes))
+	payload.WriteString(`"}}]}`)
+	for turn := range turns {
+		fmt.Fprintf(
+			&payload,
+			`,{"role":"model","parts":[{"functionCall":{"id":"call-%d","name":"lookup","args":{"turn":%d}}}]}`,
+			turn,
+			turn,
+		)
+		fmt.Fprintf(
+			&payload,
+			`,{"role":"user","parts":[{"functionResponse":{"id":"call-%d","name":"unknown","response":{"result":"ok"}}}]}`,
+			turn,
+		)
+	}
+	payload.WriteString(`]}}`)
+	return []byte(payload.String())
 }

--- a/internal/runtime/executor/claude_executor_execute.go
+++ b/internal/runtime/executor/claude_executor_execute.go
@@ -398,18 +398,19 @@ func (e *ClaudeExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, r
 			commitClaudeContinuity(diagnosticsState, msgID, helps.HeaderValueCaseInsensitive(httpResp.Header, "request-id"))
 		}
 		lines := bytes.Split(data, []byte("\n"))
+		var streamUsage helps.StreamUsageBuffer
 		for i, line := range lines {
-			if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
-				reporter.Publish(ctx, detail)
-			}
+			streamUsage.ObserveClaudeStream(line)
 			restoredLine, errRestore := restoreClaudeOAuthToolNamesFromStreamLine(line, oauthToolNamesReverseMap)
 			if errRestore != nil {
 				errRestore = fmt.Errorf("restore Claude OAuth tool name from streaming response: %w", errRestore)
 				helps.RecordAPIResponseError(ctx, e.cfg, errRestore)
+				streamUsage.PublishFailure(ctx, reporter, errRestore)
 				return resp, wrapClaudeFastRequestError(fastRequest, httpResp.StatusCode, errRestore)
 			}
 			lines[i] = restoredLine
 		}
+		streamUsage.Publish(ctx, reporter)
 		data = bytes.Join(lines, []byte("\n"))
 	} else {
 		commitClaudeContinuity(diagnosticsState, claudeMessageIDFromResponse(data), helps.HeaderValueCaseInsensitive(httpResp.Header, "request-id"))

--- a/internal/runtime/executor/claude_executor_native_helper_test.go
+++ b/internal/runtime/executor/claude_executor_native_helper_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
@@ -284,6 +285,66 @@ func TestClaudeBodyNeedsBillingFallbackTracksSystemPresence(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			if got := claudeBodyNeedsBillingFallback([]byte(test.body)); got != test.want {
 				t.Fatalf("claudeBodyNeedsBillingFallback() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+// A 2.1.258 helper that reaches CPA through ANTHROPIC_BASE_URL carries no
+// x-client-request-id, because the client attaches it only for a first-party base
+// URL. The header must stay absent on a custom upstream instead of being
+// synthesized, while a helper that did carry one keeps its own value.
+func TestApplyClaudeHeadersHelperRequestIDFollowsUpstreamBase(t *testing.T) {
+	const nativeRequestID = "66666666-7777-4888-8999-aaaaaaaaaaaa"
+	for _, test := range []struct {
+		name          string
+		url           string
+		incomingID    string
+		wantGenerated bool
+		wantID        string
+	}{
+		{name: "first party base without caller id", url: "https://api.anthropic.com/v1/messages?beta=true", wantGenerated: true},
+		{name: "custom base without caller id", url: "https://gateway.example.com/v1/messages"},
+		{name: "custom base keeps caller id", url: "https://gateway.example.com/v1/messages", incomingID: nativeRequestID, wantID: nativeRequestID},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request, errRequest := http.NewRequest(http.MethodPost, test.url, nil)
+			if errRequest != nil {
+				t.Fatal(errRequest)
+			}
+			incoming := http.Header{}
+			if test.incomingID != "" {
+				incoming.Set("X-Client-Request-Id", test.incomingID)
+			}
+			if errHeaders := applyClaudeHeadersWithNativeProfile(
+				request,
+				&cliproxyauth.Auth{Attributes: map[string]string{"api_key": "test-api-key"}},
+				"test-api-key",
+				false,
+				nil,
+				[]byte(`{"model":"claude-haiku-4-5-20251001"}`),
+				&config.Config{},
+				incoming,
+				true,
+				true,
+				claudeNativeHelperSessionID,
+			); errHeaders != nil {
+				t.Fatalf("applyClaudeHeadersWithNativeProfile() error = %v", errHeaders)
+			}
+			got := request.Header.Get("X-Client-Request-Id")
+			switch {
+			case test.wantID != "":
+				if got != test.wantID {
+					t.Fatalf("X-Client-Request-Id = %q, want caller value %q", got, test.wantID)
+				}
+			case test.wantGenerated:
+				if _, errParse := uuid.Parse(got); errParse != nil {
+					t.Fatalf("X-Client-Request-Id = %q, want a generated UUID", got)
+				}
+			default:
+				if got != "" {
+					t.Fatalf("X-Client-Request-Id = %q, want the header to stay absent", got)
+				}
 			}
 		})
 	}

--- a/internal/runtime/executor/claude_executor_native_helper_test.go
+++ b/internal/runtime/executor/claude_executor_native_helper_test.go
@@ -23,7 +23,7 @@ const (
 	claudeNativeHelperCoreBetas = "oauth-2025-04-20,interleaved-thinking-2025-05-14,redact-thinking-2026-02-12,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05"
 )
 
-func claudeNativeHelperHeaders(betas, compression string, structured bool) http.Header {
+func claudeNativeHelperHeaders(betas, compression string) http.Header {
 	headers := http.Header{
 		"Accept":            {"application/json"},
 		"Accept-Encoding":   {compression},
@@ -43,9 +43,6 @@ func claudeNativeHelperHeaders(betas, compression string, structured bool) http.
 		"X-Stainless-Arch":                          {"arm64"},
 		"X-Stainless-Retry-Count":                   {"0"},
 		"X-Stainless-Timeout":                       {"600"},
-	}
-	if structured {
-		headers.Set("X-Stainless-Async", "async")
 	}
 	canonical := make(http.Header, len(headers))
 	for name, values := range headers {
@@ -121,7 +118,7 @@ func TestClaudeExecutorMinimalNativeHelperPreservesMarkerlessWire(t *testing.T) 
 	defer server.Close()
 
 	payload := []byte(`{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":[{"role":"user","content":"helper probe"}],"metadata":{"user_id":"` + strings.ReplaceAll(claudeNativeHelperUserID, `"`, `\"`) + `"}}`)
-	headers := claudeNativeHelperHeaders(claudeNativeHelperCoreBetas, "gzip", false)
+	headers := claudeNativeHelperHeaders(claudeNativeHelperCoreBetas, "gzip, deflate, br, zstd")
 	executor := NewClaudeExecutor(&config.Config{})
 	_, errExecute := executor.Execute(context.Background(), claudeNativeHelperOAuthAuth(server.URL), cliproxyexecutor.Request{
 		Model:   "claude-haiku-4-5-20251001",
@@ -165,7 +162,7 @@ func TestClaudeExecutorStructuredNativeHelperPreservesStreamProfile(t *testing.T
 
 	betas := claudeNativeHelperCoreBetas + ",structured-outputs-2025-12-15"
 	payload := []byte(`{"model":"claude-haiku-4-5-20251001","messages":[{"role":"user","content":[{"type":"text","text":"helper probe"}]}],"system":[{"type":"text","text":"x-anthropic-billing-header: cc_version=2.1.258; cc_entrypoint=cli; cch=00000;"},{"type":"text","text":"You are Claude Code, Anthropic's official CLI for Claude."},{"type":"text","text":"Return a short title."}],"tools":[],"metadata":{"user_id":"` + strings.ReplaceAll(claudeNativeHelperUserID, `"`, `\"`) + `"},"max_tokens":32000,"thinking":{"type":"disabled"},"temperature":1,"output_config":{"format":{"type":"json_schema","schema":{"type":"object","properties":{"title":{"type":"string"}},"required":["title"],"additionalProperties":false}}},"stream":true}`)
-	headers := claudeNativeHelperHeaders(betas, "gzip, deflate, br, zstd", true)
+	headers := claudeNativeHelperHeaders(betas, "gzip, deflate, br, zstd")
 	executor := NewClaudeExecutor(&config.Config{})
 	result, errStream := executor.ExecuteStream(context.Background(), claudeNativeHelperOAuthAuth(server.URL), cliproxyexecutor.Request{
 		Model:   "claude-haiku-4-5-20251001",

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -1098,8 +1098,11 @@ func applyClaudeHeadersWithNativeProfile(
 	// Per-request UUID, matches Claude Code's x-client-request-id for first-party API.
 	// identityHeader prefers the incoming value for a confirmed client, so a confirmed
 	// helper keeps its own native request ID and this fresh UUID only covers a caller
-	// that sent none. Helpers opt in on custom gateways too.
-	if isAnthropicBase || helperProfile {
+	// that sent none. Helpers opt in on custom gateways too, but only to carry the
+	// request ID they already sent: 2.1.258 attaches the header just for a first-party
+	// base URL, so a helper that arrived without one keeps it absent upstream rather
+	// than gaining a synthesized ID the real client would not have sent.
+	if isAnthropicBase || (helperProfile && helps.HeaderValueCaseInsensitive(incomingHeaders, "x-client-request-id") != "") {
 		identityHeader("x-client-request-id", uuid.New().String())
 	}
 	r.Header.Set("Connection", "keep-alive")

--- a/internal/runtime/executor/claude_executor_request.go
+++ b/internal/runtime/executor/claude_executor_request.go
@@ -50,6 +50,7 @@ const (
 	claudeExtendedCacheTTLBeta       = "extended-cache-ttl-2025-04-11"
 	claudeCacheDiagnosisBeta         = "cache-diagnosis-2026-04-07"
 	claudeRedactThinkingBeta         = "redact-thinking-2026-02-12"
+	claudeAFKModeBeta                = "afk-mode-2026-01-31"
 )
 
 // claudeCodeCLIConstantBetas are the betas Claude Code sends on every
@@ -94,20 +95,21 @@ var claudeCodeTrailingBetas = []string{
 //	 8 prompt-caching-scope-2026-01-05
 //	 9 mid-conversation-system-2026-04-07  models accepting a role=system turn
 //	10 advisor-tool-2026-03-01             requests declaring advisor tools or requesting advisor beta
-//	11 advanced-tool-use-2025-11-20       requests with tools
+//	11 advanced-tool-use-2025-11-20       requests using tool search or another advanced tool-use feature
 //	12 effort-2025-11-24                  effort-supporting models with active thinking
 //	13 server-side-fallback-2026-06-01    requests with fallbacks or requested
 //	14 fallback-credit-2026-06-01         OAuth credentials
 //	15 structured-outputs-2025-12-15      structured output requests
 //	16 thinking-display-updates-2026-08-18 requests with thinking.display=updates
 //	17 fast-mode-2026-02-01               speed:fast requests only
-//	18 extended-cache-ttl-2025-04-11      OAuth credentials (omitted on subagent & probe)
-//	19 cache-diagnosis-2026-04-07         requests with diagnostics only
+//	18 afk-mode-2026-01-31                auto-mode sessions, forwarded when the caller sends it
+//	19 extended-cache-ttl-2025-04-11      OAuth credentials (omitted on subagent & probe)
+//	20 cache-diagnosis-2026-04-07         requests with diagnostics only
 //
 // An empty body keeps the optimistic role=system default, matching the cloaking
 // policy for unknown and future model IDs.
 func claudeCodeCLIBetas(body []byte, requested map[string]bool, oauthToken bool) string {
-	betas := make([]string, 0, len(claudeCodeCLIConstantBetas)+len(claudeCodeTrailingBetas)+8)
+	betas := make([]string, 0, len(claudeCodeCLIConstantBetas)+len(claudeCodeTrailingBetas)+9)
 	betas = append(betas, claudeCodeBeta)
 	if oauthToken {
 		betas = append(betas, claudeOAuthBeta)
@@ -128,7 +130,7 @@ func claudeCodeCLIBetas(body []byte, requested map[string]bool, oauthToken bool)
 	if requested[claudeAdvisorToolBeta] || claudeBodyHasAdvisorTool(body) {
 		betas = append(betas, claudeAdvisorToolBeta)
 	}
-	if tools := gjson.GetBytes(body, "tools"); tools.IsArray() && len(tools.Array()) > 0 {
+	if requested[claudeAdvancedToolUseBeta] || claudeBodyUsesAdvancedToolUse(body) {
 		betas = append(betas, claudeAdvancedToolUseBeta)
 	}
 	if claudeRequestSupportsEffort(body, requested) {
@@ -155,6 +157,9 @@ func claudeCodeCLIBetas(body []byte, requested map[string]bool, oauthToken bool)
 	}
 	if claudeRequestUsesFastMode(body, requested) {
 		betas = append(betas, claudeFastModeBeta)
+	}
+	if requested[claudeAFKModeBeta] {
+		betas = append(betas, claudeAFKModeBeta)
 	}
 	if oauthToken && !helps.IsClaudeSubagentRequest(nil, body) && !isProbeOrHelper {
 		betas = append(betas, claudeExtendedCacheTTLBeta)
@@ -192,6 +197,31 @@ func claudeRequestSupportsEffort(body []byte, requested map[string]bool) bool {
 func claudeThinkingDisplayUpdates(body []byte) bool {
 	display := gjson.GetBytes(body, "thinking.display")
 	return display.Type == gjson.String && strings.EqualFold(strings.TrimSpace(display.String()), "updates")
+}
+
+// claudeBodyUsesAdvancedToolUse reports whether the request needs
+// advanced-tool-use-2025-11-20. Claude Code 2.1.258 adds the beta only while
+// tool search is active, which puts a tool_search_tool_* server tool and
+// defer_loading tools on the wire; plain tool declarations no longer carry it
+// (measured 2026-09-02: 158 inline tools, no beta). Tool use examples
+// (input_examples) and programmatic tool calling (allowed_callers) sit behind
+// the same beta and are just as visible in the body, so callers using them keep
+// working without requesting the beta explicitly.
+func claudeBodyUsesAdvancedToolUse(body []byte) bool {
+	tools := gjson.GetBytes(body, "tools")
+	if !tools.IsArray() {
+		return false
+	}
+	for _, tool := range tools.Array() {
+		toolType := strings.ToLower(strings.TrimSpace(tool.Get("type").String()))
+		if strings.HasPrefix(toolType, "tool_search_tool_") {
+			return true
+		}
+		if tool.Get("defer_loading").Bool() || tool.Get("input_examples").Exists() || tool.Get("allowed_callers").Exists() {
+			return true
+		}
+	}
+	return false
 }
 
 // claudeBodyHasAdvisorTool reports whether the request body declares an
@@ -333,7 +363,9 @@ func withoutClaudeBeta(betas, removeBeta string) string {
 
 // withClaudeAdvisorToolBeta ensures advisor-tool-2026-03-01 is present when
 // the body declares an advisor server tool, placed at the observed wire position
-// before advanced-tool-use-2025-11-20 or effort-2025-11-24.
+// before advanced-tool-use-2025-11-20 or effort-2025-11-24. Every beta that
+// follows advisor on the wire, afk-mode-2026-01-31 included, is an insertion
+// boundary so a caller-supplied trailer never ends up ahead of it.
 func withClaudeAdvisorToolBeta(betas string) string {
 	if strings.TrimSpace(betas) == "" {
 		return claudeAdvisorToolBeta
@@ -354,6 +386,7 @@ func withClaudeAdvisorToolBeta(betas string) string {
 			beta == claudeFallbackCreditBeta ||
 			beta == claudeStructuredOutputsBeta ||
 			beta == claudeFastModeBeta ||
+			beta == claudeAFKModeBeta ||
 			beta == claudeExtendedCacheTTLBeta ||
 			beta == claudeCacheDiagnosisBeta {
 			insertAt = index
@@ -1071,14 +1104,13 @@ func applyClaudeHeadersWithNativeProfile(
 	}
 	r.Header.Set("Connection", "keep-alive")
 	// Regular Claude Code requests negotiate transport identically for streaming
-	// and non-streaming requests. Measured Haiku helpers are the exception: their
-	// minimal non-stream request offers gzip only, while the structured streaming
-	// helper offers the full compression set. Confirmed helpers preserve the
-	// incoming native values.
+	// and non-streaming requests. Claude Code 2.1.258 Haiku helpers offer the same
+	// full compression set as the main thread (2.1.220's minimal probe offered gzip
+	// only). Confirmed helpers preserve the incoming native values.
 	applyTransportNegotiation := func() {
 		if helperProfile {
 			identityHeader("Accept", "application/json")
-			identityHeader("Accept-Encoding", "gzip")
+			identityHeader("Accept-Encoding", "gzip, deflate, br, zstd")
 			return
 		}
 		if stream && !isAnthropicBase {

--- a/internal/runtime/executor/claude_executor_stream.go
+++ b/internal/runtime/executor/claude_executor_stream.go
@@ -378,13 +378,15 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				log.Errorf("response body close error: %v", errClose)
 			}
 		}()
+		var streamUsage helps.StreamUsageBuffer
+		defer streamUsage.Publish(ctx, reporter)
 		emitCancellation := func(cause error) bool {
 			cancelErr := newClaudeOAuthCancellationError(ctx, fp.OAuthCancellation, cause)
 			if cancelErr == nil {
 				return false
 			}
 			helps.RecordAPIResponseError(ctx, e.cfg, cancelErr)
-			reporter.PublishFailure(ctx, cancelErr)
+			streamUsage.PublishFailure(ctx, reporter, cancelErr)
 			select {
 			case out <- cliproxyexecutor.StreamChunk{Err: cancelErr}:
 			default:
@@ -394,7 +396,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		emitResponseError := func(errResponse error) {
 			errResponse = wrapClaudeFastRequestError(fastRequest, httpResp.StatusCode, errResponse)
 			helps.RecordAPIResponseError(ctx, e.cfg, errResponse)
-			reporter.PublishFailure(ctx, errResponse)
+			streamUsage.PublishFailure(ctx, reporter, errResponse)
 			select {
 			case out <- cliproxyexecutor.StreamChunk{Err: errResponse}:
 			case <-ctx.Done():
@@ -425,9 +427,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 				line := scanner.Bytes()
 				observeClaudeStreamLine(line, &upstreamMessageID, &upstreamCompleted)
 				helps.AppendAPIResponseChunk(ctx, e.cfg, line)
-				if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
-					reporter.Publish(ctx, detail)
-				}
+				streamUsage.ObserveClaudeStream(line)
 				restoredLine, errRestore := restoreClaudeOAuthToolNamesFromStreamLine(line, oauthToolNamesReverseMap)
 				if errRestore != nil {
 					emitResponseError(fmt.Errorf("restore Claude OAuth tool name from streaming response: %w", errRestore))
@@ -451,7 +451,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			if errScan := scanner.Err(); errScan != nil {
 				errScan = wrapClaudeFastRequestError(fastRequest, httpResp.StatusCode, errScan)
 				helps.RecordAPIResponseError(ctx, e.cfg, errScan)
-				reporter.PublishFailure(ctx, errScan)
+				streamUsage.PublishFailure(ctx, reporter, errScan)
 				select {
 				case out <- cliproxyexecutor.StreamChunk{Err: errScan}:
 				case <-ctx.Done():
@@ -474,9 +474,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 			line := scanner.Bytes()
 			observeClaudeStreamLine(line, &upstreamMessageID, &upstreamCompleted)
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
-			if detail, ok := helps.ParseClaudeStreamUsage(line); ok {
-				reporter.Publish(ctx, detail)
-			}
+			streamUsage.ObserveClaudeStream(line)
 			restoredLine, errRestore := restoreClaudeOAuthToolNamesFromStreamLine(line, oauthToolNamesReverseMap)
 			if errRestore != nil {
 				emitResponseError(fmt.Errorf("restore Claude OAuth tool name from streaming response: %w", errRestore))
@@ -513,7 +511,7 @@ func (e *ClaudeExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.A
 		if errScan := scanner.Err(); errScan != nil {
 			errScan = wrapClaudeFastRequestError(fastRequest, httpResp.StatusCode, errScan)
 			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
-			reporter.PublishFailure(ctx, errScan)
+			streamUsage.PublishFailure(ctx, reporter, errScan)
 			select {
 			case out <- cliproxyexecutor.StreamChunk{Err: errScan}:
 			case <-ctx.Done():

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -7786,7 +7786,7 @@ func TestClaudeCodeCLIBetas_MatchesObservedClientMatrix(t *testing.T) {
 		},
 		{
 			name: "opus-5 1m variant reproduces the full observed order",
-			body: `{"model":"claude-opus-5","tools":[{"name":"Read"}]}`,
+			body: `{"model":"claude-opus-5","tools":[{"name":"Read","defer_loading":true}]}`,
 			requested: map[string]bool{
 				claudeContext1MBeta:          true,
 				claudeServerSideFallbackBeta: true,
@@ -7832,8 +7832,8 @@ func TestClaudeCodeCLIBetas_MatchesObservedClientMatrix(t *testing.T) {
 			want: constants + ",effort-2025-11-24",
 		},
 		{
-			name:  "oauth uses advanced tools and the current cache TTL trailer",
-			body:  `{"model":"claude-opus-4-6","tools":[{"name":"Read"}]}`,
+			name:  "oauth uses tool search and the current cache TTL trailer",
+			body:  `{"model":"claude-opus-4-6","tools":[{"name":"Read","defer_loading":true}]}`,
 			oauth: true,
 			want: "claude-code-20250219,oauth-2025-04-20," +
 				"interleaved-thinking-2025-05-14,redact-thinking-2026-02-12," +
@@ -7844,7 +7844,7 @@ func TestClaudeCodeCLIBetas_MatchesObservedClientMatrix(t *testing.T) {
 		},
 		{
 			name:  "oauth precedes context-1m",
-			body:  `{"model":"claude-opus-5","tools":[{"name":"Read"}]}`,
+			body:  `{"model":"claude-opus-5","tools":[{"name":"Read","defer_loading":true}]}`,
 			oauth: true,
 			requested: map[string]bool{
 				claudeContext1MBeta:          true,
@@ -7870,9 +7870,35 @@ func TestClaudeCodeCLIBetas_MatchesObservedClientMatrix(t *testing.T) {
 			want: constants,
 		},
 		{
-			name: "legacy model with tools adds advanced tool use only",
+			name: "legacy model with inline tools no longer adds advanced tool use",
 			body: `{"model":"claude-sonnet-4-6","tools":[{"name":"Read"}]}`,
+			want: constants + ",effort-2025-11-24",
+		},
+		{
+			name: "deferred tool adds advanced tool use",
+			body: `{"model":"claude-sonnet-4-6","tools":[{"name":"Read","defer_loading":true}]}`,
 			want: constants + ",advanced-tool-use-2025-11-20,effort-2025-11-24",
+		},
+		{
+			name: "tool search server tool adds advanced tool use",
+			body: `{"model":"claude-sonnet-4-6","tools":[{"type":"tool_search_tool_regex_20251119","name":"tool_search_tool_regex"},{"name":"Read"}]}`,
+			want: constants + ",advanced-tool-use-2025-11-20,effort-2025-11-24",
+		},
+		{
+			name: "tool use examples add advanced tool use",
+			body: `{"model":"claude-sonnet-4-6","tools":[{"name":"Read","input_examples":[{"path":"a.go"}]}]}`,
+			want: constants + ",advanced-tool-use-2025-11-20,effort-2025-11-24",
+		},
+		{
+			name: "programmatic tool calling adds advanced tool use",
+			body: `{"model":"claude-sonnet-4-6","tools":[{"name":"Read","allowed_callers":["code_execution_20250825"]}]}`,
+			want: constants + ",advanced-tool-use-2025-11-20,effort-2025-11-24",
+		},
+		{
+			name:      "requested advanced tool use is honored for inline tools",
+			body:      `{"model":"claude-sonnet-4-6","tools":[{"name":"Read"}]}`,
+			requested: map[string]bool{claudeAdvancedToolUseBeta: true},
+			want:      constants + ",advanced-tool-use-2025-11-20,effort-2025-11-24",
 		},
 		{
 			name: "role=system model without tools adds mid conversation system only",
@@ -7880,8 +7906,8 @@ func TestClaudeCodeCLIBetas_MatchesObservedClientMatrix(t *testing.T) {
 			want: constants + ",mid-conversation-system-2026-04-07,effort-2025-11-24",
 		},
 		{
-			name: "role=system model with tools adds both in wire order",
-			body: `{"model":"claude-opus-5","tools":[{"name":"Read"}]}`,
+			name: "role=system model with tool search adds both in wire order",
+			body: `{"model":"claude-opus-5","tools":[{"name":"Read","defer_loading":true}]}`,
 			want: constants + ",mid-conversation-system-2026-04-07,advanced-tool-use-2025-11-20,effort-2025-11-24",
 		},
 		{
@@ -7921,14 +7947,54 @@ func TestClaudeCodeCLIBetas_MatchesObservedClientMatrix(t *testing.T) {
 		},
 		{
 			name:      "advisor tool beta requested placed before advanced-tool-use",
-			body:      `{"model":"claude-opus-5","tools":[{"name":"Read"}]}`,
+			body:      `{"model":"claude-opus-5","tools":[{"name":"Read","defer_loading":true}]}`,
 			requested: map[string]bool{"advisor-tool-2026-03-01": true},
 			want:      constants + ",mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24",
 		},
 		{
 			name: "body with advisor server tool automatically adds advisor-tool beta",
 			body: `{"model":"claude-opus-5","tools":[{"type":"advisor_20260301","name":"advisor"}]}`,
-			want: constants + ",mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24",
+			want: constants + ",mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,effort-2025-11-24",
+		},
+		{
+			// Captured 2026-09-02 from Claude Code 2.1.258 (cli entrypoint, OAuth,
+			// auto mode on): 158 inline tools without tool search, advisor beta
+			// enabled for the account, thinking adaptive without display.
+			name:  "2.1.258 main thread capture with inline tools and afk-mode",
+			body:  `{"model":"claude-fable-5-1","tools":[{"name":"Read"}],"thinking":{"type":"adaptive"}}`,
+			oauth: true,
+			requested: map[string]bool{
+				claudeAdvisorToolBeta: true,
+				claudeAFKModeBeta:     true,
+			},
+			want: "claude-code-20250219,oauth-2025-04-20," +
+				"interleaved-thinking-2025-05-14,redact-thinking-2026-02-12," +
+				"thinking-token-count-2026-05-13,context-management-2025-06-27," +
+				"prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07," +
+				"advisor-tool-2026-03-01,effort-2025-11-24,fallback-credit-2026-06-01," +
+				"afk-mode-2026-01-31,extended-cache-ttl-2025-04-11",
+		},
+		{
+			name:      "afk-mode sits between fast-mode and extended-cache-ttl",
+			body:      `{"model":"claude-opus-5","speed":"fast"}`,
+			oauth:     true,
+			requested: map[string]bool{claudeAFKModeBeta: true},
+			want: "claude-code-20250219,oauth-2025-04-20," +
+				"interleaved-thinking-2025-05-14,redact-thinking-2026-02-12," +
+				"thinking-token-count-2026-05-13,context-management-2025-06-27," +
+				"prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07," +
+				"effort-2025-11-24,fallback-credit-2026-06-01,fast-mode-2026-02-01," +
+				"afk-mode-2026-01-31,extended-cache-ttl-2025-04-11",
+		},
+		{
+			name:  "afk-mode is not added unless the caller sent it",
+			body:  `{"model":"claude-opus-5"}`,
+			oauth: true,
+			want: "claude-code-20250219,oauth-2025-04-20," +
+				"interleaved-thinking-2025-05-14,redact-thinking-2026-02-12," +
+				"thinking-token-count-2026-05-13,context-management-2025-06-27," +
+				"prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07," +
+				"effort-2025-11-24,fallback-credit-2026-06-01,extended-cache-ttl-2025-04-11",
 		},
 		{
 			name: "thinking display updates emits thinking-display-updates beta and drops redact-thinking",
@@ -8000,6 +8066,47 @@ func TestClaudeCodeCLIBetas_MatchesObservedClientMatrix(t *testing.T) {
 // behaviour: a streaming request to api.anthropic.com negotiates exactly like a
 // non-streaming one, because Anthropic selects SSE from the body. Other
 // Anthropic-compatible upstreams keep the conservative SSE contract.
+
+// TestWithClaudeAdvisorToolBeta_InsertsBeforeTrailingBetas pins the advisor
+// insertion point against every beta that follows it on the 2.1.258 wire,
+// including a caller-supplied afk-mode-2026-01-31.
+func TestWithClaudeAdvisorToolBeta_InsertsBeforeTrailingBetas(t *testing.T) {
+	const head = "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,mid-conversation-system-2026-04-07"
+	tests := []struct {
+		name  string
+		betas string
+		want  string
+	}{
+		{
+			name:  "afk-mode only trailer",
+			betas: head + ",afk-mode-2026-01-31,extended-cache-ttl-2025-04-11",
+			want:  head + ",advisor-tool-2026-03-01,afk-mode-2026-01-31,extended-cache-ttl-2025-04-11",
+		},
+		{
+			name:  "effort ahead of afk-mode",
+			betas: head + ",effort-2025-11-24,fallback-credit-2026-06-01,afk-mode-2026-01-31,extended-cache-ttl-2025-04-11",
+			want:  head + ",advisor-tool-2026-03-01,effort-2025-11-24,fallback-credit-2026-06-01,afk-mode-2026-01-31,extended-cache-ttl-2025-04-11",
+		},
+		{
+			name:  "already present stays put",
+			betas: head + ",advisor-tool-2026-03-01,effort-2025-11-24,afk-mode-2026-01-31",
+			want:  head + ",advisor-tool-2026-03-01,effort-2025-11-24,afk-mode-2026-01-31",
+		},
+		{
+			name:  "no trailer appends",
+			betas: head,
+			want:  head + ",advisor-tool-2026-03-01",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := withClaudeAdvisorToolBeta(tt.betas); got != tt.want {
+				t.Fatalf("withClaudeAdvisorToolBeta() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestApplyClaudeHeaders_StreamTransportNegotiation(t *testing.T) {
 	auth := &cliproxyauth.Auth{Attributes: map[string]string{"api_key": "key-stream-accept"}}
 	body := []byte(`{"model":"claude-opus-4-6","stream":true}`)

--- a/internal/runtime/executor/claude_executor_test.go
+++ b/internal/runtime/executor/claude_executor_test.go
@@ -2028,6 +2028,75 @@ func TestClaudeExecutor_ExecuteStreamDirectPassthroughEmitsCompleteSSEEvents(t *
 	}
 }
 
+func TestClaudeExecutor_ExecuteStreamOpenAIResponseTranslatesCacheAndTrailingUsageChunk(t *testing.T) {
+	upstreamStream := "event: message_start\n" +
+		`data: {"type":"message_start","message":{"id":"msg_123","type":"message","role":"assistant","content":[],"model":"claude-opus-5","stop_reason":null,"usage":{"input_tokens":2095,"cache_creation_input_tokens":7185,"cache_read_input_tokens":355598,"output_tokens":1}}}` + "\n\n" +
+		"event: content_block_delta\n" +
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}` + "\n\n" +
+		"event: message_delta\n" +
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":15}}` + "\n\n" +
+		"event: message_stop\n" +
+		`data: {"type":"message_stop"}` + "\n\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(upstreamStream))
+	}))
+	defer server.Close()
+
+	executor := NewClaudeExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"api_key":  "key-123",
+		"base_url": server.URL,
+	}}
+	payload := []byte(`{"model":"claude-opus-5","messages":[{"role":"user","content":"hello"}],"stream":true}`)
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "claude-opus-5",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FormatOpenAI,
+		ResponseFormat: sdktranslator.FormatOpenAI,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+
+	var allChunks [][]byte
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("unexpected chunk error: %v", chunk.Err)
+		}
+		allChunks = append(allChunks, chunk.Payload)
+	}
+
+	var trailingUsageChunk []byte
+	for _, chunk := range allChunks {
+		choices := gjson.GetBytes(chunk, "choices")
+		if choices.Exists() && len(choices.Array()) == 0 && gjson.GetBytes(chunk, "usage").Exists() {
+			trailingUsageChunk = chunk
+			break
+		}
+	}
+
+	if trailingUsageChunk == nil {
+		t.Fatalf("expected trailing usage chunk with choices: [], got: %s", string(bytes.Join(allChunks, []byte("\n"))))
+	}
+
+	if gotCached := gjson.GetBytes(trailingUsageChunk, "usage.prompt_tokens_details.cached_tokens").Int(); gotCached != 355598 {
+		t.Errorf("cached_tokens = %d, want 355598", gotCached)
+	}
+	if gotWrite := gjson.GetBytes(trailingUsageChunk, "usage.prompt_tokens_details.cache_write_tokens").Int(); gotWrite != 7185 {
+		t.Errorf("cache_write_tokens = %d, want 7185", gotWrite)
+	}
+	if gotCreation := gjson.GetBytes(trailingUsageChunk, "usage.prompt_tokens_details.cached_creation_tokens").Int(); gotCreation != 7185 {
+		t.Errorf("cached_creation_tokens = %d, want 7185", gotCreation)
+	}
+	if gotOutput := gjson.GetBytes(trailingUsageChunk, "usage.completion_tokens").Int(); gotOutput != 15 {
+		t.Errorf("completion_tokens = %d, want 15", gotOutput)
+	}
+}
+
 // TestClaudeExecutor_ExecuteStreamDecodesCompressedSSE guards the dependency that
 // lets CPA advertise the real client's Accept-Encoding on streaming requests:
 // once compression is offered the upstream may compress the SSE body, so the

--- a/internal/runtime/executor/claude_mid_system_model_test.go
+++ b/internal/runtime/executor/claude_mid_system_model_test.go
@@ -282,7 +282,7 @@ func TestClaudeExecutor_PayloadOverrideReconcilesRelocatedSystemPrompt(t *testin
 func TestClaudeExecutor_ConfirmedNativeLegacyMidSystemMessageForwarded(t *testing.T) {
 	upstream := &midSystemUpstream{}
 	ex := NewClaudeExecutor(midSystemConfig())
-	headers := claudeNativeHelperHeaders("claude-code-20250219,"+claudeNativeHelperCoreBetas, "gzip", false)
+	headers := claudeNativeHelperHeaders("claude-code-20250219,"+claudeNativeHelperCoreBetas, "gzip, deflate, br, zstd")
 
 	if _, err := ex.Execute(upstream.context(t, headers), midSystemAuth(), cliproxyexecutor.Request{
 		Model:   "claude-haiku-4-5-20251001",

--- a/internal/runtime/executor/helps/claude_client_detection.go
+++ b/internal/runtime/executor/helps/claude_client_detection.go
@@ -273,18 +273,24 @@ func measuredClaudeCodeHelperHeadersMatch(headers http.Header, cfg *config.Confi
 	if !meetsClaudeDeviceProfileBaseline(candidate, profile) {
 		return false
 	}
-	if async := headerValue(headers, "X-Stainless-Async"); (shape == claudeCodeHelperShapeStructured && async != "async") ||
-		(shape == claudeCodeHelperShapeMinimal && async != "") {
+	// Claude Code 2.1.258 (@anthropic-ai/sdk 0.112.1), measured 2026-09-02 on the
+	// quota probe and the session-title helper: X-Stainless-Async is never sent
+	// and both shapes offer the full compression set. x-client-request-id is
+	// attached only when the client's base URL is api.anthropic.com, so a client
+	// pointed at CPA through ANTHROPIC_BASE_URL sends none while one that reaches
+	// CPA through a transparent proxy still carries the UUID; both are accepted.
+	if headerValue(headers, "X-Stainless-Async") != "" {
 		return false
 	}
-	compression := headerValue(headers, "Accept-Encoding")
-	if (shape == claudeCodeHelperShapeStructured && compression != "gzip, deflate, br, zstd") ||
-		(shape == claudeCodeHelperShapeMinimal && compression != "gzip") {
+	if headerValue(headers, "Accept-Encoding") != "gzip, deflate, br, zstd" {
 		return false
 	}
-	requestID := headerValue(headers, "X-Client-Request-Id")
-	_, errRequestID := uuid.Parse(requestID)
-	return errRequestID == nil
+	if requestID := headerValue(headers, "X-Client-Request-Id"); requestID != "" {
+		if _, errRequestID := uuid.Parse(requestID); errRequestID != nil {
+			return false
+		}
+	}
+	return true
 }
 
 func measuredClaudeCodeHelperSessionMatches(headers http.Header, payload []byte) bool {

--- a/internal/runtime/executor/helps/claude_client_detection_test.go
+++ b/internal/runtime/executor/helps/claude_client_detection_test.go
@@ -24,11 +24,11 @@ func confirmedClaudeCodeHeaders() http.Header {
 	}
 }
 
-func measuredClaudeCodeHelperHeaders(betaProfile string, structured bool) http.Header {
+func measuredClaudeCodeHelperHeaders(betaProfile string) http.Header {
 	profile := defaultClaudeDeviceProfile(&config.Config{})
 	headers := http.Header{
 		"Accept":            {"application/json"},
-		"Accept-Encoding":   {"gzip"},
+		"Accept-Encoding":   {"gzip, deflate, br, zstd"},
 		"Content-Type":      {"application/json"},
 		"User-Agent":        {profile.UserAgent},
 		"X-App":             {"cli"},
@@ -45,10 +45,6 @@ func measuredClaudeCodeHelperHeaders(betaProfile string, structured bool) http.H
 		"X-Stainless-Arch":                          {profile.Arch},
 		"X-Stainless-Retry-Count":                   {"0"},
 		"X-Stainless-Timeout":                       {"600"},
-	}
-	if structured {
-		headers.Set("Accept-Encoding", "gzip, deflate, br, zstd")
-		headers.Set("X-Stainless-Async", "async")
 	}
 	canonical := make(http.Header, len(headers))
 	for name, values := range headers {
@@ -174,10 +170,9 @@ func TestDetectClaudeCodeCountTokensAllowsMissingMetadata(t *testing.T) {
 
 func TestDetectClaudeCodeRequestRecognizesMeasuredHaikuHelpers(t *testing.T) {
 	tests := []struct {
-		name       string
-		beta       string
-		structured bool
-		payload    []byte
+		name    string
+		beta    string
+		payload []byte
 	}{
 		{
 			name:    "minimal with redact thinking",
@@ -190,34 +185,30 @@ func TestDetectClaudeCodeRequestRecognizesMeasuredHaikuHelpers(t *testing.T) {
 			payload: measuredClaudeCodeMinimalHelperPayload(),
 		},
 		{
-			name:       "structured title helper with advisor",
-			beta:       claudeCodeHelperBetaProfile(true, "advisor-tool-2026-03-01", "structured-outputs-2025-12-15", "cache-diagnosis-2026-04-07"),
-			structured: true,
-			payload:    measuredClaudeCodeStructuredHelperPayload(),
+			name:    "structured title helper with advisor",
+			beta:    claudeCodeHelperBetaProfile(true, "advisor-tool-2026-03-01", "structured-outputs-2025-12-15", "cache-diagnosis-2026-04-07"),
+			payload: measuredClaudeCodeStructuredHelperPayload(),
 		},
 		{
-			name:       "structured title helper with fallback credit",
-			beta:       claudeCodeHelperBetaProfile(true, "structured-outputs-2025-12-15", "fallback-credit-2026-06-01"),
-			structured: true,
-			payload:    measuredClaudeCodeStructuredHelperPayload(),
+			name:    "structured title helper with fallback credit",
+			beta:    claudeCodeHelperBetaProfile(true, "structured-outputs-2025-12-15", "fallback-credit-2026-06-01"),
+			payload: measuredClaudeCodeStructuredHelperPayload(),
 		},
 		{
-			name:       "structured title helper with lowercase hex CCH",
-			beta:       claudeCodeHelperBetaProfile(true, "structured-outputs-2025-12-15"),
-			structured: true,
-			payload:    []byte(strings.Replace(string(measuredClaudeCodeStructuredHelperPayload()), "cch=00000", "cch=7ee87", 1)),
+			name:    "structured title helper with lowercase hex CCH",
+			beta:    claudeCodeHelperBetaProfile(true, "structured-outputs-2025-12-15"),
+			payload: []byte(strings.Replace(string(measuredClaudeCodeStructuredHelperPayload()), "cch=00000", "cch=7ee87", 1)),
 		},
 		{
-			name:       "structured title helper without redact thinking",
-			beta:       claudeCodeHelperBetaProfile(false, "structured-outputs-2025-12-15"),
-			structured: true,
-			payload:    measuredClaudeCodeStructuredHelperPayload(),
+			name:    "structured title helper without redact thinking",
+			beta:    claudeCodeHelperBetaProfile(false, "structured-outputs-2025-12-15"),
+			payload: measuredClaudeCodeStructuredHelperPayload(),
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			detection := DetectClaudeCodeRequest(
-				measuredClaudeCodeHelperHeaders(test.beta, test.structured),
+				measuredClaudeCodeHelperHeaders(test.beta),
 				test.payload,
 				false,
 			)
@@ -244,7 +235,7 @@ func TestDetectClaudeCodeRequestRejectsMalformedStructuredHaikuHelpers(t *testin
 		{name: "open schema", payload: strings.Replace(basePayload, `"additionalProperties":false`, `"additionalProperties":true`, 1)},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			detection := DetectClaudeCodeRequest(measuredClaudeCodeHelperHeaders(beta, true), []byte(test.payload), false)
+			detection := DetectClaudeCodeRequest(measuredClaudeCodeHelperHeaders(beta), []byte(test.payload), false)
 			if detection.Confirmed || detection.HelperProfile {
 				t.Fatalf("detection = %#v, want malformed structured helper rejected", detection)
 			}
@@ -277,7 +268,7 @@ func TestDetectClaudeCodeRequestRejectsNearMissHaikuHelpers(t *testing.T) {
 		{
 			name: "wrong compression profile",
 			mutate: func(headers http.Header) {
-				headers.Set("Accept-Encoding", "gzip, deflate, br, zstd")
+				headers.Set("Accept-Encoding", "gzip")
 			},
 			payload: minimalPayload,
 		},
@@ -326,7 +317,7 @@ func TestDetectClaudeCodeRequestRejectsNearMissHaikuHelpers(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false)
+			headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true))
 			if test.mutate != nil {
 				test.mutate(headers)
 			}
@@ -374,7 +365,7 @@ func TestDetectClaudeCodeRequestAcceptsHelperSubagentParentSessionID(t *testing.
 	payload := []byte(`{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":[{"role":"user","content":"helper probe"}],"metadata":{"user_id":` + string(encoded) + `}}`)
 
 	detection := DetectClaudeCodeRequest(
-		measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false),
+		measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true)),
 		payload,
 		false,
 	)
@@ -389,7 +380,7 @@ func TestDetectClaudeCodeRequestRejectsHelperIdentityWithUnknownKeys(t *testing.
 	payload := []byte(`{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":[{"role":"user","content":"helper probe"}],"metadata":{"user_id":` + string(encoded) + `}}`)
 
 	detection := DetectClaudeCodeRequest(
-		measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false),
+		measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true)),
 		payload,
 		false,
 	)
@@ -408,7 +399,7 @@ func TestDetectClaudeCodeRequestAcceptsHelperFromNonBaselinePlatform(t *testing.
 		{"MacOS", "x64"},
 	} {
 		t.Run(platform.os+"/"+platform.arch, func(t *testing.T) {
-			headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false)
+			headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true))
 			headers.Set("X-Stainless-OS", platform.os)
 			headers.Set("X-Stainless-Arch", platform.arch)
 
@@ -428,7 +419,7 @@ func TestDetectClaudeCodeRequestRejectsHelperWithoutPlatformHeaders(t *testing.T
 		"X-Stainless-Runtime-Version",
 	} {
 		t.Run("missing "+name, func(t *testing.T) {
-			headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false)
+			headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true))
 			headers.Del(name)
 
 			detection := DetectClaudeCodeRequest(headers, measuredClaudeCodeMinimalHelperPayload(), false)
@@ -445,7 +436,7 @@ func TestDetectClaudeCodeRequestRejectsHelperWithForeignSoftwareTuple(t *testing
 		"X-Stainless-Runtime-Version": "v0.0.1",
 	} {
 		t.Run(name, func(t *testing.T) {
-			headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false)
+			headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true))
 			headers.Set(name, value)
 
 			detection := DetectClaudeCodeRequest(headers, measuredClaudeCodeMinimalHelperPayload(), false)
@@ -489,7 +480,7 @@ func TestNormalizedClaudeBetaHeaderIsDeterministic(t *testing.T) {
 // detector on claude-header-defaults.timeout instead of the measured constant
 // therefore rejected every genuine helper whenever that value was customized.
 func TestMeasuredHelperProfileIgnoresConfiguredStainlessTimeout(t *testing.T) {
-	headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false)
+	headers := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true))
 	payload := measuredClaudeCodeMinimalHelperPayload()
 	if got := headers.Get("X-Stainless-Timeout"); got != claudeDefaultStainlessTimeout {
 		t.Fatalf("measured helper timeout = %q, want %q", got, claudeDefaultStainlessTimeout)
@@ -521,7 +512,7 @@ func TestMeasuredHelperProfileIgnoresConfiguredStainlessTimeout(t *testing.T) {
 	// The measured constant stays the only accepted value, so a caller that does not
 	// send it is still disqualified even when the operator default happens to match.
 	t.Run("foreign timeout stays rejected", func(t *testing.T) {
-		foreign := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true), false)
+		foreign := measuredClaudeCodeHelperHeaders(claudeCodeHelperBetaProfile(true))
 		foreign.Set("X-Stainless-Timeout", "900")
 		if detection := DetectClaudeCodeRequest(foreign, payload, false, withTimeout("900")); detection.HelperProfile {
 			t.Fatalf("detection = %#v, want a non-measured timeout to disqualify the helper profile", detection)

--- a/internal/runtime/executor/helps/kimi_responses.go
+++ b/internal/runtime/executor/helps/kimi_responses.go
@@ -1,0 +1,21 @@
+package helps
+
+import (
+	"strings"
+
+	kimiauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/kimi"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+// ResolveKimiResponsesURL resolves the upstream URL for Kimi Responses API requests.
+func ResolveKimiResponsesURL(auth *cliproxyauth.Auth) string {
+	if auth != nil && auth.Attributes != nil {
+		if raw := strings.TrimRight(strings.TrimSpace(auth.Attributes["base_url"]), "/"); raw != "" {
+			if strings.HasSuffix(raw, "/v1") {
+				return raw + "/responses"
+			}
+			return raw + "/v1/responses"
+		}
+	}
+	return kimiauth.KimiAPIBaseURL + "/v1/responses"
+}

--- a/internal/runtime/executor/helps/kimi_responses_test.go
+++ b/internal/runtime/executor/helps/kimi_responses_test.go
@@ -1,0 +1,56 @@
+package helps
+
+import (
+	"testing"
+
+	kimiauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/kimi"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestResolveKimiResponsesURL(t *testing.T) {
+	tests := []struct {
+		name string
+		auth *cliproxyauth.Auth
+		want string
+	}{
+		{
+			name: "nil auth",
+			auth: nil,
+			want: kimiauth.KimiAPIBaseURL + "/v1/responses",
+		},
+		{
+			name: "empty attributes",
+			auth: &cliproxyauth.Auth{Attributes: map[string]string{}},
+			want: kimiauth.KimiAPIBaseURL + "/v1/responses",
+		},
+		{
+			name: "base_url without v1",
+			auth: &cliproxyauth.Auth{Attributes: map[string]string{"base_url": "https://api.kimi.com/coding"}},
+			want: "https://api.kimi.com/coding/v1/responses",
+		},
+		{
+			name: "base_url with trailing slash",
+			auth: &cliproxyauth.Auth{Attributes: map[string]string{"base_url": "https://api.kimi.com/coding/"}},
+			want: "https://api.kimi.com/coding/v1/responses",
+		},
+		{
+			name: "base_url with v1",
+			auth: &cliproxyauth.Auth{Attributes: map[string]string{"base_url": "https://api.kimi.com/coding/v1"}},
+			want: "https://api.kimi.com/coding/v1/responses",
+		},
+		{
+			name: "base_url with v1 and trailing slash",
+			auth: &cliproxyauth.Auth{Attributes: map[string]string{"base_url": "https://api.kimi.com/coding/v1/"}},
+			want: "https://api.kimi.com/coding/v1/responses",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveKimiResponsesURL(tt.auth)
+			if got != tt.want {
+				t.Fatalf("ResolveKimiResponsesURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -137,6 +137,9 @@ func isHierarchyParent(primary, parent string) bool {
 	if idx1 > 0 && idx2 > 0 && primary[:idx1] == parent[:idx2] {
 		return true
 	}
+	if idx1 == -1 && idx2 == -1 {
+		return true
+	}
 	return false
 }
 

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -695,6 +695,16 @@ func (b *StreamUsageBuffer) ObserveOpenAIStream(line []byte) {
 	b.Observe(detail, usageOK || detail.ResponseServiceTier != "")
 }
 
+// ObserveClaudeStream records and merges usage from a Claude SSE line.
+func (b *StreamUsageBuffer) ObserveClaudeStream(line []byte) {
+	if b == nil {
+		return
+	}
+	if detail, ok := ParseClaudeStreamUsage(line); ok {
+		ObserveMergedStreamUsage(b, detail)
+	}
+}
+
 // Publish emits the latest observed usage detail, if any.
 func (b *StreamUsageBuffer) Publish(ctx context.Context, reporter *UsageReporter) bool {
 	if b == nil || !b.ok || reporter == nil {
@@ -886,6 +896,9 @@ func ParseClaudeStreamUsage(line []byte) (usage.Detail, bool) {
 		return usage.Detail{}, false
 	}
 	usageNode := gjson.GetBytes(payload, "usage")
+	if !usageNode.Exists() {
+		usageNode = gjson.GetBytes(payload, "message.usage")
+	}
 	if !usageNode.Exists() {
 		return usage.Detail{}, false
 	}

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -375,6 +375,26 @@ func TestParseClaudeStreamUsagePreservesThinkingTokensAsReasoningSubset(t *testi
 	}
 }
 
+func TestParseClaudeStreamUsage_MessageStart(t *testing.T) {
+	line := []byte(`data: {"type":"message_start","message":{"id":"msg_123","type":"message","role":"assistant","content":[],"model":"claude-opus-5","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":2095,"cache_creation_input_tokens":7185,"cache_read_input_tokens":355598,"output_tokens":1}}}`)
+	detail, ok := ParseClaudeStreamUsage(line)
+	if !ok {
+		t.Fatal("expected stream usage to parse from message_start")
+	}
+	if detail.InputTokens != 2095 {
+		t.Errorf("input tokens = %d, want 2095", detail.InputTokens)
+	}
+	if detail.CacheReadTokens != 355598 {
+		t.Errorf("cache read tokens = %d, want 355598", detail.CacheReadTokens)
+	}
+	if detail.CacheCreationTokens != 7185 {
+		t.Errorf("cache creation tokens = %d, want 7185", detail.CacheCreationTokens)
+	}
+	if detail.CachedTokens != 355598 {
+		t.Errorf("cached tokens = %d, want 355598", detail.CachedTokens)
+	}
+}
+
 func TestParseClaudeUsageFallsBackToTopLevelThinkingTokens(t *testing.T) {
 	data := []byte(`{"usage":{"input_tokens":3,"output_tokens":10,"thinking_tokens":4}}`)
 	detail := ParseClaudeUsage(data)
@@ -944,6 +964,71 @@ func TestStreamUsageBufferPublishFailure(t *testing.T) {
 	}
 	if record.Detail.TotalTokens != 15 {
 		t.Fatalf("Detail.TotalTokens = %d, want 15", record.Detail.TotalTokens)
+	}
+}
+
+func TestStreamUsageBufferObserveClaudeStream_MergesStartAndDelta(t *testing.T) {
+	var buffer StreamUsageBuffer
+
+	lineStart := []byte(`data: {"type":"message_start","message":{"id":"msg_123","model":"claude-opus-5","usage":{"input_tokens":2095,"cache_creation_input_tokens":7185,"cache_read_input_tokens":355598,"output_tokens":1}}}`)
+	buffer.ObserveClaudeStream(lineStart)
+
+	lineDelta := []byte(`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":15}}`)
+	buffer.ObserveClaudeStream(lineDelta)
+
+	detail, ok := buffer.Detail()
+	if !ok {
+		t.Fatal("expected buffer to contain usage detail")
+	}
+	if detail.InputTokens != 2095 {
+		t.Errorf("InputTokens = %d, want 2095", detail.InputTokens)
+	}
+	if detail.OutputTokens != 15 {
+		t.Errorf("OutputTokens = %d, want 15", detail.OutputTokens)
+	}
+	if detail.CacheReadTokens != 355598 {
+		t.Errorf("CacheReadTokens = %d, want 355598", detail.CacheReadTokens)
+	}
+	if detail.CacheCreationTokens != 7185 {
+		t.Errorf("CacheCreationTokens = %d, want 7185", detail.CacheCreationTokens)
+	}
+	if detail.CachedTokens != 355598 {
+		t.Errorf("CachedTokens = %d, want 355598", detail.CachedTokens)
+	}
+	wantTotal := int64(2095 + 15 + 355598 + 7185)
+	if detail.TotalTokens != wantTotal {
+		t.Errorf("TotalTokens = %d, want %d", detail.TotalTokens, wantTotal)
+	}
+}
+
+func TestStreamUsageBufferObserveClaudeStream_FailurePreservesUsage(t *testing.T) {
+	var buffer StreamUsageBuffer
+
+	lineStart := []byte(`data: {"type":"message_start","message":{"id":"msg_123","model":"claude-opus-5","usage":{"input_tokens":2095,"cache_creation_input_tokens":7185,"cache_read_input_tokens":355598,"output_tokens":1}}}`)
+	buffer.ObserveClaudeStream(lineStart)
+
+	reporter := &UsageReporter{
+		provider: "claude",
+		model:    "claude-opus-5",
+	}
+
+	record := reporter.buildRecord(buffer.detail, true, failFromErrors(context.Canceled))
+	if !record.Failed {
+		t.Fatal("expected record to be marked failed")
+	}
+	if record.Detail.InputTokens != 2095 {
+		t.Errorf("InputTokens = %d, want 2095", record.Detail.InputTokens)
+	}
+	if record.Detail.CacheReadTokens != 355598 {
+		t.Errorf("CacheReadTokens = %d, want 355598", record.Detail.CacheReadTokens)
+	}
+	if record.Detail.CacheCreationTokens != 7185 {
+		t.Errorf("CacheCreationTokens = %d, want 7185", record.Detail.CacheCreationTokens)
+	}
+
+	// Verify buffer.PublishFailure succeeds with the accumulated usage detail
+	if !buffer.PublishFailure(context.Background(), reporter, context.Canceled) {
+		t.Fatal("expected PublishFailure to return true")
 	}
 }
 

--- a/internal/runtime/executor/kimi_executor.go
+++ b/internal/runtime/executor/kimi_executor.go
@@ -55,6 +55,9 @@ func (e *KimiExecutor) RequestToFormat(_ cliproxyexecutor.Request, opts cliproxy
 	if opts.SourceFormat == sdktranslator.FormatClaude {
 		return sdktranslator.FormatClaude
 	}
+	if opts.SourceFormat == sdktranslator.FormatOpenAIResponse {
+		return sdktranslator.FormatOpenAIResponse
+	}
 	return sdktranslator.FormatOpenAI
 }
 
@@ -106,6 +109,9 @@ func (e *KimiExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, req
 		}
 		cacheKimiThinkingReplayResponse(ctx, replayScope, claudeResp.Payload)
 		return claudeResp, nil
+	}
+	if from == sdktranslator.FormatOpenAIResponse {
+		return e.executeResponses(ctx, auth, req, opts)
 	}
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 
@@ -228,6 +234,9 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 			return nil, errExecute
 		}
 		return wrapKimiThinkingReplayStream(ctx, claudeResult, replayScope), nil
+	}
+	if from == sdktranslator.FormatOpenAIResponse {
+		return e.executeResponsesStream(ctx, auth, req, opts)
 	}
 	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
 
@@ -363,6 +372,266 @@ func (e *KimiExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Aut
 			}
 		}
 	}()
+	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
+}
+
+func (e *KimiExecutor) executeResponses(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (resp cliproxyexecutor.Response, err error) {
+	if opts.Alt == "responses/compact" {
+		return resp, statusErr{code: http.StatusNotImplemented, msg: "/responses/compact not supported"}
+	}
+
+	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	token := kimiCreds(auth)
+
+	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
+	defer reporter.TrackFailure(ctx, &err)
+
+	body := bytes.Clone(req.Payload)
+	upstreamModel := normalizeKimiUpstreamModel(baseModel)
+	var errSet error
+	body, errSet = sjson.SetBytes(body, "model", upstreamModel)
+	if errSet != nil {
+		return resp, fmt.Errorf("kimi executor: failed to set model in payload: %w", errSet)
+	}
+
+	body = helps.SetBoolIfDifferent(body, "stream", false)
+
+	var errThinking error
+	body, errThinking = helps.ApplyRequestThinking(body, req, opts, opts.SourceFormat.String(), sdktranslator.FormatCodex.String(), e.Identifier())
+	if errThinking != nil {
+		return resp, errThinking
+	}
+
+	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
+	requestPath := helps.PayloadRequestPath(opts)
+	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, "openai-response", opts.SourceFormat.String(), "", body, req.Payload, requestedModel, requestPath, opts.Headers)
+	body = normalizeKimiTools(body)
+	reporter.SetTranslatedReasoningEffort(body, e.Identifier())
+
+	url := helps.ResolveKimiResponsesURL(auth)
+	httpReq, errNewRequest := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if errNewRequest != nil {
+		return resp, errNewRequest
+	}
+	applyKimiHeadersWithAuth(httpReq, token, false, auth)
+	var attrs map[string]string
+	if auth != nil {
+		attrs = auth.Attributes
+	}
+	util.ApplyCustomHeadersFromAttrs(httpReq, attrs)
+
+	var authID, authLabel, authType, authValue string
+	if auth != nil {
+		authID = auth.ID
+		authLabel = auth.Label
+		authType, authValue = auth.AccountInfo()
+	}
+	helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+		URL:       url,
+		Method:    http.MethodPost,
+		Headers:   httpReq.Header.Clone(),
+		Body:      body,
+		Provider:  e.Identifier(),
+		AuthID:    authID,
+		AuthLabel: authLabel,
+		AuthType:  authType,
+		AuthValue: authValue,
+	})
+
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpClient = reporter.TrackHTTPClient(httpClient)
+	httpResp, errDo := httpClient.Do(httpReq)
+	if errDo != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, errDo)
+		return resp, errDo
+	}
+	defer func() {
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("kimi executor: close response body error: %v", errClose)
+		}
+	}()
+
+	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		b, _ := io.ReadAll(httpResp.Body)
+		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
+		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		return resp, err
+	}
+
+	data, errRead := io.ReadAll(httpResp.Body)
+	if errRead != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, errRead)
+		return resp, errRead
+	}
+	helps.AppendAPIResponseChunk(ctx, e.cfg, data)
+
+	if usage, ok := helps.ParseCodexUsage(data); ok && (usage.TotalTokens > 0 || usage.InputTokens > 0) {
+		reporter.Publish(ctx, usage)
+	} else if usage := helps.ParseOpenAIUsage(data); usage.TotalTokens > 0 || usage.InputTokens > 0 {
+		reporter.Publish(ctx, usage)
+	}
+
+	out := data
+	if responseFormat != sdktranslator.FormatOpenAIResponse {
+		var param any
+		out = sdktranslator.TranslateNonStream(ctx, sdktranslator.FormatOpenAIResponse, responseFormat, req.Model, opts.OriginalRequest, body, data, &param)
+	}
+	resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
+	return resp, nil
+}
+
+func (e *KimiExecutor) executeResponsesStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
+	if opts.Alt == "responses/compact" {
+		return nil, statusErr{code: http.StatusBadRequest, msg: "streaming not supported for /responses/compact"}
+	}
+
+	responseFormat := cliproxyexecutor.ResponseFormatOrSource(opts)
+	baseModel := thinking.ParseSuffix(req.Model).ModelName
+	token := kimiCreds(auth)
+
+	reporter := helps.NewExecutorUsageReporter(ctx, e, baseModel, auth)
+	defer reporter.TrackFailure(ctx, &err)
+
+	body := bytes.Clone(req.Payload)
+	upstreamModel := normalizeKimiUpstreamModel(baseModel)
+	var errSet error
+	body, errSet = sjson.SetBytes(body, "model", upstreamModel)
+	if errSet != nil {
+		return nil, fmt.Errorf("kimi executor: failed to set model in payload: %w", errSet)
+	}
+
+	body = helps.SetBoolIfDifferent(body, "stream", true)
+
+	var errThinking error
+	body, errThinking = helps.ApplyRequestThinking(body, req, opts, opts.SourceFormat.String(), sdktranslator.FormatCodex.String(), e.Identifier())
+	if errThinking != nil {
+		return nil, errThinking
+	}
+
+	requestedModel := helps.PayloadRequestedModel(opts, req.Model)
+	requestPath := helps.PayloadRequestPath(opts)
+	body = helps.ApplyPayloadConfigWithRequest(e.cfg, baseModel, "openai-response", opts.SourceFormat.String(), "", body, req.Payload, requestedModel, requestPath, opts.Headers)
+	body = normalizeKimiTools(body)
+	reporter.SetTranslatedReasoningEffort(body, e.Identifier())
+
+	url := helps.ResolveKimiResponsesURL(auth)
+	httpReq, errNewRequest := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if errNewRequest != nil {
+		return nil, errNewRequest
+	}
+	applyKimiHeadersWithAuth(httpReq, token, true, auth)
+	var attrs map[string]string
+	if auth != nil {
+		attrs = auth.Attributes
+	}
+	util.ApplyCustomHeadersFromAttrs(httpReq, attrs)
+
+	var authID, authLabel, authType, authValue string
+	if auth != nil {
+		authID = auth.ID
+		authLabel = auth.Label
+		authType, authValue = auth.AccountInfo()
+	}
+	helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+		URL:       url,
+		Method:    http.MethodPost,
+		Headers:   httpReq.Header.Clone(),
+		Body:      body,
+		Provider:  e.Identifier(),
+		AuthID:    authID,
+		AuthLabel: authLabel,
+		AuthType:  authType,
+		AuthValue: authValue,
+	})
+
+	httpClient := helps.NewProxyAwareHTTPClient(ctx, e.cfg, auth, 0)
+	httpClient = reporter.TrackHTTPClient(httpClient)
+	httpResp, errDo := httpClient.Do(httpReq)
+	if errDo != nil {
+		helps.RecordAPIResponseError(ctx, e.cfg, errDo)
+		return nil, errDo
+	}
+
+	helps.RecordAPIResponseMetadata(ctx, e.cfg, httpResp.StatusCode, httpResp.Header.Clone())
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		b, _ := io.ReadAll(httpResp.Body)
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("kimi executor: close response body error: %v", errClose)
+		}
+		helps.AppendAPIResponseChunk(ctx, e.cfg, b)
+		helps.LogWithRequestID(ctx).Debugf("request error, error status: %d, error message: %s", httpResp.StatusCode, helps.SummarizeErrorBody(httpResp.Header.Get("Content-Type"), b))
+		err = statusErr{code: httpResp.StatusCode, msg: string(b)}
+		return nil, err
+	}
+
+	out := make(chan cliproxyexecutor.StreamChunk)
+	go func() {
+		defer close(out)
+		defer func() {
+			if errClose := httpResp.Body.Close(); errClose != nil {
+				log.Errorf("kimi executor: close response body error: %v", errClose)
+			}
+		}()
+
+		scanner := bufio.NewScanner(httpResp.Body)
+		scanner.Buffer(nil, 52_428_800)
+		var param any
+
+		emitTranslatedLine := func(line []byte) bool {
+			if responseFormat == sdktranslator.FormatOpenAIResponse {
+				chunkPayload := append(bytes.Clone(line), '\n')
+				select {
+				case out <- cliproxyexecutor.StreamChunk{Payload: chunkPayload}:
+					return true
+				case <-ctx.Done():
+					return false
+				}
+			}
+			chunks := sdktranslator.TranslateStream(ctx, sdktranslator.FormatOpenAIResponse, responseFormat, req.Model, opts.OriginalRequest, body, line, &param)
+			for i := range chunks {
+				select {
+				case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}:
+				case <-ctx.Done():
+					return false
+				}
+			}
+			return true
+		}
+
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
+
+			if bytes.HasPrefix(line, dataTag) {
+				dataBytes := bytes.TrimSpace(line[len(dataTag):])
+				eventType := gjson.GetBytes(dataBytes, "type").String()
+				if eventType == "response.completed" || eventType == "response.incomplete" || eventType == "response.done" {
+					if usage, ok := helps.ParseCodexUsage(dataBytes); ok && (usage.TotalTokens > 0 || usage.InputTokens > 0) {
+						reporter.Publish(ctx, usage)
+					} else if usage := helps.ParseOpenAIUsage(dataBytes); usage.TotalTokens > 0 || usage.InputTokens > 0 {
+						reporter.Publish(ctx, usage)
+					}
+				}
+			}
+
+			if !emitTranslatedLine(line) {
+				return
+			}
+		}
+
+		if errScan := scanner.Err(); errScan != nil {
+			helps.RecordAPIResponseError(ctx, e.cfg, errScan)
+			reporter.PublishFailure(ctx, errScan)
+			select {
+			case out <- cliproxyexecutor.StreamChunk{Err: errScan}:
+			case <-ctx.Done():
+			}
+		}
+	}()
+
 	return &cliproxyexecutor.StreamResult{Headers: httpResp.Header.Clone(), Chunks: out}, nil
 }
 

--- a/internal/runtime/executor/kimi_executor_test.go
+++ b/internal/runtime/executor/kimi_executor_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -49,6 +50,8 @@ func TestKimiExecutorRequestToFormatMatchesWireProtocol(t *testing.T) {
 		{name: "Claude streaming", stream: true, source: sdktranslator.FormatClaude, want: sdktranslator.FormatClaude},
 		{name: "OpenAI non-streaming", source: sdktranslator.FormatOpenAI, want: sdktranslator.FormatOpenAI},
 		{name: "OpenAI streaming", stream: true, source: sdktranslator.FormatOpenAI, want: sdktranslator.FormatOpenAI},
+		{name: "OpenAI Responses non-streaming", source: sdktranslator.FormatOpenAIResponse, want: sdktranslator.FormatOpenAIResponse},
+		{name: "OpenAI Responses streaming", stream: true, source: sdktranslator.FormatOpenAIResponse, want: sdktranslator.FormatOpenAIResponse},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -60,6 +63,300 @@ func TestKimiExecutorRequestToFormatMatchesWireProtocol(t *testing.T) {
 				t.Fatalf("RequestToFormat() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestKimiExecutorResponsesPassthrough(t *testing.T) {
+	var upstreamURL string
+	var upstreamBody []byte
+	var authHeader string
+
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", kimiRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		upstreamURL = req.URL.String()
+		authHeader = req.Header.Get("Authorization")
+		var errRead error
+		upstreamBody, errRead = io.ReadAll(req.Body)
+		if errRead != nil {
+			return nil, errRead
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(
+				`{"id":"resp_123","object":"response","status":"completed","model":"k3","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello world"}]}],"usage":{"total_tokens":10,"input_tokens":6,"output_tokens":4}}`,
+			)),
+		}, nil
+	}))
+
+	executor := NewKimiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{},
+		Metadata:   map[string]any{"access_token": "test-kimi-key"},
+	}
+
+	payload := []byte(`{
+		"model":"kimi-k3",
+		"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}]
+	}`)
+
+	resp, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "kimi-k3",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if upstreamURL != "https://api.kimi.com/coding/v1/responses" {
+		t.Fatalf("upstreamURL = %q, want %q", upstreamURL, "https://api.kimi.com/coding/v1/responses")
+	}
+	if authHeader != "Bearer test-kimi-key" {
+		t.Fatalf("Authorization = %q, want Bearer test-kimi-key", authHeader)
+	}
+	if gotModel := gjson.GetBytes(upstreamBody, "model").String(); gotModel != "k3" {
+		t.Fatalf("upstreamBody model = %q, want k3", gotModel)
+	}
+	if gotText := gjson.GetBytes(resp.Payload, "output.0.content.0.text").String(); gotText != "hello world" {
+		t.Fatalf("response output text = %q, want hello world", gotText)
+	}
+}
+
+func TestKimiExecutorResponsesStreamPassthrough(t *testing.T) {
+	var upstreamURL string
+	var upstreamBody []byte
+	var streamHeader string
+
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", kimiRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		upstreamURL = req.URL.String()
+		streamHeader = req.Header.Get("Accept")
+		var errRead error
+		upstreamBody, errRead = io.ReadAll(req.Body)
+		if errRead != nil {
+			return nil, errRead
+		}
+		sseData := "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_stream\",\"status\":\"in_progress\",\"service_tier\":\"default\",\"model\":\"k3\"}}\n\n" +
+			"event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[]}}\n\n" +
+			"event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"output_index\":0,\"content_index\":0,\"delta\":\"hello stream\"}\n\n" +
+			"event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_stream\",\"status\":\"completed\",\"usage\":{\"total_tokens\":12,\"input_tokens\":5,\"output_tokens\":7}}}\n\n"
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       io.NopCloser(strings.NewReader(sseData)),
+		}, nil
+	}))
+
+	executor := NewKimiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{},
+		Metadata:   map[string]any{"access_token": "test-kimi-key"},
+	}
+
+	payload := []byte(`{
+		"model":"kimi-k3",
+		"stream":true,
+		"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}]
+	}`)
+
+	result, err := executor.ExecuteStream(ctx, auth, cliproxyexecutor.Request{
+		Model:   "kimi-k3",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+
+	if upstreamURL != "https://api.kimi.com/coding/v1/responses" {
+		t.Fatalf("upstreamURL = %q, want %q", upstreamURL, "https://api.kimi.com/coding/v1/responses")
+	}
+	if streamHeader != "text/event-stream" {
+		t.Fatalf("Accept header = %q, want text/event-stream", streamHeader)
+	}
+	if gotModel := gjson.GetBytes(upstreamBody, "model").String(); gotModel != "k3" {
+		t.Fatalf("upstreamBody model = %q, want k3", gotModel)
+	}
+
+	var chunks []string
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error = %v", chunk.Err)
+		}
+		chunks = append(chunks, string(chunk.Payload))
+	}
+	combined := strings.Join(chunks, "")
+	if !strings.Contains(combined, "event: response.created") {
+		t.Fatalf("stream chunks missing response.created: %s", combined)
+	}
+	if !strings.Contains(combined, "event: response.completed") {
+		t.Fatalf("stream chunks missing response.completed: %s", combined)
+	}
+	if !strings.Contains(combined, "hello stream") {
+		t.Fatalf("stream chunks missing expected text: %s", combined)
+	}
+}
+
+func TestKimiExecutorResponsesCompactReturnsNotImplemented(t *testing.T) {
+	executor := NewKimiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{},
+		Metadata:   map[string]any{"access_token": "test-kimi-key"},
+	}
+	payload := []byte(`{"model":"kimi-k3","input":[]}`)
+
+	_, errExecute := executor.Execute(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "kimi-k3",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Alt:          "responses/compact",
+	})
+	if errExecute == nil {
+		t.Fatal("Execute(compact) expected error, got nil")
+	}
+	var statusCoder interface{ StatusCode() int }
+	if !errors.As(errExecute, &statusCoder) || statusCoder.StatusCode() != http.StatusNotImplemented {
+		t.Fatalf("Execute(compact) status = %v, want 501", errExecute)
+	}
+
+	_, errStream := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "kimi-k3",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Alt:          "responses/compact",
+	})
+	if errStream == nil {
+		t.Fatal("ExecuteStream(compact) expected error, got nil")
+	}
+	if !errors.As(errStream, &statusCoder) || statusCoder.StatusCode() != http.StatusBadRequest {
+		t.Fatalf("ExecuteStream(compact) status = %v, want 400", errStream)
+	}
+}
+
+func TestKimiExecutorResponsesAppliesSuffixThinking(t *testing.T) {
+	var upstreamBody []byte
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", kimiRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		var errRead error
+		upstreamBody, errRead = io.ReadAll(req.Body)
+		if errRead != nil {
+			return nil, errRead
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(
+				`{"id":"resp_think","object":"response","status":"completed","model":"k3","output":[],"usage":{"total_tokens":2}}`,
+			)),
+		}, nil
+	}))
+
+	executor := NewKimiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{},
+		Metadata:   map[string]any{"access_token": "test-kimi-key"},
+	}
+
+	payload := []byte(`{"model":"kimi-k3","input":[{"type":"message","role":"user","content":"hello"}]}`)
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "kimi-k3(high)",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if gotModel := gjson.GetBytes(upstreamBody, "model").String(); gotModel != "k3" {
+		t.Fatalf("upstream model = %q, want k3", gotModel)
+	}
+	if gotEffort := gjson.GetBytes(upstreamBody, "reasoning.effort").String(); gotEffort != "high" {
+		t.Fatalf("upstream reasoning.effort = %q, want high; body=%s", gotEffort, upstreamBody)
+	}
+}
+
+func TestKimiExecutorResponsesSuffixOverridesBodyThinking(t *testing.T) {
+	var upstreamBody []byte
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", kimiRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		var errRead error
+		upstreamBody, errRead = io.ReadAll(req.Body)
+		if errRead != nil {
+			return nil, errRead
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(
+				`{"id":"resp_think","object":"response","status":"completed","model":"k3","output":[],"usage":{"total_tokens":2}}`,
+			)),
+		}, nil
+	}))
+
+	executor := NewKimiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{},
+		Metadata:   map[string]any{"access_token": "test-kimi-key"},
+	}
+
+	payload := []byte(`{"model":"kimi-k3","reasoning":{"effort":"low"},"input":[{"type":"message","role":"user","content":"hello"}]}`)
+	_, err := executor.Execute(ctx, auth, cliproxyexecutor.Request{
+		Model:   "kimi-k3(max)",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if gotEffort := gjson.GetBytes(upstreamBody, "reasoning.effort").String(); gotEffort != "max" {
+		t.Fatalf("upstream reasoning.effort = %q, want max (suffix overrides body); body=%s", gotEffort, upstreamBody)
+	}
+}
+
+func TestKimiExecutorResponsesStreamAppliesSuffixThinking(t *testing.T) {
+	var upstreamBody []byte
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", kimiRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		var errRead error
+		upstreamBody, errRead = io.ReadAll(req.Body)
+		if errRead != nil {
+			return nil, errRead
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body: io.NopCloser(strings.NewReader(
+				"event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"status\":\"completed\",\"usage\":{\"total_tokens\":2}}}\n\n",
+			)),
+		}, nil
+	}))
+
+	executor := NewKimiExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{
+		Attributes: map[string]string{},
+		Metadata:   map[string]any{"access_token": "test-kimi-key"},
+	}
+
+	payload := []byte(`{"model":"kimi-k3","stream":true,"input":[{"type":"message","role":"user","content":"hello"}]}`)
+	result, err := executor.ExecuteStream(ctx, auth, cliproxyexecutor.Request{
+		Model:   "kimi-k3(low)",
+		Payload: payload,
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FormatOpenAIResponse,
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream() error = %v", err)
+	}
+	for range result.Chunks {
+	}
+
+	if gotEffort := gjson.GetBytes(upstreamBody, "reasoning.effort").String(); gotEffort != "low" {
+		t.Fatalf("upstream reasoning.effort = %q, want low; body=%s", gotEffort, upstreamBody)
 	}
 }
 
@@ -120,7 +417,7 @@ func TestKimiExecutorPreservesAssistantContentAndToolCallsFromResponsesHistory(t
 			StatusCode: http.StatusOK,
 			Header:     http.Header{"Content-Type": []string{"application/json"}},
 			Body: io.NopCloser(strings.NewReader(
-				`{"id":"chatcmpl_test","object":"chat.completion","created":1,"model":"k3","choices":[{"index":0,"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+				`{"id":"resp_test","object":"response","status":"completed","model":"k3","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}],"usage":{"total_tokens":2,"input_tokens":1,"output_tokens":1}}`,
 			)),
 		}, nil
 	}))
@@ -151,22 +448,22 @@ func TestKimiExecutorPreservesAssistantContentAndToolCallsFromResponsesHistory(t
 		t.Fatalf("Execute() error = %v", err)
 	}
 
-	messages := gjson.GetBytes(upstreamBody, "messages").Array()
-	if got := len(messages); got != 2 {
-		t.Fatalf("upstream messages count = %d, want 2; body=%s", got, upstreamBody)
+	input := gjson.GetBytes(upstreamBody, "input").Array()
+	if got := len(input); got != 4 {
+		t.Fatalf("upstream input count = %d, want 4; body=%s", got, upstreamBody)
 	}
-	assistant := messages[0]
+	assistant := input[1]
 	if got := assistant.Get("content.0.text").String(); got != "Step 3 completed; continue to step 4." {
 		t.Fatalf("assistant content = %q, want preserved text; body=%s", got, upstreamBody)
 	}
-	if got := assistant.Get("reasoning_content").String(); got != "inspect the next step" {
-		t.Fatalf("assistant reasoning_content = %q, want inspect the next step; body=%s", got, upstreamBody)
+	if got := input[0].Get("summary.0.text").String(); got != "inspect the next step" {
+		t.Fatalf("reasoning summary text = %q, want inspect the next step; body=%s", got, upstreamBody)
 	}
-	if got := assistant.Get("tool_calls.0.id").String(); got != "call_4" {
-		t.Fatalf("assistant tool call ID = %q, want call_4; body=%s", got, upstreamBody)
+	if got := input[2].Get("call_id").String(); got != "call_4" {
+		t.Fatalf("function call ID = %q, want call_4; body=%s", got, upstreamBody)
 	}
-	if got := messages[1].Get("tool_call_id").String(); got != "call_4" {
-		t.Fatalf("tool output call ID = %q, want call_4; body=%s", got, upstreamBody)
+	if got := input[3].Get("call_id").String(); got != "call_4" {
+		t.Fatalf("function output call ID = %q, want call_4; body=%s", got, upstreamBody)
 	}
 }
 
@@ -805,8 +1102,7 @@ func TestKimiExecutorStreamNormalizesToolSchemasFromResponses(t *testing.T) {
 			StatusCode: http.StatusOK,
 			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
 			Body: io.NopCloser(strings.NewReader(
-				"data: {\"id\":\"chatcmpl_1\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"k3\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\n" +
-					"data: [DONE]\n\n",
+				"event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"object\":\"response\",\"status\":\"completed\",\"usage\":{\"total_tokens\":2}}}\n\n",
 			)),
 		}, nil
 	}))
@@ -859,9 +1155,9 @@ func TestKimiExecutorStreamNormalizesToolSchemasFromResponses(t *testing.T) {
 		}
 	}
 
-	tool := gjson.GetBytes(upstreamBody, "tools.0.function")
+	tool := gjson.GetBytes(upstreamBody, "tools.0")
 	if !tool.Exists() {
-		t.Fatalf("upstream tool function not found in stream body: %s", upstreamBody)
+		t.Fatalf("upstream tool not found in stream body: %s", upstreamBody)
 	}
 	if ref := tool.Get("parameters.properties.field.$ref"); ref.Exists() {
 		t.Fatalf("upstream stream tool parameter still contains $ref: %s", tool.Get("parameters").Raw)

--- a/internal/thinking/apply.go
+++ b/internal/thinking/apply.go
@@ -195,7 +195,7 @@ func ApplyThinkingWithModelInfoAndSummary(body, sourceBody []byte, model string,
 
 func applyThinking(body, sourceBody []byte, model string, fromFormat string, toFormat string, providerKey string, resolvedModelInfo *registry.ModelInfo, modelInfoResolved bool, summaryConfig SummaryConfig) ([]byte, error) {
 	providerFormat := strings.ToLower(strings.TrimSpace(toFormat))
-	if modelInfoResolved && providerFormat == "openai-response" {
+	if providerFormat == "openai-response" {
 		providerFormat = "codex"
 	}
 	providerKey = strings.ToLower(strings.TrimSpace(providerKey))

--- a/internal/translator/antigravity/gemini/antigravity_gemini_request.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request.go
@@ -58,6 +58,8 @@ func ConvertGeminiRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 		rawJSON, _ = sjson.DeleteBytes(rawJSON, "request.system_instruction")
 	}
 
+	rawJSON = normalizeGeminiGenerationConfigResponseSchema(rawJSON)
+
 	// Normalize roles in request.contents: default to valid values if missing/invalid.
 	// The contents array is only materialized when a role actually changes; copying
 	// every content up front duplicates the whole payload for large inline data.
@@ -154,6 +156,27 @@ func ConvertGeminiRequestToAntigravity(modelName string, inputRawJSON []byte, _ 
 	}
 
 	return common.AttachDefaultSafetySettings(rawJSON, "request.safetySettings")
+}
+
+// normalizeGeminiGenerationConfigResponseSchema converts generationConfig.responseJsonSchema
+// (and snake_case response_json_schema) to generationConfig.responseSchema for Antigravity compatibility.
+func normalizeGeminiGenerationConfigResponseSchema(rawJSON []byte) []byte {
+	for _, container := range []string{"request.generationConfig", "request.generation_config"} {
+		if !util.GetGJSONBytesNoCopy(rawJSON, container).Exists() {
+			continue
+		}
+		for _, schemaKey := range []string{"responseJsonSchema", "response_json_schema"} {
+			oldPath := container + "." + schemaKey
+			if schema := util.GetGJSONBytesNoCopy(rawJSON, oldPath); schema.Exists() {
+				targetPath := container + ".responseSchema"
+				if !util.GetGJSONBytesNoCopy(rawJSON, targetPath).Exists() {
+					rawJSON, _ = sjson.SetRawBytes(rawJSON, targetPath, []byte(schema.Raw))
+				}
+				rawJSON, _ = sjson.DeleteBytes(rawJSON, oldPath)
+			}
+		}
+	}
+	return rawJSON
 }
 
 // geminiContentRolesNeedNormalization reports whether any content role is missing

--- a/internal/translator/antigravity/gemini/antigravity_gemini_request_test.go
+++ b/internal/translator/antigravity/gemini/antigravity_gemini_request_test.go
@@ -1177,3 +1177,92 @@ func TestNormalizeRoles_InvalidRoleWithFunctionResponseNormalizesToUser(t *testi
 		}
 	}
 }
+
+func TestConvertGeminiRequestToAntigravity_TranslatesResponseJsonSchemaToResponseSchema(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputJSON string
+	}{
+		{
+			name: "camelCase responseJsonSchema",
+			inputJSON: `{
+				"contents": [{"role": "user", "parts": [{"text": "hello"}]}],
+				"generationConfig": {
+					"responseMimeType": "application/json",
+					"responseJsonSchema": {
+						"type": "OBJECT",
+						"properties": {"message": {"type": "STRING"}},
+						"required": ["message"]
+					}
+				}
+			}`,
+		},
+		{
+			name: "snake_case response_json_schema",
+			inputJSON: `{
+				"contents": [{"role": "user", "parts": [{"text": "hello"}]}],
+				"generationConfig": {
+					"responseMimeType": "application/json",
+					"response_json_schema": {
+						"type": "OBJECT",
+						"properties": {"message": {"type": "STRING"}},
+						"required": ["message"]
+					}
+				}
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := ConvertGeminiRequestToAntigravity("gemini-3-flash", []byte(tt.inputJSON), false)
+
+			schema := gjson.GetBytes(out, "request.generationConfig.responseSchema")
+			if !schema.Exists() {
+				t.Fatalf("request.generationConfig.responseSchema missing. Output: %s", out)
+			}
+			if got := schema.Get("properties.message.type").String(); got != "STRING" {
+				t.Fatalf("responseSchema.properties.message.type = %q, want STRING. Output: %s", got, out)
+			}
+			if gjson.GetBytes(out, "request.generationConfig.responseJsonSchema").Exists() {
+				t.Fatalf("request.generationConfig.responseJsonSchema should have been removed. Output: %s", out)
+			}
+			if gjson.GetBytes(out, "request.generationConfig.response_json_schema").Exists() {
+				t.Fatalf("request.generationConfig.response_json_schema should have been removed. Output: %s", out)
+			}
+		})
+	}
+}
+
+func TestConvertGeminiRequestToAntigravity_PreservesExistingResponseSchema(t *testing.T) {
+	inputJSON := []byte(`{
+		"contents": [{"role": "user", "parts": [{"text": "hello"}]}],
+		"generationConfig": {
+			"responseMimeType": "application/json",
+			"responseSchema": {
+				"type": "OBJECT",
+				"properties": {"name": {"type": "STRING"}},
+				"required": ["name"]
+			},
+			"responseJsonSchema": {
+				"type": "OBJECT",
+				"properties": {"stale": {"type": "STRING"}}
+			}
+		}
+	}`)
+	out := ConvertGeminiRequestToAntigravity("gemini-3-flash", inputJSON, false)
+
+	schema := gjson.GetBytes(out, "request.generationConfig.responseSchema")
+	if !schema.Exists() {
+		t.Fatalf("request.generationConfig.responseSchema missing. Output: %s", out)
+	}
+	if got := schema.Get("properties.name.type").String(); got != "STRING" {
+		t.Fatalf("responseSchema.properties.name.type = %q, want STRING. Output: %s", got, out)
+	}
+	if schema.Get("properties.stale").Exists() {
+		t.Fatalf("stale properties survived. Output: %s", out)
+	}
+	if gjson.GetBytes(out, "request.generationConfig.responseJsonSchema").Exists() {
+		t.Fatalf("request.generationConfig.responseJsonSchema should have been removed. Output: %s", out)
+	}
+}

--- a/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request_test.go
+++ b/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request_test.go
@@ -574,3 +574,25 @@ func TestConvertOpenAIResponsesRequestToAntigravity_ReasoningSummaries(t *testin
 		})
 	}
 }
+
+func TestConvertOpenAIResponsesRequestToAntigravity_FunctionCallOutputAlternateIDs(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.7-flash-high",
+		"input": [
+			{"role":"user","content":"run command"},
+			{"type":"function_call","call_id":"call_bash_1","name":"Bash","arguments":"{\"command\":\"ls\"}"},
+			{"type":"function_call_output","id":"call_bash_1","output":"main.go"}
+		]
+	}`
+
+	out := ConvertOpenAIResponsesRequestToAntigravity("gemini-3.7-flash-high", []byte(inputJSON), false)
+	rawRequest := gjson.GetBytes(out, "request").Raw
+	if errPair := sigcompat.ValidateGeminiFunctionCallPairing([]byte(rawRequest)); errPair != nil {
+		t.Fatalf("ValidateGeminiFunctionCallPairing failed on Antigravity request: %v; output=%s", errPair, out)
+	}
+
+	responseID := gjson.GetBytes(out, "request.contents.2.parts.0.functionResponse.id").String()
+	if responseID != "call_bash_1" {
+		t.Fatalf("functionResponse.id = %q, want call_bash_1", responseID)
+	}
+}

--- a/internal/translator/claude/openai/chat-completions/claude_openai_response.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_response.go
@@ -22,10 +22,11 @@ var (
 
 // ConvertAnthropicResponseToOpenAIParams holds parameters for response conversion
 type ConvertAnthropicResponseToOpenAIParams struct {
-	CreatedAt    int64
-	ResponseID   string
-	FinishReason string
-	Usage        claudeUsageTokens
+	CreatedAt         int64
+	ResponseID        string
+	FinishReason      string
+	Usage             claudeUsageTokens
+	TrailingUsageSent bool
 	// Tool calls accumulator for streaming
 	ToolCallsAccumulator map[int]*ToolCallAccumulator
 	NextToolCallIndex    int
@@ -255,11 +256,34 @@ func ConvertClaudeResponseToOpenAI(_ context.Context, modelName string, original
 			template, _ = sjson.SetBytes(template, "usage.total_tokens", totalTokens)
 			template, _ = sjson.SetBytes(template, "usage.prompt_tokens_details.cached_tokens", cachedTokens)
 			template, _ = sjson.SetBytes(template, "usage.prompt_tokens_details.cached_creation_tokens", cachedCreationTokens)
+			template, _ = sjson.SetBytes(template, "usage.prompt_tokens_details.cache_write_tokens", cachedCreationTokens)
 		}
 		return [][]byte{template}
 
 	case "message_stop":
-		// Final message event - no additional output needed
+		// Final message event - emit standard OpenAI trailing usage chunk with empty choices array if usage was tracked.
+		p := (*param).(*ConvertAnthropicResponseToOpenAIParams)
+		if p.Usage.HasUsage && !p.TrailingUsageSent {
+			p.TrailingUsageSent = true
+			usageTemplate := []byte(`{"id":"","object":"chat.completion.chunk","created":0,"model":"","choices":[]}`)
+			if p.ResponseID != "" {
+				usageTemplate, _ = sjson.SetBytes(usageTemplate, "id", p.ResponseID)
+			}
+			if modelName != "" {
+				usageTemplate, _ = sjson.SetBytes(usageTemplate, "model", modelName)
+			}
+			if p.CreatedAt > 0 {
+				usageTemplate, _ = sjson.SetBytes(usageTemplate, "created", p.CreatedAt)
+			}
+			promptTokens, completionTokens, totalTokens, cachedTokens, cachedCreationTokens := p.Usage.OpenAIUsage()
+			usageTemplate, _ = sjson.SetBytes(usageTemplate, "usage.prompt_tokens", promptTokens)
+			usageTemplate, _ = sjson.SetBytes(usageTemplate, "usage.completion_tokens", completionTokens)
+			usageTemplate, _ = sjson.SetBytes(usageTemplate, "usage.total_tokens", totalTokens)
+			usageTemplate, _ = sjson.SetBytes(usageTemplate, "usage.prompt_tokens_details.cached_tokens", cachedTokens)
+			usageTemplate, _ = sjson.SetBytes(usageTemplate, "usage.prompt_tokens_details.cached_creation_tokens", cachedCreationTokens)
+			usageTemplate, _ = sjson.SetBytes(usageTemplate, "usage.prompt_tokens_details.cache_write_tokens", cachedCreationTokens)
+			return [][]byte{usageTemplate}
+		}
 		return [][]byte{}
 
 	case "ping":
@@ -422,6 +446,7 @@ func ConvertClaudeResponseToOpenAINonStream(_ context.Context, _ string, origina
 		out, _ = sjson.SetBytes(out, "usage.total_tokens", totalTokens)
 		out, _ = sjson.SetBytes(out, "usage.prompt_tokens_details.cached_tokens", cachedTokens)
 		out, _ = sjson.SetBytes(out, "usage.prompt_tokens_details.cached_creation_tokens", cachedCreationTokens)
+		out, _ = sjson.SetBytes(out, "usage.prompt_tokens_details.cache_write_tokens", cachedCreationTokens)
 	}
 
 	// Set basic response fields including message ID, creation time, and model

--- a/internal/translator/claude/openai/chat-completions/claude_openai_response_test.go
+++ b/internal/translator/claude/openai/chat-completions/claude_openai_response_test.go
@@ -1,6 +1,7 @@
 package chat_completions
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -438,5 +439,71 @@ func TestConvertClaudeResponseToOpenAI_StreamToolCallIndexIsZeroBased(t *testing
 	}
 	if streamedCalls[1].ID != "toolu_2" || streamedCalls[1].Name != "get_time" || streamedCalls[1].Arguments != `{"city":"Tokyo"}` {
 		t.Errorf("tool call toolu_2 payload mismatch: %+v", streamedCalls[1])
+	}
+}
+
+func TestConvertClaudeResponseToOpenAI_StreamEmitsTrailingUsageChunkWithCacheDetails(t *testing.T) {
+	ctx := context.Background()
+	var param any
+
+	events := [][]byte{
+		[]byte(`data: {"type":"message_start","message":{"id":"msg_123","model":"claude-opus-4-6","usage":{"input_tokens":100,"cache_creation_input_tokens":20,"cache_read_input_tokens":50,"output_tokens":1}}}`),
+		[]byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`),
+		[]byte(`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}`),
+		[]byte(`data: {"type":"content_block_stop","index":0}`),
+		[]byte(`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":15}}`),
+		[]byte(`data: {"type":"message_stop"}`),
+		[]byte(`data: {"type":"message_stop"}`), // Duplicate message_stop should be ignored via TrailingUsageSent
+	}
+
+	var allChunks [][]byte
+	for _, ev := range events {
+		chunks := ConvertClaudeResponseToOpenAI(ctx, "claude-opus-4-6", nil, nil, ev, &param)
+		allChunks = append(allChunks, chunks...)
+	}
+
+	// Verify exactly one trailing usage chunk with empty choices array exists as expected by OpenAI streaming spec and LiteLLM
+	var trailingUsageChunk []byte
+	var trailingUsageChunkIndex = -1
+	var finishReasonChunkIndex = -1
+	trailingUsageChunkCount := 0
+
+	for i, chunk := range allChunks {
+		if gjson.GetBytes(chunk, "choices.0.finish_reason").Exists() && gjson.GetBytes(chunk, "choices.0.finish_reason").String() != "" {
+			finishReasonChunkIndex = i
+		}
+		choices := gjson.GetBytes(chunk, "choices")
+		if choices.Exists() && len(choices.Array()) == 0 && gjson.GetBytes(chunk, "usage").Exists() {
+			trailingUsageChunk = chunk
+			trailingUsageChunkIndex = i
+			trailingUsageChunkCount++
+		}
+	}
+
+	if trailingUsageChunkCount != 1 {
+		t.Fatalf("expected exactly 1 trailing usage chunk with empty choices array (choices: []), got %d; chunks: %s", trailingUsageChunkCount, string(bytes.Join(allChunks, []byte("\n"))))
+	}
+
+	if finishReasonChunkIndex >= trailingUsageChunkIndex {
+		t.Fatalf("expected finish_reason chunk (index %d) before trailing usage chunk (index %d)", finishReasonChunkIndex, trailingUsageChunkIndex)
+	}
+
+	if gotPromptTokens := gjson.GetBytes(trailingUsageChunk, "usage.prompt_tokens").Int(); gotPromptTokens != 170 {
+		t.Errorf("expected prompt_tokens 170, got %d", gotPromptTokens)
+	}
+	if gotCompletionTokens := gjson.GetBytes(trailingUsageChunk, "usage.completion_tokens").Int(); gotCompletionTokens != 15 {
+		t.Errorf("expected completion_tokens 15, got %d", gotCompletionTokens)
+	}
+	if gotTotalTokens := gjson.GetBytes(trailingUsageChunk, "usage.total_tokens").Int(); gotTotalTokens != 185 {
+		t.Errorf("expected total_tokens 185, got %d", gotTotalTokens)
+	}
+	if gotCachedTokens := gjson.GetBytes(trailingUsageChunk, "usage.prompt_tokens_details.cached_tokens").Int(); gotCachedTokens != 50 {
+		t.Errorf("expected cached_tokens 50, got %d", gotCachedTokens)
+	}
+	if gotCacheWriteTokens := gjson.GetBytes(trailingUsageChunk, "usage.prompt_tokens_details.cache_write_tokens").Int(); gotCacheWriteTokens != 20 {
+		t.Errorf("expected cache_write_tokens 20, got %d", gotCacheWriteTokens)
+	}
+	if gotCachedCreationTokens := gjson.GetBytes(trailingUsageChunk, "usage.prompt_tokens_details.cached_creation_tokens").Int(); gotCachedCreationTokens != 20 {
+		t.Errorf("expected cached_creation_tokens 20, got %d", gotCachedCreationTokens)
 	}
 }

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request.go
@@ -273,116 +273,92 @@ func convertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 		pendingParts = append(pendingParts, reasoningPart)
 	}
 
-	lastToolResult := map[string]gjson.Result{}
+	var inputItems []gjson.Result
 	if input := root.Get("input"); input.Exists() && input.IsArray() {
-		input.ForEach(func(_, item gjson.Result) bool {
-			switch item.Get("type").String() {
-			case "function_call_output", "custom_tool_call_output":
-				rawID := item.Get("call_id").String()
-				if rawID != "" {
-					lastToolResult[rawID] = item
-				}
+		inputItems = common.NormalizeResponsesToolCallOutputs(input.Array())
+	}
+
+	lastToolResult := map[string]gjson.Result{}
+	for _, item := range inputItems {
+		switch item.Get("type").String() {
+		case "function_call_output", "custom_tool_call_output":
+			rawID := common.ExtractResponsesCallID(item)
+			if rawID != "" {
+				lastToolResult[rawID] = item
 			}
-			return true
-		})
+		}
 	}
 	emittedToolResults := map[string]struct{}{}
 
-	if input := root.Get("input"); input.Exists() && input.IsArray() {
-		input.ForEach(func(_, item gjson.Result) bool {
-			// System-level items already became top-level system blocks.
-			if isResponsesSystemLevelRole(item.Get("role").String()) {
-				return true
-			}
-			typ := item.Get("type").String()
-			if typ == "" && item.Get("role").String() != "" {
-				typ = "message"
-			}
-			switch typ {
-			case "message":
-				// Determine role and construct Claude-compatible content parts.
-				var role string
-				var partsJSON [][]byte
-				if parts := item.Get("content"); parts.Exists() && parts.IsArray() {
-					parts.ForEach(func(_, part gjson.Result) bool {
-						ptype := part.Get("type").String()
-						switch ptype {
-						case "input_text", "output_text":
-							if t := part.Get("text"); t.Exists() {
-								txt := t.String()
-								contentPart := []byte(`{"type":"text","text":""}`)
-								contentPart, _ = sjson.SetBytes(contentPart, "text", txt)
-								contentPart = attachClaudeCitations(contentPart, part.Get("annotations"))
-								contentPart = common.AttachCacheControl(contentPart, part)
-								partsJSON = append(partsJSON, contentPart)
-							}
-							if ptype == "input_text" {
-								role = "user"
-							} else {
-								role = "assistant"
-							}
-						case "refusal":
-							// Claude has no refusal block; the text keeps the turn intact.
-							if t := part.Get("refusal"); t.Exists() && t.String() != "" {
-								contentPart := []byte(`{"type":"text","text":""}`)
-								contentPart, _ = sjson.SetBytes(contentPart, "text", t.String())
-								contentPart = common.AttachCacheControl(contentPart, part)
-								partsJSON = append(partsJSON, contentPart)
-							}
+	for _, item := range inputItems {
+		// System-level items already became top-level system blocks.
+		if isResponsesSystemLevelRole(item.Get("role").String()) {
+			continue
+		}
+		typ := item.Get("type").String()
+		if typ == "" && item.Get("role").String() != "" {
+			typ = "message"
+		}
+		switch typ {
+		case "message":
+			// Determine role and construct Claude-compatible content parts.
+			var role string
+			var partsJSON [][]byte
+			if parts := item.Get("content"); parts.Exists() && parts.IsArray() {
+				parts.ForEach(func(_, part gjson.Result) bool {
+					ptype := part.Get("type").String()
+					switch ptype {
+					case "input_text", "output_text":
+						if t := part.Get("text"); t.Exists() {
+							txt := t.String()
+							contentPart := []byte(`{"type":"text","text":""}`)
+							contentPart, _ = sjson.SetBytes(contentPart, "text", txt)
+							contentPart = attachClaudeCitations(contentPart, part.Get("annotations"))
+							contentPart = common.AttachCacheControl(contentPart, part)
+							partsJSON = append(partsJSON, contentPart)
+						}
+						if ptype == "input_text" {
+							role = "user"
+						} else {
 							role = "assistant"
-						case "input_image":
-							url := part.Get("image_url").String()
-							if url == "" {
-								url = part.Get("url").String()
-							}
-							if url != "" {
-								var contentPart []byte
-								if strings.HasPrefix(url, "data:") {
-									trimmed := strings.TrimPrefix(url, "data:")
-									mediaAndData := strings.SplitN(trimmed, ";base64,", 2)
-									mediaType := "application/octet-stream"
-									data := ""
-									if len(mediaAndData) == 2 {
-										if mediaAndData[0] != "" {
-											mediaType = mediaAndData[0]
-										}
-										data = mediaAndData[1]
-									}
-									if data != "" {
-										contentPart = []byte(`{"type":"image","source":{"type":"base64","media_type":"","data":""}}`)
-										contentPart, _ = sjson.SetBytes(contentPart, "source.media_type", mediaType)
-										contentPart, _ = sjson.SetBytes(contentPart, "source.data", data)
-									}
-								} else {
-									contentPart = []byte(`{"type":"image","source":{"type":"url","url":""}}`)
-									contentPart, _ = sjson.SetBytes(contentPart, "source.url", url)
-								}
-								if len(contentPart) > 0 {
-									contentPart = common.AttachCacheControl(contentPart, part)
-									partsJSON = append(partsJSON, contentPart)
-									if role == "" {
-										role = "user"
-									}
-								}
-							}
-						case "input_file":
-							fileData := part.Get("file_data").String()
-							if fileData != "" {
+						}
+					case "refusal":
+						// Claude has no refusal block; the text keeps the turn intact.
+						if t := part.Get("refusal"); t.Exists() && t.String() != "" {
+							contentPart := []byte(`{"type":"text","text":""}`)
+							contentPart, _ = sjson.SetBytes(contentPart, "text", t.String())
+							contentPart = common.AttachCacheControl(contentPart, part)
+							partsJSON = append(partsJSON, contentPart)
+						}
+						role = "assistant"
+					case "input_image":
+						url := part.Get("image_url").String()
+						if url == "" {
+							url = part.Get("url").String()
+						}
+						if url != "" {
+							var contentPart []byte
+							if strings.HasPrefix(url, "data:") {
+								trimmed := strings.TrimPrefix(url, "data:")
+								mediaAndData := strings.SplitN(trimmed, ";base64,", 2)
 								mediaType := "application/octet-stream"
-								data := fileData
-								if strings.HasPrefix(fileData, "data:") {
-									trimmed := strings.TrimPrefix(fileData, "data:")
-									mediaAndData := strings.SplitN(trimmed, ";base64,", 2)
-									if len(mediaAndData) == 2 {
-										if mediaAndData[0] != "" {
-											mediaType = mediaAndData[0]
-										}
-										data = mediaAndData[1]
+								data := ""
+								if len(mediaAndData) == 2 {
+									if mediaAndData[0] != "" {
+										mediaType = mediaAndData[0]
 									}
+									data = mediaAndData[1]
 								}
-								contentPart := []byte(`{"type":"document","source":{"type":"base64","media_type":"","data":""}}`)
-								contentPart, _ = sjson.SetBytes(contentPart, "source.media_type", mediaType)
-								contentPart, _ = sjson.SetBytes(contentPart, "source.data", data)
+								if data != "" {
+									contentPart = []byte(`{"type":"image","source":{"type":"base64","media_type":"","data":""}}`)
+									contentPart, _ = sjson.SetBytes(contentPart, "source.media_type", mediaType)
+									contentPart, _ = sjson.SetBytes(contentPart, "source.data", data)
+								}
+							} else {
+								contentPart = []byte(`{"type":"image","source":{"type":"url","url":""}}`)
+								contentPart, _ = sjson.SetBytes(contentPart, "source.url", url)
+							}
+							if len(contentPart) > 0 {
 								contentPart = common.AttachCacheControl(contentPart, part)
 								partsJSON = append(partsJSON, contentPart)
 								if role == "" {
@@ -390,108 +366,131 @@ func convertOpenAIResponsesRequestToClaude(modelName string, inputRawJSON []byte
 								}
 							}
 						}
-						return true
-					})
-				} else if parts.Type == gjson.String && parts.String() != "" {
-					contentPart := []byte(`{"type":"text","text":""}`)
-					contentPart, _ = sjson.SetBytes(contentPart, "text", parts.String())
-					partsJSON = append(partsJSON, contentPart)
-				}
-
-				// Fallback to given role if content types not decisive
-				if role == "" {
-					r := item.Get("role").String()
-					switch r {
-					case "user", "assistant":
-						role = r
-					default:
-						role = "user"
-					}
-				}
-
-				if len(partsJSON) > 0 {
-					lastIdx := len(partsJSON) - 1
-					if !gjson.GetBytes(partsJSON[lastIdx], "cache_control").Exists() {
-						partsJSON[lastIdx] = common.AttachCacheControl(partsJSON[lastIdx], item)
-					}
-					appendParts(role, partsJSON...)
-				}
-
-			case "web_search_call":
-				// Rebuild the Claude server-side search pair so the replayed turn
-				// still shows the search and its hits.
-				if blocks := convertResponsesWebSearchCallToClaudeBlocks(item); len(blocks) > 0 {
-					appendParts("assistant", blocks...)
-				}
-
-			case "reasoning":
-				appendReasoning(convertResponsesReasoningToClaudeThinking(item, preserveEmptyThinkingBlocks))
-
-			case "function_call", "custom_tool_call":
-				// Map to assistant tool_use. Freeform custom input is wrapped in an
-				// object because Claude tool_use input must be a JSON object.
-				callID := item.Get("call_id").String()
-				if callID == "" {
-					callID = common.GenerateClaudeToolCallID()
-				}
-				callID = util.SanitizeClaudeToolID(callID)
-				name := item.Get("name").String()
-				if namespaceName := strings.TrimSpace(item.Get("namespace").String()); namespaceName != "" {
-					// Rebuild the qualified name emitted by the previous Responses turn.
-					name = qualifyResponsesNamespaceToolName(namespaceName, name)
-				}
-				isCustomToolCall := typ == "custom_tool_call"
-
-				toolUse := []byte(`{"type":"tool_use","id":"","name":"","input":{}}`)
-				toolUse, _ = sjson.SetBytes(toolUse, "id", callID)
-				toolUse, _ = sjson.SetBytes(toolUse, "name", name)
-				if isCustomToolCall {
-					toolUse, _ = sjson.SetBytes(toolUse, "input.input", item.Get("input").String())
-				} else {
-					argsStr := item.Get("arguments").String()
-					if argsStr != "" && gjson.Valid(argsStr) {
-						argsJSON := gjson.Parse(argsStr)
-						if argsJSON.IsObject() {
-							toolUse, _ = sjson.SetRawBytes(toolUse, "input", []byte(argsJSON.Raw))
+					case "input_file":
+						fileData := part.Get("file_data").String()
+						if fileData != "" {
+							mediaType := "application/octet-stream"
+							data := fileData
+							if strings.HasPrefix(fileData, "data:") {
+								trimmed := strings.TrimPrefix(fileData, "data:")
+								mediaAndData := strings.SplitN(trimmed, ";base64,", 2)
+								if len(mediaAndData) == 2 {
+									if mediaAndData[0] != "" {
+										mediaType = mediaAndData[0]
+									}
+									data = mediaAndData[1]
+								}
+							}
+							contentPart := []byte(`{"type":"document","source":{"type":"base64","media_type":"","data":""}}`)
+							contentPart, _ = sjson.SetBytes(contentPart, "source.media_type", mediaType)
+							contentPart, _ = sjson.SetBytes(contentPart, "source.data", data)
+							contentPart = common.AttachCacheControl(contentPart, part)
+							partsJSON = append(partsJSON, contentPart)
+							if role == "" {
+								role = "user"
+							}
 						}
 					}
-				}
+					return true
+				})
+			} else if parts.Type == gjson.String && parts.String() != "" {
+				contentPart := []byte(`{"type":"text","text":""}`)
+				contentPart, _ = sjson.SetBytes(contentPart, "text", parts.String())
+				partsJSON = append(partsJSON, contentPart)
+			}
 
-				appendToolUse(toolUse)
-
-			case "function_call_output", "custom_tool_call_output":
-				// Map to user tool_result
-				rawID := item.Get("call_id").String()
-				callID := util.SanitizeClaudeToolID(rawID)
-				if rawID != "" {
-					if _, exists := emittedToolResults[rawID]; exists {
-						return true
-					}
-					emittedToolResults[rawID] = struct{}{}
-				}
-				output := item.Get("output")
-				if rawID != "" {
-					if lastItem, exists := lastToolResult[rawID]; exists {
-						output = lastItem.Get("output")
-					}
-				}
-				toolResult := []byte(`{"type":"tool_result","tool_use_id":"","content":""}`)
-				toolResult, _ = sjson.SetBytes(toolResult, "tool_use_id", callID)
-				toolResult = applyResponsesToolResultContent(toolResult, output)
-
-				appendParts("user", toolResult)
-
-			default:
-				// Reachability guard: Claude only ever receives the item types this
-				// switch handles. A new one means the client gained a capability
-				// whose Claude counterpart still has to be decided, so make the gap
-				// visible instead of dropping the turn content in silence.
-				if typ := item.Get("type").String(); typ != "" {
-					log.Debugf("responses->claude: unmapped input item type %q", typ)
+			// Fallback to given role if content types not decisive
+			if role == "" {
+				r := item.Get("role").String()
+				switch r {
+				case "user", "assistant":
+					role = r
+				default:
+					role = "user"
 				}
 			}
-			return true
-		})
+
+			if len(partsJSON) > 0 {
+				lastIdx := len(partsJSON) - 1
+				if !gjson.GetBytes(partsJSON[lastIdx], "cache_control").Exists() {
+					partsJSON[lastIdx] = common.AttachCacheControl(partsJSON[lastIdx], item)
+				}
+				appendParts(role, partsJSON...)
+			}
+
+		case "web_search_call":
+			// Rebuild the Claude server-side search pair so the replayed turn
+			// still shows the search and its hits.
+			if blocks := convertResponsesWebSearchCallToClaudeBlocks(item); len(blocks) > 0 {
+				appendParts("assistant", blocks...)
+			}
+
+		case "reasoning":
+			appendReasoning(convertResponsesReasoningToClaudeThinking(item, preserveEmptyThinkingBlocks))
+
+		case "function_call", "custom_tool_call":
+			// Map to assistant tool_use. Freeform custom input is wrapped in an
+			// object because Claude tool_use input must be a JSON object.
+			callID := common.ExtractResponsesCallID(item)
+			if callID == "" {
+				callID = common.GenerateClaudeToolCallID()
+			}
+			callID = util.SanitizeClaudeToolID(callID)
+			name := item.Get("name").String()
+			if namespaceName := strings.TrimSpace(item.Get("namespace").String()); namespaceName != "" {
+				// Rebuild the qualified name emitted by the previous Responses turn.
+				name = qualifyResponsesNamespaceToolName(namespaceName, name)
+			}
+			isCustomToolCall := typ == "custom_tool_call"
+
+			toolUse := []byte(`{"type":"tool_use","id":"","name":"","input":{}}`)
+			toolUse, _ = sjson.SetBytes(toolUse, "id", callID)
+			toolUse, _ = sjson.SetBytes(toolUse, "name", name)
+			if isCustomToolCall {
+				toolUse, _ = sjson.SetBytes(toolUse, "input.input", item.Get("input").String())
+			} else {
+				argsStr := item.Get("arguments").String()
+				if argsStr != "" && gjson.Valid(argsStr) {
+					argsJSON := gjson.Parse(argsStr)
+					if argsJSON.IsObject() {
+						toolUse, _ = sjson.SetRawBytes(toolUse, "input", []byte(argsJSON.Raw))
+					}
+				}
+			}
+
+			appendToolUse(toolUse)
+
+		case "function_call_output", "custom_tool_call_output":
+			// Map to user tool_result
+			rawID := common.ExtractResponsesCallID(item)
+			callID := util.SanitizeClaudeToolID(rawID)
+			if rawID != "" {
+				if _, exists := emittedToolResults[rawID]; exists {
+					continue
+				}
+				emittedToolResults[rawID] = struct{}{}
+			}
+			output := item.Get("output")
+			if rawID != "" {
+				if lastItem, exists := lastToolResult[rawID]; exists {
+					output = lastItem.Get("output")
+				}
+			}
+			toolResult := []byte(`{"type":"tool_result","tool_use_id":"","content":""}`)
+			toolResult, _ = sjson.SetBytes(toolResult, "tool_use_id", callID)
+			toolResult = applyResponsesToolResultContent(toolResult, output)
+
+			appendParts("user", toolResult)
+
+		default:
+			// Reachability guard: Claude only ever receives the item types this
+			// switch handles. A new one means the client gained a capability
+			// whose Claude counterpart still has to be decided, so make the gap
+			// visible instead of dropping the turn content in silence.
+			if typ := item.Get("type").String(); typ != "" {
+				log.Debugf("responses->claude: unmapped input item type %q", typ)
+			}
+		}
 	}
 	flushPendingMessage()
 	hadMessages := len(messageBlocks) > 0

--- a/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
+++ b/internal/translator/claude/openai/responses/claude_openai-responses_request_test.go
@@ -1895,3 +1895,161 @@ func TestConvertOpenAIResponsesRequestToClaude_TextFormatStructuredOutput(t *tes
 		}
 	})
 }
+
+func TestConvertOpenAIResponsesRequestToClaude_FunctionCallOutputAlternateIDsAndQueueFallback(t *testing.T) {
+	testCases := []struct {
+		name        string
+		outputField string
+		wantToolUse string
+	}{
+		{
+			name:        "call_id standard",
+			outputField: `"call_id":"call_123"`,
+			wantToolUse: "call_123",
+		},
+		{
+			name:        "tool_call_id alternate field",
+			outputField: `"tool_call_id":"call_123"`,
+			wantToolUse: "call_123",
+		},
+		{
+			name:        "callId alternate field",
+			outputField: `"callId":"call_123"`,
+			wantToolUse: "call_123",
+		},
+		{
+			name:        "id alternate field",
+			outputField: `"id":"call_123"`,
+			wantToolUse: "call_123",
+		},
+		{
+			name:        "missing call_id completely fallback to pending queue",
+			outputField: ``,
+			wantToolUse: "call_123",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			outputJSON := `{"type":"function_call_output","output":"tool_result_ok"`
+			if tc.outputField != "" {
+				outputJSON += `,` + tc.outputField
+			}
+			outputJSON += `}`
+
+			inputJSON := []byte(`{
+				"model": "claude-sonnet-4-6",
+				"input": [
+					{"type":"message","role":"user","content":[{"type":"input_text","text":"run"}]},
+					{"type":"function_call","call_id":"call_123","name":"Bash","arguments":"{\"command\":\"ls\"}"},
+					` + outputJSON + `
+				]
+			}`)
+
+			out := ConvertOpenAIResponsesRequestToClaude("claude-sonnet-4-6", inputJSON, false)
+			messages := gjson.GetBytes(out, "messages").Array()
+			if len(messages) != 3 {
+				t.Fatalf("expected 3 messages (user, assistant, user), got %d; output=%s", len(messages), string(out))
+			}
+
+			// Assistant message has tool_use with id call_123
+			toolUse := messages[1].Get("content.0")
+			if toolUse.Get("type").String() != "tool_use" {
+				t.Fatalf("expected tool_use, got %s", toolUse.Raw)
+			}
+			if gotID := toolUse.Get("id").String(); gotID != "call_123" {
+				t.Fatalf("tool_use.id = %q, want call_123", gotID)
+			}
+
+			// User message has tool_result with tool_use_id matching tool_use.id
+			toolResult := messages[2].Get("content.0")
+			if toolResult.Get("type").String() != "tool_result" {
+				t.Fatalf("expected tool_result, got %s", toolResult.Raw)
+			}
+			if gotID := toolResult.Get("tool_use_id").String(); gotID != tc.wantToolUse {
+				t.Fatalf("tool_result.tool_use_id = %q, want %q; output=%s", gotID, tc.wantToolUse, string(out))
+			}
+			if gotContent := toolResult.Get("content").String(); gotContent != "tool_result_ok" {
+				t.Fatalf("tool_result.content = %q, want tool_result_ok", gotContent)
+			}
+		})
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToClaude_MixedMissingAndExplicitParallelOutputs(t *testing.T) {
+	// Call A, Call B.
+	// Output 1 has NO ID (result B).
+	// Output 2 explicitly has call_id: call_a (result A).
+	// Call A must NOT be stolen by Output 1; Output 1 must get Call B.
+	inputJSON := []byte(`{
+		"model": "claude-sonnet-4-6",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"run"}]},
+			{"type":"function_call","call_id":"call_a","name":"tool_a","arguments":"{}"},
+			{"type":"function_call","call_id":"call_b","name":"tool_b","arguments":"{}"},
+			{"type":"function_call_output","output":"result_b"},
+			{"type":"function_call_output","call_id":"call_a","output":"result_a"}
+		]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToClaude("claude-sonnet-4-6", inputJSON, false)
+	messages := gjson.GetBytes(out, "messages").Array()
+	if len(messages) != 3 {
+		t.Fatalf("expected 3 messages, got %d; output=%s", len(messages), string(out))
+	}
+
+	results := messages[2].Get("content").Array()
+	if len(results) != 2 {
+		t.Fatalf("expected 2 tool_results, got %d; output=%s", len(results), string(out))
+	}
+
+	resultMap := make(map[string]string)
+	for _, r := range results {
+		resultMap[r.Get("tool_use_id").String()] = r.Get("content").String()
+	}
+
+	if got := resultMap["call_a"]; got != "result_a" {
+		t.Fatalf("result for call_a = %q, want result_a", got)
+	}
+	if got := resultMap["call_b"]; got != "result_b" {
+		t.Fatalf("result for call_b = %q, want result_b", got)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToClaude_MixedMissingAndExplicitParallelOutputsAcrossUserMessage(t *testing.T) {
+	// Call A, Call B.
+	// Output 1 has NO ID (result B).
+	// Intervening user message.
+	// Output 2 explicitly has call_id: call_a (result A).
+	// Call A must NOT be stolen by Output 1; Output 1 must get Call B.
+	inputJSON := []byte(`{
+		"model": "claude-sonnet-4-6",
+		"input": [
+			{"type":"function_call","call_id":"call_a","name":"tool_a","arguments":"{}"},
+			{"type":"function_call","call_id":"call_b","name":"tool_b","arguments":"{}"},
+			{"type":"function_call_output","output":"result_b"},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"status?"}]},
+			{"type":"function_call_output","call_id":"call_a","output":"result_a"}
+		]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToClaude("claude-sonnet-4-6", inputJSON, false)
+	messages := gjson.GetBytes(out, "messages").Array()
+	resultMap := make(map[string]string)
+	for _, m := range messages {
+		if m.Get("role").String() == "user" {
+			for _, part := range m.Get("content").Array() {
+				if part.Get("type").String() == "tool_result" {
+					resultMap[part.Get("tool_use_id").String()] = part.Get("content").String()
+				}
+			}
+		}
+	}
+
+	if got := resultMap["call_a"]; got != "result_a" {
+		t.Fatalf("result for call_a = %q, want result_a", got)
+	}
+	if got := resultMap["call_b"]; got != "result_b" {
+		t.Fatalf("result for call_b = %q, want result_b", got)
+	}
+}

--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -6,8 +6,10 @@
 package claude
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -663,23 +665,88 @@ func buildReverseMapFromClaudeOriginalToShort(original []byte) map[string]string
 	return m
 }
 
-// normalizeToolParameters ensures object schemas contain at least an empty properties map.
+// normalizeToolParameters ensures object schemas contain at least an empty properties map
+// and strips dialect keywords ($schema, $id) from schema objects.
 func normalizeToolParameters(raw string) string {
 	raw = strings.TrimSpace(raw)
 	if raw == "" || raw == "null" || !gjson.Valid(raw) {
 		return `{"type":"object","properties":{}}`
 	}
-	result := gjson.Parse(raw)
-	schema := []byte(raw)
-	schemaType := result.Get("type").String()
-	if schemaType == "" {
-		schema, _ = sjson.SetBytes(schema, "type", "object")
-		schemaType = "object"
+	var root map[string]any
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.UseNumber()
+	if errDecode := decoder.Decode(&root); errDecode != nil || root == nil {
+		return `{"type":"object","properties":{}}`
 	}
-	if schemaType == "object" && !result.Get("properties").Exists() {
-		schema, _ = sjson.SetRawBytes(schema, "properties", []byte(`{}`))
+
+	stripDialectKeywordsFromSchema(root)
+
+	typeVal, typeExists := root["type"]
+	isObject := false
+	if !typeExists || typeVal == nil || typeVal == "" {
+		root["type"] = "object"
+		isObject = true
+	} else {
+		switch t := typeVal.(type) {
+		case string:
+			if t == "object" {
+				isObject = true
+			}
+		case []any:
+			for _, elem := range t {
+				if elemStr, ok := elem.(string); ok && elemStr == "object" {
+					isObject = true
+					break
+				}
+			}
+		}
 	}
-	return string(schema)
+	if isObject {
+		if props, ok := root["properties"]; !ok || props == nil {
+			root["properties"] = map[string]any{}
+		}
+	}
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if errEncode := enc.Encode(root); errEncode != nil {
+		return `{"type":"object","properties":{}}`
+	}
+	return strings.TrimSpace(buf.String())
+}
+
+func stripDialectKeywordsFromSchema(v any) {
+	switch schema := v.(type) {
+	case map[string]any:
+		delete(schema, "$schema")
+		delete(schema, "$id")
+
+		for _, mapKey := range codexSchemaMapKeywords {
+			if subMap, ok := schema[mapKey].(map[string]any); ok {
+				for _, subSchema := range subMap {
+					stripDialectKeywordsFromSchema(subSchema)
+				}
+			}
+		}
+
+		for _, valKey := range codexSchemaValueKeywords {
+			if val, exists := schema[valKey]; exists {
+				switch sub := val.(type) {
+				case map[string]any:
+					stripDialectKeywordsFromSchema(sub)
+				case []any:
+					for _, item := range sub {
+						stripDialectKeywordsFromSchema(item)
+					}
+				}
+			}
+		}
+	case []any:
+		for _, item := range schema {
+			stripDialectKeywordsFromSchema(item)
+		}
+	}
 }
 
 // codexSchemaMapKeywords holds JSON Schema keywords whose values are maps of

--- a/internal/translator/codex/claude/codex_claude_request_test.go
+++ b/internal/translator/codex/claude/codex_claude_request_test.go
@@ -939,3 +939,188 @@ func TestConvertClaudeRequestToCodex_OutputConfigFormat(t *testing.T) {
 		}
 	})
 }
+
+func TestNormalizeToolParameters_StripsNestedSchemaAndId(t *testing.T) {
+	input := `{
+		"type": "object",
+		"$schema": "http://json-schema.org/draft-07/schema#",
+		"$id": "https://example.invalid/root",
+		"properties": {
+			"q": {
+				"type": "string",
+				"$schema": "http://json-schema.org/draft-07/schema#",
+				"$id": "https://example.invalid/q"
+			},
+			"tags": {
+				"type": "array",
+				"items": {"type": "string", "$id": "https://example.invalid/tag"}
+			},
+			"mode": {
+				"anyOf": [
+					{"type": "string", "$schema": "http://json-schema.org/draft-07/schema#"},
+					{"type": "null"}
+				]
+			},
+			"refField": {
+				"$ref": "#/$defs/hint"
+			}
+		},
+		"$defs": {
+			"hint": {"type": "string", "$id": "https://example.invalid/hint"}
+		},
+		"required": ["q"]
+	}`
+
+	got := normalizeToolParameters(input)
+	parsed := gjson.Parse(got)
+
+	if parsed.Get("$schema").Exists() {
+		t.Errorf("expected root $schema to be removed, got %v", parsed.Get("$schema").Raw)
+	}
+	if parsed.Get("$id").Exists() {
+		t.Errorf("expected root $id to be removed, got %v", parsed.Get("$id").Raw)
+	}
+	if parsed.Get("properties.q.$schema").Exists() {
+		t.Errorf("expected properties.q.$schema to be removed, got %v", parsed.Get("properties.q.$schema").Raw)
+	}
+	if parsed.Get("properties.q.$id").Exists() {
+		t.Errorf("expected properties.q.$id to be removed, got %v", parsed.Get("properties.q.$id").Raw)
+	}
+	if parsed.Get("properties.tags.items.$id").Exists() {
+		t.Errorf("expected properties.tags.items.$id to be removed, got %v", parsed.Get("properties.tags.items.$id").Raw)
+	}
+	if parsed.Get("properties.mode.anyOf.0.$schema").Exists() {
+		t.Errorf("expected properties.mode.anyOf.0.$schema to be removed, got %v", parsed.Get("properties.mode.anyOf.0.$schema").Raw)
+	}
+	if parsed.Get("$defs.hint.$id").Exists() {
+		t.Errorf("expected $defs.hint.$id to be removed, got %v", parsed.Get("$defs.hint.$id").Raw)
+	}
+	if parsed.Get("properties.refField.$ref").String() != "#/$defs/hint" {
+		t.Errorf("expected $ref to be preserved, got %v", parsed.Get("properties.refField.$ref").Raw)
+	}
+	if parsed.Get("properties.q.type").String() != "string" {
+		t.Errorf("expected properties.q.type to be 'string', got %v", parsed.Get("properties.q.type").Raw)
+	}
+}
+
+func TestNormalizeToolParameters_PreservesPropertyNamesAndLiteralData(t *testing.T) {
+	input := `{
+		"type": "object",
+		"properties": {
+			"$schema": {
+				"type": "string",
+				"$schema": "http://json-schema.org/draft-07/schema#",
+				"$id": "https://example.invalid/sub-schema"
+			},
+			"$id": {
+				"type": "string"
+			},
+			"config": {
+				"type": "object",
+				"default": {
+					"$id": "default-id-123"
+				}
+			}
+		}
+	}`
+
+	got := normalizeToolParameters(input)
+	parsed := gjson.Parse(got)
+
+	if !parsed.Get("properties.$schema").Exists() {
+		t.Errorf("expected property named '$schema' to be preserved")
+	}
+	if parsed.Get("properties.$schema.$schema").Exists() {
+		t.Errorf("expected properties.$schema.$schema dialect keyword to be removed")
+	}
+	if parsed.Get("properties.$schema.$id").Exists() {
+		t.Errorf("expected properties.$schema.$id dialect keyword to be removed")
+	}
+	if !parsed.Get("properties.$id").Exists() {
+		t.Errorf("expected property named '$id' to be preserved")
+	}
+	if gotDefaultID := parsed.Get("properties.config.default.$id").String(); gotDefaultID != "default-id-123" {
+		t.Errorf("expected literal default.$id to be preserved, got %q", gotDefaultID)
+	}
+
+	// Test empty / null / invalid fallback
+	if emptyGot := normalizeToolParameters(""); emptyGot != `{"type":"object","properties":{}}` {
+		t.Errorf("expected empty string to normalize to empty object schema, got %s", emptyGot)
+	}
+	if nullGot := normalizeToolParameters("null"); nullGot != `{"type":"object","properties":{}}` {
+		t.Errorf("expected null to normalize to empty object schema, got %s", nullGot)
+	}
+
+	// Test array union type preservation (e.g. ["object", "null"])
+	unionInput := `{"type": ["object", "null"]}`
+	unionGot := normalizeToolParameters(unionInput)
+	unionParsed := gjson.Parse(unionGot)
+	typeArr := unionParsed.Get("type").Array()
+	if len(typeArr) != 2 || typeArr[0].String() != "object" || typeArr[1].String() != "null" {
+		t.Errorf("expected union type array to be preserved, got %s", unionParsed.Get("type").Raw)
+	}
+	if !unionParsed.Get("properties").Exists() {
+		t.Errorf("expected properties to be added when object is part of union type")
+	}
+}
+
+func TestConvertClaudeRequestToCodex_StripsNestedToolSchemaMeta(t *testing.T) {
+	inputJSON := `{
+		"model": "gpt-5",
+		"messages": [{"role": "user", "content": "hi"}],
+		"tools": [{
+			"name": "lookup",
+			"description": "Lookup",
+			"input_schema": {
+				"type": "object",
+				"$schema": "http://json-schema.org/draft-07/schema#",
+				"properties": {
+					"q": {
+						"type": "string",
+						"$schema": "http://json-schema.org/draft-07/schema#",
+						"$id": "https://example.invalid/q"
+					},
+					"tags": {
+						"type": "array",
+						"items": {"type": "string", "$id": "https://example.invalid/tag"}
+					},
+					"mode": {
+						"anyOf": [
+							{"type": "string", "$schema": "http://json-schema.org/draft-07/schema#"},
+							{"type": "null"}
+						]
+					}
+				},
+				"$defs": {
+					"hint": {"type": "string", "$id": "https://example.invalid/hint"}
+				},
+				"required": ["q"]
+			}
+		}]
+	}`
+
+	translated := ConvertClaudeRequestToCodex("gpt-5", []byte(inputJSON), false)
+	tools := gjson.GetBytes(translated, "tools").Array()
+	if len(tools) == 0 {
+		t.Fatalf("expected tools in translated payload, got: %s", translated)
+	}
+	params := tools[0].Get("parameters")
+	if params.Get("$schema").Exists() {
+		t.Errorf("expected root parameters.$schema to be removed, got %v", params.Get("$schema").Raw)
+	}
+	if params.Get("properties.q.$schema").Exists() {
+		t.Errorf("expected parameters.properties.q.$schema to be removed, got %v", params.Get("properties.q.$schema").Raw)
+	}
+	if params.Get("properties.q.$id").Exists() {
+		t.Errorf("expected parameters.properties.q.$id to be removed, got %v", params.Get("properties.q.$id").Raw)
+	}
+	if params.Get("properties.tags.items.$id").Exists() {
+		t.Errorf("expected parameters.properties.tags.items.$id to be removed, got %v", params.Get("properties.tags.items.$id").Raw)
+	}
+	if params.Get("properties.mode.anyOf.0.$schema").Exists() {
+		t.Errorf("expected parameters.properties.mode.anyOf.0.$schema to be removed, got %v", params.Get("properties.mode.anyOf.0.$schema").Raw)
+	}
+	if params.Get("$defs.hint.$id").Exists() {
+		t.Errorf("expected parameters.$defs.hint.$id to be removed, got %v", params.Get("$defs.hint.$id").Raw)
+	}
+}

--- a/internal/translator/codex/claude/codex_claude_response.go
+++ b/internal/translator/codex/claude/codex_claude_response.go
@@ -166,6 +166,7 @@ func ConvertCodexResponseToClaude(_ context.Context, _ string, originalRequestRa
 		if cacheWriteTokens > 0 {
 			template, _ = sjson.SetBytes(template, "usage.cache_creation_input_tokens", cacheWriteTokens)
 		}
+		template = setClaudeReasoningUsage(template, responseData.Get("usage"))
 
 		output = translatorcommon.AppendSSEEventBytes(output, "message_delta", template, 2)
 		output = translatorcommon.AppendSSEEventBytes(output, "message_stop", []byte(`{"type":"message_stop"}`), 2)
@@ -373,6 +374,7 @@ func ConvertCodexResponseToClaudeNonStream(_ context.Context, _ string, original
 	if cacheWriteTokens > 0 {
 		out, _ = sjson.SetBytes(out, "usage.cache_creation_input_tokens", cacheWriteTokens)
 	}
+	out = setClaudeReasoningUsage(out, responseData.Get("usage"))
 
 	hasToolCall := false
 	webSearchSeen := make(map[string]struct{})
@@ -822,6 +824,28 @@ func extractResponsesUsage(usage gjson.Result) (int64, int64, int64, int64) {
 	}
 
 	return inputTokens, outputTokens, cachedTokens, cacheWriteTokens
+}
+
+func setClaudeReasoningUsage(out []byte, usage gjson.Result) []byte {
+	detail := usage.Get("output_tokens_details.reasoning_tokens")
+	if !detail.Exists() || detail.Type != gjson.Number {
+		return out
+	}
+	if strings.HasPrefix(detail.Raw, "-") || detail.Num < 0 {
+		return out
+	}
+	outputTokens := max(int64(0), usage.Get("output_tokens").Int())
+	var tokens int64
+	if detail.Num >= float64(outputTokens) {
+		tokens = outputTokens
+	} else {
+		tokens = detail.Int()
+	}
+	updated, errSetBytes := sjson.SetBytes(out, "usage.output_tokens_details.thinking_tokens", tokens)
+	if errSetBytes != nil {
+		return out
+	}
+	return updated
 }
 
 // buildReverseMapFromClaudeOriginalShortToOriginal builds a map[short]original from original Claude request tools.

--- a/internal/translator/codex/claude/codex_claude_response_test.go
+++ b/internal/translator/codex/claude/codex_claude_response_test.go
@@ -1522,3 +1522,232 @@ func TestConvertCodexResponseToClaudeNonStream_PreservesCacheWriteUsage(t *testi
 		})
 	}
 }
+
+func TestConvertCodexResponseToClaude_PreservesReasoningUsage(t *testing.T) {
+	tests := []struct {
+		name                string
+		terminalUsageJSON   string
+		wantOutputTokens    int64
+		wantReasoningExist  bool
+		wantReasoningTokens int64
+	}{
+		{
+			name:                "preserves positive reasoning tokens",
+			terminalUsageJSON:   `{"input_tokens":420,"output_tokens":518,"output_tokens_details":{"reasoning_tokens":163},"total_tokens":938}`,
+			wantOutputTokens:    518,
+			wantReasoningExist:  true,
+			wantReasoningTokens: 163,
+		},
+		{
+			name:                "preserves explicit zero reasoning tokens",
+			terminalUsageJSON:   `{"input_tokens":100,"output_tokens":50,"output_tokens_details":{"reasoning_tokens":0}}`,
+			wantOutputTokens:    50,
+			wantReasoningExist:  true,
+			wantReasoningTokens: 0,
+		},
+		{
+			name:               "omits reasoning detail when absent",
+			terminalUsageJSON:  `{"input_tokens":100,"output_tokens":50}`,
+			wantOutputTokens:   50,
+			wantReasoningExist: false,
+		},
+		{
+			name:                "clamps oversized reasoning tokens to output tokens",
+			terminalUsageJSON:   `{"input_tokens":100,"output_tokens":50,"output_tokens_details":{"reasoning_tokens":999}}`,
+			wantOutputTokens:    50,
+			wantReasoningExist:  true,
+			wantReasoningTokens: 50,
+		},
+		{
+			name:               "rejects negative reasoning tokens",
+			terminalUsageJSON:  `{"input_tokens":100,"output_tokens":50,"output_tokens_details":{"reasoning_tokens":-5}}`,
+			wantOutputTokens:   50,
+			wantReasoningExist: false,
+		},
+		{
+			name:               "rejects negative float reasoning tokens",
+			terminalUsageJSON:  `{"input_tokens":100,"output_tokens":50,"output_tokens_details":{"reasoning_tokens":-0.5}}`,
+			wantOutputTokens:   50,
+			wantReasoningExist: false,
+		},
+		{
+			name:                "clamps oversized int64 overflow reasoning tokens to output tokens",
+			terminalUsageJSON:   `{"input_tokens":100,"output_tokens":50,"output_tokens_details":{"reasoning_tokens":9223372036854775808}}`,
+			wantOutputTokens:    50,
+			wantReasoningExist:  true,
+			wantReasoningTokens: 50,
+		},
+		{
+			name:               "omits string reasoning detail",
+			terminalUsageJSON:  `{"input_tokens":100,"output_tokens":50,"output_tokens_details":{"reasoning_tokens":"163"}}`,
+			wantOutputTokens:   50,
+			wantReasoningExist: false,
+		},
+		{
+			name:               "omits boolean reasoning detail",
+			terminalUsageJSON:  `{"input_tokens":100,"output_tokens":50,"output_tokens_details":{"reasoning_tokens":true}}`,
+			wantOutputTokens:   50,
+			wantReasoningExist: false,
+		},
+		{
+			name:               "omits null reasoning detail",
+			terminalUsageJSON:  `{"input_tokens":100,"output_tokens":50,"output_tokens_details":{"reasoning_tokens":null}}`,
+			wantOutputTokens:   50,
+			wantReasoningExist: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			originalRequest := []byte(`{"messages":[]}`)
+			var param any
+
+			chunks := [][]byte{
+				[]byte(`data: {"type":"response.created","response":{"id":"resp_1","model":"gpt-5"}}`),
+				[]byte(`data: {"type":"response.output_item.done","item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"ok"}]}}`),
+				[]byte(fmt.Sprintf(`data: {"type":"response.completed","response":{"stop_reason":"stop","usage":%s}}`, tt.terminalUsageJSON)),
+			}
+
+			var outputs [][]byte
+			for _, chunk := range chunks {
+				outputs = append(outputs, ConvertCodexResponseToClaude(ctx, "", originalRequest, nil, chunk, &param)...)
+			}
+
+			delta, ok := findClaudeStreamMessageDelta(outputs)
+			if !ok {
+				t.Fatalf("missing message_delta event; outputs=%q", outputs)
+			}
+
+			usage := delta.Get("usage")
+			if got := usage.Get("output_tokens").Int(); got != tt.wantOutputTokens {
+				t.Fatalf("output_tokens = %d, want %d", got, tt.wantOutputTokens)
+			}
+			thinkingNode := usage.Get("output_tokens_details.thinking_tokens")
+			if tt.wantReasoningExist {
+				if !thinkingNode.Exists() {
+					t.Fatalf("expected output_tokens_details.thinking_tokens to exist, got none in %s", usage.Raw)
+				}
+				if got := thinkingNode.Int(); got != tt.wantReasoningTokens {
+					t.Fatalf("thinking_tokens = %d, want %d", got, tt.wantReasoningTokens)
+				}
+			} else {
+				if thinkingNode.Exists() {
+					t.Fatalf("expected output_tokens_details.thinking_tokens to be absent, got %v", thinkingNode.Raw)
+				}
+			}
+		})
+	}
+}
+
+func TestConvertCodexResponseToClaudeNonStream_PreservesReasoningUsage(t *testing.T) {
+	tests := []struct {
+		name                string
+		usageJSON           string
+		wantOutputTokens    int64
+		wantReasoningExist  bool
+		wantReasoningTokens int64
+	}{
+		{
+			name:                "preserves positive reasoning tokens",
+			usageJSON:           `{"input_tokens":420,"output_tokens":518,"output_tokens_details":{"reasoning_tokens":163},"total_tokens":938}`,
+			wantOutputTokens:    518,
+			wantReasoningExist:  true,
+			wantReasoningTokens: 163,
+		},
+		{
+			name:                "preserves explicit zero reasoning tokens",
+			usageJSON:           `{"input_tokens":100,"output_tokens":50,"output_tokens_details":{"reasoning_tokens":0}}`,
+			wantOutputTokens:    50,
+			wantReasoningExist:  true,
+			wantReasoningTokens: 0,
+		},
+		{
+			name:               "omits reasoning detail when absent",
+			usageJSON:          `{"input_tokens":100,"output_tokens":50}`,
+			wantOutputTokens:   50,
+			wantReasoningExist: false,
+		},
+		{
+			name:                "clamps oversized reasoning tokens to output tokens",
+			usageJSON:           `{"input_tokens":100,"output_tokens":50,"output_tokens_details":{"reasoning_tokens":999}}`,
+			wantOutputTokens:    50,
+			wantReasoningExist:  true,
+			wantReasoningTokens: 50,
+		},
+		{
+			name:               "rejects negative reasoning tokens",
+			usageJSON:          `{"input_tokens":100,"output_tokens":50,"output_tokens_details":{"reasoning_tokens":-5}}`,
+			wantOutputTokens:   50,
+			wantReasoningExist: false,
+		},
+		{
+			name:               "rejects negative float reasoning tokens",
+			usageJSON:          `{"input_tokens":100,"output_tokens":50,"output_tokens_details":{"reasoning_tokens":-0.5}}`,
+			wantOutputTokens:   50,
+			wantReasoningExist: false,
+		},
+		{
+			name:                "clamps oversized int64 overflow reasoning tokens to output tokens",
+			usageJSON:           `{"input_tokens":100,"output_tokens":50,"output_tokens_details":{"reasoning_tokens":9223372036854775808}}`,
+			wantOutputTokens:    50,
+			wantReasoningExist:  true,
+			wantReasoningTokens: 50,
+		},
+		{
+			name:               "omits string reasoning detail",
+			usageJSON:          `{"input_tokens":100,"output_tokens":50,"output_tokens_details":{"reasoning_tokens":"163"}}`,
+			wantOutputTokens:   50,
+			wantReasoningExist: false,
+		},
+		{
+			name:               "omits boolean reasoning detail",
+			usageJSON:          `{"input_tokens":100,"output_tokens":50,"output_tokens_details":{"reasoning_tokens":true}}`,
+			wantOutputTokens:   50,
+			wantReasoningExist: false,
+		},
+		{
+			name:               "omits null reasoning detail",
+			usageJSON:          `{"input_tokens":100,"output_tokens":50,"output_tokens_details":{"reasoning_tokens":null}}`,
+			wantOutputTokens:   50,
+			wantReasoningExist: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			originalRequest := []byte(`{"messages":[]}`)
+			responseJSON := fmt.Sprintf(`{
+				"type":"response.completed",
+				"response":{
+					"id":"resp_1",
+					"model":"gpt-5",
+					"stop_reason":"stop",
+					"usage":%s,
+					"output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]
+				}
+			}`, tt.usageJSON)
+			out := ConvertCodexResponseToClaudeNonStream(ctx, "", originalRequest, nil, []byte(responseJSON), nil)
+			parsed := gjson.ParseBytes(out)
+
+			usage := parsed.Get("usage")
+			if got := usage.Get("output_tokens").Int(); got != tt.wantOutputTokens {
+				t.Fatalf("output_tokens = %d, want %d", got, tt.wantOutputTokens)
+			}
+			thinkingNode := usage.Get("output_tokens_details.thinking_tokens")
+			if tt.wantReasoningExist {
+				if !thinkingNode.Exists() {
+					t.Fatalf("expected output_tokens_details.thinking_tokens to exist, got none in %s", usage.Raw)
+				}
+				if got := thinkingNode.Int(); got != tt.wantReasoningTokens {
+					t.Fatalf("thinking_tokens = %d, want %d", got, tt.wantReasoningTokens)
+				}
+			} else {
+				if thinkingNode.Exists() {
+					t.Fatalf("expected output_tokens_details.thinking_tokens to be absent, got %v", thinkingNode.Raw)
+				}
+			}
+		})
+	}
+}

--- a/internal/translator/common/gemini.go
+++ b/internal/translator/common/gemini.go
@@ -43,6 +43,7 @@ func MergeAdjacentGeminiContents(contents [][]byte) [][]byte {
 				for _, p := range partsResult.Array() {
 					combinedParts = append(combinedParts, []byte(p.Raw))
 				}
+				combinedParts = ReorderGeminiUserParts(combinedParts)
 				updated, err := sjson.SetRawBytes(lastJSON, "parts", JoinRawArray(combinedParts))
 				if err == nil {
 					merged[lastIndex] = updated
@@ -66,6 +67,39 @@ func ContentHasGeminiFunctionResponse(content []byte) bool {
 		return true
 	})
 	return hasFR
+}
+
+// ReorderGeminiUserParts reorders parts within a Gemini user turn so that
+// text parts (such as prompt text and system reminders) precede functionResponse
+// parts. This resolves upstream provider validation failures (such as Google Cloud
+// Vertex AI returning 400 "Requests ending with a model turn are not supported" when
+// functionResponse is followed by text in the same turn).
+func ReorderGeminiUserParts(parts [][]byte) [][]byte {
+	hasFR := false
+	hasTrailingText := false
+	for _, p := range parts {
+		isFR := gjson.GetBytes(p, "functionResponse").Exists() || gjson.GetBytes(p, "function_response").Exists()
+		if isFR {
+			hasFR = true
+		} else if hasFR && gjson.GetBytes(p, "text").Exists() {
+			hasTrailingText = true
+			break
+		}
+	}
+	if !hasFR || !hasTrailingText {
+		return parts
+	}
+
+	promptParts := make([][]byte, 0, len(parts))
+	toolParts := make([][]byte, 0, len(parts))
+	for _, p := range parts {
+		if gjson.GetBytes(p, "text").Exists() {
+			promptParts = append(promptParts, p)
+		} else {
+			toolParts = append(toolParts, p)
+		}
+	}
+	return append(promptParts, toolParts...)
 }
 
 // MergeAdjacentGeminiUserContents merges consecutive user Content turns,

--- a/internal/translator/common/gemini_test.go
+++ b/internal/translator/common/gemini_test.go
@@ -83,6 +83,27 @@ func TestMergeAdjacentGeminiContents(t *testing.T) {
 			t.Fatalf("expected 1 turn, got %d", len(merged))
 		}
 	})
+
+	t.Run("merges consecutive user turns and reorders trailing text before functionResponse", func(t *testing.T) {
+		contents := [][]byte{
+			[]byte(`{"role":"user","parts":[{"functionResponse":{"name":"read","response":{"result":"ok"}}}]}`),
+			[]byte(`{"role":"user","parts":[{"text":"<system-reminder>reminder</system-reminder>"}]}`),
+		}
+		merged := MergeAdjacentGeminiContents(contents)
+		if len(merged) != 1 {
+			t.Fatalf("expected 1 merged turn, got %d", len(merged))
+		}
+		parts := gjson.GetBytes(merged[0], "parts").Array()
+		if len(parts) != 2 {
+			t.Fatalf("expected 2 parts, got %d", len(parts))
+		}
+		if got := parts[0].Get("text").String(); got != "<system-reminder>reminder</system-reminder>" {
+			t.Fatalf("expected parts[0] to be text, got %q", got)
+		}
+		if got := parts[1].Get("functionResponse.name").String(); got != "read" {
+			t.Fatalf("expected parts[1] to be functionResponse, got %q", got)
+		}
+	})
 }
 
 func TestMergeAdjacentGeminiUserContents(t *testing.T) {
@@ -110,6 +131,72 @@ func TestMergeAdjacentGeminiUserContents(t *testing.T) {
 		merged := MergeAdjacentGeminiUserContents(contents)
 		if len(merged) != 3 {
 			t.Fatalf("expected 3 separate turns preserving functionResponse, got %d", len(merged))
+		}
+	})
+}
+
+func TestReorderGeminiUserParts(t *testing.T) {
+	t.Run("returns unchanged when no functionResponse", func(t *testing.T) {
+		parts := [][]byte{
+			[]byte(`{"text":"hello"}`),
+			[]byte(`{"inline_data":{"mime_type":"image/png","data":"abc"}}`),
+		}
+		reordered := ReorderGeminiUserParts(parts)
+		if len(reordered) != 2 || gjson.GetBytes(reordered[0], "text").String() != "hello" {
+			t.Fatalf("unexpected parts: %v", reordered)
+		}
+	})
+
+	t.Run("returns unchanged when text already precedes functionResponse", func(t *testing.T) {
+		parts := [][]byte{
+			[]byte(`{"text":"context"}`),
+			[]byte(`{"functionResponse":{"name":"read","response":{"result":"ok"}}}`),
+		}
+		reordered := ReorderGeminiUserParts(parts)
+		if len(reordered) != 2 || gjson.GetBytes(reordered[0], "text").String() != "context" {
+			t.Fatalf("unexpected parts: %v", reordered)
+		}
+	})
+
+	t.Run("reorders trailing text before functionResponse", func(t *testing.T) {
+		parts := [][]byte{
+			[]byte(`{"functionResponse":{"name":"read","response":{"result":"ok"}}}`),
+			[]byte(`{"text":"<system-reminder>reminder</system-reminder>"}`),
+		}
+		reordered := ReorderGeminiUserParts(parts)
+		if len(reordered) != 2 {
+			t.Fatalf("expected 2 parts, got %d", len(reordered))
+		}
+		if got := gjson.GetBytes(reordered[0], "text").String(); got != "<system-reminder>reminder</system-reminder>" {
+			t.Fatalf("expected parts[0] to be text, got %q", got)
+		}
+		if got := gjson.GetBytes(reordered[1], "functionResponse.name").String(); got != "read" {
+			t.Fatalf("expected parts[1] to be functionResponse, got %q", got)
+		}
+	})
+
+	t.Run("preserves relative order with multiple functionResponses and texts", func(t *testing.T) {
+		parts := [][]byte{
+			[]byte(`{"text":"leading"}`),
+			[]byte(`{"functionResponse":{"name":"tool1","response":{"result":"1"}}}`),
+			[]byte(`{"functionResponse":{"name":"tool2","response":{"result":"2"}}}`),
+			[]byte(`{"text":"trailing"}`),
+		}
+		reordered := ReorderGeminiUserParts(parts)
+		if len(reordered) != 4 {
+			t.Fatalf("expected 4 parts, got %d", len(reordered))
+		}
+		if got := gjson.GetBytes(reordered[0], "text").String(); got != "leading" {
+			t.Fatalf("parts[0] text = %q, want leading", got)
+		}
+		if got := gjson.GetBytes(reordered[1], "text").String(); got != "trailing" {
+			t.Fatalf("parts[1] text = %q, want trailing", got)
+		}
+		if got := gjson.GetBytes(reordered[2], "functionResponse.name").String(); got != "tool1" {
+			t.Fatalf("parts[2] name = %q, want tool1", got)
+		}
+		if got := gjson.GetBytes(reordered[3], "functionResponse.name").String(); got != "tool2" {
+			t.Fatalf("parts[3] name = %q, want tool2", got)
 		}
 	})
 }

--- a/internal/translator/common/responses.go
+++ b/internal/translator/common/responses.go
@@ -1,6 +1,11 @@
 package common
 
-import "github.com/tidwall/sjson"
+import (
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
 
 // SetResponsesToolCallIdentity writes a resolved Responses tool name and namespace.
 func SetResponsesToolCallIdentity(item []byte, name, namespace, itemPath string) []byte {
@@ -17,4 +22,155 @@ func SetResponsesToolCallIdentity(item []byte, name, namespace, itemPath string)
 		item, _ = sjson.DeleteBytes(item, namespacePath)
 	}
 	return item
+}
+
+// ExtractResponsesCallID extracts the tool call ID from a Responses API item,
+// prioritizing dedicated tool call references over generic item IDs:
+// call_id -> tool_call_id -> callId -> id
+func ExtractResponsesCallID(node gjson.Result) string {
+	if callID := strings.TrimSpace(node.Get("call_id").String()); callID != "" {
+		return callID
+	}
+	if toolCallID := strings.TrimSpace(node.Get("tool_call_id").String()); toolCallID != "" {
+		return toolCallID
+	}
+	if callId := strings.TrimSpace(node.Get("callId").String()); callId != "" {
+		return callId
+	}
+	return strings.TrimSpace(node.Get("id").String())
+}
+
+// NormalizeResponsesToolCallOutputs scans a slice of Responses input items,
+// pairs function_call_output / custom_tool_call_output with preceding pending tool calls,
+// and assigns missing call_ids to tool outputs using a multi-pass matching strategy:
+// 1. Exact explicit call ID match (reserving calls for outputs that explicitly reference them across the entire conversation).
+// 2. Function name match for outputs that omit a call ID (skipping pending calls reserved by future explicit outputs).
+// 3. FIFO queue fallback for remaining outputs that omit a call ID (skipping pending calls reserved by future explicit outputs).
+// Outputs that already carry an explicit call ID that does not match any pending call
+// are never rewritten or stolen.
+func NormalizeResponsesToolCallOutputs(items []gjson.Result) []gjson.Result {
+	if len(items) == 0 {
+		return items
+	}
+
+	normalized := make([]gjson.Result, len(items))
+	copy(normalized, items)
+
+	explicitOutputCounts := make(map[string]int)
+	for _, item := range items {
+		typ := item.Get("type").String()
+		if typ == "function_call_output" || typ == "custom_tool_call_output" {
+			if id := ExtractResponsesCallID(item); id != "" {
+				explicitOutputCounts[id]++
+			}
+		}
+	}
+
+	var pendingCallIDs []string
+	pendingCallNames := make(map[string]string)
+
+	i := 0
+	for i < len(normalized) {
+		item := normalized[i]
+		itemType := item.Get("type").String()
+
+		switch itemType {
+		case "function_call", "custom_tool_call":
+			callID := ExtractResponsesCallID(item)
+			if callID != "" {
+				pendingCallIDs = append(pendingCallIDs, callID)
+				name := item.Get("name").String()
+				pendingCallNames[callID] = name
+			}
+			i++
+
+		case "function_call_output", "custom_tool_call_output":
+			start := i
+			for i < len(normalized) && (normalized[i].Get("type").String() == "function_call_output" || normalized[i].Get("type").String() == "custom_tool_call_output") {
+				i++
+			}
+			outputs := normalized[start:i]
+
+			if len(pendingCallIDs) > 0 {
+				used := make([]bool, len(outputs))
+				matchedForPending := make([]int, len(pendingCallIDs))
+				for idx := range matchedForPending {
+					matchedForPending[idx] = -1
+				}
+
+				// Pass 1: exact explicit call ID match
+				for pendingIdx, pendingID := range pendingCallIDs {
+					for outIdx, out := range outputs {
+						if !used[outIdx] && ExtractResponsesCallID(out) == pendingID {
+							used[outIdx] = true
+							matchedForPending[pendingIdx] = outIdx
+							explicitOutputCounts[pendingID]--
+							break
+						}
+					}
+				}
+
+				// Pass 2: match by function name for outputs with no explicit call ID (skipping pending IDs reserved by future explicit outputs)
+				for pendingIdx, pendingID := range pendingCallIDs {
+					if matchedForPending[pendingIdx] >= 0 || explicitOutputCounts[pendingID] > 0 {
+						continue
+					}
+					expectedName := pendingCallNames[pendingID]
+					if expectedName != "" {
+						for outIdx, out := range outputs {
+							if !used[outIdx] && ExtractResponsesCallID(out) == "" {
+								outName := strings.TrimSpace(out.Get("name").String())
+								if outName != "" && outName == expectedName {
+									used[outIdx] = true
+									matchedForPending[pendingIdx] = outIdx
+									break
+								}
+							}
+						}
+					}
+				}
+
+				// Pass 3: FIFO fallback for outputs with no explicit call ID (skipping pending IDs reserved by future explicit outputs)
+				for pendingIdx := range pendingCallIDs {
+					pendingID := pendingCallIDs[pendingIdx]
+					if matchedForPending[pendingIdx] >= 0 || explicitOutputCounts[pendingID] > 0 {
+						continue
+					}
+					for outIdx, out := range outputs {
+						if !used[outIdx] && ExtractResponsesCallID(out) == "" {
+							outName := strings.TrimSpace(out.Get("name").String())
+							expectedName := pendingCallNames[pendingID]
+							if outName == "" || expectedName == "" || outName == expectedName {
+								used[outIdx] = true
+								matchedForPending[pendingIdx] = outIdx
+								break
+							}
+						}
+					}
+				}
+
+				// Apply matched call_ids to outputs
+				var remainingPending []string
+				for pendingIdx, pendingID := range pendingCallIDs {
+					outIdx := matchedForPending[pendingIdx]
+					if outIdx < 0 {
+						remainingPending = append(remainingPending, pendingID)
+						continue
+					}
+					matchedOut := outputs[outIdx]
+					if matchedOut.Get("call_id").String() != pendingID {
+						raw := []byte(matchedOut.Raw)
+						raw, _ = sjson.SetBytes(raw, "call_id", pendingID)
+						normalized[start+outIdx] = gjson.ParseBytes(raw)
+					}
+				}
+				pendingCallIDs = remainingPending
+			}
+
+		default:
+			i++
+		}
+	}
+
+	return normalized
 }

--- a/internal/translator/common/responses_test.go
+++ b/internal/translator/common/responses_test.go
@@ -68,3 +68,123 @@ func TestSetResponsesToolCallIdentity(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractResponsesCallID(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "call_id standard",
+			input:    `{"call_id":"call_1"}`,
+			expected: "call_1",
+		},
+		{
+			name:     "tool_call_id",
+			input:    `{"tool_call_id":"call_2"}`,
+			expected: "call_2",
+		},
+		{
+			name:     "callId",
+			input:    `{"callId":"call_3"}`,
+			expected: "call_3",
+		},
+		{
+			name:     "id fallback",
+			input:    `{"id":"call_4"}`,
+			expected: "call_4",
+		},
+		{
+			name:     "dedicated call_id takes precedence over id",
+			input:    `{"id":"item_5","call_id":"call_5"}`,
+			expected: "call_5",
+		},
+		{
+			name:     "tool_call_id takes precedence over id",
+			input:    `{"id":"item_6","tool_call_id":"call_6"}`,
+			expected: "call_6",
+		},
+		{
+			name:     "callId takes precedence over id",
+			input:    `{"id":"item_7","callId":"call_7"}`,
+			expected: "call_7",
+		},
+		{
+			name:     "empty",
+			input:    `{"output":"result"}`,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := gjson.Parse(tt.input)
+			if got := ExtractResponsesCallID(node); got != tt.expected {
+				t.Fatalf("ExtractResponsesCallID(%s) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNormalizeResponsesToolCallOutputs(t *testing.T) {
+	t.Run("preserves explicit call_id and fills missing in reverse order", func(t *testing.T) {
+		input := []byte(`[
+			{"type":"function_call","call_id":"call_a","name":"tool_a"},
+			{"type":"function_call","call_id":"call_b","name":"tool_b"},
+			{"type":"function_call_output","output":"result_b"},
+			{"type":"function_call_output","tool_call_id":"call_a","output":"result_a"}
+		]`)
+		items := gjson.ParseBytes(input).Array()
+		normalized := NormalizeResponsesToolCallOutputs(items)
+		if len(normalized) != 4 {
+			t.Fatalf("expected 4 items, got %d", len(normalized))
+		}
+
+		// First output had no ID, but call_a is reserved by second output, so first output gets call_b
+		if got := normalized[2].Get("call_id").String(); got != "call_b" {
+			t.Fatalf("normalized[2].call_id = %q, want call_b", got)
+		}
+		// Second output had explicit tool_call_id call_a, so its call_id is set to call_a
+		if got := normalized[3].Get("call_id").String(); got != "call_a" {
+			t.Fatalf("normalized[3].call_id = %q, want call_a", got)
+		}
+	})
+
+	t.Run("preserves explicit call_id across intervening user message", func(t *testing.T) {
+		input := []byte(`[
+			{"type":"function_call","call_id":"call_a","name":"tool_a"},
+			{"type":"function_call","call_id":"call_b","name":"tool_b"},
+			{"type":"function_call_output","output":"result_b"},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"intervening"}]},
+			{"type":"function_call_output","call_id":"call_a","output":"result_a"}
+		]`)
+		items := gjson.ParseBytes(input).Array()
+		normalized := NormalizeResponsesToolCallOutputs(items)
+		if len(normalized) != 5 {
+			t.Fatalf("expected 5 items, got %d", len(normalized))
+		}
+
+		// First output (index 2) had no ID, but call_a is reserved across the intervening message by index 4,
+		// so index 2 must get call_b
+		if got := normalized[2].Get("call_id").String(); got != "call_b" {
+			t.Fatalf("normalized[2].call_id = %q, want call_b", got)
+		}
+		// Last output (index 4) has explicit call_a
+		if got := normalized[4].Get("call_id").String(); got != "call_a" {
+			t.Fatalf("normalized[4].call_id = %q, want call_a", got)
+		}
+	})
+
+	t.Run("does not steal explicit unmatched call_id", func(t *testing.T) {
+		input := []byte(`[
+			{"type":"function_call","call_id":"call_a","name":"tool_a"},
+			{"type":"function_call_output","call_id":"call_other","output":"result_other"}
+		]`)
+		items := gjson.ParseBytes(input).Array()
+		normalized := NormalizeResponsesToolCallOutputs(items)
+		if got := normalized[1].Get("call_id").String(); got != "call_other" {
+			t.Fatalf("normalized[1].call_id = %q, want call_other", got)
+		}
+	})
+}

--- a/internal/translator/gemini/claude/gemini_claude_request.go
+++ b/internal/translator/gemini/claude/gemini_claude_request.go
@@ -205,6 +205,9 @@ func convertClaudeRequestToGemini(modelName string, inputRawJSON []byte, _ bool,
 					}
 					return true
 				})
+				if role == "user" {
+					partItems = translatorcommon.ReorderGeminiUserParts(partItems)
+				}
 				contentItems = append(contentItems, geminiContentWithParts(role, partItems))
 			} else if contentsResult.Type == gjson.String {
 				part := []byte(`{"text":""}`)

--- a/internal/translator/gemini/claude/gemini_claude_request_test.go
+++ b/internal/translator/gemini/claude/gemini_claude_request_test.go
@@ -393,17 +393,17 @@ func TestConvertClaudeRequestToGemini_AlignsPermutedParallelToolResultsWithMixed
 	if got := responseParts[0].Get("text").String(); got != "Results arrived." {
 		t.Fatalf("leading text = %q; output=%s", got, output)
 	}
+	if got := responseParts[1].Get("text").String(); got != "Continue." {
+		t.Fatalf("trailing text reordered before functionResponse = %q; output=%s", got, output)
+	}
 	for index, wantID := range []string{"call_1", "call_2", "call_3"} {
-		responsePart := responseParts[index+1]
+		responsePart := responseParts[index+2]
 		if gotID := responsePart.Get("functionResponse.id").String(); gotID != wantID {
 			t.Fatalf("functionResponse[%d].id = %q, want %q; output=%s", index, gotID, wantID, output)
 		}
 		if gotName := responsePart.Get("functionResponse.name").String(); gotName != "Read" {
 			t.Fatalf("functionResponse[%d].name = %q, want Read; output=%s", index, gotName, output)
 		}
-	}
-	if got := responseParts[4].Get("text").String(); got != "Continue." {
-		t.Fatalf("trailing text = %q; output=%s", got, output)
 	}
 	if errPairing := internalsignature.ValidateGeminiFunctionCallPairing(output); errPairing != nil {
 		t.Fatalf("translated parallel tool history is invalid: %v; output=%s", errPairing, output)
@@ -438,5 +438,57 @@ func TestConvertClaudeRequestToGemini_StringToolResult(t *testing.T) {
 	// String content must not be double-encoded: result should be exactly "alpha".
 	if got := fr.Get("response.result").String(); got != "alpha" {
 		t.Fatalf("expected result 'alpha', got '%s' (raw=%s)", got, fr.Get("response.result").Raw)
+	}
+}
+
+func TestConvertClaudeRequestToGemini_ToolResultWithTrailingSystemReminderReordersParts(t *testing.T) {
+	inputJSON := []byte(`{
+		"model": "gemini-3.8-flash",
+		"messages": [
+			{
+				"role": "user",
+				"content": [{"type": "text", "text": "Read the file"}]
+			},
+			{
+				"role": "assistant",
+				"content": [
+					{"type": "tool_use", "id": "toolu_01_read", "name": "Read", "input": {"path": "main.go"}}
+				]
+			},
+			{
+				"role": "user",
+				"content": [
+					{"type": "tool_result", "tool_use_id": "toolu_01_read", "content": "package main"},
+					{"type": "text", "text": "<system-reminder>\n<total_tokens>1234</total_tokens>\n</system-reminder>"}
+				]
+			}
+		]
+	}`)
+
+	output := ConvertClaudeRequestToGemini("gemini-3.8-flash", inputJSON, false)
+
+	contents := gjson.GetBytes(output, "contents").Array()
+	if len(contents) != 3 {
+		t.Fatalf("expected 3 contents turns, got %d: %s", len(contents), output)
+	}
+
+	userParts := contents[2].Get("parts").Array()
+	if len(userParts) != 2 {
+		t.Fatalf("expected 2 parts in user response turn, got %d: %s", len(userParts), contents[2].Raw)
+	}
+
+	// Text part must precede functionResponse part to prevent Vertex AI 400
+	// ("Requests ending with a model turn are not supported").
+	if !userParts[0].Get("text").Exists() {
+		t.Fatalf("expected parts[0] to be text part, got: %s", userParts[0].Raw)
+	}
+	if gotText := userParts[0].Get("text").String(); gotText != "<system-reminder>\n<total_tokens>1234</total_tokens>\n</system-reminder>" {
+		t.Fatalf("unexpected text in parts[0]: %q", gotText)
+	}
+	if !userParts[1].Get("functionResponse").Exists() {
+		t.Fatalf("expected parts[1] to be functionResponse part, got: %s", userParts[1].Raw)
+	}
+	if gotID := userParts[1].Get("functionResponse.id").String(); gotID != "toolu_01_read" {
+		t.Fatalf("unexpected functionResponse.id in parts[1]: %q", gotID)
 	}
 }

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
@@ -54,6 +54,7 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 		if hasGeminiCarrier {
 			useGeminiNativeReasoningLayout = true
 		}
+		inputItems = translatorcommon.NormalizeResponsesToolCallOutputs(inputItems)
 		items := pairOpenAIResponsesReasoningWithFunctionCalls(inputItems)
 		contentItems := make([][]byte, 0, len(items))
 		functionNamesByCallID := make(map[string]string)
@@ -61,7 +62,7 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 		for _, item := range items {
 			itemType := item.Get("type").String()
 			if itemType == "function_call" || itemType == "custom_tool_call" {
-				callID := item.Get("call_id").String()
+				callID := extractOpenAIResponsesCallID(item)
 				if _, exists := functionNamesByCallID[callID]; !exists {
 					name := item.Get("name").String()
 					if ns := item.Get("namespace").String(); ns != "" {
@@ -279,7 +280,7 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 				} else {
 					contentItems = append(contentItems, buildOpenAIResponsesFunctionCallModelContent(item, signature, forwardMap))
 				}
-				if callID := strings.TrimSpace(item.Get("call_id").String()); callID != "" {
+				if callID := extractOpenAIResponsesCallID(item); callID != "" {
 					pendingFunctionCallIDs = append(pendingFunctionCallIDs, callID)
 				}
 
@@ -327,7 +328,7 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 						i++
 					} else if (next.Get("type").String() == "function_call" || next.Get("type").String() == "custom_tool_call") && canBindFunction && strings.TrimSpace(next.Get("_cpa_reasoning_signature").String()) == "" && signature != geminiResponsesThoughtSignature {
 						contentItems = append(contentItems, buildOpenAIResponsesReasoningFunctionCallModelContent(thoughtText, next, signature, forwardMap))
-						if callID := strings.TrimSpace(next.Get("call_id").String()); callID != "" {
+						if callID := extractOpenAIResponsesCallID(next); callID != "" {
 							pendingFunctionCallIDs = append(pendingFunctionCallIDs, callID)
 						}
 						i++
@@ -623,12 +624,12 @@ func pairOpenAIResponsesReasoningWithFunctionCalls(items []gjson.Result) []gjson
 					postCallCarrier[carrierEnd] = true
 					carrierEnd++
 				}
-				callID := strings.TrimSpace(item.Get("call_id").String())
+				callID := extractOpenAIResponsesCallID(item)
 				if callID == "" {
 					continue
 				}
 				for outputIndex := groupEnd; outputIndex < outputEnd; outputIndex++ {
-					if strings.TrimSpace(items[outputIndex].Get("call_id").String()) == callID {
+					if extractOpenAIResponsesCallID(items[outputIndex]) == callID {
 						postCallSignature[callIndex] = strings.TrimSpace(items[callIndex+1].Get("encrypted_content").String())
 						consumedPostCallCarrier[callIndex+1] = true
 						break
@@ -742,7 +743,7 @@ func buildOpenAIResponsesFunctionCallPart(item gjson.Result, signature string, f
 	functionCall := []byte(`{"functionCall":{"name":"","args":{}}}`)
 	functionCall, _ = sjson.SetBytes(functionCall, "functionCall.name", name)
 	functionCall, _ = sjson.SetBytes(functionCall, "thoughtSignature", signature)
-	functionCall, _ = sjson.SetBytes(functionCall, "functionCall.id", item.Get("call_id").String())
+	functionCall, _ = sjson.SetBytes(functionCall, "functionCall.id", extractOpenAIResponsesCallID(item))
 
 	if item.Get("type").String() == "custom_tool_call" {
 		inputVal := item.Get("input")
@@ -903,11 +904,17 @@ func parseOpenAIResponsesArrayOutput(outputResult gjson.Result) (result string, 
 	}
 }
 
+func extractOpenAIResponsesCallID(node gjson.Result) string {
+	return translatorcommon.ExtractResponsesCallID(node)
+}
+
 func buildOpenAIResponsesFunctionResponseParts(item gjson.Result, functionNamesByCallID map[string]string) [][]byte {
-	callID := item.Get("call_id").String()
+	callID := extractOpenAIResponsesCallID(item)
 	functionName := "unknown"
 	if matchedName, ok := functionNamesByCallID[callID]; ok {
 		functionName = matchedName
+	} else if name := strings.TrimSpace(item.Get("name").String()); name != "" {
+		functionName = name
 	}
 	functionResponse := []byte(`{"functionResponse":{"name":"","response":{}}}`)
 	functionResponse, _ = sjson.SetBytes(functionResponse, "functionResponse.name", util.SanitizeFunctionName(functionName))
@@ -976,7 +983,7 @@ func orderOpenAIResponsesFunctionCallOutputs(outputs []gjson.Result, pendingCall
 	for _, pendingID := range pendingCallIDs {
 		match := -1
 		for outputIndex, output := range outputs {
-			if !used[outputIndex] && output.Get("call_id").String() == pendingID {
+			if !used[outputIndex] && extractOpenAIResponsesCallID(output) == pendingID {
 				match = outputIndex
 				break
 			}

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
@@ -1980,3 +1980,306 @@ func TestConvertOpenAIResponsesRequestToGemini_TwoTurnCustomToolRoundtripWithRea
 		t.Fatalf("expected functionResponse result '/workspace', got: %s", userRespParts[0].Raw)
 	}
 }
+
+func TestConvertOpenAIResponsesRequestToGemini_FunctionCallOutputAlternateIDsAndQueueFallback(t *testing.T) {
+	testCases := []struct {
+		name        string
+		outputField string
+		wantCallID  string
+		wantName    string
+	}{
+		{
+			name:        "call_id standard",
+			outputField: `"call_id":"call_123"`,
+			wantCallID:  "call_123",
+			wantName:    "Bash",
+		},
+		{
+			name:        "id alternate field",
+			outputField: `"id":"call_123"`,
+			wantCallID:  "call_123",
+			wantName:    "Bash",
+		},
+		{
+			name:        "tool_call_id alternate field",
+			outputField: `"tool_call_id":"call_123"`,
+			wantCallID:  "call_123",
+			wantName:    "Bash",
+		},
+		{
+			name:        "callId alternate field",
+			outputField: `"callId":"call_123"`,
+			wantCallID:  "call_123",
+			wantName:    "Bash",
+		},
+		{
+			name:        "missing call_id with name fallback to pending queue",
+			outputField: `"name":"Bash"`,
+			wantCallID:  "call_123",
+			wantName:    "Bash",
+		},
+		{
+			name:        "missing call_id completely fallback to pending queue",
+			outputField: ``,
+			wantCallID:  "call_123",
+			wantName:    "Bash",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			outputJSON := `{"type":"function_call_output","output":"result"`
+			if tc.outputField != "" {
+				outputJSON += `,` + tc.outputField
+			}
+			outputJSON += `}`
+
+			inputJSON := `{
+				"model": "gemini-3.7-flash-high",
+				"input": [
+					{"role":"user","content":"run bash"},
+					{"type":"function_call","call_id":"call_123","name":"Bash","arguments":"{\"command\":\"pwd\"}"},
+					` + outputJSON + `
+				]
+			}`
+
+			output := ConvertOpenAIResponsesRequestToGemini("gemini-3.7-flash-high", []byte(inputJSON), false)
+			contents := gjson.GetBytes(output, "contents").Array()
+			if len(contents) != 3 {
+				t.Fatalf("expected 3 contents, got %d; output=%s", len(contents), string(output))
+			}
+
+			userContent := contents[2]
+			parts := userContent.Get("parts").Array()
+			if len(parts) == 0 {
+				t.Fatalf("expected at least 1 part in user response, got 0; output=%s", string(output))
+			}
+
+			fr := parts[0].Get("functionResponse")
+			if !fr.Exists() {
+				t.Fatalf("missing functionResponse: %s", userContent.Raw)
+			}
+			if gotID := fr.Get("id").String(); gotID != tc.wantCallID {
+				t.Fatalf("functionResponse.id = %q, want %q; output=%s", gotID, tc.wantCallID, string(output))
+			}
+			if gotName := fr.Get("name").String(); gotName != tc.wantName {
+				t.Fatalf("functionResponse.name = %q, want %q; output=%s", gotName, tc.wantName, string(output))
+			}
+
+			if errValidate := internalsignature.ValidateGeminiFunctionCallPairing(output); errValidate != nil {
+				t.Fatalf("ValidateGeminiFunctionCallPairing failed: %v; output=%s", errValidate, string(output))
+			}
+		})
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToGemini_ParallelFunctionCallOutputsAlternateIDs(t *testing.T) {
+	// Two tool calls: call-1 and call-2
+	// Two outputs: reversed order with tool_call_id and id
+	inputJSON := `{
+		"model": "gemini-3.7-flash-high",
+		"input": [
+			{"role":"user","content":"run tools"},
+			{"type":"function_call","call_id":"call-1","name":"tool_a","arguments":"{}"},
+			{"type":"function_call","call_id":"call-2","name":"tool_b","arguments":"{}"},
+			{"type":"function_call_output","tool_call_id":"call-2","output":"result_b"},
+			{"type":"function_call_output","id":"call-1","output":"result_a"}
+		]
+	}`
+
+	output := ConvertOpenAIResponsesRequestToGemini("gemini-3.7-flash-high", []byte(inputJSON), false)
+	if errValidate := internalsignature.ValidateGeminiFunctionCallPairing(output); errValidate != nil {
+		t.Fatalf("parallel tool pairing validation failed: %v; output=%s", errValidate, string(output))
+	}
+
+	contents := gjson.GetBytes(output, "contents").Array()
+	if len(contents) != 3 {
+		t.Fatalf("expected 3 contents (user, model, user), got %d; output=%s", len(contents), string(output))
+	}
+
+	responses := contents[2].Get("parts").Array()
+	if len(responses) != 2 {
+		t.Fatalf("expected 2 response parts, got %d; output=%s", len(responses), string(output))
+	}
+
+	// Must be ordered call-1 then call-2 to match model functionCall order
+	if gotID := responses[0].Get("functionResponse.id").String(); gotID != "call-1" {
+		t.Fatalf("first response id = %q, want call-1", gotID)
+	}
+	if gotName := responses[0].Get("functionResponse.name").String(); gotName != "tool_a" {
+		t.Fatalf("first response name = %q, want tool_a", gotName)
+	}
+	if gotID := responses[1].Get("functionResponse.id").String(); gotID != "call-2" {
+		t.Fatalf("second response id = %q, want call-2", gotID)
+	}
+	if gotName := responses[1].Get("functionResponse.name").String(); gotName != "tool_b" {
+		t.Fatalf("second response name = %q, want tool_b", gotName)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToGemini_DedicatedCallIDTakesPrecedenceOverItemID(t *testing.T) {
+	// Items have item IDs (id: "item_b", "item_a") in addition to tool_call_id ("call_b", "call_a") in reverse order.
+	// Dedicated tool_call_id must take precedence over item id so content results are not swapped.
+	inputJSON := `{
+		"model": "gemini-3.7-flash-high",
+		"input": [
+			{"role":"user","content":"run tasks"},
+			{"type":"function_call","call_id":"call_a","name":"tool_a","arguments":"{}"},
+			{"type":"function_call","call_id":"call_b","name":"tool_b","arguments":"{}"},
+			{"type":"function_call_output","id":"item_b","tool_call_id":"call_b","output":"content_b"},
+			{"type":"function_call_output","id":"item_a","tool_call_id":"call_a","output":"content_a"}
+		]
+	}`
+
+	output := ConvertOpenAIResponsesRequestToGemini("gemini-3.7-flash-high", []byte(inputJSON), false)
+	if errValidate := internalsignature.ValidateGeminiFunctionCallPairing(output); errValidate != nil {
+		t.Fatalf("pairing validation failed: %v; output=%s", errValidate, string(output))
+	}
+
+	contents := gjson.GetBytes(output, "contents").Array()
+	if len(contents) != 3 {
+		t.Fatalf("expected 3 contents, got %d; output=%s", len(contents), string(output))
+	}
+
+	responses := contents[2].Get("parts").Array()
+	if len(responses) != 2 {
+		t.Fatalf("expected 2 responses, got %d; output=%s", len(responses), string(output))
+	}
+
+	// First response must pair with call_a and have content_a
+	if gotID := responses[0].Get("functionResponse.id").String(); gotID != "call_a" {
+		t.Fatalf("first response id = %q, want call_a", gotID)
+	}
+	if gotResult := responses[0].Get("functionResponse.response.result").String(); gotResult != "content_a" {
+		t.Fatalf("first response result = %q, want content_a (tool_call_id precedence check failed)", gotResult)
+	}
+
+	// Second response must pair with call_b and have content_b
+	if gotID := responses[1].Get("functionResponse.id").String(); gotID != "call_b" {
+		t.Fatalf("second response id = %q, want call_b", gotID)
+	}
+	if gotResult := responses[1].Get("functionResponse.response.result").String(); gotResult != "content_b" {
+		t.Fatalf("second response result = %q, want content_b (tool_call_id precedence check failed)", gotResult)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToGemini_ExplicitUnmatchedCallIDNotRebound(t *testing.T) {
+	// Pending call is call_1, but output has an explicit call_id: "call_other".
+	// It must NOT be hijacked and rewritten to call_1.
+	inputJSON := `{
+		"model": "gemini-3.7-flash-high",
+		"input": [
+			{"role":"user","content":"run bash"},
+			{"type":"function_call","call_id":"call_1","name":"Bash","arguments":"{}"},
+			{"type":"function_call_output","call_id":"call_other","output":"other_result"}
+		]
+	}`
+
+	output := ConvertOpenAIResponsesRequestToGemini("gemini-3.7-flash-high", []byte(inputJSON), false)
+	contents := gjson.GetBytes(output, "contents").Array()
+	if len(contents) != 3 {
+		t.Fatalf("expected 3 contents, got %d; output=%s", len(contents), string(output))
+	}
+
+	responses := contents[2].Get("parts").Array()
+	if len(responses) != 1 {
+		t.Fatalf("expected 1 response part, got %d; output=%s", len(responses), string(output))
+	}
+
+	// Output retains its explicit call_other ID and is not rebound to call_1
+	if gotID := responses[0].Get("functionResponse.id").String(); gotID != "call_other" {
+		t.Fatalf("response id = %q, want call_other (unmatched explicit ID was rewritten)", gotID)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToGemini_MixedMissingAndExplicitParallelOutputsAcrossUserMessage(t *testing.T) {
+	// Call A, Call B.
+	// Output 1 has NO ID (result B).
+	// Intervening user message.
+	// Output 2 explicitly has call_id: call_a (result A).
+	// Call A must NOT be stolen by Output 1; Output 1 must get Call B.
+	inputJSON := `{
+		"model": "gemini-3.7-flash-high",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"run"}]},
+			{"type":"function_call","call_id":"call_a","name":"tool_a","arguments":"{}"},
+			{"type":"function_call","call_id":"call_b","name":"tool_b","arguments":"{}"},
+			{"type":"function_call_output","output":"result_b"},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"intervening"}]},
+			{"type":"function_call_output","call_id":"call_a","output":"result_a"}
+		]
+	}`
+
+	output := ConvertOpenAIResponsesRequestToGemini("gemini-3.7-flash-high", []byte(inputJSON), false)
+	contents := gjson.GetBytes(output, "contents").Array()
+
+	resultMap := make(map[string]string)
+	for _, c := range contents {
+		if c.Get("role").String() == "user" {
+			for _, part := range c.Get("parts").Array() {
+				if fr := part.Get("functionResponse"); fr.Exists() {
+					resultMap[fr.Get("id").String()] = fr.Get("response.result").String()
+				}
+			}
+		}
+	}
+
+	if got := resultMap["call_a"]; got != "result_a" {
+		t.Fatalf("result for call_a = %q, want result_a", got)
+	}
+	if got := resultMap["call_b"]; got != "result_b" {
+		t.Fatalf("result for call_b = %q, want result_b", got)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToGemini_AllPendingCallsReservedByFutureExplicitOutputsDoesNotDuplicate(t *testing.T) {
+	// Call A is the only pending call.
+	// Output 1 has NO ID.
+	// Intervening user message.
+	// Output 2 explicitly has call_id: call_a.
+	// Output 1 must NOT be bound to call_a; call_a must not be duplicated.
+	inputJSON := `{
+		"model": "gemini-3.7-flash-high",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"run"}]},
+			{"type":"function_call","call_id":"call_a","name":"tool_a","arguments":"{}"},
+			{"type":"function_call_output","output":"result_1"},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"continue"}]},
+			{"type":"function_call_output","call_id":"call_a","output":"result_2"}
+		]
+	}`
+
+	output := ConvertOpenAIResponsesRequestToGemini("gemini-3.7-flash-high", []byte(inputJSON), false)
+	contents := gjson.GetBytes(output, "contents").Array()
+
+	var responseIDs []string
+	var responseResults []string
+	for _, c := range contents {
+		if c.Get("role").String() == "user" {
+			for _, part := range c.Get("parts").Array() {
+				if fr := part.Get("functionResponse"); fr.Exists() {
+					responseIDs = append(responseIDs, fr.Get("id").String())
+					responseResults = append(responseResults, fr.Get("response.result").String())
+				}
+			}
+		}
+	}
+
+	// Verify call_a is not duplicated
+	callACount := 0
+	for _, id := range responseIDs {
+		if id == "call_a" {
+			callACount++
+		}
+	}
+	if callACount != 1 {
+		t.Fatalf("call_a appeared %d times in responseIDs %v, want exactly 1", callACount, responseIDs)
+	}
+
+	// The response that carries call_a must be result_2 (the explicit one), not result_1
+	for idx, id := range responseIDs {
+		if id == "call_a" && responseResults[idx] != "result_2" {
+			t.Fatalf("call_a was bound to result %q, want result_2", responseResults[idx])
+		}
+	}
+}

--- a/internal/translator/openai/claude/openai_claude_request.go
+++ b/internal/translator/openai/claude/openai_claude_request.go
@@ -338,8 +338,10 @@ func convertClaudeRequestToOpenAI(modelName string, inputRawJSON []byte, stream 
 			openAIToolJSON, _ = sjson.SetBytes(openAIToolJSON, "function.description", tool.Get("description").String())
 
 			// Convert Anthropic input_schema to OpenAI function parameters
-			if inputSchema := tool.Get("input_schema"); inputSchema.Exists() {
+			if inputSchema := tool.Get("input_schema"); inputSchema.Exists() && inputSchema.Type != gjson.Null {
 				openAIToolJSON, _ = sjson.SetBytes(openAIToolJSON, "function.parameters", normalizeObjectSchemaProperties(inputSchema.Value()))
+			} else {
+				openAIToolJSON, _ = sjson.SetRawBytes(openAIToolJSON, "function.parameters", []byte(`{"type":"object","properties":{}}`))
 			}
 
 			toolItems = append(toolItems, openAIToolJSON)

--- a/internal/translator/openai/claude/openai_claude_request_test.go
+++ b/internal/translator/openai/claude/openai_claude_request_test.go
@@ -976,3 +976,44 @@ func TestConvertClaudeRequestToOpenAI_StopSequences(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertClaudeRequestToOpenAI_ToolWithoutInputSchemaDefaultsParameters(t *testing.T) {
+	inputJSON := []byte(`{
+		"model": "claude-opus-5",
+		"tools": [
+			{
+				"type": "web_search_20250305",
+				"name": "web_search",
+				"max_uses": 8
+			},
+			{
+				"name": "no_schema_custom"
+			},
+			{
+				"name": "null_schema_custom",
+				"input_schema": null
+			}
+		],
+		"messages": [{"role": "user", "content": "hello"}]
+	}`)
+
+	output := ConvertClaudeRequestToOpenAI("test-model", inputJSON, false)
+	outputJSON := gjson.ParseBytes(output)
+
+	for i, toolName := range []string{"web_search", "no_schema_custom", "null_schema_custom"} {
+		path := fmt.Sprintf("tools.%d.function", i)
+		if got := outputJSON.Get(path + ".name").String(); got != toolName {
+			t.Fatalf("tool %d name = %q, want %q", i, got, toolName)
+		}
+		params := outputJSON.Get(path + ".parameters")
+		if !params.Exists() {
+			t.Fatalf("tool %d function.parameters missing: %s", i, outputJSON.Get(path).Raw)
+		}
+		if got := params.Get("type").String(); got != "object" {
+			t.Fatalf("tool %d function.parameters.type = %q, want object", i, got)
+		}
+		if got := params.Get("properties"); !got.Exists() || !got.IsObject() {
+			t.Fatalf("tool %d function.parameters.properties missing or not object: %s", i, params.Raw)
+		}
+	}
+}

--- a/internal/translator/openai/claude/openai_claude_response.go
+++ b/internal/translator/openai/claude/openai_claude_response.go
@@ -58,11 +58,21 @@ type ConvertOpenAIResponseToAnthropicParams struct {
 	ThinkingContentBlockIndex int
 	// Next available content block index
 	NextContentBlockIndex int
+	// Currently open tool call index (-1 if none)
+	OpenToolCallIndex int
+	// Queue of interleaved text or thinking chunks arriving while a tool call is open
+	InterleavedContentChunks []InterleavedContentChunk
 	// Usage metrics cached from streaming chunks
 	UsageInputTokens      int64
 	UsageOutputTokens     int64
 	UsageCachedTokens     int64
 	UsageCacheWriteTokens int64
+}
+
+// InterleavedContentChunk stores a buffered chunk of text or thinking arriving while a tool call is open
+type InterleavedContentChunk struct {
+	Type string // "text" or "thinking"
+	Text string
 }
 
 // ToolCallAccumulator holds the state for accumulating tool call data
@@ -106,6 +116,8 @@ func ConvertOpenAIResponseToClaude(_ context.Context, _ string, originalRequestR
 			TextContentBlockIndex:       -1,
 			ThinkingContentBlockIndex:   -1,
 			NextContentBlockIndex:       0,
+			OpenToolCallIndex:           -1,
+			InterleavedContentChunks:    nil,
 			UsageInputTokens:            0,
 			UsageOutputTokens:           0,
 			UsageCachedTokens:           0,
@@ -188,51 +200,76 @@ func convertOpenAIStreamingChunkToAnthropic(rawJSON []byte, param *ConvertOpenAI
 				if reasoningText == "" {
 					continue
 				}
-				stopTextContentBlock(param, &results)
-				if !param.ThinkingContentBlockStarted {
-					if param.ThinkingContentBlockIndex == -1 {
-						param.ThinkingContentBlockIndex = param.NextContentBlockIndex
-						param.NextContentBlockIndex++
+				if param.OpenToolCallIndex != -1 {
+					if n := len(param.InterleavedContentChunks); n > 0 && param.InterleavedContentChunks[n-1].Type == "thinking" {
+						param.InterleavedContentChunks[n-1].Text += reasoningText
+					} else {
+						param.InterleavedContentChunks = append(param.InterleavedContentChunks, InterleavedContentChunk{
+							Type: "thinking",
+							Text: reasoningText,
+						})
 					}
-					contentBlockStartJSON := `{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`
-					contentBlockStartJSONBytes := []byte(contentBlockStartJSON)
-					contentBlockStartJSONBytes, _ = sjson.SetBytes(contentBlockStartJSONBytes, "index", param.ThinkingContentBlockIndex)
-					results = append(results, translatorcommon.AppendSSEEventBytes(nil, "content_block_start", contentBlockStartJSONBytes, 2))
-					param.ThinkingContentBlockStarted = true
-				}
+				} else {
+					stopTextContentBlock(param, &results)
+					if !param.ThinkingContentBlockStarted {
+						if param.ThinkingContentBlockIndex == -1 {
+							param.ThinkingContentBlockIndex = param.NextContentBlockIndex
+							param.NextContentBlockIndex++
+						}
+						contentBlockStartJSON := `{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`
+						contentBlockStartJSONBytes := []byte(contentBlockStartJSON)
+						contentBlockStartJSONBytes, _ = sjson.SetBytes(contentBlockStartJSONBytes, "index", param.ThinkingContentBlockIndex)
+						results = append(results, translatorcommon.AppendSSEEventBytes(nil, "content_block_start", contentBlockStartJSONBytes, 2))
+						param.ThinkingContentBlockStarted = true
+					}
 
-				thinkingDeltaJSON := `{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":""}}`
-				thinkingDeltaJSONBytes := []byte(thinkingDeltaJSON)
-				thinkingDeltaJSONBytes, _ = sjson.SetBytes(thinkingDeltaJSONBytes, "index", param.ThinkingContentBlockIndex)
-				thinkingDeltaJSONBytes, _ = sjson.SetBytes(thinkingDeltaJSONBytes, "delta.thinking", reasoningText)
-				results = append(results, translatorcommon.AppendSSEEventBytes(nil, "content_block_delta", thinkingDeltaJSONBytes, 2))
+					thinkingDeltaJSON := `{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":""}}`
+					thinkingDeltaJSONBytes := []byte(thinkingDeltaJSON)
+					thinkingDeltaJSONBytes, _ = sjson.SetBytes(thinkingDeltaJSONBytes, "index", param.ThinkingContentBlockIndex)
+					thinkingDeltaJSONBytes, _ = sjson.SetBytes(thinkingDeltaJSONBytes, "delta.thinking", reasoningText)
+					results = append(results, translatorcommon.AppendSSEEventBytes(nil, "content_block_delta", thinkingDeltaJSONBytes, 2))
+				}
 			}
 		}
 
 		// Handle content delta
 		if content := delta.Get("content"); content.Exists() && content.String() != "" {
-			// Send content_block_start for text if not already sent
-			if !param.TextContentBlockStarted {
-				stopThinkingContentBlock(param, &results)
-				if param.TextContentBlockIndex == -1 {
-					param.TextContentBlockIndex = param.NextContentBlockIndex
-					param.NextContentBlockIndex++
+			if param.OpenToolCallIndex != -1 {
+				// Tool call content block is currently active on the wire.
+				// Buffer this text so content blocks remain strictly sequential.
+				if n := len(param.InterleavedContentChunks); n > 0 && param.InterleavedContentChunks[n-1].Type == "text" {
+					param.InterleavedContentChunks[n-1].Text += content.String()
+				} else {
+					param.InterleavedContentChunks = append(param.InterleavedContentChunks, InterleavedContentChunk{
+						Type: "text",
+						Text: content.String(),
+					})
 				}
-				contentBlockStartJSON := `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`
-				contentBlockStartJSONBytes := []byte(contentBlockStartJSON)
-				contentBlockStartJSONBytes, _ = sjson.SetBytes(contentBlockStartJSONBytes, "index", param.TextContentBlockIndex)
-				results = append(results, translatorcommon.AppendSSEEventBytes(nil, "content_block_start", contentBlockStartJSONBytes, 2))
-				param.TextContentBlockStarted = true
+				param.ContentAccumulator.WriteString(content.String())
+			} else {
+				// Send content_block_start for text if not already sent
+				if !param.TextContentBlockStarted {
+					stopThinkingContentBlock(param, &results)
+					if param.TextContentBlockIndex == -1 {
+						param.TextContentBlockIndex = param.NextContentBlockIndex
+						param.NextContentBlockIndex++
+					}
+					contentBlockStartJSON := `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`
+					contentBlockStartJSONBytes := []byte(contentBlockStartJSON)
+					contentBlockStartJSONBytes, _ = sjson.SetBytes(contentBlockStartJSONBytes, "index", param.TextContentBlockIndex)
+					results = append(results, translatorcommon.AppendSSEEventBytes(nil, "content_block_start", contentBlockStartJSONBytes, 2))
+					param.TextContentBlockStarted = true
+				}
+
+				contentDeltaJSON := `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":""}}`
+				contentDeltaJSONBytes := []byte(contentDeltaJSON)
+				contentDeltaJSONBytes, _ = sjson.SetBytes(contentDeltaJSONBytes, "index", param.TextContentBlockIndex)
+				contentDeltaJSONBytes, _ = sjson.SetBytes(contentDeltaJSONBytes, "delta.text", content.String())
+				results = append(results, translatorcommon.AppendSSEEventBytes(nil, "content_block_delta", contentDeltaJSONBytes, 2))
+
+				// Accumulate content
+				param.ContentAccumulator.WriteString(content.String())
 			}
-
-			contentDeltaJSON := `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":""}}`
-			contentDeltaJSONBytes := []byte(contentDeltaJSON)
-			contentDeltaJSONBytes, _ = sjson.SetBytes(contentDeltaJSONBytes, "index", param.TextContentBlockIndex)
-			contentDeltaJSONBytes, _ = sjson.SetBytes(contentDeltaJSONBytes, "delta.text", content.String())
-			results = append(results, translatorcommon.AppendSSEEventBytes(nil, "content_block_delta", contentDeltaJSONBytes, 2))
-
-			// Accumulate content
-			param.ContentAccumulator.WriteString(content.String())
 		}
 
 		// Handle tool calls
@@ -287,8 +324,12 @@ func convertOpenAIStreamingChunkToAnthropic(rawJSON []byte, param *ConvertOpenAI
 				// Re-check on every chunk, not only chunks with a function
 				// object. Some upstreams split function.name and id across
 				// separate deltas.
+				// Anthropic requires strictly sequential content blocks.
+				// Only emit mid-stream start if no other tool call block is currently open.
 				if !accumulator.StartEmitted && accumulator.Name != "" && accumulator.ID != "" && !param.ContentBlocksStopped {
-					emitToolUseStart(param, index, accumulator, &results)
+					if param.OpenToolCallIndex == -1 {
+						emitToolUseStart(param, index, accumulator, &results)
+					}
 				}
 
 				return true
@@ -324,7 +365,7 @@ func convertOpenAIStreamingChunkToAnthropic(rawJSON []byte, param *ConvertOpenAI
 	// 1. Upstream provided a finish_reason, or
 	// 2. Upstream sent a trailing usage-only chunk (choices array is empty or absent) after content/tools started.
 	isTrailingUsageChunk := hasUsage && !root.Get("choices.0").Exists() &&
-		(param.FinishReason != "" || param.SawToolCall || param.TextContentBlockStarted || param.ThinkingContentBlockStarted || param.ContentAccumulator.Len() > 0)
+		(param.FinishReason != "" || param.SawToolCall || param.TextContentBlockStarted || param.ThinkingContentBlockStarted || param.ContentAccumulator.Len() > 0 || len(param.InterleavedContentChunks) > 0)
 
 	if !param.MessageDeltaSent && (param.FinishReason != "" || isTrailingUsageChunk) && hasUsage {
 		finalizeOpenAIAnthropicContentBlocks(param, &results)
@@ -532,6 +573,7 @@ func emitToolUseStart(param *ConvertOpenAIResponseToAnthropicParams, openAIToolI
 	*results = append(*results, translatorcommon.AppendSSEEventBytes(nil, "content_block_start", contentBlockStartJSON, 2))
 	accumulator.StartEmitted = true
 	param.SawToolCall = true
+	param.OpenToolCallIndex = openAIToolIndex
 }
 
 // emitBelatedToolUseStart finalizes a tool_use block that never received a
@@ -557,6 +599,76 @@ func emitBelatedToolUseStart(param *ConvertOpenAIResponseToAnthropicParams, open
 	return true
 }
 
+func finalizeSingleToolCall(param *ConvertOpenAIResponseToAnthropicParams, openAIToolIndex int, results *[][]byte) {
+	accumulator := param.ToolCallsAccumulator[openAIToolIndex]
+	if accumulator == nil {
+		return
+	}
+	if !accumulator.StartEmitted {
+		if !emitBelatedToolUseStart(param, openAIToolIndex, accumulator, results) {
+			return
+		}
+	}
+	blockIndex := param.toolContentBlockIndex(openAIToolIndex)
+
+	// Send complete input_json_delta with all accumulated arguments
+	if accumulator.Arguments.Len() > 0 {
+		inputDeltaJSON := []byte(`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}`)
+		inputDeltaJSON, _ = sjson.SetBytes(inputDeltaJSON, "index", blockIndex)
+		inputDeltaJSON, _ = sjson.SetBytes(inputDeltaJSON, "delta.partial_json", util.FixJSON(accumulator.Arguments.String()))
+		*results = append(*results, translatorcommon.AppendSSEEventBytes(nil, "content_block_delta", inputDeltaJSON, 2))
+	}
+
+	contentBlockStopJSON := []byte(`{"type":"content_block_stop","index":0}`)
+	contentBlockStopJSON, _ = sjson.SetBytes(contentBlockStopJSON, "index", blockIndex)
+	*results = append(*results, translatorcommon.AppendSSEEventBytes(nil, "content_block_stop", contentBlockStopJSON, 2))
+	delete(param.ToolCallBlockIndexes, openAIToolIndex)
+	param.OpenToolCallIndex = -1
+}
+
+func emitBufferedInterleavedContent(param *ConvertOpenAIResponseToAnthropicParams, results *[][]byte) {
+	if param == nil || len(param.InterleavedContentChunks) == 0 {
+		return
+	}
+	for _, chunk := range param.InterleavedContentChunks {
+		if chunk.Text == "" {
+			continue
+		}
+		idx := param.NextContentBlockIndex
+		param.NextContentBlockIndex++
+
+		switch chunk.Type {
+		case "thinking":
+			startJSON := []byte(`{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`)
+			startJSON, _ = sjson.SetBytes(startJSON, "index", idx)
+			*results = append(*results, translatorcommon.AppendSSEEventBytes(nil, "content_block_start", startJSON, 2))
+
+			deltaJSON := []byte(`{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":""}}`)
+			deltaJSON, _ = sjson.SetBytes(deltaJSON, "index", idx)
+			deltaJSON, _ = sjson.SetBytes(deltaJSON, "delta.thinking", chunk.Text)
+			*results = append(*results, translatorcommon.AppendSSEEventBytes(nil, "content_block_delta", deltaJSON, 2))
+
+			stopJSON := []byte(`{"type":"content_block_stop","index":0}`)
+			stopJSON, _ = sjson.SetBytes(stopJSON, "index", idx)
+			*results = append(*results, translatorcommon.AppendSSEEventBytes(nil, "content_block_stop", stopJSON, 2))
+		case "text":
+			startJSON := []byte(`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`)
+			startJSON, _ = sjson.SetBytes(startJSON, "index", idx)
+			*results = append(*results, translatorcommon.AppendSSEEventBytes(nil, "content_block_start", startJSON, 2))
+
+			deltaJSON := []byte(`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":""}}`)
+			deltaJSON, _ = sjson.SetBytes(deltaJSON, "index", idx)
+			deltaJSON, _ = sjson.SetBytes(deltaJSON, "delta.text", chunk.Text)
+			*results = append(*results, translatorcommon.AppendSSEEventBytes(nil, "content_block_delta", deltaJSON, 2))
+
+			stopJSON := []byte(`{"type":"content_block_stop","index":0}`)
+			stopJSON, _ = sjson.SetBytes(stopJSON, "index", idx)
+			*results = append(*results, translatorcommon.AppendSSEEventBytes(nil, "content_block_stop", stopJSON, 2))
+		}
+	}
+	param.InterleavedContentChunks = nil
+}
+
 func finalizeOpenAIAnthropicContentBlocks(param *ConvertOpenAIResponseToAnthropicParams, results *[][]byte) {
 	if param == nil {
 		return
@@ -565,27 +677,20 @@ func finalizeOpenAIAnthropicContentBlocks(param *ConvertOpenAIResponseToAnthropi
 	stopTextContentBlock(param, results)
 
 	if !param.ContentBlocksStopped {
+		if param.OpenToolCallIndex != -1 {
+			finalizeSingleToolCall(param, param.OpenToolCallIndex, results)
+		}
+
 		for _, index := range toolCallAccumulatorIndexes(param.ToolCallsAccumulator) {
 			accumulator := param.ToolCallsAccumulator[index]
-			if !emitBelatedToolUseStart(param, index, accumulator, results) {
+			if accumulator == nil || accumulator.StartEmitted {
 				continue
 			}
-			blockIndex := param.toolContentBlockIndex(index)
-
-			// Send complete input_json_delta with all accumulated arguments
-			if accumulator.Arguments.Len() > 0 {
-				inputDeltaJSON := []byte(`{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}`)
-				inputDeltaJSON, _ = sjson.SetBytes(inputDeltaJSON, "index", blockIndex)
-				inputDeltaJSON, _ = sjson.SetBytes(inputDeltaJSON, "delta.partial_json", util.FixJSON(accumulator.Arguments.String()))
-				*results = append(*results, translatorcommon.AppendSSEEventBytes(nil, "content_block_delta", inputDeltaJSON, 2))
-			}
-
-			contentBlockStopJSON := []byte(`{"type":"content_block_stop","index":0}`)
-			contentBlockStopJSON, _ = sjson.SetBytes(contentBlockStopJSON, "index", blockIndex)
-			*results = append(*results, translatorcommon.AppendSSEEventBytes(nil, "content_block_stop", contentBlockStopJSON, 2))
-			delete(param.ToolCallBlockIndexes, index)
+			finalizeSingleToolCall(param, index, results)
 		}
 		param.ContentBlocksStopped = true
+
+		emitBufferedInterleavedContent(param, results)
 	}
 }
 

--- a/internal/translator/openai/claude/openai_claude_response_test.go
+++ b/internal/translator/openai/claude/openai_claude_response_test.go
@@ -865,3 +865,171 @@ func TestNonStreamingUsage_PreservesCacheWriteTokens(t *testing.T) {
 		})
 	}
 }
+
+func assertSequentialContentBlocks(t *testing.T, events []sseEvent) {
+	t.Helper()
+	activeBlockIndex := int64(-1)
+	for _, e := range events {
+		switch e.Type {
+		case "content_block_start":
+			if activeBlockIndex != -1 {
+				t.Fatalf("content_block_start emitted for index %d while block %d is still open (events=%+v)",
+					gjson.Get(e.Payload, "index").Int(), activeBlockIndex, events)
+			}
+			activeBlockIndex = gjson.Get(e.Payload, "index").Int()
+		case "content_block_delta":
+			idx := gjson.Get(e.Payload, "index").Int()
+			if activeBlockIndex == -1 {
+				t.Fatalf("content_block_delta emitted for index %d but no block is open (events=%+v)", idx, events)
+			}
+			if idx != activeBlockIndex {
+				t.Fatalf("content_block_delta emitted for index %d but active block is %d (events=%+v)", idx, activeBlockIndex, events)
+			}
+		case "content_block_stop":
+			idx := gjson.Get(e.Payload, "index").Int()
+			if activeBlockIndex == -1 {
+				t.Fatalf("content_block_stop emitted for index %d but no block is open (events=%+v)", idx, events)
+			}
+			if idx != activeBlockIndex {
+				t.Fatalf("content_block_stop emitted for index %d but active block is %d (events=%+v)", idx, activeBlockIndex, events)
+			}
+			activeBlockIndex = -1
+		}
+	}
+	if activeBlockIndex != -1 {
+		t.Fatalf("stream ended with unclosed block %d (events=%+v)", activeBlockIndex, events)
+	}
+}
+
+func TestStreaming_InterleavedContentAndToolUse_StrictSequentialBlocks(t *testing.T) {
+	events := runStream(t, streamReq,
+		`{"id":"c1","model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"Bash","arguments":"{\"command\":"}}]},"finish_reason":null}]}`,
+		`{"id":"c1","model":"m","choices":[{"index":0,"delta":{"content":"\n"},"finish_reason":null}]}`,
+		`{"id":"c1","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"ls\"}"}}]},"finish_reason":null}]}`,
+		`{"id":"c1","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+	)
+
+	assertSequentialContentBlocks(t, events)
+
+	// Ensure tool call arguments were preserved and complete
+	var toolDeltas []sseEvent
+	for _, e := range events {
+		if e.Type == "content_block_delta" && gjson.Get(e.Payload, "delta.type").String() == "input_json_delta" {
+			toolDeltas = append(toolDeltas, e)
+		}
+	}
+	if len(toolDeltas) != 1 {
+		t.Fatalf("expected 1 tool input_json_delta, got %d", len(toolDeltas))
+	}
+	partialJSON := gjson.Get(toolDeltas[0].Payload, "delta.partial_json").String()
+	if gotCmd := gjson.Get(partialJSON, "command").String(); gotCmd != "ls" {
+		t.Fatalf("expected command 'ls', got %q", gotCmd)
+	}
+}
+
+func TestStreaming_ParallelToolCalls_StrictSequentialBlocks(t *testing.T) {
+	events := runStream(t, streamReq,
+		`{"id":"c1","model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[
+			{"index":0,"id":"call_1","type":"function","function":{"name":"Bash","arguments":"{\"command\":\"ls\"}"}},
+			{"index":1,"id":"call_2","type":"function","function":{"name":"Read","arguments":"{\"path\":\"/tmp\"}"}}
+		]},"finish_reason":"tool_calls"}]}`,
+	)
+
+	assertSequentialContentBlocks(t, events)
+
+	starts := toolUseStarts(events)
+	if len(starts) != 2 {
+		t.Fatalf("expected 2 tool_use starts, got %d", len(starts))
+	}
+	if id := gjson.Get(starts[0].Payload, "content_block.id").String(); id != "call_1" {
+		t.Fatalf("first tool id = %q, want %q", id, "call_1")
+	}
+	if name := gjson.Get(starts[0].Payload, "content_block.name").String(); name != "Bash" {
+		t.Fatalf("first tool name = %q, want %q", name, "Bash")
+	}
+	if id := gjson.Get(starts[1].Payload, "content_block.id").String(); id != "call_2" {
+		t.Fatalf("second tool id = %q, want %q", id, "call_2")
+	}
+	if name := gjson.Get(starts[1].Payload, "content_block.name").String(); name != "Read" {
+		t.Fatalf("second tool name = %q, want %q", name, "Read")
+	}
+
+	var toolDeltas []sseEvent
+	for _, e := range events {
+		if e.Type == "content_block_delta" && gjson.Get(e.Payload, "delta.type").String() == "input_json_delta" {
+			toolDeltas = append(toolDeltas, e)
+		}
+	}
+	if len(toolDeltas) != 2 {
+		t.Fatalf("expected 2 tool input_json_delta, got %d", len(toolDeltas))
+	}
+	if cmd := gjson.Get(gjson.Get(toolDeltas[0].Payload, "delta.partial_json").String(), "command").String(); cmd != "ls" {
+		t.Fatalf("first tool cmd = %q, want 'ls'", cmd)
+	}
+	if path := gjson.Get(gjson.Get(toolDeltas[1].Payload, "delta.partial_json").String(), "path").String(); path != "/tmp" {
+		t.Fatalf("second tool path = %q, want '/tmp'", path)
+	}
+}
+
+func TestStreaming_InterleavedTextAndThinkingPreservesOrder(t *testing.T) {
+	events := runStream(t, streamReq,
+		`{"id":"c1","model":"m","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"Bash","arguments":"{\"command\":"}}]},"finish_reason":null}]}`,
+		`{"id":"c1","model":"m","choices":[{"index":0,"delta":{"content":"Note A: "},"finish_reason":null}]}`,
+		`{"id":"c1","model":"m","choices":[{"index":0,"delta":{"content":"running check"},"finish_reason":null}]}`,
+		`{"id":"c1","model":"m","choices":[{"index":0,"delta":{"reasoning_content":"Thinking about safety"},"finish_reason":null}]}`,
+		`{"id":"c1","model":"m","choices":[{"index":0,"delta":{"content":"Note B: done"},"finish_reason":null}]}`,
+		`{"id":"c1","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"pwd\"}"}}]},"finish_reason":null}]}`,
+		`{"id":"c1","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+	)
+
+	assertSequentialContentBlocks(t, events)
+
+	// Block sequence should be:
+	// 0: tool_use (Bash, command: "pwd")
+	// 1: text ("Note A: running check")
+	// 2: thinking ("Thinking about safety")
+	// 3: text ("Note B: done")
+	var blockStarts []string
+	for _, e := range events {
+		if e.Type == "content_block_start" {
+			blockStarts = append(blockStarts, gjson.Get(e.Payload, "content_block.type").String())
+		}
+	}
+	expectedStarts := []string{"tool_use", "text", "thinking", "text"}
+	if len(blockStarts) != len(expectedStarts) {
+		t.Fatalf("expected block starts %v, got %v", expectedStarts, blockStarts)
+	}
+	for i, want := range expectedStarts {
+		if blockStarts[i] != want {
+			t.Fatalf("block %d type = %q, want %q", i, blockStarts[i], want)
+		}
+	}
+
+	// Verify text and thinking contents
+	var textDeltas []string
+	var thinkingDeltas []string
+	var toolDelta string
+	for _, e := range events {
+		if e.Type == "content_block_delta" {
+			dt := gjson.Get(e.Payload, "delta.type").String()
+			switch dt {
+			case "text_delta":
+				textDeltas = append(textDeltas, gjson.Get(e.Payload, "delta.text").String())
+			case "thinking_delta":
+				thinkingDeltas = append(thinkingDeltas, gjson.Get(e.Payload, "delta.thinking").String())
+			case "input_json_delta":
+				toolDelta = gjson.Get(e.Payload, "delta.partial_json").String()
+			}
+		}
+	}
+
+	if gotCmd := gjson.Get(toolDelta, "command").String(); gotCmd != "pwd" {
+		t.Fatalf("tool command = %q, want 'pwd'", gotCmd)
+	}
+	if len(textDeltas) != 2 || textDeltas[0] != "Note A: running check" || textDeltas[1] != "Note B: done" {
+		t.Fatalf("unexpected text deltas: %v", textDeltas)
+	}
+	if len(thinkingDeltas) != 1 || thinkingDeltas[0] != "Thinking about safety" {
+		t.Fatalf("unexpected thinking deltas: %v", thinkingDeltas)
+	}
+}

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request.go
@@ -66,14 +66,14 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 
 	// Convert input array to messages
 	if input := root.Get("input"); input.Exists() && input.IsArray() {
-		inputItems := input.Array()
+		inputItems := translatorcommon.NormalizeResponsesToolCallOutputs(input.Array())
 		outputCallIDs := make(map[string]struct{})
 		for _, item := range inputItems {
 			itemType := item.Get("type").String()
 			if itemType != "function_call_output" && itemType != "custom_tool_call_output" {
 				continue
 			}
-			callID := strings.TrimSpace(item.Get("call_id").String())
+			callID := translatorcommon.ExtractResponsesCallID(item)
 			if callID == "" {
 				continue
 			}
@@ -120,10 +120,11 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 				appendMessage(assistantMessage)
 			}
 			for _, id := range pendingToolCallIDs {
-				if strings.TrimSpace(id) == "" {
+				trimmed := strings.TrimSpace(id)
+				if trimmed == "" {
 					continue
 				}
-				awaitingToolOutputs[id] = struct{}{}
+				awaitingToolOutputs[trimmed] = struct{}{}
 			}
 			pendingToolCalls = pendingToolCalls[:0]
 			pendingToolCallIDs = pendingToolCallIDs[:0]
@@ -237,8 +238,8 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 				// Buffer consecutive function calls and emit them as one assistant message.
 				toolCall := []byte(`{"id":"","type":"function","function":{"name":"","arguments":""}}`)
 
-				if callId := item.Get("call_id"); callId.Exists() {
-					toolCall, _ = sjson.SetBytes(toolCall, "id", callId.String())
+				if callId := translatorcommon.ExtractResponsesCallID(item); callId != "" {
+					toolCall, _ = sjson.SetBytes(toolCall, "id", callId)
 				}
 
 				if name := item.Get("name"); name.Exists() {
@@ -255,7 +256,7 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 					toolCall, _ = sjson.SetBytes(toolCall, "function.arguments", arguments.String())
 				}
 				pendingToolCalls = append(pendingToolCalls, gjson.ParseBytes(toolCall).Value())
-				if callID := strings.TrimSpace(item.Get("call_id").String()); callID != "" {
+				if callID := translatorcommon.ExtractResponsesCallID(item); callID != "" {
 					pendingToolCallIDs = append(pendingToolCallIDs, callID)
 				}
 
@@ -263,11 +264,10 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 				mergeableAssistantIndex = -1
 				// Handle function call output conversion to tool message
 				toolMessage := []byte(`{"role":"tool","tool_call_id":"","content":""}`)
-				callID := ""
-
-				if callId := item.Get("call_id"); callId.Exists() {
-					callID = strings.TrimSpace(callId.String())
+				callID := translatorcommon.ExtractResponsesCallID(item)
+				if callID != "" {
 					toolMessage, _ = sjson.SetBytes(toolMessage, "tool_call_id", callID)
+					delete(awaitingToolOutputs, callID)
 				}
 
 				if output := item.Get("output"); output.Exists() {
@@ -275,9 +275,6 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 				}
 
 				appendMessage(toolMessage)
-				if callID != "" {
-					delete(awaitingToolOutputs, callID)
-				}
 				if len(awaitingToolOutputs) == 0 && len(deferredMessages) > 0 {
 					flushDeferredMessages()
 				}
@@ -288,7 +285,7 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 				// matches the {"input": string} function shape used when
 				// converting custom tool definitions.
 				toolCall := []byte(`{"id":"","type":"function","function":{"name":"","arguments":""}}`)
-				toolCall, _ = sjson.SetBytes(toolCall, "id", item.Get("call_id").String())
+				toolCall, _ = sjson.SetBytes(toolCall, "id", translatorcommon.ExtractResponsesCallID(item))
 				functionName := item.Get("name").String()
 				if namespace := item.Get("namespace").String(); namespace != "" {
 					functionName = qualifyResponsesNamespaceToolName(namespace, functionName)
@@ -299,22 +296,22 @@ func ConvertOpenAIResponsesRequestToOpenAIChatCompletions(modelName string, inpu
 				wrappedArgs, _ := sjson.SetBytes([]byte(`{"input":""}`), "input", item.Get("input").String())
 				toolCall, _ = sjson.SetBytes(toolCall, "function.arguments", string(wrappedArgs))
 				pendingToolCalls = append(pendingToolCalls, gjson.ParseBytes(toolCall).Value())
-				if callID := strings.TrimSpace(item.Get("call_id").String()); callID != "" {
+				if callID := translatorcommon.ExtractResponsesCallID(item); callID != "" {
 					pendingToolCallIDs = append(pendingToolCallIDs, callID)
 				}
 
 			case "custom_tool_call_output":
 				mergeableAssistantIndex = -1
 				toolMessage := []byte(`{"role":"tool","tool_call_id":"","content":""}`)
-				callID := strings.TrimSpace(item.Get("call_id").String())
-				toolMessage, _ = sjson.SetBytes(toolMessage, "tool_call_id", callID)
+				callID := translatorcommon.ExtractResponsesCallID(item)
+				if callID != "" {
+					toolMessage, _ = sjson.SetBytes(toolMessage, "tool_call_id", callID)
+					delete(awaitingToolOutputs, callID)
+				}
 				if output := item.Get("output"); output.Exists() {
 					toolMessage = setCustomToolCallOutputContent(toolMessage, output)
 				}
 				appendMessage(toolMessage)
-				if callID != "" {
-					delete(awaitingToolOutputs, callID)
-				}
 				if len(awaitingToolOutputs) == 0 && len(deferredMessages) > 0 {
 					flushDeferredMessages()
 				}

--- a/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_request_test.go
@@ -1139,3 +1139,186 @@ func TestResponsesCustomToolNames_OnlyReportsMergedTools(t *testing.T) {
 		}
 	}
 }
+
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_FunctionCallOutputAlternateIDsAndQueueFallback(t *testing.T) {
+	testCases := []struct {
+		name           string
+		outputField    string
+		wantToolCallID string
+	}{
+		{
+			name:           "call_id standard",
+			outputField:    `"call_id":"call_123"`,
+			wantToolCallID: "call_123",
+		},
+		{
+			name:           "tool_call_id alternate field",
+			outputField:    `"tool_call_id":"call_123"`,
+			wantToolCallID: "call_123",
+		},
+		{
+			name:           "callId alternate field",
+			outputField:    `"callId":"call_123"`,
+			wantToolCallID: "call_123",
+		},
+		{
+			name:           "id alternate field",
+			outputField:    `"id":"call_123"`,
+			wantToolCallID: "call_123",
+		},
+		{
+			name:           "missing call_id completely fallback to pending queue",
+			outputField:    ``,
+			wantToolCallID: "call_123",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			outputJSON := `{"type":"function_call_output","output":"tool_result_ok"`
+			if tc.outputField != "" {
+				outputJSON += `,` + tc.outputField
+			}
+			outputJSON += `}`
+
+			inputJSON := []byte(`{
+				"model": "deepseek-v4-flash",
+				"input": [
+					{"type":"function_call","call_id":"call_123","name":"Bash","arguments":"{\"command\":\"ls\"}"},
+					` + outputJSON + `
+				]
+			}`)
+
+			out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("deepseek-v4-flash", inputJSON, false)
+			messages := gjson.GetBytes(out, "messages").Array()
+			if len(messages) != 2 {
+				t.Fatalf("expected 2 messages (assistant, tool), got %d; output=%s", len(messages), string(out))
+			}
+
+			// Assistant message has tool_calls with id call_123
+			toolCallID := messages[0].Get("tool_calls.0.id").String()
+			if toolCallID != "call_123" {
+				t.Fatalf("tool_calls.0.id = %q, want call_123", toolCallID)
+			}
+
+			// Tool message has tool_call_id matching call_123
+			toolMessage := messages[1]
+			if toolMessage.Get("role").String() != "tool" {
+				t.Fatalf("expected role tool, got %s", toolMessage.Raw)
+			}
+			if gotID := toolMessage.Get("tool_call_id").String(); gotID != tc.wantToolCallID {
+				t.Fatalf("tool_call_id = %q, want %q; output=%s", gotID, tc.wantToolCallID, string(out))
+			}
+			if gotContent := toolMessage.Get("content").String(); gotContent != "tool_result_ok" {
+				t.Fatalf("tool message content = %q, want tool_result_ok", gotContent)
+			}
+		})
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_MixedMissingAndExplicitParallelOutputs(t *testing.T) {
+	// Call A, Call B.
+	// Output 1 has NO ID (result B).
+	// Output 2 explicitly has call_id: call_a (result A).
+	// Call A must NOT be stolen by Output 1; Output 1 must get Call B.
+	inputJSON := []byte(`{
+		"model": "deepseek-v4-flash",
+		"input": [
+			{"type":"function_call","call_id":"call_a","name":"tool_a","arguments":"{}"},
+			{"type":"function_call","call_id":"call_b","name":"tool_b","arguments":"{}"},
+			{"type":"function_call_output","output":"result_b"},
+			{"type":"function_call_output","call_id":"call_a","output":"result_a"}
+		]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("deepseek-v4-flash", inputJSON, false)
+	messages := gjson.GetBytes(out, "messages").Array()
+	if len(messages) != 3 {
+		t.Fatalf("expected 3 messages (assistant, tool_b, tool_a), got %d; output=%s", len(messages), string(out))
+	}
+
+	resultMap := make(map[string]string)
+	for _, m := range messages[1:] {
+		resultMap[m.Get("tool_call_id").String()] = m.Get("content").String()
+	}
+
+	if got := resultMap["call_a"]; got != "result_a" {
+		t.Fatalf("result for call_a = %q, want result_a", got)
+	}
+	if got := resultMap["call_b"]; got != "result_b" {
+		t.Fatalf("result for call_b = %q, want result_b", got)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_DefersMessageUntilMissingIDToolOutput(t *testing.T) {
+	// Call A -> intervening user message -> Output with missing call_id
+	// The user message must be deferred until AFTER the tool output!
+	inputJSON := []byte(`{
+		"model": "deepseek-v4-flash",
+		"input": [
+			{"type":"function_call","call_id":"call_a","name":"tool_a","arguments":"{}"},
+			{"type":"message","role":"user","content":"User command while running"},
+			{"type":"function_call_output","output":"result_a"}
+		]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("deepseek-v4-flash", inputJSON, false)
+	messages := gjson.GetBytes(out, "messages").Array()
+	if len(messages) != 3 {
+		t.Fatalf("expected 3 messages (assistant, tool, user), got %d; output=%s", len(messages), string(out))
+	}
+
+	// Message 0: assistant with tool_call
+	if got := messages[0].Get("role").String(); got != "assistant" {
+		t.Fatalf("messages[0].role = %q, want assistant", got)
+	}
+	// Message 1: tool response for call_a (strictly adjacent to assistant tool_calls!)
+	if got := messages[1].Get("role").String(); got != "tool" {
+		t.Fatalf("messages[1].role = %q, want tool (user message was not deferred!)", got)
+	}
+	if got := messages[1].Get("tool_call_id").String(); got != "call_a" {
+		t.Fatalf("messages[1].tool_call_id = %q, want call_a", got)
+	}
+	// Message 2: deferred user message
+	if got := messages[2].Get("role").String(); got != "user" {
+		t.Fatalf("messages[2].role = %q, want user", got)
+	}
+	if got := messages[2].Get("content").String(); got != "User command while running" {
+		t.Fatalf("messages[2].content = %q, want 'User command while running'", got)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToOpenAIChatCompletions_MixedMissingAndExplicitParallelOutputsAcrossUserMessage(t *testing.T) {
+	// Call A, Call B.
+	// Output 1 has NO ID (result B).
+	// Intervening user message.
+	// Output 2 explicitly has call_id: call_a (result A).
+	// Call A must NOT be stolen by Output 1; Output 1 must get Call B.
+	inputJSON := []byte(`{
+		"model": "deepseek-v4-flash",
+		"input": [
+			{"type":"function_call","call_id":"call_a","name":"tool_a","arguments":"{}"},
+			{"type":"function_call","call_id":"call_b","name":"tool_b","arguments":"{}"},
+			{"type":"function_call_output","output":"result_b"},
+			{"type":"message","role":"user","content":"status?"},
+			{"type":"function_call_output","call_id":"call_a","output":"result_a"}
+		]
+	}`)
+
+	out := ConvertOpenAIResponsesRequestToOpenAIChatCompletions("deepseek-v4-flash", inputJSON, false)
+	messages := gjson.GetBytes(out, "messages").Array()
+
+	resultMap := make(map[string]string)
+	for _, m := range messages {
+		if m.Get("role").String() == "tool" {
+			resultMap[m.Get("tool_call_id").String()] = m.Get("content").String()
+		}
+	}
+
+	if got := resultMap["call_a"]; got != "result_a" {
+		t.Fatalf("result for call_a = %q, want result_a", got)
+	}
+	if got := resultMap["call_b"]; got != "result_b" {
+		t.Fatalf("result for call_b = %q, want result_b", got)
+	}
+}

--- a/sdk/api/handlers/handlers_metadata_test.go
+++ b/sdk/api/handlers/handlers_metadata_test.go
@@ -283,4 +283,20 @@ func TestEnrichContextWithSessionHierarchyFromBody(t *testing.T) {
 	if metaCleared.SessionID != "" || metaCleared.ParentSessionID != "" {
 		t.Fatalf("cleared context = (%q, %q), want (empty, empty)", metaCleared.SessionID, metaCleared.ParentSessionID)
 	}
+
+	// 7. Roo Code task delegation from body
+	rooBody := []byte(`{"taskId":"task-child-99","parentTaskId":"task-parent-99"}`)
+	ctx7 := EnrichContextWithSessionHierarchy(context.Background(), nil, rooBody, nil)
+	meta7 := logging.GetClientRequestMetadata(ctx7)
+	if meta7.SessionID != "task:task-child-99" || meta7.ParentSessionID != "task:task-parent-99" {
+		t.Fatalf("Roo Code task session = (%q, %q), want (task:task-child-99, task:task-parent-99)", meta7.SessionID, meta7.ParentSessionID)
+	}
+
+	// 8. OpenCode parent_id in payload
+	opencodeBody := []byte(`{"session_id":"opencode-sess-1","parent_id":"opencode-root-1"}`)
+	ctx8 := EnrichContextWithSessionHierarchy(context.Background(), nil, opencodeBody, nil)
+	meta8 := logging.GetClientRequestMetadata(ctx8)
+	if meta8.SessionID != "session:opencode-sess-1" || meta8.ParentSessionID != "session:opencode-root-1" {
+		t.Fatalf("OpenCode parent_id session = (%q, %q), want (session:opencode-sess-1, session:opencode-root-1)", meta8.SessionID, meta8.ParentSessionID)
+	}
 }

--- a/sdk/auth/antigravity.go
+++ b/sdk/auth/antigravity.go
@@ -187,39 +187,16 @@ waitForCallback:
 		return nil, fmt.Errorf("antigravity: project ID discovery returned empty project")
 	}
 
-	now := time.Now()
-	metadata := map[string]any{
-		"type":          "antigravity",
-		"access_token":  tokenResp.AccessToken,
-		"refresh_token": tokenResp.RefreshToken,
-		"expires_in":    tokenResp.ExpiresIn,
-		"timestamp":     now.UnixMilli(),
-		"expired":       now.Add(time.Duration(tokenResp.ExpiresIn) * time.Second).Format(time.RFC3339),
-	}
-	if email != "" {
-		metadata["email"] = email
-	}
-	if projectID != "" {
-		metadata["project_id"] = projectID
-	}
-
-	fileName := antigravity.CredentialFileName(email)
-	label := email
-	if label == "" {
-		label = "antigravity"
-	}
-
 	fmt.Println("Antigravity authentication successful")
 	if projectID != "" {
 		fmt.Printf("Using GCP project: %s\n", util.HideAPIKey(projectID))
 	}
-	return &coreauth.Auth{
-		ID:       fileName,
-		Provider: "antigravity",
-		FileName: fileName,
-		Label:    label,
-		Metadata: metadata,
-	}, nil
+	return BuildAntigravityAuth(&AntigravityTokenResponse{
+		AccessToken:  tokenResp.AccessToken,
+		RefreshToken: tokenResp.RefreshToken,
+		ExpiresIn:    tokenResp.ExpiresIn,
+		TokenType:    tokenResp.TokenType,
+	}, email, projectID), nil
 }
 
 type callbackResult struct {
@@ -271,4 +248,131 @@ func FetchAntigravityProjectID(ctx context.Context, accessToken string, httpClie
 	cfg := &config.Config{}
 	authSvc := antigravity.NewAntigravityAuth(cfg, httpClient)
 	return authSvc.FetchProjectID(ctx, accessToken)
+}
+
+// AntigravityDefaultCallbackPort is the default local port used for Antigravity OAuth loopback callbacks.
+const AntigravityDefaultCallbackPort = antigravity.CallbackPort
+
+// AntigravityTokenResponse captures the tokens returned by Antigravity OAuth exchange.
+type AntigravityTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int64  `json:"expires_in"`
+	TokenType    string `json:"token_type"`
+}
+
+// AntigravityDefaultCallbackURI returns the default loopback redirect URI for Antigravity OAuth.
+func AntigravityDefaultCallbackURI() string {
+	return fmt.Sprintf("http://localhost:%d/oauth-callback", AntigravityDefaultCallbackPort)
+}
+
+// AntigravityUserAgent returns the canonical User-Agent string used by the Antigravity Hub family.
+func AntigravityUserAgent() string {
+	return misc.AntigravityUserAgent()
+}
+
+// BuildAntigravityAuthURL generates the OAuth authorization URL for Antigravity.
+// If redirectURI is empty, the default loopback callback URI is used.
+func BuildAntigravityAuthURL(state, redirectURI string) string {
+	authSvc := antigravity.NewAntigravityAuth(nil, nil)
+	return authSvc.BuildAuthURL(state, redirectURI)
+}
+
+// ExchangeAntigravityCode exchanges an authorization code for access and refresh tokens.
+func ExchangeAntigravityCode(ctx context.Context, code, redirectURI string, httpClient *http.Client) (*AntigravityTokenResponse, error) {
+	if strings.TrimSpace(redirectURI) == "" {
+		redirectURI = AntigravityDefaultCallbackURI()
+	}
+	authSvc := antigravity.NewAntigravityAuth(nil, httpClient)
+	tokenResp, errExchange := authSvc.ExchangeCodeForTokens(ctx, code, redirectURI)
+	if errExchange != nil {
+		return nil, errExchange
+	}
+	if tokenResp == nil {
+		return nil, fmt.Errorf("antigravity: empty token response")
+	}
+	return &AntigravityTokenResponse{
+		AccessToken:  tokenResp.AccessToken,
+		RefreshToken: tokenResp.RefreshToken,
+		ExpiresIn:    tokenResp.ExpiresIn,
+		TokenType:    tokenResp.TokenType,
+	}, nil
+}
+
+// FetchAntigravityUserInfo retrieves the user email address using the given access token.
+func FetchAntigravityUserInfo(ctx context.Context, accessToken string, httpClient *http.Client) (string, error) {
+	authSvc := antigravity.NewAntigravityAuth(nil, httpClient)
+	return authSvc.FetchUserInfo(ctx, accessToken)
+}
+
+// BuildAntigravityAuth constructs an in-memory *coreauth.Auth object from token credentials and metadata.
+func BuildAntigravityAuth(tokenResp *AntigravityTokenResponse, email, projectID string) *coreauth.Auth {
+	if tokenResp == nil {
+		return nil
+	}
+	now := time.Now()
+	metadata := map[string]any{
+		"type":          "antigravity",
+		"access_token":  tokenResp.AccessToken,
+		"refresh_token": tokenResp.RefreshToken,
+		"expires_in":    tokenResp.ExpiresIn,
+		"timestamp":     now.UnixMilli(),
+		"expired":       now.Add(time.Duration(tokenResp.ExpiresIn) * time.Second).Format(time.RFC3339),
+	}
+	email = strings.TrimSpace(email)
+	if email != "" {
+		metadata["email"] = email
+	}
+	projectID = strings.TrimSpace(projectID)
+	if projectID != "" {
+		metadata["project_id"] = projectID
+	}
+
+	fileName := antigravity.CredentialFileName(email)
+	label := email
+	if label == "" {
+		label = "antigravity"
+	}
+
+	return &coreauth.Auth{
+		ID:       fileName,
+		Provider: "antigravity",
+		FileName: fileName,
+		Label:    label,
+		Metadata: metadata,
+	}
+}
+
+// CompleteAntigravityOAuth performs code exchange, user identity retrieval, and GCP project discovery
+// using an injected HTTP client, returning an assembled *coreauth.Auth without touching the filesystem.
+func CompleteAntigravityOAuth(ctx context.Context, code, redirectURI string, httpClient *http.Client) (*coreauth.Auth, error) {
+	tokenResp, errExchange := ExchangeAntigravityCode(ctx, code, redirectURI, httpClient)
+	if errExchange != nil {
+		return nil, fmt.Errorf("antigravity: token exchange failed: %w", errExchange)
+	}
+
+	accessToken := strings.TrimSpace(tokenResp.AccessToken)
+	if accessToken == "" {
+		return nil, fmt.Errorf("antigravity: token exchange returned empty access token")
+	}
+
+	email, errUserInfo := FetchAntigravityUserInfo(ctx, accessToken, httpClient)
+	if errUserInfo != nil {
+		return nil, fmt.Errorf("antigravity: fetch user info failed: %w", errUserInfo)
+	}
+	email = strings.TrimSpace(email)
+	if email == "" {
+		return nil, fmt.Errorf("antigravity: empty email returned from user info")
+	}
+
+	projectID, errProject := FetchAntigravityProjectID(ctx, accessToken, httpClient)
+	if errProject != nil {
+		return nil, fmt.Errorf("antigravity: failed to fetch project ID: %w", errProject)
+	}
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return nil, fmt.Errorf("antigravity: project ID discovery returned empty project")
+	}
+
+	return BuildAntigravityAuth(tokenResp, email, projectID), nil
 }

--- a/sdk/auth/antigravity_headless_test.go
+++ b/sdk/auth/antigravity_headless_test.go
@@ -1,0 +1,323 @@
+package auth_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
+)
+
+type mockRoundTripper func(req *http.Request) (*http.Response, error)
+
+func (m mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m(req)
+}
+
+func TestAntigravityConstantsAndURLBuilder(t *testing.T) {
+	if auth.AntigravityDefaultCallbackPort != 51121 {
+		t.Fatalf("expected callback port 51121, got %d", auth.AntigravityDefaultCallbackPort)
+	}
+
+	expectedDefaultURI := "http://localhost:51121/oauth-callback"
+	if got := auth.AntigravityDefaultCallbackURI(); got != expectedDefaultURI {
+		t.Fatalf("expected default callback URI %q, got %q", expectedDefaultURI, got)
+	}
+
+	// Test with custom redirect URI
+	customURI := "https://admin.example.com/oauth/antigravity/callback"
+	authURL := auth.BuildAntigravityAuthURL("state-123", customURI)
+	parsed, err := url.Parse(authURL)
+	if err != nil {
+		t.Fatalf("failed to parse auth URL: %v", err)
+	}
+	q := parsed.Query()
+	if q.Get("state") != "state-123" {
+		t.Fatalf("expected state=state-123, got %q", q.Get("state"))
+	}
+	if q.Get("redirect_uri") != customURI {
+		t.Fatalf("expected redirect_uri=%s, got %q", customURI, q.Get("redirect_uri"))
+	}
+	if q.Get("response_type") != "code" {
+		t.Fatalf("expected response_type=code, got %q", q.Get("response_type"))
+	}
+	if q.Get("access_type") != "offline" {
+		t.Fatalf("expected access_type=offline, got %q", q.Get("access_type"))
+	}
+	if q.Get("prompt") != "consent" {
+		t.Fatalf("expected prompt=consent, got %q", q.Get("prompt"))
+	}
+	if !strings.Contains(q.Get("scope"), "cloud-platform") {
+		t.Fatalf("scope should include cloud-platform: %s", q.Get("scope"))
+	}
+
+	// Test with empty redirect URI (should fallback to default)
+	authURLDefault := auth.BuildAntigravityAuthURL("state-456", "")
+	parsedDefault, err := url.Parse(authURLDefault)
+	if err != nil {
+		t.Fatalf("failed to parse auth URL: %v", err)
+	}
+	if parsedDefault.Query().Get("redirect_uri") != expectedDefaultURI {
+		t.Fatalf("expected default redirect URI fallback, got %q", parsedDefault.Query().Get("redirect_uri"))
+	}
+}
+
+func TestAntigravityUserAgent(t *testing.T) {
+	ua := auth.AntigravityUserAgent()
+	if !strings.HasPrefix(ua, "antigravity/hub/") {
+		t.Fatalf("expected AntigravityUserAgent to start with antigravity/hub/, got %q", ua)
+	}
+}
+
+func TestExchangeAntigravityCode(t *testing.T) {
+	client := &http.Client{
+		Transport: mockRoundTripper(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodPost || req.URL.String() != "https://oauth2.googleapis.com/token" {
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			}
+			bodyBytes, _ := io.ReadAll(req.Body)
+			bodyStr := string(bodyBytes)
+			if !strings.Contains(bodyStr, "code=auth-code-123") {
+				t.Fatalf("request body missing code: %s", bodyStr)
+			}
+			if !strings.Contains(bodyStr, "grant_type=authorization_code") {
+				t.Fatalf("request body missing grant_type: %s", bodyStr)
+			}
+			respJSON := `{"access_token":"mock-access-token","refresh_token":"mock-refresh-token","expires_in":3600,"token_type":"Bearer"}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(respJSON)),
+			}, nil
+		}),
+	}
+
+	tokenResp, err := auth.ExchangeAntigravityCode(context.Background(), "auth-code-123", "http://localhost:51121/oauth-callback", client)
+	if err != nil {
+		t.Fatalf("ExchangeAntigravityCode error: %v", err)
+	}
+	if tokenResp.AccessToken != "mock-access-token" {
+		t.Fatalf("AccessToken = %q, want mock-access-token", tokenResp.AccessToken)
+	}
+	if tokenResp.RefreshToken != "mock-refresh-token" {
+		t.Fatalf("RefreshToken = %q, want mock-refresh-token", tokenResp.RefreshToken)
+	}
+	if tokenResp.ExpiresIn != 3600 {
+		t.Fatalf("ExpiresIn = %d, want 3600", tokenResp.ExpiresIn)
+	}
+}
+
+func TestFetchAntigravityUserInfo(t *testing.T) {
+	client := &http.Client{
+		Transport: mockRoundTripper(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodGet || !strings.HasPrefix(req.URL.String(), "https://www.googleapis.com/oauth2/v2/userinfo") {
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			}
+			if req.Header.Get("Authorization") != "Bearer mock-access-token" {
+				t.Fatalf("unexpected Authorization header: %s", req.Header.Get("Authorization"))
+			}
+			respJSON := `{"email":"engineer@example.com"}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(respJSON)),
+			}, nil
+		}),
+	}
+
+	email, err := auth.FetchAntigravityUserInfo(context.Background(), "mock-access-token", client)
+	if err != nil {
+		t.Fatalf("FetchAntigravityUserInfo error: %v", err)
+	}
+	if email != "engineer@example.com" {
+		t.Fatalf("email = %q, want engineer@example.com", email)
+	}
+}
+
+func TestBuildAntigravityAuth(t *testing.T) {
+	tokenResp := &auth.AntigravityTokenResponse{
+		AccessToken:  "mock-access-token",
+		RefreshToken: "mock-refresh-token",
+		ExpiresIn:    3600,
+		TokenType:    "Bearer",
+	}
+
+	record := auth.BuildAntigravityAuth(tokenResp, "engineer@example.com", "my-gcp-project")
+	if record == nil {
+		t.Fatal("BuildAntigravityAuth returned nil")
+	}
+	if record.Provider != "antigravity" {
+		t.Fatalf("Provider = %q, want antigravity", record.Provider)
+	}
+	if record.ID != "antigravity-engineer@example.com.json" {
+		t.Fatalf("ID = %q", record.ID)
+	}
+	if record.FileName != "antigravity-engineer@example.com.json" {
+		t.Fatalf("FileName = %q", record.FileName)
+	}
+	if record.Label != "engineer@example.com" {
+		t.Fatalf("Label = %q", record.Label)
+	}
+	meta := record.Metadata
+	if meta["type"] != "antigravity" {
+		t.Fatalf("Metadata[type] = %v", meta["type"])
+	}
+	if meta["access_token"] != "mock-access-token" {
+		t.Fatalf("Metadata[access_token] = %v", meta["access_token"])
+	}
+	if meta["refresh_token"] != "mock-refresh-token" {
+		t.Fatalf("Metadata[refresh_token] = %v", meta["refresh_token"])
+	}
+	if meta["email"] != "engineer@example.com" {
+		t.Fatalf("Metadata[email] = %v", meta["email"])
+	}
+	if meta["project_id"] != "my-gcp-project" {
+		t.Fatalf("Metadata[project_id] = %v", meta["project_id"])
+	}
+	if _, ok := meta["timestamp"].(int64); !ok {
+		t.Fatalf("Metadata[timestamp] missing or wrong type: %v", meta["timestamp"])
+	}
+	if expiredStr, ok := meta["expired"].(string); !ok || expiredStr == "" {
+		t.Fatalf("Metadata[expired] missing: %v", meta["expired"])
+	}
+}
+
+func TestCompleteAntigravityOAuth(t *testing.T) {
+	client := &http.Client{
+		Transport: mockRoundTripper(func(req *http.Request) (*http.Response, error) {
+			switch {
+			case strings.HasPrefix(req.URL.String(), "https://oauth2.googleapis.com/token"):
+				respJSON := `{"access_token":"mock-token","refresh_token":"mock-refresh","expires_in":3600,"token_type":"Bearer"}`
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader(respJSON)),
+				}, nil
+			case strings.HasPrefix(req.URL.String(), "https://www.googleapis.com/oauth2/v2/userinfo"):
+				respJSON := `{"email":"complete@example.com"}`
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader(respJSON)),
+				}, nil
+			case strings.Contains(req.URL.String(), "loadCodeAssist"):
+				respJSON := `{"cloudaicompanionProject":"complete-proj-123"}`
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader(respJSON)),
+				}, nil
+			default:
+				t.Fatalf("unexpected mock URL: %s", req.URL.String())
+				return nil, nil
+			}
+		}),
+	}
+
+	record, err := auth.CompleteAntigravityOAuth(context.Background(), "auth-code-xyz", "http://localhost:51121/oauth-callback", client)
+	if err != nil {
+		t.Fatalf("CompleteAntigravityOAuth error: %v", err)
+	}
+	if record == nil {
+		t.Fatal("expected non-nil Auth record")
+	}
+	if record.Label != "complete@example.com" {
+		t.Fatalf("Label = %q, want complete@example.com", record.Label)
+	}
+	if record.Metadata["project_id"] != "complete-proj-123" {
+		t.Fatalf("Metadata[project_id] = %v, want complete-proj-123", record.Metadata["project_id"])
+	}
+}
+
+func TestExchangeAntigravityCodeDefaultRedirectAndErrors(t *testing.T) {
+	// Verify default redirect URI fallback during exchange
+	var capturedBody string
+	client := &http.Client{
+		Transport: mockRoundTripper(func(req *http.Request) (*http.Response, error) {
+			b, _ := io.ReadAll(req.Body)
+			capturedBody = string(b)
+			respJSON := `{"access_token":"mock-token","refresh_token":"mock-refresh","expires_in":3600,"token_type":"Bearer"}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(respJSON)),
+			}, nil
+		}),
+	}
+
+	_, err := auth.ExchangeAntigravityCode(context.Background(), "code-123", "", client)
+	if err != nil {
+		t.Fatalf("ExchangeAntigravityCode error: %v", err)
+	}
+	expectedRedirect := url.QueryEscape(auth.AntigravityDefaultCallbackURI())
+	if !strings.Contains(capturedBody, expectedRedirect) {
+		t.Fatalf("expected default redirect %q in body: %s", expectedRedirect, capturedBody)
+	}
+
+	// Verify upstream error response
+	errorClient := &http.Client{
+		Transport: mockRoundTripper(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"error":"invalid_grant"}`)),
+			}, nil
+		}),
+	}
+	_, err = auth.ExchangeAntigravityCode(context.Background(), "bad-code", "", errorClient)
+	if err == nil {
+		t.Fatal("expected error on upstream 400 response")
+	}
+
+	// Verify context cancellation
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	contextAwareClient := &http.Client{
+		Transport: mockRoundTripper(func(req *http.Request) (*http.Response, error) {
+			if errCtx := req.Context().Err(); errCtx != nil {
+				return nil, errCtx
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{}`)),
+			}, nil
+		}),
+	}
+	_, err = auth.ExchangeAntigravityCode(canceledCtx, "code", "", contextAwareClient)
+	if err == nil {
+		t.Fatal("expected error with canceled context")
+	}
+}
+
+func TestFetchAntigravityUserInfoErrors(t *testing.T) {
+	// Empty token check
+	_, err := auth.FetchAntigravityUserInfo(context.Background(), "", nil)
+	if err == nil {
+		t.Fatal("expected error with empty access token")
+	}
+
+	// Upstream error check
+	errorClient := &http.Client{
+		Transport: mockRoundTripper(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"error":"invalid_token"}`)),
+			}, nil
+		}),
+	}
+	_, err = auth.FetchAntigravityUserInfo(context.Background(), "invalid-token", errorClient)
+	if err == nil {
+		t.Fatal("expected error on upstream 401 response")
+	}
+}
+
+func TestBuildAntigravityAuthNilCheck(t *testing.T) {
+	if auth.BuildAntigravityAuth(nil, "a@b.com", "proj") != nil {
+		t.Fatal("expected nil return for nil token response")
+	}
+}

--- a/sdk/cliproxy/auth/auto_refresh_loop.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop.go
@@ -10,6 +10,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// maxRefreshTimerWait caps the sleep duration for the refresh timer.
+// On Linux systems, CLOCK_MONOTONIC stops ticking during suspend/sleep.
+// Capping the timer ensures that when the system resumes, the loop wakes
+// up promptly to detect and refresh any credentials that expired during sleep.
+const maxRefreshTimerWait = 30 * time.Second
+
 type authAutoRefreshLoop struct {
 	manager     *Manager
 	interval    time.Duration
@@ -149,8 +155,24 @@ func (l *authAutoRefreshLoop) loop(ctx context.Context) {
 	}
 }
 
-func (l *authAutoRefreshLoop) resetTimer(timer *time.Timer, timerCh *<-chan time.Time, now time.Time) {
+func (l *authAutoRefreshLoop) nextWait(now time.Time) (time.Duration, bool) {
 	next, ok := l.peek()
+	if !ok {
+		return 0, false
+	}
+
+	wait := next.Sub(now)
+	if wait < 0 {
+		wait = 0
+	}
+	if wait > maxRefreshTimerWait {
+		wait = maxRefreshTimerWait
+	}
+	return wait, true
+}
+
+func (l *authAutoRefreshLoop) resetTimer(timer *time.Timer, timerCh *<-chan time.Time, now time.Time) {
+	wait, ok := l.nextWait(now)
 	if !ok {
 		if !timer.Stop() {
 			select {
@@ -162,10 +184,6 @@ func (l *authAutoRefreshLoop) resetTimer(timer *time.Timer, timerCh *<-chan time
 		return
 	}
 
-	wait := next.Sub(now)
-	if wait < 0 {
-		wait = 0
-	}
 	if !timer.Stop() {
 		select {
 		case <-timer.C:

--- a/sdk/cliproxy/auth/auto_refresh_loop_test.go
+++ b/sdk/cliproxy/auth/auto_refresh_loop_test.go
@@ -185,3 +185,63 @@ func TestNextRefreshCheckAt_RefreshEvaluatorFallback(t *testing.T) {
 		t.Fatalf("nextRefreshCheckAt() = %s, want %s", got, want)
 	}
 }
+
+func TestAuthAutoRefreshLoop_TimerWaitClampedForLongNextExpiry(t *testing.T) {
+	loop := newAuthAutoRefreshLoop(nil, 5*time.Second, 1)
+	now := time.Date(2026, 4, 12, 0, 0, 0, 0, time.UTC)
+	loop.upsert("a1", now.Add(time.Hour))
+
+	got, ok := loop.nextWait(now)
+	if !ok {
+		t.Fatalf("nextWait() ok = false, want true")
+	}
+	if got > maxRefreshTimerWait {
+		t.Fatalf("nextWait() = %v, want <= %v", got, maxRefreshTimerWait)
+	}
+	if got != maxRefreshTimerWait {
+		t.Fatalf("nextWait() = %v, want exactly %v", got, maxRefreshTimerWait)
+	}
+
+	// Short wait should not be clamped
+	shortNext := now.Add(10 * time.Second)
+	loop.upsert("a2", shortNext)
+	gotShort, okShort := loop.nextWait(now)
+	if !okShort || gotShort != 10*time.Second {
+		t.Fatalf("nextWait() short = (%v, %t), want (10s, true)", gotShort, okShort)
+	}
+}
+
+func TestAuthAutoRefreshLoop_PopDue_AfterSystemSuspendResume(t *testing.T) {
+	loop := newAuthAutoRefreshLoop(nil, 5*time.Second, 1)
+	beforeSleep := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
+
+	// Credential scheduled to refresh 50 minutes later
+	scheduledRefresh := beforeSleep.Add(50 * time.Minute)
+	loop.upsert("gemini-oauth", scheduledRefresh)
+
+	// Before sleep, wait is clamped to maxRefreshTimerWait
+	wait, ok := loop.nextWait(beforeSleep)
+	if !ok || wait != maxRefreshTimerWait {
+		t.Fatalf("nextWait() before sleep = (%v, %t), want (%v, true)", wait, ok, maxRefreshTimerWait)
+	}
+
+	// Not due yet before sleep
+	dueBefore := loop.popDue(beforeSleep)
+	if len(dueBefore) != 0 {
+		t.Fatalf("popDue() before sleep = %v, want empty", dueBefore)
+	}
+
+	// System resumes 2 hours later (monotonic clock froze, but wall clock jumped)
+	afterResume := beforeSleep.Add(2 * time.Hour)
+
+	// Upon wake, the clamped timer fires within maxRefreshTimerWait and checks with current wall clock
+	waitAfter, okAfter := loop.nextWait(afterResume)
+	if !okAfter || waitAfter != 0 {
+		t.Fatalf("nextWait() after resume = (%v, %t), want (0, true)", waitAfter, okAfter)
+	}
+
+	dueAfter := loop.popDue(afterResume)
+	if len(dueAfter) != 1 || dueAfter[0] != "gemini-oauth" {
+		t.Fatalf("popDue() after resume = %v, want [gemini-oauth]", dueAfter)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -850,7 +850,7 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 									if cooldown < minQuotaCooldownFloor {
 										cooldown = minQuotaCooldownFloor
 									}
-									next = now.Add(cooldown)
+									next = now.Add(cooldown).Round(0)
 								} else {
 									next, backoffLevel = quotaCooldownAfterFailure(state.Quota, now)
 								}
@@ -2076,7 +2076,7 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 					if cooldown < minQuotaCooldownFloor {
 						cooldown = minQuotaCooldownFloor
 					}
-					next = now.Add(cooldown)
+					next = now.Add(cooldown).Round(0)
 				} else {
 					next, auth.Quota.BackoffLevel = quotaCooldownAfterFailure(auth.Quota, now)
 				}
@@ -2121,7 +2121,7 @@ func quotaCooldownAfterFailure(quota QuotaState, now time.Time) (time.Time, int)
 	cooldown, nextLevel := nextQuotaCooldown(quota.BackoffLevel, false)
 	var next time.Time
 	if cooldown > 0 {
-		next = now.Add(cooldown)
+		next = now.Add(cooldown).Round(0)
 	}
 	return next, nextLevel
 }

--- a/sdk/cliproxy/auth/conductor_quota_clock_test.go
+++ b/sdk/cliproxy/auth/conductor_quota_clock_test.go
@@ -1,0 +1,149 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestQuotaDeadlineUsesWallClock_ModelExplicitRetry(t *testing.T) {
+	withQuotaCooldownEnabled(t)
+
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "quota-clock-model-explicit", Provider: "codex"}
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	retryAfter := time.Hour
+	manager.MarkResult(context.Background(), Result{
+		AuthID:     auth.ID,
+		Provider:   auth.Provider,
+		Model:      "gpt-5",
+		RetryAfter: &retryAfter,
+		Error:      &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota exceeded"},
+	})
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil || updated.ModelStates["gpt-5"] == nil {
+		t.Fatal("missing model state for gpt-5")
+	}
+
+	retryDeadline := updated.ModelStates["gpt-5"].NextRetryAfter
+	if retryDeadline.IsZero() || retryDeadline != retryDeadline.Round(0) {
+		t.Errorf("model NextRetryAfter is zero or retains monotonic clock reading: %v", retryDeadline)
+	}
+	recoverDeadline := updated.ModelStates["gpt-5"].Quota.NextRecoverAt
+	if recoverDeadline.IsZero() || recoverDeadline != recoverDeadline.Round(0) {
+		t.Errorf("model Quota.NextRecoverAt is zero or retains monotonic clock reading: %v", recoverDeadline)
+	}
+	if !retryDeadline.Equal(recoverDeadline) {
+		t.Errorf("expected NextRetryAfter and Quota.NextRecoverAt to match, got %v and %v", retryDeadline, recoverDeadline)
+	}
+}
+
+func TestQuotaDeadlineUsesWallClock_ModelFallbackBackoff(t *testing.T) {
+	withQuotaCooldownEnabled(t)
+
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "quota-clock-model-fallback", Provider: "codex"}
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    "gpt-5",
+		Error:    &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota exceeded"},
+	})
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil || updated.ModelStates["gpt-5"] == nil {
+		t.Fatal("missing model state for gpt-5")
+	}
+
+	retryDeadline := updated.ModelStates["gpt-5"].NextRetryAfter
+	if retryDeadline.IsZero() || retryDeadline != retryDeadline.Round(0) {
+		t.Errorf("fallback model NextRetryAfter is zero or retains monotonic clock reading: %v", retryDeadline)
+	}
+	recoverDeadline := updated.ModelStates["gpt-5"].Quota.NextRecoverAt
+	if recoverDeadline.IsZero() || recoverDeadline != recoverDeadline.Round(0) {
+		t.Errorf("fallback model Quota.NextRecoverAt is zero or retains monotonic clock reading: %v", recoverDeadline)
+	}
+	if !retryDeadline.Equal(recoverDeadline) {
+		t.Errorf("expected fallback NextRetryAfter and Quota.NextRecoverAt to match, got %v and %v", retryDeadline, recoverDeadline)
+	}
+}
+
+func TestQuotaDeadlineUsesWallClock_AuthExplicitRetry(t *testing.T) {
+	withQuotaCooldownEnabled(t)
+
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "quota-clock-auth-explicit", Provider: "codex"}
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	retryAfter := time.Hour
+	manager.MarkResult(context.Background(), Result{
+		AuthID:          auth.ID,
+		Provider:        auth.Provider,
+		Model:           "gpt-5",
+		CredentialScope: true,
+		RetryAfter:      &retryAfter,
+		Error:           &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota exceeded"},
+	})
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatal("missing updated auth")
+	}
+
+	retryDeadline := updated.NextRetryAfter
+	if retryDeadline.IsZero() || retryDeadline != retryDeadline.Round(0) {
+		t.Errorf("auth NextRetryAfter is zero or retains monotonic clock reading: %v", retryDeadline)
+	}
+	recoverDeadline := updated.Quota.NextRecoverAt
+	if recoverDeadline.IsZero() || recoverDeadline != recoverDeadline.Round(0) {
+		t.Errorf("auth Quota.NextRecoverAt is zero or retains monotonic clock reading: %v", recoverDeadline)
+	}
+	if !retryDeadline.Equal(recoverDeadline) {
+		t.Errorf("expected auth NextRetryAfter and Quota.NextRecoverAt to match, got %v and %v", retryDeadline, recoverDeadline)
+	}
+}
+
+func TestQuotaDeadlineUsesWallClock_AuthFallbackBackoff(t *testing.T) {
+	withQuotaCooldownEnabled(t)
+
+	manager := NewManager(nil, nil, nil)
+	auth := &Auth{ID: "quota-clock-auth-fallback", Provider: "codex"}
+	if _, errRegister := manager.Register(WithSkipPersist(context.Background()), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+
+	manager.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    "", // no model -> auth-level failure
+		Error:    &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota exceeded"},
+	})
+
+	updated, ok := manager.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatal("missing updated auth")
+	}
+
+	retryDeadline := updated.NextRetryAfter
+	if retryDeadline.IsZero() || retryDeadline != retryDeadline.Round(0) {
+		t.Errorf("auth fallback NextRetryAfter is zero or retains monotonic clock reading: %v", retryDeadline)
+	}
+	recoverDeadline := updated.Quota.NextRecoverAt
+	if recoverDeadline.IsZero() || recoverDeadline != recoverDeadline.Round(0) {
+		t.Errorf("auth fallback Quota.NextRecoverAt is zero or retains monotonic clock reading: %v", recoverDeadline)
+	}
+	if !retryDeadline.Equal(recoverDeadline) {
+		t.Errorf("expected auth fallback NextRetryAfter and Quota.NextRecoverAt to match, got %v and %v", retryDeadline, recoverDeadline)
+	}
+}

--- a/sdk/cliproxy/auth/conductor_selection.go
+++ b/sdk/cliproxy/auth/conductor_selection.go
@@ -419,6 +419,71 @@ func (m *Manager) Selector() Selector {
 	return m.selector
 }
 
+// LookupSessionAffinity observes the current session affinity binding without side effects.
+// It returns (auth, status) where status can be "bound", "unbound", "ambiguous", or "unsupported".
+func (m *Manager) LookupSessionAffinity(provider, model, sessionID string) (*Auth, string) {
+	if m == nil {
+		return nil, "unsupported"
+	}
+	m.mu.RLock()
+	if m.pluginScheduler != nil {
+		m.mu.RUnlock()
+		return nil, "unsupported"
+	}
+	sel := m.selector
+	authProviderMap := make(map[string]string, len(m.auths))
+	for id, a := range m.auths {
+		if a != nil {
+			authProviderMap[id] = a.Provider
+		}
+	}
+	m.mu.RUnlock()
+
+	if sel == nil {
+		return nil, "unsupported"
+	}
+
+	authFilter := func(authID string) bool {
+		if provider == "mixed" {
+			return true
+		}
+		p, ok := authProviderMap[authID]
+		return ok && p == provider
+	}
+
+	var authID, status string
+	if observerWithFilter, ok := sel.(interface {
+		LookupAffinity(provider, model, sessionID string, authFilters ...func(authID string) bool) (string, string)
+	}); ok && observerWithFilter != nil {
+		authID, status = observerWithFilter.LookupAffinity(provider, model, sessionID, authFilter)
+	} else if observer, ok := sel.(interface {
+		LookupAffinity(provider, model, sessionID string) (string, string)
+	}); ok && observer != nil {
+		authID, status = observer.LookupAffinity(provider, model, sessionID)
+	} else {
+		return nil, "unsupported"
+	}
+
+	if status != "bound" || authID == "" {
+		return nil, status
+	}
+
+	m.mu.RLock()
+	auth, okAuth := m.auths[authID]
+	if !okAuth || auth == nil {
+		m.mu.RUnlock()
+		return nil, "unbound"
+	}
+	snapshot := auth.Clone()
+	m.mu.RUnlock()
+
+	if provider != "mixed" && snapshot.Provider != provider {
+		return nil, "unbound"
+	}
+	snapshot.EnsureIndex()
+	return snapshot, "bound"
+}
+
 // SetStore swaps the underlying persistence store.
 func (m *Manager) SetStore(store Store) {
 	m.mu.Lock()

--- a/sdk/cliproxy/auth/home_session_alias.go
+++ b/sdk/cliproxy/auth/home_session_alias.go
@@ -246,6 +246,9 @@ func isHierarchyParent(primary, fallback string) bool {
 	if idx1 > 0 && idx2 > 0 && primary[:idx1] == fallback[:idx2] {
 		return true
 	}
+	if idx1 == -1 && idx2 == -1 {
+		return true
+	}
 	return false
 }
 

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -20,7 +20,6 @@ import (
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/credentialweight"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/thinking"
-	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	cliproxysession "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/session"
 )
@@ -1387,27 +1386,6 @@ func (s *SessionAffinitySelector) OnResult(res Result) {
 	}
 }
 
-func isBodyForkCandidate(root, reqRoot gjson.Result, hasNestedReq bool) bool {
-	if !root.Exists() {
-		return false
-	}
-	for _, k := range []string{
-		"forked_from_thread_id", "forked_from_id",
-		"metadata.forked_from_thread_id", "metadata.forked_from_id",
-		"extra_body.forked_from_thread_id", "extra_body.forked_from_id",
-	} {
-		if val := normalizedSessionCandidate(root.Get(k).String()); val != "" {
-			return true
-		}
-		if hasNestedReq {
-			if val := normalizedSessionCandidate(reqRoot.Get(k).String()); val != "" {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 // normalizedSessionCandidate validates an explicit client-provided session signal.
 // It keeps opaque printable IDs intact while rejecting values that are unsafe or
 // implausibly large for routing keys and logs.
@@ -1423,26 +1401,6 @@ func isSubagentSession(primaryID, fallbackID string) bool {
 		return false
 	}
 	return isHierarchyParent(primaryID, fallbackID)
-}
-
-func sessionHeaderValue(headers http.Header, name string) string {
-	if headers == nil {
-		return ""
-	}
-	if value := normalizedSessionCandidate(headers.Get(name)); value != "" {
-		return value
-	}
-	for key, values := range headers {
-		if !strings.EqualFold(key, name) {
-			continue
-		}
-		for _, raw := range values {
-			if value := normalizedSessionCandidate(raw); value != "" {
-				return value
-			}
-		}
-	}
-	return ""
 }
 
 // CanonicalSessionID resolves the single authoritative session identity from request options and metadata.
@@ -1481,506 +1439,48 @@ func ExtractSessionID(headers http.Header, payload []byte, metadata map[string]a
 	return primary
 }
 
+func extractConversationAlias(payload []byte) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	root := gjson.ParseBytes(payload)
+	conversation := root.Get("conversation")
+	if !conversation.Exists() {
+		req := root.Get("request")
+		if req.Exists() && !root.Get("contents").Exists() {
+			conversation = req.Get("conversation")
+		}
+	}
+	if sid := normalizedSessionCandidate(conversation.Get("id").String()); sid != "" {
+		return "conv:" + sid
+	} else if conversation.Type == gjson.String {
+		if sid := normalizedSessionCandidate(conversation.String()); sid != "" {
+			return "conv:" + sid
+		}
+	}
+	return ""
+}
+
 // extractExplicitSessionIDs returns only client- or execution-provided identities.
 // LCP fallback must run after this function so explicit harness sessions remain authoritative.
 func extractExplicitSessionIDs(headers http.Header, payload []byte, metadata map[string]any) (string, string) {
-	var primary, fallback string
-
-	// Extract parent candidate from payload once if payload is non-empty
-	var root gjson.Result
-	var reqRoot gjson.Result
-	var hasNestedReq bool
-	var parentIDCandidate string
-	if len(payload) > 0 {
-		root = util.ParseGJSONBytesNoCopy(payload)
-		reqRoot = root
-		req := root.Get("request")
-		hasNestedReq = req.Exists() && !root.Get("contents").Exists()
-		if hasNestedReq {
-			reqRoot = req
+	info, ok := cliproxysession.ExtractSessionInfo(headers, payload, metadata)
+	if !ok || info.ClientType == "lcp" {
+		return "", ""
+	}
+	if metadata != nil {
+		if info.IsFork {
+			metadata[cliproxyexecutor.IsForkMetadataKey] = true
 		}
-		for _, parentPath := range []string{
-			"parent_session_id", "parentSessionId",
-			"parent_thread_id", "parentThreadId",
-			"forked_from_thread_id", "forked_from_id",
-			"parent_conversation_id", "parentConversationId",
-			"metadata.parent_session_id", "metadata.parent_thread_id",
-			"metadata.forked_from_thread_id", "metadata.forked_from_id",
-			"extra_body.parent_session_id", "extra_body.parent_thread_id",
-			"extra_body.forked_from_thread_id", "extra_body.forked_from_id",
-		} {
-			if psid := normalizedSessionCandidate(root.Get(parentPath).String()); psid != "" {
-				parentIDCandidate = psid
-				break
-			}
-			if hasNestedReq {
-				if psid := normalizedSessionCandidate(reqRoot.Get(parentPath).String()); psid != "" {
-					parentIDCandidate = psid
-					break
-				}
-			}
-		}
-		if parentIDCandidate == "" {
-			parentIDCandidate = cliproxysession.ClaudeMetadataParentSessionID(payload)
+		if info.ParentSessionID != "" {
+			metadata[cliproxyexecutor.ParentSessionIDMetadataKey] = info.ParentSessionID
 		}
 	}
-
-	// 1. Anthropic / Claude Code
-	if sid := sessionHeaderValue(headers, "X-Claude-Code-Session-Id"); sid != "" {
-		agentID := sessionHeaderValue(headers, "X-Claude-Code-Agent-Id")
-		if agentID == "" && root.Exists() {
-			agentID = normalizedSessionCandidate(root.Get("metadata.agent_id").String())
-			if agentID == "" {
-				agentID = normalizedSessionCandidate(root.Get("metadata.subagent_id").String())
-			}
-			if agentID == "" && hasNestedReq {
-				agentID = normalizedSessionCandidate(reqRoot.Get("metadata.agent_id").String())
-				if agentID == "" {
-					agentID = normalizedSessionCandidate(reqRoot.Get("metadata.subagent_id").String())
-				}
-			}
-		}
-		if agentID == "" {
-			_, _, agentID = cliproxysession.ClaudeMetadataIdentities(payload)
-		}
-		parentAgentID := sessionHeaderValue(headers, "X-Claude-Code-Parent-Agent-Id")
-		if agentID != "" && agentID != "main" {
-			primary = "claude:" + sid + ":agent:" + agentID
-			fallback = "claude:" + sid
-			if parentAgentID != "" && parentAgentID != "main" && parentAgentID != agentID {
-				fallback = "claude:" + sid + ":agent:" + parentAgentID
-			} else if parentIDCandidate != "" && parentIDCandidate != sid {
-				fallback = "claude:" + parentIDCandidate
-			}
-			return primary, fallback
-		}
-		primary = "claude:" + sid
-		if parentIDCandidate != "" && parentIDCandidate != sid {
-			fallback = "claude:" + parentIDCandidate
-		}
-		return primary, fallback
+	fallback := info.ParentSessionID
+	if fallback == "" && strings.HasPrefix(info.SessionID, "pck:") && len(payload) > 0 {
+		fallback = extractConversationAlias(payload)
 	}
-	if sid, parentSID, agentID := cliproxysession.ClaudeMetadataIdentities(payload); sid != "" {
-		if agentID == "" {
-			agentID = sessionHeaderValue(headers, "X-Claude-Code-Agent-Id")
-		}
-		if agentID == "" && root.Exists() {
-			agentID = normalizedSessionCandidate(root.Get("metadata.agent_id").String())
-			if agentID == "" {
-				agentID = normalizedSessionCandidate(root.Get("metadata.subagent_id").String())
-			}
-			if agentID == "" && hasNestedReq {
-				agentID = normalizedSessionCandidate(reqRoot.Get("metadata.agent_id").String())
-				if agentID == "" {
-					agentID = normalizedSessionCandidate(reqRoot.Get("metadata.subagent_id").String())
-				}
-			}
-		}
-		parentAgentID := sessionHeaderValue(headers, "X-Claude-Code-Parent-Agent-Id")
-		if agentID != "" && agentID != "main" {
-			primary = "claude:" + sid + ":agent:" + agentID
-			fallback = "claude:" + sid
-			if parentAgentID != "" && parentAgentID != "main" && parentAgentID != agentID {
-				fallback = "claude:" + sid + ":agent:" + parentAgentID
-			} else if parentSID != "" && parentSID != sid {
-				fallback = "claude:" + parentSID
-			} else if parentIDCandidate != "" && parentIDCandidate != sid {
-				fallback = "claude:" + parentIDCandidate
-			}
-			return primary, fallback
-		}
-		primary = "claude:" + sid
-		if parentSID != "" && parentSID != sid {
-			fallback = "claude:" + parentSID
-		} else if parentIDCandidate != "" && parentIDCandidate != sid {
-			fallback = "claude:" + parentIDCandidate
-		}
-		return primary, fallback
-	}
-
-	// 2. OpenAI / Codex CLI
-	sid := sessionHeaderValue(headers, "Session-Id")
-	if sid == "" {
-		sid = sessionHeaderValue(headers, "Session_id")
-	}
-	tid := sessionHeaderValue(headers, "Thread-Id")
-	if tid == "" {
-		tid = sessionHeaderValue(headers, "Thread_id")
-	}
-
-	var codexTurnMeta string
-	for k, v := range headers {
-		if strings.EqualFold(k, "X-Codex-Turn-Metadata") && len(v) > 0 {
-			codexTurnMeta = strings.TrimSpace(v[0])
-			break
-		}
-	}
-	var codexTurnMetaJSON gjson.Result
-	if codexTurnMeta != "" {
-		codexTurnMetaJSON = gjson.Parse(codexTurnMeta)
-	}
-
-	if sid == "" && codexTurnMetaJSON.Exists() {
-		sid = normalizedSessionCandidate(codexTurnMetaJSON.Get("session_id").String())
-	}
-	if tid == "" && codexTurnMetaJSON.Exists() {
-		tid = normalizedSessionCandidate(codexTurnMetaJSON.Get("thread_id").String())
-	}
-	if tid == "" && sid != "" && root.Exists() {
-		for _, path := range []string{"thread_id", "threadId", "metadata.thread_id"} {
-			if tid = normalizedSessionCandidate(root.Get(path).String()); tid != "" {
-				break
-			}
-			if hasNestedReq {
-				if tid = normalizedSessionCandidate(reqRoot.Get(path).String()); tid != "" {
-					break
-				}
-			}
-		}
-	}
-
-	if sid != "" || tid != "" {
-		parentThreadID := sessionHeaderValue(headers, "x-codex-parent-thread-id")
-		if parentThreadID == "" {
-			parentThreadID = sessionHeaderValue(headers, "X-Codex-Parent-Thread-Id")
-		}
-		if parentThreadID == "" && codexTurnMetaJSON.Exists() {
-			parentThreadID = normalizedSessionCandidate(codexTurnMetaJSON.Get("parent_thread_id").String())
-		}
-
-		forkedFrom := ""
-		if codexTurnMetaJSON.Exists() {
-			forkedFrom = normalizedSessionCandidate(codexTurnMetaJSON.Get("forked_from_thread_id").String())
-			if forkedFrom == "" {
-				forkedFrom = normalizedSessionCandidate(codexTurnMetaJSON.Get("forked_from_id").String())
-			}
-		}
-		if forkedFrom == "" && root.Exists() {
-			for _, forkPath := range []string{
-				"forked_from_thread_id", "forked_from_id",
-				"metadata.forked_from_thread_id", "metadata.forked_from_id",
-				"extra_body.forked_from_thread_id", "extra_body.forked_from_id",
-			} {
-				if forkedFrom = normalizedSessionCandidate(root.Get(forkPath).String()); forkedFrom != "" {
-					break
-				}
-				if hasNestedReq {
-					if forkedFrom = normalizedSessionCandidate(reqRoot.Get(forkPath).String()); forkedFrom != "" {
-						break
-					}
-				}
-			}
-		}
-
-		cleanAgentName := ""
-		if codexTurnMetaJSON.Exists() {
-			rawName := codexTurnMetaJSON.Get("agent_name").String()
-			rawName = strings.TrimPrefix(rawName, "/root/")
-			rawName = strings.TrimPrefix(rawName, "/")
-			rawName = strings.TrimSpace(rawName)
-			rawName = normalizedSessionCandidate(rawName)
-			if rawName != "" && rawName != "root" && rawName != "main" {
-				cleanAgentName = rawName
-			}
-		}
-
-		subVal := sessionHeaderValue(headers, "X-Openai-Subagent")
-		subagentSignal := subVal != "" && !strings.EqualFold(subVal, "false") && subVal != "0"
-		if codexTurnMetaJSON.Exists() && codexTurnMetaJSON.Get("subagent_kind").String() == "thread_spawn" {
-			subagentSignal = true
-		}
-
-		// 1. Fork detection
-		if forkedFrom != "" {
-			forkSessionID := tid
-			if forkSessionID == "" {
-				forkSessionID = sid
-			}
-			if forkSessionID == forkedFrom && sid != "" && sid != forkedFrom {
-				forkSessionID = sid
-			}
-			primary = "codex:" + forkSessionID
-			fallback = "codex:" + forkedFrom
-			if metadata != nil {
-				metadata[cliproxyexecutor.IsForkMetadataKey] = true
-				metadata[cliproxyexecutor.ParentSessionIDMetadataKey] = fallback
-			}
-			return primary, fallback
-		}
-
-		// 2. Multi-Agent / Subagent detection
-		if subagentSignal || (tid != "" && sid != "" && tid != sid) || (parentThreadID != "" && parentThreadID != tid && parentThreadID != sid) {
-			childSessionID := tid
-			if childSessionID == "" {
-				childSessionID = sid
-			}
-			parentSID := parentThreadID
-			if parentSID == "" {
-				parentSID = sid
-			}
-			if cleanAgentName != "" && sid != "" {
-				primary = "codex:" + sid + ":agent:" + cleanAgentName
-				if parentSID != "" {
-					fallback = "codex:" + parentSID
-				} else if parentIDCandidate != "" && parentIDCandidate != sid {
-					fallback = "codex:" + parentIDCandidate
-				}
-			} else {
-				primary = "codex:" + childSessionID
-				if parentSID != "" && parentSID != childSessionID {
-					fallback = "codex:" + parentSID
-				} else if parentIDCandidate != "" && parentIDCandidate != childSessionID {
-					fallback = "codex:" + parentIDCandidate
-				}
-			}
-			if metadata != nil && fallback != "" {
-				metadata[cliproxyexecutor.ParentSessionIDMetadataKey] = fallback
-			}
-			return primary, fallback
-		}
-
-		// 3. Normal session
-		sessionID := sid
-		if sessionID == "" {
-			sessionID = tid
-		}
-		primary = "codex:" + sessionID
-		if parentThreadID != "" && parentThreadID != sessionID {
-			fallback = "codex:" + parentThreadID
-		} else if parentIDCandidate != "" && parentIDCandidate != sessionID {
-			fallback = "codex:" + parentIDCandidate
-		}
-		if metadata != nil && fallback != "" {
-			metadata[cliproxyexecutor.ParentSessionIDMetadataKey] = fallback
-		}
-		return primary, fallback
-	}
-
-	// 3. Antigravity CLI (agy) / Google Cloud Code
-	if sid := sessionHeaderValue(headers, "X-Http-Session-Id"); sid != "" {
-		parentSID := sessionHeaderValue(headers, "X-Parent-Session-ID")
-		if parentSID == "" {
-			parentSID = sessionHeaderValue(headers, "X-Parent-Session-Id")
-		}
-		if parentSID != "" && parentSID != sid {
-			return "agy:" + sid, "agy:" + parentSID
-		}
-		if parentIDCandidate != "" && parentIDCandidate != sid {
-			return "agy:" + sid, "agy:" + parentIDCandidate
-		}
-		return "agy:" + sid, ""
-	}
-
-	// 4. OpenCode / Pi Slot / Generic Headers
-	if sid := sessionHeaderValue(headers, "X-Session-ID"); sid != "" {
-		parentSID := sessionHeaderValue(headers, "X-Parent-Session-ID")
-		if parentSID == "" {
-			parentSID = sessionHeaderValue(headers, "X-Parent-Session-Id")
-		}
-		if parentSID != "" && parentSID != sid {
-			return "header:" + sid, "header:" + parentSID
-		}
-		if parentIDCandidate != "" && parentIDCandidate != sid {
-			return "header:" + sid, "header:" + parentIDCandidate
-		}
-		return "header:" + sid, ""
-	}
-	if sid := sessionHeaderValue(headers, "X-Session-Affinity"); sid != "" {
-		parentAffinity := sessionHeaderValue(headers, "X-Parent-Session-Affinity")
-		if parentAffinity == "" {
-			parentAffinity = sessionHeaderValue(headers, "X-Parent-Session-ID")
-		}
-		if parentAffinity != "" && parentAffinity != sid {
-			return "affinity:" + sid, "affinity:" + parentAffinity
-		}
-		if parentIDCandidate != "" && parentIDCandidate != sid {
-			return "affinity:" + sid, "affinity:" + parentIDCandidate
-		}
-		return "affinity:" + sid, ""
-	}
-	if sid := sessionHeaderValue(headers, "X-Slot-Session-Id"); sid != "" {
-		parentSID := sessionHeaderValue(headers, "X-Parent-Session-ID")
-		if parentSID == "" {
-			parentSID = sessionHeaderValue(headers, "X-Parent-Session-Id")
-		}
-		if parentSID != "" && parentSID != sid {
-			return "slot:" + sid, "slot:" + parentSID
-		}
-		if parentIDCandidate != "" && parentIDCandidate != sid {
-			return "slot:" + sid, "slot:" + parentIDCandidate
-		}
-		return "slot:" + sid, ""
-	}
-	if sid := sessionHeaderValue(headers, "X-Conversation-Id"); sid != "" {
-		if parentIDCandidate != "" && parentIDCandidate != sid {
-			return "conv:" + sid, "conv:" + parentIDCandidate
-		}
-		return "conv:" + sid, ""
-	}
-	if sid := sessionHeaderValue(headers, "X-Conversation-ID"); sid != "" {
-		if parentIDCandidate != "" && parentIDCandidate != sid {
-			return "conv:" + sid, "conv:" + parentIDCandidate
-		}
-		return "conv:" + sid, ""
-	}
-	if sid := sessionHeaderValue(headers, "X-Thread-Id"); sid != "" {
-		if parentIDCandidate != "" && parentIDCandidate != sid {
-			return "thread:" + sid, "thread:" + parentIDCandidate
-		}
-		return "thread:" + sid, ""
-	}
-	if sid := sessionHeaderValue(headers, "X-Thread-ID"); sid != "" {
-		if parentIDCandidate != "" && parentIDCandidate != sid {
-			return "thread:" + sid, "thread:" + parentIDCandidate
-		}
-		return "thread:" + sid, ""
-	}
-	if sid := sessionHeaderValue(headers, "X-Client-Request-Id"); sid != "" {
-		return "clientreq:" + sid, ""
-	}
-
-	// 5. Body payload inspection
-	if len(payload) > 0 && root.Exists() {
-		reqRoot := root
-		req := root.Get("request")
-		hasNestedReq := req.Exists() && !root.Get("contents").Exists()
-		if hasNestedReq {
-			reqRoot = req
-		}
-
-		// Google Gemini Context Caching
-		for _, cachePath := range []string{"cachedContent", "cached_content"} {
-			cacheID := normalizedSessionCandidate(root.Get(cachePath).String())
-			if cacheID == "" && hasNestedReq {
-				cacheID = normalizedSessionCandidate(reqRoot.Get(cachePath).String())
-			}
-			if cacheID != "" {
-				if parentIDCandidate != "" && parentIDCandidate != cacheID {
-					return "geminicache:" + cacheID, "geminicache:" + parentIDCandidate
-				}
-				return "geminicache:" + cacheID, ""
-			}
-		}
-
-		// OpenAI Assistants / Threads
-		for _, threadPath := range []string{"thread_id", "threadId", "metadata.thread_id"} {
-			tid := normalizedSessionCandidate(root.Get(threadPath).String())
-			if tid == "" && hasNestedReq {
-				tid = normalizedSessionCandidate(reqRoot.Get(threadPath).String())
-			}
-			if tid != "" {
-				if parentIDCandidate != "" && parentIDCandidate != tid {
-					if isBodyForkCandidate(root, reqRoot, hasNestedReq) && metadata != nil {
-						metadata[cliproxyexecutor.IsForkMetadataKey] = true
-						metadata[cliproxyexecutor.ParentSessionIDMetadataKey] = "thread:" + parentIDCandidate
-					}
-					return "thread:" + tid, "thread:" + parentIDCandidate
-				}
-				return "thread:" + tid, ""
-			}
-		}
-
-		// Session ID paths
-		agentID := normalizedSessionCandidate(root.Get("metadata.agent_id").String())
-		if agentID == "" {
-			agentID = normalizedSessionCandidate(root.Get("metadata.subagent_id").String())
-		}
-		if agentID == "" {
-			agentID = sessionHeaderValue(headers, "X-Claude-Code-Agent-Id")
-		}
-		if agentID == "" {
-			agentID = sessionHeaderValue(headers, "x-agent-id")
-		}
-		if agentID == "" && hasNestedReq {
-			agentID = normalizedSessionCandidate(reqRoot.Get("metadata.agent_id").String())
-			if agentID == "" {
-				agentID = normalizedSessionCandidate(reqRoot.Get("metadata.subagent_id").String())
-			}
-		}
-		for _, path := range []string{"session_id", "sessionId", "sessionID", "metadata.session_id", "extra_body.session_id"} {
-			sid := normalizedSessionCandidate(root.Get(path).String())
-			if sid == "" && hasNestedReq {
-				sid = normalizedSessionCandidate(reqRoot.Get(path).String())
-			}
-			if sid != "" {
-				if agentID != "" && agentID != "main" {
-					primary = "session:" + sid + ":agent:" + agentID
-					fallback = "session:" + sid
-					if parentIDCandidate != "" && parentIDCandidate != sid {
-						fallback = "session:" + parentIDCandidate
-					}
-					return primary, fallback
-				}
-				if parentIDCandidate != "" && parentIDCandidate != sid {
-					fallback = "session:" + parentIDCandidate
-					if isBodyForkCandidate(root, reqRoot, hasNestedReq) && metadata != nil {
-						metadata[cliproxyexecutor.IsForkMetadataKey] = true
-						metadata[cliproxyexecutor.ParentSessionIDMetadataKey] = fallback
-					}
-					return "session:" + sid, fallback
-				}
-				return "session:" + sid, ""
-			}
-		}
-
-		conversationID := ""
-		conversation := root.Get("conversation")
-		if !conversation.Exists() && hasNestedReq {
-			conversation = reqRoot.Get("conversation")
-		}
-		if sid := normalizedSessionCandidate(conversation.Get("id").String()); sid != "" {
-			conversationID = "conv:" + sid
-		} else if conversation.Type == gjson.String {
-			if sid := normalizedSessionCandidate(conversation.String()); sid != "" {
-				conversationID = "conv:" + sid
-			}
-		}
-		pck := normalizedSessionCandidate(root.Get("prompt_cache_key").String())
-		if pck == "" {
-			pck = normalizedSessionCandidate(root.Get("promptCacheKey").String())
-		}
-		if pck == "" && hasNestedReq {
-			pck = normalizedSessionCandidate(reqRoot.Get("prompt_cache_key").String())
-			if pck == "" {
-				pck = normalizedSessionCandidate(reqRoot.Get("promptCacheKey").String())
-			}
-		}
-		if pck != "" {
-			return "pck:" + pck, conversationID
-		}
-		if conversationID != "" {
-			if parentIDCandidate != "" && ("conv:"+parentIDCandidate) != conversationID {
-				return conversationID, "conv:" + parentIDCandidate
-			}
-			return conversationID, ""
-		}
-		userID := normalizedSessionCandidate(root.Get("metadata.user_id").String())
-		if userID == "" && hasNestedReq {
-			userID = normalizedSessionCandidate(reqRoot.Get("metadata.user_id").String())
-		}
-		if userID != "" {
-			return "user:" + userID, ""
-		}
-		for _, convPath := range []string{"conversation_id", "conversationId", "chat_id", "chatId", "metadata.conversation_id", "extra_body.conversation_id"} {
-			cid := normalizedSessionCandidate(root.Get(convPath).String())
-			if cid == "" && hasNestedReq {
-				cid = normalizedSessionCandidate(reqRoot.Get(convPath).String())
-			}
-			if cid != "" {
-				if parentIDCandidate != "" && ("conv:"+parentIDCandidate) != ("conv:"+cid) {
-					return "conv:" + cid, "conv:" + parentIDCandidate
-				}
-				return "conv:" + cid, ""
-			}
-		}
-	}
-
-	if executionID, ok := metadata[cliproxyexecutor.ExecutionSessionMetadataKey].(string); ok {
-		if executionID = normalizedSessionCandidate(executionID); executionID != "" {
-			return "execution:" + executionID, ""
-		}
-	}
-	return "", ""
+	return info.SessionID, fallback
 }
 
 // extractSessionIDs returns (primaryID, fallbackID) for session affinity.

--- a/sdk/cliproxy/auth/selector.go
+++ b/sdk/cliproxy/auth/selector.go
@@ -1212,6 +1212,24 @@ func lcpAffinityNamespace(provider, model string, metadata map[string]any) strin
 	return strings.Join([]string{"lcp:v1", provider, model, callerScope}, "::")
 }
 
+func parseLCPNamespace(ns string) (provider, model, callerScope string, ok bool) {
+	if !strings.HasPrefix(ns, "lcp:v1::") {
+		return "", "", "", false
+	}
+	rest := strings.TrimPrefix(ns, "lcp:v1::")
+	nsProvider, rest, found := strings.Cut(rest, "::")
+	if !found {
+		return "", "", "", false
+	}
+	lastIdx := strings.LastIndex(rest, "::")
+	if lastIdx < 0 {
+		return nsProvider, rest, "", true
+	}
+	nsModel := rest[:lastIdx]
+	nsCallerScope := rest[lastIdx+2:]
+	return nsProvider, nsModel, nsCallerScope, true
+}
+
 func lcpFingerprintsFromMetadata(metadata map[string]any) ([]string, int) {
 	if metadata == nil {
 		return nil, 0
@@ -1289,6 +1307,104 @@ func (s *SessionAffinitySelector) InvalidateAuth(authID string) {
 	if s.matcher != nil {
 		s.matcher.InvalidateAuth(authID)
 	}
+}
+
+// LookupAffinity observes the current session affinity binding without side effects.
+// It never selects a credential, creates a binding, rebinds, or refreshes TTL.
+// Optional authFilters allow callers (such as Manager) to exclude credentials that do not match the requested provider.
+func (s *SessionAffinitySelector) LookupAffinity(provider, model, sessionID string, authFilters ...func(authID string) bool) (string, string) {
+	if s == nil || s.cache == nil {
+		return "", "unsupported"
+	}
+	provider = strings.TrimSpace(provider)
+	model = strings.TrimSpace(model)
+	sessionID = strings.TrimSpace(sessionID)
+	if provider == "" || model == "" || sessionID == "" {
+		return "", "unbound"
+	}
+
+	var authFilter func(authID string) bool
+	if len(authFilters) > 0 {
+		authFilter = authFilters[0]
+	}
+
+	modelKey := canonicalModelKey(model)
+	if modelKey == "" {
+		modelKey = model
+	}
+
+	providers := []string{provider}
+	if provider != "mixed" {
+		providers = append(providers, "mixed")
+	}
+
+	candidatePrefixes := cliproxysession.CandidateSessionPrefixes
+	hasKnownPrefix := false
+	for _, p := range candidatePrefixes {
+		if strings.HasPrefix(sessionID, p) {
+			hasKnownPrefix = true
+			break
+		}
+	}
+
+	var candidates []string
+	if hasKnownPrefix {
+		candidates = []string{sessionID}
+	} else {
+		candidates = make([]string, 0, len(candidatePrefixes)+1)
+		candidates = append(candidates, sessionID)
+		for _, p := range candidatePrefixes {
+			candidates = append(candidates, p+sessionID)
+		}
+	}
+
+	foundAuths := make(map[string]struct{})
+	for _, candProvider := range providers {
+		for _, cand := range candidates {
+			bounded := cliproxysession.BoundSessionIdentity(cand)
+			key := candProvider + "::" + bounded + "::" + modelKey
+			if authID, ok := s.cache.Get(key); ok && authID != "" {
+				if authFilter != nil && !authFilter(authID) {
+					continue
+				}
+				foundAuths[authID] = struct{}{}
+			}
+		}
+	}
+
+	if s.matcher != nil {
+		for _, cand := range candidates {
+			if authIDs, ns, ok := s.matcher.LookupSession(cand); ok && len(authIDs) > 0 {
+				nsProvider, nsModel, _, okParse := parseLCPNamespace(ns)
+				matchesNS := true
+				if okParse {
+					if (provider != "mixed" && nsProvider != "mixed" && nsProvider != strings.ToLower(provider)) ||
+						(modelKey != "" && nsModel != modelKey) {
+						matchesNS = false
+					}
+				}
+				if matchesNS {
+					for _, aID := range authIDs {
+						if authFilter != nil && !authFilter(aID) {
+							continue
+						}
+						foundAuths[aID] = struct{}{}
+					}
+				}
+			}
+		}
+	}
+
+	if len(foundAuths) == 0 {
+		return "", "unbound"
+	}
+	if len(foundAuths) > 1 {
+		return "", "ambiguous"
+	}
+	for authID := range foundAuths {
+		return authID, "bound"
+	}
+	return "", "unbound"
 }
 
 // OnResult handles session affinity binding or release based on execution outcome.

--- a/sdk/cliproxy/auth/selector_test.go
+++ b/sdk/cliproxy/auth/selector_test.go
@@ -2635,3 +2635,68 @@ func TestSessionAffinitySelector_DerivedIDBoundConsistencyOnResult(t *testing.T)
 		t.Fatalf("affinity failed: got auth %s, want %s", secondPicked.ID, pickedAuth.ID)
 	}
 }
+
+func TestExtractExplicitSessionIDs_EnhancedHarnesses(t *testing.T) {
+	t.Parallel()
+
+	// 1. Roo Code / Cline task headers
+	rooHeaders := http.Header{}
+	rooHeaders.Set("X-Task-ID", "task-abc-1")
+	rooHeaders.Set("X-Parent-Task-ID", "task-root-1")
+	meta := map[string]any{}
+	primary, fallback := extractExplicitSessionIDs(rooHeaders, nil, meta)
+	if primary != "task:task-abc-1" || fallback != "task:task-root-1" {
+		t.Fatalf("Roo Code extractExplicitSessionIDs() = (%q, %q), want (task:task-abc-1, task:task-root-1)", primary, fallback)
+	}
+	if meta[cliproxyexecutor.ParentSessionIDMetadataKey] != "task:task-root-1" {
+		t.Fatalf("ParentSessionIDMetadataKey = %v, want task:task-root-1", meta[cliproxyexecutor.ParentSessionIDMetadataKey])
+	}
+
+	// 2. OpenClaw forkSource sets IsForkMetadataKey
+	clawPayload := []byte(`{"sessionId":"claw-c-1","forkSource":{"sessionId":"claw-p-1"}}`)
+	metaClaw := map[string]any{}
+	primary, fallback = extractExplicitSessionIDs(nil, clawPayload, metaClaw)
+	if primary != "session:claw-c-1" || fallback != "session:claw-p-1" {
+		t.Fatalf("OpenClaw extractExplicitSessionIDs() = (%q, %q), want (session:claw-c-1, session:claw-p-1)", primary, fallback)
+	}
+	if isFork, ok := metaClaw[cliproxyexecutor.IsForkMetadataKey].(bool); !ok || !isFork {
+		t.Fatalf("OpenClaw IsForkMetadataKey = %v, want true", metaClaw[cliproxyexecutor.IsForkMetadataKey])
+	}
+
+	// 3. Roo Code subagent task inherits parent credential via affinity selector
+	selector := NewSessionAffinitySelector(&RoundRobinSelector{})
+	defer selector.Stop()
+	auths := []*Auth{{ID: "auth-1"}, {ID: "auth-2"}}
+
+	parentOpts := cliproxyexecutor.Options{
+		Headers: http.Header{"X-Task-ID": []string{"task-parent-100"}},
+	}
+	parentAuth, err := selector.Pick(context.Background(), "openai", "gpt-5.4", parentOpts, auths)
+	if err != nil || parentAuth == nil {
+		t.Fatalf("parent Pick() failed: %v", err)
+	}
+	selector.OnResult(Result{
+		AuthID:   parentAuth.ID,
+		Provider: "openai",
+		Model:    "gpt-5.4",
+		Success:  true,
+		Options:  parentOpts,
+	})
+
+	// Subagent task request specifying parent task
+	subagentOpts := cliproxyexecutor.Options{
+		Headers: http.Header{
+			"X-Task-ID":        []string{"task-child-101"},
+			"X-Parent-Task-ID": []string{"task-parent-100"},
+		},
+	}
+	// Reverse candidate order to prove affinity, not order
+	reverseAuths := []*Auth{{ID: "auth-2"}, {ID: "auth-1"}}
+	subagentAuth, err := selector.Pick(context.Background(), "openai", "gpt-5.4", subagentOpts, reverseAuths)
+	if err != nil || subagentAuth == nil {
+		t.Fatalf("subagent Pick() failed: %v", err)
+	}
+	if subagentAuth.ID != parentAuth.ID {
+		t.Fatalf("subagent did not inherit parent task credential: got %s, want %s", subagentAuth.ID, parentAuth.ID)
+	}
+}

--- a/sdk/cliproxy/auth/session_affinity_lookup_test.go
+++ b/sdk/cliproxy/auth/session_affinity_lookup_test.go
@@ -1,0 +1,281 @@
+package auth
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+func TestSessionAffinitySelector_LookupAffinity(t *testing.T) {
+	selector := NewSessionAffinitySelector(nil)
+	defer selector.Stop()
+
+	authA := &Auth{
+		ID:       "auth-a",
+		Provider: "anthropic",
+	}
+	authA.EnsureIndex()
+
+	opts := cliproxyexecutor.Options{
+		Headers:  map[string][]string{"X-Claude-Code-Session-Id": {"sess-alpha"}},
+		Metadata: make(map[string]any),
+	}
+	picked, errPick := selector.Pick(context.Background(), "anthropic", "claude-3-7-sonnet", opts, []*Auth{authA})
+	if errPick != nil || picked.ID != authA.ID {
+		t.Fatalf("pick failed: auth=%v err=%v", picked, errPick)
+	}
+
+	t.Run("repeated reads do not extend TTL", func(t *testing.T) {
+		cacheKey := "anthropic::claude:sess-alpha::claude-3-7-sonnet"
+		selector.cache.mu.RLock()
+		initialEntry, exists := selector.cache.entries[cacheKey]
+		selector.cache.mu.RUnlock()
+		if !exists {
+			t.Fatalf("expected cache entry for %s", cacheKey)
+		}
+		originalExpiresAt := initialEntry.expiresAt
+
+		// Perform multiple lookups
+		for i := 0; i < 10; i++ {
+			authID, status := selector.LookupAffinity("anthropic", "claude-3-7-sonnet", "sess-alpha")
+			if status != "bound" || authID != authA.ID {
+				t.Fatalf("lookup failed: authID=%s status=%s", authID, status)
+			}
+		}
+
+		selector.cache.mu.RLock()
+		afterEntry, existsAfter := selector.cache.entries[cacheKey]
+		selector.cache.mu.RUnlock()
+		if !existsAfter {
+			t.Fatalf("cache entry disappeared")
+		}
+
+		if !afterEntry.expiresAt.Equal(originalExpiresAt) {
+			t.Fatalf("TTL was modified by read: original=%v, after=%v", originalExpiresAt, afterEntry.expiresAt)
+		}
+	})
+
+	t.Run("expired binding returns unbound", func(t *testing.T) {
+		cacheKey := "anthropic::claude:sess-alpha::claude-3-7-sonnet"
+		// Simulate expiration by adjusting expiresAt into the past
+		selector.cache.mu.Lock()
+		if entry, ok := selector.cache.entries[cacheKey]; ok {
+			entry.expiresAt = time.Now().Add(-time.Hour)
+			selector.cache.entries[cacheKey] = entry
+		}
+		selector.cache.mu.Unlock()
+
+		authID, status := selector.LookupAffinity("anthropic", "claude-3-7-sonnet", "sess-alpha")
+		if status != "unbound" || authID != "" {
+			t.Fatalf("expected unbound for expired entry, got status=%s authID=%s", status, authID)
+		}
+	})
+}
+
+func TestManager_LookupSessionAffinity_RemovedAuth(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	selector := NewSessionAffinitySelector(nil)
+	defer selector.Stop()
+	manager.SetSelector(selector)
+
+	authA := &Auth{
+		ID:       "auth-to-remove",
+		Provider: "anthropic",
+	}
+	authA.EnsureIndex()
+
+	if _, errReg := manager.Register(context.Background(), authA); errReg != nil {
+		t.Fatalf("register: %v", errReg)
+	}
+
+	opts := cliproxyexecutor.Options{
+		Headers:  map[string][]string{"X-Claude-Code-Session-Id": {"sess-remove"}},
+		Metadata: make(map[string]any),
+	}
+	selector.Pick(context.Background(), "anthropic", "claude-3-7-sonnet", opts, []*Auth{authA})
+
+	// Lookup when auth exists
+	found, status := manager.LookupSessionAffinity("anthropic", "claude-3-7-sonnet", "sess-remove")
+	if status != "bound" || found == nil || found.ID != authA.ID {
+		t.Fatalf("expected bound, got status=%s found=%v", status, found)
+	}
+
+	// Remove auth from manager
+	manager.Remove(context.Background(), authA.ID)
+
+	// Lookup after auth removal returns unbound
+	foundAfter, statusAfter := manager.LookupSessionAffinity("anthropic", "claude-3-7-sonnet", "sess-remove")
+	if statusAfter != "unbound" || foundAfter != nil {
+		t.Fatalf("expected unbound after removal, got status=%s found=%v", statusAfter, foundAfter)
+	}
+}
+
+func TestSessionAffinitySelector_LookupAffinity_LCP(t *testing.T) {
+	selector := NewSessionAffinitySelector(nil)
+	defer selector.Stop()
+
+	authA := &Auth{ID: "auth-lcp-a", Provider: "openai"}
+	authA.EnsureIndex()
+
+	opts := cliproxyexecutor.Options{
+		OriginalRequest: []byte(`{"messages":[{"role":"system","content":"test-lcp-sys"},{"role":"user","content":"test-lcp-user"}]}`),
+		Metadata: map[string]any{
+			cliproxyexecutor.CallerScopeMetadataKey: "scope-test",
+		},
+	}
+	picked, errPick := selector.Pick(context.Background(), "openai", "gpt-4o", opts, []*Auth{authA})
+	if errPick != nil || picked.ID != authA.ID {
+		t.Fatalf("Pick failed: auth=%v err=%v", picked, errPick)
+	}
+
+	lcpSessionID, ok := opts.Metadata[cliproxyexecutor.LCPAffinitySessionIDMetadataKey].(string)
+	if !ok || lcpSessionID == "" {
+		t.Fatalf("expected LCPAffinitySessionIDMetadataKey in opts.Metadata, got %#v", opts.Metadata)
+	}
+
+	// 1. Lookup with published LCP session ID
+	authID, status := selector.LookupAffinity("openai", "gpt-4o", lcpSessionID)
+	if status != "bound" || authID != authA.ID {
+		t.Fatalf("LCP lookup failed: status=%s authID=%s, want bound %s", status, authID, authA.ID)
+	}
+
+	// 2. Lookup with bare hash (without lcp:v1: prefix)
+	bareHash := strings.TrimPrefix(lcpSessionID, "lcp:v1:")
+	authIDBare, statusBare := selector.LookupAffinity("openai", "gpt-4o", bareHash)
+	if statusBare != "bound" || authIDBare != authA.ID {
+		t.Fatalf("LCP bare hash lookup failed: status=%s authID=%s, want bound %s", statusBare, authIDBare, authA.ID)
+	}
+
+	// 3. TTL non-refresh on LCP lookup: repeated reads do not change expiresAt
+	for i := 0; i < 5; i++ {
+		aID, st := selector.LookupAffinity("openai", "gpt-4o", lcpSessionID)
+		if st != "bound" || aID != authA.ID {
+			t.Fatalf("repeated LCP lookup failed at %d: %s %s", i, st, aID)
+		}
+	}
+
+	// 4. Multi-trajectory conversation growth sharing same session ID:
+	// Grown conversation must be deterministically observed across 100 iterations.
+	optsGrown := cliproxyexecutor.Options{
+		OriginalRequest: []byte(`{"messages":[{"role":"system","content":"test-lcp-sys"},{"role":"user","content":"test-lcp-user"},{"role":"assistant","content":"reply"},{"role":"user","content":"turn2"}]}`),
+		Metadata: map[string]any{
+			cliproxyexecutor.CallerScopeMetadataKey: "scope-test",
+		},
+	}
+	pickedGrown, errGrown := selector.Pick(context.Background(), "openai", "gpt-4o", optsGrown, []*Auth{authA})
+	if errGrown != nil || pickedGrown.ID != authA.ID {
+		t.Fatalf("Pick grown failed: auth=%v err=%v", pickedGrown, errGrown)
+	}
+	lcpGrownSessionID, okGrown := optsGrown.Metadata[cliproxyexecutor.LCPAffinitySessionIDMetadataKey].(string)
+	if !okGrown || lcpGrownSessionID != lcpSessionID {
+		t.Fatalf("expected grown conversation to share session ID: got %q want %q", lcpGrownSessionID, lcpSessionID)
+	}
+
+	for i := 0; i < 100; i++ {
+		aID, st := selector.LookupAffinity("openai", "gpt-4o", lcpSessionID)
+		if st != "bound" || aID != authA.ID {
+			t.Fatalf("lookup at iteration %d failed: status=%s auth=%s, want bound %s", i, st, aID, authA.ID)
+		}
+	}
+}
+
+func TestSessionAffinitySelector_LookupAffinity_ExactCaseModel(t *testing.T) {
+	selector := NewSessionAffinitySelector(nil)
+	defer selector.Stop()
+
+	authA := &Auth{ID: "auth-case", Provider: "openai"}
+	authA.EnsureIndex()
+
+	opts := cliproxyexecutor.Options{
+		OriginalRequest: []byte(`{"messages":[{"role":"system","content":"sys-case"},{"role":"user","content":"user-case"}]}`),
+		Metadata: map[string]any{
+			cliproxyexecutor.CallerScopeMetadataKey: "scope-case",
+		},
+	}
+	_, errPick := selector.Pick(context.Background(), "openai", "ModelA", opts, []*Auth{authA})
+	if errPick != nil {
+		t.Fatalf("Pick failed: %v", errPick)
+	}
+	lcpSessionID := opts.Metadata[cliproxyexecutor.LCPAffinitySessionIDMetadataKey].(string)
+
+	// Exact case matches
+	authID, status := selector.LookupAffinity("openai", "ModelA", lcpSessionID)
+	if status != "bound" || authID != authA.ID {
+		t.Fatalf("exact case ModelA failed: status=%s auth=%s, want bound %s", status, authID, authA.ID)
+	}
+
+	// Lowercase model does NOT match case-sensitive model binding
+	authIDLower, statusLower := selector.LookupAffinity("openai", "modela", lcpSessionID)
+	if statusLower != "unbound" || authIDLower != "" {
+		t.Fatalf("different case modela unexpectedly matched: status=%s auth=%s, want unbound", statusLower, authIDLower)
+	}
+}
+
+func TestManager_LookupSessionAffinity_CrossProviderMixedIsolation(t *testing.T) {
+	manager := NewManager(nil, nil, nil)
+	selector := NewSessionAffinitySelector(nil)
+	defer selector.Stop()
+	manager.SetSelector(selector)
+
+	authOpenAI := &Auth{ID: "auth-openai-1", Provider: "openai"}
+	authOpenAI.EnsureIndex()
+	authAnthropic := &Auth{ID: "auth-anthropic-1", Provider: "anthropic"}
+	authAnthropic.EnsureIndex()
+
+	if _, errReg := manager.Register(context.Background(), authOpenAI); errReg != nil {
+		t.Fatalf("register openai: %v", errReg)
+	}
+	if _, errReg := manager.Register(context.Background(), authAnthropic); errReg != nil {
+		t.Fatalf("register anthropic: %v", errReg)
+	}
+
+	sessionID := "cross-prov-session"
+	model := "gpt-4o"
+
+	// Bind openai directly to authOpenAI
+	selector.cache.Set("openai::header:"+sessionID+"::"+model, authOpenAI.ID)
+	// Bind mixed to authAnthropic (an anthropic credential in mixed pool)
+	selector.cache.Set("mixed::header:"+sessionID+"::"+model, authAnthropic.ID)
+
+	// When querying for provider "openai", the anthropic binding under mixed must be filtered out
+	// and NOT trigger false ambiguity. It must return authOpenAI.
+	found, status := manager.LookupSessionAffinity("openai", model, sessionID)
+	if status != "bound" || found == nil || found.ID != authOpenAI.ID {
+		t.Fatalf("expected bound to authOpenAI, got status=%s found=%v", status, found)
+	}
+}
+
+func TestSessionAffinitySelector_LookupAffinity_ModelWithColons(t *testing.T) {
+	selector := NewSessionAffinitySelector(nil)
+	defer selector.Stop()
+
+	authA := &Auth{ID: "auth-colon-model", Provider: "openai"}
+	authA.EnsureIndex()
+
+	opts := cliproxyexecutor.Options{
+		OriginalRequest: []byte(`{"messages":[{"role":"system","content":"sys-colons"},{"role":"user","content":"user-colons"}]}`),
+		Metadata: map[string]any{
+			cliproxyexecutor.CallerScopeMetadataKey: "scope-colons",
+		},
+	}
+	_, errPick := selector.Pick(context.Background(), "openai", "team::ModelA", opts, []*Auth{authA})
+	if errPick != nil {
+		t.Fatalf("Pick failed: %v", errPick)
+	}
+	lcpSessionID := opts.Metadata[cliproxyexecutor.LCPAffinitySessionIDMetadataKey].(string)
+
+	// 1. Query actual model "team::ModelA" -> returns bound
+	authID, status := selector.LookupAffinity("openai", "team::ModelA", lcpSessionID)
+	if status != "bound" || authID != authA.ID {
+		t.Fatalf("team::ModelA lookup failed: status=%s auth=%s, want bound %s", status, authID, authA.ID)
+	}
+
+	// 2. Query other model "team" -> returns unbound
+	authIDOther, statusOther := selector.LookupAffinity("openai", "team", lcpSessionID)
+	if statusOther != "unbound" || authIDOther != "" {
+		t.Fatalf("team lookup unexpectedly matched: status=%s auth=%s, want unbound", statusOther, authIDOther)
+	}
+}

--- a/sdk/cliproxy/session/identity.go
+++ b/sdk/cliproxy/session/identity.go
@@ -40,6 +40,66 @@ type canonicalPart struct {
 	Value string `json:"value"`
 }
 
+var canonicalUUIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+var knownSessionPrefixes = []string{
+	"lcp:v1:", "lcp:",
+	"codex:", "claude:", "header:", "session:",
+	"affinity:", "slot:", "task:", "conv:",
+	"thread:", "clientreq:", "geminicache:",
+	"pck:", "user:", "execution:", "agy:", "derived:",
+}
+
+// NormalizeToCanonicalUUID deterministically normalizes any session identifier to a
+// canonical 36-character lowercase UUID (RFC 4122 / RFC 9562 compliant):
+//  1. If rawID (or rawID without known protocol prefix) is already a standard UUID (e.g. Codex UUIDv7,
+//     Claude UUIDv4, Header UUID), it strips the prefix and returns the lowercase UUID.
+//  2. If rawID has a known protocol prefix but the remainder is not a UUID (e.g. custom task strings),
+//     the known prefix is stripped and the remaining identifier is deterministically projected.
+//  3. If rawID is not a standard UUID (e.g. LCP 64-hex hash, subagent hierarchy, or custom string),
+//     it deterministically projects it to an RFC 9562 UUIDv8 using SHA-256 with domain separation.
+//  4. Idempotent: NormalizeToCanonicalUUID(NormalizeToCanonicalUUID(x)) == NormalizeToCanonicalUUID(x).
+func NormalizeToCanonicalUUID(rawID string) string {
+	clean := strings.TrimSpace(rawID)
+	if clean == "" {
+		return ""
+	}
+
+	// 1. Direct UUID match (already clean UUID)
+	if canonicalUUIDPattern.MatchString(clean) {
+		return strings.ToLower(clean)
+	}
+
+	// 2. Strip known protocol prefix and check if remainder is a UUID
+	for _, p := range knownSessionPrefixes {
+		if strings.HasPrefix(clean, p) {
+			clean = strings.TrimPrefix(clean, p)
+			break
+		}
+	}
+	clean = strings.TrimSpace(clean)
+	if canonicalUUIDPattern.MatchString(clean) {
+		return strings.ToLower(clean)
+	}
+
+	// 3. Check if any generic prefix "prefix:<uuid>" exists
+	if idx := strings.Index(clean, ":"); idx > 0 {
+		candidate := strings.TrimSpace(clean[idx+1:])
+		if canonicalUUIDPattern.MatchString(candidate) {
+			return strings.ToLower(candidate)
+		}
+	}
+
+	// 4. Deterministic projection to RFC 9562 UUIDv8 for LCP hashes and arbitrary non-UUID strings
+	sum := sha256.Sum256([]byte("cpa:canonical-uuid:v1\x00" + clean))
+	u := [16]byte(sum[:16])
+	u[6] = (u[6] & 0x0f) | 0x80 // RFC 9562 Version 8
+	u[8] = (u[8] & 0x3f) | 0x80 // RFC 4122 / RFC 9562 Variant
+
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		u[0:4], u[4:6], u[6:8], u[8:10], u[10:16])
+}
+
 // NormalizeExplicitID validates an explicit client-provided session identifier.
 // It preserves opaque printable values while rejecting oversized or control-bearing IDs.
 func NormalizeExplicitID(raw string) string {
@@ -75,11 +135,32 @@ func ClaudeMetadataIdentities(payload []byte) (sessionID, parentSessionID, agent
 		parsed := gjson.Parse(userID)
 		sessionID = NormalizeExplicitID(parsed.Get("session_id").String())
 		parentSessionID = NormalizeExplicitID(parsed.Get("parent_session_id").String())
+		if parentSessionID == "" {
+			parentSessionID = NormalizeExplicitID(parsed.Get("parent_agent_id").String())
+		}
+		if parentSessionID == "" {
+			parentSessionID = NormalizeExplicitID(parsed.Get("parent_id").String())
+		}
 		agentID = NormalizeExplicitID(parsed.Get("agent_id").String())
+		if agentID == "" {
+			agentID = NormalizeExplicitID(parsed.Get("subagent_id").String())
+		}
 		return sessionID, parentSessionID, agentID
 	}
 	if matches := legacyClaudeSessionPattern.FindStringSubmatch(userID); len(matches) >= 2 {
-		return NormalizeExplicitID(matches[1]), "", ""
+		sid := NormalizeExplicitID(matches[1])
+		pAgent := NormalizeExplicitID(root.Get("metadata.parent_agent_id").String())
+		if pAgent == "" {
+			pAgent = NormalizeExplicitID(root.Get("metadata.parent_session_id").String())
+		}
+		if pAgent == "" {
+			pAgent = NormalizeExplicitID(root.Get("metadata.parent_id").String())
+		}
+		ag := NormalizeExplicitID(root.Get("metadata.agent_id").String())
+		if ag == "" {
+			ag = NormalizeExplicitID(root.Get("metadata.subagent_id").String())
+		}
+		return sid, pAgent, ag
 	}
 	return "", "", ""
 }
@@ -240,17 +321,30 @@ func hasExplicitSession(headers map[string][]string, payload []byte) bool {
 		"Session_id",
 		"x-codex-parent-thread-id",
 		"X-Codex-Parent-Thread-Id",
+		"X-Codex-Turn-Metadata",
+		"X-Openai-Subagent",
 		"X-Http-Session-Id",
 		"X-Session-ID",
 		"X-Session-Affinity",
 		"X-Parent-Session-ID",
 		"X-Parent-Session-Id",
 		"X-Parent-Session-Affinity",
+		"X-Parent-ID",
+		"X-Parent-Id",
 		"X-Slot-Session-Id",
+		"X-Parent-Slot-Session-Id",
+		"X-Task-ID",
+		"X-Task-Id",
+		"X-Parent-Task-ID",
+		"X-Parent-Task-Id",
 		"X-Conversation-Id",
 		"X-Conversation-ID",
+		"X-Parent-Conversation-Id",
+		"X-Parent-Conversation-ID",
 		"X-Thread-Id",
 		"X-Thread-ID",
+		"X-Parent-Thread-Id",
+		"X-Parent-Thread-ID",
 		"Thread-Id",
 		"X-Client-Request-Id",
 	} {
@@ -274,6 +368,13 @@ func hasExplicitSession(headers map[string][]string, payload []byte) bool {
 		"session_id",
 		"sessionId",
 		"sessionID",
+		"child_session_id",
+		"childSessionId",
+		"task_id",
+		"taskId",
+		"taskID",
+		"action_id",
+		"actionId",
 		"cachedContent",
 		"cached_content",
 		"thread_id",
@@ -288,12 +389,33 @@ func hasExplicitSession(headers map[string][]string, payload []byte) bool {
 		"parentSessionId",
 		"parent_thread_id",
 		"parentThreadId",
+		"parent_id",
+		"parentId",
+		"parentID",
+		"parent_task_id",
+		"parentTaskId",
+		"parent_action_id",
+		"parentActionId",
+		"parent_session",
+		"parentSession",
+		"parent_subagent_id",
+		"forkSource.sessionId",
+		"previousSessionId",
 		"forked_from_thread_id",
 		"forked_from_id",
 		"metadata.session_id",
+		"metadata.sessionId",
+		"metadata.task_id",
+		"metadata.taskId",
 		"metadata.thread_id",
 		"metadata.conversation_id",
+		"metadata.parent_id",
+		"metadata.parent_task_id",
+		"metadata.parent_agent_id",
 		"extra_body.session_id",
+		"extra_body.task_id",
+		"extra_body.parent_id",
+		"extra_body.parent_task_id",
 	} {
 		if NormalizeExplicitID(root.Get(path).String()) != "" {
 			return true

--- a/sdk/cliproxy/session/identity.go
+++ b/sdk/cliproxy/session/identity.go
@@ -42,8 +42,13 @@ type canonicalPart struct {
 
 var canonicalUUIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 
+// knownSessionPrefixes tracks legacy protocol-specific session prefixes that need to be
+// unwrapped before projecting to canonical UUIDv8.
+// Deprecated: This transitional table and string-stripping mechanism are scheduled to be
+// removed once session extraction directly produces canonical UUIDv8s at ingress.
 var knownSessionPrefixes = []string{
 	"lcp:v1:", "lcp:",
+	"ctx:v1:", "ctx:",
 	"codex:", "claude:", "header:", "session:",
 	"affinity:", "slot:", "task:", "conv:",
 	"thread:", "clientreq:", "geminicache:",
@@ -54,8 +59,8 @@ var knownSessionPrefixes = []string{
 // canonical 36-character lowercase UUID (RFC 4122 / RFC 9562 compliant):
 //  1. If rawID (or rawID without known protocol prefix) is already a standard UUID (e.g. Codex UUIDv7,
 //     Claude UUIDv4, Header UUID), it strips the prefix and returns the lowercase UUID.
-//  2. If rawID has a known protocol prefix but the remainder is not a UUID (e.g. custom task strings),
-//     the known prefix is stripped and the remaining identifier is deterministically projected.
+//  2. If rawID has known protocol prefixes, they are stripped iteratively (supporting chained
+//     wrappers such as "derived:ctx:v1:"). If no identifier remains after stripping, it returns empty.
 //  3. If rawID is not a standard UUID (e.g. LCP 64-hex hash, subagent hierarchy, or custom string),
 //     it deterministically projects it to an RFC 9562 UUIDv8 using SHA-256 with domain separation.
 //  4. Idempotent: NormalizeToCanonicalUUID(NormalizeToCanonicalUUID(x)) == NormalizeToCanonicalUUID(x).
@@ -70,14 +75,28 @@ func NormalizeToCanonicalUUID(rawID string) string {
 		return strings.ToLower(clean)
 	}
 
-	// 2. Strip known protocol prefix and check if remainder is a UUID
-	for _, p := range knownSessionPrefixes {
-		if strings.HasPrefix(clean, p) {
-			clean = strings.TrimPrefix(clean, p)
+	// 2. Strip known protocol prefixes iteratively to unwrap layered prefixes (e.g., "derived:ctx:v1:...").
+	// TODO: Deprecate and remove this legacy prefix stripping once all session extractors
+	// natively emit canonical UUIDv8 at the protocol ingress boundary.
+	for {
+		stripped := false
+		for _, p := range knownSessionPrefixes {
+			if strings.HasPrefix(clean, p) {
+				clean = strings.TrimPrefix(clean, p)
+				clean = strings.TrimSpace(clean)
+				stripped = true
+				break
+			}
+		}
+		if !stripped {
 			break
 		}
 	}
-	clean = strings.TrimSpace(clean)
+	// If only prefix was provided without an identifier body (e.g. "slot:", "task:"), return empty
+	// rather than projecting empty string into a shared ghost UUIDv8.
+	if clean == "" {
+		return ""
+	}
 	if canonicalUUIDPattern.MatchString(clean) {
 		return strings.ToLower(clean)
 	}

--- a/sdk/cliproxy/session/identity.go
+++ b/sdk/cliproxy/session/identity.go
@@ -42,6 +42,15 @@ type canonicalPart struct {
 
 var canonicalUUIDPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 
+// CandidateSessionPrefixes lists recognized protocol-specific session prefixes used in affinity lookup and routing.
+var CandidateSessionPrefixes = []string{
+	"lcp:v1:", "lcp:",
+	"codex:", "claude:", "header:", "session:",
+	"affinity:", "slot:", "task:", "conv:",
+	"thread:", "clientreq:", "geminicache:",
+	"pck:", "user:", "execution:", "agy:", "derived:",
+}
+
 // knownSessionPrefixes tracks legacy protocol-specific session prefixes that need to be
 // unwrapped before projecting to canonical UUIDv8.
 // Deprecated: This transitional table and string-stripping mechanism are scheduled to be

--- a/sdk/cliproxy/session/identity_test.go
+++ b/sdk/cliproxy/session/identity_test.go
@@ -482,12 +482,29 @@ func TestEnrich_MetadataOnlyCanonicalAndParentSessionPreserved(t *testing.T) {
 func TestNormalizeToCanonicalUUID(t *testing.T) {
 	t.Parallel()
 
-	// 1. Empty and whitespace
+	// 1. Empty, whitespace, and bare/empty prefixes
 	if got := NormalizeToCanonicalUUID(""); got != "" {
 		t.Fatalf("NormalizeToCanonicalUUID(\"\") = %q, want empty", got)
 	}
 	if got := NormalizeToCanonicalUUID("   "); got != "" {
 		t.Fatalf("NormalizeToCanonicalUUID(\"   \") = %q, want empty", got)
+	}
+	emptyPrefixCases := []string{
+		"lcp:v1:", "lcp:",
+		"ctx:v1:", "ctx:",
+		"codex:", "claude:", "header:", "session:",
+		"affinity:", "slot:", "task:", "conv:",
+		"thread:", "clientreq:", "geminicache:",
+		"pck:", "user:", "execution:", "agy:", "derived:",
+		"slot:   ",
+		"task:   ",
+		"derived:ctx:v1:",
+		"derived:slot:   ",
+	}
+	for _, input := range emptyPrefixCases {
+		if got := NormalizeToCanonicalUUID(input); got != "" {
+			t.Fatalf("NormalizeToCanonicalUUID(%q) = %q, want empty", input, got)
+		}
 	}
 
 	// 2. Native UUIDs (v4 and v7, various casings)
@@ -572,5 +589,35 @@ func TestNormalizeToCanonicalUUID(t *testing.T) {
 	if NormalizeToCanonicalUUID(lcpPrefixed) != NormalizeToCanonicalUUID(lcpBare) {
 		t.Fatalf("lcp prefixed (%q) and bare (%q) produced different UUIDs",
 			NormalizeToCanonicalUUID(lcpPrefixed), NormalizeToCanonicalUUID(lcpBare))
+	}
+
+	// 7. Same content with or without "ctx:v1:" / "ctx:" prefix produces identical UUID
+	ctxV1Prefixed := "ctx:v1:c28621bab78eacdb3ae128c0f6aaa0147842f063fda10ae9dc5473cc81d58985"
+	ctxShortPrefixed := "ctx:c28621bab78eacdb3ae128c0f6aaa0147842f063fda10ae9dc5473cc81d58985"
+	if NormalizeToCanonicalUUID(ctxV1Prefixed) != NormalizeToCanonicalUUID(lcpBare) {
+		t.Fatalf("ctx:v1: prefixed (%q) and bare (%q) produced different UUIDs: %q vs %q",
+			ctxV1Prefixed, lcpBare, NormalizeToCanonicalUUID(ctxV1Prefixed), NormalizeToCanonicalUUID(lcpBare))
+	}
+	if NormalizeToCanonicalUUID(ctxShortPrefixed) != NormalizeToCanonicalUUID(lcpBare) {
+		t.Fatalf("ctx: prefixed (%q) and bare (%q) produced different UUIDs: %q vs %q",
+			ctxShortPrefixed, lcpBare, NormalizeToCanonicalUUID(ctxShortPrefixed), NormalizeToCanonicalUUID(lcpBare))
+	}
+	// Fixed Golden UUIDv8 check
+	const wantGoldenUUID = "2ad1939c-98ca-81da-8b69-3d084d5614c4"
+	if got := NormalizeToCanonicalUUID(lcpBare); got != wantGoldenUUID {
+		t.Fatalf("NormalizeToCanonicalUUID(lcpBare) = %q, want golden %q", got, wantGoldenUUID)
+	}
+
+	// 8. Chained prefixes (e.g. "derived:ctx:v1:") are stripped iteratively
+	derivedCtxPrefixed := "derived:ctx:v1:c28621bab78eacdb3ae128c0f6aaa0147842f063fda10ae9dc5473cc81d58985"
+	if got := NormalizeToCanonicalUUID(derivedCtxPrefixed); got != NormalizeToCanonicalUUID(lcpBare) {
+		t.Fatalf("derived:ctx:v1: prefixed (%q) produced %q, want %q",
+			derivedCtxPrefixed, got, NormalizeToCanonicalUUID(lcpBare))
+	}
+
+	// 9. Chained prefixes with standard UUID
+	derivedUUID := "derived:ctx:v1:01a07e72-c84d-7fd3-8207-d217b41cc649"
+	if got := NormalizeToCanonicalUUID(derivedUUID); got != "01a07e72-c84d-7fd3-8207-d217b41cc649" {
+		t.Fatalf("NormalizeToCanonicalUUID(%q) = %q, want 01a07e72-c84d-7fd3-8207-d217b41cc649", derivedUUID, got)
 	}
 }

--- a/sdk/cliproxy/session/identity_test.go
+++ b/sdk/cliproxy/session/identity_test.go
@@ -478,3 +478,99 @@ func TestEnrich_MetadataOnlyCanonicalAndParentSessionPreserved(t *testing.T) {
 		t.Fatalf("self-loop parent was not eliminated in metadata-only mode")
 	}
 }
+
+func TestNormalizeToCanonicalUUID(t *testing.T) {
+	t.Parallel()
+
+	// 1. Empty and whitespace
+	if got := NormalizeToCanonicalUUID(""); got != "" {
+		t.Fatalf("NormalizeToCanonicalUUID(\"\") = %q, want empty", got)
+	}
+	if got := NormalizeToCanonicalUUID("   "); got != "" {
+		t.Fatalf("NormalizeToCanonicalUUID(\"   \") = %q, want empty", got)
+	}
+
+	// 2. Native UUIDs (v4 and v7, various casings)
+	rawUUIDv4 := "b2839f64-668d-4dc3-a42a-64da829d1e33"
+	if got := NormalizeToCanonicalUUID(rawUUIDv4); got != rawUUIDv4 {
+		t.Fatalf("NormalizeToCanonicalUUID(rawUUIDv4) = %q, want %q", got, rawUUIDv4)
+	}
+	upperUUID := "B2839F64-668D-4DC3-A42A-64DA829D1E33"
+	if got := NormalizeToCanonicalUUID(upperUUID); got != rawUUIDv4 {
+		t.Fatalf("NormalizeToCanonicalUUID(upperUUID) = %q, want %q", got, rawUUIDv4)
+	}
+	rawUUIDv7 := "01a07e72-c84d-7fd3-8207-d217b41cc649"
+	if got := NormalizeToCanonicalUUID(rawUUIDv7); got != rawUUIDv7 {
+		t.Fatalf("NormalizeToCanonicalUUID(rawUUIDv7) = %q, want %q", got, rawUUIDv7)
+	}
+
+	// 3. Known prefixes with UUIDs
+	prefixedCases := map[string]string{
+		"codex:01a07e72-c84d-7fd3-8207-d217b41cc649":         "01a07e72-c84d-7fd3-8207-d217b41cc649",
+		"claude:b2839f64-668d-4dc3-a42a-64da829d1e33":        "b2839f64-668d-4dc3-a42a-64da829d1e33",
+		"header:7a8b9c0d-1111-2222-3333-444455556666":        "7a8b9c0d-1111-2222-3333-444455556666",
+		"session:b2839f64-668d-4dc3-a42a-64da829d1e33":       "b2839f64-668d-4dc3-a42a-64da829d1e33",
+		"thread:01a07e72-c84d-7fd3-8207-d217b41cc649":        "01a07e72-c84d-7fd3-8207-d217b41cc649",
+		"custom-prefix:01a07e72-c84d-7fd3-8207-d217b41cc649": "01a07e72-c84d-7fd3-8207-d217b41cc649",
+	}
+	for input, want := range prefixedCases {
+		got := NormalizeToCanonicalUUID(input)
+		if got != want {
+			t.Errorf("NormalizeToCanonicalUUID(%q) = %q, want %q", input, got, want)
+		}
+	}
+
+	// 4. LCP 64-hex and non-UUID inputs projected to RFC 9562 UUIDv8
+	nonUUIDCases := []string{
+		"lcp:v1:c28621bab78eacdb3ae128c0f6aaa0147842f063fda10ae9dc5473cc81d58985",
+		"lcp:c28621bab78eacdb3ae128c0f6aaa0147842f063fda10ae9dc5473cc81d58985",
+		"c28621bab78eacdb3ae128c0f6aaa0147842f063fda10ae9dc5473cc81d58985",
+		"claude:b2839f64-668d-4dc3-a42a-64da829d1e33:agent:worker-reviewer",
+		"task:task-abc-1",
+		"slot:pi-slot-789",
+		"ses_f8189891effeCLIq0MasUgMQsC",
+		"my-custom-test-task",
+	}
+
+	for _, input := range nonUUIDCases {
+		got := NormalizeToCanonicalUUID(input)
+		if len(got) != 36 {
+			t.Errorf("NormalizeToCanonicalUUID(%q) length = %d, want 36", input, len(got))
+		}
+		if !canonicalUUIDPattern.MatchString(got) {
+			t.Errorf("NormalizeToCanonicalUUID(%q) = %q, does not match UUID pattern", input, got)
+		}
+		// Verify RFC 9562 Version 8 (13th char is '8', index 14)
+		if got[14] != '8' {
+			t.Errorf("NormalizeToCanonicalUUID(%q) = %q, version char is %c, want '8'", input, got, got[14])
+		}
+		// Verify RFC 4122 Variant (17th char is '8', '9', 'a', or 'b', index 19)
+		variantChar := got[19]
+		if variantChar != '8' && variantChar != '9' && variantChar != 'a' && variantChar != 'b' {
+			t.Errorf("NormalizeToCanonicalUUID(%q) = %q, variant char is %c, want 8/9/a/b", input, got, variantChar)
+		}
+		// Verify Idempotency
+		if reGot := NormalizeToCanonicalUUID(got); reGot != got {
+			t.Errorf("NormalizeToCanonicalUUID is not idempotent: first=%q, second=%q", got, reGot)
+		}
+	}
+
+	// 5. Uniqueness and determinism
+	id1 := NormalizeToCanonicalUUID("lcp:v1:hash-A")
+	id1Again := NormalizeToCanonicalUUID("lcp:v1:hash-A")
+	id2 := NormalizeToCanonicalUUID("lcp:v1:hash-B")
+	if id1 != id1Again {
+		t.Fatalf("NormalizeToCanonicalUUID is non-deterministic: %q != %q", id1, id1Again)
+	}
+	if id1 == id2 {
+		t.Fatalf("NormalizeToCanonicalUUID collided for different inputs: %q == %q", id1, id2)
+	}
+
+	// 6. Same content with or without "lcp:v1:" prefix produces identical UUID
+	lcpPrefixed := "lcp:v1:c28621bab78eacdb3ae128c0f6aaa0147842f063fda10ae9dc5473cc81d58985"
+	lcpBare := "c28621bab78eacdb3ae128c0f6aaa0147842f063fda10ae9dc5473cc81d58985"
+	if NormalizeToCanonicalUUID(lcpPrefixed) != NormalizeToCanonicalUUID(lcpBare) {
+		t.Fatalf("lcp prefixed (%q) and bare (%q) produced different UUIDs",
+			NormalizeToCanonicalUUID(lcpPrefixed), NormalizeToCanonicalUUID(lcpBare))
+	}
+}

--- a/sdk/cliproxy/session/info.go
+++ b/sdk/cliproxy/session/info.go
@@ -67,14 +67,44 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 			reqRoot = req
 		}
 		for _, p := range []string{
-			"parent_session_id", "parentSessionId",
-			"parent_thread_id", "parentThreadId",
+			// Standard session / thread parent keys
+			"parent_session_id", "parentSessionId", "parentSessionID",
+			"parent_thread_id", "parentThreadId", "parentThreadID",
 			"forked_from_thread_id", "forked_from_id",
-			"parent_conversation_id", "parentConversationId",
-			"metadata.parent_session_id", "metadata.parent_thread_id",
+			"parent_conversation_id", "parentConversationId", "parentConversationID",
+			// OpenCode / generic parent ID keys
+			"parent_id", "parentId", "parentID",
+			// Roo Code / Cline task delegation keys
+			"parent_task_id", "parentTaskId", "parentTaskID",
+			// OpenHands action tree keys
+			"parent_action_id", "parentActionId", "parentActionID",
+			// Pi session keys
+			"parent_session", "parentSession",
+			// Hermes subagent keys
+			"parent_subagent_id", "parentSubagentId",
+			// OpenClaw fork sources
+			"forkSource.sessionId", "fork_source.session_id",
+			"previousSessionId", "previous_session_id",
+			// Metadata nested keys
+			"metadata.parent_session_id", "metadata.parentSessionId", "metadata.parentSessionID",
+			"metadata.parent_thread_id", "metadata.parentThreadId",
 			"metadata.forked_from_thread_id", "metadata.forked_from_id",
-			"extra_body.parent_session_id", "extra_body.parent_thread_id",
+			"metadata.parent_id", "metadata.parentId", "metadata.parentID",
+			"metadata.parent_task_id", "metadata.parentTaskId", "metadata.parentTaskID",
+			"metadata.parent_action_id", "metadata.parentActionId",
+			"metadata.parent_subagent_id", "metadata.parentSubagentId",
+			"metadata.parent_session", "metadata.parentSession",
+			"metadata.parent_agent_id", "metadata.parentAgentId",
+			"metadata.forkSource.sessionId", "metadata.previousSessionId",
+			// Extra body nested keys
+			"extra_body.parent_session_id", "extra_body.parentSessionId", "extra_body.parentSessionID",
+			"extra_body.parent_thread_id", "extra_body.parentThreadId",
 			"extra_body.forked_from_thread_id", "extra_body.forked_from_id",
+			"extra_body.parent_id", "extra_body.parentId", "extra_body.parentID",
+			"extra_body.parent_task_id", "extra_body.parentTaskId",
+			"extra_body.parent_action_id", "extra_body.parentActionId",
+			"extra_body.parent_subagent_id", "extra_body.parentSubagentId",
+			"extra_body.parent_session", "extra_body.parentSession",
 		} {
 			if val := normalizedSessionCandidate(root.Get(p).String()); val != "" {
 				parentCandidate = val
@@ -112,6 +142,18 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 			_, _, agentID = ClaudeMetadataIdentities(payload)
 		}
 		parentAgentID := sessionHeaderValue(headers, "X-Claude-Code-Parent-Agent-Id")
+		if parentAgentID == "" && root.Exists() {
+			parentAgentID = normalizedSessionCandidate(root.Get("metadata.parent_agent_id").String())
+			if parentAgentID == "" {
+				parentAgentID = normalizedSessionCandidate(root.Get("metadata.parentAgentId").String())
+			}
+			if parentAgentID == "" && hasNestedReq {
+				parentAgentID = normalizedSessionCandidate(reqRoot.Get("metadata.parent_agent_id").String())
+				if parentAgentID == "" {
+					parentAgentID = normalizedSessionCandidate(reqRoot.Get("metadata.parentAgentId").String())
+				}
+			}
+		}
 		if agentID != "" && agentID != "main" {
 			info.AgentName = agentID
 			info.ParentSessionID = "claude:" + sid
@@ -152,6 +194,18 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 				}
 			}
 			parentAgentID := sessionHeaderValue(headers, "X-Claude-Code-Parent-Agent-Id")
+			if parentAgentID == "" && root.Exists() {
+				parentAgentID = normalizedSessionCandidate(root.Get("metadata.parent_agent_id").String())
+				if parentAgentID == "" {
+					parentAgentID = normalizedSessionCandidate(root.Get("metadata.parentAgentId").String())
+				}
+				if parentAgentID == "" && hasNestedReq {
+					parentAgentID = normalizedSessionCandidate(reqRoot.Get("metadata.parent_agent_id").String())
+					if parentAgentID == "" {
+						parentAgentID = normalizedSessionCandidate(reqRoot.Get("metadata.parentAgentId").String())
+					}
+				}
+			}
 			if agentID != "" && agentID != "main" {
 				info.SessionID = "claude:" + sid + ":agent:" + agentID
 				info.ParentSessionID = "claude:" + sid
@@ -352,6 +406,12 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 		if parentSID == "" {
 			parentSID = sessionHeaderValue(headers, "X-Parent-Session-Id")
 		}
+		if parentSID == "" {
+			parentSID = sessionHeaderValue(headers, "X-Parent-ID")
+		}
+		if parentSID == "" {
+			parentSID = sessionHeaderValue(headers, "X-Parent-Id")
+		}
 		if parentSID != "" && parentSID != sid {
 			info.ParentSessionID = "agy:" + parentSID
 			info.AgentName = "subagent"
@@ -364,13 +424,19 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 		return finalizeSessionInfo(info)
 	}
 
-	// 5. OpenCode / Pi Slot / Generic Headers
+	// 5. OpenCode / Pi Slot / Task / Generic Headers
 	if sid := sessionHeaderValue(headers, "X-Session-ID"); sid != "" {
 		info.ClientType = "generic"
 		info.SessionID = "header:" + sid
 		parentSID := sessionHeaderValue(headers, "X-Parent-Session-ID")
 		if parentSID == "" {
 			parentSID = sessionHeaderValue(headers, "X-Parent-Session-Id")
+		}
+		if parentSID == "" {
+			parentSID = sessionHeaderValue(headers, "X-Parent-ID")
+		}
+		if parentSID == "" {
+			parentSID = sessionHeaderValue(headers, "X-Parent-Id")
 		}
 		if parentSID != "" && parentSID != sid {
 			info.ParentSessionID = "header:" + parentSID
@@ -390,6 +456,12 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 		if parentAffinity == "" {
 			parentAffinity = sessionHeaderValue(headers, "X-Parent-Session-ID")
 		}
+		if parentAffinity == "" {
+			parentAffinity = sessionHeaderValue(headers, "X-Parent-ID")
+		}
+		if parentAffinity == "" {
+			parentAffinity = sessionHeaderValue(headers, "X-Parent-Id")
+		}
 		if parentAffinity != "" && parentAffinity != sid {
 			info.ParentSessionID = "affinity:" + parentAffinity
 			info.AgentName = "subagent"
@@ -404,9 +476,18 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 	if sid := sessionHeaderValue(headers, "X-Slot-Session-Id"); sid != "" {
 		info.ClientType = "pi"
 		info.SessionID = "slot:" + sid
-		parentSID := sessionHeaderValue(headers, "X-Parent-Session-ID")
+		parentSID := sessionHeaderValue(headers, "X-Parent-Slot-Session-Id")
+		if parentSID == "" {
+			parentSID = sessionHeaderValue(headers, "X-Parent-Session-ID")
+		}
 		if parentSID == "" {
 			parentSID = sessionHeaderValue(headers, "X-Parent-Session-Id")
+		}
+		if parentSID == "" {
+			parentSID = sessionHeaderValue(headers, "X-Parent-ID")
+		}
+		if parentSID == "" {
+			parentSID = sessionHeaderValue(headers, "X-Parent-Id")
 		}
 		if parentSID != "" && parentSID != sid {
 			info.ParentSessionID = "slot:" + parentSID
@@ -419,21 +500,54 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 		}
 		return finalizeSessionInfo(info)
 	}
-	if sid := sessionHeaderValue(headers, "X-Conversation-Id"); sid != "" {
-		info.ClientType = "conv"
-		info.SessionID = "conv:" + sid
-		if parentCandidate != "" && parentCandidate != sid {
-			info.ParentSessionID = "conv:" + parentCandidate
+	taskID := sessionHeaderValue(headers, "X-Task-ID")
+	if taskID == "" {
+		taskID = sessionHeaderValue(headers, "X-Task-Id")
+	}
+	if taskID == "" {
+		taskID = sessionHeaderValue(headers, "X-Task_ID")
+	}
+	if taskID != "" {
+		info.ClientType = "task"
+		info.SessionID = "task:" + taskID
+		parentTaskID := sessionHeaderValue(headers, "X-Parent-Task-ID")
+		if parentTaskID == "" {
+			parentTaskID = sessionHeaderValue(headers, "X-Parent-Task-Id")
+		}
+		if parentTaskID == "" {
+			parentTaskID = sessionHeaderValue(headers, "X-Parent-Session-ID")
+		}
+		if parentTaskID == "" {
+			parentTaskID = sessionHeaderValue(headers, "X-Parent-Session-Id")
+		}
+		if parentTaskID == "" {
+			parentTaskID = sessionHeaderValue(headers, "X-Parent-ID")
+		}
+		if parentTaskID == "" {
+			parentTaskID = sessionHeaderValue(headers, "X-Parent-Id")
+		}
+		if parentTaskID != "" && parentTaskID != taskID {
+			info.ParentSessionID = "task:" + parentTaskID
+			info.AgentName = "subagent"
+		} else if parentCandidate != "" && parentCandidate != taskID {
+			info.ParentSessionID = "task:" + parentCandidate
 			info.AgentName = "subagent"
 		} else {
 			info.AgentName = "main"
 		}
 		return finalizeSessionInfo(info)
 	}
-	if sid := sessionHeaderValue(headers, "X-Conversation-ID"); sid != "" {
+	if sid := sessionHeaderValue(headers, "X-Conversation-Id"); sid != "" {
 		info.ClientType = "conv"
 		info.SessionID = "conv:" + sid
-		if parentCandidate != "" && parentCandidate != sid {
+		parentCID := sessionHeaderValue(headers, "X-Parent-Conversation-Id")
+		if parentCID == "" {
+			parentCID = sessionHeaderValue(headers, "X-Parent-ID")
+		}
+		if parentCID != "" && parentCID != sid {
+			info.ParentSessionID = "conv:" + parentCID
+			info.AgentName = "subagent"
+		} else if parentCandidate != "" && parentCandidate != sid {
 			info.ParentSessionID = "conv:" + parentCandidate
 			info.AgentName = "subagent"
 		} else {
@@ -444,18 +558,14 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 	if sid := sessionHeaderValue(headers, "X-Thread-Id"); sid != "" {
 		info.ClientType = "openai-thread"
 		info.SessionID = "thread:" + sid
-		if parentCandidate != "" && parentCandidate != sid {
-			info.ParentSessionID = "thread:" + parentCandidate
-			info.AgentName = "subagent"
-		} else {
-			info.AgentName = "main"
+		parentTID := sessionHeaderValue(headers, "X-Parent-Thread-Id")
+		if parentTID == "" {
+			parentTID = sessionHeaderValue(headers, "X-Parent-ID")
 		}
-		return finalizeSessionInfo(info)
-	}
-	if sid := sessionHeaderValue(headers, "X-Thread-ID"); sid != "" {
-		info.ClientType = "openai-thread"
-		info.SessionID = "thread:" + sid
-		if parentCandidate != "" && parentCandidate != sid {
+		if parentTID != "" && parentTID != sid {
+			info.ParentSessionID = "thread:" + parentTID
+			info.AgentName = "subagent"
+		} else if parentCandidate != "" && parentCandidate != sid {
 			info.ParentSessionID = "thread:" + parentCandidate
 			info.AgentName = "subagent"
 		} else {
@@ -466,7 +576,22 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 	if sid := sessionHeaderValue(headers, "X-Client-Request-Id"); sid != "" {
 		info.ClientType = "generic"
 		info.SessionID = "clientreq:" + sid
-		info.AgentName = "main"
+		parentSID := sessionHeaderValue(headers, "X-Parent-Session-ID")
+		if parentSID == "" {
+			parentSID = sessionHeaderValue(headers, "X-Parent-ID")
+		}
+		if parentSID == "" {
+			parentSID = sessionHeaderValue(headers, "X-Parent-Id")
+		}
+		if parentSID != "" && parentSID != sid {
+			info.ParentSessionID = "clientreq:" + parentSID
+			info.AgentName = "subagent"
+		} else if parentCandidate != "" && parentCandidate != sid {
+			info.ParentSessionID = "clientreq:" + parentCandidate
+			info.AgentName = "subagent"
+		} else {
+			info.AgentName = "main"
+		}
 		return finalizeSessionInfo(info)
 	}
 
@@ -535,7 +660,13 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 			}
 		}
 
-		for _, path := range []string{"session_id", "sessionId", "sessionID", "metadata.session_id", "extra_body.session_id"} {
+		for _, path := range []string{
+			"session_id", "sessionId", "sessionID",
+			"child_session_id", "childSessionId",
+			"metadata.session_id", "metadata.sessionId", "metadata.sessionID",
+			"metadata.child_session_id",
+			"extra_body.session_id", "extra_body.sessionId", "extra_body.sessionID",
+		} {
 			sid := normalizedSessionCandidate(root.Get(path).String())
 			if sid == "" && hasNestedReq {
 				sid = normalizedSessionCandidate(reqRoot.Get(path).String())
@@ -564,6 +695,38 @@ func ExtractSessionInfo(headers http.Header, payload []byte, metadata map[string
 					} else {
 						info.AgentName = "main"
 					}
+				}
+				return finalizeSessionInfo(info)
+			}
+		}
+
+		// Task / Action in payload (Roo Code, Cline, OpenHands)
+		for _, path := range []string{
+			"task_id", "taskId", "taskID",
+			"action_id", "actionId", "actionID",
+			"metadata.task_id", "metadata.taskId", "metadata.taskID",
+			"metadata.action_id", "metadata.actionId", "metadata.actionID",
+			"extra_body.task_id", "extra_body.taskId", "extra_body.taskID",
+		} {
+			tid := normalizedSessionCandidate(root.Get(path).String())
+			if tid == "" && hasNestedReq {
+				tid = normalizedSessionCandidate(reqRoot.Get(path).String())
+			}
+			if tid != "" {
+				info.ClientType = "task"
+				info.SessionID = "task:" + tid
+				if parentCandidate != "" && parentCandidate != tid {
+					info.ParentSessionID = "task:" + parentCandidate
+					if isBodyForkCandidate(root, reqRoot, hasNestedReq) {
+						info.IsFork = true
+						info.IsSubagent = false
+						info.AgentName = "main"
+					} else {
+						info.AgentName = "subagent"
+						info.IsSubagent = true
+					}
+				} else {
+					info.AgentName = "main"
 				}
 				return finalizeSessionInfo(info)
 			}
@@ -686,8 +849,12 @@ func isBodyForkCandidate(root, reqRoot gjson.Result, hasNestedReq bool) bool {
 	}
 	for _, k := range []string{
 		"forked_from_thread_id", "forked_from_id",
+		"forkSource.sessionId", "fork_source.session_id",
+		"previousSessionId", "previous_session_id",
 		"metadata.forked_from_thread_id", "metadata.forked_from_id",
+		"metadata.forkSource.sessionId", "metadata.previousSessionId",
 		"extra_body.forked_from_thread_id", "extra_body.forked_from_id",
+		"extra_body.forkSource.sessionId", "extra_body.previousSessionId",
 	} {
 		if val := normalizedSessionCandidate(root.Get(k).String()); val != "" {
 			return true

--- a/sdk/cliproxy/session/info_test.go
+++ b/sdk/cliproxy/session/info_test.go
@@ -647,3 +647,118 @@ func TestBoundSessionIdentitySafetyAndUniqueness(t *testing.T) {
 		t.Fatalf("bounded lengths = (%d, %d), want <= 256", len(boundedA), len(boundedB))
 	}
 }
+
+func TestExtractSessionInfoEnhancedHarnesses(t *testing.T) {
+	t.Parallel()
+
+	// 1. Roo Code / Cline task headers
+	rooHeaders := http.Header{}
+	rooHeaders.Set("X-Task-ID", "task-child-001")
+	rooHeaders.Set("X-Parent-Task-ID", "task-parent-001")
+	info, ok := ExtractSessionInfo(rooHeaders, nil, nil)
+	if !ok || info.SessionID != "task:task-child-001" || info.ParentSessionID != "task:task-parent-001" || info.ClientType != "task" || info.AgentName != "subagent" {
+		t.Fatalf("Roo Code headers extraction failed: %+v", info)
+	}
+
+	// 2. Roo Code / Cline payload
+	rooPayload := []byte(`{"taskId":"task-child-002","parentTaskId":"task-parent-002"}`)
+	info, ok = ExtractSessionInfo(nil, rooPayload, nil)
+	if !ok || info.SessionID != "task:task-child-002" || info.ParentSessionID != "task:task-parent-002" || info.ClientType != "task" || info.AgentName != "subagent" {
+		t.Fatalf("Roo Code payload extraction failed: %+v", info)
+	}
+
+	// 3. OpenCode parent_id / parentID in payload
+	opencodePayload := []byte(`{"session_id":"opencode-child-100","parent_id":"opencode-parent-100"}`)
+	info, ok = ExtractSessionInfo(nil, opencodePayload, nil)
+	if !ok || info.SessionID != "session:opencode-child-100" || info.ParentSessionID != "session:opencode-parent-100" || info.AgentName != "subagent" {
+		t.Fatalf("OpenCode parent_id extraction failed: %+v", info)
+	}
+
+	opencodePayload2 := []byte(`{"sessionID":"opencode-child-200","parentID":"opencode-parent-200"}`)
+	info, ok = ExtractSessionInfo(nil, opencodePayload2, nil)
+	if !ok || info.SessionID != "session:opencode-child-200" || info.ParentSessionID != "session:opencode-parent-200" {
+		t.Fatalf("OpenCode parentID extraction failed: %+v", info)
+	}
+
+	// 4. OpenClaw forkSource.sessionId & previousSessionId
+	openclawPayload1 := []byte(`{"sessionId":"claw-child-1","forkSource":{"sessionId":"claw-parent-1"}}`)
+	info, ok = ExtractSessionInfo(nil, openclawPayload1, nil)
+	if !ok || info.SessionID != "session:claw-child-1" || info.ParentSessionID != "session:claw-parent-1" || !info.IsFork {
+		t.Fatalf("OpenClaw forkSource extraction failed: %+v", info)
+	}
+
+	openclawPayload2 := []byte(`{"sessionId":"claw-child-2","previousSessionId":"claw-parent-2"}`)
+	info, ok = ExtractSessionInfo(nil, openclawPayload2, nil)
+	if !ok || info.SessionID != "session:claw-child-2" || info.ParentSessionID != "session:claw-parent-2" || !info.IsFork {
+		t.Fatalf("OpenClaw previousSessionId extraction failed: %+v", info)
+	}
+
+	// 5. Hermes Agent child_session_id & parent_subagent_id
+	hermesPayload := []byte(`{"child_session_id":"hermes-child-1","parent_subagent_id":"hermes-parent-1"}`)
+	info, ok = ExtractSessionInfo(nil, hermesPayload, nil)
+	if !ok || info.SessionID != "session:hermes-child-1" || info.ParentSessionID != "session:hermes-parent-1" {
+		t.Fatalf("Hermes Agent extraction failed: %+v", info)
+	}
+
+	// 6. OpenHands action_id & parent_action_id
+	openhandsPayload := []byte(`{"action_id":"openhands-action-1","parent_action_id":"openhands-parent-action"}`)
+	info, ok = ExtractSessionInfo(nil, openhandsPayload, nil)
+	if !ok || info.SessionID != "task:openhands-action-1" || info.ParentSessionID != "task:openhands-parent-action" || info.ClientType != "task" {
+		t.Fatalf("OpenHands action extraction failed: %+v", info)
+	}
+
+	// 7. Pi Coding Agent slot parent & parent_session payload
+	piSlotHeaders := http.Header{}
+	piSlotHeaders.Set("X-Slot-Session-Id", "slot-child-001")
+	piSlotHeaders.Set("X-Parent-Slot-Session-Id", "slot-parent-001")
+	info, ok = ExtractSessionInfo(piSlotHeaders, nil, nil)
+	if !ok || info.SessionID != "slot:slot-child-001" || info.ParentSessionID != "slot:slot-parent-001" || info.ClientType != "pi" || info.AgentName != "subagent" {
+		t.Fatalf("Pi slot parent extraction failed: %+v", info)
+	}
+
+	piPayload := []byte(`{"prompt_cache_key":"pi-pck-001","parent_session":"pi-parent-001"}`)
+	info, ok = ExtractSessionInfo(nil, piPayload, nil)
+	if !ok || info.SessionID != "pck:pi-pck-001" || info.ParentSessionID != "pck:pi-parent-001" {
+		t.Fatalf("Pi parent_session extraction failed: %+v", info)
+	}
+
+	// 8. Claude Code Body metadata.parent_agent_id
+	claudeBody := []byte(`{
+		"metadata": {
+			"user_id": "user_123_acc__session_01a06a06-e830-7da9-a866-98470a94389c",
+			"agent_id": "worker-reviewer",
+			"parent_agent_id": "orchestrator-main"
+		}
+	}`)
+	info, ok = ExtractSessionInfo(nil, claudeBody, nil)
+	if !ok || info.SessionID != "claude:01a06a06-e830-7da9-a866-98470a94389c:agent:worker-reviewer" ||
+		info.ParentSessionID != "claude:01a06a06-e830-7da9-a866-98470a94389c:agent:orchestrator-main" ||
+		info.AgentName != "worker-reviewer" {
+		t.Fatalf("Claude metadata parent_agent_id extraction failed: %+v", info)
+	}
+
+	// 9. Generic universal parent headers
+	genericHeaders := http.Header{}
+	genericHeaders.Set("X-Session-ID", "gen-child-001")
+	genericHeaders.Set("X-Parent-ID", "gen-parent-001")
+	info, ok = ExtractSessionInfo(genericHeaders, nil, nil)
+	if !ok || info.SessionID != "header:gen-child-001" || info.ParentSessionID != "header:gen-parent-001" {
+		t.Fatalf("Generic X-Parent-ID header extraction failed: %+v", info)
+	}
+
+	convHeaders := http.Header{}
+	convHeaders.Set("X-Conversation-Id", "conv-child-001")
+	convHeaders.Set("X-Parent-Conversation-Id", "conv-parent-001")
+	info, ok = ExtractSessionInfo(convHeaders, nil, nil)
+	if !ok || info.SessionID != "conv:conv-child-001" || info.ParentSessionID != "conv:conv-parent-001" {
+		t.Fatalf("Conversation X-Parent-Conversation-Id extraction failed: %+v", info)
+	}
+
+	threadHeaders := http.Header{}
+	threadHeaders.Set("X-Thread-Id", "thread-child-001")
+	threadHeaders.Set("X-Parent-Thread-Id", "thread-parent-001")
+	info, ok = ExtractSessionInfo(threadHeaders, nil, nil)
+	if !ok || info.SessionID != "thread:thread-child-001" || info.ParentSessionID != "thread:thread-parent-001" {
+		t.Fatalf("Thread X-Parent-Thread-Id extraction failed: %+v", info)
+	}
+}

--- a/sdk/cliproxy/session/lcp.go
+++ b/sdk/cliproxy/session/lcp.go
@@ -921,6 +921,56 @@ func (m *MerklePrefixMatcher) Clear() {
 	m.mu.Unlock()
 }
 
+// LookupSession observes the bound authIDs for an LCP sessionID without side effects or TTL refresh.
+// It skips expired groups and cleans them up, returning all distinct active authIDs.
+func (m *MerklePrefixMatcher) LookupSession(sessionID string) (authIDs []string, namespace string, ok bool) {
+	if m == nil || sessionID == "" {
+		return nil, "", false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	now := m.now()
+
+	var expired []*lcpGroup
+	var active []*lcpGroup
+
+	for _, ns := range m.groups {
+		if ns == nil {
+			continue
+		}
+		for _, group := range ns.groups {
+			if group == nil || group.sessionID != sessionID {
+				continue
+			}
+			if now.Before(group.expiresAt) {
+				active = append(active, group)
+			} else {
+				expired = append(expired, group)
+			}
+		}
+	}
+
+	for _, exp := range expired {
+		m.removeGroupLocked(exp)
+	}
+
+	if len(active) == 0 {
+		return nil, "", false
+	}
+
+	ns := active[0].namespace
+	seen := make(map[string]struct{})
+	var result []string
+	for _, grp := range active {
+		if _, exists := seen[grp.authID]; !exists && grp.authID != "" {
+			seen[grp.authID] = struct{}{}
+			result = append(result, grp.authID)
+		}
+	}
+	sort.Strings(result)
+	return result, ns, len(result) > 0
+}
+
 func (m *MerklePrefixMatcher) fingerprints(turns []CanonicalTurn) []string {
 	if len(turns) == 0 {
 		return nil

--- a/sdk/cliproxy/session/lcp_lookup_test.go
+++ b/sdk/cliproxy/session/lcp_lookup_test.go
@@ -1,0 +1,120 @@
+package session
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestMerklePrefixMatcher_LookupSession_PartialExpiration_ControllableClock(t *testing.T) {
+	mockNow := time.Date(2026, 9, 9, 10, 0, 0, 0, time.UTC)
+	matcher := NewMerklePrefixMatcherWithConfig(MerklePrefixMatcherConfig{TTL: 10 * time.Minute})
+	matcher.nowFunc = func() time.Time { return mockNow }
+
+	ns := "lcp:v1::openai::gpt-4o::caller"
+
+	// 1. Bind turn 1 at T0
+	bindRes1 := matcher.BindFingerprintsWithResult(ns, []string{"turn1"}, 1, "auth-1")
+	sessionID := bindRes1.SessionID
+	if sessionID == "" {
+		t.Fatalf("expected valid sessionID on bindRes1")
+	}
+
+	// 2. Advance clock by 5 minutes and bind turn 2 (conversation growth)
+	mockNow = mockNow.Add(5 * time.Minute)
+	bindRes2 := matcher.BindFingerprintsWithResult(ns, []string{"turn1", "turn2"}, 1, "auth-1")
+	if bindRes2.SessionID != sessionID {
+		t.Fatalf("expected grown conversation to share sessionID, got %q != %q", bindRes2.SessionID, sessionID)
+	}
+
+	// Record group 2 state
+	matcher.mu.Lock()
+	nsObj := matcher.groups[ns]
+	group2 := nsObj.groups[sequenceKey([]string{"turn1", "turn2"})]
+	if group2 == nil {
+		matcher.mu.Unlock()
+		t.Fatalf("expected group2 to exist")
+	}
+	expectedExpiresAt := group2.expiresAt
+	expectedAccessNumber := group2.lastAccessNumber
+	matcher.mu.Unlock()
+
+	// 3. Explicitly expire group 1 while keeping group 2 active
+	matcher.mu.Lock()
+	group1 := nsObj.groups[sequenceKey([]string{"turn1"})]
+	if group1 == nil {
+		matcher.mu.Unlock()
+		t.Fatalf("expected group1 to exist")
+	}
+	group1.expiresAt = mockNow.Add(-time.Minute)
+	matcher.mu.Unlock()
+
+	// 4. LookupSession: must return auth-1 without error, must not report false/unbound
+	authIDs, nsResult, ok := matcher.LookupSession(sessionID)
+	if !ok {
+		t.Fatalf("expected ok=true for partially expired session, got false")
+	}
+	if !reflect.DeepEqual(authIDs, []string{"auth-1"}) {
+		t.Fatalf("expected [auth-1], got %v", authIDs)
+	}
+	if nsResult != ns {
+		t.Fatalf("expected namespace %q, got %q", ns, nsResult)
+	}
+
+	// 5. Assert group 1 was removed and group 2 was NOT mutated (TTL/accessNumber untouched)
+	matcher.mu.Lock()
+	if nsObj.groups[sequenceKey([]string{"turn1"})] != nil {
+		t.Fatalf("expected expired group1 to be removed by LookupSession")
+	}
+	group2After := nsObj.groups[sequenceKey([]string{"turn1", "turn2"})]
+	if group2After == nil {
+		t.Fatalf("expected active group2 to still exist")
+	}
+	if !group2After.expiresAt.Equal(expectedExpiresAt) {
+		t.Fatalf("group2 expiresAt was modified: original=%v, after=%v", expectedExpiresAt, group2After.expiresAt)
+	}
+	if group2After.lastAccessNumber != expectedAccessNumber {
+		t.Fatalf("group2 lastAccessNumber was modified: original=%d, after=%d", expectedAccessNumber, group2After.lastAccessNumber)
+	}
+	matcher.mu.Unlock()
+
+	// 6. Advance clock past group 2 expiration
+	mockNow = mockNow.Add(15 * time.Minute)
+	authIDsExpired, _, okExpired := matcher.LookupSession(sessionID)
+	if okExpired || len(authIDsExpired) > 0 {
+		t.Fatalf("expected ok=false for completely expired session, got %v ok=%v", authIDsExpired, okExpired)
+	}
+}
+
+func TestMerklePrefixMatcher_LookupSession_ConflictingTrajectories(t *testing.T) {
+	matcher := NewMerklePrefixMatcherWithConfig(MerklePrefixMatcherConfig{TTL: 10 * time.Minute})
+	ns := "lcp:v1::openai::gpt-4o::caller"
+
+	bindRes1 := matcher.BindFingerprintsWithResult(ns, []string{"turnA"}, 1, "auth-a")
+	sessionID := bindRes1.SessionID
+
+	// Manually inject a second group with different authID sharing the same sessionID
+	matcher.mu.Lock()
+	groupConflict := &lcpGroup{
+		key:              sequenceKey([]string{"turnA", "turnB"}),
+		namespace:        ns,
+		authID:           "auth-b",
+		sessionID:        sessionID,
+		minPrefixLength:  1,
+		fingerprints:     []string{"turnA", "turnB"},
+		prefixKeys:       rollingPrefixKeys([]string{"turnA", "turnB"}),
+		expiresAt:        time.Now().Add(10 * time.Minute),
+		lastAccessNumber: matcher.nextAccessNumberLocked(),
+	}
+	matcher.addGroupLocked(groupConflict)
+	matcher.mu.Unlock()
+
+	authIDs, _, ok := matcher.LookupSession(sessionID)
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	expected := []string{"auth-a", "auth-b"}
+	if !reflect.DeepEqual(authIDs, expected) {
+		t.Fatalf("expected conflicting auths %v, got %v", expected, authIDs)
+	}
+}

--- a/sdk/pluginabi/types.go
+++ b/sdk/pluginabi/types.go
@@ -14,7 +14,10 @@ const (
 	// Version 5 omits HistoryChunks on payload stream chunks (ChunkIndex >= 0);
 	// those fields remain on StreamChunkHeaderInitIndex only. Plugins that still need
 	// per-chunk history chunks should keep schema_version < 5.
-	SchemaVersion uint32 = 5
+	// Version 6 preserves raw JSON bodies for plugin management responses.
+	// Plugins that still require HTML entity escaping on JSON response strings
+	// should keep schema_version < 6.
+	SchemaVersion uint32 = 6
 	// SchemaVersionStreamChunkOmitRequestBody is the first schema version that omits
 	// request bodies on payload stream-chunk interceptor calls.
 	SchemaVersionStreamChunkOmitRequestBody uint32 = 3
@@ -24,6 +27,9 @@ const (
 	// SchemaVersionStreamChunkOmitHistory is the first schema version that omits
 	// history chunks on payload stream-chunk interceptor calls.
 	SchemaVersionStreamChunkOmitHistory uint32 = 5
+	// SchemaVersionRawManagementResponse is the first schema version where plugin
+	// management JSON responses are preserved without HTML-escaping strings.
+	SchemaVersionRawManagementResponse uint32 = 6
 )
 
 const (

--- a/sdk/pluginabi/types.go
+++ b/sdk/pluginabi/types.go
@@ -102,6 +102,7 @@ const (
 	MethodHostAuthGet            = "host.auth.get"
 	MethodHostAuthGetRuntime     = "host.auth.get_runtime"
 	MethodHostAuthSave           = "host.auth.save"
+	MethodHostAffinityLookup     = "host.affinity.lookup"
 )
 
 type Envelope struct {

--- a/sdk/pluginabi/types_test.go
+++ b/sdk/pluginabi/types_test.go
@@ -27,8 +27,8 @@ func TestEnvelopeRoundTrip(t *testing.T) {
 }
 
 func TestMethodNamesAreStable(t *testing.T) {
-	if SchemaVersion != 5 {
-		t.Fatalf("SchemaVersion = %d, want 5", SchemaVersion)
+	if SchemaVersion != 6 {
+		t.Fatalf("SchemaVersion = %d, want 6", SchemaVersion)
 	}
 	if SchemaVersionWebSocketResponseObserver != 4 {
 		t.Fatalf("SchemaVersionWebSocketResponseObserver = %d, want 4", SchemaVersionWebSocketResponseObserver)
@@ -38,6 +38,9 @@ func TestMethodNamesAreStable(t *testing.T) {
 	}
 	if SchemaVersionStreamChunkOmitHistory != 5 {
 		t.Fatalf("SchemaVersionStreamChunkOmitHistory = %d, want 5", SchemaVersionStreamChunkOmitHistory)
+	}
+	if SchemaVersionRawManagementResponse != 6 {
+		t.Fatalf("SchemaVersionRawManagementResponse = %d, want 6", SchemaVersionRawManagementResponse)
 	}
 	if MethodPluginRegister != "plugin.register" {
 		t.Fatalf("MethodPluginRegister = %q", MethodPluginRegister)

--- a/sdk/pluginabi/types_test.go
+++ b/sdk/pluginabi/types_test.go
@@ -96,6 +96,9 @@ func TestMethodNamesAreStable(t *testing.T) {
 	if MethodHostAuthSave != "host.auth.save" {
 		t.Fatalf("MethodHostAuthSave = %q", MethodHostAuthSave)
 	}
+	if MethodHostAffinityLookup != "host.affinity.lookup" {
+		t.Fatalf("MethodHostAffinityLookup = %q", MethodHostAffinityLookup)
+	}
 	if MethodExecutorExecuteStream != "executor.execute_stream" {
 		t.Fatalf("MethodExecutorExecuteStream = %q", MethodExecutorExecuteStream)
 	}

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -1351,6 +1351,8 @@ type ManagementResponse struct {
 	// Headers contains response headers.
 	Headers http.Header
 	// Body contains the raw response body.
+	// On schema_version >= 6, JSON bodies are returned without HTML entity escaping.
+	// On schema_version < 6, JSON response string values are HTML-escaped for legacy compatibility.
 	Body []byte
 }
 

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -774,6 +774,38 @@ type HostAuthSaveResponse struct {
 	Path string `json:"path"`
 }
 
+// Host affinity lookup status outcomes.
+const (
+	HostAffinityStatusBound       = "bound"
+	HostAffinityStatusUnbound     = "unbound"
+	HostAffinityStatusAmbiguous   = "ambiguous"
+	HostAffinityStatusUnsupported = "unsupported"
+)
+
+// HostAffinityLookupRequest asks the host to observe the current affinity binding for a session.
+type HostAffinityLookupRequest struct {
+	// Provider identifies the model provider (e.g., "anthropic", "openai").
+	Provider string `json:"provider"`
+	// Model identifies the requested model.
+	Model string `json:"model"`
+	// SessionID identifies the client session.
+	SessionID string `json:"session_id"`
+}
+
+// HostAffinityLookupResponse describes the observed affinity binding state for a session.
+type HostAffinityLookupResponse struct {
+	// Status reports the observation outcome ("bound", "unbound", "ambiguous", "unsupported").
+	Status string `json:"status"`
+	// AuthIndex identifies the bound credential index usable with host.auth.get_runtime when Status is "bound".
+	AuthIndex string `json:"auth_index,omitempty"`
+	// ObservedAt reports the observation timestamp.
+	ObservedAt time.Time `json:"observed_at,omitempty"`
+	// Disabled reports whether the bound credential is known to be disabled.
+	Disabled bool `json:"disabled,omitempty"`
+	// Unavailable reports whether the bound credential is currently unavailable.
+	Unavailable bool `json:"unavailable,omitempty"`
+}
+
 // HTTPWireProfile configures transport-level wire representation for plugin HTTP requests.
 type HTTPWireProfile struct {
 	// HTTP1Only forces the transport to use HTTP/1.1 and disables HTTP/2 negotiation.

--- a/sdk/pluginapi/types_test.go
+++ b/sdk/pluginapi/types_test.go
@@ -555,3 +555,53 @@ func (compileTimePlugin) RegisterManagement(context.Context, ManagementRegistrat
 func (compileTimePlugin) HandleManagement(context.Context, ManagementRequest) (ManagementResponse, error) {
 	return ManagementResponse{}, nil
 }
+
+func TestHostAffinityLookupTypes(t *testing.T) {
+	if HostAffinityStatusBound != "bound" {
+		t.Fatalf("HostAffinityStatusBound = %q", HostAffinityStatusBound)
+	}
+	if HostAffinityStatusUnbound != "unbound" {
+		t.Fatalf("HostAffinityStatusUnbound = %q", HostAffinityStatusUnbound)
+	}
+	if HostAffinityStatusAmbiguous != "ambiguous" {
+		t.Fatalf("HostAffinityStatusAmbiguous = %q", HostAffinityStatusAmbiguous)
+	}
+	if HostAffinityStatusUnsupported != "unsupported" {
+		t.Fatalf("HostAffinityStatusUnsupported = %q", HostAffinityStatusUnsupported)
+	}
+
+	req := HostAffinityLookupRequest{
+		Provider:  "anthropic",
+		Model:     "claude-3-7-sonnet",
+		SessionID: "sess-1",
+	}
+	data, errMarshal := json.Marshal(req)
+	if errMarshal != nil {
+		t.Fatalf("marshal request: %v", errMarshal)
+	}
+	var decodedReq HostAffinityLookupRequest
+	if errUnmarshal := json.Unmarshal(data, &decodedReq); errUnmarshal != nil {
+		t.Fatalf("unmarshal request: %v", errUnmarshal)
+	}
+	if decodedReq != req {
+		t.Fatalf("decoded request = %#v, want %#v", decodedReq, req)
+	}
+
+	resp := HostAffinityLookupResponse{
+		Status:      HostAffinityStatusBound,
+		AuthIndex:   "idx-1",
+		Disabled:    true,
+		Unavailable: false,
+	}
+	respData, errRespMarshal := json.Marshal(resp)
+	if errRespMarshal != nil {
+		t.Fatalf("marshal response: %v", errRespMarshal)
+	}
+	var decodedResp HostAffinityLookupResponse
+	if errRespUnmarshal := json.Unmarshal(respData, &decodedResp); errRespUnmarshal != nil {
+		t.Fatalf("unmarshal response: %v", errRespUnmarshal)
+	}
+	if decodedResp.Status != resp.Status || decodedResp.AuthIndex != resp.AuthIndex || decodedResp.Disabled != resp.Disabled {
+		t.Fatalf("decoded response = %#v, want %#v", decodedResp, resp)
+	}
+}

--- a/sdk/pluginstore/network_scope_test.go
+++ b/sdk/pluginstore/network_scope_test.go
@@ -1,0 +1,70 @@
+package pluginstore
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	internalpluginstore "github.com/router-for-me/CLIProxyAPI/v7/internal/pluginstore"
+)
+
+type networkScopeDoer func(*http.Request) (*http.Response, error)
+
+func (f networkScopeDoer) Do(req *http.Request) (*http.Response, error) { return f(req) }
+
+func TestClientWithNetworkScope(t *testing.T) {
+	for name, client := range map[string]Client{
+		"plain":           NewClient(nil, ""),
+		"auth":            NewClientWithAuth(nil, "", nil),
+		"resolved":        NewClientWithResolvedAuth(nil, "", nil),
+		"resolved expiry": NewClientWithResolvedAuthExpiry(nil, "", nil, time.Time{}),
+	} {
+		t.Run(name, func(t *testing.T) {
+			scoped := client.WithNetworkScope("  http://proxy.example:8080  ")
+			if scoped.inner.NetworkScope != "http://proxy.example:8080" || client.inner.NetworkScope != "" {
+				t.Fatal("WithNetworkScope must normalize the scope without modifying the original client")
+			}
+			if scoped.WithNetworkScope("").inner.NetworkScope != "" {
+				t.Fatal("empty scope must restore the direct-network identity")
+			}
+		})
+	}
+}
+
+func TestClientNetworkScopeIsolatesAndSharesCooldowns(t *testing.T) {
+	t.Parallel()
+	limiter := &internalpluginstore.GitHubRateLimiter{}
+	plugin := Plugin{Repository: "https://github.com/test/network-scope"}
+	calls := 0
+	client := NewClient(networkScopeDoer(func(*http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return &http.Response{StatusCode: http.StatusTooManyRequests, Header: http.Header{"Retry-After": {"3600"}}, Body: io.NopCloser(strings.NewReader("limited"))}, nil
+		}
+		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"tag_name":"v1.0.0"}`))}, nil
+	}), "")
+	client.inner.RateLimiter = limiter
+	proxyA := client.WithNetworkScope("http://proxy-a.example")
+	_, errRelease := proxyA.FetchLatestRelease(context.Background(), plugin)
+	var rateLimit *internalpluginstore.RateLimitError
+	if !errors.As(errRelease, &rateLimit) || calls != 1 {
+		t.Fatalf("first lookup: calls=%d error=%v", calls, errRelease)
+	}
+	for _, scope := range []string{"http://proxy-b.example", ""} {
+		if _, errRelease = client.WithNetworkScope(scope).FetchLatestRelease(context.Background(), plugin); errRelease != nil {
+			t.Fatalf("independent scope %q was blocked: %v", scope, errRelease)
+		}
+	}
+	if calls != 3 {
+		t.Fatalf("requests=%d, want 3", calls)
+	}
+	plugin.Repository = "https://github.com/test/another-repository"
+	_, errRelease = client.WithNetworkScope(" http://proxy-a.example ").FetchLatestRelease(context.Background(), plugin)
+	if !errors.As(errRelease, &rateLimit) || calls != 3 {
+		t.Fatalf("same scope must share cooldown across clients and repositories: calls=%d error=%v", calls, errRelease)
+	}
+}

--- a/sdk/pluginstore/pluginstore.go
+++ b/sdk/pluginstore/pluginstore.go
@@ -91,6 +91,15 @@ func NewClientWithResolvedAuthExpiry(httpClient HTTPDoer, registryURL string, au
 	}}
 }
 
+// WithNetworkScope returns a copy with the given proxy/egress identity for shared
+// GitHub API cooldowns. Use the same scope for clients with the same egress and
+// credentials; an empty scope denotes direct connections. This does not configure
+// the HTTP transport, which must use the corresponding proxy/egress separately.
+func (c Client) WithNetworkScope(networkScope string) Client {
+	c.inner.NetworkScope = strings.TrimSpace(networkScope)
+	return c
+}
+
 func (c *Client) ClearAuth() {
 	if c == nil {
 		return


### PR DESCRIPTION
## 结果与合并方式

Core protected full-sync 第 1/2 阶段：吸收协议、会话和插件维护修复，同时保留 LTS canonical 统计、Flow、Codex fallback/continuity 和插件兼容。**必须使用 Create a merge commit，禁止 squash/rebase**，因为包含 upstream merge ancestry 和 ledger 引用的实现提交。未发布、部署或写线上配置。

- Upstream: `router-for-me/CLIProxyAPI main`
- From: `d198db54d4c4886c99b21488d54fc576933019a3`
- To: `a59b1764e781e0c20bf102349cd9bc202ce8f668`
- Stage: 1/2；27 个非 merge 和 2 个 merge 提交。后续认证、模型级冷却、错误和 SSE 修复留给阶段二，不将本 PR 描述为全部同步完成。

## 关键取舍

- 接纳 Kimi native Responses、Claude 顺序 tool blocks/usage 聚合、helper 请求身份、会话提取去重、插件 release 查询缓存/限流、raw Management JSON 和只读 affinity callback。
- 保留 execution/canonical session 优先级；修复提取去重遗漏的 Amp thread ID，不把原有会话身份当作可丢弃的实现细节。
- 保留 Claude inclusive input 及 cache-write 子项，适配 3 个上游测试的断言口径，不弱化 canonical v3 或 double-counting 检查。
- 不启用 responseJsonSchema 到 responseSchema 的无条件改名：两种方言不等价，冲突字段不能静默丢弃。
- schema 6 raw JSON 与 LTS schema 5 executor lifecycle 共存；stream history 仍由显式能力协商，不因版本号提升而减少旧插件收到的数据。
- 两个原 dev 窄回补（连接池 settings key、missing tool schema）现已进入 main ancestry，ledger 标为 removable；未越级退休或删除功能。

## Protected delta review

- Retained capabilities: preserved；完整 usage、canonical v3/timing v1、Management `/usage*`、API key/auth/source attribution、Panel asset source、config/hot reload 均保留。
- LTS-owned features: preserved/adapted；Flow/abnormal retry/fallback/continuity/Redis queue 不被新的 session/plugin 路径替代。
- Shared seams: reviewed；session extraction/selection context、stream lifecycle/usage aggregation、plugin ABI/host callbacks、store network identity。
- 文本冲突：`internal/redisqueue/plugin.go`，`sdk/cliproxy/auth/conductor_cooldown.go`、`conductor_selection.go`、`selector.go`，`sdk/pluginabi/types.go`；逐块保留 LTS 行为，不整文件覆盖。
- 已有自有功能分支 #254/#255/#256 均已合并，无需重复接管；本轮新增 upstream ancestry，不恢复旧 port PR。

## 验证

- 首次 `go test ./...` 发现 3 个 Amp 回归和 3 个 canonical input 断言冲突，已修正。
- 修正后 `go test -count=1 ./...` 通过。
- `go test -race ./sdk/cliproxy/auth ./sdk/cliproxy/session ./sdk/cliproxy/flowcontrol ./internal/redisqueue ./internal/pluginhost ./internal/pluginstore` 通过。
- `scripts/check-lts-contract.sh`、`go run ./scripts/ltsregistry --root . --base-ref origin/main`、Usage/Management 专项、完整 OpenAI Responses translator 测试、server build、`git diff --check` 通过。
- 当前配套 Panel 的临时真实 Core smoke 通过，含源码/可视化保存回读、Flow/SSE、provider CRUD；没有真实账号付费生成或在线配置写入。
- 首轮 CI 发现嵌套 CodeBuddy/Qoder module 的 schema-5 固定断言；已改为当前 schema 加 lifecycle 最低版本检查，保留 capability 断言。两个 module 的 race/vet/c-shared build 本地通过。
- GitHub 精确 head `aa531e5f` 的 9 项检查通过，publish 按 PR 条件跳过（未发布）；lts-contract run 34596495038、pr-test-build run 34596495039、双架构构建 run 34596494998 均成功。HF Space/生产部署不在授权范围，未执行；模拟 helper 请求通过不是实际官方客户端抓包验收。

## Downstream patch 逐项结论

以下逐项对照本阶段 from/to diff 和当前 regression tests；没有等价 upstream 实现的条目继续保留，不因无文本冲突或能构建而退休。

| Patch | Conclusion | 本阶段依据 |
|---|---|---|
| `responses-effort-summary-independence` | patch-still-required | 触及相关路径；LTS 行为及所列回归保留，新增上游能力不构成完整等价替代。 |
| `codex-model-fallback` | patch-still-required | 触及相关路径；LTS 行为及所列回归保留，新增上游能力不构成完整等价替代。 |
| `codex-rate-limit-continuity` | patch-still-required | 触及相关路径；LTS 行为及所列回归保留，新增上游能力不构成完整等价替代。 |
| `codex-interactions-service-tier-response` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `plugin-configured-enable-default` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `codex-gpt56-ultra-level` | patch-still-required | 触及相关路径；LTS 行为及所列回归保留，新增上游能力不构成完整等价替代。 |
| `codex-model-header-provider-snapshot` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `codex-oauth-client-identity-finalization` | patch-still-required | 触及相关路径；LTS 行为及所列回归保留，新增上游能力不构成完整等价替代。 |
| `codex-client-metadata-privacy` | patch-still-required | 触及相关路径；LTS 行为及所列回归保留，新增上游能力不构成完整等价替代。 |
| `codex-model-not-found-request-scope` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `codex-websocket-reader-generation` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `codex-spark-reasoning-summary-compat` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `xai-explicit-tool-choice-none` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `kimi-claude-delegated-auth-immutability` | patch-still-required | 触及相关路径；LTS 行为及所列回归保留，新增上游能力不构成完整等价替代。 |
| `request-body-panic-tempfile-cleanup` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `api-request-body-size-limit` | patch-still-required | 触及相关路径；LTS 行为及所列回归保留，新增上游能力不构成完整等价替代。 |
| `object-store-auth-path-containment` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `auth-token-private-file-permissions` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `auth-store-list-error-propagation` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `auth-store-metadata-hydration` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `panel-release-token-isolation` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `gemini-unknown-method-not-found` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `count-tokens-not-found-no-cooldown` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `management-logs-bounded-response` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `transient-eof-cooldown` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `expired-availability-pruning` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `responses-chat-tool-call-turn-grouping` | patch-still-required | 触及相关路径；LTS 行为及所列回归保留，新增上游能力不构成完整等价替代。 |
| `codex-desktop-tool-overlay` | patch-still-required | 触及相关路径；LTS 行为及所列回归保留，新增上游能力不构成完整等价替代。 |
| `codex-multi-agent-plaintext-contract` | patch-still-required | 触及相关路径；LTS 行为及所列回归保留，新增上游能力不构成完整等价替代。 |
| `xai-multi-agent-plaintext-provenance` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `provider-runtime-state-isolation` | patch-still-required | 触及相关路径；LTS 行为及所列回归保留，新增上游能力不构成完整等价替代。 |
| `auth-provider-generation-fence` | patch-still-required | 触及相关路径；LTS 行为及所列回归保留，新增上游能力不构成完整等价替代。 |
| `codex-live-bootstrap-accounting-and-egress` | patch-still-required | 触及相关路径；LTS 行为及所列回归保留，新增上游能力不构成完整等价替代。 |
| `xai-implicit-responses-message-token-accounting` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `xai-websocket-saturated-reader-invalidation` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `xai-model-bad-credentials-auth-normalization` | patch-still-required | 触及相关路径；LTS 行为及所列回归保留，新增上游能力不构成完整等价替代。 |
| `dynamic-custom-header-transport-coverage` | patch-still-required | 触及相关路径；LTS 行为及所列回归保留，新增上游能力不构成完整等价替代。 |
| `astra-native-responses-controls` | patch-still-required | 触及相关路径；LTS 行为及所列回归保留，新增上游能力不构成完整等价替代。 |
| `astra-async-guidance-hotfix` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `local-flow-control` | patch-still-required | 触及相关路径；LTS 行为及所列回归保留，新增上游能力不构成完整等价替代。 |
| `openai-claude-cache-write-accounting` | patch-still-required | 触及相关路径；LTS 行为及所列回归保留，新增上游能力不构成完整等价替代。 |
| `plugin-stream-history-capability-negotiation` | patch-still-required | 触及相关路径；LTS 行为及所列回归保留，新增上游能力不构成完整等价替代。 |
| `wsrelay-terminal-frame-preservation` | upstream-equivalent | 等价实现已纳入；保留 regression tests，未越级退休。 |
| `codex-dotted-collaboration-tool-restoration` | upstream-equivalent | 等价实现已纳入；保留 regression tests，未越级退休。 |
| `session-dispatch-context-after-selection` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `antigravity-compaction-completion-validation` | patch-still-required | 本阶段无对应实现变更，原回归仍保留。 |
| `gemini-explicit-text-signature-carriers` | patch-still-required | 触及相关路径；LTS 行为及所列回归保留，新增上游能力不构成完整等价替代。 |
| `antigravity-pool-settings-cache-key` | upstream-equivalent | 等价实现已纳入；保留 regression tests，未越级退休。 |
| `claude-missing-tool-schema-default` | upstream-equivalent | 等价实现已纳入；保留 regression tests，未越级退休。 |
| `amp-session-extraction-priority` | patch-still-required | 触及相关路径；LTS 行为及所列回归保留，新增上游能力不构成完整等价替代。 |
| `antigravity-response-json-schema-dialect-preservation` | patch-still-required | 触及相关路径；LTS 行为及所列回归保留，新增上游能力不构成完整等价替代。 |

详细逐提交审查：`docs/lts/sync-review-20260911.md`。
