### PR TITLE
sync(lts): 吸收认证与协议修复并保留身份和统计契约（1/2）

### DIFF
--- a/cmd/fetch_codex_models/main.go
+++ b/cmd/fetch_codex_models/main.go
@@ -11,7 +11,7 @@
 //	--auths-dir       <path>  Directory containing auth JSON files (default: config auth-dir)
 //	--config          <path>  Config file path                 (default: "config.yaml")
 //	--output          <path>  Output JSON file path             (default: "codex_client_models.json")
-//	--client-version <ver>   Codex client_version query value  (default: "0.144.1")
+//	--client-version <ver>   Codex client_version query value  (default: "0.154.0")
 //	--pretty                 Pretty-print the output JSON      (default: true)
 package main
 
@@ -42,8 +42,8 @@ import (
 const (
 	codexModelsBaseURL       = "https://chatgpt.com/backend-api/codex"
 	codexModelsPath          = "/models"
-	defaultClientVersion     = "0.153.3"
-	defaultCodexUserAgent    = "codex_cli_rs/0.153.3 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9"
+	defaultClientVersion     = "0.154.0"
+	defaultCodexUserAgent    = "codex_cli_rs/0.154.0 (Mac OS 26.3.1; arm64) iTerm.app/3.6.9"
 	defaultCodexOriginator   = "codex_cli_rs"
 	accessTokenRefreshLeeway = 30 * time.Second
 )

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -202,7 +202,7 @@ disable-image-generation: false
 # to the credential that created them. Default: 3h.
 video-result-auth-cache-ttl: "3h"
 
-# Core auth auto-refresh worker pool size (OAuth/file-based auth token refresh).
+# Core auth auto-refresh and manual refresh-all worker pool size (OAuth/file-based auth token refresh).
 # When > 0, overrides the default worker count (16).
 # auth-auto-refresh-workers: 16
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -172,7 +172,7 @@ disable-cooling: false
 # Default is false; when false, cooldown status is kept in memory only.
 save-cooldown-status: false
 
-# Cooldown duration in seconds for transient upstream errors (408/500/502/503/504).
+# Cooldown duration in seconds for transient upstream errors (408/500/502/503/504/520-526).
 # Set to 0 to keep the legacy 60-second cooldown; set to -1 to disable transient error cooldowns.
 transient-error-cooldown-seconds: 0
 

--- a/internal/api/handlers/management/auth_files_fields.go
+++ b/internal/api/handlers/management/auth_files_fields.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	claudeauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/claude"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/credentialweight"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/watcher/synthesizer"
 	sdkAuth "github.com/router-for-me/CLIProxyAPI/v7/sdk/auth"
@@ -849,14 +850,33 @@ func (h *Handler) saveTokenRecord(ctx context.Context, record *coreauth.Auth) (s
 	if store == nil {
 		return "", fmt.Errorf("token store unavailable")
 	}
+	legacyClaudeCredential, errLegacy := claudeauth.FindMatchingLegacyCredential(ctx, store, record)
+	if errLegacy != nil {
+		return "", errLegacy
+	}
+	if legacyClaudeCredential != nil {
+		coreauth.MergeExistingAuthMetadata(record, legacyClaudeCredential.Metadata)
+	}
 	if h.postAuthHook != nil {
 		if err := h.postAuthHook(ctx, record); err != nil {
 			return "", fmt.Errorf("post-auth hook failed: %w", err)
 		}
 	}
-	savedPath, errSave := store.Save(ctx, record)
+	savedPath, errSave := store.Save(coreauth.WithAuthCreationIntent(ctx), record)
 	if errSave != nil {
 		return savedPath, errSave
+	}
+	if legacyClaudeCredential != nil {
+		if strings.TrimSpace(savedPath) == "" {
+			return "", fmt.Errorf("canonical Claude credential was not persisted; legacy credential retained")
+		}
+		legacyID := strings.TrimSpace(legacyClaudeCredential.ID)
+		if legacyID == "" {
+			legacyID = strings.TrimSpace(legacyClaudeCredential.FileName)
+		}
+		if errDelete := store.Delete(ctx, legacyID); errDelete != nil {
+			return savedPath, fmt.Errorf("canonical Claude credential saved but legacy credential cleanup failed: %w", errDelete)
+		}
 	}
 	if h.postAuthPersistHook != nil {
 		persistedRecord := record

--- a/internal/api/handlers/management/auth_files_provider_oauth.go
+++ b/internal/api/handlers/management/auth_files_provider_oauth.go
@@ -165,10 +165,11 @@ func (h *Handler) RequestAnthropicToken(c *gin.Context) {
 		if len(tokenStorage.DeviceIDs) > 0 {
 			metadata[claude.ClaudeDeviceIDsMetadataKey] = append([]string(nil), tokenStorage.DeviceIDs...)
 		}
+		fileName := claude.CredentialFileName(tokenStorage.Email, tokenStorage.OrganizationUUID, tokenStorage.AccountUUID)
 		record := &coreauth.Auth{
-			ID:       fmt.Sprintf("claude-%s.json", tokenStorage.Email),
+			ID:       fileName,
 			Provider: "claude",
-			FileName: fmt.Sprintf("claude-%s.json", tokenStorage.Email),
+			FileName: fileName,
 			Storage:  tokenStorage,
 			Metadata: metadata,
 		}

--- a/internal/api/handlers/management/auth_files_relogin_preserve_test.go
+++ b/internal/api/handlers/management/auth_files_relogin_preserve_test.go
@@ -173,6 +173,87 @@ func TestSaveTokenRecord_PreservesExistingAuthFileSettings(t *testing.T) {
 	}
 }
 
+func TestSaveTokenRecord_MigratesMatchingLegacyClaudeCredential(t *testing.T) {
+	authDir := t.TempDir()
+	legacyFileName := "claude-user@example.com.json"
+	targetFileName := claude.CredentialFileName("user@example.com", "organization-a", "account-a")
+	legacyPath := filepath.Join(authDir, legacyFileName)
+	targetPath := filepath.Join(authDir, targetFileName)
+
+	existing := map[string]any{
+		"type":              "claude",
+		"email":             "user@example.com",
+		"organization_uuid": "organization-a",
+		"account_uuid":      "account-a",
+		"access_token":      "old-token",
+		"refresh_token":     "old-refresh",
+		"prefix":            "team",
+		"proxy_url":         "http://127.0.0.1:8080",
+		"disabled":          true,
+		"weight":            float64(5),
+	}
+	raw, errMarshal := json.Marshal(existing)
+	if errMarshal != nil {
+		t.Fatalf("marshal legacy credential: %v", errMarshal)
+	}
+	if errWrite := os.WriteFile(legacyPath, raw, 0o600); errWrite != nil {
+		t.Fatalf("write legacy credential: %v", errWrite)
+	}
+
+	tokenStorage := &claude.ClaudeTokenStorage{
+		AccessToken:      "new-token",
+		RefreshToken:     "new-refresh",
+		Email:            "user@example.com",
+		OrganizationUUID: "organization-a",
+		AccountUUID:      "account-a",
+		Expire:           "2026-12-31T23:59:59Z",
+	}
+	record := &coreauth.Auth{
+		ID:       targetFileName,
+		Provider: "claude",
+		FileName: targetFileName,
+		Storage:  tokenStorage,
+		Metadata: map[string]any{
+			"email":             tokenStorage.Email,
+			"organization_uuid": tokenStorage.OrganizationUUID,
+			"account_uuid":      tokenStorage.AccountUUID,
+		},
+	}
+
+	h := NewHandler(&config.Config{AuthDir: authDir}, "", nil)
+	savedPath, errSave := h.saveTokenRecord(context.Background(), record)
+	if errSave != nil {
+		t.Fatalf("saveTokenRecord error: %v", errSave)
+	}
+	if savedPath != targetPath {
+		t.Fatalf("savedPath = %s, want %s", savedPath, targetPath)
+	}
+	if _, errStat := os.Stat(legacyPath); !os.IsNotExist(errStat) {
+		t.Fatalf("legacy credential still exists or stat failed: %v", errStat)
+	}
+
+	savedRaw, errRead := os.ReadFile(targetPath)
+	if errRead != nil {
+		t.Fatalf("read migrated credential: %v", errRead)
+	}
+	var saved map[string]any
+	if errUnmarshal := json.Unmarshal(savedRaw, &saved); errUnmarshal != nil {
+		t.Fatalf("unmarshal migrated credential: %v", errUnmarshal)
+	}
+	for key, want := range map[string]any{
+		"access_token":  "new-token",
+		"refresh_token": "new-refresh",
+		"prefix":        "team",
+		"proxy_url":     "http://127.0.0.1:8080",
+		"disabled":      true,
+		"weight":        float64(5),
+	} {
+		if got := saved[key]; got != want {
+			t.Errorf("%s = %#v, want %#v", key, got, want)
+		}
+	}
+}
+
 func TestPatchAuthFileFields_DeletesPluginFields(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	authDir := t.TempDir()

--- a/internal/auth/claude/filename.go
+++ b/internal/auth/claude/filename.go
@@ -1,0 +1,116 @@
+package claude
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+// CredentialFileName returns the filename used to persist Claude OAuth credentials.
+// The organization hash is preferred to keep organizations with the same email
+// distinct. The account hash is used when no organization is available, and the
+// legacy email-based format remains the fallback.
+func CredentialFileName(email, organizationUUID, accountUUID string) string {
+	email = strings.TrimSpace(email)
+	identity := strings.TrimSpace(organizationUUID)
+	if identity == "" {
+		identity = strings.TrimSpace(accountUUID)
+	}
+	if identity == "" {
+		return fmt.Sprintf("claude-%s.json", email)
+	}
+
+	digest := sha256.Sum256([]byte(identity))
+	identityHash := hex.EncodeToString(digest[:])[:8]
+	return fmt.Sprintf("claude-%s-%s.json", identityHash, email)
+}
+
+// FindMatchingLegacyCredential locates a prior filename for the same Claude
+// identity as target. In addition to the email-only legacy name, an
+// account-hashed name can precede an organization-hashed target when an earlier
+// login did not return organization identity.
+func FindMatchingLegacyCredential(ctx context.Context, store coreauth.Store, target *coreauth.Auth) (*coreauth.Auth, error) {
+	if store == nil || !isHashedCredentialTarget(target) {
+		return nil, nil
+	}
+
+	records, errList := store.List(ctx)
+	if errList != nil {
+		if errors.Is(errList, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("list Claude credentials for legacy migration: %w", errList)
+	}
+
+	targetEmail := metadataString(target.Metadata, "email")
+	targetOrganization := metadataString(target.Metadata, "organization_uuid")
+	targetAccount := metadataString(target.Metadata, "account_uuid")
+	legacyFileName := CredentialFileName(targetEmail, "", "")
+	accountFileName := ""
+	if targetOrganization != "" && targetAccount != "" {
+		accountFileName = CredentialFileName(targetEmail, "", targetAccount)
+	}
+
+	for _, candidate := range records {
+		if candidate == nil || !strings.EqualFold(strings.TrimSpace(candidate.Provider), "claude") {
+			continue
+		}
+		candidateFileName := strings.TrimSpace(candidate.FileName)
+		if candidateFileName == "" {
+			candidateFileName = strings.TrimSpace(candidate.ID)
+		}
+		candidateBaseName := filepath.Base(candidateFileName)
+		isEmailLegacy := strings.EqualFold(candidateBaseName, legacyFileName)
+		isAccountPredecessor := accountFileName != "" && strings.EqualFold(candidateBaseName, accountFileName)
+		if !isEmailLegacy && !isAccountPredecessor {
+			continue
+		}
+
+		candidateOrganization := metadataString(candidate.Metadata, "organization_uuid")
+		candidateAccount := metadataString(candidate.Metadata, "account_uuid")
+		switch {
+		case targetOrganization != "":
+			if candidateOrganization != "" && strings.EqualFold(candidateOrganization, targetOrganization) {
+				return candidate, nil
+			}
+			if candidateOrganization == "" && isAccountPredecessor && candidateAccount != "" && strings.EqualFold(candidateAccount, targetAccount) {
+				return candidate, nil
+			}
+		case isEmailLegacy && candidateOrganization == "" && targetAccount != "":
+			if candidateAccount != "" && strings.EqualFold(candidateAccount, targetAccount) {
+				return candidate, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+func isHashedCredentialTarget(target *coreauth.Auth) bool {
+	if target == nil || !strings.EqualFold(strings.TrimSpace(target.Provider), "claude") {
+		return false
+	}
+	email := metadataString(target.Metadata, "email")
+	organizationUUID := metadataString(target.Metadata, "organization_uuid")
+	accountUUID := metadataString(target.Metadata, "account_uuid")
+	if email == "" || (organizationUUID == "" && accountUUID == "") {
+		return false
+	}
+	targetFileName := strings.TrimSpace(target.FileName)
+	if targetFileName == "" {
+		targetFileName = strings.TrimSpace(target.ID)
+	}
+	return strings.EqualFold(filepath.Base(targetFileName), CredentialFileName(email, organizationUUID, accountUUID))
+}
+
+func metadataString(metadata map[string]any, key string) string {
+	value, _ := metadata[key].(string)
+	return strings.TrimSpace(value)
+}

--- a/internal/auth/claude/filename_test.go
+++ b/internal/auth/claude/filename_test.go
@@ -1,0 +1,177 @@
+package claude
+
+import (
+	"context"
+	"testing"
+
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+type credentialListStore struct {
+	records []*coreauth.Auth
+}
+
+func (s *credentialListStore) List(context.Context) ([]*coreauth.Auth, error) {
+	return s.records, nil
+}
+
+func (*credentialListStore) Save(context.Context, *coreauth.Auth) (string, error) {
+	panic("unexpected Save call")
+}
+
+func (*credentialListStore) Delete(context.Context, string) error {
+	panic("unexpected Delete call")
+}
+
+func TestCredentialFileName(t *testing.T) {
+	tests := []struct {
+		name             string
+		email            string
+		organizationUUID string
+		accountUUID      string
+		want             string
+	}{
+		{
+			name:             "organization hash keeps organizations with the same email distinct",
+			email:            "user@example.com",
+			organizationUUID: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+			accountUUID:      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+			want:             "claude-00f765af-user@example.com.json",
+		},
+		{
+			name:             "different organization produces a different filename",
+			email:            "user@example.com",
+			organizationUUID: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+			accountUUID:      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+			want:             "claude-50d86b12-user@example.com.json",
+		},
+		{
+			name:        "account hash is used without organization",
+			email:       " user@example.com ",
+			accountUUID: " aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa ",
+			want:        "claude-303617b9-user@example.com.json",
+		},
+		{
+			name:  "missing identities fall back to legacy email filename",
+			email: " user@example.com ",
+			want:  "claude-user@example.com.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CredentialFileName(tt.email, tt.organizationUUID, tt.accountUUID)
+			if got != tt.want {
+				t.Fatalf("CredentialFileName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindMatchingLegacyCredential(t *testing.T) {
+	const email = "user@example.com"
+	legacyFileName := CredentialFileName(email, "", "")
+
+	tests := []struct {
+		name              string
+		targetMetadata    map[string]any
+		legacyMetadata    map[string]any
+		candidateFileName string
+		wantMatch         bool
+	}{
+		{
+			name: "matching organization",
+			targetMetadata: map[string]any{
+				"email": email, "organization_uuid": "organization-a", "account_uuid": "shared-account",
+			},
+			legacyMetadata: map[string]any{
+				"email": email, "organization_uuid": "organization-a", "account_uuid": "shared-account",
+			},
+			wantMatch: true,
+		},
+		{
+			name: "different organization with shared account",
+			targetMetadata: map[string]any{
+				"email": email, "organization_uuid": "organization-b", "account_uuid": "shared-account",
+			},
+			legacyMetadata: map[string]any{
+				"email": email, "organization_uuid": "organization-a", "account_uuid": "shared-account",
+			},
+		},
+		{
+			name: "missing legacy organization remains ambiguous",
+			targetMetadata: map[string]any{
+				"email": email, "organization_uuid": "organization-a", "account_uuid": "shared-account",
+			},
+			legacyMetadata: map[string]any{
+				"email": email, "account_uuid": "shared-account",
+			},
+		},
+		{
+			name: "matching account when neither has organization",
+			targetMetadata: map[string]any{
+				"email": email, "account_uuid": "account-a",
+			},
+			legacyMetadata: map[string]any{
+				"email": email, "account_uuid": "account-a",
+			},
+			wantMatch: true,
+		},
+		{
+			name: "matching account-hashed predecessor when target gains organization",
+			targetMetadata: map[string]any{
+				"email": email, "organization_uuid": "organization-a", "account_uuid": "account-a",
+			},
+			legacyMetadata: map[string]any{
+				"email": email, "account_uuid": "account-a",
+			},
+			candidateFileName: CredentialFileName(email, "", "account-a"),
+			wantMatch:         true,
+		},
+		{
+			name: "different account-hashed predecessor",
+			targetMetadata: map[string]any{
+				"email": email, "organization_uuid": "organization-a", "account_uuid": "account-a",
+			},
+			legacyMetadata: map[string]any{
+				"email": email, "account_uuid": "account-b",
+			},
+			candidateFileName: CredentialFileName(email, "", "account-b"),
+		},
+		{
+			name: "account-hashed predecessor associated with another organization",
+			targetMetadata: map[string]any{
+				"email": email, "organization_uuid": "organization-a", "account_uuid": "shared-account",
+			},
+			legacyMetadata: map[string]any{
+				"email": email, "organization_uuid": "organization-b", "account_uuid": "shared-account",
+			},
+			candidateFileName: CredentialFileName(email, "", "shared-account"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := &coreauth.Auth{
+				ID:       CredentialFileName(email, metadataString(tt.targetMetadata, "organization_uuid"), metadataString(tt.targetMetadata, "account_uuid")),
+				FileName: CredentialFileName(email, metadataString(tt.targetMetadata, "organization_uuid"), metadataString(tt.targetMetadata, "account_uuid")),
+				Provider: "claude",
+				Metadata: tt.targetMetadata,
+			}
+			candidateFileName := tt.candidateFileName
+			if candidateFileName == "" {
+				candidateFileName = legacyFileName
+			}
+			legacy := &coreauth.Auth{
+				ID: candidateFileName, FileName: candidateFileName, Provider: "claude", Metadata: tt.legacyMetadata,
+			}
+			got, err := FindMatchingLegacyCredential(context.Background(), &credentialListStore{records: []*coreauth.Auth{legacy}}, target)
+			if err != nil {
+				t.Fatalf("FindMatchingLegacyCredential() error = %v", err)
+			}
+			if (got != nil) != tt.wantMatch {
+				t.Fatalf("FindMatchingLegacyCredential() match = %v, want %v", got != nil, tt.wantMatch)
+			}
+		})
+	}
+}

--- a/internal/client/codex/models/models.go
+++ b/internal/client/codex/models/models.go
@@ -73,12 +73,22 @@ func buildCodexClientModels(models []map[string]any, providersForModel Providers
 			continue
 		}
 
-		if template, ok := templates[id]; ok {
+		metadataID := codexClientMetadataModelID(id)
+
+		if template, ok := templates[metadataID]; ok {
 			entry := cloneCodexClientModelMap(template)
+			entry["slug"] = id
+			info := registry.LookupModelInfo(id)
+			applyCodexClientModelCapabilities(entry, id, metadataID, info, providersForModel, clientVersion)
 			applyCodexClientDisplayName(entry, model)
+			applyCodexClientDescription(entry, model)
+			applyCodexClientBaseInstructions(entry, model)
 			applyCodexClientMaxContextLengthOverride(entry, model)
 			applyCodexClientMaxTokens(entry, model)
-			applyCodexClientSearchToolSupport(entry, id, true, providersForModel)
+			if thinkingSupport := codexClientThinkingSupport(model); thinkingSupport != nil {
+				applyCodexClientThinkingMetadata(entry, thinkingSupport, clientVersion)
+			}
+			applyCodexClientProviderCapabilities(entry, id, true, providersForModel)
 			sanitizeCodexClientReasoningMetadata(entry, clientVersion)
 			applyCodexClientVisibilityOverride(entry, id)
 			if optimizeMultiAgentV2 {
@@ -91,7 +101,7 @@ func buildCodexClientModels(models []map[string]any, providersForModel Providers
 		entry := cloneCodexClientModelMap(defaultTemplate)
 		applyCodexClientModelMetadata(entry, id, model, optimizeMultiAgentV2, clientVersion)
 		applyCodexClientMaxTokens(entry, model)
-		applyCodexClientSearchToolSupport(entry, id, false, providersForModel)
+		applyCodexClientProviderCapabilities(entry, id, false, providersForModel)
 		sanitizeCodexClientReasoningMetadata(entry, clientVersion)
 		applyCodexClientVisibilityOverride(entry, id)
 		result = append(result, entry)
@@ -132,7 +142,7 @@ func applyCodexClientNonTemplatePriorities(result []map[string]any, templates ma
 	pending := make([]nonTemplateEntry, 0)
 	for index, entry := range result {
 		slug := stringModelValue(entry, "slug")
-		if _, ok := templates[slug]; ok {
+		if _, ok := templates[codexClientMetadataModelID(slug)]; ok {
 			continue
 		}
 		displayName := stringModelValue(entry, "display_name")
@@ -198,10 +208,187 @@ func loadCodexClientModelTemplatesSnapshot(raw []byte, revision uint64) (map[str
 	return codexClientModelTemplates, codexClientDefaultTemplate, codexClientModelTemplatesErr
 }
 
+func codexClientMetadataModelID(id string) string {
+	id = strings.TrimSpace(id)
+	if info := registry.LookupModelInfo(id); info != nil {
+		if metadataID := strings.TrimSpace(info.MetadataModelID); metadataID != "" {
+			return metadataID
+		}
+	}
+	if idx := strings.Index(id, "/"); idx != -1 {
+		base := strings.TrimSpace(id[idx+1:])
+		if info := registry.LookupModelInfo(base); info != nil && strings.TrimSpace(info.MetadataModelID) != "" {
+			return strings.TrimSpace(info.MetadataModelID)
+		}
+		return base
+	}
+	return id
+}
+
 func applyCodexClientDisplayName(entry map[string]any, model map[string]any) {
 	if displayName := stringModelValue(model, "display_name"); displayName != "" {
 		entry["display_name"] = displayName
 	}
+}
+
+func applyCodexClientDescription(entry map[string]any, model map[string]any) {
+	if description := stringModelValue(model, "description"); description != "" {
+		entry["description"] = description
+	}
+}
+
+func applyCodexClientBaseInstructions(entry map[string]any, model map[string]any) {
+	if baseInstructions := stringModelValue(model, "base_instructions"); baseInstructions != "" {
+		entry["base_instructions"] = baseInstructions
+	}
+}
+
+func applyCodexClientModelCapabilities(entry map[string]any, id, metadataID string, info *registry.ModelInfo, providersForModel ProvidersForModelFunc, clientVersion string) {
+	if info != nil && info.Type == registry.OpenAIImageModelType {
+		entry["visibility"] = "hide"
+		delete(entry, "input_modalities")
+		delete(entry, "supports_image_detail_original")
+		return
+	}
+
+	var providers []string
+	if providersForModel != nil {
+		providers = providersForModel(id)
+		if len(providers) == 0 && strings.Contains(id, "/") {
+			idx := strings.Index(id, "/")
+			base := strings.TrimSpace(id[idx+1:])
+			providers = providersForModel(base)
+		}
+	}
+
+	isAlias := metadataID != "" && !strings.EqualFold(id, metadataID)
+
+	var constrainedModalities []string
+	hasModalitiesConstraint := false
+	for _, p := range providers {
+		pInfo := registry.LookupModelInfo(id, p)
+		if pInfo == nil && strings.Contains(id, "/") {
+			idx := strings.Index(id, "/")
+			pInfo = registry.LookupModelInfo(strings.TrimSpace(id[idx+1:]), p)
+		}
+		if pInfo == nil {
+			continue
+		}
+		isCodex := strings.EqualFold(strings.TrimSpace(p), "codex")
+		if (!isCodex && isAlias) || pInfo.ExplicitInputModalities {
+			mods := pInfo.SupportedInputModalities
+			if mods == nil {
+				mods = []string{}
+			}
+			if !hasModalitiesConstraint {
+				constrainedModalities = append([]string(nil), mods...)
+				hasModalitiesConstraint = true
+			} else {
+				constrainedModalities = intersectStringSlices(constrainedModalities, mods)
+			}
+		}
+	}
+	if !hasModalitiesConstraint && info != nil && info.ExplicitInputModalities {
+		mods := info.SupportedInputModalities
+		if mods == nil {
+			mods = []string{}
+		}
+		constrainedModalities = append([]string(nil), mods...)
+		hasModalitiesConstraint = true
+	}
+	if hasModalitiesConstraint {
+		codexModalities := filterCodexInputModalities(constrainedModalities)
+		entry["input_modalities"] = codexModalities
+		if hasImageModality(codexModalities) {
+			entry["supports_image_detail_original"] = true
+		} else {
+			delete(entry, "supports_image_detail_original")
+		}
+	}
+
+	var constrainedThinking *registry.ThinkingSupport
+	hasThinkingConstraint := false
+	for _, p := range providers {
+		pInfo := registry.LookupModelInfo(id, p)
+		if pInfo == nil && strings.Contains(id, "/") {
+			idx := strings.Index(id, "/")
+			pInfo = registry.LookupModelInfo(strings.TrimSpace(id[idx+1:]), p)
+		}
+		if pInfo == nil {
+			continue
+		}
+		isCodex := strings.EqualFold(strings.TrimSpace(p), "codex")
+		if (!isCodex && isAlias) || pInfo.ExplicitThinking {
+			hasThinkingConstraint = true
+			pThinking := pInfo.Thinking
+			if pThinking == nil {
+				pThinking = &registry.ThinkingSupport{Levels: []string{}}
+			}
+			if constrainedThinking == nil {
+				constrainedThinking = pThinking
+			} else {
+				constrainedThinking = intersectThinkingSupport(constrainedThinking, pThinking)
+			}
+		}
+	}
+	if !hasThinkingConstraint && info != nil && info.ExplicitThinking {
+		pThinking := info.Thinking
+		if pThinking == nil {
+			pThinking = &registry.ThinkingSupport{Levels: []string{}}
+		}
+		constrainedThinking = pThinking
+		hasThinkingConstraint = true
+	}
+	if hasThinkingConstraint && constrainedThinking != nil {
+		applyCodexClientThinkingMetadata(entry, constrainedThinking, clientVersion)
+	}
+}
+
+func intersectThinkingSupport(a, b *registry.ThinkingSupport) *registry.ThinkingSupport {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	levels := intersectStringSlices(a.Levels, b.Levels)
+	min := a.Min
+	if b.Min > min {
+		min = b.Min
+	}
+	max := a.Max
+	if b.Max > 0 && (max == 0 || b.Max < max) {
+		max = b.Max
+	}
+	return &registry.ThinkingSupport{
+		Min:            min,
+		Max:            max,
+		ZeroAllowed:    a.ZeroAllowed && b.ZeroAllowed,
+		DynamicAllowed: a.DynamicAllowed && b.DynamicAllowed,
+		Levels:         levels,
+	}
+}
+
+func intersectStringSlices(a, b []string) []string {
+	if len(a) == 0 || len(b) == 0 {
+		return []string{}
+	}
+	bMap := make(map[string]struct{}, len(b))
+	for _, item := range b {
+		bMap[strings.ToLower(strings.TrimSpace(item))] = struct{}{}
+	}
+	out := make([]string, 0, len(a))
+	seen := make(map[string]struct{}, len(a))
+	for _, item := range a {
+		key := strings.ToLower(strings.TrimSpace(item))
+		if _, inB := bMap[key]; inB {
+			if _, inSeen := seen[key]; !inSeen {
+				seen[key] = struct{}{}
+				out = append(out, item)
+			}
+		}
+	}
+	return out
 }
 
 func applyCodexClientMaxContextLengthOverride(entry map[string]any, model map[string]any) {
@@ -215,6 +402,44 @@ func applyCodexClientMaxTokens(entry map[string]any, model map[string]any) {
 	if maxCompletionTokens := intModelValue(model, "max_completion_tokens"); maxCompletionTokens > 0 {
 		entry["max_tokens"] = maxCompletionTokens
 	}
+}
+
+func applyCodexClientProviderCapabilities(entry map[string]any, id string, isTemplate bool, providersForModel ProvidersForModelFunc) {
+	if !isTemplate {
+		applyCodexClientSearchToolSupport(entry, id, false, providersForModel)
+		return
+	}
+	if providersForModel != nil && !isPureCodexProvider(id, providersForModel) {
+		entry["supports_search_tool"] = false
+		entry["prefer_websockets"] = false
+		delete(entry, "apply_patch_tool_type")
+		entry["service_tiers"] = []any{}
+		delete(entry, "upgrade")
+		delete(entry, "availability_nux")
+		return
+	}
+	applyCodexClientSearchToolSupport(entry, id, isTemplate, providersForModel)
+}
+
+func isPureCodexProvider(id string, providersForModel ProvidersForModelFunc) bool {
+	if providersForModel == nil {
+		return true
+	}
+	providers := providersForModel(id)
+	if len(providers) == 0 && strings.Contains(id, "/") {
+		idx := strings.Index(id, "/")
+		base := strings.TrimSpace(id[idx+1:])
+		providers = providersForModel(base)
+	}
+	if len(providers) == 0 {
+		return false
+	}
+	for _, provider := range providers {
+		if !strings.EqualFold(strings.TrimSpace(provider), "codex") {
+			return false
+		}
+	}
+	return true
 }
 
 func applyCodexClientSearchToolSupport(entry map[string]any, id string, templateModel bool, providersForModel ProvidersForModelFunc) {
@@ -233,6 +458,11 @@ func applyCodexClientSearchToolSupport(entry map[string]any, id string, template
 	}
 
 	providers := providersForModel(id)
+	if len(providers) == 0 && strings.Contains(id, "/") {
+		idx := strings.Index(id, "/")
+		base := strings.TrimSpace(id[idx+1:])
+		providers = providersForModel(base)
+	}
 	if len(providers) == 0 {
 		entry["supports_search_tool"] = false
 		return
@@ -335,7 +565,11 @@ func codexClientThinkingSupport(model map[string]any) *registry.ThinkingSupport 
 }
 
 func applyCodexClientVisibilityOverride(entry map[string]any, id string) {
-	switch strings.TrimSpace(id) {
+	target := strings.TrimSpace(id)
+	if idx := strings.Index(target, "/"); idx != -1 {
+		target = strings.TrimSpace(target[idx+1:])
+	}
+	switch target {
 	case "grok-imagine-image-quality", "gpt-image-1.5", "gpt-image-2", "gpt-image-2.5-flare", "gpt-image-2.5-sunburst", "gpt-image-2.5", "grok-imagine-image", "grok-imagine-image-2.0", "grok-imagine-video", "grok-imagine-video-1.5", "grok-imagine-video-1.5-preview":
 		entry["visibility"] = "hide"
 	}
@@ -345,10 +579,24 @@ func applyCodexClientInputModalitiesMetadata(entry map[string]any, modalities []
 	if len(modalities) == 0 {
 		return
 	}
-	// Codex client only accepts text/image input modalities.
+	codexModalities := filterCodexInputModalities(modalities)
+	if len(codexModalities) == 0 {
+		return
+	}
+	entry["input_modalities"] = codexModalities
+	if hasImageModality(codexModalities) {
+		entry["supports_image_detail_original"] = true
+	} else {
+		delete(entry, "supports_image_detail_original")
+	}
+}
+
+func filterCodexInputModalities(modalities []string) []any {
+	if len(modalities) == 0 {
+		return []any{}
+	}
 	codexModalities := make([]any, 0, 2)
 	seen := make(map[string]struct{}, 2)
-	supportsImage := false
 	for _, raw := range modalities {
 		switch modality := strings.ToLower(strings.TrimSpace(raw)); modality {
 		case "text", "image":
@@ -357,20 +605,18 @@ func applyCodexClientInputModalitiesMetadata(entry map[string]any, modalities []
 			}
 			seen[modality] = struct{}{}
 			codexModalities = append(codexModalities, modality)
-			if modality == "image" {
-				supportsImage = true
-			}
 		}
 	}
-	if len(codexModalities) == 0 {
-		return
+	return codexModalities
+}
+
+func hasImageModality(modalities []any) bool {
+	for _, m := range modalities {
+		if s, ok := m.(string); ok && s == "image" {
+			return true
+		}
 	}
-	entry["input_modalities"] = codexModalities
-	if supportsImage {
-		entry["supports_image_detail_original"] = true
-	} else {
-		delete(entry, "supports_image_detail_original")
-	}
+	return false
 }
 
 func applyCodexClientThinkingMetadata(entry map[string]any, thinking *registry.ThinkingSupport, clientVersion string) {

--- a/internal/client/codex/models/models_test.go
+++ b/internal/client/codex/models/models_test.go
@@ -591,3 +591,803 @@ func TestSanitizeCodexClientReasoningMetadataPreservesEmptyArray(t *testing.T) {
 		})
 	}
 }
+
+func TestCodexClientModelsResponse_PrefixedRouteInheritsCanonicalTemplate(t *testing.T) {
+	resp := BuildResponseForClient([]map[string]any{{
+		"id": "1/gpt-6-astra",
+	}}, nil, false, "")
+	models, ok := resp["models"].([]map[string]any)
+	if !ok || len(models) != 1 {
+		t.Fatalf("models = %#v, want one model", resp["models"])
+	}
+	model := models[0]
+	if got := stringModelValue(model, "slug"); got != "1/gpt-6-astra" {
+		t.Fatalf("slug = %q, want 1/gpt-6-astra", got)
+	}
+	if got := stringModelValue(model, "comp_hash"); got != "3000" {
+		t.Fatalf("comp_hash = %q, want 3000", got)
+	}
+	if got := intModelValue(model, "max_context_window"); got != 872000 {
+		t.Fatalf("max_context_window = %d, want 872000", got)
+	}
+}
+
+func TestCodexClientModelsResponse_OAuthAliasesInheritCanonicalMetadata(t *testing.T) {
+	modelRegistry := registry.GetGlobalRegistry()
+	clientID := "codex-oauth-alias-metadata-test-client"
+	modelRegistry.RegisterClient(clientID, "codex", []*registry.ModelInfo{
+		{
+			ID:              "codex-main",
+			MetadataModelID: "gpt-6-astra",
+			DisplayName:     "GPT 6.0 Astra",
+		},
+		{
+			ID:              "codex-compact",
+			MetadataModelID: "gpt-6-astra",
+			DisplayName:     "GPT 6.0 Astra",
+		},
+		{
+			ID:              "codex-luna",
+			MetadataModelID: "gpt-5.6-luna",
+			DisplayName:     "GPT 5.6 Luna",
+		},
+		{
+			ID:              "1/codex-main",
+			MetadataModelID: "gpt-6-astra",
+			DisplayName:     "Prefixed Astra Alias",
+		},
+	})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(clientID)
+	})
+
+	availableModels := []map[string]any{
+		{"id": "codex-main", "display_name": "GPT 6.0 Astra"},
+		{"id": "codex-compact", "display_name": "GPT 6.0 Astra"},
+		{"id": "codex-luna", "display_name": "GPT 5.6 Luna"},
+		{"id": "1/codex-main", "display_name": "Prefixed Astra Alias"},
+	}
+
+	resp := BuildResponseForClient(availableModels, modelRegistry.GetModelProviders, false, "0.153.4")
+	models, ok := resp["models"].([]map[string]any)
+	if !ok {
+		t.Fatalf("models type = %T, want []map[string]any", resp["models"])
+	}
+
+	entries := make(map[string]map[string]any, len(models))
+	for _, entry := range models {
+		entries[stringModelValue(entry, "slug")] = entry
+	}
+
+	for _, slug := range []string{"codex-main", "codex-compact", "1/codex-main"} {
+		entry := entries[slug]
+		if entry == nil {
+			t.Fatalf("missing entry for %q", slug)
+		}
+		if got := stringModelValue(entry, "comp_hash"); got != "3000" {
+			t.Errorf("%s comp_hash = %q, want 3000", slug, got)
+		}
+		if got := intModelValue(entry, "max_context_window"); got != 872000 {
+			t.Errorf("%s max_context_window = %d, want 872000", slug, got)
+		}
+		if got, _ := entry["supports_search_tool"].(bool); !got {
+			t.Errorf("%s supports_search_tool = %v, want true", slug, got)
+		}
+	}
+
+	lunaEntry := entries["codex-luna"]
+	if lunaEntry == nil {
+		t.Fatal("missing entry for codex-luna")
+	}
+	if got := stringModelValue(lunaEntry, "comp_hash"); got != "3000" {
+		t.Errorf("codex-luna comp_hash = %q, want 3000", got)
+	}
+	if got := intModelValue(lunaEntry, "max_context_window"); got != 872000 {
+		t.Errorf("codex-luna max_context_window = %d, want 872000", got)
+	}
+	if got, _ := lunaEntry["supports_search_tool"].(bool); !got {
+		t.Errorf("codex-luna supports_search_tool = %v, want true", got)
+	}
+}
+
+func TestCodexClientModelsResponse_ExplicitRouteOverridesHonored(t *testing.T) {
+	modelRegistry := registry.GetGlobalRegistry()
+	clientID := "codex-route-override-test-client"
+	modelRegistry.RegisterClient(clientID, "codex", []*registry.ModelInfo{
+		{
+			ID:               "custom-sol",
+			MetadataModelID:  "gpt-5.6-sol",
+			DisplayName:      "Overridden Display Name",
+			MaxContextLength: 123456,
+			ExplicitThinking: true,
+			Thinking: &registry.ThinkingSupport{
+				Levels: []string{"low", "high"},
+			},
+		},
+		{
+			ID:               "custom-astra-explicit-no-ultra",
+			MetadataModelID:  "gpt-6-astra",
+			DisplayName:      "Astra Without Ultra",
+			ExplicitThinking: true,
+			Thinking: &registry.ThinkingSupport{
+				// Levels equal registry default (low..max) but explicitly defined by user
+				Levels: []string{"low", "medium", "high", "xhigh", "max"},
+			},
+		},
+		{
+			ID:               "gpt-6-astra",
+			DisplayName:      "Direct Canonical With Explicit Thinking",
+			ExplicitThinking: true,
+			Thinking: &registry.ThinkingSupport{
+				Levels: []string{"low", "high"},
+			},
+		},
+	})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(clientID)
+	})
+
+	availableModels := []map[string]any{
+		{
+			"id":                 "custom-sol",
+			"display_name":       "Overridden Display Name",
+			"max_context_length": 123456,
+		},
+		{
+			"id":           "custom-astra-explicit-no-ultra",
+			"display_name": "Astra Without Ultra",
+		},
+		{
+			"id":           "gpt-6-astra",
+			"display_name": "Direct Canonical With Explicit Thinking",
+		},
+	}
+
+	resp := BuildResponseForClient(availableModels, modelRegistry.GetModelProviders, false, "0.153.4")
+	models, ok := resp["models"].([]map[string]any)
+	if !ok || len(models) != 3 {
+		t.Fatalf("models = %#v, want three models", resp["models"])
+	}
+
+	entries := make(map[string]map[string]any, len(models))
+	for _, entry := range models {
+		entries[stringModelValue(entry, "slug")] = entry
+	}
+
+	entry := entries["custom-sol"]
+	if entry == nil {
+		t.Fatal("missing custom-sol")
+	}
+	if got := stringModelValue(entry, "slug"); got != "custom-sol" {
+		t.Errorf("slug = %q, want custom-sol", got)
+	}
+	if got := stringModelValue(entry, "display_name"); got != "Overridden Display Name" {
+		t.Errorf("display_name = %q, want Overridden Display Name", got)
+	}
+	if got := intModelValue(entry, "context_window"); got != 123456 {
+		t.Errorf("context_window = %d, want 123456", got)
+	}
+	if got := intModelValue(entry, "max_context_window"); got != 123456 {
+		t.Errorf("max_context_window = %d, want 123456", got)
+	}
+	if got := stringModelValue(entry, "comp_hash"); got != "3000" {
+		t.Errorf("comp_hash = %q, want 3000 (inherited from gpt-5.6-sol)", got)
+	}
+	// Assert reasoning levels were overridden to [low, high]
+	levels, okLevels := entry["supported_reasoning_levels"].([]any)
+	if !okLevels || len(levels) != 2 {
+		t.Fatalf("custom-sol supported_reasoning_levels = %#v, want [low, high]", entry["supported_reasoning_levels"])
+	}
+	if got := stringModelValue(entry, "default_reasoning_level"); got != "low" {
+		t.Errorf("default_reasoning_level = %q, want low", got)
+	}
+
+	// Assert custom-astra-explicit-no-ultra has exactly the 5 explicit levels and NO ultra
+	astraNoUltra := entries["custom-astra-explicit-no-ultra"]
+	if astraNoUltra == nil {
+		t.Fatal("missing custom-astra-explicit-no-ultra")
+	}
+	astraLevels, okAstraLevels := astraNoUltra["supported_reasoning_levels"].([]any)
+	if !okAstraLevels || len(astraLevels) != 5 {
+		t.Fatalf("custom-astra-explicit-no-ultra supported_reasoning_levels = %#v, want 5 levels", astraNoUltra["supported_reasoning_levels"])
+	}
+	for _, l := range astraLevels {
+		lMap, _ := l.(map[string]any)
+		if stringModelValue(lMap, "effort") == "ultra" {
+			t.Error("custom-astra-explicit-no-ultra must not contain 'ultra' because user explicitly excluded it")
+		}
+	}
+
+	// Assert direct canonical model gpt-6-astra also honors explicit thinking override
+	directAstra := entries["gpt-6-astra"]
+	if directAstra == nil {
+		t.Fatal("missing direct gpt-6-astra entry")
+	}
+	directLevels, okDirectLevels := directAstra["supported_reasoning_levels"].([]any)
+	if !okDirectLevels || len(directLevels) != 2 {
+		t.Fatalf("direct gpt-6-astra supported_reasoning_levels = %#v, want [low, high]", directAstra["supported_reasoning_levels"])
+	}
+	if got := stringModelValue(directAstra, "default_reasoning_level"); got != "low" {
+		t.Errorf("direct gpt-6-astra default_reasoning_level = %q, want low", got)
+	}
+}
+
+func TestCodexClientModelsResponse_UnrelatedCustomProviderRetainsFallback(t *testing.T) {
+	modelRegistry := registry.GetGlobalRegistry()
+	clientID := "codex-unrelated-custom-provider-test-client"
+	modelRegistry.RegisterClient(clientID, "openai-compatibility", []*registry.ModelInfo{
+		{
+			ID:          "my-unrelated-custom-model",
+			DisplayName: "Unrelated Model",
+		},
+	})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(clientID)
+	})
+
+	availableModels := []map[string]any{
+		{
+			"id":           "my-unrelated-custom-model",
+			"display_name": "Unrelated Model",
+		},
+	}
+
+	resp := BuildResponseForClient(availableModels, modelRegistry.GetModelProviders, false, "0.153.4")
+	models, ok := resp["models"].([]map[string]any)
+	if !ok || len(models) != 1 {
+		t.Fatalf("models = %#v, want one model", resp["models"])
+	}
+
+	entry := models[0]
+	if got := stringModelValue(entry, "slug"); got != "my-unrelated-custom-model" {
+		t.Errorf("slug = %q, want my-unrelated-custom-model", got)
+	}
+	if got := stringModelValue(entry, "comp_hash"); got != "2911" {
+		t.Errorf("comp_hash = %q, want 2911 (from generic gpt-5.5 fallback)", got)
+	}
+	if got, _ := entry["supports_search_tool"].(bool); got {
+		t.Errorf("supports_search_tool = %v, want false for non-template fallback", got)
+	}
+	// Fallback model without explicit modalities retains generic gpt-5.5 fallback modalities
+	mods, okMods := entry["input_modalities"].([]any)
+	if !okMods || len(mods) != 2 {
+		t.Fatalf("unrelated model input_modalities = %#v, want generic [text image]", entry["input_modalities"])
+	}
+	if got, _ := entry["supports_image_detail_original"].(bool); !got {
+		t.Errorf("supports_image_detail_original = %v, want true for generic fallback", got)
+	}
+}
+
+func TestCodexClientModelsResponse_UnrelatedProviderCannotWidenSearchTool(t *testing.T) {
+	modelRegistry := registry.GetGlobalRegistry()
+	clientID := "codex-unrelated-provider-widen-test-client"
+	modelRegistry.RegisterClient(clientID, "openai-compatibility", []*registry.ModelInfo{
+		{
+			ID:              "custom-astra-on-openai-compat",
+			MetadataModelID: "gpt-6-astra",
+			DisplayName:     "Astra on OpenAI Compat",
+			// OpenAI compatibility models get low/medium/high registered without ExplicitThinking
+			Thinking: &registry.ThinkingSupport{
+				Levels: []string{"low", "medium", "high"},
+			},
+		},
+	})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(clientID)
+	})
+
+	availableModels := []map[string]any{
+		{
+			"id":           "custom-astra-on-openai-compat",
+			"display_name": "Astra on OpenAI Compat",
+		},
+	}
+
+	resp := BuildResponseForClient(availableModels, modelRegistry.GetModelProviders, false, "0.153.4")
+	models, ok := resp["models"].([]map[string]any)
+	if !ok || len(models) != 1 {
+		t.Fatalf("models = %#v, want one model", resp["models"])
+	}
+
+	entry := models[0]
+	if got := stringModelValue(entry, "slug"); got != "custom-astra-on-openai-compat" {
+		t.Errorf("slug = %q, want custom-astra-on-openai-compat", got)
+	}
+	// Inherited model metadata from canonical gpt-6-astra
+	if got := stringModelValue(entry, "comp_hash"); got != "3000" {
+		t.Errorf("comp_hash = %q, want 3000", got)
+	}
+	if got := intModelValue(entry, "max_context_window"); got != 872000 {
+		t.Errorf("max_context_window = %d, want 872000", got)
+	}
+	// Protocol-level capabilities MUST be restricted for non-Codex providers
+	if got, _ := entry["supports_search_tool"].(bool); got {
+		t.Errorf("supports_search_tool = %v, want false because provider is openai-compatibility, not codex", got)
+	}
+	if got, _ := entry["prefer_websockets"].(bool); got {
+		t.Errorf("prefer_websockets = %v, want false for non-Codex provider", got)
+	}
+	if _, exists := entry["apply_patch_tool_type"]; exists {
+		t.Errorf("apply_patch_tool_type should be deleted for non-Codex provider, got %#v", entry["apply_patch_tool_type"])
+	}
+	if tiers, okTiers := entry["service_tiers"].([]any); !okTiers || len(tiers) != 0 {
+		t.Errorf("service_tiers = %#v, want empty array for non-Codex provider", entry["service_tiers"])
+	}
+	if _, exists := entry["upgrade"]; exists {
+		t.Errorf("upgrade should be deleted for non-Codex provider")
+	}
+	if _, exists := entry["availability_nux"]; exists {
+		t.Errorf("availability_nux should be deleted for non-Codex provider")
+	}
+	// Reasoning levels must NOT be widened beyond provider's registered capabilities
+	levels, okLevels := entry["supported_reasoning_levels"].([]any)
+	if !okLevels || len(levels) != 3 {
+		t.Fatalf("supported_reasoning_levels = %#v, want 3 levels restricted to provider", entry["supported_reasoning_levels"])
+	}
+	for _, l := range levels {
+		lMap, _ := l.(map[string]any)
+		effort := stringModelValue(lMap, "effort")
+		if effort == "ultra" || effort == "max" || effort == "xhigh" {
+			t.Errorf("non-Codex provider must not widen reasoning levels to %q", effort)
+		}
+	}
+}
+
+func TestCodexClientModelsResponse_MixedProvidersRestrictProtocolCapabilities(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		codexFirst bool
+	}{
+		{name: "codex_first_compat_second", codexFirst: true},
+		{name: "compat_first_codex_second", codexFirst: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			modelRegistry := registry.GetGlobalRegistry()
+			clientCodex := "codex-mixed-provider-client-codex-" + tt.name
+			clientCompat := "codex-mixed-provider-client-compat-" + tt.name
+			aliasName := "mixed-astra-alias-" + tt.name
+
+			registerCodex := func() {
+				modelRegistry.RegisterClient(clientCodex, "codex", []*registry.ModelInfo{
+					{
+						ID:              aliasName,
+						MetadataModelID: "gpt-6-astra",
+						DisplayName:     "Mixed Astra Alias",
+					},
+				})
+			}
+			registerCompat := func() {
+				modelRegistry.RegisterClient(clientCompat, "openai-compatibility", []*registry.ModelInfo{
+					{
+						ID:              aliasName,
+						MetadataModelID: "gpt-6-astra",
+						DisplayName:     "Mixed Astra Alias",
+						Thinking: &registry.ThinkingSupport{
+							Levels: []string{"low", "medium", "high"},
+						},
+					},
+				})
+			}
+
+			if tt.codexFirst {
+				registerCodex()
+				registerCompat()
+			} else {
+				registerCompat()
+				registerCodex()
+			}
+
+			t.Cleanup(func() {
+				modelRegistry.UnregisterClient(clientCodex)
+				modelRegistry.UnregisterClient(clientCompat)
+			})
+
+			availableModels := []map[string]any{
+				{"id": aliasName},
+			}
+
+			resp := BuildResponseForClient(availableModels, modelRegistry.GetModelProviders, false, "0.153.4")
+			models, ok := resp["models"].([]map[string]any)
+			if !ok || len(models) != 1 {
+				t.Fatalf("models = %#v, want one model", resp["models"])
+			}
+
+			entry := models[0]
+			// Inherited model metadata from canonical gpt-6-astra
+			if got := stringModelValue(entry, "comp_hash"); got != "3000" {
+				t.Errorf("comp_hash = %q, want 3000", got)
+			}
+			if got := intModelValue(entry, "max_context_window"); got != 872000 {
+				t.Errorf("max_context_window = %d, want 872000", got)
+			}
+			// Protocol-level capabilities MUST be restricted because providers are mixed (not pure Codex)
+			if got, _ := entry["supports_search_tool"].(bool); got {
+				t.Errorf("supports_search_tool = %v, want false for mixed provider", got)
+			}
+			if got, _ := entry["prefer_websockets"].(bool); got {
+				t.Errorf("prefer_websockets = %v, want false for mixed provider", got)
+			}
+			if _, exists := entry["apply_patch_tool_type"]; exists {
+				t.Errorf("apply_patch_tool_type should be deleted for mixed provider")
+			}
+			if tiers, okTiers := entry["service_tiers"].([]any); !okTiers || len(tiers) != 0 {
+				t.Errorf("service_tiers = %#v, want empty array for mixed provider", entry["service_tiers"])
+			}
+			if _, exists := entry["upgrade"]; exists {
+				t.Errorf("upgrade should be deleted for mixed provider")
+			}
+			if _, exists := entry["availability_nux"]; exists {
+				t.Errorf("availability_nux should be deleted for mixed provider")
+			}
+			// Reasoning levels must NOT be widened to ultra/max/xhigh regardless of registration order
+			levels, okLevels := entry["supported_reasoning_levels"].([]any)
+			if !okLevels || len(levels) != 3 {
+				t.Fatalf("supported_reasoning_levels = %#v, want 3 levels restricted to mixed provider", entry["supported_reasoning_levels"])
+			}
+			for _, l := range levels {
+				lMap, _ := l.(map[string]any)
+				effort := stringModelValue(lMap, "effort")
+				if effort == "ultra" || effort == "max" || effort == "xhigh" {
+					t.Errorf("mixed provider must not widen reasoning levels to %q", effort)
+				}
+			}
+		})
+	}
+}
+
+func TestCodexClientModelsResponse_MixedProvidersIntersectCodexExplicitRestrictions(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		codexFirst bool
+	}{
+		{name: "codex_explicit_first", codexFirst: true},
+		{name: "compat_first_codex_explicit_second", codexFirst: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			modelRegistry := registry.GetGlobalRegistry()
+			clientCodex := "codex-explicit-client-" + tt.name
+			clientCompat := "compat-client-" + tt.name
+			aliasName := "intersect-explicit-alias-" + tt.name
+
+			registerCodex := func() {
+				modelRegistry.RegisterClient(clientCodex, "codex", []*registry.ModelInfo{
+					{
+						ID:               aliasName,
+						MetadataModelID:  "gpt-6-astra",
+						DisplayName:      "Astra Mixed Explicit",
+						ExplicitThinking: true,
+						Thinking: &registry.ThinkingSupport{
+							// Codex explicitly restricted to low, high
+							Levels: []string{"low", "high"},
+						},
+					},
+				})
+			}
+			registerCompat := func() {
+				modelRegistry.RegisterClient(clientCompat, "openai-compatibility", []*registry.ModelInfo{
+					{
+						ID:              aliasName,
+						MetadataModelID: "gpt-6-astra",
+						DisplayName:     "Astra Mixed Explicit",
+						Thinking: &registry.ThinkingSupport{
+							// Compat supports low, medium, high
+							Levels: []string{"low", "medium", "high"},
+						},
+					},
+				})
+			}
+
+			if tt.codexFirst {
+				registerCodex()
+				registerCompat()
+			} else {
+				registerCompat()
+				registerCodex()
+			}
+
+			t.Cleanup(func() {
+				modelRegistry.UnregisterClient(clientCodex)
+				modelRegistry.UnregisterClient(clientCompat)
+			})
+
+			availableModels := []map[string]any{
+				{"id": aliasName},
+			}
+
+			resp := BuildResponseForClient(availableModels, modelRegistry.GetModelProviders, false, "0.153.4")
+			models, ok := resp["models"].([]map[string]any)
+			if !ok || len(models) != 1 {
+				t.Fatalf("models = %#v, want one model", resp["models"])
+			}
+
+			entry := models[0]
+			// The intersection of [low, high] and [low, medium, high] is exactly [low, high]
+			levels, okLevels := entry["supported_reasoning_levels"].([]any)
+			if !okLevels || len(levels) != 2 {
+				t.Fatalf("supported_reasoning_levels = %#v, want exactly 2 levels (low, high)", entry["supported_reasoning_levels"])
+			}
+			for _, l := range levels {
+				lMap, _ := l.(map[string]any)
+				effort := stringModelValue(lMap, "effort")
+				if effort == "medium" || effort == "ultra" || effort == "max" || effort == "xhigh" {
+					t.Errorf("mixed route must not contain %q because Codex explicitly excluded it", effort)
+				}
+			}
+		})
+	}
+}
+
+func TestCodexClientModelsResponse_DisjointModalitiesIntersectionDoesNotRestoreTemplate(t *testing.T) {
+	modelRegistry := registry.GetGlobalRegistry()
+	clientA := "modalities-client-a"
+	clientB := "modalities-client-b"
+	clientC := "modalities-client-c"
+	aliasName := "disjoint-modalities-alias"
+
+	// Provider A supports text only
+	modelRegistry.RegisterClient(clientA, "openai-compatibility", []*registry.ModelInfo{
+		{
+			ID:                       aliasName,
+			MetadataModelID:          "gpt-6-astra",
+			SupportedInputModalities: []string{"text"},
+		},
+	})
+	// Provider B supports image only
+	modelRegistry.RegisterClient(clientB, "custom-provider-b", []*registry.ModelInfo{
+		{
+			ID:                       aliasName,
+			MetadataModelID:          "gpt-6-astra",
+			SupportedInputModalities: []string{"image"},
+		},
+	})
+	// Provider C supports audio only (3-provider test)
+	modelRegistry.RegisterClient(clientC, "custom-provider-c", []*registry.ModelInfo{
+		{
+			ID:                       aliasName,
+			MetadataModelID:          "gpt-6-astra",
+			SupportedInputModalities: []string{"audio"},
+		},
+	})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(clientA)
+		modelRegistry.UnregisterClient(clientB)
+		modelRegistry.UnregisterClient(clientC)
+	})
+
+	availableModels := []map[string]any{
+		{"id": aliasName},
+	}
+
+	resp := BuildResponseForClient(availableModels, modelRegistry.GetModelProviders, false, "0.153.4")
+	models, ok := resp["models"].([]map[string]any)
+	if !ok || len(models) != 1 {
+		t.Fatalf("models = %#v, want one model", resp["models"])
+	}
+
+	entry := models[0]
+	// Empty intersection must remain empty and NOT restore template's ["text", "image"]
+	mods, okMods := entry["input_modalities"].([]any)
+	if !okMods || len(mods) != 0 {
+		t.Fatalf("disjoint input_modalities = %#v, want empty array []", entry["input_modalities"])
+	}
+	if got, _ := entry["supports_image_detail_original"].(bool); got {
+		t.Errorf("supports_image_detail_original must be absent/false for disjoint modalities")
+	}
+}
+
+func TestCodexClientModelsResponse_AudioOnlyModalitiesDoesNotRestoreTemplate(t *testing.T) {
+	modelRegistry := registry.GetGlobalRegistry()
+	clientA := "audio-only-client"
+	aliasName := "audio-only-astra-alias"
+
+	modelRegistry.RegisterClient(clientA, "openai-compatibility", []*registry.ModelInfo{
+		{
+			ID:                       aliasName,
+			MetadataModelID:          "gpt-6-astra",
+			SupportedInputModalities: []string{"audio"},
+		},
+	})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(clientA)
+	})
+
+	availableModels := []map[string]any{
+		{"id": aliasName},
+	}
+
+	resp := BuildResponseForClient(availableModels, modelRegistry.GetModelProviders, false, "0.153.4")
+	models, ok := resp["models"].([]map[string]any)
+	if !ok || len(models) != 1 {
+		t.Fatalf("models = %#v, want one model", resp["models"])
+	}
+
+	entry := models[0]
+	mods, okMods := entry["input_modalities"].([]any)
+	if !okMods || len(mods) != 0 {
+		t.Fatalf("audio-only input_modalities = %#v, want empty array []", entry["input_modalities"])
+	}
+	if got, _ := entry["supports_image_detail_original"].(bool); got {
+		t.Errorf("supports_image_detail_original must be absent/false for audio-only model")
+	}
+}
+
+func TestCodexClientModelsResponse_MixedProviderWithoutThinkingRestrictsReasoning(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		codexFirst bool
+	}{
+		{name: "codex_first_no_thinking_second", codexFirst: true},
+		{name: "no_thinking_first_codex_second", codexFirst: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			modelRegistry := registry.GetGlobalRegistry()
+			clientCodex := "codex-mixed-no-think-" + tt.name
+			clientCompat := "compat-mixed-no-think-" + tt.name
+			aliasName := "mixed-no-think-alias-" + tt.name
+
+			registerCodex := func() {
+				modelRegistry.RegisterClient(clientCodex, "codex", []*registry.ModelInfo{
+					{
+						ID:              aliasName,
+						MetadataModelID: "gpt-6-astra",
+						DisplayName:     "Mixed Astra Alias",
+					},
+				})
+			}
+			registerCompat := func() {
+				modelRegistry.RegisterClient(clientCompat, "openai-compatibility", []*registry.ModelInfo{
+					{
+						ID:              aliasName,
+						MetadataModelID: "gpt-6-astra",
+						DisplayName:     "Mixed Astra Alias",
+						// Compat provider does NOT support thinking (Thinking == nil)
+						Thinking: nil,
+					},
+				})
+			}
+
+			if tt.codexFirst {
+				registerCodex()
+				registerCompat()
+			} else {
+				registerCompat()
+				registerCodex()
+			}
+
+			t.Cleanup(func() {
+				modelRegistry.UnregisterClient(clientCodex)
+				modelRegistry.UnregisterClient(clientCompat)
+			})
+
+			availableModels := []map[string]any{
+				{"id": aliasName},
+			}
+
+			resp := BuildResponseForClient(availableModels, modelRegistry.GetModelProviders, false, "0.153.4")
+			models, ok := resp["models"].([]map[string]any)
+			if !ok || len(models) != 1 {
+				t.Fatalf("models = %#v, want one model", resp["models"])
+			}
+
+			entry := models[0]
+			// Because compat provider does not support thinking, mixed route must NOT advertise reasoning levels
+			levels, okLevels := entry["supported_reasoning_levels"].([]any)
+			if !okLevels || len(levels) != 0 {
+				t.Fatalf("supported_reasoning_levels = %#v, want empty array [] when one provider has no thinking support", entry["supported_reasoning_levels"])
+			}
+			if _, exists := entry["default_reasoning_level"]; exists {
+				t.Fatalf("default_reasoning_level should be deleted when no reasoning levels supported")
+			}
+		})
+	}
+}
+
+func TestCodexClientModelsResponse_OAuthAliasesInheritCompleteReasoningLevelsWithUltra(t *testing.T) {
+	// Look up real Astra definition from registry
+	realAstra := registry.LookupModelInfo("gpt-6-astra")
+	if realAstra == nil {
+		t.Fatal("expected gpt-6-astra in static/dynamic registry")
+	}
+
+	// Create alias and prefixed alias models that inherit real Astra's Thinking from registry
+	codexMain := *realAstra
+	codexMain.ID = "codex-main"
+	codexMain.MetadataModelID = "gpt-6-astra"
+
+	prefixedMain := *realAstra
+	prefixedMain.ID = "1/codex-main"
+	prefixedMain.MetadataModelID = "gpt-6-astra"
+
+	modelRegistry := registry.GetGlobalRegistry()
+	clientID := "codex-reasoning-levels-test-client"
+	modelRegistry.RegisterClient(clientID, "codex", []*registry.ModelInfo{
+		realAstra,
+		&codexMain,
+		&prefixedMain,
+	})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(clientID)
+	})
+
+	availableModels := []map[string]any{
+		{"id": "gpt-6-astra"},
+		{"id": "codex-main"},
+		{"id": "1/codex-main"},
+	}
+
+	// 1. Test for modern client version (0.153.4) which supports "ultra"
+	respModern := BuildResponseForClient(availableModels, modelRegistry.GetModelProviders, false, "0.153.4")
+	modelsModern, ok := respModern["models"].([]map[string]any)
+	if !ok {
+		t.Fatalf("models type = %T, want []map[string]any", respModern["models"])
+	}
+
+	entriesModern := make(map[string]map[string]any, len(modelsModern))
+	for _, entry := range modelsModern {
+		entriesModern[stringModelValue(entry, "slug")] = entry
+	}
+
+	for _, slug := range []string{"gpt-6-astra", "codex-main", "1/codex-main"} {
+		entry := entriesModern[slug]
+		if entry == nil {
+			t.Fatalf("missing modern entry for %q", slug)
+		}
+		rawLevels, okLevels := entry["supported_reasoning_levels"].([]any)
+		if !okLevels {
+			t.Fatalf("%s supported_reasoning_levels missing or wrong type: %#v", slug, entry["supported_reasoning_levels"])
+		}
+		hasUltra := false
+		hasDescriptions := false
+		for _, rawLevel := range rawLevels {
+			levelMap, okMap := rawLevel.(map[string]any)
+			if !okMap {
+				continue
+			}
+			if stringModelValue(levelMap, "effort") == "ultra" {
+				hasUltra = true
+			}
+			if stringModelValue(levelMap, "description") != "" {
+				hasDescriptions = true
+			}
+		}
+		if !hasUltra {
+			t.Errorf("%s must support 'ultra' reasoning level on modern client (inherited from gpt-6-astra template)", slug)
+		}
+		if !hasDescriptions {
+			t.Errorf("%s reasoning levels must retain rich descriptions from template", slug)
+		}
+	}
+
+	// 2. Test for older client version (0.137.0) which does not support "ultra" or "max"
+	respLegacy := BuildResponseForClient(availableModels, modelRegistry.GetModelProviders, false, "0.137.0")
+	modelsLegacy, ok := respLegacy["models"].([]map[string]any)
+	if !ok {
+		t.Fatalf("models type = %T, want []map[string]any", respLegacy["models"])
+	}
+
+	entriesLegacy := make(map[string]map[string]any, len(modelsLegacy))
+	for _, entry := range modelsLegacy {
+		entriesLegacy[stringModelValue(entry, "slug")] = entry
+	}
+
+	for _, slug := range []string{"gpt-6-astra", "codex-main", "1/codex-main"} {
+		entry := entriesLegacy[slug]
+		if entry == nil {
+			t.Fatalf("missing legacy entry for %q", slug)
+		}
+		rawLevels, okLevels := entry["supported_reasoning_levels"].([]any)
+		if !okLevels {
+			t.Fatalf("%s legacy supported_reasoning_levels missing: %#v", slug, entry["supported_reasoning_levels"])
+		}
+		for _, rawLevel := range rawLevels {
+			levelMap, okMap := rawLevel.(map[string]any)
+			if !okMap {
+				continue
+			}
+			effort := stringModelValue(levelMap, "effort")
+			if effort == "ultra" || effort == "max" {
+				t.Errorf("%s legacy client must filter out %q", slug, effort)
+			}
+		}
+	}
+}

--- a/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2_test.go
+++ b/internal/client/codex/optimize-multi-agent-v2/optimize_multi_agent_v2_test.go
@@ -30,7 +30,7 @@ func TestIsCodexMultiAgentClient(t *testing.T) {
 		},
 		{
 			name:      "codex tui",
-			userAgent: "codex-tui/0.153.3 (Mac OS 26.5.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.153.3)",
+			userAgent: "codex-tui/0.154.0 (Mac OS 26.5.2; arm64) iTerm.app/3.6.11 (codex-tui; 0.154.0)",
 			want:      true,
 		},
 		{
@@ -237,7 +237,7 @@ func TestOptimizeCodexMultiAgentV2RequestSkipsNamespaceConflict(t *testing.T) {
 	t.Parallel()
 
 	payload := []byte(`{"tools":[{"type":"namespace","name":"collaboration","tools":[{"type":"function","name":"spawn_agent"}]},{"type":"namespace","name":"collaboration-optimize","tools":[]}]}`)
-	headers := http.Header{"User-Agent": []string{"codex-tui/0.153.3"}}
+	headers := http.Header{"User-Agent": []string{"codex-tui/0.154.0"}}
 	cfg := &config.Config{Codex: config.CodexConfig{OptimizeMultiAgentV2: true}}
 	got, optimized := OptimizeCodexMultiAgentV2Request(context.Background(), headers, payload, cfg)
 	if optimized {
@@ -252,7 +252,7 @@ func TestOptimizeCodexMultiAgentV2RequestSkipsDotPrefixConflict(t *testing.T) {
 	t.Parallel()
 
 	payload := []byte(`{"tools":[{"type":"namespace","name":"collaboration","tools":[{"type":"function","name":"spawn_agent"}]},{"type":"function","name":"collaboration-optimize.tool"}]}`)
-	headers := http.Header{"User-Agent": []string{"codex-tui/0.153.3"}}
+	headers := http.Header{"User-Agent": []string{"codex-tui/0.154.0"}}
 	cfg := &config.Config{Codex: config.CodexConfig{OptimizeMultiAgentV2: true}}
 	got, optimized := OptimizeCodexMultiAgentV2Request(context.Background(), headers, payload, cfg)
 	if optimized {
@@ -566,13 +566,13 @@ func TestRewriteCodexMultiAgentV2InputConditions(t *testing.T) {
 		{
 			name:      "codex tui enabled",
 			cfg:       &config.Config{Codex: config.CodexConfig{OptimizeMultiAgentV2: true}},
-			userAgent: "codex-tui/0.153.3",
+			userAgent: "codex-tui/0.154.0",
 			want:      true,
 		},
 		{
 			name:      "optimization disabled",
 			cfg:       &config.Config{},
-			userAgent: "codex-tui/0.153.3",
+			userAgent: "codex-tui/0.154.0",
 		},
 		{
 			name:      "unrelated client",
@@ -657,7 +657,7 @@ func TestRewriteCodexSpawnAgentDescriptionDisabledLeavesPayloadUnchanged(t *test
 	t.Parallel()
 
 	payload := []byte(`{"tools":[{"type":"function","name":"spawn_agent","description":"unchanged","parameters":{"properties":{"message":{"encrypted":true}}}}]}`)
-	headers := http.Header{"User-Agent": []string{"codex-tui/0.153.3"}}
+	headers := http.Header{"User-Agent": []string{"codex-tui/0.154.0"}}
 	got := RewriteCodexSpawnAgentDescription(context.Background(), headers, payload, &config.Config{})
 	if string(got) != string(payload) {
 		t.Fatalf("disabled optimization changed payload: %s", got)
@@ -695,13 +695,13 @@ func TestReplaceCodexSpawnAgentModelsNormalizesSectionsAndPreservesInstructions(
 func TestCodexClientUserAgentPrefersGinRequest(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	request := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
-	request.Header.Set("User-Agent", "codex-tui/0.153.3")
+	request.Header.Set("User-Agent", "codex-tui/0.154.0")
 	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
 	ginCtx.Request = request
 	ctx := context.WithValue(context.Background(), "gin", ginCtx)
 	headers := http.Header{"User-Agent": []string{"overridden-client/1.0"}}
 
-	if got := codexClientUserAgent(ctx, headers); got != "codex-tui/0.153.3" {
+	if got := codexClientUserAgent(ctx, headers); got != "codex-tui/0.154.0" {
 		t.Fatalf("codexClientUserAgent() = %q, want gin request User-Agent", got)
 	}
 }
@@ -835,7 +835,7 @@ func TestOptimizeCodexMultiAgentV2RequestRemovesEncryptionInAdditionalTools(t *t
 			]}
 		]
 	}`)
-	headers := http.Header{"User-Agent": []string{"codex-tui/0.153.3"}}
+	headers := http.Header{"User-Agent": []string{"codex-tui/0.154.0"}}
 	cfg := &config.Config{Codex: config.CodexConfig{OptimizeMultiAgentV2: true}}
 	got, _ := OptimizeCodexMultiAgentV2Request(context.Background(), headers, payload, cfg)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,7 +68,7 @@ type Config struct {
 	// SaveCooldownStatus persists runtime cooldown status next to auth files when true.
 	SaveCooldownStatus bool `yaml:"save-cooldown-status" json:"save-cooldown-status"`
 
-	// TransientErrorCooldownSeconds controls cooldowns for transient upstream errors.
+	// TransientErrorCooldownSeconds controls cooldowns for transient upstream errors (408/500/502/503/504/520-526).
 	// 0 keeps the legacy default cooldown. Negative values disable these cooldowns.
 	TransientErrorCooldownSeconds int `yaml:"transient-error-cooldown-seconds" json:"transient-error-cooldown-seconds"`
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,7 +72,7 @@ type Config struct {
 	// 0 keeps the legacy default cooldown. Negative values disable these cooldowns.
 	TransientErrorCooldownSeconds int `yaml:"transient-error-cooldown-seconds" json:"transient-error-cooldown-seconds"`
 
-	// AuthAutoRefreshWorkers overrides the size of the core auth auto-refresh worker pool.
+	// AuthAutoRefreshWorkers overrides the size of the core auth auto-refresh and manual refresh-all worker pool.
 	// When <= 0, the default worker count is used.
 	AuthAutoRefreshWorkers int `yaml:"auth-auto-refresh-workers" json:"auth-auto-refresh-workers"`
 

--- a/internal/pluginhost/adapters_test.go
+++ b/internal/pluginhost/adapters_test.go
@@ -2337,6 +2337,32 @@ func TestUsageAdapterNormalizesOmittedGenerateToTrue(t *testing.T) {
 	}
 }
 
+func TestUsageAdapterPropagatesBaseURL(t *testing.T) {
+	var gotBaseURL string
+	plugin := usagePluginFunc(func(ctx context.Context, record pluginapi.UsageRecord) {
+		gotBaseURL = record.BaseURL
+	})
+	host := newHostWithRecords(capabilityRecord{
+		id: "usage-base-url",
+		plugin: pluginapi.Plugin{Capabilities: pluginapi.Capabilities{
+			UsagePlugin: plugin,
+		}},
+	})
+	adapter := &usageAdapter{
+		host:     host,
+		pluginID: "usage-base-url",
+	}
+
+	adapter.HandleUsage(context.Background(), coreusage.Record{
+		Provider: "provider",
+		Model:    "gpt-5.4",
+		BaseURL:  "https://custom-proxy.example.com/v1",
+	})
+	if gotBaseURL != "https://custom-proxy.example.com/v1" {
+		t.Fatalf("plugin BaseURL = %q, want https://custom-proxy.example.com/v1", gotBaseURL)
+	}
+}
+
 func TestUsageAdapterPreservesExplicitGenerateFalse(t *testing.T) {
 	var gotGenerate bool
 	plugin := usagePluginFunc(func(ctx context.Context, record pluginapi.UsageRecord) {

--- a/internal/pluginhost/adapters_usage_translation.go
+++ b/internal/pluginhost/adapters_usage_translation.go
@@ -164,6 +164,7 @@ func (a *usageAdapter) HandleUsage(ctx context.Context, record coreusage.Record)
 	}
 	plugin.HandleUsage(ctx, pluginapi.UsageRecord{
 		Provider:        record.Provider,
+		BaseURL:         record.BaseURL,
 		ExecutorType:    record.ExecutorType,
 		Model:           record.Model,
 		Alias:           record.Alias,

--- a/internal/pluginhost/auth_callbacks.go
+++ b/internal/pluginhost/auth_callbacks.go
@@ -199,6 +199,9 @@ func (h *Host) listAuthFilesFromDisk() ([]pluginapi.HostAuthFileEntry, error) {
 				if note, ok := metadata["note"].(string); ok {
 					fileEntry.Note = strings.TrimSpace(note)
 				}
+				if baseURL, ok := metadata["base_url"].(string); ok {
+					fileEntry.BaseURL = strings.TrimSpace(baseURL)
+				}
 				if websockets, okWebsockets := parseWebsocketsValue(metadata["websockets"]); okWebsockets {
 					fileEntry.Websockets = websockets
 				}
@@ -472,6 +475,13 @@ func (h *Host) buildHostAuthFileEntry(auth *coreauth.Auth) *pluginapi.HostAuthFi
 	} else if auth.Metadata != nil {
 		if rawNote, ok := auth.Metadata["note"].(string); ok {
 			entry.Note = strings.TrimSpace(rawNote)
+		}
+	}
+	if baseURL := strings.TrimSpace(authAttribute(auth, "base_url")); baseURL != "" {
+		entry.BaseURL = baseURL
+	} else if auth.Metadata != nil {
+		if rawBaseURL, ok := auth.Metadata["base_url"].(string); ok {
+			entry.BaseURL = strings.TrimSpace(rawBaseURL)
 		}
 	}
 	if websockets, ok := authWebsocketsValue(auth); ok {

--- a/internal/pluginhost/auth_callbacks_test.go
+++ b/internal/pluginhost/auth_callbacks_test.go
@@ -211,6 +211,131 @@ func TestHostAuthGetRuntimeCallbackReturnsRuntimeInfo(t *testing.T) {
 	}
 }
 
+func TestHostAuthGetRuntimeCallbackReturnsBaseURL(t *testing.T) {
+	auth := &coreauth.Auth{
+		ID:       "demo-base-url.json",
+		Provider: "demo",
+		FileName: "demo-base-url.json",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"runtime_only": "true",
+			"base_url":     "https://api.custom.example.com/v1",
+		},
+	}
+	auth.EnsureIndex()
+
+	authMeta := &coreauth.Auth{
+		ID:       "demo-meta-base-url.json",
+		Provider: "demo",
+		FileName: "demo-meta-base-url.json",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"runtime_only": "true",
+		},
+		Metadata: map[string]any{
+			"base_url": "https://meta.custom.example.com/v1",
+		},
+	}
+	authMeta.EnsureIndex()
+
+	host := New()
+	host.SetAuthManager(coreauth.NewManager(nil, nil, nil))
+	if _, errRegister := host.currentAuthManager().Register(context.Background(), auth); errRegister != nil {
+		t.Fatalf("register auth: %v", errRegister)
+	}
+	if _, errRegister := host.currentAuthManager().Register(context.Background(), authMeta); errRegister != nil {
+		t.Fatalf("register authMeta: %v", errRegister)
+	}
+
+	req, errMarshal := json.Marshal(pluginapi.HostAuthGetRequest{AuthIndex: auth.Index})
+	if errMarshal != nil {
+		t.Fatalf("marshal request: %v", errMarshal)
+	}
+	rawResp, errCall := host.callFromPlugin(context.Background(), pluginabi.MethodHostAuthGetRuntime, req)
+	if errCall != nil {
+		t.Fatalf("callFromPlugin() error = %v", errCall)
+	}
+	resp, errDecode := decodeRPCEnvelope[pluginapi.HostAuthGetRuntimeResponse](rawResp)
+	if errDecode != nil {
+		t.Fatalf("decode response: %v", errDecode)
+	}
+	if resp.Auth.BaseURL != "https://api.custom.example.com/v1" {
+		t.Fatalf("resp.Auth.BaseURL = %q, want %q", resp.Auth.BaseURL, "https://api.custom.example.com/v1")
+	}
+
+	reqMeta, errMarshalMeta := json.Marshal(pluginapi.HostAuthGetRequest{AuthIndex: authMeta.Index})
+	if errMarshalMeta != nil {
+		t.Fatalf("marshal request meta: %v", errMarshalMeta)
+	}
+	rawRespMeta, errCallMeta := host.callFromPlugin(context.Background(), pluginabi.MethodHostAuthGetRuntime, reqMeta)
+	if errCallMeta != nil {
+		t.Fatalf("callFromPlugin() meta error = %v", errCallMeta)
+	}
+	respMeta, errDecodeMeta := decodeRPCEnvelope[pluginapi.HostAuthGetRuntimeResponse](rawRespMeta)
+	if errDecodeMeta != nil {
+		t.Fatalf("decode response meta: %v", errDecodeMeta)
+	}
+	if respMeta.Auth.BaseURL != "https://meta.custom.example.com/v1" {
+		t.Fatalf("respMeta.Auth.BaseURL = %q, want %q", respMeta.Auth.BaseURL, "https://meta.custom.example.com/v1")
+	}
+
+	authBoth := &coreauth.Auth{
+		ID:       "demo-both-base-url.json",
+		Provider: "demo",
+		FileName: "demo-both-base-url.json",
+		Status:   coreauth.StatusActive,
+		Attributes: map[string]string{
+			"runtime_only": "true",
+			"base_url":     "https://attr.custom.example.com/v1",
+		},
+		Metadata: map[string]any{
+			"base_url": "https://meta.custom.example.com/v1",
+		},
+	}
+	authBoth.EnsureIndex()
+	if _, errRegister := host.currentAuthManager().Register(context.Background(), authBoth); errRegister != nil {
+		t.Fatalf("register authBoth: %v", errRegister)
+	}
+
+	reqBoth, errMarshalBoth := json.Marshal(pluginapi.HostAuthGetRequest{AuthIndex: authBoth.Index})
+	if errMarshalBoth != nil {
+		t.Fatalf("marshal request both: %v", errMarshalBoth)
+	}
+	rawRespBoth, errCallBoth := host.callFromPlugin(context.Background(), pluginabi.MethodHostAuthGetRuntime, reqBoth)
+	if errCallBoth != nil {
+		t.Fatalf("callFromPlugin() both error = %v", errCallBoth)
+	}
+	respBoth, errDecodeBoth := decodeRPCEnvelope[pluginapi.HostAuthGetRuntimeResponse](rawRespBoth)
+	if errDecodeBoth != nil {
+		t.Fatalf("decode response both: %v", errDecodeBoth)
+	}
+	if respBoth.Auth.BaseURL != "https://attr.custom.example.com/v1" {
+		t.Fatalf("respBoth.Auth.BaseURL = %q, want %q", respBoth.Auth.BaseURL, "https://attr.custom.example.com/v1")
+	}
+}
+
+func TestListAuthFilesFromDiskReadsBaseURL(t *testing.T) {
+	authDir := t.TempDir()
+	filePath := filepath.Join(authDir, "test-auth.json")
+	fileData := []byte(`{"type":"openai","base_url":"https://disk-proxy.example.com/v1","email":"user@example.com"}`)
+	if errWrite := os.WriteFile(filePath, fileData, 0o600); errWrite != nil {
+		t.Fatalf("write file: %v", errWrite)
+	}
+
+	host := New()
+	host.runtimeConfig = &config.Config{AuthDir: authDir}
+	entries, errList := host.listAuthFilesFromDisk()
+	if errList != nil {
+		t.Fatalf("listAuthFilesFromDisk error: %v", errList)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("entries count = %d, want 1", len(entries))
+	}
+	if entries[0].BaseURL != "https://disk-proxy.example.com/v1" {
+		t.Fatalf("entry BaseURL = %q, want https://disk-proxy.example.com/v1", entries[0].BaseURL)
+	}
+}
+
 func TestHostAuthSaveCallbackRejectsInvalidWeightBeforePersistence(t *testing.T) {
 	for _, rawWeight := range []string{`1.5`, `1000001`, `9223372036854775808`, `"invalid"`} {
 		t.Run(rawWeight, func(t *testing.T) {

--- a/internal/registry/model_definitions_test.go
+++ b/internal/registry/model_definitions_test.go
@@ -10,7 +10,7 @@ func TestGetStaticModelDefinitionsByChannelSupportsGeminiInteractions(t *testing
 }
 
 func TestModelOverrideHeadersFromEmbeddedModels(t *testing.T) {
-	const wantUA = "codex-tui/0.153.3 (Mac OS 26.5.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.153.3)"
+	const wantUA = "codex-tui/0.154.0 (Mac OS 26.5.2; arm64) iTerm.app/3.6.11 (codex-tui; 0.154.0)"
 	got := ModelOverrideHeaders("gpt-5.6-luna")
 	if got == nil {
 		t.Fatal("ModelOverrideHeaders(gpt-5.6-luna) = nil, want headers")

--- a/internal/registry/model_registry.go
+++ b/internal/registry/model_registry.go
@@ -27,6 +27,13 @@ const (
 type ModelInfo struct {
 	// ID is the unique identifier for the model
 	ID string `json:"id"`
+	// MetadataModelID identifies the canonical model used to resolve client metadata.
+	// It is internal and must not be exposed in model-list responses.
+	MetadataModelID string `json:"-"`
+	// ExplicitThinking indicates thinking/reasoning configuration was explicitly configured for this model.
+	ExplicitThinking bool `json:"-"`
+	// ExplicitInputModalities indicates input modalities were explicitly configured for this model.
+	ExplicitInputModalities bool `json:"-"`
 	// Object type for the model (typically "model")
 	Object string `json:"object"`
 	// Created timestamp when the model was created

--- a/internal/registry/models/models.json
+++ b/internal/registry/models/models.json
@@ -2459,7 +2459,7 @@
       },
       "config": {
         "override_header": {
-          "user-agent": "codex-tui/0.153.3 (Mac OS 26.5.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.153.3)",
+          "user-agent": "codex-tui/0.154.0 (Mac OS 26.5.2; arm64) iTerm.app/3.6.11 (codex-tui; 0.154.0)",
           "originator": "codex-tui"
         }
       },
@@ -2651,7 +2651,7 @@
       },
       "config": {
         "override_header": {
-          "user-agent": "codex-tui/0.153.3 (Mac OS 26.5.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.153.3)",
+          "user-agent": "codex-tui/0.154.0 (Mac OS 26.5.2; arm64) iTerm.app/3.6.11 (codex-tui; 0.154.0)",
           "originator": "codex-tui"
         }
       },
@@ -2872,7 +2872,7 @@
       },
       "config": {
         "override_header": {
-          "user-agent": "codex-tui/0.153.3 (Mac OS 26.5.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.153.3)",
+          "user-agent": "codex-tui/0.154.0 (Mac OS 26.5.2; arm64) iTerm.app/3.6.11 (codex-tui; 0.154.0)",
           "originator": "codex-tui"
         }
       },
@@ -3093,7 +3093,7 @@
       },
       "config": {
         "override_header": {
-          "user-agent": "codex-tui/0.153.3 (Mac OS 26.5.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.153.3)",
+          "user-agent": "codex-tui/0.154.0 (Mac OS 26.5.2; arm64) iTerm.app/3.6.11 (codex-tui; 0.154.0)",
           "originator": "codex-tui"
         }
       },

--- a/internal/runtime/executor/antigravity_reasoning_replay.go
+++ b/internal/runtime/executor/antigravity_reasoning_replay.go
@@ -268,6 +268,8 @@ func prepareAntigravityGeminiReasoningReplayPayload(ctx context.Context, modelNa
 				// the pairing diagnosis below with an untyped error.
 				logAntigravityReasoningReplayDegraded(scope, "invalidate", errDelete)
 			}
+			log.Warnf("antigravity executor: reasoning replay broke Gemini function call pairing (%v); degrading to original payload", errPairing)
+			return payload, scope, nil
 		}
 		return payload, scope, statusErr{code: http.StatusBadRequest, msg: fmt.Sprintf("antigravity executor: invalid Gemini function call history: %v", errPairing)}
 	}

--- a/internal/runtime/executor/antigravity_reasoning_replay_test.go
+++ b/internal/runtime/executor/antigravity_reasoning_replay_test.go
@@ -1943,3 +1943,31 @@ func TestPrepareAntigravityGeminiReasoningReplayStillRejectsBrokenPairing(t *tes
 		t.Fatalf("error = %v, want structural pairing rejection", errPrepare)
 	}
 }
+
+func TestPrepareAntigravityGeminiReasoningReplayDegradesWhenReplayBreaksPairing(t *testing.T) {
+	internalcache.ClearAntigravityReasoningReplayCache()
+	t.Cleanup(internalcache.ClearAntigravityReasoningReplayCache)
+
+	const model = "gemini-3.6-flash-high"
+	const args = `{"file_path":"/tmp/a"}`
+	payload := []byte(`{"sessionId":"sess-pairing-break","request":{"contents":[{"role":"model","parts":[{"thoughtSignature":"skip_thought_signature_validator","functionCall":{"name":"Read","args":` + args + `}}]},{"role":"user","parts":[{"functionResponse":{"name":"Read","response":{"result":"ok"}}}]}]}}`)
+	payload = normalizeAntigravityGeminiFunctionResponseRoles(payload)
+	if err := internalsignature.ValidateGeminiFunctionCallPairing(payload); err != nil {
+		t.Fatalf("original payload pairing invalid: %v", err)
+	}
+
+	item := []byte(`{"type":"function_call_part","contentIndex":0,"partIndex":0,"targetOccurrence":0,"name":"Write","args":` + args + `,"thoughtSignature":"EsMTCsATARFNMg/XNVix5lDpkKaHR7Xg"}`)
+	sessionKey := antigravityReasoningReplayScopeFromPayload(model, payload).sessionKey
+	if !internalcache.CacheAntigravityReasoningReplayItems(model, sessionKey, [][]byte{item}) {
+		t.Fatal("failed to cache replay item")
+	}
+	opts := cliproxyexecutor.Options{}
+
+	out, _, errPrepare := prepareAntigravityGeminiReasoningReplayPayload(context.Background(), model, cliproxyexecutor.Request{Model: model, Payload: payload}, opts, payload)
+	if errPrepare != nil {
+		t.Fatalf("prepareAntigravityGeminiReasoningReplayPayload error: %v, want graceful degradation to original payload", errPrepare)
+	}
+	if !bytes.Equal(out, payload) {
+		t.Fatalf("out = %s, want original payload %s", out, payload)
+	}
+}

--- a/internal/runtime/executor/codex_executor_request.go
+++ b/internal/runtime/executor/codex_executor_request.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	codexUserAgent             = "codex-tui/0.153.3 (Mac OS 26.5.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.153.3)"
+	codexUserAgent             = "codex-tui/0.154.0 (Mac OS 26.5.2; arm64) iTerm.app/3.6.11 (codex-tui; 0.154.0)"
 	codexOriginator            = "codex-tui"
 	codexDefaultImageToolModel = "gpt-image-2"
 	codexResponsesLiteHeader   = "X-OpenAI-Internal-Codex-Responses-Lite"

--- a/internal/runtime/executor/codex_executor_spawn_agent_test.go
+++ b/internal/runtime/executor/codex_executor_spawn_agent_test.go
@@ -234,7 +234,7 @@ func codexSpawnAgentTestPayload() []byte {
 
 func codexSpawnAgentTestContext() context.Context {
 	request := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
-	request.Header.Set("User-Agent", "codex-tui/0.153.3")
+	request.Header.Set("User-Agent", "codex-tui/0.154.0")
 	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
 	ginCtx.Request = request
 	return context.WithValue(context.Background(), "gin", ginCtx)

--- a/internal/runtime/executor/codex_websockets_executor_test.go
+++ b/internal/runtime/executor/codex_websockets_executor_test.go
@@ -1822,7 +1822,7 @@ func TestApplyCodexWebsocketHeaders_EmptyAPIKey_OmitsAuthorizationAndOAuthHeader
 }
 
 func TestApplyModelHeaderOverridesFromModelConfig(t *testing.T) {
-	const wantUA = "codex-tui/0.153.3 (Mac OS 26.5.1; arm64) iTerm.app/3.6.11 (codex-tui; 0.153.3)"
+	const wantUA = "codex-tui/0.154.0 (Mac OS 26.5.2; arm64) iTerm.app/3.6.11 (codex-tui; 0.154.0)"
 	req, err := http.NewRequest(http.MethodPost, "https://example.com/responses", nil)
 	if err != nil {
 		t.Fatalf("NewRequest() error = %v", err)

--- a/internal/runtime/executor/helps/usage_helpers.go
+++ b/internal/runtime/executor/helps/usage_helpers.go
@@ -25,6 +25,7 @@ import (
 
 type UsageReporter struct {
 	provider            string
+	baseURL             string
 	executorType        string
 	model               string
 	alias               string
@@ -81,8 +82,20 @@ func NewUsageReporter(ctx context.Context, provider, model string, auth *cliprox
 			parentSessionID = ""
 		}
 	}
+	baseURL := ""
+	if auth != nil {
+		if auth.Attributes != nil {
+			baseURL = strings.TrimSpace(auth.Attributes["base_url"])
+		}
+		if baseURL == "" && auth.Metadata != nil {
+			if v, ok := auth.Metadata["base_url"].(string); ok {
+				baseURL = strings.TrimSpace(v)
+			}
+		}
+	}
 	reporter := &UsageReporter{
 		provider:        provider,
+		baseURL:         baseURL,
 		model:           model,
 		alias:           strings.TrimSpace(alias),
 		requestedAt:     time.Now(),
@@ -433,6 +446,7 @@ func (r *UsageReporter) buildRecordForModel(model string, detail usage.Detail, f
 	}
 	return usage.Record{
 		Provider:            r.provider,
+		BaseURL:             r.baseURL,
 		ExecutorType:        r.executorType,
 		Model:               model,
 		Alias:               r.alias,

--- a/internal/runtime/executor/helps/usage_helpers_test.go
+++ b/internal/runtime/executor/helps/usage_helpers_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/clienterror"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/logging"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 	"github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/usage"
 )
@@ -1092,5 +1093,76 @@ func TestUsageReporterPropagatesSessionHierarchy(t *testing.T) {
 	recordAlias2 := reporterAlias.buildRecord(usage.Detail{TotalTokens: 100}, false, usage.Failure{})
 	if recordAlias2.SessionID != "pck:key-999" || recordAlias2.ParentSessionID != "" {
 		t.Fatalf("SetSessionHierarchy cross prefix alias emitted as parent: (%q, %q), want (pck:key-999, empty)", recordAlias2.SessionID, recordAlias2.ParentSessionID)
+	}
+}
+
+func TestUsageReporterPropagatesBaseURL(t *testing.T) {
+	ctx := context.Background()
+	auth := &cliproxyauth.Auth{
+		ID:       "auth-base-url-test",
+		Provider: "codex",
+		Attributes: map[string]string{
+			"api_key":  "test-api-key",
+			"base_url": "https://custom.endpoint.example.com/v1",
+		},
+	}
+	reporter := NewUsageReporter(ctx, "codex", "gpt-5.6-luna", auth)
+	record := reporter.buildRecord(usage.Detail{TotalTokens: 10}, false, usage.Failure{})
+	if record.BaseURL != "https://custom.endpoint.example.com/v1" {
+		t.Fatalf("record.BaseURL = %q, want %q", record.BaseURL, "https://custom.endpoint.example.com/v1")
+	}
+
+	authMeta := &cliproxyauth.Auth{
+		ID:       "auth-meta-base-url-test",
+		Provider: "openai",
+		Metadata: map[string]any{
+			"base_url": "https://meta.endpoint.example.com/v1",
+		},
+	}
+	reporterMeta := NewUsageReporter(ctx, "openai", "gpt-5.4", authMeta)
+	recordMeta := reporterMeta.buildRecord(usage.Detail{TotalTokens: 10}, false, usage.Failure{})
+	if recordMeta.BaseURL != "https://meta.endpoint.example.com/v1" {
+		t.Fatalf("recordMeta.BaseURL = %q, want %q", recordMeta.BaseURL, "https://meta.endpoint.example.com/v1")
+	}
+
+	// Attribute precedence over metadata
+	authBoth := &cliproxyauth.Auth{
+		ID:       "auth-both-test",
+		Provider: "openai",
+		Attributes: map[string]string{
+			"base_url": "https://attr.example.com",
+		},
+		Metadata: map[string]any{
+			"base_url": "https://meta.example.com",
+		},
+	}
+	reporterBoth := NewUsageReporter(ctx, "openai", "gpt-5.4", authBoth)
+	recordBoth := reporterBoth.buildRecord(usage.Detail{TotalTokens: 10}, false, usage.Failure{})
+	if recordBoth.BaseURL != "https://attr.example.com" {
+		t.Fatalf("recordBoth.BaseURL = %q, want %q", recordBoth.BaseURL, "https://attr.example.com")
+	}
+
+	// Blank attribute falls back to metadata
+	authBlankAttr := &cliproxyauth.Auth{
+		ID:       "auth-blank-test",
+		Provider: "openai",
+		Attributes: map[string]string{
+			"base_url": "   ",
+		},
+		Metadata: map[string]any{
+			"base_url": "https://meta.example.com",
+		},
+	}
+	reporterBlankAttr := NewUsageReporter(ctx, "openai", "gpt-5.4", authBlankAttr)
+	recordBlankAttr := reporterBlankAttr.buildRecord(usage.Detail{TotalTokens: 10}, false, usage.Failure{})
+	if recordBlankAttr.BaseURL != "https://meta.example.com" {
+		t.Fatalf("recordBlankAttr.BaseURL = %q, want %q", recordBlankAttr.BaseURL, "https://meta.example.com")
+	}
+
+	// Nil auth or unconfigured auth leaves BaseURL empty
+	reporterNilAuth := NewUsageReporter(ctx, "openai", "gpt-5.4", nil)
+	recordNilAuth := reporterNilAuth.buildRecord(usage.Detail{TotalTokens: 10}, false, usage.Failure{})
+	if recordNilAuth.BaseURL != "" {
+		t.Fatalf("recordNilAuth.BaseURL = %q, want empty", recordNilAuth.BaseURL)
 	}
 }

--- a/internal/store/disabled_login_save_test.go
+++ b/internal/store/disabled_login_save_test.go
@@ -1,0 +1,65 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestRemoteStoresDisabledLoginReachesTokenStorage(t *testing.T) {
+	tests := []struct {
+		name  string
+		store cliproxyauth.Store
+	}{
+		{
+			name: "postgres",
+			store: &PostgresStore{
+				authDir: filepath.Join(t.TempDir(), "auths"),
+			},
+		},
+		{
+			name: "object",
+			store: &ObjectTokenStore{
+				authDir: filepath.Join(t.TempDir(), "auths"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errReachedStorage := errors.New("reached token storage")
+			storageReached := false
+			auth := &cliproxyauth.Auth{
+				ID:       "canonical-disabled.json",
+				FileName: "canonical-disabled.json",
+				Provider: "claude",
+				Disabled: true,
+				Storage: &callbackTokenStorage{save: func(string) error {
+					storageReached = true
+					return errReachedStorage
+				}},
+				Metadata: map[string]any{"type": "claude"},
+			}
+
+			savedPath, errSave := tt.store.Save(context.Background(), auth)
+			if errSave != nil {
+				t.Fatalf("runtime Save() error = %v", errSave)
+			}
+			if savedPath != "" {
+				t.Fatalf("runtime Save() path = %q, want empty", savedPath)
+			}
+			if storageReached {
+				t.Fatal("runtime Save() reached token storage for a missing disabled credential")
+			}
+
+			ctx := cliproxyauth.WithAuthCreationIntent(context.Background())
+			_, errSave = tt.store.Save(ctx, auth)
+			if !errors.Is(errSave, errReachedStorage) {
+				t.Fatalf("Save() error = %v, want token storage sentinel", errSave)
+			}
+		})
+	}
+}

--- a/internal/store/gitstore.go
+++ b/internal/store/gitstore.go
@@ -404,7 +404,7 @@ func (s *GitTokenStore) ensureRepositoryLocked() (errResult error) {
 }
 
 // Save persists token storage and metadata to the resolved auth file path.
-func (s *GitTokenStore) Save(_ context.Context, auth *cliproxyauth.Auth) (string, error) {
+func (s *GitTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (string, error) {
 	if auth == nil {
 		return "", fmt.Errorf("auth filestore: auth is nil")
 	}
@@ -424,7 +424,10 @@ func (s *GitTokenStore) Save(_ context.Context, auth *cliproxyauth.Auth) (string
 		return "", fmt.Errorf("auth filestore: missing file path attribute for %s", auth.ID)
 	}
 
-	if auth.Disabled {
+	// Runtime updates must not recreate a disabled credential whose source file
+	// was deliberately removed. Login and migration callers explicitly mark the
+	// save when creating a missing disabled credential is intentional.
+	if auth.Disabled && !cliproxyauth.HasAuthCreationIntent(ctx) {
 		if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
 			return "", nil
 		}

--- a/internal/store/gitstore_test.go
+++ b/internal/store/gitstore_test.go
@@ -32,6 +32,45 @@ func (s *callbackTokenStorage) SaveTokenToFile(path string) error {
 	return s.save(path)
 }
 
+func TestGitTokenStoreDisabledLoginReachesTokenStorage(t *testing.T) {
+	root := t.TempDir()
+	remoteDir := setupGitRemoteRepository(t, root, "master",
+		testBranchSpec{name: "master", contents: "remote default branch\n"},
+	)
+	store := NewGitTokenStore(remoteDir, "", "", "")
+	store.SetBaseDir(filepath.Join(root, "workspace", "auths"))
+	errReachedStorage := errors.New("reached token storage")
+	storageReached := false
+	auth := &cliproxyauth.Auth{
+		ID:       "canonical-disabled.json",
+		FileName: "canonical-disabled.json",
+		Provider: "claude",
+		Disabled: true,
+		Storage: &callbackTokenStorage{save: func(string) error {
+			storageReached = true
+			return errReachedStorage
+		}},
+		Metadata: map[string]any{"type": "claude"},
+	}
+
+	savedPath, errSave := store.Save(context.Background(), auth)
+	if errSave != nil {
+		t.Fatalf("runtime Save() error = %v", errSave)
+	}
+	if savedPath != "" {
+		t.Fatalf("runtime Save() path = %q, want empty", savedPath)
+	}
+	if storageReached {
+		t.Fatal("runtime Save() reached token storage for a missing disabled credential")
+	}
+
+	ctx := cliproxyauth.WithAuthCreationIntent(context.Background())
+	_, errSave = store.Save(ctx, auth)
+	if !errors.Is(errSave, errReachedStorage) {
+		t.Fatalf("Save() error = %v, want token storage sentinel", errSave)
+	}
+}
+
 func TestEnsureRepositoryUsesRemoteDefaultBranchWhenBranchNotConfigured(t *testing.T) {
 	root := t.TempDir()
 	remoteDir := setupGitRemoteRepository(t, root, "trunk",

--- a/internal/store/objectstore.go
+++ b/internal/store/objectstore.go
@@ -173,7 +173,10 @@ func (s *ObjectTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (s
 		return "", fmt.Errorf("object store: missing file path attribute for %s", auth.ID)
 	}
 
-	if auth.Disabled {
+	// Runtime updates must not recreate a disabled credential whose source file
+	// was deliberately removed. Login and migration callers explicitly mark the
+	// save when creating a missing disabled credential is intentional.
+	if auth.Disabled && !cliproxyauth.HasAuthCreationIntent(ctx) {
 		if _, statErr := os.Stat(path); errors.Is(statErr, fs.ErrNotExist) {
 			return "", nil
 		}

--- a/internal/store/postgresstore.go
+++ b/internal/store/postgresstore.go
@@ -224,7 +224,10 @@ func (s *PostgresStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (stri
 		return "", fmt.Errorf("postgres store: missing file path attribute for %s", auth.ID)
 	}
 
-	if auth.Disabled {
+	// Runtime updates must not recreate a disabled credential whose source file
+	// was deliberately removed. Login and migration callers explicitly mark the
+	// save when creating a missing disabled credential is intentional.
+	if auth.Disabled && !cliproxyauth.HasAuthCreationIntent(ctx) {
 		if _, statErr := os.Stat(path); errors.Is(statErr, fs.ErrNotExist) {
 			return "", nil
 		}

--- a/internal/translator/antigravity/claude/antigravity_claude_response.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_response.go
@@ -320,25 +320,20 @@ func ConvertAntigravityResponseToClaude(ctx context.Context, _ string, originalR
 					if hasThoughtSignature {
 						signatureTargetsVisibleText = appendPartSignature(thoughtSignatureResult.String(), geminiClaudeCarrierNext, geminiClaudeCarrierText)
 					}
-					finishReasonResult := gjson.GetBytes(rawJSON, "response.candidates.0.finishReason")
-					if partText != "" || !finishReasonResult.Exists() {
-						if params.ResponseType == 1 {
-							data, _ := sjson.SetBytes([]byte(fmt.Sprintf(`{"type":"content_block_delta","index":%d,"delta":{"type":"text_delta","text":""}}`, params.ResponseIndex)), "delta.text", partText)
-							appendEvent("content_block_delta", string(data))
-							params.HasContent = true
-						} else {
-							if params.ResponseType != 0 {
-								appendEvent("content_block_stop", fmt.Sprintf(`{"type":"content_block_stop","index":%d}`, params.ResponseIndex))
-								params.ResponseIndex++
-							}
-							if partText != "" {
-								appendEvent("content_block_start", fmt.Sprintf(`{"type":"content_block_start","index":%d,"content_block":{"type":"text","text":""}}`, params.ResponseIndex))
-								data, _ := sjson.SetBytes([]byte(fmt.Sprintf(`{"type":"content_block_delta","index":%d,"delta":{"type":"text_delta","text":""}}`, params.ResponseIndex)), "delta.text", partText)
-								appendEvent("content_block_delta", string(data))
-								params.ResponseType = 1
-								params.HasContent = true
-							}
+					if params.ResponseType == 1 {
+						data, _ := sjson.SetBytes([]byte(fmt.Sprintf(`{"type":"content_block_delta","index":%d,"delta":{"type":"text_delta","text":""}}`, params.ResponseIndex)), "delta.text", partText)
+						appendEvent("content_block_delta", string(data))
+						params.HasContent = true
+					} else if partText != "" {
+						if params.ResponseType != 0 {
+							appendEvent("content_block_stop", fmt.Sprintf(`{"type":"content_block_stop","index":%d}`, params.ResponseIndex))
+							params.ResponseIndex++
 						}
+						appendEvent("content_block_start", fmt.Sprintf(`{"type":"content_block_start","index":%d,"content_block":{"type":"text","text":""}}`, params.ResponseIndex))
+						data, _ := sjson.SetBytes([]byte(fmt.Sprintf(`{"type":"content_block_delta","index":%d,"delta":{"type":"text_delta","text":""}}`, params.ResponseIndex)), "delta.text", partText)
+						appendEvent("content_block_delta", string(data))
+						params.ResponseType = 1
+						params.HasContent = true
 					}
 					if partText != "" {
 						params.HasSemanticContent = true

--- a/internal/translator/antigravity/claude/antigravity_claude_response_test.go
+++ b/internal/translator/antigravity/claude/antigravity_claude_response_test.go
@@ -1441,3 +1441,127 @@ func TestConvertAntigravityResponseToClaude_EmitsNativeSignaturesWithoutProvider
 		t.Fatalf("Claude native thought/tool signatures did not round-trip in cache mode: %s", translated)
 	}
 }
+
+func TestConvertAntigravityResponseToClaudeStream_EmptyTextPartKeepsThinkingBlockOpen(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-3-flash-agent"}`)
+	thinkingChunk := []byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Thinking","thought":true}]}}],"responseId":"resp-1"}}`)
+	emptyTextChunk := []byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":""}]}}]}}`)
+	finishChunk := []byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":""}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":100,"thoughtsTokenCount":20,"totalTokenCount":120}}}`)
+
+	var param any
+	ctx := context.Background()
+	output1 := bytes.Join(ConvertAntigravityResponseToClaude(ctx, "gemini-3-flash-agent", requestJSON, requestJSON, thinkingChunk, &param), nil)
+	if !strings.Contains(string(output1), `"type":"content_block_start","index":0,"content_block":{"type":"thinking"`) {
+		t.Fatalf("expected thinking block start at index 0: %s", string(output1))
+	}
+
+	// Verify empty text chunk does not close thinking block or emit content_block_stop
+	output2 := bytes.Join(ConvertAntigravityResponseToClaude(ctx, "gemini-3-flash-agent", requestJSON, requestJSON, emptyTextChunk, &param), nil)
+	if strings.Contains(string(output2), "content_block_stop") {
+		t.Fatalf("empty text chunk should not emit content_block_stop: %s", string(output2))
+	}
+
+	output3 := bytes.Join(ConvertAntigravityResponseToClaude(ctx, "gemini-3-flash-agent", requestJSON, requestJSON, finishChunk, &param), nil)
+	output4 := bytes.Join(ConvertAntigravityResponseToClaude(ctx, "gemini-3-flash-agent", requestJSON, requestJSON, []byte("[DONE]"), &param), nil)
+
+	fullOutput := string(output1) + string(output2) + string(output3) + string(output4)
+
+	started := make(map[int64]bool)
+	stopped := make(map[int64]bool)
+	for _, line := range strings.Split(fullOutput, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "data: ") {
+			continue
+		}
+		data := strings.TrimPrefix(trimmed, "data: ")
+		eventType := gjson.Get(data, "type").String()
+		switch eventType {
+		case "content_block_start":
+			idx := gjson.Get(data, "index").Int()
+			started[idx] = true
+		case "content_block_delta":
+			idx := gjson.Get(data, "index").Int()
+			if !started[idx] {
+				t.Fatalf("event %s for index %d before content_block_start; full stream:\n%s", eventType, idx, fullOutput)
+			}
+			if stopped[idx] {
+				t.Fatalf("event %s for index %d after content_block_stop; full stream:\n%s", eventType, idx, fullOutput)
+			}
+		case "content_block_stop":
+			idx := gjson.Get(data, "index").Int()
+			if !started[idx] {
+				t.Fatalf("event %s for index %d before content_block_start; full stream:\n%s", eventType, idx, fullOutput)
+			}
+			if stopped[idx] {
+				t.Fatalf("duplicate content_block_stop for index %d; full stream:\n%s", idx, fullOutput)
+			}
+			stopped[idx] = true
+		}
+	}
+
+	if len(started) != 1 || !started[0] {
+		t.Fatalf("expected exactly 1 started block at index 0, got: %v", started)
+	}
+	if len(stopped) != 1 || !stopped[0] {
+		t.Fatalf("expected exactly 1 stopped block at index 0, got: %v", stopped)
+	}
+}
+
+func TestConvertAntigravityResponseToClaudeStream_EmptyTextPartFollowedByThinkingAndText(t *testing.T) {
+	requestJSON := []byte(`{"model":"gemini-3-flash-agent"}`)
+	thinkingChunk1 := []byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Thinking 1... ","thought":true}]}}],"responseId":"resp-2"}}`)
+	emptyTextChunk := []byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":""}]}}]}}`)
+	thinkingChunk2 := []byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Thinking 2...","thought":true}]}}]}}`)
+	textChunk := []byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello world"}]}}]}}`)
+	finishChunk := []byte(`{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":""}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":100,"thoughtsTokenCount":20,"totalTokenCount":120}}}`)
+
+	var param any
+	ctx := context.Background()
+	output := bytes.Join(ConvertAntigravityResponseToClaude(ctx, "gemini-3-flash-agent", requestJSON, requestJSON, thinkingChunk1, &param), nil)
+	output = append(output, bytes.Join(ConvertAntigravityResponseToClaude(ctx, "gemini-3-flash-agent", requestJSON, requestJSON, emptyTextChunk, &param), nil)...)
+	output = append(output, bytes.Join(ConvertAntigravityResponseToClaude(ctx, "gemini-3-flash-agent", requestJSON, requestJSON, thinkingChunk2, &param), nil)...)
+	output = append(output, bytes.Join(ConvertAntigravityResponseToClaude(ctx, "gemini-3-flash-agent", requestJSON, requestJSON, textChunk, &param), nil)...)
+	output = append(output, bytes.Join(ConvertAntigravityResponseToClaude(ctx, "gemini-3-flash-agent", requestJSON, requestJSON, finishChunk, &param), nil)...)
+	output = append(output, bytes.Join(ConvertAntigravityResponseToClaude(ctx, "gemini-3-flash-agent", requestJSON, requestJSON, []byte("[DONE]"), &param), nil)...)
+
+	fullOutput := string(output)
+	started := make(map[int64]bool)
+	stopped := make(map[int64]bool)
+	for _, line := range strings.Split(fullOutput, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "data: ") {
+			continue
+		}
+		data := strings.TrimPrefix(trimmed, "data: ")
+		eventType := gjson.Get(data, "type").String()
+		switch eventType {
+		case "content_block_start":
+			idx := gjson.Get(data, "index").Int()
+			started[idx] = true
+		case "content_block_delta":
+			idx := gjson.Get(data, "index").Int()
+			if !started[idx] {
+				t.Fatalf("event %s for index %d before content_block_start; full stream:\n%s", eventType, idx, fullOutput)
+			}
+			if stopped[idx] {
+				t.Fatalf("event %s for index %d after content_block_stop; full stream:\n%s", eventType, idx, fullOutput)
+			}
+		case "content_block_stop":
+			idx := gjson.Get(data, "index").Int()
+			if !started[idx] {
+				t.Fatalf("event %s for index %d before content_block_start; full stream:\n%s", eventType, idx, fullOutput)
+			}
+			if stopped[idx] {
+				t.Fatalf("duplicate content_block_stop for index %d; full stream:\n%s", idx, fullOutput)
+			}
+			stopped[idx] = true
+		}
+	}
+
+	if len(started) != 2 || !started[0] || !started[1] {
+		t.Fatalf("expected exactly 2 started blocks (0=thinking, 1=text), got: %v", started)
+	}
+	if len(stopped) != 2 || !stopped[0] || !stopped[1] {
+		t.Fatalf("expected exactly 2 stopped blocks (0=thinking, 1=text), got: %v", stopped)
+	}
+}

--- a/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request_test.go
+++ b/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request_test.go
@@ -596,3 +596,149 @@ func TestConvertOpenAIResponsesRequestToAntigravity_FunctionCallOutputAlternateI
 		t.Fatalf("functionResponse.id = %q, want call_bash_1", responseID)
 	}
 }
+
+func TestConvertOpenAIResponsesRequestToAntigravity_InterruptedFunctionCallPreservesPairing(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.8-flash-high",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"List the files."}]},
+			{"type":"function_call","call_id":"c1","name":"shell","arguments":"{\"command\":[\"ls\"]}"},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"Stop, do something else instead."}]},
+			{"type":"function_call","call_id":"c2","name":"shell","arguments":"{\"command\":[\"pwd\"]}"},
+			{"type":"function_call_output","call_id":"c2","output":"/tmp\n"}
+		],
+		"tools": [{"type":"function","name":"shell","description":"Runs a shell command.","strict":false,
+			"parameters":{"type":"object","properties":{"command":{"type":"array","items":{"type":"string"}}},
+			"required":["command"],"additionalProperties":false}}],
+		"tool_choice": "auto",
+		"parallel_tool_calls": false,
+		"store": false,
+		"stream": false
+	}`
+
+	out := ConvertOpenAIResponsesRequestToAntigravity("gemini-3.8-flash-high", []byte(inputJSON), false)
+	rawRequest := gjson.GetBytes(out, "request").Raw
+	if errPair := sigcompat.ValidateGeminiFunctionCallPairing([]byte(rawRequest)); errPair != nil {
+		t.Fatalf("ValidateGeminiFunctionCallPairing failed on Antigravity request: %v; output=%s", errPair, out)
+	}
+
+	c1Resp := gjson.GetBytes(out, "request.contents.2.parts.0.functionResponse")
+	if c1Resp.Get("id").String() != "c1" || c1Resp.Get("name").String() != "shell" || c1Resp.Get("response.result").String() != "call interrupted, no output" {
+		t.Fatalf("unexpected synthesized response for c1: %s", c1Resp.Raw)
+	}
+	c2Resp := gjson.GetBytes(out, "request.contents.5.parts.0.functionResponse")
+	if c2Resp.Get("id").String() != "c2" || c2Resp.Get("name").String() != "shell" || c2Resp.Get("response.result").String() != "/tmp\n" {
+		t.Fatalf("unexpected real response for c2: %s", c2Resp.Raw)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToAntigravity_ParallelInterruptedFunctionCallPreservesPairingAndOrder(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.8-flash-high",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"List and print."}]},
+			{"type":"function_call","call_id":"c1","name":"shell","arguments":"{\"command\":[\"ls\"]}"},
+			{"type":"function_call","call_id":"c2","name":"shell","arguments":"{\"command\":[\"pwd\"]}"},
+			{"type":"function_call_output","call_id":"c2","output":"/tmp\n"},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"Stop, do something else instead."}]},
+			{"type":"function_call","call_id":"c3","name":"shell","arguments":"{\"command\":[\"whoami\"]}"},
+			{"type":"function_call_output","call_id":"c3","output":"root\n"}
+		],
+		"tools": [{"type":"function","name":"shell","description":"Runs a shell command.","strict":false,
+			"parameters":{"type":"object","properties":{"command":{"type":"array","items":{"type":"string"}}},
+			"required":["command"],"additionalProperties":false}}],
+		"tool_choice": "auto",
+		"parallel_tool_calls": false,
+		"store": false,
+		"stream": false
+	}`
+
+	out := ConvertOpenAIResponsesRequestToAntigravity("gemini-3.8-flash-high", []byte(inputJSON), false)
+	rawRequest := gjson.GetBytes(out, "request").Raw
+	if errPair := sigcompat.ValidateGeminiFunctionCallPairing([]byte(rawRequest)); errPair != nil {
+		t.Fatalf("ValidateGeminiFunctionCallPairing failed on Antigravity request: %v; output=%s", errPair, out)
+	}
+
+	c1Resp := gjson.GetBytes(out, "request.contents.2.parts.0.functionResponse")
+	if c1Resp.Get("id").String() != "c1" || c1Resp.Get("name").String() != "shell" || c1Resp.Get("response.result").String() != "call interrupted, no output" {
+		t.Fatalf("unexpected synthesized response for c1: %s", c1Resp.Raw)
+	}
+	c2Resp := gjson.GetBytes(out, "request.contents.2.parts.1.functionResponse")
+	if c2Resp.Get("id").String() != "c2" || c2Resp.Get("name").String() != "shell" || c2Resp.Get("response.result").String() != "/tmp\n" {
+		t.Fatalf("unexpected real response for c2: %s", c2Resp.Raw)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToAntigravity_TrailingPartialParallelCallsPreservesPairingAndOrder(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.8-flash-high",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"List and print."}]},
+			{"type":"function_call","call_id":"c1","name":"shell","arguments":"{\"command\":[\"ls\"]}"},
+			{"type":"function_call","call_id":"c2","name":"shell","arguments":"{\"command\":[\"pwd\"]}"},
+			{"type":"function_call_output","call_id":"c2","output":"/tmp\n"}
+		],
+		"tools": [{"type":"function","name":"shell","description":"Runs a shell command.","strict":false,
+			"parameters":{"type":"object","properties":{"command":{"type":"array","items":{"type":"string"}}},
+			"required":["command"],"additionalProperties":false}}],
+		"tool_choice": "auto",
+		"parallel_tool_calls": false,
+		"store": false,
+		"stream": false
+	}`
+
+	out := ConvertOpenAIResponsesRequestToAntigravity("gemini-3.8-flash-high", []byte(inputJSON), false)
+	rawRequest := gjson.GetBytes(out, "request").Raw
+	if errPair := sigcompat.ValidateGeminiFunctionCallPairing([]byte(rawRequest)); errPair != nil {
+		t.Fatalf("ValidateGeminiFunctionCallPairing failed on Antigravity trailing partial parallel request: %v; output=%s", errPair, out)
+	}
+
+	c1Resp := gjson.GetBytes(out, "request.contents.2.parts.0.functionResponse")
+	if c1Resp.Get("id").String() != "c1" || c1Resp.Get("name").String() != "shell" || c1Resp.Get("response.result").String() != "call interrupted, no output" {
+		t.Fatalf("unexpected synthesized response for c1: %s", c1Resp.Raw)
+	}
+	c2Resp := gjson.GetBytes(out, "request.contents.2.parts.1.functionResponse")
+	if c2Resp.Get("id").String() != "c2" || c2Resp.Get("name").String() != "shell" || c2Resp.Get("response.result").String() != "/tmp\n" {
+		t.Fatalf("unexpected real response for c2: %s", c2Resp.Raw)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToAntigravity_InterruptedMessageBeforeRealOutputPreservesPairingAndOrder(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.8-flash-high",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"List and print."}]},
+			{"type":"function_call","call_id":"c1","name":"shell","arguments":"{\"command\":[\"ls\"]}"},
+			{"type":"function_call","call_id":"c2","name":"shell","arguments":"{\"command\":[\"pwd\"]}"},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"Stop, do something else instead."}]},
+			{"type":"function_call_output","call_id":"c2","output":"/tmp\n"}
+		],
+		"tools": [{"type":"function","name":"shell","description":"Runs a shell command.","strict":false,
+			"parameters":{"type":"object","properties":{"command":{"type":"array","items":{"type":"string"}}},
+			"required":["command"],"additionalProperties":false}}],
+		"tool_choice": "auto",
+		"parallel_tool_calls": false,
+		"store": false,
+		"stream": false
+	}`
+
+	out := ConvertOpenAIResponsesRequestToAntigravity("gemini-3.8-flash-high", []byte(inputJSON), false)
+	rawRequest := gjson.GetBytes(out, "request").Raw
+	if errPair := sigcompat.ValidateGeminiFunctionCallPairing([]byte(rawRequest)); errPair != nil {
+		t.Fatalf("ValidateGeminiFunctionCallPairing failed on Antigravity interrupted message before real output request: %v; output=%s", errPair, out)
+	}
+
+	// The user message precedes the completed tool response turn
+	stopText := gjson.GetBytes(out, "request.contents.2.parts.0.text").String()
+	if stopText != "Stop, do something else instead." {
+		t.Fatalf("unexpected text in request.contents[2]: %q", stopText)
+	}
+	c1Resp := gjson.GetBytes(out, "request.contents.3.parts.0.functionResponse")
+	if c1Resp.Get("id").String() != "c1" || c1Resp.Get("name").String() != "shell" || c1Resp.Get("response.result").String() != "call interrupted, no output" {
+		t.Fatalf("unexpected synthesized response for c1: %s", c1Resp.Raw)
+	}
+	c2Resp := gjson.GetBytes(out, "request.contents.3.parts.1.functionResponse")
+	if c2Resp.Get("id").String() != "c2" || c2Resp.Get("name").String() != "shell" || c2Resp.Get("response.result").String() != "/tmp\n" {
+		t.Fatalf("unexpected real response for c2: %s", c2Resp.Raw)
+	}
+}

--- a/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request_test.go
+++ b/internal/translator/antigravity/openai/responses/antigravity_openai-responses_request_test.go
@@ -742,3 +742,44 @@ func TestConvertOpenAIResponsesRequestToAntigravity_InterruptedMessageBeforeReal
 		t.Fatalf("unexpected real response for c2: %s", c2Resp.Raw)
 	}
 }
+
+func TestConvertOpenAIResponsesRequestToAntigravity_FunctionCallOutputWithFCOItemID(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.7-flash-high",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"run command"}]},
+			{"type":"function_call","call_id":"call_1788961125480214178_817","name":"Bash","arguments":"{\"command\":\"pwd\"}"},
+			{"type":"function_call_output","id":"fco_01a08664-2d16-7a91-8ab2-2eccd49e4c3e","output":"/tmp"}
+		],
+		"tools": [{"type":"function","name":"Bash","description":"Runs Bash command.","strict":false,
+			"parameters":{"type":"object","properties":{"command":{"type":"string"}},
+			"required":["command"],"additionalProperties":false}}],
+		"tool_choice": "auto",
+		"parallel_tool_calls": false,
+		"store": false,
+		"stream": false
+	}`
+
+	out := ConvertOpenAIResponsesRequestToAntigravity("gemini-3.7-flash-high", []byte(inputJSON), false)
+	rawRequest := gjson.GetBytes(out, "request").Raw
+	if errPair := sigcompat.ValidateGeminiFunctionCallPairing([]byte(rawRequest)); errPair != nil {
+		t.Fatalf("ValidateGeminiFunctionCallPairing failed on Antigravity fco item ID request: %v; output=%s", errPair, out)
+	}
+
+	contents := gjson.GetBytes(out, "request.contents").Array()
+	if len(contents) != 3 {
+		t.Fatalf("expected 3 contents, got %d; output=%s", len(contents), string(out))
+	}
+
+	responses := contents[2].Get("parts").Array()
+	if len(responses) != 1 {
+		t.Fatalf("expected 1 response part, got %d; output=%s", len(responses), string(out))
+	}
+
+	if gotID := responses[0].Get("functionResponse.id").String(); gotID != "call_1788961125480214178_817" {
+		t.Fatalf("response id = %q, want call_1788961125480214178_817", gotID)
+	}
+	if gotName := responses[0].Get("functionResponse.name").String(); gotName != "Bash" {
+		t.Fatalf("response name = %q, want Bash", gotName)
+	}
+}

--- a/internal/translator/codex/claude/codex_claude_compat_test.go
+++ b/internal/translator/codex/claude/codex_claude_compat_test.go
@@ -22,3 +22,99 @@ func TestConvertClaudeRequestToCodexWithCompatPreservesEmptyThinking(t *testing.
 		t.Fatalf("compat translation missing empty encrypted_content: %s", withCompat)
 	}
 }
+
+func TestConvertClaudeRequestToCodexWithCompat_UnknownThinkingSignatures(t *testing.T) {
+	const unknownSig = "opaque-encrypted-reasoning-token-xyz"
+	unknownPayload := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"` + unknownSig + `"}]}]}`)
+
+	withCompatNonStream := ConvertClaudeRequestToCodexWithCompat("deepseek-v4", unknownPayload, false)
+	if gjson.GetBytes(withCompatNonStream, "input.0.type").String() != "reasoning" || gjson.GetBytes(withCompatNonStream, "input.0.encrypted_content").String() != unknownSig {
+		t.Fatalf("compat non-stream translation failed to preserve unknown signature: %s", withCompatNonStream)
+	}
+
+	withCompatStream := ConvertClaudeRequestToCodexWithCompat("deepseek-v4", unknownPayload, true)
+	if gjson.GetBytes(withCompatStream, "input.0.type").String() != "reasoning" || gjson.GetBytes(withCompatStream, "input.0.encrypted_content").String() != unknownSig {
+		t.Fatalf("compat stream translation failed to preserve unknown signature: %s", withCompatStream)
+	}
+
+	withoutCompatNonStream := ConvertClaudeRequestToCodex("deepseek-v4", unknownPayload, false)
+	if gjson.GetBytes(withoutCompatNonStream, "input.#").Int() != 0 {
+		t.Fatalf("non-compat translation unexpectedly preserved unknown signature: %s", withoutCompatNonStream)
+	}
+
+	withoutCompatStream := ConvertClaudeRequestToCodex("deepseek-v4", unknownPayload, true)
+	if gjson.GetBytes(withoutCompatStream, "input.#").Int() != 0 {
+		t.Fatalf("non-compat stream translation unexpectedly preserved unknown signature: %s", withoutCompatStream)
+	}
+
+	const claudeSig = "CAISqwIKiAEIEBgCKkBHRlRBsNiptQUWfPoOhuQKwi5LnncZVO9bB5jqOs76D7uBtgktML0zqJtNmLHXHHcgD6lk4MQu4QBXzFd1lbC3Mg5jbGF1ZGUtZmFibGUtNTgBQgh0aGlua2luZ1okZDk3NDM5NzUtNGJiMC00OTM2LTllMjgtZDViMGQyMWJkYzQ4EgxCGh+XVFFFeySAjtAaDL/A1LltGu6MMJ+eXSIwsN0oBpDrqLv22UBfkMnTotnIbkvkOyb9xZHgigG6OZVHaI3gThm+maLKmgO5PrFLKlDFYp+YZksy/wKwszJlnLTPzAK+NUlfzagOE1ymtZTXhAYK260XyFYmg/te/C231+Fr/hoX+EJoUBnrn0gD7hqMISOT+TaFEuOXYsN517GfaxgB"
+	claudePayload := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"` + claudeSig + `"}]}]}`)
+	claudeCompat := ConvertClaudeRequestToCodexWithCompat("deepseek-v4", claudePayload, false)
+	if gjson.GetBytes(claudeCompat, "input.#").Int() != 0 {
+		t.Fatalf("compat translation unexpectedly preserved valid Claude signature: %s", claudeCompat)
+	}
+
+	gptRawSig := validCodexReasoningSignature()
+	gptPayload := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"gpt#` + gptRawSig + `"}]}]}`)
+	gptCompat := ConvertClaudeRequestToCodexWithCompat("deepseek-v4", gptPayload, false)
+	if gjson.GetBytes(gptCompat, "input.0.type").String() != "reasoning" || gjson.GetBytes(gptCompat, "input.0.encrypted_content").String() != gptRawSig {
+		t.Fatalf("compat translation failed to normalize gpt# signature: %s", gptCompat)
+	}
+
+	nonStringPayloadInt := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":12345}]}]}`)
+	nonStringCompatInt := ConvertClaudeRequestToCodexWithCompat("deepseek-v4", nonStringPayloadInt, false)
+	if gjson.GetBytes(nonStringCompatInt, "input.#").Int() != 0 {
+		t.Fatalf("compat translation unexpectedly preserved non-string int signature: %s", nonStringCompatInt)
+	}
+
+	nonStringPayloadObj := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":{"opaque":"data"}}]}]}`)
+	nonStringCompatObj := ConvertClaudeRequestToCodexWithCompat("deepseek-v4", nonStringPayloadObj, false)
+	if gjson.GetBytes(nonStringCompatObj, "input.#").Int() != 0 {
+		t.Fatalf("compat translation unexpectedly preserved non-string object signature: %s", nonStringCompatObj)
+	}
+
+	nonStringPayloadBool := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":true}]}]}`)
+	nonStringCompatBool := ConvertClaudeRequestToCodexWithCompat("deepseek-v4", nonStringPayloadBool, false)
+	if gjson.GetBytes(nonStringCompatBool, "input.#").Int() != 0 {
+		t.Fatalf("compat translation unexpectedly preserved non-string bool signature: %s", nonStringCompatBool)
+	}
+
+	nonStringPayloadArr := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":["arr"]}]}]}`)
+	nonStringCompatArr := ConvertClaudeRequestToCodexWithCompat("deepseek-v4", nonStringPayloadArr, false)
+	if gjson.GetBytes(nonStringCompatArr, "input.#").Int() != 0 {
+		t.Fatalf("compat translation unexpectedly preserved non-string array signature: %s", nonStringCompatArr)
+	}
+}
+
+func TestConvertClaudeRequestToCodexWithCompat_PreservesMessageFlushingAndEscapedUnknownSignature(t *testing.T) {
+	const escapedSig = "enc:\"token\"\\with\\unicode-\u4e00"
+	escapedPayload := []byte(`{"messages":[{"role":"assistant","content":[{"type":"text","text":"before"},{"type":"thinking","thinking":"reason","signature":"enc:\"token\"\\with\\unicode-\u4e00"},{"type":"text","text":"after"}]}]}`)
+
+	withCompat := ConvertClaudeRequestToCodexWithCompat("deepseek-v4", escapedPayload, false)
+	if gjson.GetBytes(withCompat, "input.#").Int() != 3 {
+		t.Fatalf("compat translation expected 3 items after message flush, got: %s", withCompat)
+	}
+	if gjson.GetBytes(withCompat, "input.0.role").String() != "assistant" || gjson.GetBytes(withCompat, "input.0.content.0.text").String() != "before" {
+		t.Fatalf("first item unexpected: %s", withCompat)
+	}
+	if gjson.GetBytes(withCompat, "input.1.type").String() != "reasoning" || gjson.GetBytes(withCompat, "input.1.encrypted_content").String() != escapedSig {
+		t.Fatalf("second item unexpected reasoning signature: %s", withCompat)
+	}
+	if gjson.GetBytes(withCompat, "input.2.role").String() != "assistant" || gjson.GetBytes(withCompat, "input.2.content.0.text").String() != "after" {
+		t.Fatalf("third item unexpected: %s", withCompat)
+	}
+}
+
+func TestConvertClaudeRequestToCodexWithCompat_WhitespaceAndNullSignatures(t *testing.T) {
+	whitespacePayload := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":"   "}]}]}`)
+	whitespaceCompat := ConvertClaudeRequestToCodexWithCompat("deepseek-v4", whitespacePayload, false)
+	if gjson.GetBytes(whitespaceCompat, "input.0.type").String() != "reasoning" || gjson.GetBytes(whitespaceCompat, "input.0.encrypted_content").String() != "   " {
+		t.Fatalf("compat translation failed to preserve whitespace signature via empty fallback: %s", whitespaceCompat)
+	}
+
+	nullPayload := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"reason","signature":null}]}]}`)
+	nullCompat := ConvertClaudeRequestToCodexWithCompat("deepseek-v4", nullPayload, false)
+	if gjson.GetBytes(nullCompat, "input.0.type").String() != "reasoning" || gjson.GetBytes(nullCompat, "input.0.encrypted_content").String() != "" {
+		t.Fatalf("compat translation failed to preserve null signature via empty fallback: %s", nullCompat)
+	}
+}

--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -46,7 +46,7 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, stream b
 }
 
 // ConvertClaudeRequestToCodexWithCompat preserves assistant thinking blocks with
-// empty signatures for configured compatibility endpoints.
+// empty or unknown-format signatures for configured compatibility endpoints.
 func ConvertClaudeRequestToCodexWithCompat(modelName string, inputRawJSON []byte, stream bool) []byte {
 	return convertClaudeRequestToCodex(modelName, inputRawJSON, stream, true)
 }
@@ -165,6 +165,11 @@ func convertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool, 
 
 				rawSignature := part.Get("signature").String()
 				signature, ok := sigcompat.CompatibleSignatureForProvider(sigcompat.SignatureProviderGPT, rawSignature)
+				if !ok && preserveEmptyThinkingBlocks && part.Get("signature").Type == gjson.String && strings.TrimSpace(rawSignature) != "" &&
+					sigcompat.DetectSignatureProviderForBlock(rawSignature, sigcompat.SignatureBlockKindClaudeThinking) == sigcompat.SignatureProviderUnknown {
+					signature = rawSignature
+					ok = true
+				}
 				if !ok {
 					if preserveEmptyThinkingBlocks && strings.TrimSpace(rawSignature) == "" {
 						signature = rawSignature

--- a/internal/translator/common/responses.go
+++ b/internal/translator/common/responses.go
@@ -26,7 +26,7 @@ func SetResponsesToolCallIdentity(item []byte, name, namespace, itemPath string)
 
 // ExtractResponsesCallID extracts the tool call ID from a Responses API item,
 // prioritizing dedicated tool call references over generic item IDs:
-// call_id -> tool_call_id -> callId -> id
+// call_id -> tool_call_id -> callId -> id (excluding fco_ output item IDs)
 func ExtractResponsesCallID(node gjson.Result) string {
 	if callID := strings.TrimSpace(node.Get("call_id").String()); callID != "" {
 		return callID
@@ -37,7 +37,11 @@ func ExtractResponsesCallID(node gjson.Result) string {
 	if callId := strings.TrimSpace(node.Get("callId").String()); callId != "" {
 		return callId
 	}
-	return strings.TrimSpace(node.Get("id").String())
+	id := strings.TrimSpace(node.Get("id").String())
+	if strings.HasPrefix(id, "fco_") {
+		return ""
+	}
+	return id
 }
 
 // NormalizeResponsesToolCallOutputs scans a slice of Responses input items,

--- a/internal/translator/common/responses_test.go
+++ b/internal/translator/common/responses_test.go
@@ -115,6 +115,16 @@ func TestExtractResponsesCallID(t *testing.T) {
 			input:    `{"output":"result"}`,
 			expected: "",
 		},
+		{
+			name:     "fco item id is ignored",
+			input:    `{"id":"fco_01a08664-2d16-7a91-8ab2-2eccd49e4c3e"}`,
+			expected: "",
+		},
+		{
+			name:     "fco item id with explicit call_id retains call_id",
+			input:    `{"id":"fco_01a08664-2d16-7a91-8ab2-2eccd49e4c3e","call_id":"call_1"}`,
+			expected: "call_1",
+		},
 	}
 
 	for _, tt := range tests {
@@ -185,6 +195,41 @@ func TestNormalizeResponsesToolCallOutputs(t *testing.T) {
 		normalized := NormalizeResponsesToolCallOutputs(items)
 		if got := normalized[1].Get("call_id").String(); got != "call_other" {
 			t.Fatalf("normalized[1].call_id = %q, want call_other", got)
+		}
+	})
+
+	t.Run("pairs function_call_output with fco item id and no call_id using fallback", func(t *testing.T) {
+		input := []byte(`[
+			{"type":"function_call","call_id":"call_1788961125480214178_817","name":"Bash"},
+			{"type":"function_call_output","id":"fco_01a08664-2d16-7a91-8ab2-2eccd49e4c3e","output":"result"}
+		]`)
+		items := gjson.ParseBytes(input).Array()
+		normalized := NormalizeResponsesToolCallOutputs(items)
+		if len(normalized) != 2 {
+			t.Fatalf("expected 2 items, got %d", len(normalized))
+		}
+		if got := normalized[1].Get("call_id").String(); got != "call_1788961125480214178_817" {
+			t.Fatalf("normalized[1].call_id = %q, want call_1788961125480214178_817", got)
+		}
+	})
+
+	t.Run("preserves explicit call_id while pairing fco item id output via fallback", func(t *testing.T) {
+		input := []byte(`[
+			{"type":"function_call","call_id":"call_a","name":"tool_a"},
+			{"type":"function_call","call_id":"call_b","name":"tool_b"},
+			{"type":"function_call_output","id":"fco_b","output":"result_b"},
+			{"type":"function_call_output","call_id":"call_a","output":"result_a"}
+		]`)
+		items := gjson.ParseBytes(input).Array()
+		normalized := NormalizeResponsesToolCallOutputs(items)
+		if len(normalized) != 4 {
+			t.Fatalf("expected 4 items, got %d", len(normalized))
+		}
+		if got := normalized[2].Get("call_id").String(); got != "call_b" {
+			t.Fatalf("normalized[2].call_id = %q, want call_b", got)
+		}
+		if got := normalized[3].Get("call_id").String(); got != "call_a" {
+			t.Fatalf("normalized[3].call_id = %q, want call_a", got)
 		}
 	})
 }

--- a/internal/translator/gemini/openai/chat-completions/gemini_openai_response.go
+++ b/internal/translator/gemini/openai/chat-completions/gemini_openai_response.go
@@ -173,6 +173,13 @@ func ConvertGeminiResponseToOpenAI(_ context.Context, _ string, originalRequestR
 						thoughtSignatureResult = partResult.Get("thought_signature")
 					}
 
+					// Speech-to-text models (gemini-3.5-transcribe) deliver the
+					// transcript in an audioTranscription part instead of text.
+					audioTranscriptionResult := partResult.Get("audioTranscription")
+					if audioTranscriptionResult.Exists() && !partTextResult.Exists() {
+						partTextResult = audioTranscriptionResult.Get("text")
+					}
+
 					hasThoughtSignature := thoughtSignatureResult.Exists() && thoughtSignatureResult.String() != ""
 					hasContentPayload := partTextResult.Exists() || functionCallResult.Exists() || inlineDataResult.Exists()
 
@@ -369,6 +376,13 @@ func ConvertGeminiResponseToOpenAINonStream(_ context.Context, _ string, origina
 						inlineDataResult = partResult.Get("inline_data")
 					}
 
+					// Speech-to-text models (gemini-3.5-transcribe) deliver the
+					// transcript in an audioTranscription part instead of text.
+					audioTranscriptionResult := partResult.Get("audioTranscription")
+					if audioTranscriptionResult.Exists() && !partTextResult.Exists() {
+						partTextResult = audioTranscriptionResult.Get("text")
+					}
+
 					if partTextResult.Exists() {
 						// Append text content, distinguishing between regular content and reasoning.
 						if partResult.Get("thought").Bool() {
@@ -409,11 +423,7 @@ func ConvertGeminiResponseToOpenAINonStream(_ context.Context, _ string, origina
 				}
 
 				if hasTextContent {
-					if !hasReasoningContent && len(partsResults) == 1 && len(toolCalls) == 0 && len(images) == 0 {
-						choiceTemplate, _ = sjson.SetBytes(choiceTemplate, "message.content", partsResults[0].Get("text").String())
-					} else {
-						choiceTemplate, _ = sjson.SetBytes(choiceTemplate, "message.content", textContent.String())
-					}
+					choiceTemplate, _ = sjson.SetBytes(choiceTemplate, "message.content", textContent.String())
 				}
 				if hasReasoningContent {
 					choiceTemplate, _ = sjson.SetBytes(choiceTemplate, "message.reasoning_content", reasoningContent.String())

--- a/internal/translator/gemini/openai/chat-completions/gemini_openai_response_test.go
+++ b/internal/translator/gemini/openai/chat-completions/gemini_openai_response_test.go
@@ -77,3 +77,52 @@ func TestConvertGeminiResponseToOpenAINonStream_EmptyTextProducesEmptyString(t *
 		t.Fatalf("expected reasoning_content to be empty string \"\", got %v (type %v)", reasoning.Value(), reasoning.Type)
 	}
 }
+
+// Gemini 3.5 Transcribe returns its transcript in an audioTranscription part instead
+// of the regular text part. Without handling it, the transcript is silently dropped
+// and the OpenAI client sees an empty assistant message.
+func TestConvertGeminiResponseToOpenAINonStream_AudioTranscriptionPartProducesContent(t *testing.T) {
+	response := []byte(`{"candidates":[{"content":{"parts":[{"text":""},{"audioTranscription":{"text":"Hello world"}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":185,"totalTokenCount":185}}`)
+	result := ConvertGeminiResponseToOpenAINonStream(context.Background(), "model", nil, nil, response, nil)
+
+	content := gjson.GetBytes(result, "choices.0.message.content")
+	if !content.Exists() || content.String() != "Hello world" {
+		t.Fatalf("expected content to carry the transcript, got %v. Output: %s", content.Raw, result)
+	}
+}
+
+func TestConvertGeminiResponseToOpenAINonStream_SingleAudioTranscriptionPart(t *testing.T) {
+	response := []byte(`{"candidates":[{"content":{"parts":[{"audioTranscription":{"text":"Single transcription part"}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":185,"totalTokenCount":185}}`)
+	result := ConvertGeminiResponseToOpenAINonStream(context.Background(), "model", nil, nil, response, nil)
+
+	content := gjson.GetBytes(result, "choices.0.message.content")
+	if !content.Exists() || content.String() != "Single transcription part" {
+		t.Fatalf("expected content to carry the transcript, got %v. Output: %s", content.Raw, result)
+	}
+}
+
+func TestConvertGeminiResponseToOpenAI_AudioTranscriptionPartStreamsContent(t *testing.T) {
+	ctx := context.Background()
+	var param any
+
+	chunk := []byte(`{"candidates":[{"content":{"parts":[{"text":""},{"audioTranscription":{"text":"Testing one two three."}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":185,"candidatesTokenCount":8,"totalTokenCount":193}}`)
+	result := ConvertGeminiResponseToOpenAI(ctx, "model", nil, nil, chunk, &param)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result))
+	}
+
+	content := gjson.GetBytes(result[0], "choices.0.delta.content")
+	if !content.Exists() || content.String() != "Testing one two three." {
+		t.Fatalf("expected delta.content to carry the transcript, got %v. Output: %s", content.Raw, result[0])
+	}
+}
+
+func TestConvertGeminiResponseToOpenAINonStream_TextPrecedenceOverAudioTranscription(t *testing.T) {
+	response := []byte(`{"candidates":[{"content":{"parts":[{"text":"explicit text","audioTranscription":{"text":"ignored transcription"}}]},"finishReason":"STOP"}]}`)
+	result := ConvertGeminiResponseToOpenAINonStream(context.Background(), "model", nil, nil, response, nil)
+
+	content := gjson.GetBytes(result, "choices.0.message.content")
+	if !content.Exists() || content.String() != "explicit text" {
+		t.Fatalf("expected content to prioritize explicit text, got %v. Output: %s", content.Raw, result)
+	}
+}

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request.go
@@ -143,11 +143,29 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 
 				hasEncounteredConversation = true
 				if _, isAssistantOutput := openAIResponsesAssistantVisibleText(item); !isAssistantOutput {
+					if len(pendingFunctionCallIDs) > 0 {
+						anyHasFutureOutput := false
+						for _, callID := range pendingFunctionCallIDs {
+							if responsesHasMatchingOutput(normalized[i:], callID) {
+								anyHasFutureOutput = true
+								break
+							}
+						}
+						if !anyHasFutureOutput {
+							var synthesizedParts [][]byte
+							for _, callID := range pendingFunctionCallIDs {
+								synthesizedParts = append(synthesizedParts, buildOpenAIResponsesSynthesizedFunctionResponsePart(callID, functionNamesByCallID))
+							}
+							if len(synthesizedParts) > 0 {
+								contentItems = append(contentItems, geminiContent("user", synthesizedParts))
+							}
+							pendingFunctionCallIDs = nil
+						}
+					}
 					if len(pendingDeveloperParts) > 0 {
 						contentItems = append(contentItems, geminiContent("user", pendingDeveloperParts))
 						pendingDeveloperParts = nil
 					}
-					pendingFunctionCallIDs = nil
 				}
 
 				// Handle regular messages
@@ -286,15 +304,57 @@ func ConvertOpenAIResponsesRequestToGemini(modelName string, inputRawJSON []byte
 
 			case "function_call_output", "custom_tool_call_output":
 				hasEncounteredConversation = true
-				orderedOutputs, consumedIndexes, remainingPending := collectOpenAIResponsesFunctionCallOutputs(normalized, i, pendingFunctionCallIDs)
-				pendingFunctionCallIDs = remainingPending
+				orderedOutputs, consumedIndexes, _ := collectOpenAIResponsesFunctionCallOutputs(normalized, i, pendingFunctionCallIDs)
 				for consumedIndex := range consumedIndexes {
 					consumedFunctionOutputIndexes[consumedIndex] = true
 				}
-				responseParts := make([][]byte, 0, len(orderedOutputs))
-				for _, output := range orderedOutputs {
-					responseParts = append(responseParts, buildOpenAIResponsesFunctionResponseParts(output, functionNamesByCallID)...)
+				end := i + len(consumedIndexes)
+				hasSubsequent := responsesHasSubsequentTurn(normalized[end:])
+
+				outputByCallID := make(map[string]gjson.Result)
+				var extraOutputs []gjson.Result
+				anyMatched := false
+				for _, out := range orderedOutputs {
+					id := extractOpenAIResponsesCallID(out)
+					if id != "" {
+						outputByCallID[id] = out
+					} else {
+						extraOutputs = append(extraOutputs, out)
+					}
 				}
+				for _, pendingID := range pendingFunctionCallIDs {
+					if _, ok := outputByCallID[pendingID]; ok {
+						anyMatched = true
+						break
+					}
+				}
+
+				responseParts := make([][]byte, 0, len(pendingFunctionCallIDs)+len(extraOutputs))
+				stillPending := make([]string, 0, len(pendingFunctionCallIDs))
+
+				for _, pendingID := range pendingFunctionCallIDs {
+					if out, ok := outputByCallID[pendingID]; ok {
+						responseParts = append(responseParts, buildOpenAIResponsesFunctionResponseParts(out, functionNamesByCallID)...)
+						delete(outputByCallID, pendingID)
+					} else if (hasSubsequent || anyMatched) && !responsesHasMatchingOutput(normalized[end:], pendingID) {
+						responseParts = append(responseParts, buildOpenAIResponsesSynthesizedFunctionResponsePart(pendingID, functionNamesByCallID))
+					} else {
+						stillPending = append(stillPending, pendingID)
+					}
+				}
+
+				for _, out := range orderedOutputs {
+					id := extractOpenAIResponsesCallID(out)
+					if _, remaining := outputByCallID[id]; remaining {
+						responseParts = append(responseParts, buildOpenAIResponsesFunctionResponseParts(out, functionNamesByCallID)...)
+						delete(outputByCallID, id)
+					}
+				}
+				for _, out := range extraOutputs {
+					responseParts = append(responseParts, buildOpenAIResponsesFunctionResponseParts(out, functionNamesByCallID)...)
+				}
+
+				pendingFunctionCallIDs = stillPending
 				if len(responseParts) > 0 {
 					contentItems = append(contentItems, geminiContent("user", responseParts))
 				}
@@ -906,6 +966,48 @@ func parseOpenAIResponsesArrayOutput(outputResult gjson.Result) (result string, 
 
 func extractOpenAIResponsesCallID(node gjson.Result) string {
 	return translatorcommon.ExtractResponsesCallID(node)
+}
+
+func buildOpenAIResponsesSynthesizedFunctionResponsePart(callID string, functionNamesByCallID map[string]string) []byte {
+	functionName := "unknown"
+	if matchedName, ok := functionNamesByCallID[callID]; ok && matchedName != "" {
+		functionName = matchedName
+	}
+	functionResponse := []byte(`{"functionResponse":{"name":"","response":{"result":"call interrupted, no output"}}}`)
+	functionResponse, _ = sjson.SetBytes(functionResponse, "functionResponse.name", util.SanitizeFunctionName(functionName))
+	if callID != "" {
+		functionResponse, _ = sjson.SetBytes(functionResponse, "functionResponse.id", callID)
+	}
+	return functionResponse
+}
+
+func responsesHasMatchingOutput(items []gjson.Result, callID string) bool {
+	if callID == "" {
+		return false
+	}
+	for _, item := range items {
+		typ := item.Get("type").String()
+		if typ == "function_call_output" || typ == "custom_tool_call_output" {
+			if extractOpenAIResponsesCallID(item) == callID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func responsesHasSubsequentTurn(items []gjson.Result) bool {
+	for _, item := range items {
+		typ := item.Get("type").String()
+		role := item.Get("role").String()
+		if typ == "message" || (typ == "" && role != "") {
+			return true
+		}
+		if typ == "function_call" || typ == "custom_tool_call" {
+			return true
+		}
+	}
+	return false
 }
 
 func buildOpenAIResponsesFunctionResponseParts(item gjson.Result, functionNamesByCallID map[string]string) [][]byte {

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
@@ -2402,3 +2402,36 @@ func TestConvertOpenAIResponsesRequestToGemini_InterruptedMessageBeforeRealOutpu
 		t.Fatalf("unexpected response part 1 for c2: %s", c2Resp.Raw)
 	}
 }
+
+func TestConvertOpenAIResponsesRequestToGemini_FunctionCallOutputWithFCOItemID(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.7-flash-high",
+		"input": [
+			{"role":"user","content":"run command"},
+			{"type":"function_call","call_id":"call_1788961125480214178_817","name":"Bash","arguments":"{\"command\":\"pwd\"}"},
+			{"type":"function_call_output","id":"fco_01a08664-2d16-7a91-8ab2-2eccd49e4c3e","output":"/tmp"}
+		]
+	}`
+
+	output := ConvertOpenAIResponsesRequestToGemini("gemini-3.7-flash-high", []byte(inputJSON), false)
+	if errValidate := internalsignature.ValidateGeminiFunctionCallPairing(output); errValidate != nil {
+		t.Fatalf("pairing validation failed: %v; output=%s", errValidate, string(output))
+	}
+
+	contents := gjson.GetBytes(output, "contents").Array()
+	if len(contents) != 3 {
+		t.Fatalf("expected 3 contents, got %d; output=%s", len(contents), string(output))
+	}
+
+	responses := contents[2].Get("parts").Array()
+	if len(responses) != 1 {
+		t.Fatalf("expected 1 response part, got %d; output=%s", len(responses), string(output))
+	}
+
+	if gotID := responses[0].Get("functionResponse.id").String(); gotID != "call_1788961125480214178_817" {
+		t.Fatalf("response id = %q, want call_1788961125480214178_817", gotID)
+	}
+	if gotName := responses[0].Get("functionResponse.name").String(); gotName != "Bash" {
+		t.Fatalf("response name = %q, want Bash", gotName)
+	}
+}

--- a/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
+++ b/internal/translator/gemini/openai/responses/gemini_openai-responses_request_test.go
@@ -2283,3 +2283,122 @@ func TestConvertOpenAIResponsesRequestToGemini_AllPendingCallsReservedByFutureEx
 		}
 	}
 }
+
+func TestConvertOpenAIResponsesRequestToGemini_InterruptedFunctionCallPreservesPairing(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.8-flash-high",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"List the files."}]},
+			{"type":"function_call","call_id":"c1","name":"shell","arguments":"{\"command\":[\"ls\"]}"},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"Stop, do something else instead."}]},
+			{"type":"function_call","call_id":"c2","name":"shell","arguments":"{\"command\":[\"pwd\"]}"},
+			{"type":"function_call_output","call_id":"c2","output":"/tmp\n"}
+		]
+	}`
+
+	result := ConvertOpenAIResponsesRequestToGemini("gemini-3.8-flash-high", []byte(inputJSON), false)
+	if err := internalsignature.ValidateGeminiFunctionCallPairing(result); err != nil {
+		t.Fatalf("ValidateGeminiFunctionCallPairing failed on Gemini request: %v; output=%s", err, result)
+	}
+
+	// Verify synthesized response for c1
+	c1Resp := gjson.GetBytes(result, "contents.2.parts.0.functionResponse")
+	if c1Resp.Get("id").String() != "c1" || c1Resp.Get("name").String() != "shell" || c1Resp.Get("response.result").String() != "call interrupted, no output" {
+		t.Fatalf("unexpected synthesized response for c1: %s", c1Resp.Raw)
+	}
+	// Verify real response for c2
+	c2Resp := gjson.GetBytes(result, "contents.5.parts.0.functionResponse")
+	if c2Resp.Get("id").String() != "c2" || c2Resp.Get("name").String() != "shell" || c2Resp.Get("response.result").String() != "/tmp\n" {
+		t.Fatalf("unexpected real response for c2: %s", c2Resp.Raw)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToGemini_ParallelInterruptedFunctionCallPreservesPairingAndOrder(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.8-flash-high",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"List and print."}]},
+			{"type":"function_call","call_id":"c1","name":"shell","arguments":"{\"command\":[\"ls\"]}"},
+			{"type":"function_call","call_id":"c2","name":"shell","arguments":"{\"command\":[\"pwd\"]}"},
+			{"type":"function_call_output","call_id":"c2","output":"/tmp\n"},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"Stop, do something else instead."}]},
+			{"type":"function_call","call_id":"c3","name":"shell","arguments":"{\"command\":[\"whoami\"]}"},
+			{"type":"function_call_output","call_id":"c3","output":"root\n"}
+		]
+	}`
+
+	result := ConvertOpenAIResponsesRequestToGemini("gemini-3.8-flash-high", []byte(inputJSON), false)
+	if err := internalsignature.ValidateGeminiFunctionCallPairing(result); err != nil {
+		t.Fatalf("ValidateGeminiFunctionCallPairing failed on parallel interrupted request: %v; output=%s", err, result)
+	}
+
+	// In the response turn for [c1, c2], c1 must be first (synthesized) and c2 must be second (real)
+	c1Resp := gjson.GetBytes(result, "contents.2.parts.0.functionResponse")
+	if c1Resp.Get("id").String() != "c1" || c1Resp.Get("name").String() != "shell" || c1Resp.Get("response.result").String() != "call interrupted, no output" {
+		t.Fatalf("unexpected response part 0 for c1: %s", c1Resp.Raw)
+	}
+	c2Resp := gjson.GetBytes(result, "contents.2.parts.1.functionResponse")
+	if c2Resp.Get("id").String() != "c2" || c2Resp.Get("name").String() != "shell" || c2Resp.Get("response.result").String() != "/tmp\n" {
+		t.Fatalf("unexpected response part 1 for c2: %s", c2Resp.Raw)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToGemini_TrailingPartialParallelCallsPreservesPairingAndOrder(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.8-flash-high",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"List and print."}]},
+			{"type":"function_call","call_id":"c1","name":"shell","arguments":"{\"command\":[\"ls\"]}"},
+			{"type":"function_call","call_id":"c2","name":"shell","arguments":"{\"command\":[\"pwd\"]}"},
+			{"type":"function_call_output","call_id":"c2","output":"/tmp\n"}
+		]
+	}`
+
+	result := ConvertOpenAIResponsesRequestToGemini("gemini-3.8-flash-high", []byte(inputJSON), false)
+	if err := internalsignature.ValidateGeminiFunctionCallPairing(result); err != nil {
+		t.Fatalf("ValidateGeminiFunctionCallPairing failed on trailing partial parallel request: %v; output=%s", err, result)
+	}
+
+	// In the response turn for [c1, c2], c1 must be first (synthesized) and c2 must be second (real)
+	c1Resp := gjson.GetBytes(result, "contents.2.parts.0.functionResponse")
+	if c1Resp.Get("id").String() != "c1" || c1Resp.Get("name").String() != "shell" || c1Resp.Get("response.result").String() != "call interrupted, no output" {
+		t.Fatalf("unexpected response part 0 for c1: %s", c1Resp.Raw)
+	}
+	c2Resp := gjson.GetBytes(result, "contents.2.parts.1.functionResponse")
+	if c2Resp.Get("id").String() != "c2" || c2Resp.Get("name").String() != "shell" || c2Resp.Get("response.result").String() != "/tmp\n" {
+		t.Fatalf("unexpected response part 1 for c2: %s", c2Resp.Raw)
+	}
+}
+
+func TestConvertOpenAIResponsesRequestToGemini_InterruptedMessageBeforeRealOutputPreservesPairingAndOrder(t *testing.T) {
+	inputJSON := `{
+		"model": "gemini-3.8-flash-high",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"List and print."}]},
+			{"type":"function_call","call_id":"c1","name":"shell","arguments":"{\"command\":[\"ls\"]}"},
+			{"type":"function_call","call_id":"c2","name":"shell","arguments":"{\"command\":[\"pwd\"]}"},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"Stop, do something else instead."}]},
+			{"type":"function_call_output","call_id":"c2","output":"/tmp\n"}
+		]
+	}`
+
+	result := ConvertOpenAIResponsesRequestToGemini("gemini-3.8-flash-high", []byte(inputJSON), false)
+	if err := internalsignature.ValidateGeminiFunctionCallPairing(result); err != nil {
+		t.Fatalf("ValidateGeminiFunctionCallPairing failed on interrupted message before real output request: %v; output=%s", err, result)
+	}
+
+	// The user message precedes the completed tool response turn
+	stopText := gjson.GetBytes(result, "contents.2.parts.0.text").String()
+	if stopText != "Stop, do something else instead." {
+		t.Fatalf("unexpected text in contents[2]: %q", stopText)
+	}
+	// In the response turn for [c1, c2], c1 must be first (synthesized) and c2 must be second (real)
+	c1Resp := gjson.GetBytes(result, "contents.3.parts.0.functionResponse")
+	if c1Resp.Get("id").String() != "c1" || c1Resp.Get("name").String() != "shell" || c1Resp.Get("response.result").String() != "call interrupted, no output" {
+		t.Fatalf("unexpected response part 0 for c1: %s", c1Resp.Raw)
+	}
+	c2Resp := gjson.GetBytes(result, "contents.3.parts.1.functionResponse")
+	if c2Resp.Get("id").String() != "c2" || c2Resp.Get("name").String() != "shell" || c2Resp.Get("response.result").String() != "/tmp\n" {
+		t.Fatalf("unexpected response part 1 for c2: %s", c2Resp.Raw)
+	}
+}

--- a/internal/translator/openai/claude/openai_claude_request.go
+++ b/internal/translator/openai/claude/openai_claude_request.go
@@ -178,7 +178,8 @@ func convertClaudeRequestToOpenAI(modelName string, inputRawJSON []byte, stream 
 				contentItems := make([][]byte, 0)
 				var reasoningParts []string // Accumulate thinking text for reasoning_content
 				var toolCalls []interface{}
-				toolResults := make([][]byte, 0) // Collect tool_result messages to emit after the main message
+				toolResults := make([][]byte, 0)       // Collect tool_result messages to emit after the main message
+				relayedToolImages := make([][]byte, 0) // Images pulled out of tool_result content for user-message relay
 
 				contentResult.ForEach(func(_, part gjson.Result) bool {
 					partType := part.Get("type").String()
@@ -231,12 +232,9 @@ func convertClaudeRequestToOpenAI(modelName string, inputRawJSON []byte, stream 
 						// Collect tool_result to emit after the main message (ensures tool results follow tool_calls)
 						toolResultJSON := []byte(`{"role":"tool","tool_call_id":"","content":""}`)
 						toolResultJSON, _ = sjson.SetBytes(toolResultJSON, "tool_call_id", part.Get("tool_use_id").String())
-						toolResultContent, toolResultContentRaw := convertClaudeToolResultContent(part.Get("content"))
-						if toolResultContentRaw {
-							toolResultJSON, _ = sjson.SetRawBytes(toolResultJSON, "content", []byte(toolResultContent))
-						} else {
-							toolResultJSON, _ = sjson.SetBytes(toolResultJSON, "content", toolResultContent)
-						}
+						toolResultContent, toolResultImages := convertClaudeToolResultContent(part.Get("content"))
+						toolResultJSON, _ = sjson.SetBytes(toolResultJSON, "content", toolResultContent)
+						relayedToolImages = append(relayedToolImages, toolResultImages...)
 						toolResults = append(toolResults, toolResultJSON)
 					}
 					return true
@@ -263,6 +261,25 @@ func convertClaudeRequestToOpenAI(modelName string, inputRawJSON []byte, stream 
 				// Therefore, we emit tool_result messages FIRST (they respond to the previous assistant's tool_calls),
 				// then emit any queued system reminders, then emit the current message's content.
 				messageItems = append(messageItems, toolResults...)
+
+				// OpenAI tool messages cannot carry image parts, so images returned by a tool are
+				// replayed as a user message directly after the tool results.
+				if len(relayedToolImages) > 0 {
+					relayItems := make([][]byte, 0, len(relayedToolImages)+1)
+					noticeJSON := []byte(`{"type":"text","text":""}`)
+					noticeJSON, _ = sjson.SetBytes(noticeJSON, "text", toolResultImageRelayNotice)
+					relayItems = append(relayItems, noticeJSON)
+					relayItems = append(relayItems, relayedToolImages...)
+
+					if role == "user" && hasContent {
+						// Merge into the current user message so the request keeps a single user turn.
+						contentItems = append(relayItems, contentItems...)
+					} else {
+						relayJSON := []byte(`{"role":"user"}`)
+						relayJSON, _ = sjson.SetRawBytes(relayJSON, "content", translatorcommon.JoinRawArray(relayItems))
+						messageItems = append(messageItems, relayJSON)
+					}
+				}
 
 				if len(pendingSystemReminders) > 0 {
 					messageItems = append(messageItems, pendingSystemReminders...)
@@ -502,38 +519,34 @@ func convertClaudeContentPart(part gjson.Result) (string, bool) {
 	}
 }
 
-func convertClaudeToolResultContent(content gjson.Result) (string, bool) {
+// toolResultImagePlaceholder keeps the OpenAI tool message non-empty when a Claude
+// tool_result carried nothing but images.
+const toolResultImagePlaceholder = "[Tool returned image content; the images follow in the next user message.]"
+
+// toolResultImageRelayNotice labels the user message that carries relayed tool images.
+const toolResultImageRelayNotice = "Images returned by the preceding tool call(s):"
+
+func convertClaudeToolResultContent(content gjson.Result) (string, [][]byte) {
 	if !content.Exists() {
-		return "", false
+		return "", nil
 	}
 
 	if content.Type == gjson.String {
-		return content.String(), false
+		return content.String(), nil
 	}
 
 	if content.IsArray() {
 		var parts []string
-		contentItems := make([][]byte, 0, 4)
-		hasImagePart := false
+		var images [][]byte
 		content.ForEach(func(_, item gjson.Result) bool {
 			switch {
 			case item.Type == gjson.String:
-				text := item.String()
-				parts = append(parts, text)
-				textContent := []byte(`{"type":"text","text":""}`)
-				textContent, _ = sjson.SetBytes(textContent, "text", text)
-				contentItems = append(contentItems, textContent)
+				parts = append(parts, item.String())
 			case item.IsObject() && item.Get("type").String() == "text":
-				text := item.Get("text").String()
-				parts = append(parts, text)
-				textContent := []byte(`{"type":"text","text":""}`)
-				textContent, _ = sjson.SetBytes(textContent, "text", text)
-				contentItems = append(contentItems, textContent)
+				parts = append(parts, item.Get("text").String())
 			case item.IsObject() && item.Get("type").String() == "image":
-				contentItem, ok := convertClaudeContentPart(item)
-				if ok {
-					contentItems = append(contentItems, []byte(contentItem))
-					hasImagePart = true
+				if contentItem, ok := convertClaudeContentPart(item); ok {
+					images = append(images, []byte(contentItem))
 				} else {
 					parts = append(parts, item.Raw)
 				}
@@ -545,29 +558,27 @@ func convertClaudeToolResultContent(content gjson.Result) (string, bool) {
 			return true
 		})
 
-		if hasImagePart {
-			return string(translatorcommon.JoinRawArray(contentItems)), true
-		}
-
 		joined := strings.Join(parts, "\n\n")
-		if strings.TrimSpace(joined) != "" {
-			return joined, false
+		if strings.TrimSpace(joined) == "" {
+			if len(images) > 0 {
+				return toolResultImagePlaceholder, images
+			}
+			return content.Raw, nil
 		}
-		return content.Raw, false
+		return joined, images
 	}
 
 	if content.IsObject() {
 		if content.Get("type").String() == "image" {
-			contentItem, ok := convertClaudeContentPart(content)
-			if ok {
-				return string(translatorcommon.JoinRawArray([][]byte{[]byte(contentItem)})), true
+			if contentItem, ok := convertClaudeContentPart(content); ok {
+				return toolResultImagePlaceholder, [][]byte{[]byte(contentItem)}
 			}
 		}
 		if text := content.Get("text"); text.Exists() && text.Type == gjson.String {
-			return text.String(), false
+			return text.String(), nil
 		}
-		return content.Raw, false
+		return content.Raw, nil
 	}
 
-	return content.Raw, false
+	return content.Raw, nil
 }

--- a/internal/translator/openai/claude/openai_claude_request_test.go
+++ b/internal/translator/openai/claude/openai_claude_request_test.go
@@ -733,24 +733,37 @@ func TestConvertClaudeRequestToOpenAI_ToolResultTextAndImageContent(t *testing.T
 	resultJSON := gjson.ParseBytes(result)
 	messages := resultJSON.Get("messages").Array()
 
-	if len(messages) != 2 {
-		t.Fatalf("Expected 2 messages, got %d. Messages: %s", len(messages), resultJSON.Get("messages").Raw)
+	if len(messages) != 3 {
+		t.Fatalf("Expected 3 messages, got %d. Messages: %s", len(messages), resultJSON.Get("messages").Raw)
 	}
 
-	toolContent := messages[1].Get("content")
-	if !toolContent.IsArray() {
-		t.Fatalf("Expected tool content array, got %s", toolContent.Raw)
+	// The tool message keeps only the textual payload; OpenAI drops image parts there.
+	if got := messages[1].Get("role").String(); got != "tool" {
+		t.Fatalf("Expected second message role %q, got %q", "tool", got)
 	}
-	if got := toolContent.Get("0.type").String(); got != "text" {
-		t.Fatalf("Expected first tool content type %q, got %q", "text", got)
+	if messages[1].Get("content").IsArray() {
+		t.Fatalf("Tool content must not be an array, got %s", messages[1].Get("content").Raw)
 	}
-	if got := toolContent.Get("0.text").String(); got != "tool ok" {
-		t.Fatalf("Expected first tool content text %q, got %q", "tool ok", got)
+	if got := messages[1].Get("content").String(); got != "tool ok" {
+		t.Fatalf("Expected tool content %q, got %q", "tool ok", got)
 	}
-	if got := toolContent.Get("1.type").String(); got != "image_url" {
-		t.Fatalf("Expected second tool content type %q, got %q", "image_url", got)
+
+	// The image is relayed as a user message directly after the tool result.
+	relay := messages[2]
+	if got := relay.Get("role").String(); got != "user" {
+		t.Fatalf("Expected relay message role %q, got %q", "user", got)
 	}
-	if got := toolContent.Get("1.image_url.url").String(); got != "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==" {
+	relayContent := relay.Get("content")
+	if !relayContent.IsArray() {
+		t.Fatalf("Expected relay content array, got %s", relayContent.Raw)
+	}
+	if got := relayContent.Get("0.text").String(); got != toolResultImageRelayNotice {
+		t.Fatalf("Expected relay notice %q, got %q", toolResultImageRelayNotice, got)
+	}
+	if got := relayContent.Get("1.type").String(); got != "image_url" {
+		t.Fatalf("Expected relay content type %q, got %q", "image_url", got)
+	}
+	if got := relayContent.Get("1.image_url.url").String(); got != "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==" {
 		t.Fatalf("Unexpected image_url: %q", got)
 	}
 }
@@ -788,19 +801,167 @@ func TestConvertClaudeRequestToOpenAI_ToolResultURLImageOnly(t *testing.T) {
 	resultJSON := gjson.ParseBytes(result)
 	messages := resultJSON.Get("messages").Array()
 
-	if len(messages) != 2 {
-		t.Fatalf("Expected 2 messages, got %d. Messages: %s", len(messages), resultJSON.Get("messages").Raw)
+	if len(messages) != 3 {
+		t.Fatalf("Expected 3 messages, got %d. Messages: %s", len(messages), resultJSON.Get("messages").Raw)
 	}
 
-	toolContent := messages[1].Get("content")
-	if !toolContent.IsArray() {
-		t.Fatalf("Expected tool content array, got %s", toolContent.Raw)
+	// An image-only tool_result still needs a non-empty text payload on the tool message.
+	if got := messages[1].Get("content").String(); got != toolResultImagePlaceholder {
+		t.Fatalf("Expected tool content %q, got %q", toolResultImagePlaceholder, got)
 	}
-	if got := toolContent.Get("0.type").String(); got != "image_url" {
-		t.Fatalf("Expected tool content type %q, got %q", "image_url", got)
+
+	relayContent := messages[2].Get("content")
+	if got := messages[2].Get("role").String(); got != "user" {
+		t.Fatalf("Expected relay message role %q, got %q", "user", got)
 	}
-	if got := toolContent.Get("0.image_url.url").String(); got != "https://example.com/tool.png" {
+	if got := relayContent.Get("1.type").String(); got != "image_url" {
+		t.Fatalf("Expected relay content type %q, got %q", "image_url", got)
+	}
+	if got := relayContent.Get("1.image_url.url").String(); got != "https://example.com/tool.png" {
 		t.Fatalf("Unexpected image_url: %q", got)
+	}
+}
+
+func TestConvertClaudeRequestToOpenAI_ToolResultImageMergesIntoUserText(t *testing.T) {
+	inputJSON := `{
+		"model": "claude-3-opus",
+		"messages": [
+			{
+				"role": "assistant",
+				"content": [
+					{"type": "tool_use", "id": "call_1", "name": "screenshot", "input": {}}
+				]
+			},
+			{
+				"role": "user",
+				"content": [
+					{
+						"type": "tool_result",
+						"tool_use_id": "call_1",
+						"content": [
+							{
+								"type": "image",
+								"source": {
+									"type": "base64",
+									"media_type": "image/png",
+									"data": "iVBORw0KGgoAAAANSUhEUg=="
+								}
+							}
+						]
+					},
+					{"type": "text", "text": "What color?"}
+				]
+			}
+		]
+	}`
+
+	result := ConvertClaudeRequestToOpenAI("test-model", []byte(inputJSON), false)
+	resultJSON := gjson.ParseBytes(result)
+	messages := resultJSON.Get("messages").Array()
+
+	// The relayed image joins the user text instead of adding a second user turn.
+	if len(messages) != 3 {
+		t.Fatalf("Expected 3 messages, got %d. Messages: %s", len(messages), resultJSON.Get("messages").Raw)
+	}
+	if got := messages[2].Get("role").String(); got != "user" {
+		t.Fatalf("Expected third message role %q, got %q", "user", got)
+	}
+
+	content := messages[2].Get("content")
+	if got := len(content.Array()); got != 3 {
+		t.Fatalf("Expected 3 user content parts, got %d: %s", got, content.Raw)
+	}
+	if got := content.Get("0.text").String(); got != toolResultImageRelayNotice {
+		t.Fatalf("Expected relay notice %q, got %q", toolResultImageRelayNotice, got)
+	}
+	if got := content.Get("1.type").String(); got != "image_url" {
+		t.Fatalf("Expected second part type %q, got %q", "image_url", got)
+	}
+	if got := content.Get("2.text").String(); got != "What color?" {
+		t.Fatalf("Expected trailing user text %q, got %q", "What color?", got)
+	}
+}
+
+func TestConvertClaudeRequestToOpenAI_MultipleToolResultsWithImages(t *testing.T) {
+	inputJSON := `{
+		"model": "claude-3-opus",
+		"messages": [
+			{
+				"role": "assistant",
+				"content": [
+					{"type": "tool_use", "id": "call_1", "name": "shot1", "input": {}},
+					{"type": "tool_use", "id": "call_2", "name": "shot2", "input": {}}
+				]
+			},
+			{
+				"role": "user",
+				"content": [
+					{
+						"type": "tool_result",
+						"tool_use_id": "call_1",
+						"content": [
+							{"type": "text", "text": "result 1"},
+							{
+								"type": "image",
+								"source": {
+									"type": "base64",
+									"media_type": "image/png",
+									"data": "img1"
+								}
+							}
+						]
+					},
+					{
+						"type": "tool_result",
+						"tool_use_id": "call_2",
+						"content": {
+							"type": "image",
+							"source": {
+								"type": "url",
+								"url": "https://example.com/2.png"
+							}
+						}
+					}
+				]
+			}
+		]
+	}`
+
+	result := ConvertClaudeRequestToOpenAI("test-model", []byte(inputJSON), false)
+	resultJSON := gjson.ParseBytes(result)
+	messages := resultJSON.Get("messages").Array()
+
+	// Expected: assistant(2 tool calls), tool(call_1), tool(call_2), user(relay 2 images)
+	if len(messages) != 4 {
+		t.Fatalf("Expected 4 messages, got %d. Messages: %s", len(messages), resultJSON.Get("messages").Raw)
+	}
+	if got := messages[1].Get("role").String(); got != "tool" || messages[1].Get("tool_call_id").String() != "call_1" {
+		t.Fatalf("Expected tool 1 message, got: %s", messages[1].Raw)
+	}
+	if got := messages[1].Get("content").String(); got != "result 1" {
+		t.Fatalf("Expected tool 1 content 'result 1', got %q", got)
+	}
+	if got := messages[2].Get("role").String(); got != "tool" || messages[2].Get("tool_call_id").String() != "call_2" {
+		t.Fatalf("Expected tool 2 message, got: %s", messages[2].Raw)
+	}
+	if got := messages[2].Get("content").String(); got != toolResultImagePlaceholder {
+		t.Fatalf("Expected tool 2 placeholder, got %q", got)
+	}
+	if got := messages[3].Get("role").String(); got != "user" {
+		t.Fatalf("Expected user relay message, got: %s", messages[3].Raw)
+	}
+	relayContent := messages[3].Get("content").Array()
+	if len(relayContent) != 3 {
+		t.Fatalf("Expected 3 parts in relay (notice + 2 images), got %d: %s", len(relayContent), messages[3].Get("content").Raw)
+	}
+	if got := relayContent[0].Get("text").String(); got != toolResultImageRelayNotice {
+		t.Fatalf("Expected notice %q, got %q", toolResultImageRelayNotice, got)
+	}
+	if got := relayContent[1].Get("image_url.url").String(); got != "data:image/png;base64,img1" {
+		t.Fatalf("Expected image 1 url, got %q", got)
+	}
+	if got := relayContent[2].Get("image_url.url").String(); got != "https://example.com/2.png" {
+		t.Fatalf("Expected image 2 url, got %q", got)
 	}
 }
 

--- a/internal/translator/openai/interactions/responses/interactions_openai_responses_response.go
+++ b/internal/translator/openai/interactions/responses/interactions_openai_responses_response.go
@@ -596,6 +596,9 @@ func ConvertOpenAIResponsesResponseToInteractionsNonStream(ctx context.Context, 
 	_ = requestRawJSON
 	root := gjson.ParseBytes(rawJSON)
 	out := []byte(`{"id":"","object":"interaction","status":"completed","model":"","steps":[]}`)
+	if status := root.Get("status").String(); status != "" {
+		out, _ = sjson.SetBytes(out, "status", status)
+	}
 	out, _ = sjson.SetBytes(out, "id", root.Get("id").String())
 	out, _ = sjson.SetBytes(out, "model", responseModel(modelName, root))
 	forAntigravity := isAntigravityModel(modelName)
@@ -645,7 +648,7 @@ func convertOpenAIResponsesEventToInteractions(modelName string, rawJSON []byte,
 		return out
 	case "response.output_item.done":
 		return openAIResponsesOutputItemDoneToInteractions(modelName, root, st)
-	case "response.completed":
+	case "response.completed", "response.incomplete":
 		return openAIResponsesCompletedToInteractions(modelName, root.Get("response"), st)
 	}
 	return nil
@@ -883,6 +886,9 @@ func appendInteractionsCompletedDirect(out [][]byte, st *responsesToInteractions
 	payload, _ = sjson.SetBytes(payload, "interaction.created", now)
 	payload, _ = sjson.SetBytes(payload, "interaction.updated", now)
 	payload, _ = sjson.SetBytes(payload, "interaction.model", responseModel(modelName, response))
+	if status := response.Get("status").String(); status != "" {
+		payload, _ = sjson.SetBytes(payload, "interaction.status", status)
+	}
 	payload = setInteractionsUsageFromResponses(payload, "interaction.usage", response.Get("usage"))
 	out = append(out, emitInteractionsEvent("interaction.completed", payload))
 	st.Completed = true

--- a/internal/translator/openai/interactions/responses/interactions_openai_responses_response_test.go
+++ b/internal/translator/openai/interactions/responses/interactions_openai_responses_response_test.go
@@ -596,6 +596,61 @@ func TestConvertOpenAIResponsesResponseToInteractionsStreamSkipsCompletedTextAft
 	}
 }
 
+func TestConvertOpenAIResponsesResponseToInteractionsIncompleteTerminal(t *testing.T) {
+	t.Run("NonStream", func(t *testing.T) {
+		raw := []byte(`{"id":"resp_1","status":"incomplete","output":[{"type":"message","content":[{"type":"output_text","text":"partial"}]}],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}`)
+		out := ConvertOpenAIResponsesResponseToInteractionsNonStream(context.Background(), "gpt-test", nil, nil, raw, nil)
+		if got := gjson.GetBytes(out, "status").String(); got != "incomplete" {
+			t.Fatalf("status = %q, want incomplete. Output: %s", got, string(out))
+		}
+		if gotText := gjson.GetBytes(out, "steps.0.content.0.text").String(); gotText != "partial" {
+			t.Fatalf("step text = %q, want partial. Output: %s", gotText, string(out))
+		}
+		if gotTokens := gjson.GetBytes(out, "usage.total_tokens").Int(); gotTokens != 3 {
+			t.Fatalf("total_tokens = %d, want 3. Output: %s", gotTokens, string(out))
+		}
+	})
+
+	t.Run("Stream", func(t *testing.T) {
+		var param any
+		raw := []byte(`{"type":"response.incomplete","response":{"id":"resp_1","status":"incomplete","output":[{"type":"message","id":"msg_1","content":[{"type":"output_text","text":"partial"}]}],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}`)
+		out := ConvertOpenAIResponsesResponseToInteractions(context.Background(), "gpt-test", nil, nil, raw, &param)
+		if got := countInteractionsEventType(out, "interaction.completed"); got != 1 {
+			t.Fatalf("interaction.completed count = %d, want 1", got)
+		}
+		if got := countInteractionsEventType(out, "done"); got != 1 {
+			t.Fatalf("done count = %d, want 1", got)
+		}
+		deltaPayload := findInteractionsStepDeltaPayload(out)
+		if gotText := gjson.GetBytes(deltaPayload, "delta.text").String(); gotText != "partial" {
+			t.Fatalf("delta.text = %q, want partial. Payload: %s", gotText, string(deltaPayload))
+		}
+		completedPayload := findInteractionsEventPayload(out, "interaction.completed")
+		if got := gjson.GetBytes(completedPayload, "interaction.status").String(); got != "incomplete" {
+			t.Fatalf("interaction.status = %q, want incomplete. Payload: %s", got, string(completedPayload))
+		}
+		if gotTokens := gjson.GetBytes(completedPayload, "interaction.usage.total_tokens").Int(); gotTokens != 3 {
+			t.Fatalf("total_tokens = %d, want 3. Payload: %s", gotTokens, string(completedPayload))
+		}
+
+		doneOut := ConvertOpenAIResponsesResponseToInteractions(context.Background(), "gpt-test", nil, nil, []byte(`data: [DONE]`), &param)
+		if got := countInteractionsEventType(doneOut, "interaction.completed"); got != 0 {
+			t.Fatalf("subsequent done interaction.completed count = %d, want 0", got)
+		}
+		if got := countInteractionsEventType(doneOut, "done"); got != 0 {
+			t.Fatalf("subsequent done event count = %d, want 0", got)
+		}
+	})
+
+	t.Run("CompletedControl", func(t *testing.T) {
+		raw := []byte(`{"id":"resp_1","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}`)
+		out := ConvertOpenAIResponsesResponseToInteractionsNonStream(context.Background(), "gpt-test", nil, nil, raw, nil)
+		if got := gjson.GetBytes(out, "status").String(); got != "completed" {
+			t.Fatalf("status = %q, want completed. Output: %s", got, string(out))
+		}
+	})
+}
+
 func findInteractionsStepDeltaPayload(events [][]byte) []byte {
 	return findInteractionsEventPayload(events, "step.delta")
 }

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response.go
@@ -652,6 +652,37 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 			idx := int(choice.Get("index").Int())
 			delta := choice.Get("delta")
 			if delta.Exists() {
+				// reasoning_content (OpenAI reasoning incremental text)
+				rc := delta.Get("reasoning_content")
+				if !rc.Exists() || rc.String() == "" {
+					rc = delta.Get("reasoning")
+				}
+				if rc.Exists() && rc.String() != "" {
+					// On first appearance, add reasoning item and part
+					if st.ReasoningID == "" {
+						st.ReasoningID = fmt.Sprintf("rs_%s_%d", st.ResponseID, idx)
+						st.ReasoningIndex = allocOutputIndex()
+						item := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"reasoning","status":"in_progress","summary":[]}}`)
+						item, _ = sjson.SetBytes(item, "sequence_number", nextSeq())
+						item, _ = sjson.SetBytes(item, "output_index", st.ReasoningIndex)
+						item, _ = sjson.SetBytes(item, "item.id", st.ReasoningID)
+						out = append(out, emitRespEvent("response.output_item.added", item))
+						part := []byte(`{"type":"response.reasoning_summary_part.added","sequence_number":0,"item_id":"","output_index":0,"summary_index":0,"part":{"type":"summary_text","text":""}}`)
+						part, _ = sjson.SetBytes(part, "sequence_number", nextSeq())
+						part, _ = sjson.SetBytes(part, "item_id", st.ReasoningID)
+						part, _ = sjson.SetBytes(part, "output_index", st.ReasoningIndex)
+						out = append(out, emitRespEvent("response.reasoning_summary_part.added", part))
+					}
+					// Append incremental text to reasoning buffer
+					st.ReasoningBuf.WriteString(rc.String())
+					msg := []byte(`{"type":"response.reasoning_summary_text.delta","sequence_number":0,"item_id":"","output_index":0,"summary_index":0,"delta":""}`)
+					msg, _ = sjson.SetBytes(msg, "sequence_number", nextSeq())
+					msg, _ = sjson.SetBytes(msg, "item_id", st.ReasoningID)
+					msg, _ = sjson.SetBytes(msg, "output_index", st.ReasoningIndex)
+					msg, _ = sjson.SetBytes(msg, "delta", rc.String())
+					out = append(out, emitRespEvent("response.reasoning_summary_text.delta", msg))
+				}
+
 				if c := delta.Get("content"); c.Exists() && c.String() != "" {
 					// Ensure the message item and its first content part are announced before any text deltas
 					if st.ReasoningID != "" {
@@ -692,37 +723,6 @@ func ConvertOpenAIChatCompletionsResponseToOpenAIResponses(ctx context.Context, 
 						st.MsgTextBuf[idx] = &strings.Builder{}
 					}
 					st.MsgTextBuf[idx].WriteString(c.String())
-				}
-
-				// reasoning_content (OpenAI reasoning incremental text)
-				rc := delta.Get("reasoning_content")
-				if !rc.Exists() || rc.String() == "" {
-					rc = delta.Get("reasoning")
-				}
-				if rc.Exists() && rc.String() != "" {
-					// On first appearance, add reasoning item and part
-					if st.ReasoningID == "" {
-						st.ReasoningID = fmt.Sprintf("rs_%s_%d", st.ResponseID, idx)
-						st.ReasoningIndex = allocOutputIndex()
-						item := []byte(`{"type":"response.output_item.added","sequence_number":0,"output_index":0,"item":{"id":"","type":"reasoning","status":"in_progress","summary":[]}}`)
-						item, _ = sjson.SetBytes(item, "sequence_number", nextSeq())
-						item, _ = sjson.SetBytes(item, "output_index", st.ReasoningIndex)
-						item, _ = sjson.SetBytes(item, "item.id", st.ReasoningID)
-						out = append(out, emitRespEvent("response.output_item.added", item))
-						part := []byte(`{"type":"response.reasoning_summary_part.added","sequence_number":0,"item_id":"","output_index":0,"summary_index":0,"part":{"type":"summary_text","text":""}}`)
-						part, _ = sjson.SetBytes(part, "sequence_number", nextSeq())
-						part, _ = sjson.SetBytes(part, "item_id", st.ReasoningID)
-						part, _ = sjson.SetBytes(part, "output_index", st.ReasoningIndex)
-						out = append(out, emitRespEvent("response.reasoning_summary_part.added", part))
-					}
-					// Append incremental text to reasoning buffer
-					st.ReasoningBuf.WriteString(rc.String())
-					msg := []byte(`{"type":"response.reasoning_summary_text.delta","sequence_number":0,"item_id":"","output_index":0,"summary_index":0,"delta":""}`)
-					msg, _ = sjson.SetBytes(msg, "sequence_number", nextSeq())
-					msg, _ = sjson.SetBytes(msg, "item_id", st.ReasoningID)
-					msg, _ = sjson.SetBytes(msg, "output_index", st.ReasoningIndex)
-					msg, _ = sjson.SetBytes(msg, "delta", rc.String())
-					out = append(out, emitRespEvent("response.reasoning_summary_text.delta", msg))
 				}
 
 				// tool calls

--- a/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
+++ b/internal/translator/openai/openai/responses/openai_openai-responses_response_test.go
@@ -2,6 +2,7 @@ package responses
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -1423,5 +1424,154 @@ func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_EmptyToolCallsArr
 	}
 	if got := completedData.Get("response.output.1.content.0.text").String(); got != "Hello world!" {
 		t.Fatalf("unexpected completed response message text: got %q, want %q", got, "Hello world!")
+	}
+}
+
+func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_ChunkWithContentAndReasoningContent(t *testing.T) {
+	request := []byte(`{"model":"deepseek-v4-flash"}`)
+	chunks := []string{
+		`data: {"id":"chatcmpl_ds","object":"chat.completion.chunk","created":1773896263,"model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"Thinking part 1,"},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl_ds","object":"chat.completion.chunk","created":1773896263,"model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"Bien","reasoning_content":" Just professional."},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl_ds","object":"chat.completion.chunk","created":1773896263,"model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":" continues here."},"finish_reason":"stop"}]}`,
+		`data: [DONE]`,
+	}
+
+	var param any
+	var reasoningAddedCount, reasoningDoneCount int
+	var messageAddedCount, messageDoneCount int
+	var completedCount int
+	var lastReasoningSummaryText string
+	var lastMessageContentText string
+	var eventOrder []string
+	var completedData gjson.Result
+	var addedItemIDs []string
+
+	for _, line := range chunks {
+		for _, chunk := range ConvertOpenAIChatCompletionsResponseToOpenAIResponses(context.Background(), "deepseek-v4-flash", request, request, []byte(line), &param) {
+			event, data := parseOpenAIResponsesSSEEvent(t, chunk)
+			switch event {
+			case "response.output_item.added":
+				itemType := data.Get("item.type").String()
+				itemID := data.Get("item.id").String()
+				addedItemIDs = append(addedItemIDs, itemID)
+				eventOrder = append(eventOrder, fmt.Sprintf("added:%s:%d", itemType, data.Get("output_index").Int()))
+				if itemType == "reasoning" {
+					reasoningAddedCount++
+				} else if itemType == "message" {
+					messageAddedCount++
+				}
+			case "response.output_item.done":
+				itemType := data.Get("item.type").String()
+				eventOrder = append(eventOrder, fmt.Sprintf("done:%s:%d", itemType, data.Get("output_index").Int()))
+				if itemType == "reasoning" {
+					reasoningDoneCount++
+					lastReasoningSummaryText = data.Get("item.summary.0.text").String()
+				} else if itemType == "message" {
+					messageDoneCount++
+					lastMessageContentText = data.Get("item.content.0.text").String()
+				}
+			case "response.completed":
+				completedCount++
+				completedData = data
+			}
+		}
+	}
+
+	if reasoningAddedCount != 1 {
+		t.Fatalf("expected exactly 1 reasoning output_item.added, got %d (events: %v)", reasoningAddedCount, eventOrder)
+	}
+	if reasoningDoneCount != 1 {
+		t.Fatalf("expected exactly 1 reasoning output_item.done, got %d (events: %v)", reasoningDoneCount, eventOrder)
+	}
+	if lastReasoningSummaryText != "Thinking part 1, Just professional." {
+		t.Fatalf("unexpected reasoning summary text: got %q, want %q", lastReasoningSummaryText, "Thinking part 1, Just professional.")
+	}
+	if messageAddedCount != 1 {
+		t.Fatalf("expected exactly 1 message output_item.added, got %d (events: %v)", messageAddedCount, eventOrder)
+	}
+	if messageDoneCount != 1 {
+		t.Fatalf("expected exactly 1 message output_item.done, got %d", messageDoneCount)
+	}
+	if lastMessageContentText != "Bien continues here." {
+		t.Fatalf("unexpected message content text: got %q, want %q", lastMessageContentText, "Bien continues here.")
+	}
+	if completedCount != 1 {
+		t.Fatalf("expected exactly 1 response.completed, got %d", completedCount)
+	}
+
+	// Verify strict event ordering: reasoning completes before message starts
+	wantOrder := []string{
+		"added:reasoning:0",
+		"done:reasoning:0",
+		"added:message:1",
+		"done:message:1",
+	}
+	if len(eventOrder) != len(wantOrder) {
+		t.Fatalf("unexpected event order length: got %v, want %v", eventOrder, wantOrder)
+	}
+	for i, want := range wantOrder {
+		if eventOrder[i] != want {
+			t.Fatalf("eventOrder[%d] = %q, want %q; full sequence: %v", i, eventOrder[i], want, eventOrder)
+		}
+	}
+
+	// Verify item IDs are unique
+	if len(addedItemIDs) != 2 || addedItemIDs[0] == addedItemIDs[1] {
+		t.Fatalf("expected 2 distinct item IDs, got %v", addedItemIDs)
+	}
+
+	// Verify completed response contains both outputs in ascending order
+	if got := completedData.Get("response.output.0.summary.0.text").String(); got != "Thinking part 1, Just professional." {
+		t.Fatalf("unexpected completed reasoning: got %q", got)
+	}
+	if got := completedData.Get("response.output.1.content.0.text").String(); got != "Bien continues here." {
+		t.Fatalf("unexpected completed message: got %q", got)
+	}
+}
+
+func TestConvertOpenAIChatCompletionsResponseToOpenAIResponses_SingleChunkWithBothContentAndReasoningContent(t *testing.T) {
+	request := []byte(`{"model":"deepseek-v4-flash"}`)
+	chunks := []string{
+		`data: {"id":"chatcmpl_single","object":"chat.completion.chunk","created":1773896263,"model":"deepseek-v4-flash","choices":[{"index":0,"delta":{"content":"Answer","reasoning_content":"Thought"},"finish_reason":"stop"}]}`,
+		`data: [DONE]`,
+	}
+
+	var param any
+	var eventOrder []string
+	var completedData gjson.Result
+
+	for _, line := range chunks {
+		for _, chunk := range ConvertOpenAIChatCompletionsResponseToOpenAIResponses(context.Background(), "deepseek-v4-flash", request, request, []byte(line), &param) {
+			event, data := parseOpenAIResponsesSSEEvent(t, chunk)
+			switch event {
+			case "response.output_item.added":
+				eventOrder = append(eventOrder, fmt.Sprintf("added:%s:%d", data.Get("item.type").String(), data.Get("output_index").Int()))
+			case "response.output_item.done":
+				eventOrder = append(eventOrder, fmt.Sprintf("done:%s:%d", data.Get("item.type").String(), data.Get("output_index").Int()))
+			case "response.completed":
+				completedData = data
+			}
+		}
+	}
+
+	wantOrder := []string{
+		"added:reasoning:0",
+		"done:reasoning:0",
+		"added:message:1",
+		"done:message:1",
+	}
+	if len(eventOrder) != len(wantOrder) {
+		t.Fatalf("unexpected event order length: got %v, want %v", eventOrder, wantOrder)
+	}
+	for i, want := range wantOrder {
+		if eventOrder[i] != want {
+			t.Fatalf("eventOrder[%d] = %q, want %q; full sequence: %v", i, eventOrder[i], want, eventOrder)
+		}
+	}
+	if got := completedData.Get("response.output.0.summary.0.text").String(); got != "Thought" {
+		t.Fatalf("unexpected completed reasoning: got %q", got)
+	}
+	if got := completedData.Get("response.output.1.content.0.text").String(); got != "Answer" {
+		t.Fatalf("unexpected completed message: got %q", got)
 	}
 }

--- a/sdk/api/handlers/openai/codex_client_models_test.go
+++ b/sdk/api/handlers/openai/codex_client_models_test.go
@@ -126,3 +126,106 @@ func TestCodexClientModelsResponseClientVersionFiltering(t *testing.T) {
 		t.Fatal("0.149.1 expected ultra reasoning effort to be preserved")
 	}
 }
+
+func TestOpenAIModels_DoesNotExposeMetadataModelID(t *testing.T) {
+	clientID := "openai-models-no-metadata-id-test"
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.RegisterClient(clientID, "codex", []*registry.ModelInfo{
+		{
+			ID:              "codex-main",
+			MetadataModelID: "gpt-6-astra",
+			DisplayName:     "GPT 6.0 Astra",
+		},
+	})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(clientID)
+	})
+
+	openaiModels := modelRegistry.GetAvailableModels("openai")
+	for _, m := range openaiModels {
+		if _, exists := m["metadata_model_id"]; exists {
+			t.Fatalf("model map exposed internal metadata_model_id: %#v", m)
+		}
+		if _, exists := m["MetadataModelID"]; exists {
+			t.Fatalf("model map exposed internal MetadataModelID: %#v", m)
+		}
+	}
+}
+
+func testIntModelValue(model map[string]any, key string) int {
+	if model == nil {
+		return 0
+	}
+	switch value := model[key].(type) {
+	case int:
+		return value
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	}
+	return 0
+}
+
+func TestCodexClientModelsResponse_OAuthAliasesIntegration(t *testing.T) {
+	clientID := "codex-client-models-integration-test"
+	modelRegistry := registry.GetGlobalRegistry()
+	modelRegistry.RegisterClient(clientID, "codex", []*registry.ModelInfo{
+		{
+			ID:              "codex-main",
+			MetadataModelID: "gpt-6-astra",
+			DisplayName:     "GPT 6.0 Astra",
+		},
+		{
+			ID:              "codex-luna",
+			MetadataModelID: "gpt-5.6-luna",
+			DisplayName:     "GPT 5.6 Luna",
+		},
+	})
+	t.Cleanup(func() {
+		modelRegistry.UnregisterClient(clientID)
+	})
+
+	base := handlers.NewBaseAPIHandlers(&config.SDKConfig{}, nil)
+	handler := NewOpenAIAPIHandler(base)
+	resp := handler.codexClientModelsResponse("0.153.4")
+	models, ok := resp["models"].([]map[string]any)
+	if !ok {
+		t.Fatalf("models type = %T, want []map[string]any", resp["models"])
+	}
+
+	entries := make(map[string]map[string]any, len(models))
+	for _, entry := range models {
+		if slug, ok := entry["slug"].(string); ok {
+			entries[slug] = entry
+		}
+	}
+
+	if mainEntry := entries["codex-main"]; mainEntry == nil {
+		t.Fatal("missing codex-main entry")
+	} else {
+		if compHash, _ := mainEntry["comp_hash"].(string); compHash != "3000" {
+			t.Errorf("codex-main comp_hash = %q, want 3000", compHash)
+		}
+		if maxContext := testIntModelValue(mainEntry, "max_context_window"); maxContext != 872000 {
+			t.Errorf("codex-main max_context_window = %d, want 872000", maxContext)
+		}
+		if search, _ := mainEntry["supports_search_tool"].(bool); !search {
+			t.Errorf("codex-main supports_search_tool = %v, want true", search)
+		}
+	}
+
+	if lunaEntry := entries["codex-luna"]; lunaEntry == nil {
+		t.Fatal("missing codex-luna entry")
+	} else {
+		if compHash, _ := lunaEntry["comp_hash"].(string); compHash != "3000" {
+			t.Errorf("codex-luna comp_hash = %q, want 3000", compHash)
+		}
+		if maxContext := testIntModelValue(lunaEntry, "max_context_window"); maxContext != 872000 {
+			t.Errorf("codex-luna max_context_window = %d, want 872000", maxContext)
+		}
+		if search, _ := lunaEntry["supports_search_tool"].(bool); !search {
+			t.Errorf("codex-luna supports_search_tool = %v, want true", search)
+		}
+	}
+}

--- a/sdk/auth/claude.go
+++ b/sdk/auth/claude.go
@@ -200,7 +200,7 @@ waitForCallback:
 		return nil, fmt.Errorf("claude token storage missing account information")
 	}
 
-	fileName := fmt.Sprintf("claude-%s.json", tokenStorage.Email)
+	fileName := claude.CredentialFileName(tokenStorage.Email, tokenStorage.OrganizationUUID, tokenStorage.AccountUUID)
 	metadata := map[string]any{
 		"email": tokenStorage.Email,
 	}

--- a/sdk/auth/filestore.go
+++ b/sdk/auth/filestore.go
@@ -89,7 +89,10 @@ func (s *FileTokenStore) Save(ctx context.Context, auth *cliproxyauth.Auth) (str
 		return "", fmt.Errorf("auth filestore: missing file path attribute for %s", auth.ID)
 	}
 
-	if auth.Disabled {
+	// Runtime updates must not recreate a disabled credential whose source file
+	// was deliberately removed. Login and migration callers explicitly mark the
+	// save when creating a missing disabled credential is intentional.
+	if auth.Disabled && !cliproxyauth.HasAuthCreationIntent(ctx) {
 		if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
 			return "", nil
 		}

--- a/sdk/auth/filestore_disabled_test.go
+++ b/sdk/auth/filestore_disabled_test.go
@@ -62,3 +62,66 @@ func TestFileTokenStore_Save_DisabledPersistsFlagForTokenStorage(t *testing.T) {
 		t.Fatalf("disabled=%v, want true (raw=%s)", meta["disabled"], string(raw))
 	}
 }
+
+func TestFileTokenStore_Save_DisabledLoginCreatesCanonicalFile(t *testing.T) {
+	baseDir := t.TempDir()
+	path := filepath.Join(baseDir, "canonical-disabled.json")
+	store := NewFileTokenStore()
+	store.SetBaseDir(baseDir)
+
+	auth := &cliproxyauth.Auth{
+		ID:       "canonical-disabled.json",
+		Provider: "test",
+		FileName: "canonical-disabled.json",
+		Disabled: true,
+		Storage:  &testTokenStorage{},
+		Metadata: map[string]any{"type": "test"},
+	}
+
+	ctx := cliproxyauth.WithAuthCreationIntent(context.Background())
+	savedPath, err := store.Save(ctx, auth)
+	if err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	if savedPath != path {
+		t.Fatalf("Save() path = %q, want %q", savedPath, path)
+	}
+	raw, errRead := os.ReadFile(path)
+	if errRead != nil {
+		t.Fatalf("read canonical disabled credential: %v", errRead)
+	}
+	var metadata map[string]any
+	if errUnmarshal := json.Unmarshal(raw, &metadata); errUnmarshal != nil {
+		t.Fatalf("unmarshal canonical disabled credential: %v", errUnmarshal)
+	}
+	if disabled, _ := metadata["disabled"].(bool); !disabled {
+		t.Fatalf("disabled = %v, want true", metadata["disabled"])
+	}
+}
+
+func TestFileTokenStore_Save_DisabledStorageBackedRuntimeDoesNotRecreateMissingFile(t *testing.T) {
+	baseDir := t.TempDir()
+	path := filepath.Join(baseDir, "removed-disabled.json")
+	store := NewFileTokenStore()
+	store.SetBaseDir(baseDir)
+
+	auth := &cliproxyauth.Auth{
+		ID:       "removed-disabled.json",
+		Provider: "test",
+		FileName: "removed-disabled.json",
+		Disabled: true,
+		Storage:  &testTokenStorage{},
+		Metadata: map[string]any{"type": "test"},
+	}
+
+	savedPath, err := store.Save(context.Background(), auth)
+	if err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	if savedPath != "" {
+		t.Fatalf("Save() path = %q, want empty", savedPath)
+	}
+	if _, errStat := os.Stat(path); !os.IsNotExist(errStat) {
+		t.Fatalf("removed credential was recreated or stat failed: %v", errStat)
+	}
+}

--- a/sdk/auth/manager.go
+++ b/sdk/auth/manager.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	claudeauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/claude"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
@@ -86,10 +87,29 @@ func (m *Manager) Login(ctx context.Context, provider string, cfg *config.Config
 			}
 		}
 	}
+	legacyClaudeCredential, errLegacy := claudeauth.FindMatchingLegacyCredential(ctx, m.store, record)
+	if errLegacy != nil {
+		return record, "", errLegacy
+	}
+	if legacyClaudeCredential != nil {
+		coreauth.MergeExistingAuthMetadata(record, legacyClaudeCredential.Metadata)
+	}
 
-	savedPath, err := m.store.Save(ctx, record)
+	savedPath, err := m.store.Save(coreauth.WithAuthCreationIntent(ctx), record)
 	if err != nil {
 		return record, "", err
+	}
+	if legacyClaudeCredential != nil {
+		if strings.TrimSpace(savedPath) == "" {
+			return record, "", fmt.Errorf("cliproxy auth: canonical Claude credential was not persisted; legacy credential retained")
+		}
+		legacyID := strings.TrimSpace(legacyClaudeCredential.ID)
+		if legacyID == "" {
+			legacyID = strings.TrimSpace(legacyClaudeCredential.FileName)
+		}
+		if errDelete := m.store.Delete(ctx, legacyID); errDelete != nil {
+			return record, savedPath, fmt.Errorf("cliproxy auth: canonical Claude credential saved but legacy credential cleanup failed: %w", errDelete)
+		}
 	}
 	return record, savedPath, nil
 }

--- a/sdk/auth/manager_test.go
+++ b/sdk/auth/manager_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	claudeauth "github.com/router-for-me/CLIProxyAPI/v7/internal/auth/claude"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
 	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
 )
@@ -107,5 +108,210 @@ func TestManagerLogin_PreservesExistingAuthFileMetadata(t *testing.T) {
 	}
 	if saved["weight"] != float64(10) {
 		t.Errorf("weight = %v, want 10", saved["weight"])
+	}
+}
+
+func TestManagerLogin_MigratesMatchingLegacyClaudeCredential(t *testing.T) {
+	authDir := t.TempDir()
+	legacyFileName := "claude-user@example.com.json"
+	targetFileName := claudeauth.CredentialFileName("user@example.com", "organization-a", "account-a")
+	legacyPath := filepath.Join(authDir, legacyFileName)
+	targetPath := filepath.Join(authDir, targetFileName)
+
+	existing := map[string]any{
+		"type":              "claude",
+		"email":             "user@example.com",
+		"organization_uuid": "organization-a",
+		"account_uuid":      "account-a",
+		"access_token":      "old-token",
+		"prefix":            "team",
+		"proxy_url":         "http://127.0.0.1:8080",
+		"disabled":          true,
+		"weight":            float64(5),
+	}
+	raw, errMarshal := json.Marshal(existing)
+	if errMarshal != nil {
+		t.Fatalf("marshal legacy credential: %v", errMarshal)
+	}
+	if errWrite := os.WriteFile(legacyPath, raw, 0o600); errWrite != nil {
+		t.Fatalf("write legacy credential: %v", errWrite)
+	}
+
+	newRecord := &coreauth.Auth{
+		ID:       targetFileName,
+		FileName: targetFileName,
+		Provider: "claude",
+		Storage: &claudeauth.ClaudeTokenStorage{
+			Type:             "claude",
+			Email:            "user@example.com",
+			OrganizationUUID: "organization-a",
+			AccountUUID:      "account-a",
+			AccessToken:      "new-token",
+		},
+		Metadata: map[string]any{
+			"type":              "claude",
+			"email":             "user@example.com",
+			"organization_uuid": "organization-a",
+			"account_uuid":      "account-a",
+			"access_token":      "new-token",
+		},
+	}
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(authDir)
+	mgr := NewManager(store, &dummyAuthenticator{provider: "claude", record: newRecord})
+
+	_, savedPath, errLogin := mgr.Login(context.Background(), "claude", &config.Config{AuthDir: authDir}, nil)
+	if errLogin != nil {
+		t.Fatalf("Login error: %v", errLogin)
+	}
+	if savedPath != targetPath {
+		t.Fatalf("savedPath = %s, want %s", savedPath, targetPath)
+	}
+	if _, errStat := os.Stat(legacyPath); !os.IsNotExist(errStat) {
+		t.Fatalf("legacy credential still exists or stat failed: %v", errStat)
+	}
+
+	savedRaw, errRead := os.ReadFile(targetPath)
+	if errRead != nil {
+		t.Fatalf("read migrated credential: %v", errRead)
+	}
+	var saved map[string]any
+	if errUnmarshal := json.Unmarshal(savedRaw, &saved); errUnmarshal != nil {
+		t.Fatalf("unmarshal migrated credential: %v", errUnmarshal)
+	}
+	for key, want := range map[string]any{
+		"access_token": "new-token",
+		"prefix":       "team",
+		"proxy_url":    "http://127.0.0.1:8080",
+		"disabled":     true,
+		"weight":       float64(5),
+	} {
+		if got := saved[key]; got != want {
+			t.Errorf("%s = %#v, want %#v", key, got, want)
+		}
+	}
+}
+
+func TestManagerLogin_DoesNotMigrateLegacyClaudeCredentialFromDifferentOrganization(t *testing.T) {
+	authDir := t.TempDir()
+	legacyFileName := "claude-user@example.com.json"
+	targetFileName := claudeauth.CredentialFileName("user@example.com", "organization-b", "shared-account")
+	legacyPath := filepath.Join(authDir, legacyFileName)
+
+	existing := map[string]any{
+		"type":              "claude",
+		"email":             "user@example.com",
+		"organization_uuid": "organization-a",
+		"account_uuid":      "shared-account",
+		"access_token":      "old-token",
+		"prefix":            "team",
+	}
+	raw, errMarshal := json.Marshal(existing)
+	if errMarshal != nil {
+		t.Fatalf("marshal legacy credential: %v", errMarshal)
+	}
+	if errWrite := os.WriteFile(legacyPath, raw, 0o600); errWrite != nil {
+		t.Fatalf("write legacy credential: %v", errWrite)
+	}
+
+	newRecord := &coreauth.Auth{
+		ID:       targetFileName,
+		FileName: targetFileName,
+		Provider: "claude",
+		Metadata: map[string]any{
+			"type":              "claude",
+			"email":             "user@example.com",
+			"organization_uuid": "organization-b",
+			"account_uuid":      "shared-account",
+			"access_token":      "new-token",
+		},
+	}
+
+	store := NewFileTokenStore()
+	store.SetBaseDir(authDir)
+	mgr := NewManager(store, &dummyAuthenticator{provider: "claude", record: newRecord})
+
+	if _, _, errLogin := mgr.Login(context.Background(), "claude", &config.Config{AuthDir: authDir}, nil); errLogin != nil {
+		t.Fatalf("Login error: %v", errLogin)
+	}
+	if _, errStat := os.Stat(legacyPath); errStat != nil {
+		t.Fatalf("different-organization legacy credential was removed: %v", errStat)
+	}
+
+	savedRaw, errRead := os.ReadFile(filepath.Join(authDir, targetFileName))
+	if errRead != nil {
+		t.Fatalf("read new credential: %v", errRead)
+	}
+	var saved map[string]any
+	if errUnmarshal := json.Unmarshal(savedRaw, &saved); errUnmarshal != nil {
+		t.Fatalf("unmarshal new credential: %v", errUnmarshal)
+	}
+	if _, inherited := saved["prefix"]; inherited {
+		t.Fatalf("new credential inherited prefix from a different organization: %#v", saved["prefix"])
+	}
+}
+
+func TestManagerLogin_MultipleOrganizationsSharingEmailCoexist(t *testing.T) {
+	authDir := t.TempDir()
+	store := NewFileTokenStore()
+	store.SetBaseDir(authDir)
+
+	file1 := claudeauth.CredentialFileName("shared@example.com", "org-team-1", "account-1")
+	record1 := &coreauth.Auth{
+		ID:       file1,
+		FileName: file1,
+		Provider: "claude",
+		Storage: &claudeauth.ClaudeTokenStorage{
+			Type:             "claude",
+			Email:            "shared@example.com",
+			OrganizationUUID: "org-team-1",
+			AccessToken:      "token-team",
+		},
+		Metadata: map[string]any{
+			"type":              "claude",
+			"email":             "shared@example.com",
+			"organization_uuid": "org-team-1",
+		},
+	}
+	mgr1 := NewManager(store, &dummyAuthenticator{provider: "claude", record: record1})
+	_, savedPath1, errLogin1 := mgr1.Login(context.Background(), "claude", &config.Config{AuthDir: authDir}, nil)
+	if errLogin1 != nil {
+		t.Fatalf("Login 1 error: %v", errLogin1)
+	}
+
+	file2 := claudeauth.CredentialFileName("shared@example.com", "org-enterprise-2", "account-1")
+	record2 := &coreauth.Auth{
+		ID:       file2,
+		FileName: file2,
+		Provider: "claude",
+		Storage: &claudeauth.ClaudeTokenStorage{
+			Type:             "claude",
+			Email:            "shared@example.com",
+			OrganizationUUID: "org-enterprise-2",
+			AccessToken:      "token-enterprise",
+		},
+		Metadata: map[string]any{
+			"type":              "claude",
+			"email":             "shared@example.com",
+			"organization_uuid": "org-enterprise-2",
+		},
+	}
+	mgr2 := NewManager(store, &dummyAuthenticator{provider: "claude", record: record2})
+	_, savedPath2, errLogin2 := mgr2.Login(context.Background(), "claude", &config.Config{AuthDir: authDir}, nil)
+	if errLogin2 != nil {
+		t.Fatalf("Login 2 error: %v", errLogin2)
+	}
+
+	if savedPath1 == savedPath2 {
+		t.Fatalf("savedPath1 and savedPath2 are identical: %s; expected distinct files", savedPath1)
+	}
+
+	records, errList := store.List(context.Background())
+	if errList != nil {
+		t.Fatalf("store.List error: %v", errList)
+	}
+	if len(records) != 2 {
+		t.Fatalf("store.List returned %d records, want 2 distinct organization records", len(records))
 	}
 }

--- a/sdk/cliproxy/auth/conductor.go
+++ b/sdk/cliproxy/auth/conductor.go
@@ -110,6 +110,25 @@ func (NoopHook) OnAuthUpdated(context.Context, *Auth) {}
 // OnResult implements Hook.
 func (NoopHook) OnResult(context.Context, Result) {}
 
+// ResultPolicy allows inspecting and mutating an execution result before in-memory quota mutations,
+// cooldown persistence, and scheduler/registry publishing.
+// Implementations of ResultPolicy must be safe for concurrent use by multiple goroutines.
+type ResultPolicy interface {
+	ApplyResultPolicy(ctx context.Context, result Result) Result
+}
+
+// ResultPolicyFunc enables using a plain function as a ResultPolicy.
+type ResultPolicyFunc func(ctx context.Context, result Result) Result
+
+// ApplyResultPolicy calls f(ctx, result).
+func (f ResultPolicyFunc) ApplyResultPolicy(ctx context.Context, result Result) Result {
+	return f(ctx, result)
+}
+
+type resultPolicyHolder struct {
+	policy ResultPolicy
+}
+
 // Manager orchestrates auth lifecycle, selection, execution, and persistence.
 type Manager struct {
 	store                     Store
@@ -118,6 +137,7 @@ type Manager struct {
 	executors                 map[string]ProviderExecutor
 	selector                  Selector
 	hook                      Hook
+	resultPolicy              atomic.Pointer[resultPolicyHolder]
 	mu                        sync.RWMutex
 	selectorMu                sync.Mutex
 	configCooldownMu          sync.Mutex
@@ -202,4 +222,28 @@ func NewManager(store Store, selector Selector, hook Hook) *Manager {
 	}
 	manager.scheduler = newAuthScheduler(selector)
 	return manager
+}
+
+// SetResultPolicy sets an execution result policy invoked before in-memory quota mutations and persistence.
+func (m *Manager) SetResultPolicy(policy ResultPolicy) {
+	if m == nil {
+		return
+	}
+	if policy == nil {
+		m.resultPolicy.Store(nil)
+		return
+	}
+	m.resultPolicy.Store(&resultPolicyHolder{policy: policy})
+}
+
+// ResultPolicy returns the current execution result policy, or nil if none is configured.
+func (m *Manager) ResultPolicy() ResultPolicy {
+	if m == nil {
+		return nil
+	}
+	holder := m.resultPolicy.Load()
+	if holder == nil {
+		return nil
+	}
+	return holder.policy
 }

--- a/sdk/cliproxy/auth/conductor_cloudflare_520_test.go
+++ b/sdk/cliproxy/auth/conductor_cloudflare_520_test.go
@@ -1,0 +1,535 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestIsCloudflareChallengeErrorMessage_ExcludesOriginErrors(t *testing.T) {
+	origin520 := `<html><head><title>Web server is returning an unknown error</title></head><body><div class="cf-error-details cf-error-520"><h1>Web server is returning an unknown error</h1><p>There is an unknown connection issue between Cloudflare and the origin web server.</p><ul><li>Ray ID: a385507da9eeb4c4</li><li>Error reference number: 520</li><li>Cloudflare Location: Los Angeles</li></ul></div></body></html>`
+	if isCloudflareChallengeErrorMessage(origin520) {
+		t.Fatalf("expected origin 520 error not to be classified as cloudflare challenge")
+	}
+
+	minimalOrigin := `<html><body><h1>Web server is returning an unknown error</h1><p>There is an unknown connection issue between Cloudflare and the origin web server.</p></body></html>`
+	if isCloudflareChallengeErrorMessage(minimalOrigin) {
+		t.Fatalf("expected minimal origin error not to be classified as cloudflare challenge")
+	}
+
+	// Legitimate challenge messages must still be recognized.
+	challenges := []string{
+		"cf-mitigated: challenge",
+		`<html><body><script src="/cdn-cgi/challenge-platform/h/b/orchestrate/chl_page/v1"></script></body></html>`,
+		"cloudflare challenge required",
+		// Isolated "Just a moment..." challenge page test without "cloudflare challenge" phrase
+		`<html><head><title>Just a moment...</title></head><body>Checking your browser... cloudflare</body></html>`,
+	}
+	for _, ch := range challenges {
+		if !isCloudflareChallengeErrorMessage(ch) {
+			t.Fatalf("expected %q to be classified as cloudflare challenge", ch)
+		}
+	}
+}
+
+func TestManager_MarkResult_Cloudflare520OriginError_NotTreatedAsChallenge(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "auth-test-520",
+		Provider: "codex",
+		Status:   StatusActive,
+	}
+	m.Register(context.Background(), auth)
+
+	origin520Msg := `<html><body><div class="cf-error-details cf-error-520"><h1>Web server is returning an unknown error</h1><p>There is an unknown connection issue between Cloudflare and the origin web server.</p></div></body></html>`
+
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: "codex",
+		Model:    "gpt-5.6-sol",
+		Success:  false,
+		Error: &Error{
+			HTTPStatus: 520,
+			Message:    origin520Msg,
+		},
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be found")
+	}
+	state := updated.ModelStates["gpt-5.6-sol"]
+	if state == nil {
+		t.Fatalf("expected model state to be present")
+	}
+
+	// Quota must not be marked as exceeded or challenged.
+	if state.Quota.Exceeded {
+		t.Fatalf("expected Quota.Exceeded to be false for 520 origin error")
+	}
+	if state.Quota.Reason != "" {
+		t.Fatalf("expected Quota.Reason to be empty for 520 origin error, got %q", state.Quota.Reason)
+	}
+	if state.StatusMessage == "cloudflare challenge" {
+		t.Fatalf("expected StatusMessage not to be 'cloudflare challenge' for 520 origin error")
+	}
+	if state.StatusMessage != origin520Msg {
+		t.Fatalf("expected StatusMessage to preserve upstream error, got %q", state.StatusMessage)
+	}
+
+	// LastError must retain the 520 error.
+	if state.LastError == nil || state.LastError.HTTPStatus != 520 {
+		t.Fatalf("expected LastError to retain HTTP 520, got %#v", state.LastError)
+	}
+
+	// By default, transient errors apply a 1-minute retry window.
+	if !state.Unavailable {
+		t.Fatalf("expected model to be marked unavailable during transient cooldown")
+	}
+	diff := time.Until(state.NextRetryAfter)
+	if diff < 45*time.Second || diff > 75*time.Second {
+		t.Fatalf("expected default transient cooldown of ~60s, got %v", diff)
+	}
+}
+
+func TestManager_MarkResult_Cloudflare520_CustomTransientCooldown(t *testing.T) {
+	prevTransient := transientErrorCooldownSeconds.Load()
+	transientErrorCooldownSeconds.Store(5)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "auth-test-520-custom-cooldown",
+		Provider: "codex",
+		Status:   StatusActive,
+	}
+	m.Register(context.Background(), auth)
+
+	origin520Msg := `<html><body><div class="cf-error-details cf-error-520"><h1>Web server is returning an unknown error</h1></div></body></html>`
+
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: "codex",
+		Model:    "gpt-5.6-sol",
+		Success:  false,
+		Error: &Error{
+			HTTPStatus: 520,
+			Message:    origin520Msg,
+		},
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be found")
+	}
+	state := updated.ModelStates["gpt-5.6-sol"]
+	if state == nil {
+		t.Fatalf("expected model state to be present")
+	}
+
+	diff := time.Until(state.NextRetryAfter)
+	if diff < 3*time.Second || diff > 7*time.Second {
+		t.Fatalf("expected custom transient cooldown of ~5s, got %v", diff)
+	}
+}
+
+func TestManager_MarkResult_Cloudflare520_DisabledTransientCooldown(t *testing.T) {
+	prevTransient := transientErrorCooldownSeconds.Load()
+	transientErrorCooldownSeconds.Store(-1)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "auth-test-520-disabled-cooldown",
+		Provider: "codex",
+		Status:   StatusActive,
+	}
+	m.Register(context.Background(), auth)
+
+	origin520Msg := `<html><body><div class="cf-error-details cf-error-520"><h1>Web server is returning an unknown error</h1></div></body></html>`
+
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: "codex",
+		Model:    "gpt-5.6-sol",
+		Success:  false,
+		Error: &Error{
+			HTTPStatus: 520,
+			Message:    origin520Msg,
+		},
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be found")
+	}
+	state := updated.ModelStates["gpt-5.6-sol"]
+	if state == nil {
+		t.Fatalf("expected model state to be present")
+	}
+
+	if !state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected NextRetryAfter to be zero when transient cooldown disabled, got %v", state.NextRetryAfter)
+	}
+	if state.Unavailable {
+		t.Fatalf("expected model not to be unavailable when cooldown is disabled")
+	}
+}
+
+func TestManager_MarkResult_Cloudflare520_DisableCoolingAuth(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "auth-test-520-disable-cooling-auth",
+		Provider: "codex",
+		Status:   StatusActive,
+		Metadata: map[string]any{
+			"disable_cooling": true,
+		},
+	}
+	m.Register(context.Background(), auth)
+
+	origin520Msg := `<html><body><div class="cf-error-details cf-error-520"><h1>Web server is returning an unknown error</h1></div></body></html>`
+
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: "codex",
+		Model:    "gpt-5.6-sol",
+		Success:  false,
+		Error: &Error{
+			HTTPStatus: 520,
+			Message:    origin520Msg,
+		},
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be found")
+	}
+	state := updated.ModelStates["gpt-5.6-sol"]
+	if state == nil {
+		t.Fatalf("expected model state to be present")
+	}
+
+	if !state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected NextRetryAfter to be zero when disable_cooling is true, got %v", state.NextRetryAfter)
+	}
+	if state.Unavailable {
+		t.Fatalf("expected model not to be unavailable when disable_cooling is true")
+	}
+}
+
+func TestManager_MarkResult_Cloudflare520_WithRetryAfterHint(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "auth-test-520-hint",
+		Provider: "codex",
+		Status:   StatusActive,
+	}
+	m.Register(context.Background(), auth)
+
+	origin520Msg := `<html><body><div class="cf-error-details cf-error-520"><h1>Web server is returning an unknown error</h1></div></body></html>`
+	hint := 15 * time.Second
+
+	m.MarkResult(context.Background(), Result{
+		AuthID:     auth.ID,
+		Provider:   "codex",
+		Model:      "gpt-5.6-sol",
+		Success:    false,
+		RetryAfter: &hint,
+		Error: &Error{
+			HTTPStatus: 520,
+			Message:    origin520Msg,
+		},
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be found")
+	}
+	state := updated.ModelStates["gpt-5.6-sol"]
+	if state == nil {
+		t.Fatalf("expected model state to be present")
+	}
+
+	diff := time.Until(state.NextRetryAfter)
+	if diff < 10*time.Second || diff > 20*time.Second {
+		t.Fatalf("expected hint-based cooldown of ~15s, got %v", diff)
+	}
+}
+
+func TestManager_MarkResult_Cloudflare520_DisabledTransientCooldown_IgnoresHint(t *testing.T) {
+	prevTransient := transientErrorCooldownSeconds.Load()
+	transientErrorCooldownSeconds.Store(-1)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "auth-test-520-disabled-with-hint",
+		Provider: "codex",
+		Status:   StatusActive,
+	}
+	m.Register(context.Background(), auth)
+
+	origin520Msg := `<html><body><div class="cf-error-details cf-error-520"><h1>Web server is returning an unknown error</h1></div></body></html>`
+	hint := 15 * time.Second
+
+	m.MarkResult(context.Background(), Result{
+		AuthID:     auth.ID,
+		Provider:   "codex",
+		Model:      "gpt-5.6-sol",
+		Success:    false,
+		RetryAfter: &hint,
+		Error: &Error{
+			HTTPStatus: 520,
+			Message:    origin520Msg,
+		},
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be found")
+	}
+	state := updated.ModelStates["gpt-5.6-sol"]
+	if state == nil {
+		t.Fatalf("expected model state to be present")
+	}
+
+	if !state.NextRetryAfter.IsZero() {
+		t.Fatalf("expected NextRetryAfter to be zero when transient cooldown is disabled (-1) despite RetryAfter hint, got %v", state.NextRetryAfter)
+	}
+	if state.Unavailable {
+		t.Fatalf("expected model not to be unavailable when transient cooldown is disabled")
+	}
+}
+
+func TestManager_MarkResult_AuthLevelCloudflare520_DisabledTransientCooldown_IgnoresHint(t *testing.T) {
+	prevTransient := transientErrorCooldownSeconds.Load()
+	transientErrorCooldownSeconds.Store(-1)
+	t.Cleanup(func() { transientErrorCooldownSeconds.Store(prevTransient) })
+
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "auth-test-520-auth-disabled-with-hint",
+		Provider: "codex",
+		Status:   StatusActive,
+	}
+	m.Register(context.Background(), auth)
+
+	origin520Msg := `<html><body><div class="cf-error-details cf-error-520"><h1>Web server is returning an unknown error</h1></div></body></html>`
+	hint := 15 * time.Second
+
+	m.MarkResult(context.Background(), Result{
+		AuthID:     auth.ID,
+		Provider:   "codex",
+		Model:      "",
+		Success:    false,
+		RetryAfter: &hint,
+		Error: &Error{
+			HTTPStatus: 520,
+			Message:    origin520Msg,
+		},
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be found")
+	}
+
+	if !updated.NextRetryAfter.IsZero() {
+		t.Fatalf("expected auth NextRetryAfter to be zero when transient cooldown is disabled (-1) despite RetryAfter hint, got %v", updated.NextRetryAfter)
+	}
+	if updated.Unavailable {
+		t.Fatalf("expected auth not to be unavailable when transient cooldown is disabled")
+	}
+}
+
+func TestManager_MarkResult_HTTP503_TransientCooldown_RespectsDisabledAndHint(t *testing.T) {
+	// 1. When disabled (-1), 503 with RetryAfter hint must NOT apply cooldown.
+	{
+		prevTransient := transientErrorCooldownSeconds.Load()
+		transientErrorCooldownSeconds.Store(-1)
+		defer transientErrorCooldownSeconds.Store(prevTransient)
+
+		m := NewManager(nil, nil, nil)
+		auth := &Auth{
+			ID:       "auth-test-503-disabled",
+			Provider: "claude",
+			Status:   StatusActive,
+		}
+		m.Register(context.Background(), auth)
+
+		hint := 20 * time.Second
+		m.MarkResult(context.Background(), Result{
+			AuthID:     auth.ID,
+			Provider:   "claude",
+			Model:      "claude-3-5-sonnet",
+			Success:    false,
+			RetryAfter: &hint,
+			Error: &Error{
+				HTTPStatus: 503,
+				Message:    "service unavailable",
+			},
+		})
+
+		updated, ok := m.GetByID(auth.ID)
+		if !ok || updated == nil {
+			t.Fatalf("expected auth to be found")
+		}
+		state := updated.ModelStates["claude-3-5-sonnet"]
+		if state == nil {
+			t.Fatalf("expected model state to be present")
+		}
+		if !state.NextRetryAfter.IsZero() {
+			t.Fatalf("expected 503 NextRetryAfter to be zero when transient cooldown is disabled (-1), got %v", state.NextRetryAfter)
+		}
+		if state.Unavailable {
+			t.Fatalf("expected model not to be unavailable when transient cooldown is disabled")
+		}
+	}
+
+	// 2. When enabled (0 = default), 503 with RetryAfter hint must use hint.
+	{
+		prevTransient := transientErrorCooldownSeconds.Load()
+		transientErrorCooldownSeconds.Store(0)
+		defer transientErrorCooldownSeconds.Store(prevTransient)
+
+		m := NewManager(nil, nil, nil)
+		auth := &Auth{
+			ID:       "auth-test-503-hint",
+			Provider: "claude",
+			Status:   StatusActive,
+		}
+		m.Register(context.Background(), auth)
+
+		hint := 20 * time.Second
+		m.MarkResult(context.Background(), Result{
+			AuthID:     auth.ID,
+			Provider:   "claude",
+			Model:      "claude-3-5-sonnet",
+			Success:    false,
+			RetryAfter: &hint,
+			Error: &Error{
+				HTTPStatus: 503,
+				Message:    "service unavailable",
+			},
+		})
+
+		updated, ok := m.GetByID(auth.ID)
+		if !ok || updated == nil {
+			t.Fatalf("expected auth to be found")
+		}
+		state := updated.ModelStates["claude-3-5-sonnet"]
+		if state == nil {
+			t.Fatalf("expected model state to be present")
+		}
+		diff := time.Until(state.NextRetryAfter)
+		if diff < 15*time.Second || diff > 25*time.Second {
+			t.Fatalf("expected 503 hint cooldown of ~20s, got %v", diff)
+		}
+		if !state.Unavailable {
+			t.Fatalf("expected model to be unavailable during cooldown")
+		}
+	}
+}
+
+func TestManager_MarkResult_AuthLevelCloudflare520_SetsTransientError(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	auth := &Auth{
+		ID:       "auth-test-520-authlevel",
+		Provider: "codex",
+		Status:   StatusActive,
+	}
+	m.Register(context.Background(), auth)
+
+	origin520Msg := `<html><body><div class="cf-error-details cf-error-520"><h1>Web server is returning an unknown error</h1><p>There is an unknown connection issue between Cloudflare and the origin web server.</p></div></body></html>`
+
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: "codex",
+		Model:    "",
+		Success:  false,
+		Error: &Error{
+			HTTPStatus: 520,
+			Message:    origin520Msg,
+		},
+	})
+
+	updated, ok := m.GetByID(auth.ID)
+	if !ok || updated == nil {
+		t.Fatalf("expected auth to be found")
+	}
+	if updated.Quota.Exceeded {
+		t.Fatalf("expected Quota.Exceeded to be false for 520 origin error")
+	}
+	if updated.Quota.Reason != "" {
+		t.Fatalf("expected Quota.Reason to be empty for 520 origin error, got %q", updated.Quota.Reason)
+	}
+	if updated.StatusMessage != "transient upstream error" {
+		t.Fatalf("expected StatusMessage to be 'transient upstream error', got %q", updated.StatusMessage)
+	}
+	if updated.LastError == nil || updated.LastError.HTTPStatus != 520 {
+		t.Fatalf("expected LastError to retain HTTP 520, got %#v", updated.LastError)
+	}
+	if !updated.Unavailable {
+		t.Fatalf("expected auth to be marked unavailable during transient cooldown")
+	}
+	diff := time.Until(updated.NextRetryAfter)
+	if diff < 45*time.Second || diff > 75*time.Second {
+		t.Fatalf("expected default transient cooldown of ~60s, got %v", diff)
+	}
+}
+
+func TestIsCloudflareChallengeResultError_Excludes5xx(t *testing.T) {
+	// Status >= 500 origin errors must not be classified as challenges even if containing challenge strings.
+	for _, status := range []int{500, 502, 503, 504, 520, 521, 522, 523, 524, 525, 526} {
+		err5xx := &Error{
+			HTTPStatus: status,
+			Message:    "cf-mitigated: challenge but with 5xx status code",
+		}
+		if isCloudflareChallengeResultError(err5xx) {
+			t.Fatalf("expected %d status code to be excluded from cloudflare challenge", status)
+		}
+	}
+
+	err403 := &Error{
+		HTTPStatus: 403,
+		Message:    "cf-mitigated: challenge",
+	}
+	if !isCloudflareChallengeResultError(err403) {
+		t.Fatalf("expected 403 challenge to be recognized")
+	}
+}
+
+func TestIsCloudflareChallengeError(t *testing.T) {
+	// 520 error wrapped in standard error interface must not be treated as challenge.
+	err520 := &Error{
+		HTTPStatus: 520,
+		Message:    "cf-error-details cf-error-520: Web server is returning an unknown error",
+	}
+	if isCloudflareChallengeError(err520) {
+		t.Fatalf("expected 520 error not to be cloudflare challenge")
+	}
+
+	// 403 challenge error must be recognized.
+	err403 := &Error{
+		HTTPStatus: http.StatusForbidden,
+		Message:    "cf-mitigated: challenge",
+	}
+	if !isCloudflareChallengeError(err403) {
+		t.Fatalf("expected 403 challenge error to be recognized")
+	}
+
+	// Plain error without status but with challenge message must be recognized.
+	plainChallenge := errors.New("challenge-platform orchestrate script blocked")
+	if !isCloudflareChallengeError(plainChallenge) {
+		t.Fatalf("expected plain challenge error to be recognized")
+	}
+
+	// Plain origin error without challenge markers must not be recognized.
+	plainOrigin := errors.New("Web server is returning an unknown error between Cloudflare and origin")
+	if isCloudflareChallengeError(plainOrigin) {
+		t.Fatalf("expected plain origin error not to be recognized as challenge")
+	}
+}

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -742,6 +742,17 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 	if result.AuthID == "" {
 		return
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if m != nil {
+		if policy := m.ResultPolicy(); policy != nil {
+			result = policy.ApplyResultPolicy(ctx, result)
+			if result.AuthID == "" {
+				return
+			}
+		}
+	}
 	modelKey := canonicalModelKey(result.Model)
 
 	var authSnapshot *Auth

--- a/sdk/cliproxy/auth/conductor_cooldown.go
+++ b/sdk/cliproxy/auth/conductor_cooldown.go
@@ -97,21 +97,28 @@ func providerCoolingOverrideForAuth(auth *Auth, cfg *internalconfig.Config) (boo
 }
 
 func nextTransientErrorRetryAfter(now time.Time) time.Time {
+	return recoverableFailureRetryAfterWithHint(now, nil, false)
+}
+
+func recoverableFailureRetryAfter(now time.Time, disableCooling bool) time.Time {
+	return recoverableFailureRetryAfterWithHint(now, nil, disableCooling)
+}
+
+func recoverableFailureRetryAfterWithHint(now time.Time, retryAfter *time.Duration, disableCooling bool) time.Time {
+	if disableCooling {
+		return time.Time{}
+	}
 	seconds := transientErrorCooldownSeconds.Load()
 	if seconds < 0 {
 		return time.Time{}
+	}
+	if retryAfter != nil && *retryAfter > 0 {
+		return now.Add(*retryAfter)
 	}
 	if seconds == 0 {
 		return now.Add(transientErrorCooldown)
 	}
 	return now.Add(time.Duration(seconds) * time.Second)
-}
-
-func recoverableFailureRetryAfter(now time.Time, disableCooling bool) time.Time {
-	if disableCooling {
-		return time.Time{}
-	}
-	return nextTransientErrorRetryAfter(now)
 }
 
 // SetConfig updates the runtime config snapshot used by request-time helpers.
@@ -903,8 +910,8 @@ func (m *Manager) MarkResult(ctx context.Context, result Result) {
 								auth.Quota.NextRecoverAt = authNext
 								auth.NextRetryAfter = authNext
 							}
-						case 408, 500, 502, 503, 504:
-							state.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
+						case 408, 500, 502, 503, 504, 520, 521, 522, 523, 524, 525, 526:
+							state.NextRetryAfter = recoverableFailureRetryAfterWithHint(now, result.RetryAfter, disableCooling)
 							state.Unavailable = !state.NextRetryAfter.IsZero()
 						default:
 							state.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
@@ -1687,18 +1694,31 @@ func isCloudflareChallengeErrorMessage(message string) bool {
 	return strings.Contains(lower, "challenge-platform") ||
 		strings.Contains(lower, "cf-mitigated") ||
 		strings.Contains(lower, "cloudflare challenge") ||
-		(strings.Contains(lower, "cloudflare") && strings.Contains(lower, "<html"))
+		(strings.Contains(lower, "just a moment") && strings.Contains(lower, "cloudflare"))
 }
 
+// isCloudflareChallengeError checks whether err is a Cloudflare bot/waf challenge.
+// Cloudflare challenges are served with HTTP 403. HTTP status >= 500 indicates an
+// upstream gateway/origin failure (such as 520-526 origin errors) and takes precedence
+// over challenge classification.
 func isCloudflareChallengeError(err error) bool {
 	if err == nil {
+		return false
+	}
+	if status := statusCodeFromError(err); status >= 500 {
 		return false
 	}
 	return isCloudflareChallengeErrorMessage(err.Error())
 }
 
+// isCloudflareChallengeResultError checks whether err is a Cloudflare bot/waf challenge.
+// Responses with HTTP status >= 500 represent upstream gateway/origin failures
+// (such as Cloudflare 520-526) and are excluded from challenge classification.
 func isCloudflareChallengeResultError(err *Error) bool {
 	if err == nil {
+		return false
+	}
+	if status := statusCodeFromResult(err); status >= 500 {
 		return false
 	}
 	return isCloudflareChallengeErrorMessage(err.Message)
@@ -2104,9 +2124,9 @@ func applyAuthFailureState(auth *Auth, resultErr *Error, retryAfter *time.Durati
 			}
 			auth.Quota.NextRecoverAt = next
 			auth.NextRetryAfter = next
-		case 408, 500, 502, 503, 504:
+		case 408, 500, 502, 503, 504, 520, 521, 522, 523, 524, 525, 526:
 			auth.StatusMessage = "transient upstream error"
-			auth.NextRetryAfter = recoverableFailureRetryAfter(now, disableCooling)
+			auth.NextRetryAfter = recoverableFailureRetryAfterWithHint(now, retryAfter, disableCooling)
 			auth.Unavailable = !auth.NextRetryAfter.IsZero()
 		default:
 			if auth.StatusMessage == "" {

--- a/sdk/cliproxy/auth/conductor_refresh.go
+++ b/sdk/cliproxy/auth/conductor_refresh.go
@@ -55,10 +55,7 @@ func (m *Manager) StartAutoRefresh(parent context.Context, interval time.Duratio
 	}
 
 	ctx, cancelCtx := context.WithCancel(parent)
-	workers := refreshMaxConcurrency
-	if cfg, ok := m.runtimeConfig.Load().(*internalconfig.Config); ok && cfg != nil && cfg.AuthAutoRefreshWorkers > 0 {
-		workers = cfg.AuthAutoRefreshWorkers
-	}
+	workers := m.refreshWorkers()
 	loop := newAuthAutoRefreshLoop(m, interval, workers)
 
 	m.mu.Lock()
@@ -585,6 +582,16 @@ func (m *Manager) ForceRefreshAuth(ctx context.Context, id string) (*Auth, error
 	return m.refreshAuthForRequest(ctx, id, "")
 }
 
+func (m *Manager) refreshWorkers() int {
+	workers := refreshMaxConcurrency
+	if m != nil {
+		if cfg, ok := m.runtimeConfig.Load().(*internalconfig.Config); ok && cfg != nil && cfg.AuthAutoRefreshWorkers > 0 {
+			workers = cfg.AuthAutoRefreshWorkers
+		}
+	}
+	return workers
+}
+
 // ForceRefreshResult records the outcome of a forced refresh for one credential.
 type ForceRefreshResult struct {
 	ID      string `json:"id"`
@@ -597,6 +604,9 @@ func (m *Manager) ForceRefreshAll(ctx context.Context) []ForceRefreshResult {
 	if m == nil {
 		return nil
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	m.mu.RLock()
 	ids := make([]string, 0, len(m.auths))
 	for id, auth := range m.auths {
@@ -607,18 +617,52 @@ func (m *Manager) ForceRefreshAll(ctx context.Context) []ForceRefreshResult {
 	m.mu.RUnlock()
 
 	results := make([]ForceRefreshResult, len(ids))
-	var wg sync.WaitGroup
+	if len(ids) == 0 {
+		return results
+	}
+
+	workers := m.refreshWorkers()
+	if workers <= 0 {
+		workers = 1
+	}
+	if workers > len(ids) {
+		workers = len(ids)
+	}
+
+	type refreshJob struct {
+		index  int
+		authID string
+	}
+
+	jobCh := make(chan refreshJob, len(ids))
 	for i, id := range ids {
+		jobCh <- refreshJob{index: i, authID: id}
+	}
+	close(jobCh)
+
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
 		wg.Add(1)
-		go func(index int, authID string) {
+		go func() {
 			defer wg.Done()
-			_, err := m.ForceRefreshAuth(ctx, authID)
-			res := ForceRefreshResult{ID: authID, Success: err == nil}
-			if err != nil {
-				res.Error = err.Error()
+			for job := range jobCh {
+				if errCtx := ctx.Err(); errCtx != nil {
+					results[job.index] = ForceRefreshResult{
+						ID:      job.authID,
+						Success: false,
+						Error:   errCtx.Error(),
+					}
+					continue
+				}
+
+				_, err := m.ForceRefreshAuth(ctx, job.authID)
+				res := ForceRefreshResult{ID: job.authID, Success: err == nil}
+				if err != nil {
+					res.Error = err.Error()
+				}
+				results[job.index] = res
 			}
-			results[index] = res
-		}(i, id)
+		}()
 	}
 	wg.Wait()
 	return results

--- a/sdk/cliproxy/auth/conductor_result_policy_test.go
+++ b/sdk/cliproxy/auth/conductor_result_policy_test.go
@@ -1,0 +1,294 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+)
+
+type recordingHook struct {
+	NoopHook
+	lastResult atomic.Pointer[Result]
+}
+
+func (h *recordingHook) OnResult(_ context.Context, res Result) {
+	h.lastResult.Store(&res)
+}
+
+type recordingCooldownStore struct {
+	mu      sync.Mutex
+	records []CooldownStateRecord
+}
+
+func (s *recordingCooldownStore) Load(context.Context) ([]CooldownStateRecord, error) {
+	return nil, nil
+}
+
+func (s *recordingCooldownStore) Save(_ context.Context, records []CooldownStateRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records = append([]CooldownStateRecord(nil), records...)
+	return nil
+}
+
+func (s *recordingCooldownStore) getRecords() []CooldownStateRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]CooldownStateRecord(nil), s.records...)
+}
+
+func TestManager_MarkResult_ResultPolicy_DemotesCredentialScopeBeforeMutationAndPersist(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	m, auth := newCooldownMonotonicManager(t, "claude-3-7-sonnet", "claude-3-5-haiku")
+	auth.ModelStates = map[string]*ModelState{
+		canonicalModelKey("claude-3-5-haiku"):  {Status: StatusActive},
+		canonicalModelKey("claude-3-7-sonnet"): {Status: StatusActive},
+	}
+	if _, errUpdate := m.Update(context.Background(), auth); errUpdate != nil {
+		t.Fatalf("update auth: %v", errUpdate)
+	}
+
+	store := &recordingCooldownStore{}
+	m.SetCooldownStateStore(store)
+
+	hook := &recordingHook{}
+	m.hook = hook
+
+	var policyInvoked atomic.Bool
+	var stateCheckedBeforeMutation atomic.Bool
+
+	policy := ResultPolicyFunc(func(ctx context.Context, res Result) Result {
+		policyInvoked.Store(true)
+		// Check that at the time policy runs, auth is not yet marked unavailable or in credential quota cooldown
+		current, exists := m.GetByID(auth.ID)
+		if exists && current != nil && !current.Unavailable && current.Quota.Reason != "credential_quota" {
+			stateCheckedBeforeMutation.Store(true)
+		}
+
+		// Downstream use case: Demote consumable-quota 429 so it cannot become a credential-scope gate.
+		if res.Error != nil && res.Error.HTTPStatus == http.StatusTooManyRequests && res.CredentialScope {
+			res.CredentialScope = false
+		}
+		return res
+	})
+
+	m.SetResultPolicy(policy)
+	if m.ResultPolicy() == nil {
+		t.Fatal("expected ResultPolicy to be non-nil after SetResultPolicy")
+	}
+
+	retryDuration := 10 * time.Minute
+	m.MarkResult(context.Background(), Result{
+		AuthID:          auth.ID,
+		Provider:        auth.Provider,
+		Model:           "claude-3-7-sonnet",
+		Success:         false,
+		RetryAfter:      &retryDuration,
+		CredentialScope: true, // Originally constructed as credential-scoped
+		Error:           &Error{HTTPStatus: http.StatusTooManyRequests, Message: "organic consumable quota exceeded"},
+	})
+
+	if !policyInvoked.Load() {
+		t.Fatal("expected ResultPolicy to be invoked during MarkResult")
+	}
+	if !stateCheckedBeforeMutation.Load() {
+		t.Fatal("expected ResultPolicy to run before in-memory quota and auth state mutation")
+	}
+
+	updated, exists := m.GetByID(auth.ID)
+	if !exists || updated == nil {
+		t.Fatal("auth not found after MarkResult")
+	}
+
+	// Sibling model (claude-3-5-haiku) must NOT be demoted/unavailable because CredentialScope was cleared by policy
+	haikuState := existingModelState(updated, canonicalModelKey("claude-3-5-haiku"))
+	if haikuState != nil && haikuState.Unavailable {
+		t.Fatalf("expected sibling model claude-3-5-haiku to remain available, but got unavailable: %+v", haikuState)
+	}
+	if haikuState != nil && haikuState.Quota.Reason == "credential_quota" {
+		t.Fatalf("expected sibling model claude-3-5-haiku not to have credential_quota, got: %+v", haikuState.Quota)
+	}
+
+	// Verify sibling model is not blocked, while target model is blocked
+	blockedHaiku, _, _ := isAuthBlockedForModel(updated, "claude-3-5-haiku", time.Now())
+	if blockedHaiku {
+		t.Fatalf("expected sibling model claude-3-5-haiku not to be blocked")
+	}
+	blockedSonnet, _, _ := isAuthBlockedForModel(updated, "claude-3-7-sonnet", time.Now())
+	if !blockedSonnet {
+		t.Fatalf("expected target model claude-3-7-sonnet to be blocked by per-model 429")
+	}
+
+	// Verify sibling model remains selectable via Selector
+	picked, errPick := m.Selector().Pick(context.Background(), auth.Provider, "claude-3-5-haiku", cliproxyexecutor.Options{}, []*Auth{updated})
+	if errPick != nil || picked == nil || picked.ID != auth.ID {
+		t.Fatalf("expected sibling model claude-3-5-haiku to remain selectable via Selector, got err=%v picked=%v", errPick, picked)
+	}
+
+	// Target model (claude-3-7-sonnet) should have per-model quota cooldown
+	sonnetState := existingModelState(updated, canonicalModelKey("claude-3-7-sonnet"))
+	if sonnetState == nil || !sonnetState.Unavailable {
+		t.Fatalf("expected target model claude-3-7-sonnet to be unavailable due to per-model 429: %+v", sonnetState)
+	}
+
+	// Entire credential auth must NOT be marked credential_quota
+	if updated.Quota.Reason == "credential_quota" {
+		t.Fatalf("expected auth.Quota.Reason not to be 'credential_quota' after demotion, got %q", updated.Quota.Reason)
+	}
+
+	// Cooldown persistence must NOT contain a credential-scoped record (Model == ""), but must contain target model record
+	savedRecords := store.getRecords()
+	if len(savedRecords) == 0 {
+		t.Fatal("expected at least one cooldown record to be persisted for target model")
+	}
+	for _, rec := range savedRecords {
+		if strings.TrimSpace(rec.Model) == "" {
+			t.Fatalf("expected no credential-scoped cooldown record to be persisted after demotion, found: %+v", rec)
+		}
+	}
+
+	// Downstream OnResult hook must receive the demoted result
+	received := hook.lastResult.Load()
+	if received == nil {
+		t.Fatal("expected OnResult to receive result")
+	}
+	if received.CredentialScope {
+		t.Fatal("expected OnResult hook to receive result with demoted CredentialScope=false")
+	}
+}
+
+func TestManager_MarkResult_ResultPolicy_NilPolicyNoop(t *testing.T) {
+	previous := quotaCooldownDisabled.Load()
+	quotaCooldownDisabled.Store(false)
+	t.Cleanup(func() { quotaCooldownDisabled.Store(previous) })
+
+	m, auth := newCooldownMonotonicManager(t, "model-1", "model-2")
+
+	// No policy set - MarkResult proceeds normally
+	retryDuration := 5 * time.Minute
+	m.MarkResult(context.Background(), Result{
+		AuthID:          auth.ID,
+		Provider:        auth.Provider,
+		Model:           "model-1",
+		Success:         false,
+		RetryAfter:      &retryDuration,
+		CredentialScope: true,
+		Error:           &Error{HTTPStatus: http.StatusTooManyRequests, Message: "quota exceeded"},
+	})
+
+	updated, _ := m.GetByID(auth.ID)
+	if updated == nil || updated.Quota.Reason != "credential_quota" {
+		t.Fatalf("expected auth to be in credential_quota without policy, got: %+v", updated)
+	}
+}
+
+func TestManager_MarkResult_ResultPolicy_ClearWithNil(t *testing.T) {
+	m := NewManager(nil, nil, nil)
+	policy := ResultPolicyFunc(func(_ context.Context, res Result) Result { return res })
+	m.SetResultPolicy(policy)
+	if m.ResultPolicy() == nil {
+		t.Fatal("expected policy to be set")
+	}
+
+	// Clearing policy with nil must not panic and must set policy to nil
+	m.SetResultPolicy(nil)
+	if m.ResultPolicy() != nil {
+		t.Fatal("expected policy to be nil after SetResultPolicy(nil)")
+	}
+}
+
+func TestManager_MarkResult_ResultPolicy_EmptyAuthIDAborts(t *testing.T) {
+	m, auth := newCooldownMonotonicManager(t, "model-abort")
+
+	policy := ResultPolicyFunc(func(_ context.Context, res Result) Result {
+		res.AuthID = "" // Drop result by emptying AuthID
+		return res
+	})
+	m.SetResultPolicy(policy)
+
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    "model-abort",
+		Success:  false,
+		Error:    &Error{HTTPStatus: http.StatusInternalServerError, Message: "error"},
+	})
+
+	updated, _ := m.GetByID(auth.ID)
+	if updated != nil && updated.Failed > 0 {
+		t.Fatalf("expected MarkResult to abort when AuthID cleared by policy, got Failed=%d", updated.Failed)
+	}
+}
+
+func TestManager_MarkResult_ResultPolicy_ConcurrentSafety(t *testing.T) {
+	m, auth := newCooldownMonotonicManager(t, "concurrent-model")
+
+	var invokedCount atomic.Int64
+	p1 := ResultPolicyFunc(func(_ context.Context, res Result) Result {
+		invokedCount.Add(1)
+		return res
+	})
+	p2 := ResultPolicyFunc(func(_ context.Context, res Result) Result {
+		invokedCount.Add(1)
+		return res
+	})
+	m.SetResultPolicy(p1)
+
+	// Ensure policy is operational before running concurrent swap stress
+	m.MarkResult(context.Background(), Result{
+		AuthID:   auth.ID,
+		Provider: auth.Provider,
+		Model:    "concurrent-model",
+		Success:  true,
+	})
+	if invokedCount.Load() == 0 {
+		t.Fatal("expected policy to be invoked")
+	}
+
+	const goroutines = 30
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	// Goroutines executing MarkResult concurrently
+	for i := 0; i < 20; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 10; j++ {
+				m.MarkResult(context.Background(), Result{
+					AuthID:   auth.ID,
+					Provider: auth.Provider,
+					Model:    "concurrent-model",
+					Success:  true,
+				})
+			}
+		}()
+	}
+
+	// Goroutines concurrently mutating and swapping policy
+	for i := 0; i < 10; i++ {
+		idx := i
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 10; j++ {
+				if (idx+j)%3 == 0 {
+					m.SetResultPolicy(p1)
+				} else if (idx+j)%3 == 1 {
+					m.SetResultPolicy(p2)
+				} else {
+					m.SetResultPolicy(nil)
+				}
+				_ = m.ResultPolicy()
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/sdk/cliproxy/auth/force_refresh_test.go
+++ b/sdk/cliproxy/auth/force_refresh_test.go
@@ -2,7 +2,13 @@ package auth
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"sync/atomic"
 	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
 )
 
 func TestManager_ForceRefreshAuth_ClearsErrorAndRefreshes(t *testing.T) {
@@ -125,5 +131,235 @@ func TestManager_ForceRefreshAuth_PreservesErrorOnFailure(t *testing.T) {
 	}
 	if current.LastError == nil {
 		t.Fatal("LastError should not be wiped on failure")
+	}
+}
+
+type concurrencyTrackingRefreshExecutor struct {
+	id            string
+	current       atomic.Int32
+	maxConcurrent atomic.Int32
+	totalEntered  atomic.Int32
+	enteredCh     chan struct{}
+	releaseCh     chan struct{}
+}
+
+func (e *concurrencyTrackingRefreshExecutor) Identifier() string { return e.id }
+func (e *concurrencyTrackingRefreshExecutor) Execute(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (e *concurrencyTrackingRefreshExecutor) ExecuteStream(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (*cliproxyexecutor.StreamResult, error) {
+	return nil, nil
+}
+func (e *concurrencyTrackingRefreshExecutor) CountTokens(context.Context, *Auth, cliproxyexecutor.Request, cliproxyexecutor.Options) (cliproxyexecutor.Response, error) {
+	return cliproxyexecutor.Response{}, nil
+}
+func (e *concurrencyTrackingRefreshExecutor) HttpRequest(context.Context, *Auth, *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+func (e *concurrencyTrackingRefreshExecutor) Refresh(_ context.Context, auth *Auth) (*Auth, error) {
+	e.totalEntered.Add(1)
+	cur := e.current.Add(1)
+	for {
+		max := e.maxConcurrent.Load()
+		if cur <= max || e.maxConcurrent.CompareAndSwap(max, cur) {
+			break
+		}
+	}
+	if e.enteredCh != nil {
+		e.enteredCh <- struct{}{}
+	}
+	if e.releaseCh != nil {
+		<-e.releaseCh
+	}
+	e.current.Add(-1)
+	if auth.Metadata == nil {
+		auth.Metadata = make(map[string]any)
+	}
+	auth.Metadata["access_token"] = "refreshed-token"
+	return auth, nil
+}
+
+func TestManager_ForceRefreshAll_WorkersBounded(t *testing.T) {
+	ctx := context.Background()
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.runtimeConfig.Store(&internalconfig.Config{AuthAutoRefreshWorkers: 2})
+
+	executor := &concurrencyTrackingRefreshExecutor{
+		id:        "antigravity",
+		enteredCh: make(chan struct{}, 6),
+		releaseCh: make(chan struct{}),
+	}
+	manager.RegisterExecutor(executor)
+
+	for i := 0; i < 6; i++ {
+		auth := &Auth{
+			ID:       fmt.Sprintf("ag-%d", i),
+			Provider: "antigravity",
+			Metadata: map[string]any{"refresh_token": fmt.Sprintf("ref-%d", i)},
+		}
+		if _, err := manager.Register(ctx, auth); err != nil {
+			t.Fatalf("register auth: %v", err)
+		}
+	}
+
+	done := make(chan struct{})
+	var results []ForceRefreshResult
+	go func() {
+		results = manager.ForceRefreshAll(ctx)
+		close(done)
+	}()
+
+	// Wait for 2 workers to enter Refresh
+	<-executor.enteredCh
+	<-executor.enteredCh
+
+	// If unbounded, remaining goroutines also enter Refresh
+	// Release the blocked workers
+	close(executor.releaseCh)
+	<-done
+
+	if len(results) != 6 {
+		t.Fatalf("expected 6 results, got %d", len(results))
+	}
+	for _, res := range results {
+		if !res.Success {
+			t.Fatalf("expected success for %s, got error: %s", res.ID, res.Error)
+		}
+	}
+
+	if max := executor.maxConcurrent.Load(); max > 2 {
+		t.Fatalf("expected max concurrent calls <= 2, got %d", max)
+	}
+}
+
+func TestManager_ForceRefreshAll_CanceledContextSkipsExecutors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.runtimeConfig.Store(&internalconfig.Config{AuthAutoRefreshWorkers: 2})
+	executor := &countingRefreshExecutor{id: "antigravity"}
+	manager.RegisterExecutor(executor)
+
+	for i := 0; i < 6; i++ {
+		auth := &Auth{
+			ID:       fmt.Sprintf("ag-%d", i),
+			Provider: "antigravity",
+			Metadata: map[string]any{"refresh_token": fmt.Sprintf("ref-%d", i)},
+		}
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatalf("register auth: %v", err)
+		}
+	}
+
+	results := manager.ForceRefreshAll(ctx)
+	if len(results) != 6 {
+		t.Fatalf("expected 6 results, got %d", len(results))
+	}
+	for _, res := range results {
+		if res.Success {
+			t.Fatalf("expected failure due to cancellation for %s", res.ID)
+		}
+		if res.Error != context.Canceled.Error() {
+			t.Fatalf("expected error %q, got %q", context.Canceled.Error(), res.Error)
+		}
+	}
+	if executor.refreshCalls.Load() != 0 {
+		t.Fatalf("expected 0 refresh calls when context canceled, got %d", executor.refreshCalls.Load())
+	}
+}
+
+func TestManager_ForceRefreshAll_DynamicCancellationSkipsRemaining(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+	manager.runtimeConfig.Store(&internalconfig.Config{AuthAutoRefreshWorkers: 2})
+
+	executor := &concurrencyTrackingRefreshExecutor{
+		id:        "antigravity",
+		enteredCh: make(chan struct{}, 6),
+		releaseCh: make(chan struct{}),
+	}
+	manager.RegisterExecutor(executor)
+
+	for i := 0; i < 6; i++ {
+		auth := &Auth{
+			ID:       fmt.Sprintf("ag-%d", i),
+			Provider: "antigravity",
+			Metadata: map[string]any{"refresh_token": fmt.Sprintf("ref-%d", i)},
+		}
+		if _, err := manager.Register(context.Background(), auth); err != nil {
+			t.Fatalf("register auth: %v", err)
+		}
+	}
+
+	done := make(chan struct{})
+	var results []ForceRefreshResult
+	go func() {
+		results = manager.ForceRefreshAll(ctx)
+		close(done)
+	}()
+
+	// Wait for 2 workers to enter Refresh
+	<-executor.enteredCh
+	<-executor.enteredCh
+
+	// Cancel context while first batch is in flight
+	cancel()
+
+	// Release the blocked workers
+	close(executor.releaseCh)
+	<-done
+
+	if len(results) != 6 {
+		t.Fatalf("expected 6 results, got %d", len(results))
+	}
+
+	// Exactly 2 workers entered Refresh; remaining 4 were canceled in queue
+	if entered := executor.totalEntered.Load(); entered != 2 {
+		t.Fatalf("expected exactly 2 entered calls, got %d", entered)
+	}
+
+	successCount := 0
+	cancelCount := 0
+	for _, res := range results {
+		if res.Success {
+			successCount++
+		} else if res.Error == context.Canceled.Error() {
+			cancelCount++
+		}
+	}
+	if successCount != 2 {
+		t.Fatalf("expected 2 successful refreshes, got %d", successCount)
+	}
+	if cancelCount != 4 {
+		t.Fatalf("expected 4 canceled refreshes, got %d", cancelCount)
+	}
+}
+
+func TestManager_RefreshWorkersResolution(t *testing.T) {
+	manager := NewManager(nil, &RoundRobinSelector{}, nil)
+
+	// Default when config is empty
+	if w := manager.refreshWorkers(); w != 16 {
+		t.Fatalf("expected default 16 workers, got %d", w)
+	}
+
+	// Zero should keep default 16
+	manager.runtimeConfig.Store(&internalconfig.Config{AuthAutoRefreshWorkers: 0})
+	if w := manager.refreshWorkers(); w != 16 {
+		t.Fatalf("expected 16 workers for 0, got %d", w)
+	}
+
+	// Negative should keep default 16
+	manager.runtimeConfig.Store(&internalconfig.Config{AuthAutoRefreshWorkers: -5})
+	if w := manager.refreshWorkers(); w != 16 {
+		t.Fatalf("expected 16 workers for -5, got %d", w)
+	}
+
+	// Positive override
+	manager.runtimeConfig.Store(&internalconfig.Config{AuthAutoRefreshWorkers: 4})
+	if w := manager.refreshWorkers(); w != 4 {
+		t.Fatalf("expected 4 workers, got %d", w)
 	}
 }

--- a/sdk/cliproxy/auth/metadata_merge.go
+++ b/sdk/cliproxy/auth/metadata_merge.go
@@ -28,6 +28,11 @@ func MergeExistingAuthMetadata(target *Auth, existingMap map[string]any) {
 	if target.Metadata == nil {
 		target.Metadata = make(map[string]any)
 	}
+	if _, explicitlySet := target.Metadata["disabled"]; !explicitlySet {
+		if disabled, ok := existingMap["disabled"].(bool); ok {
+			target.Disabled = disabled
+		}
+	}
 	for k, v := range existingMap {
 		if IsAuthTokenPayloadKey(k) {
 			continue

--- a/sdk/cliproxy/auth/metadata_merge_test.go
+++ b/sdk/cliproxy/auth/metadata_merge_test.go
@@ -5,6 +5,33 @@ import (
 	"testing"
 )
 
+func TestMergeExistingAuthMetadataPreservesDisabledState(t *testing.T) {
+	target := &Auth{Metadata: map[string]any{"type": "claude"}}
+	MergeExistingAuthMetadata(target, map[string]any{"disabled": true, "prefix": "team"})
+
+	if !target.Disabled {
+		t.Fatal("Disabled = false, want true")
+	}
+	if disabled, _ := target.Metadata["disabled"].(bool); !disabled {
+		t.Fatalf("metadata disabled = %v, want true", target.Metadata["disabled"])
+	}
+	if target.Metadata["prefix"] != "team" {
+		t.Fatalf("prefix = %v, want team", target.Metadata["prefix"])
+	}
+}
+
+func TestMergeExistingAuthMetadataKeepsExplicitDisabledState(t *testing.T) {
+	target := &Auth{Metadata: map[string]any{"disabled": false}}
+	MergeExistingAuthMetadata(target, map[string]any{"disabled": true})
+
+	if target.Disabled {
+		t.Fatal("Disabled = true, want explicit false state")
+	}
+	if disabled, _ := target.Metadata["disabled"].(bool); disabled {
+		t.Fatalf("metadata disabled = %v, want false", target.Metadata["disabled"])
+	}
+}
+
 type dummyMetadataStorage struct {
 	meta map[string]any
 }

--- a/sdk/cliproxy/auth/persist_policy.go
+++ b/sdk/cliproxy/auth/persist_policy.go
@@ -4,6 +4,28 @@ import "context"
 
 type skipPersistContextKey struct{}
 type deferAPIKeyModelAliasRebuildContextKey struct{}
+type authCreationIntentContextKey struct{}
+
+// WithAuthCreationIntent returns a derived context that allows a token store to
+// create a missing disabled credential. It is intended only for the immediate
+// persistence performed by login and credential migration flows.
+func WithAuthCreationIntent(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, authCreationIntentContextKey{}, true)
+}
+
+// HasAuthCreationIntent reports whether the current save is part of a login or
+// credential migration flow that may intentionally create a disabled record.
+func HasAuthCreationIntent(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	v := ctx.Value(authCreationIntentContextKey{})
+	enabled, ok := v.(bool)
+	return ok && enabled
+}
 
 // WithSkipPersist returns a derived context that disables persistence for Manager Update/Register calls.
 // It is intended for code paths that are reacting to file watcher events, where the file on disk is

--- a/sdk/cliproxy/builder.go
+++ b/sdk/cliproxy/builder.go
@@ -57,6 +57,9 @@ type Builder struct {
 	// postAuthHook is called after auth record creation and before persistence.
 	postAuthHook coreauth.PostAuthHook
 
+	// resultPolicy intercepts execution results before quota mutation and persistence.
+	resultPolicy coreauth.ResultPolicy
+
 	// serverOptions contains additional server configuration options.
 	serverOptions []api.ServerOption
 }
@@ -186,6 +189,12 @@ func (b *Builder) WithPostAuthHook(hook coreauth.PostAuthHook) *Builder {
 	return b
 }
 
+// WithResultPolicy sets an execution result policy invoked before in-memory quota mutations and persistence.
+func (b *Builder) WithResultPolicy(policy coreauth.ResultPolicy) *Builder {
+	b.resultPolicy = policy
+	return b
+}
+
 // Build validates inputs, applies defaults, and returns a ready-to-run service.
 func (b *Builder) Build() (*Service, error) {
 	if b.cfg == nil {
@@ -262,6 +271,9 @@ func (b *Builder) Build() (*Service, error) {
 	coreManager.SetOAuthModelAlias(b.cfg.OAuthModelAlias)
 	if pluginHost != nil {
 		coreManager.SetPluginScheduler(pluginHost)
+	}
+	if b.resultPolicy != nil {
+		coreManager.SetResultPolicy(b.resultPolicy)
 	}
 
 	service := &Service{

--- a/sdk/cliproxy/service.go
+++ b/sdk/cliproxy/service.go
@@ -126,3 +126,19 @@ type Service struct {
 	homePluginDeleteTask         func(context.Context, *config.Config, home.PluginTask) homeplugins.SyncReport
 	antigravityProbeWg           sync.WaitGroup
 }
+
+// SetResultPolicy sets an execution result policy on the underlying core auth manager.
+func (s *Service) SetResultPolicy(policy coreauth.ResultPolicy) {
+	if s == nil || s.coreManager == nil {
+		return
+	}
+	s.coreManager.SetResultPolicy(policy)
+}
+
+// ResultPolicy returns the execution result policy configured on the core auth manager.
+func (s *Service) ResultPolicy() coreauth.ResultPolicy {
+	if s == nil || s.coreManager == nil {
+		return nil
+	}
+	return s.coreManager.ResultPolicy()
+}

--- a/sdk/cliproxy/service_models.go
+++ b/sdk/cliproxy/service_models.go
@@ -612,6 +612,11 @@ func applyModelPrefixes(models []*ModelInfo, prefix string, forceModelPrefix boo
 		}
 		clone := *model
 		clone.ID = trimmedPrefix + "/" + baseID
+		if clone.MetadataModelID == "" {
+			clone.MetadataModelID = baseID
+		}
+		clone.ExplicitThinking = model.ExplicitThinking
+		clone.ExplicitInputModalities = model.ExplicitInputModalities
 		addModel(&clone)
 	}
 	return out
@@ -692,14 +697,19 @@ func buildConfiguredModelInfo(model modelEntry, ownedBy, modelType string, creat
 	if displayName == "" {
 		displayName = alias
 	}
+	metadataModelID := name
+	if metadataModelID == "" {
+		metadataModelID = alias
+	}
 	info := &ModelInfo{
-		ID:          alias,
-		Object:      "model",
-		Created:     created,
-		OwnedBy:     ownedBy,
-		Type:        modelType,
-		DisplayName: displayName,
-		UserDefined: userDefined,
+		ID:              alias,
+		MetadataModelID: metadataModelID,
+		Object:          "model",
+		Created:         created,
+		OwnedBy:         ownedBy,
+		Type:            modelType,
+		DisplayName:     displayName,
+		UserDefined:     userDefined,
 	}
 	if maxContextModel, okMaxContext := any(model).(modelMaxContextLengthEntry); okMaxContext {
 		if maxContextLength := maxContextModel.GetMaxContextLength(); maxContextLength > 0 {
@@ -732,6 +742,12 @@ func buildOpenAICompatibilityConfigModels(compat *config.OpenAICompatibility) []
 		thinkingSupport := model.Thinking
 		if thinkingSupport == nil && !model.Image {
 			thinkingSupport = &registry.ThinkingSupport{Levels: []string{"low", "medium", "high"}}
+		}
+		if model.Thinking != nil {
+			info.ExplicitThinking = true
+		}
+		if len(model.InputModalities) > 0 {
+			info.ExplicitInputModalities = true
 		}
 		info.Thinking = modelconfig.NormalizeThinkingSupport(thinkingSupport)
 		info.SupportedInputModalities = normalizeCompatConfigModalities(model.InputModalities)
@@ -784,6 +800,9 @@ func buildConfigModels[T modelEntry](models []T, ownedBy, modelType string) []*M
 			continue
 		}
 		seen[key] = struct{}{}
+		if model.GetThinking() != nil {
+			info.ExplicitThinking = true
+		}
 		if resolved := modelconfig.ResolveModelInfo(name, modelType, model.GetThinking()); resolved.Thinking != nil {
 			info.Thinking = resolved.Thinking
 		}
@@ -1019,6 +1038,13 @@ func applyOAuthModelAliasEntries(aliases []config.OAuthModelAlias, models []*Mod
 			seen[aliasKey] = struct{}{}
 			clone := *model
 			clone.ID = mappedID
+			if model.MetadataModelID != "" {
+				clone.MetadataModelID = model.MetadataModelID
+			} else {
+				clone.MetadataModelID = id
+			}
+			clone.ExplicitThinking = model.ExplicitThinking
+			clone.ExplicitInputModalities = model.ExplicitInputModalities
 			if entry.displayName != "" {
 				clone.DisplayName = entry.displayName
 			}

--- a/sdk/cliproxy/service_oauth_model_alias_test.go
+++ b/sdk/cliproxy/service_oauth_model_alias_test.go
@@ -184,4 +184,76 @@ func TestApplyOAuthModelAlias_PerAuthAlias(t *testing.T) {
 	if out[0].DisplayName != "Configured GPT Five" {
 		t.Fatalf("expected per-auth display name %q, got %q", "Configured GPT Five", out[0].DisplayName)
 	}
+	if out[0].MetadataModelID != "gpt-5.3-codex-spark" {
+		t.Fatalf("expected per-auth MetadataModelID %q, got %q", "gpt-5.3-codex-spark", out[0].MetadataModelID)
+	}
+}
+
+func TestApplyOAuthModelAlias_PreservesMetadataModelID(t *testing.T) {
+	cfg := &config.Config{
+		OAuthModelAlias: map[string][]config.OAuthModelAlias{
+			"codex": {
+				{Name: "gpt-6-astra", Alias: "codex-main", Fork: true},
+				{Name: "gpt-5.6-luna", Alias: "codex-luna", Fork: false},
+			},
+		},
+	}
+	models := []*ModelInfo{
+		{ID: "gpt-6-astra", Name: "models/gpt-6-astra"},
+		{ID: "gpt-5.6-luna", Name: "models/gpt-5.6-luna"},
+	}
+
+	out := applyOAuthModelAlias(cfg, "codex", "oauth", models)
+	if len(out) != 3 {
+		t.Fatalf("expected 3 models (original astra + forked astra alias + renamed luna alias), got %d", len(out))
+	}
+
+	entryMap := make(map[string]*ModelInfo, len(out))
+	for _, m := range out {
+		entryMap[m.ID] = m
+	}
+
+	if astra := entryMap["gpt-6-astra"]; astra == nil {
+		t.Fatal("missing original gpt-6-astra")
+	}
+	if codexMain := entryMap["codex-main"]; codexMain == nil {
+		t.Fatal("missing alias codex-main")
+	} else if codexMain.MetadataModelID != "gpt-6-astra" {
+		t.Fatalf("codex-main MetadataModelID = %q, want gpt-6-astra", codexMain.MetadataModelID)
+	}
+
+	if codexLuna := entryMap["codex-luna"]; codexLuna == nil {
+		t.Fatal("missing alias codex-luna")
+	} else if codexLuna.MetadataModelID != "gpt-5.6-luna" {
+		t.Fatalf("codex-luna MetadataModelID = %q, want gpt-5.6-luna", codexLuna.MetadataModelID)
+	}
+}
+
+func TestApplyModelPrefixes_PreservesMetadataModelID(t *testing.T) {
+	models := []*ModelInfo{
+		{ID: "gpt-6-astra"},
+		{ID: "codex-main", MetadataModelID: "gpt-6-astra"},
+	}
+
+	out := applyModelPrefixes(models, "1", false)
+	if len(out) != 4 {
+		t.Fatalf("expected 4 models (2 unprefixed + 2 prefixed), got %d", len(out))
+	}
+
+	entryMap := make(map[string]*ModelInfo, len(out))
+	for _, m := range out {
+		entryMap[m.ID] = m
+	}
+
+	if m := entryMap["1/gpt-6-astra"]; m == nil {
+		t.Fatal("missing 1/gpt-6-astra")
+	} else if m.MetadataModelID != "gpt-6-astra" {
+		t.Fatalf("1/gpt-6-astra MetadataModelID = %q, want gpt-6-astra", m.MetadataModelID)
+	}
+
+	if m := entryMap["1/codex-main"]; m == nil {
+		t.Fatal("missing 1/codex-main")
+	} else if m.MetadataModelID != "gpt-6-astra" {
+		t.Fatalf("1/codex-main MetadataModelID = %q, want gpt-6-astra", m.MetadataModelID)
+	}
 }

--- a/sdk/cliproxy/service_result_policy_test.go
+++ b/sdk/cliproxy/service_result_policy_test.go
@@ -1,0 +1,48 @@
+package cliproxy
+
+import (
+	"context"
+	"testing"
+
+	internalconfig "github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	coreauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+)
+
+func TestBuilder_WithResultPolicy(t *testing.T) {
+	cfg := &internalconfig.Config{}
+	policy := coreauth.ResultPolicyFunc(func(ctx context.Context, result coreauth.Result) coreauth.Result {
+		return result
+	})
+
+	service, errBuild := NewBuilder().
+		WithConfig(cfg).
+		WithConfigPath(t.TempDir() + "/config.yaml").
+		WithResultPolicy(policy).
+		Build()
+	if errBuild != nil {
+		t.Fatalf("Build() failed: %v", errBuild)
+	}
+	if service == nil {
+		t.Fatal("expected service to be non-nil")
+	}
+
+	if got := service.ResultPolicy(); got == nil {
+		t.Fatal("expected service.ResultPolicy() to be non-nil")
+	}
+
+	// Test updating policy on Service
+	policy2 := coreauth.ResultPolicyFunc(func(ctx context.Context, result coreauth.Result) coreauth.Result {
+		result.CredentialScope = false
+		return result
+	})
+	service.SetResultPolicy(policy2)
+	if service.ResultPolicy() == nil {
+		t.Fatal("expected updated policy on service")
+	}
+
+	// Test clearing policy on Service
+	service.SetResultPolicy(nil)
+	if service.ResultPolicy() != nil {
+		t.Fatal("expected service.ResultPolicy() to be nil after clearing")
+	}
+}

--- a/sdk/cliproxy/usage/manager.go
+++ b/sdk/cliproxy/usage/manager.go
@@ -21,6 +21,8 @@ const AutoServiceTier = "auto"
 // Record contains the usage statistics captured for a single provider request.
 type Record struct {
 	Provider string
+	// BaseURL stores the configured upstream base URL when available.
+	BaseURL string
 	// ExecutorType stores the concrete executor type that handled the request.
 	ExecutorType    string
 	Model           string

--- a/sdk/cliproxy/usage/manager_test.go
+++ b/sdk/cliproxy/usage/manager_test.go
@@ -29,6 +29,17 @@ func TestRecordStreamField(t *testing.T) {
 	}
 }
 
+func TestRecordBaseURLField(t *testing.T) {
+	record := Record{
+		Provider: "openai",
+		Model:    "gpt-5.4",
+		BaseURL:  "https://custom-gateway.example.com/v1",
+	}
+	if record.BaseURL != "https://custom-gateway.example.com/v1" {
+		t.Fatalf("Record.BaseURL = %q, want %q", record.BaseURL, "https://custom-gateway.example.com/v1")
+	}
+}
+
 func TestGenerateEnabledDefaultsNilToTrue(t *testing.T) {
 	if !GenerateEnabled(nil) {
 		t.Fatalf("GenerateEnabled(nil) = false, want true")

--- a/sdk/pluginapi/types.go
+++ b/sdk/pluginapi/types.go
@@ -724,6 +724,8 @@ type HostAuthFileEntry struct {
 	Priority int `json:"priority,omitempty"`
 	// Note is the credential note when available.
 	Note string `json:"note,omitempty"`
+	// BaseURL is the upstream base URL configured for the credential when available.
+	BaseURL string `json:"base_url,omitempty"`
 	// Websockets reports whether websocket mode is enabled when available.
 	Websockets bool `json:"websockets,omitempty"`
 	// Success is the recent success count.
@@ -1392,6 +1394,8 @@ type ManagementResponse struct {
 type UsageRecord struct {
 	// Provider identifies the upstream provider.
 	Provider string
+	// BaseURL is the upstream base URL configured for the request/credential when available.
+	BaseURL string
 	// ExecutorType identifies the executor implementation.
 	ExecutorType string
 	// Model is the model used for the request.

--- a/sdk/pluginapi/types_test.go
+++ b/sdk/pluginapi/types_test.go
@@ -605,3 +605,42 @@ func TestHostAffinityLookupTypes(t *testing.T) {
 		t.Fatalf("decoded response = %#v, want %#v", decodedResp, resp)
 	}
 }
+
+func TestBaseURLInUsageRecordAndHostAuthFileEntry(t *testing.T) {
+	record := UsageRecord{
+		Provider: "codex",
+		Model:    "gpt-5.6-luna",
+		BaseURL:  "https://custom-gateway.example.com/v1",
+	}
+	if record.BaseURL != "https://custom-gateway.example.com/v1" {
+		t.Fatalf("UsageRecord.BaseURL = %q, want %q", record.BaseURL, "https://custom-gateway.example.com/v1")
+	}
+
+	entry := HostAuthFileEntry{
+		ID:      "test-auth",
+		BaseURL: "https://custom-auth.example.com/v1",
+	}
+	data, errMarshal := json.Marshal(entry)
+	if errMarshal != nil {
+		t.Fatalf("marshal HostAuthFileEntry: %v", errMarshal)
+	}
+	if !strings.Contains(string(data), `"base_url":"https://custom-auth.example.com/v1"`) {
+		t.Fatalf("marshaled json does not contain base_url key: %s", string(data))
+	}
+	var decoded HostAuthFileEntry
+	if errUnmarshal := json.Unmarshal(data, &decoded); errUnmarshal != nil {
+		t.Fatalf("unmarshal HostAuthFileEntry: %v", errUnmarshal)
+	}
+	if decoded.BaseURL != "https://custom-auth.example.com/v1" {
+		t.Fatalf("decoded HostAuthFileEntry.BaseURL = %q, want %q", decoded.BaseURL, "https://custom-auth.example.com/v1")
+	}
+
+	entryEmpty := HostAuthFileEntry{ID: "test-empty"}
+	emptyData, errEmptyMarshal := json.Marshal(entryEmpty)
+	if errEmptyMarshal != nil {
+		t.Fatalf("marshal empty HostAuthFileEntry: %v", errEmptyMarshal)
+	}
+	if strings.Contains(string(emptyData), "base_url") {
+		t.Fatalf("empty base_url should be omitted, got: %s", string(emptyData))
+	}
+}


### PR DESCRIPTION
## 范围

protected full-sync stage 1/2：upstream `router-for-me/CLIProxyAPI/main` 从 `09a29bd345bc44c473abe7fd07859e32df2ea543` 到 `5c80a01c`，15 个提交。auth、usage、model 与 request lifecycle 同时变化，按 first-parent 分段，使用 merge commit 保留 upstream ancestry。

本地/云端五条遗留分支均通过 #254–#258 合入，没有独有提交；零开放 PR，无待恢复工作树。七日审查、逐提交 diff 分类及分支清单见 `docs/lts/sync-review-20260912.md`。

## Protected delta review

- retained capabilities: preserved；full usage、canonical v3、timing v1、Management `/usage*`、Panel 默认源、auth/config 兼容不变。
- LTS-owned features: preserved/adapted；Flow、retry/fallback、continuity、Redis queue 保留，ResultPolicy suppression 释放原 attempt。
- shared review seams: adapted；BaseURL 元数据脱敏；新 Claude 身份组织哈希、旧身份保留原文件名；拒绝未知签名盲 replay；显式 thinking 优先；tool image relay 保留 text-only 约束；Cloudflare 520–526 与 WAF challenge 分离。
- downstream patches: patch-still-required；4 个已回补 upstreamed 修复随稳定 ancestry 进入 removable，未越级退休；新差异有 implementation SHA 和回归测试。
- validation profiles: local and CI only；未进行真实账号生成、Home/HF 部署、浏览器 UAT、Release 或线上配置修改。
- upstream ordinary changes: absorbed，包括 Codex UA 0.154.0、alias metadata、audioTranscription 文本、incomplete Interactions、工具调用配对与 optional SDK ResultPolicy。
- contract registry features reviewed: full-usage-statistics-core、management-usage-api、panel-release-asset、auth-identity-attribution、config-compatibility-and-hot-reload、redis-compatible-usage-queue；provider-runtime-usage-seams。
- superseded upstream-port PRs: none；昨日四项窄回补已在 main，不重复 PR。

冲突：cmd/fetch_codex_models/main.go、config.example.yaml、internal/pluginhost/adapters_usage_translation.go、internal/runtime/executor/helps/usage_helpers.go、internal/store/objectstore.go、Gemini/Antigravity Responses request tests、sdk/auth/filestore_disabled_test.go、sdk/cliproxy/auth/conductor_cooldown.go。按字段/逻辑适配，未整文件选边。

## 验证

- PASS `go test ./...`；首次暴露 UA、capability、relay/explicit-thinking 适配点，修正后通过。
- PASS `go list ./... | rg -v '/tmp$' | xargs go test -count=1`。
- PASS `go test ./internal/usage ./internal/api/handlers/management ./test -run 'Usage|usage'`。
- PASS `go test ./internal/translator/openai/openai/responses`（完整包）。
- PASS 六包 race：sdk/cliproxy/auth、sdk/auth、internal/store、internal/pluginhost、internal/runtime/executor/helps、internal/client/codex/models。
- PASS ResultPolicy continuity 修正后的 auth 全包 race 和定向回归。
- PASS server build、LTS guard、registry lifecycle（base origin/main）、git diff --check。
- exact-head CI：提交后回读，通过后使用 Create a merge commit；禁止 squash/rebase（ledger 引用本 PR implementation SHA）。
